### PR TITLE
moved the 'autofill connections' to a more prominent location

### DIFF
--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -55,13 +55,7 @@ export const ObjectStorageSection = ({
           {loaded && !!connections.length && (
             <FlexItem align={{ default: 'alignRight' }}>
               <Tooltip content="Populate the form with credentials from your selected connection">
-                <div className="pf-v6-u-mt-md">
-                  <PipelineDropdown
-                    config={config}
-                    setConfig={setConfig}
-                    connections={connections}
-                  />
-                </div>
+                <PipelineDropdown config={config} setConfig={setConfig} connections={connections} />
               </Tooltip>
             </FlexItem>
           )}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -54,7 +54,7 @@ export const ObjectStorageSection = ({
           <FlexItem>Object storage connection</FlexItem>
           {loaded && !!connections.length && (
             <FlexItem align={{ default: 'alignRight' }}>
-              <Tooltip content="Populate the form with credentials from your selected data connection">
+              <Tooltip content="Populate the form with credentials from your selected connection">
                 <div className="pf-v6-u-mt-md">
                   <PipelineDropdown
                     config={config}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/ObjectStorageSection.tsx
@@ -7,6 +7,8 @@ import {
   InputGroupItem,
   Popover,
   Button,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Connection } from '~/concepts/connectionTypes/types';
@@ -47,7 +49,24 @@ export const ObjectStorageSection = ({
 
   return (
     <FormSection
-      title="Object storage connection"
+      title={
+        <Flex>
+          <FlexItem>Object storage connection</FlexItem>
+          {loaded && !!connections.length && (
+            <FlexItem align={{ default: 'alignRight' }}>
+              <Tooltip content="Populate the form with credentials from your selected data connection">
+                <div className="pf-v6-u-mt-md">
+                  <PipelineDropdown
+                    config={config}
+                    setConfig={setConfig}
+                    connections={connections}
+                  />
+                </div>
+              </Tooltip>
+            </FlexItem>
+          )}
+        </Flex>
+      }
       description="To store pipeline artifacts. Must be S3 compatible"
     >
       {PIPELINE_AWS_FIELDS.map((field) =>
@@ -67,15 +86,6 @@ export const ObjectStorageSection = ({
                   onChange={(_, value) => onChange(field.key, value)}
                 />
               </InputGroupItem>
-              {loaded && !!connections.length && (
-                <Tooltip content="Populate the form with credentials from your selected data connection">
-                  <PipelineDropdown
-                    config={config}
-                    setConfig={setConfig}
-                    connections={connections}
-                  />
-                </Tooltip>
-              )}
             </InputGroup>
           </FormGroup>
         ) : (

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -10,7 +10,7 @@ import {
   MenuToggle,
 } from '@patternfly/react-core';
 import React from 'react';
-import { EyeIcon, EyeSlashIcon, KeyIcon, OptimizeIcon } from '@patternfly/react-icons';
+import { EyeIcon, EyeSlashIcon, OptimizeIcon } from '@patternfly/react-icons';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';
 import { css } from '@patternfly/react-styles';
 import { AWSDataEntry } from '~/pages/projects/types';

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -8,8 +8,6 @@ import {
   MenuItemAction,
   MenuList,
   MenuToggle,
-  FlexItem,
-  Flex,
 } from '@patternfly/react-core';
 import React from 'react';
 import { EyeIcon, EyeSlashIcon, OptimizeIcon } from '@patternfly/react-icons';

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -83,7 +83,14 @@ export const PipelineDropdown = ({
           onClick={onToggle}
           isExpanded={isOpen}
         >
-          <OptimizeIcon /> <span style={{ marginLeft: '8px' }}>Autofill from connection</span>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>
+              <OptimizeIcon />
+            </FlexItem>
+            <FlexItem>
+              Autofill from connection
+            </FlexItem>
+          </Flex>
         </MenuToggle>
       )}
       isOpen={isOpen}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -8,6 +8,8 @@ import {
   MenuItemAction,
   MenuList,
   MenuToggle,
+  FlexItem,
+  Flex,
 } from '@patternfly/react-core';
 import React from 'react';
 import { EyeIcon, EyeSlashIcon, OptimizeIcon } from '@patternfly/react-icons';
@@ -87,9 +89,7 @@ export const PipelineDropdown = ({
             <FlexItem>
               <OptimizeIcon />
             </FlexItem>
-            <FlexItem>
-              Autofill from connection
-            </FlexItem>
+            <FlexItem>Autofill from connection</FlexItem>
           </Flex>
         </MenuToggle>
       )}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -84,13 +84,9 @@ export const PipelineDropdown = ({
           ref={toggleRef}
           onClick={onToggle}
           isExpanded={isOpen}
+          icon={<OptimizeIcon />}
         >
-          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              <OptimizeIcon />
-            </FlexItem>
-            <FlexItem>Autofill from connection</FlexItem>
-          </Flex>
+          Autofill from connection
         </MenuToggle>
       )}
       isOpen={isOpen}

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -73,7 +73,7 @@ export const PipelineDropdown = ({
   return (
     <Dropdown
       onOpenChange={(isOpened) => setIsOpen(isOpened)}
-      popperProps={{ position: 'right', maxWidth: 'trigger' }}
+      popperProps={{ position: 'right', maxWidth: '600px' }}
       toggle={(toggleRef) => (
         <MenuToggle
           data-testid="select-connection"

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -1,8 +1,6 @@
 import {
   Menu,
-  Content,
   MenuContent,
-  MenuGroup,
   MenuItem,
   Dropdown,
   MenuItemAction,
@@ -75,7 +73,7 @@ export const PipelineDropdown = ({
   return (
     <Dropdown
       onOpenChange={(isOpened) => setIsOpen(isOpened)}
-      popperProps={{ position: 'right' }}
+      popperProps={{ position: 'right', maxWidth: 'trigger' }}
       toggle={(toggleRef) => (
         <MenuToggle
           data-testid="select-connection"
@@ -91,51 +89,49 @@ export const PipelineDropdown = ({
     >
       <Menu onSelect={onSelect} isScrollable isPlain>
         <MenuContent>
-          <MenuGroup>
-            <MenuList>
-              {connections.map((dataItem, index) => (
-                <MenuItem
-                  key={dataItem.metadata.name}
-                  actions={
-                    <MenuItemAction
-                      icon={showPassword[index] ? <EyeSlashIcon /> : <EyeIcon />}
-                      actionId={index}
-                      // eslint-disable-next-line no-console
-                      onClick={(ev) => {
-                        ev.preventDefault();
-                        ev.stopPropagation();
-                        setShowPassword((s) => [
-                          ...s.slice(0, index),
-                          !s[index],
-                          ...s.slice(index + 1),
-                        ]);
-                      }}
-                      aria-label={dataItem.metadata.name}
-                    />
-                  }
-                  description={
-                    showPassword[index] ? (
-                      <Content className={css(styles.menuItemDescription)}>
-                        {existingConnection(dataItem)?.map(
-                          (field) =>
-                            field.value && (
-                              <Content component="p" key={field.key}>
-                                <b>{getLabelName(field.key)}</b> : {field.value}
-                              </Content>
-                            ),
-                        )}
-                      </Content>
-                    ) : (
-                      '•••••••••••••••••'
-                    )
-                  }
-                  itemId={dataItem.metadata.name}
-                >
-                  {getDisplayNameFromK8sResource(dataItem)}
-                </MenuItem>
-              ))}
-            </MenuList>
-          </MenuGroup>
+          <MenuList>
+            {connections.map((dataItem, index) => (
+              <MenuItem
+                key={dataItem.metadata.name}
+                actions={
+                  <MenuItemAction
+                    icon={showPassword[index] ? <EyeSlashIcon /> : <EyeIcon />}
+                    actionId={index}
+                    // eslint-disable-next-line no-console
+                    onClick={(ev) => {
+                      ev.preventDefault();
+                      ev.stopPropagation();
+                      setShowPassword((s) => [
+                        ...s.slice(0, index),
+                        !s[index],
+                        ...s.slice(index + 1),
+                      ]);
+                    }}
+                    aria-label={dataItem.metadata.name}
+                  />
+                }
+                description={
+                  showPassword[index] ? (
+                    <>
+                      {existingConnection(dataItem)?.map(
+                        (field) =>
+                          field.value && (
+                            <p key={field.key}>
+                              <b>{getLabelName(field.key)}</b> : {field.value}
+                            </p>
+                          ),
+                      )}
+                    </>
+                  ) : (
+                    '•••••••••••••••••'
+                  )
+                }
+                itemId={dataItem.metadata.name}
+              >
+                {getDisplayNameFromK8sResource(dataItem)}
+              </MenuItem>
+            ))}
+          </MenuList>
         </MenuContent>
       </Menu>
     </Dropdown>

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -10,7 +10,7 @@ import {
   MenuToggle,
 } from '@patternfly/react-core';
 import React from 'react';
-import { EyeIcon, EyeSlashIcon, KeyIcon } from '@patternfly/react-icons';
+import { EyeIcon, EyeSlashIcon, KeyIcon, OptimizeIcon } from '@patternfly/react-icons';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';
 import { css } from '@patternfly/react-styles';
 import { AWSDataEntry } from '~/pages/projects/types';
@@ -83,20 +83,14 @@ export const PipelineDropdown = ({
           onClick={onToggle}
           isExpanded={isOpen}
         >
-          <KeyIcon />
+          <OptimizeIcon /> <span style={{ marginLeft: '8px' }}>Autofill from connection</span>
         </MenuToggle>
       )}
       isOpen={isOpen}
     >
       <Menu onSelect={onSelect} isScrollable isPlain>
         <MenuContent>
-          <MenuGroup
-            label={
-              <h1 className={css(styles.menuGroupTitle)}>
-                <KeyIcon /> Populate the form with credentials from your selected connection
-              </h1>
-            }
-          >
+          <MenuGroup>
             <MenuList>
               {connections.map((dataItem, index) => (
                 <MenuItem

--- a/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
+++ b/frontend/src/concepts/pipelines/content/configurePipelinesServer/PipelineDropdown.tsx
@@ -9,8 +9,6 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 import { EyeIcon, EyeSlashIcon, OptimizeIcon } from '@patternfly/react-icons';
-import styles from '@patternfly/react-styles/css/components/Menu/menu';
-import { css } from '@patternfly/react-styles';
 import { AWSDataEntry } from '~/pages/projects/types';
 import { PIPELINE_AWS_KEY } from '~/pages/projects/dataConnections/const';
 import { Connection } from '~/concepts/connectionTypes/types';


### PR DESCRIPTION
for: https://issues.redhat.com/browse/RHOAIENG-21530 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
moved the button/dropdown for autofilling connections to a more prominent location re the [[figma](https://www.figma.com/design/6frHhyugL92eQEZO3oeuBH/My-Storage-credentials---pipeline-server-creation?node-id=1-3723&p=f&m=dev)] 


## How Has This Been Tested?
I tested it on the shared server (https://api.ilab-ui.dev.datahub.redhat.com:6443) as a clusteradmin;
with a project that has a stored connection config:
![Screenshot 2025-05-06 at 10 28 22 AM](https://github.com/user-attachments/assets/9b46db68-7be7-485a-93d8-e7271dca1fd5)

and one that does not have the config (it should not show)

![Screenshot 2025-05-06 at 10 29 19 AM](https://github.com/user-attachments/assets/237c2b9d-336e-4068-a975-7f19dcbefab6)

tested that the component works exactly as it did before; which it does.

this ticket just changes the icon and changes the layout.  there are no functional changes *at all*
@kaedward  since ashley crago is not findable on github easily

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
tests are not applicable as there are no functional changes at all.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
