### PR TITLE
RHOAIENG-24708: Part 3: Replace Deprecated Modal Instances with PF6 Modal

### DIFF
--- a/frontend/src/pages/hardwareProfiles/migration/MigrationModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/migration/MigrationModal.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
-import { Alert, Button, List, ListItem, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { MigrationAction, MigrationSourceType } from './types';
 import { MIGRATION_SOURCE_TYPE_LABELS } from './const';
 
@@ -32,12 +42,70 @@ const MigrationModal: React.FC<MigrationModalProps> = ({ onClose, onMigrate, mig
   };
 
   return (
-    <Modal
-      title="Migrate hardware profile"
-      titleIconVariant="warning"
-      isOpen
-      onClose={onClose}
-      actions={[
+    <Modal isOpen onClose={onClose} variant="small" data-testid="migration-modal">
+      <ModalHeader title="Migrate hardware profile" titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Stack hasGutter>
+              <StackItem>
+                You are migrating a legacy hardware profile that was created from the{' '}
+                <strong>{migrationAction.source.label}</strong>{' '}
+                {MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type]}
+                {migrationAction.source.type !== MigrationSourceType.ACCELERATOR_PROFILE
+                  ? ' in the ODH dashboard config.'
+                  : '.'}
+              </StackItem>
+              <StackItem>
+                Migrating this profile creates a matching resource in Kubernetes, and deletes its
+                source resource. Deployed workloads using this legacy profile will be unaffected by
+                the migration.
+              </StackItem>
+              <StackItem>
+                This migration will make the following changes:
+                <List>
+                  <ListItem>
+                    A new hardware profile will be created:{' '}
+                    <strong>
+                      {`${migrationAction.targetProfile.spec.displayName} (${migrationAction.targetProfile.metadata.name})`}
+                    </strong>
+                  </ListItem>
+                  {migrationAction.dependentProfiles.length > 0 && (
+                    <ListItem>
+                      Legacy hardware profiles dependent on the source resource will be created:{' '}
+                      <strong>
+                        {migrationAction.dependentProfiles
+                          .map(
+                            (profile) => `${profile.spec.displayName} (${profile.metadata.name})`,
+                          )
+                          .join(', ')}
+                      </strong>
+                    </ListItem>
+                  )}
+                  <ListItem>
+                    The source {MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type]} will be
+                    deleted
+                  </ListItem>
+                </List>
+              </StackItem>
+            </Stack>
+          </StackItem>
+
+          {error && (
+            <StackItem>
+              <Alert
+                data-testid="migration-modal-error-message-alert"
+                title={`Error migrating ${migrationNameSanitized}`}
+                isInline
+                variant="danger"
+              >
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="delete-button"
           variant="danger"
@@ -46,71 +114,11 @@ const MigrationModal: React.FC<MigrationModalProps> = ({ onClose, onMigrate, mig
           onClick={handleMigrate}
         >
           Migrate
-        </Button>,
+        </Button>
         <Button key="cancel-button" variant="link" onClick={onClose}>
           Cancel
-        </Button>,
-      ]}
-      variant="small"
-      data-testid="migration-modal"
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <Stack hasGutter>
-            <StackItem>
-              You are migrating a legacy hardware profile that was created from the{' '}
-              <strong>{migrationAction.source.label}</strong>{' '}
-              {MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type]}
-              {migrationAction.source.type !== MigrationSourceType.ACCELERATOR_PROFILE
-                ? ' in the ODH dashboard config.'
-                : '.'}
-            </StackItem>
-            <StackItem>
-              Migrating this profile creates a matching resource in Kubernetes, and deletes its
-              source resource. Deployed workloads using this legacy profile will be unaffected by
-              the migration.
-            </StackItem>
-            <StackItem>
-              This migration will make the following changes:
-              <List>
-                <ListItem>
-                  A new hardware profile will be created:{' '}
-                  <strong>
-                    {`${migrationAction.targetProfile.spec.displayName} (${migrationAction.targetProfile.metadata.name})`}
-                  </strong>
-                </ListItem>
-                {migrationAction.dependentProfiles.length > 0 && (
-                  <ListItem>
-                    Legacy hardware profiles dependent on the source resource will be created:{' '}
-                    <strong>
-                      {migrationAction.dependentProfiles
-                        .map((profile) => `${profile.spec.displayName} (${profile.metadata.name})`)
-                        .join(', ')}
-                    </strong>
-                  </ListItem>
-                )}
-                <ListItem>
-                  The source {MIGRATION_SOURCE_TYPE_LABELS[migrationAction.source.type]} will be
-                  deleted
-                </ListItem>
-              </List>
-            </StackItem>
-          </Stack>
-        </StackItem>
-
-        {error && (
-          <StackItem>
-            <Alert
-              data-testid="migration-modal-error-message-alert"
-              title={`Error migrating ${migrationNameSanitized}`}
-              isInline
-              variant="danger"
-            >
-              {error.message}
-            </Alert>
-          </StackItem>
-        )}
-      </Stack>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/hardwareProfiles/nodeResource/ManageNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/ManageNodeResourceModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { Identifier, IdentifierResourceType } from '~/types';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
@@ -55,26 +55,24 @@ const ManageNodeResourceModal: React.FC<ManageNodeResourceModalProps> = ({
   };
 
   return (
-    <Modal
-      title={existingIdentifier ? 'Edit node resource' : 'Add node resource'}
-      variant="medium"
-      isOpen
-      onClose={onClose}
-      footer={
+    <Modal variant="medium" isOpen onClose={onClose}>
+      <ModalHeader title={existingIdentifier ? 'Edit node resource' : 'Add node resource'} />
+      <ModalBody>
+        <NodeResourceForm
+          identifier={identifier}
+          setIdentifier={setIdentifier}
+          unitOptions={unitOptions}
+          isUniqueIdentifier={isUniqueIdentifier}
+        />
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={existingIdentifier ? 'Update' : 'Add'}
           onSubmit={handleSubmit}
           onCancel={onClose}
           isSubmitDisabled={isButtonDisabled}
         />
-      }
-    >
-      <NodeResourceForm
-        identifier={identifier}
-        setIdentifier={setIdentifier}
-        unitOptions={unitOptions}
-        isUniqueIdentifier={isUniqueIdentifier}
-      />
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/hardwareProfiles/nodeSelector/ManageNodeSelectorModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeSelector/ManageNodeSelectorModal.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
-import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import useGenericObjectState from '~/utilities/useGenericObjectState';
 import { useValidation } from '~/utilities/useValidation';
@@ -30,40 +37,38 @@ const ManageNodeSelectorModal: React.FC<ManageNodeSelectorModalProps> = ({
   const isValidated = useValidation(nodeSelector, nodeSelectorSchema);
 
   return (
-    <Modal
-      title={existingNodeSelector ? 'Edit node selector' : 'Add node selector'}
-      variant="medium"
-      isOpen
-      onClose={onClose}
-      footer={
+    <Modal variant="medium" isOpen onClose={onClose}>
+      <ModalHeader title={existingNodeSelector ? 'Edit node selector' : 'Add node selector'} />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Key" fieldId="key" isRequired>
+            <TextInput
+              aria-label="Node selector key input"
+              value={nodeSelector.key}
+              onChange={(_, value) => setNodeSelector('key', value)}
+              data-testid="node-selector-key-input"
+              placeholder="Example, node.kubernetes.io/instance-type"
+            />
+          </FormGroup>
+          <FormGroup label="Value" fieldId="value" isRequired>
+            <TextInput
+              aria-label="Node selector value input"
+              value={nodeSelector.value}
+              onChange={(_, value) => setNodeSelector('value', value)}
+              data-testid="node-selector-value-input"
+              placeholder="Example, m4.xlarge"
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={existingNodeSelector ? 'Update' : 'Add'}
           onSubmit={handleSubmit}
           onCancel={onClose}
           isSubmitDisabled={!isValidated.validationResult.success}
         />
-      }
-    >
-      <Form>
-        <FormGroup label="Key" fieldId="key" isRequired>
-          <TextInput
-            aria-label="Node selector key input"
-            value={nodeSelector.key}
-            onChange={(_, value) => setNodeSelector('key', value)}
-            data-testid="node-selector-key-input"
-            placeholder="Example, node.kubernetes.io/instance-type"
-          />
-        </FormGroup>
-        <FormGroup label="Value" fieldId="value" isRequired>
-          <TextInput
-            aria-label="Node selector value input"
-            value={nodeSelector.value}
-            onChange={(_, value) => setNodeSelector('value', value)}
-            data-testid="node-selector-value-input"
-            placeholder="Example, m4.xlarge"
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/hardwareProfiles/toleration/ManageTolerationModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/toleration/ManageTolerationModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
 import {
   Alert,
   Flex,
@@ -13,6 +12,10 @@ import {
   Stack,
   StackItem,
   TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
@@ -52,144 +55,142 @@ const ManageTolerationModal: React.FC<ManageTolerationModalProps> = ({
   const isValidated = useValidation(toleration, tolerationSchema);
 
   return (
-    <Modal
-      title={existingToleration ? 'Edit toleration' : 'Add toleration'}
-      variant="medium"
-      isOpen
-      onClose={onClose}
-      footer={
+    <Modal variant="medium" isOpen onClose={onClose}>
+      <ModalHeader title={existingToleration ? 'Edit toleration' : 'Add toleration'} />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Operator" fieldId="operator-select">
+            <SimpleSelect
+              isFullWidth
+              options={operatorDropdownOptions}
+              value={toleration.operator || ''}
+              onChange={(key) => {
+                const operator = asEnumMember(key, TolerationOperator);
+                setToleration('operator', operator ?? undefined);
+              }}
+              dataTestId="toleration-operator-select"
+            />
+          </FormGroup>
+          <FormGroup label="Effect" fieldId="effect-select">
+            <SimpleSelect
+              isFullWidth
+              options={effectDropdownOptions}
+              value={toleration.effect || ''}
+              onChange={(key) => {
+                const effect = asEnumMember(key, TolerationEffect);
+                setToleration('effect', effect ?? undefined);
+              }}
+              dataTestId="toleration-effect-select"
+            />
+          </FormGroup>
+          <FormGroup label="Key" isRequired fieldId="toleration-key">
+            <TextInput
+              id="toleration-key"
+              value={toleration.key}
+              onChange={(_, value) => setToleration('key', value)}
+              aria-label="Toleration key field"
+              data-testid="toleration-key-input"
+            />
+          </FormGroup>
+          <FormGroup label="Value" fieldId="toleration-value">
+            <Stack hasGutter>
+              <StackItem>
+                <TextInput
+                  id="toleration-value"
+                  value={toleration.value || ''}
+                  onChange={(_, value) => setToleration('value', value)}
+                  aria-label="Toleration value field"
+                  data-testid="toleration-value-input"
+                />
+              </StackItem>
+              {showAlertForValue && (
+                <StackItem>
+                  <Alert
+                    variant="info"
+                    isPlain
+                    isInline
+                    title="Value should be empty when operator is Exists."
+                    data-testid="toleration-value-alert"
+                  />
+                </StackItem>
+              )}
+            </Stack>
+          </FormGroup>
+          <FormGroup
+            label="Toleration seconds"
+            fieldId="toleration-seconds"
+            labelHelp={
+              <Popover bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted.">
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info for toleration seconds field"
+                />
+              </Popover>
+            }
+          >
+            <Stack hasGutter>
+              <StackItem>
+                <Flex>
+                  <FlexItem>
+                    <Radio
+                      id="forever"
+                      name="tolerationSeconds"
+                      label="Forever"
+                      isChecked={toleration.tolerationSeconds === undefined}
+                      onChange={() => setToleration('tolerationSeconds', undefined)}
+                    />
+                  </FlexItem>
+                  <FlexItem>
+                    <Radio
+                      id="custom-value"
+                      name="tolerationSeconds"
+                      label="Custom value"
+                      isChecked={toleration.tolerationSeconds !== undefined}
+                      onChange={() => {
+                        setToleration('tolerationSeconds', 0);
+                      }}
+                      data-testid="toleration-seconds-radio-custom"
+                    />
+                  </FlexItem>
+                </Flex>
+              </StackItem>
+              {toleration.tolerationSeconds !== undefined && (
+                <StackItem>
+                  <InputGroup>
+                    <NumberInputWrapper
+                      min={0}
+                      value={toleration.tolerationSeconds}
+                      onChange={(value) => {
+                        setToleration('tolerationSeconds', value || 0);
+                      }}
+                    />
+                    <InputGroupText isPlain>second(s)</InputGroupText>
+                  </InputGroup>
+                </StackItem>
+              )}
+              {showAlertForTolerationSeconds && (
+                <StackItem>
+                  <Alert
+                    variant="info"
+                    isInline
+                    isPlain
+                    title="Toleration seconds are ignored unless effect is NoExecute"
+                    data-testid="toleration-seconds-alert"
+                  />
+                </StackItem>
+              )}
+            </Stack>
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={existingToleration ? 'Update' : 'Add'}
           onSubmit={handleSubmit}
           onCancel={onClose}
           isSubmitDisabled={!isValidated.validationResult.success}
         />
-      }
-    >
-      <Form>
-        <FormGroup label="Operator" fieldId="operator-select">
-          <SimpleSelect
-            isFullWidth
-            options={operatorDropdownOptions}
-            value={toleration.operator || ''}
-            onChange={(key) => {
-              const operator = asEnumMember(key, TolerationOperator);
-              setToleration('operator', operator ?? undefined);
-            }}
-            dataTestId="toleration-operator-select"
-          />
-        </FormGroup>
-        <FormGroup label="Effect" fieldId="effect-select">
-          <SimpleSelect
-            isFullWidth
-            options={effectDropdownOptions}
-            value={toleration.effect || ''}
-            onChange={(key) => {
-              const effect = asEnumMember(key, TolerationEffect);
-              setToleration('effect', effect ?? undefined);
-            }}
-            dataTestId="toleration-effect-select"
-          />
-        </FormGroup>
-        <FormGroup label="Key" isRequired fieldId="toleration-key">
-          <TextInput
-            id="toleration-key"
-            value={toleration.key}
-            onChange={(_, value) => setToleration('key', value)}
-            aria-label="Toleration key field"
-            data-testid="toleration-key-input"
-          />
-        </FormGroup>
-        <FormGroup label="Value" fieldId="toleration-value">
-          <Stack hasGutter>
-            <StackItem>
-              <TextInput
-                id="toleration-value"
-                value={toleration.value || ''}
-                onChange={(_, value) => setToleration('value', value)}
-                aria-label="Toleration value field"
-                data-testid="toleration-value-input"
-              />
-            </StackItem>
-            {showAlertForValue && (
-              <StackItem>
-                <Alert
-                  variant="info"
-                  isPlain
-                  isInline
-                  title="Value should be empty when operator is Exists."
-                  data-testid="toleration-value-alert"
-                />
-              </StackItem>
-            )}
-          </Stack>
-        </FormGroup>
-        <FormGroup
-          label="Toleration seconds"
-          fieldId="toleration-seconds"
-          labelHelp={
-            <Popover bodyContent="Toleration seconds specifies how long a pod can remain bound to a node before being evicted.">
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info for toleration seconds field"
-              />
-            </Popover>
-          }
-        >
-          <Stack hasGutter>
-            <StackItem>
-              <Flex>
-                <FlexItem>
-                  <Radio
-                    id="forever"
-                    name="tolerationSeconds"
-                    label="Forever"
-                    isChecked={toleration.tolerationSeconds === undefined}
-                    onChange={() => setToleration('tolerationSeconds', undefined)}
-                  />
-                </FlexItem>
-                <FlexItem>
-                  <Radio
-                    id="custom-value"
-                    name="tolerationSeconds"
-                    label="Custom value"
-                    isChecked={toleration.tolerationSeconds !== undefined}
-                    onChange={() => {
-                      setToleration('tolerationSeconds', 0);
-                    }}
-                    data-testid="toleration-seconds-radio-custom"
-                  />
-                </FlexItem>
-              </Flex>
-            </StackItem>
-            {toleration.tolerationSeconds !== undefined && (
-              <StackItem>
-                <InputGroup>
-                  <NumberInputWrapper
-                    min={0}
-                    value={toleration.tolerationSeconds}
-                    onChange={(value) => {
-                      setToleration('tolerationSeconds', value || 0);
-                    }}
-                  />
-                  <InputGroupText isPlain>second(s)</InputGroupText>
-                </InputGroup>
-              </StackItem>
-            )}
-            {showAlertForTolerationSeconds && (
-              <StackItem>
-                <Alert
-                  variant="info"
-                  isInline
-                  isPlain
-                  title="Toleration seconds are ignored unless effect is NoExecute"
-                  data-testid="toleration-seconds-alert"
-                />
-              </StackItem>
-            )}
-          </Stack>
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationModal/ManageBiasConfigurationModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Form, FormGroup, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { BiasMetricConfig } from '~/concepts/trustyai/types';
 import { BiasMetricType } from '~/api';
 import { InferenceServiceKind } from '~/k8sTypes';
@@ -63,12 +70,129 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
   };
 
   return (
-    <Modal
-      variant="medium"
-      title="Configure bias metric"
-      isOpen
-      onClose={() => onBeforeClose(false)}
-      footer={
+    <Modal variant="medium" isOpen onClose={() => onBeforeClose(false)}>
+      <ModalHeader title="Configure bias metric" description="All fields are required." />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Metric name" fieldId="metric-name" data-testid="metric-name">
+            <TextInput
+              data-testid="metric-name-input"
+              id="metric-name"
+              value={configuration.requestName}
+              onChange={(e, value) => setConfiguration('requestName', value)}
+            />
+          </FormGroup>
+          <MetricTypeField
+            fieldId="metric-type"
+            value={metricType}
+            onChange={(value) => {
+              setMetricType(value);
+              setConfiguration('thresholdDelta', getThresholdDefaultDelta(value));
+            }}
+          />
+          <FormGroup
+            label="Protected attribute"
+            fieldId="protected-attribute"
+            labelHelp={
+              <DashboardHelpTooltip content="The protected attribute is the input feature that you want to investigate bias over." />
+            }
+          >
+            <TextInput
+              id="protected-attribute"
+              data-testid="protected-attribute"
+              value={configuration.protectedAttribute}
+              onChange={(e, value) => setConfiguration('protectedAttribute', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Privileged value"
+            fieldId="privileged-value"
+            labelHelp={
+              <DashboardHelpTooltip content="The privileged value is the value of the protected attribute that the model might be biased towards." />
+            }
+          >
+            <TextInput
+              id="privileged-value"
+              data-testid="privileged-value"
+              value={String(configuration.privilegedAttribute)}
+              onChange={(e, value) => setConfiguration('privilegedAttribute', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Unprivileged value"
+            fieldId="unprivileged-value"
+            labelHelp={
+              <DashboardHelpTooltip content="The unprivileged value is the value of the protected attribute that the model might be biased against." />
+            }
+          >
+            <TextInput
+              id="unprivileged-value"
+              data-testid="unprivileged-value"
+              value={String(configuration.unprivilegedAttribute)}
+              onChange={(e, value) => setConfiguration('unprivilegedAttribute', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Output"
+            fieldId="output"
+            labelHelp={
+              <DashboardHelpTooltip content="The output is the particular output of the model to monitor for bias." />
+            }
+          >
+            <TextInput
+              id="output"
+              data-testid="output"
+              value={configuration.outcomeName}
+              onChange={(e, value) => setConfiguration('outcomeName', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Output value"
+            fieldId="output-value"
+            labelHelp={
+              <DashboardHelpTooltip content="The output value is the value of the chosen output to monitor for bias." />
+            }
+          >
+            <TextInput
+              id="output-value"
+              data-testid="output-value"
+              value={String(configuration.favorableOutcome)}
+              onChange={(e, value) => setConfiguration('favorableOutcome', value)}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Violation threshold"
+            fieldId="violation-threshold"
+            labelHelp={
+              <DashboardHelpTooltip content='The violation threshold is how far the metric value can be from "perfect fairness" to constitute "unfairness".' />
+            }
+          >
+            <TextInput
+              id="violation-threshold"
+              data-testid="violation-threshold"
+              value={configuration.thresholdDelta}
+              type="number"
+              onChange={(e, value) => setConfiguration('thresholdDelta', Number(value))}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Metric batch size"
+            fieldId="metric-batch-size"
+            labelHelp={
+              <DashboardHelpTooltip content="The metric batch size is how many of the previous model inferences to consider in each metric calculation." />
+            }
+          >
+            <TextInput
+              id="metric-batch-size"
+              data-testid="metric-batch-size"
+              value={configuration.batchSize}
+              type="number"
+              onChange={(e, value) => setConfiguration('batchSize', Number(value))}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           error={error}
           onCancel={() => onBeforeClose(false)}
@@ -79,127 +203,7 @@ const ManageBiasConfigurationModal: React.FC<ManageBiasConfigurationModalProps> 
             !checkConfigurationFieldsValid(configuration, metricType) || actionInProgress
           }
         />
-      }
-      description="All fields are required."
-    >
-      <Form>
-        <FormGroup label="Metric name" fieldId="metric-name" data-testid="metric-name">
-          <TextInput
-            data-testid="metric-name-input"
-            id="metric-name"
-            value={configuration.requestName}
-            onChange={(e, value) => setConfiguration('requestName', value)}
-          />
-        </FormGroup>
-        <MetricTypeField
-          fieldId="metric-type"
-          value={metricType}
-          onChange={(value) => {
-            setMetricType(value);
-            setConfiguration('thresholdDelta', getThresholdDefaultDelta(value));
-          }}
-        />
-        <FormGroup
-          label="Protected attribute"
-          fieldId="protected-attribute"
-          labelHelp={
-            <DashboardHelpTooltip content="The protected attribute is the input feature that you want to investigate bias over." />
-          }
-        >
-          <TextInput
-            id="protected-attribute"
-            data-testid="protected-attribute"
-            value={configuration.protectedAttribute}
-            onChange={(e, value) => setConfiguration('protectedAttribute', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Privileged value"
-          fieldId="privileged-value"
-          labelHelp={
-            <DashboardHelpTooltip content="The privileged value is the value of the protected attribute that the model might be biased towards." />
-          }
-        >
-          <TextInput
-            id="privileged-value"
-            data-testid="privileged-value"
-            value={String(configuration.privilegedAttribute)}
-            onChange={(e, value) => setConfiguration('privilegedAttribute', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Unprivileged value"
-          fieldId="unprivileged-value"
-          labelHelp={
-            <DashboardHelpTooltip content="The unprivileged value is the value of the protected attribute that the model might be biased against." />
-          }
-        >
-          <TextInput
-            id="unprivileged-value"
-            data-testid="unprivileged-value"
-            value={String(configuration.unprivilegedAttribute)}
-            onChange={(e, value) => setConfiguration('unprivilegedAttribute', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Output"
-          fieldId="output"
-          labelHelp={
-            <DashboardHelpTooltip content="The output is the particular output of the model to monitor for bias." />
-          }
-        >
-          <TextInput
-            id="output"
-            data-testid="output"
-            value={configuration.outcomeName}
-            onChange={(e, value) => setConfiguration('outcomeName', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Output value"
-          fieldId="output-value"
-          labelHelp={
-            <DashboardHelpTooltip content="The output value is the value of the chosen output to monitor for bias." />
-          }
-        >
-          <TextInput
-            id="output-value"
-            data-testid="output-value"
-            value={String(configuration.favorableOutcome)}
-            onChange={(e, value) => setConfiguration('favorableOutcome', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Violation threshold"
-          fieldId="violation-threshold"
-          labelHelp={
-            <DashboardHelpTooltip content='The violation threshold is how far the metric value can be from "perfect fairness" to constitute "unfairness".' />
-          }
-        >
-          <TextInput
-            id="violation-threshold"
-            data-testid="violation-threshold"
-            value={configuration.thresholdDelta}
-            type="number"
-            onChange={(e, value) => setConfiguration('thresholdDelta', Number(value))}
-          />
-        </FormGroup>
-        <FormGroup
-          label="Metric batch size"
-          fieldId="metric-batch-size"
-          labelHelp={
-            <DashboardHelpTooltip content="The metric batch size is how many of the previous model inferences to consider in each metric calculation." />
-          }
-        >
-          <TextInput
-            id="metric-batch-size"
-            data-testid="metric-batch-size"
-            value={configuration.batchSize}
-            type="number"
-            onChange={(e, value) => setConfiguration('batchSize', Number(value))}
-          />
-        </FormGroup>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/DeployPrefilledModelModal.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Alert, Button, Form, FormSection, Spinner } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated'; // TODO migrate to non-deprecated modal
+import {
+  Alert,
+  Button,
+  Form,
+  FormSection,
+  Spinner,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { ProjectKind } from '~/k8sTypes';
 import useProjectErrorForPrefilledModel from '~/pages/modelServing/screens/projects/useProjectErrorForPrefilledModel';
 import ProjectSelector from '~/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector';
@@ -138,26 +147,23 @@ const DeployPrefilledModelModalContents: React.FC<
     );
 
     return (
-      <Modal
-        title="Deploy model"
-        description="Configure properties for deploying your model"
-        variant="medium"
-        isOpen
-        onClose={() => onClose(false)}
-        actions={[
-          // The Deploy button is disabled as this particular return of the Modal
-          // only happens when there's not a valid selected project, otherwise we'll
-          // render the ManageKServeModal or ManageInferenceServiceModal
+      <Modal variant="medium" isOpen onClose={() => onClose(false)}>
+        <ModalHeader
+          title="Deploy model"
+          description="Configure properties for deploying your model"
+        />
+        <ModalBody>{modalForm}</ModalBody>
+        <ModalFooter>
+          {/* The Deploy button is disabled as this particular return of the Modal
+          only happens when there's not a valid selected project, otherwise we'll
+          render the ManageKServeModal or ManageInferenceServiceModal */}
           <Button key="deploy" variant="primary" isDisabled>
             Deploy
-          </Button>,
+          </Button>
           <Button key="cancel" variant="link" onClick={() => onClose(false)}>
             Cancel
-          </Button>,
-        ]}
-        showClose
-      >
-        {modalForm}
+          </Button>
+        </ModalFooter>
       </Modal>
     );
   }

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
   submitServingRuntimeResourcesWithDryRun,
@@ -174,14 +181,61 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
   };
 
   return (
-    <Modal
-      title={`${editInfo ? 'Edit' : 'Add'} model server`}
-      description="A model server specifies resources available for use by one or more supported models, and includes a serving runtime."
-      variant="medium"
-      isOpen
-      onClose={() => onBeforeClose(false)}
-      showClose
-      footer={
+    <Modal variant="medium" isOpen onClose={() => onBeforeClose(false)}>
+      <ModalHeader
+        title={`${editInfo ? 'Edit' : 'Add'} model server`}
+        description="A model server specifies resources available for use by one or more supported models, and includes a serving runtime."
+      />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          <Stack hasGutter>
+            <StackItem>
+              <K8sNameDescriptionField
+                data={modelServerNameDesc}
+                onDataChange={setModelServerNameDesc}
+                dataTestId="serving-runtime"
+                nameLabel="Model server name"
+                hideDescription
+              />
+            </StackItem>
+            <StackItem>
+              <ServingRuntimeTemplateSection
+                data={createData}
+                setData={setCreateData}
+                templates={servingRuntimeTemplates || []}
+                isEditing={!!editInfo}
+                compatibleIdentifiers={profileIdentifiers}
+              />
+            </StackItem>
+            <StackItem>
+              <ServingRuntimeReplicaSection
+                data={createData}
+                setData={setCreateData}
+                infoContent="Consider network traffic and failover scenarios when specifying the number of model
+                server replicas."
+              />
+            </StackItem>
+            <ServingRuntimeSizeSection
+              podSpecOptionState={podSpecOptionsState}
+              servingRuntimeSelected={servingRuntimeSelected}
+              infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
+              isEditing={!!editInfo}
+            />
+            <AuthServingRuntimeSection
+              data={createData}
+              setData={setCreateData}
+              allowCreate={allowCreate}
+              publicRoute
+            />
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={editInfo ? 'Update' : 'Add'}
           onSubmit={submit}
@@ -190,55 +244,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
           alertTitle={`Error ${editInfo ? 'updating' : 'creating'} model server`}
           error={error}
         />
-      }
-    >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            <K8sNameDescriptionField
-              data={modelServerNameDesc}
-              onDataChange={setModelServerNameDesc}
-              dataTestId="serving-runtime"
-              nameLabel="Model server name"
-              hideDescription
-            />
-          </StackItem>
-          <StackItem>
-            <ServingRuntimeTemplateSection
-              data={createData}
-              setData={setCreateData}
-              templates={servingRuntimeTemplates || []}
-              isEditing={!!editInfo}
-              compatibleIdentifiers={profileIdentifiers}
-            />
-          </StackItem>
-          <StackItem>
-            <ServingRuntimeReplicaSection
-              data={createData}
-              setData={setCreateData}
-              infoContent="Consider network traffic and failover scenarios when specifying the number of model
-                server replicas."
-            />
-          </StackItem>
-          <ServingRuntimeSizeSection
-            podSpecOptionState={podSpecOptionsState}
-            servingRuntimeSelected={servingRuntimeSelected}
-            infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
-            isEditing={!!editInfo}
-          />
-          <AuthServingRuntimeSection
-            data={createData}
-            setData={setCreateData}
-            allowCreate={allowCreate}
-            publicRoute
-          />
-        </Stack>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Form, FormSection, Spinner } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormSection,
+  Spinner,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
   getCreateInferenceServiceLabels,
@@ -342,13 +349,148 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   };
 
   return (
-    <Modal
-      title={editInfo ? 'Edit model' : 'Deploy model'}
-      description="Configure properties for deploying your model"
-      variant="medium"
-      isOpen
-      onClose={() => onBeforeClose(false)}
-      footer={
+    <Modal variant="medium" isOpen onClose={() => onBeforeClose(false)}>
+      <ModalHeader
+        title={editInfo ? 'Edit model' : 'Deploy model'}
+        description="Configure properties for deploying your model"
+      />
+      <ModalBody>
+        {!isAuthAvailable && alertVisible && !isRawAvailable && (
+          <NoAuthAlert onClose={() => setAlertVisible(false)} />
+        )}
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          <FormSection title="Model deployment">
+            {projectSection || (
+              <ProjectSection
+                projectName={
+                  (projectContext?.currentProject &&
+                    getDisplayNameFromK8sResource(projectContext.currentProject)) ||
+                  editInfo?.inferenceServiceEditInfo?.metadata.namespace ||
+                  ''
+                }
+              />
+            )}
+            {!hideForm && isLoading && <Spinner data-testid="spinner" />}
+            {!hideForm && !isLoading && (
+              <>
+                <K8sNameDescriptionField
+                  data={kServeNameDesc}
+                  onDataChange={setKserveNameDesc}
+                  dataTestId="inference-service"
+                  nameLabel="Model deployment name"
+                  nameHelperText="This is the name of the inference service created when the model is deployed"
+                  hideDescription
+                />
+                <ServingRuntimeTemplateSection
+                  data={createDataServingRuntime}
+                  onConfigureParamsClick={
+                    servingRuntimeParamsEnabled
+                      ? () =>
+                          requestAnimationFrame(() => {
+                            servingRuntimeArgsInputRef.current?.focus();
+                          })
+                      : undefined
+                  }
+                  setData={setCreateDataServingRuntime}
+                  templates={servingRuntimeTemplates || []}
+                  projectSpecificTemplates={projectTemplates}
+                  isEditing={!!editInfo}
+                  compatibleIdentifiers={profileIdentifiers}
+                  resetModelFormat={() => setCreateDataInferenceService('format', { name: '' })}
+                />
+                <InferenceServiceFrameworkSection
+                  data={createDataInferenceService}
+                  setData={setCreateDataInferenceService}
+                  servingRuntimeName={servingRuntimeSelected?.metadata.name}
+                  modelContext={servingRuntimeSelected?.spec.supportedModelFormats}
+                  registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
+                />
+                {isRawAvailable && isServerlessAvailable && (
+                  <KServeDeploymentModeDropdown
+                    isRaw={!!createDataInferenceService.isKServeRawDeployment}
+                    setIsRaw={(isRaw) =>
+                      setCreateDataInferenceService('isKServeRawDeployment', isRaw)
+                    }
+                    isDisabled={!!editInfo}
+                  />
+                )}
+                {!isAuthAvailable && alertVisible && isRawAvailable && (
+                  <NoAuthAlert onClose={() => setAlertVisible(false)} />
+                )}
+                <KServeAutoscalerReplicaSection
+                  data={createDataInferenceService}
+                  setData={setCreateDataInferenceService}
+                  infoContent="Consider network traffic and failover scenarios when specifying the number of model
+                server replicas."
+                />
+                <ServingRuntimeSizeSection
+                  podSpecOptionState={podSpecOptionsState}
+                  projectName={namespace}
+                  servingRuntimeSelected={servingRuntimeSelected}
+                  infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
+                  isEditing={!!editInfo}
+                />
+                <AuthServingRuntimeSection
+                  data={createDataInferenceService}
+                  setData={setCreateDataInferenceService}
+                  allowCreate={allowCreate}
+                  publicRoute
+                  showModelRoute={isAuthAvailable}
+                />
+              </>
+            )}
+          </FormSection>
+          {!hideForm && !isLoading && (
+            <FormSection title="Source model location" id="model-location">
+              <ConnectionSection
+                existingUriOption={
+                  existingUriOption ||
+                  editInfo?.inferenceServiceEditInfo?.spec.predictor.model?.storageUri
+                }
+                data={createDataInferenceService}
+                setData={setCreateDataInferenceService}
+                initialNewConnectionType={initialNewConnectionType}
+                initialNewConnectionValues={initialNewConnectionValues}
+                loaded={
+                  modelDeployPrefillInfo
+                    ? !!projectContext?.connections && connectionsLoaded
+                    : !!projectContext?.connections || connectionsLoaded
+                }
+                loadError={connectionsLoadError}
+                connection={connection}
+                setConnection={setConnection}
+                setIsConnectionValid={setIsConnectionValid}
+                connections={connections}
+              />
+            </FormSection>
+          )}
+          {servingRuntimeParamsEnabled && !isLoading && (
+            <FormSection
+              title="Configuration parameters"
+              id="configuration-params"
+              data-testid="configuration-params"
+            >
+              <ServingRuntimeArgsSection
+                predefinedArgs={getKServeContainerArgs(servingRuntimeSelected)}
+                data={createDataInferenceService}
+                setData={setCreateDataInferenceService}
+                inputRef={servingRuntimeArgsInputRef}
+              />
+              <EnvironmentVariablesSection
+                predefinedVars={getKServeContainerEnvVarStrs(servingRuntimeSelected)}
+                data={createDataInferenceService}
+                setData={setCreateDataInferenceService}
+              />
+            </FormSection>
+          )}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={editInfo ? 'Redeploy' : 'Deploy'}
           onSubmit={submit}
@@ -357,143 +499,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
           error={error}
           alertTitle="Error creating model server"
         />
-      }
-      showClose
-    >
-      {!isAuthAvailable && alertVisible && !isRawAvailable && (
-        <NoAuthAlert onClose={() => setAlertVisible(false)} />
-      )}
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <FormSection title="Model deployment">
-          {projectSection || (
-            <ProjectSection
-              projectName={
-                (projectContext?.currentProject &&
-                  getDisplayNameFromK8sResource(projectContext.currentProject)) ||
-                editInfo?.inferenceServiceEditInfo?.metadata.namespace ||
-                ''
-              }
-            />
-          )}
-          {!hideForm && isLoading && <Spinner data-testid="spinner" />}
-          {!hideForm && !isLoading && (
-            <>
-              <K8sNameDescriptionField
-                data={kServeNameDesc}
-                onDataChange={setKserveNameDesc}
-                dataTestId="inference-service"
-                nameLabel="Model deployment name"
-                nameHelperText="This is the name of the inference service created when the model is deployed"
-                hideDescription
-              />
-              <ServingRuntimeTemplateSection
-                data={createDataServingRuntime}
-                onConfigureParamsClick={
-                  servingRuntimeParamsEnabled
-                    ? () =>
-                        requestAnimationFrame(() => {
-                          servingRuntimeArgsInputRef.current?.focus();
-                        })
-                    : undefined
-                }
-                setData={setCreateDataServingRuntime}
-                templates={servingRuntimeTemplates || []}
-                projectSpecificTemplates={projectTemplates}
-                isEditing={!!editInfo}
-                compatibleIdentifiers={profileIdentifiers}
-                resetModelFormat={() => setCreateDataInferenceService('format', { name: '' })}
-              />
-              <InferenceServiceFrameworkSection
-                data={createDataInferenceService}
-                setData={setCreateDataInferenceService}
-                servingRuntimeName={servingRuntimeSelected?.metadata.name}
-                modelContext={servingRuntimeSelected?.spec.supportedModelFormats}
-                registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
-              />
-              {isRawAvailable && isServerlessAvailable && (
-                <KServeDeploymentModeDropdown
-                  isRaw={!!createDataInferenceService.isKServeRawDeployment}
-                  setIsRaw={(isRaw) =>
-                    setCreateDataInferenceService('isKServeRawDeployment', isRaw)
-                  }
-                  isDisabled={!!editInfo}
-                />
-              )}
-              {!isAuthAvailable && alertVisible && isRawAvailable && (
-                <NoAuthAlert onClose={() => setAlertVisible(false)} />
-              )}
-              <KServeAutoscalerReplicaSection
-                data={createDataInferenceService}
-                setData={setCreateDataInferenceService}
-                infoContent="Consider network traffic and failover scenarios when specifying the number of model
-                server replicas."
-              />
-              <ServingRuntimeSizeSection
-                podSpecOptionState={podSpecOptionsState}
-                projectName={namespace}
-                servingRuntimeSelected={servingRuntimeSelected}
-                infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
-                isEditing={!!editInfo}
-              />
-              <AuthServingRuntimeSection
-                data={createDataInferenceService}
-                setData={setCreateDataInferenceService}
-                allowCreate={allowCreate}
-                publicRoute
-                showModelRoute={isAuthAvailable}
-              />
-            </>
-          )}
-        </FormSection>
-        {!hideForm && !isLoading && (
-          <FormSection title="Source model location" id="model-location">
-            <ConnectionSection
-              existingUriOption={
-                existingUriOption ||
-                editInfo?.inferenceServiceEditInfo?.spec.predictor.model?.storageUri
-              }
-              data={createDataInferenceService}
-              setData={setCreateDataInferenceService}
-              initialNewConnectionType={initialNewConnectionType}
-              initialNewConnectionValues={initialNewConnectionValues}
-              loaded={
-                modelDeployPrefillInfo
-                  ? !!projectContext?.connections && connectionsLoaded
-                  : !!projectContext?.connections || connectionsLoaded
-              }
-              loadError={connectionsLoadError}
-              connection={connection}
-              setConnection={setConnection}
-              setIsConnectionValid={setIsConnectionValid}
-              connections={connections}
-            />
-          </FormSection>
-        )}
-        {servingRuntimeParamsEnabled && !isLoading && (
-          <FormSection
-            title="Configuration parameters"
-            id="configuration-params"
-            data-testid="configuration-params"
-          >
-            <ServingRuntimeArgsSection
-              predefinedArgs={getKServeContainerArgs(servingRuntimeSelected)}
-              data={createDataInferenceService}
-              setData={setCreateDataInferenceService}
-              inputRef={servingRuntimeArgsInputRef}
-            />
-            <EnvironmentVariablesSection
-              predefinedVars={getKServeContainerEnvVarStrs(servingRuntimeSelected)}
-              data={createDataInferenceService}
-              setData={setCreateDataInferenceService}
-            />
-          </FormSection>
-        )}
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-24708
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is the second PR to replace deprecated Modal component with PF6 Modal. Below are the major changes implemented in the PR,

> In PF6, we have separate ModalBody, ModalHeader, ModalFooter components. In the deprecated version, we pass header and footer/actions as props. So we just have to use these new components instead of props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested the UI for the affected areas of the dashboard to make sure that the new Modal loads correctly with all the right content except `ManageNIMServingModal and ManageBiasConfigurationModal` modals.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
