### PR TITLE
RHOAIENG-24709: Part 4: Replace Deprecated Modal Instances with PF6 Modal

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -81,7 +81,7 @@ class SchedulesDeleteModal extends DeleteModal {
   }
 
   find() {
-    return cy.findByTestId('delete-schedule-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('delete-schedule-modal');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -91,7 +91,7 @@ class RunsDeleteModal extends DeleteModal {
   }
 
   find() {
-    return cy.findByTestId('delete-run-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('delete-run-modal');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -183,7 +183,7 @@ class PipelineDeleteModal extends DeleteModal {
   }
 
   find() {
-    return cy.findByTestId('delete-pipeline-modal').parents('div[role="dialog"]');
+    return cy.findByTestId('delete-pipeline-modal');
   }
 }
 

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
-import { Alert, Button, Form, FormAlert, Spinner, TextInputTypes } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  Form,
+  FormAlert,
+  Spinner,
+  TextInputTypes,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { isEmpty, values } from 'lodash-es';
 import { OdhApplication } from '~/types';
@@ -8,6 +18,7 @@ import { EnableApplicationStatus, useEnableApplication } from '~/utilities/useEn
 import { asEnumMember } from '~/utilities/utils';
 import EnableVariable from './EnableVariable';
 import './EnableModal.scss';
+import { ModalBoxHeader } from '@patternfly/react-core/deprecated';
 
 type EnableModalProps = {
   selectedApp: OdhApplication;
@@ -92,11 +103,75 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
       aria-label={`Enable ${enable.title}`}
       className="odh-enable-modal"
       data-id="enable-modal"
-      variant={ModalVariant.small}
-      title={enable.title || `Enable ${selectedApp.spec.displayName}`}
+      variant="small"
       isOpen
       onClose={handleClose}
-      actions={[
+    >
+      <ModalHeader title={enable.title || `Enable ${selectedApp.spec.displayName}`} />
+      <ModalBody>
+        {enable.description ? enable.description : null}
+        {enable.link ? (
+          <div className="odh-enable-modal__enable-link">
+            {enable.linkPreface ? <div>{enable.linkPreface}</div> : null}
+            <a href={enable.link} target="_blank" rel="noopener noreferrer">
+              {enable.link} <ExternalLinkAltIcon />
+            </a>
+          </div>
+        ) : null}
+        {enable.variables ? (
+          <Form>
+            {postError ? (
+              <FormAlert>
+                <Alert
+                  variantLabel="error"
+                  variant="danger"
+                  title="Validation failed"
+                  aria-live="polite"
+                  isInline
+                >
+                  {postError}
+                </Alert>
+              </FormAlert>
+            ) : null}
+            {validationInProgress ? (
+              <FormAlert>
+                <Alert
+                  className="m-no-alert-icon"
+                  variantLabel="information"
+                  variant="info"
+                  title={
+                    <div className="odh-enable-modal__progress-title">
+                      <Spinner size="md" />
+                      {enable.inProgressText ? (
+                        <div style={{ whiteSpace: 'pre-line' }}>{enable.inProgressText}</div>
+                      ) : (
+                        'Validating your entries'
+                      )}
+                    </div>
+                  }
+                  aria-live="polite"
+                  isInline
+                />
+              </FormAlert>
+            ) : null}
+            {Object.keys(enable.variables).map((key, index) => (
+              <EnableVariable
+                key={key}
+                ref={index === 0 ? focusRef : undefined}
+                label={enable.variableDisplayText?.[key] ?? ''}
+                inputType={
+                  asEnumMember(enable.variables?.[key], TextInputTypes) ?? TextInputTypes.text
+                }
+                helperText={enable.variableHelpText?.[key] ?? ''}
+                validationInProgress={validationInProgress}
+                value={enableValues[key]}
+                updateValue={(value: string) => updateEnableValue(key, value)}
+              />
+            ))}
+          </Form>
+        ) : null}
+      </ModalBody>
+      <ModalFooter>
         <Button
           data-testid="enable-app-submit"
           key="confirm"
@@ -105,73 +180,11 @@ const EnableModal: React.FC<EnableModalProps> = ({ selectedApp, onClose }) => {
           isDisabled={validationInProgress || (enable.variables && isEnableValuesHasEmptyValue)}
         >
           {enable.actionLabel || 'Enable'}
-        </Button>,
+        </Button>
         <Button key="cancel" variant="link" onClick={handleClose}>
           {validationInProgress ? 'Close' : 'Cancel'}
-        </Button>,
-      ]}
-    >
-      {enable.description ? enable.description : null}
-      {enable.link ? (
-        <div className="odh-enable-modal__enable-link">
-          {enable.linkPreface ? <div>{enable.linkPreface}</div> : null}
-          <a href={enable.link} target="_blank" rel="noopener noreferrer">
-            {enable.link} <ExternalLinkAltIcon />
-          </a>
-        </div>
-      ) : null}
-      {enable.variables ? (
-        <Form>
-          {postError ? (
-            <FormAlert>
-              <Alert
-                variantLabel="error"
-                variant="danger"
-                title="Validation failed"
-                aria-live="polite"
-                isInline
-              >
-                {postError}
-              </Alert>
-            </FormAlert>
-          ) : null}
-          {validationInProgress ? (
-            <FormAlert>
-              <Alert
-                className="m-no-alert-icon"
-                variantLabel="information"
-                variant="info"
-                title={
-                  <div className="odh-enable-modal__progress-title">
-                    <Spinner size="md" />
-                    {enable.inProgressText ? (
-                      <div style={{ whiteSpace: 'pre-line' }}>{enable.inProgressText}</div>
-                    ) : (
-                      'Validating your entries'
-                    )}
-                  </div>
-                }
-                aria-live="polite"
-                isInline
-              />
-            </FormAlert>
-          ) : null}
-          {Object.keys(enable.variables).map((key, index) => (
-            <EnableVariable
-              key={key}
-              ref={index === 0 ? focusRef : undefined}
-              label={enable.variableDisplayText?.[key] ?? ''}
-              inputType={
-                asEnumMember(enable.variables?.[key], TextInputTypes) ?? TextInputTypes.text
-              }
-              helperText={enable.variableHelpText?.[key] ?? ''}
-              validationInProgress={validationInProgress}
-              value={enableValues[key]}
-              updateValue={(value: string) => updateEnableValue(key, value)}
-            />
-          ))}
-        </Form>
-      ) : null}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/exploreApplication/EnableModal.tsx
+++ b/frontend/src/pages/exploreApplication/EnableModal.tsx
@@ -18,7 +18,6 @@ import { EnableApplicationStatus, useEnableApplication } from '~/utilities/useEn
 import { asEnumMember } from '~/utilities/utils';
 import EnableVariable from './EnableVariable';
 import './EnableModal.scss';
-import { ModalBoxHeader } from '@patternfly/react-core/deprecated';
 
 type EnableModalProps = {
   selectedApp: OdhApplication;

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
-import { Form, FormSection, HelperTextItem, Spinner } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  FormSection,
+  HelperTextItem,
+  Spinner,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { EitherOrNone } from '@openshift/dynamic-plugin-sdk';
 import {
   getCreateInferenceServiceLabels,
@@ -165,13 +173,77 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
   };
 
   return (
-    <Modal
-      title={editInfo ? 'Edit model' : 'Deploy model'}
-      description="Configure properties for deploying your model"
-      variant="medium"
-      isOpen
-      onClose={() => onClose(false)}
-      footer={
+    <Modal variant="medium" isOpen onClose={() => onClose(false)}>
+      <ModalHeader
+        title={editInfo ? 'Edit model' : 'Deploy model'}
+        description="Configure properties for deploying your model"
+      />
+      <ModalBody>
+        <Form>
+          {projectSection || (
+            <ProjectSection
+              projectName={
+                (projectContext?.currentProject &&
+                  getDisplayNameFromK8sResource(projectContext.currentProject)) ||
+                editInfo?.metadata.namespace ||
+                ''
+              }
+            />
+          )}
+          {!shouldFormHidden && isLoading && <Spinner />}
+          {!shouldFormHidden && !isLoading && (
+            <>
+              <K8sNameDescriptionField
+                data={inferenceServiceNameDesc}
+                onDataChange={setInferenceServiceNameDesc}
+                dataTestId="inference-service"
+                nameLabel="Model deployment name"
+                nameHelperText={
+                  <HelperTextItem>
+                    This is the name of the inference service created when the model is deployed
+                  </HelperTextItem>
+                }
+                hideDescription
+              />
+              <InferenceServiceServingRuntimeSection
+                data={createData}
+                setData={setCreateData}
+                currentServingRuntime={projectContext?.currentServingRuntime}
+              />
+              <InferenceServiceFrameworkSection
+                data={createData}
+                setData={setCreateData}
+                servingRuntimeName={projectContext?.currentServingRuntime?.metadata.name}
+                modelContext={projectContext?.currentServingRuntime?.spec.supportedModelFormats}
+                registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
+              />
+              <FormSection title="Source model location" id="model-location">
+                <ConnectionSection
+                  existingUriOption={editInfo?.spec.predictor.model?.storageUri}
+                  data={createData}
+                  setData={setCreateData}
+                  initialNewConnectionType={initialNewConnectionType}
+                  initialNewConnectionValues={initialNewConnectionValues}
+                  loaded={
+                    modelDeployPrefillInfo
+                      ? !!projectContext?.connections && connectionsLoaded
+                      : !!projectContext?.connections || connectionsLoaded
+                  }
+                  loadError={connectionsLoadError}
+                  connection={connection}
+                  setConnection={setConnection}
+                  setIsConnectionValid={setIsConnectionValid}
+                  connections={modelMeshConnections}
+                  connectionTypeFilter={(ct) =>
+                    !isModelServingCompatible(ct, ModelServingCompatibleTypes.OCI)
+                  }
+                />
+              </FormSection>
+            </>
+          )}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={editInfo ? 'Redeploy' : 'Deploy'}
           onSubmit={submit}
@@ -180,72 +252,7 @@ const ManageInferenceServiceModal: React.FC<ManageInferenceServiceModalProps> = 
           error={error}
           alertTitle="Error creating model server"
         />
-      }
-      showClose
-    >
-      <Form>
-        {projectSection || (
-          <ProjectSection
-            projectName={
-              (projectContext?.currentProject &&
-                getDisplayNameFromK8sResource(projectContext.currentProject)) ||
-              editInfo?.metadata.namespace ||
-              ''
-            }
-          />
-        )}
-        {!shouldFormHidden && isLoading && <Spinner />}
-        {!shouldFormHidden && !isLoading && (
-          <>
-            <K8sNameDescriptionField
-              data={inferenceServiceNameDesc}
-              onDataChange={setInferenceServiceNameDesc}
-              dataTestId="inference-service"
-              nameLabel="Model deployment name"
-              nameHelperText={
-                <HelperTextItem>
-                  This is the name of the inference service created when the model is deployed
-                </HelperTextItem>
-              }
-              hideDescription
-            />
-            <InferenceServiceServingRuntimeSection
-              data={createData}
-              setData={setCreateData}
-              currentServingRuntime={projectContext?.currentServingRuntime}
-            />
-            <InferenceServiceFrameworkSection
-              data={createData}
-              setData={setCreateData}
-              servingRuntimeName={projectContext?.currentServingRuntime?.metadata.name}
-              modelContext={projectContext?.currentServingRuntime?.spec.supportedModelFormats}
-              registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
-            />
-            <FormSection title="Source model location" id="model-location">
-              <ConnectionSection
-                existingUriOption={editInfo?.spec.predictor.model?.storageUri}
-                data={createData}
-                setData={setCreateData}
-                initialNewConnectionType={initialNewConnectionType}
-                initialNewConnectionValues={initialNewConnectionValues}
-                loaded={
-                  modelDeployPrefillInfo
-                    ? !!projectContext?.connections && connectionsLoaded
-                    : !!projectContext?.connections || connectionsLoaded
-                }
-                loadError={connectionsLoadError}
-                connection={connection}
-                setConnection={setConnection}
-                setIsConnectionValid={setIsConnectionValid}
-                connections={modelMeshConnections}
-                connectionTypeFilter={(ct) =>
-                  !isModelServingCompatible(ct, ModelServingCompatibleTypes.OCI)
-                }
-              />
-            </FormSection>
-          </>
-        )}
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Button, Stack, StackItem } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { Notebook } from '~/types';
 import { stopNotebook } from '~/services/notebookService';
 import useNotification from '~/utilities/useNotification';
@@ -106,31 +113,32 @@ const StopServerModal: React.FC<StopServerModalProps> = ({
     <Modal
       aria-label="Stop workbench modal"
       appendTo={document.body}
-      variant={ModalVariant.small}
-      title={`Stop ${textToShow}?`}
+      variant="small"
       isOpen
-      showClose
       onClose={onClose}
-      actions={modalActions}
     >
-      <Stack hasGutter>
-        <StackItem>Any unsaved changes to the {getWorkbenchName()} will be lost.</StackItem>
-        <StackItem>
-          To save changes,{' '}
-          {link !== '#' && notebooksToStop.length === 1 ? (
-            <>
-              <Button component="a" href={link} variant="link" isInline>
-                open the workbench
-              </Button>
-              .
-            </>
-          ) : notebooksToStop.length === 1 ? (
-            'open the workbench.'
-          ) : (
-            'open the workbenches.'
-          )}
-        </StackItem>
-      </Stack>
+      <ModalHeader title={`Stop ${textToShow}`} />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>Any unsaved changes to the {getWorkbenchName()} will be lost.</StackItem>
+          <StackItem>
+            To save changes,{' '}
+            {link !== '#' && notebooksToStop.length === 1 ? (
+              <>
+                <Button component="a" href={link} variant="link" isInline>
+                  open the workbench
+                </Button>
+                .
+              </>
+            ) : notebooksToStop.length === 1 ? (
+              'open the workbench.'
+            ) : (
+              'open the workbenches.'
+            )}
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>{modalActions}</ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/components/DeleteModal.tsx
+++ b/frontend/src/pages/projects/components/DeleteModal.tsx
@@ -1,6 +1,17 @@
 import * as React from 'react';
-import { Alert, Button, Flex, FlexItem, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 
 type DeleteModalProps = {
   title: string;
@@ -42,11 +53,52 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
 
   return (
     <Modal
-      title={title}
-      titleIconVariant="warning"
       isOpen
       onClose={() => onBeforeClose(false)}
-      actions={[
+      variant="small"
+      data-testid={testId || 'delete-modal'}
+    >
+      <ModalHeader title={title} titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>{children}</StackItem>
+
+          <StackItem>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                Type <strong>{deleteNameSanitized}</strong> to confirm deletion:
+              </FlexItem>
+
+              <TextInput
+                id="delete-modal-input"
+                data-testid="delete-modal-input"
+                aria-label="Delete modal input"
+                value={value}
+                onChange={(_e, newValue) => setValue(newValue)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && value.trim() === deleteNameSanitized && !deleting) {
+                    onDelete();
+                  }
+                }}
+              />
+            </Flex>
+          </StackItem>
+
+          {error && (
+            <StackItem>
+              <Alert
+                data-testid="delete-model-error-message-alert"
+                title={`Error deleting ${deleteNameSanitized}`}
+                isInline
+                variant="danger"
+              >
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="delete-button"
           variant="danger"
@@ -55,51 +107,11 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
           onClick={() => onBeforeClose(true)}
         >
           {submitButtonLabel}
-        </Button>,
+        </Button>
         <Button key="cancel-button" variant="link" onClick={() => onBeforeClose(false)}>
           Cancel
-        </Button>,
-      ]}
-      variant="small"
-      data-testid={testId || 'delete-modal'}
-    >
-      <Stack hasGutter>
-        <StackItem>{children}</StackItem>
-
-        <StackItem>
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              Type <strong>{deleteNameSanitized}</strong> to confirm deletion:
-            </FlexItem>
-
-            <TextInput
-              id="delete-modal-input"
-              data-testid="delete-modal-input"
-              aria-label="Delete modal input"
-              value={value}
-              onChange={(_e, newValue) => setValue(newValue)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && value.trim() === deleteNameSanitized && !deleting) {
-                  onDelete();
-                }
-              }}
-            />
-          </Flex>
-        </StackItem>
-
-        {error && (
-          <StackItem>
-            <Alert
-              data-testid="delete-model-error-message-alert"
-              title={`Error deleting ${deleteNameSanitized}`}
-              isInline
-              variant="danger"
-            >
-              {error.message}
-            </Alert>
-          </StackItem>
-        )}
-      </Stack>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/notebook/StopNotebookConfirmModal.tsx
+++ b/frontend/src/pages/projects/notebook/StopNotebookConfirmModal.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
-import { Button, Checkbox, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Checkbox,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 import NotebookRouteLink from './NotebookRouteLink';
 import useStopNotebookModalAvailability from './useStopNotebookModalAvailability';
@@ -29,11 +39,39 @@ const StopNotebookConfirmModal: React.FC<StopNotebookConfirmProps> = ({
   return (
     <Modal
       variant="small"
-      title="Stop workbench?"
       data-testid="stop-workbench-modal"
       isOpen
       onClose={() => onBeforeClose(false)}
-      actions={[
+    >
+      <ModalHeader title="Stop workbench?" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            Any unsaved changes to the <strong>{getDisplayNameFromK8sResource(notebook)}</strong>{' '}
+            workbench will be lost.
+          </StackItem>
+          {isRunning && (
+            <StackItem>
+              <Flex>
+                <FlexItem spacer={{ default: 'spacerXs' }}>To save changes, </FlexItem>
+                <FlexItem spacer={{ default: 'spacerNone' }}>
+                  <NotebookRouteLink label="open the workbench" notebook={notebook} isRunning />
+                </FlexItem>
+                <FlexItem spacer={{ default: 'spacerNone' }}>.</FlexItem>
+              </Flex>
+            </StackItem>
+          )}
+          <StackItem>
+            <Checkbox
+              id="dont-show-again"
+              label="Don't show again"
+              isChecked={dontShowModalValue}
+              onChange={(e, checked) => setDontShowModalValue(checked)}
+            />
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <Button
           data-testid="stop-workbench-button"
           key="confirm-stop"
@@ -41,37 +79,11 @@ const StopNotebookConfirmModal: React.FC<StopNotebookConfirmProps> = ({
           onClick={() => onBeforeClose(true)}
         >
           Stop workbench
-        </Button>,
+        </Button>
         <Button key="cancel" variant="secondary" onClick={() => onBeforeClose(false)}>
           Cancel
-        </Button>,
-      ]}
-    >
-      <Stack hasGutter>
-        <StackItem>
-          Any unsaved changes to the <strong>{getDisplayNameFromK8sResource(notebook)}</strong>{' '}
-          workbench will be lost.
-        </StackItem>
-        {isRunning && (
-          <StackItem>
-            <Flex>
-              <FlexItem spacer={{ default: 'spacerXs' }}>To save changes, </FlexItem>
-              <FlexItem spacer={{ default: 'spacerNone' }}>
-                <NotebookRouteLink label="open the workbench" notebook={notebook} isRunning />
-              </FlexItem>
-              <FlexItem spacer={{ default: 'spacerNone' }}>.</FlexItem>
-            </Flex>
-          </StackItem>
-        )}
-        <StackItem>
-          <Checkbox
-            id="dont-show-again"
-            label="Don't show again"
-            isChecked={dontShowModalValue}
-            onChange={(e, checked) => setDontShowModalValue(checked)}
-          />
-        </StackItem>
-      </Stack>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/ManageConnectionsModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Alert, Form } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Alert, Form, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import ConnectionTypeForm from '~/concepts/connectionTypes/ConnectionTypeForm';
 import {
@@ -109,13 +108,57 @@ export const ManageConnectionModal: React.FC<Props> = ({
 
   return (
     <Modal
-      title={isEdit ? 'Edit connection' : 'Create connection'}
       isOpen
       onClose={() => {
         onClose();
       }}
       variant="medium"
-      footer={
+    >
+      <ModalHeader title={isEdit ? 'Edit connection' : 'Create connection'} />
+      <ModalBody>
+        {isEdit && (
+          <Alert
+            className="pf-v6-u-mb-lg"
+            variant="warning"
+            isInline
+            title="Dependent resources require further action"
+          >
+            Connection changes are not applied to dependent resources until those resources are
+            restarted, redeployed, or otherwise regenerated.
+          </Alert>
+        )}
+        <Form>
+          <ConnectionTypeForm
+            options={!isEdit ? enabledConnectionTypes : undefined}
+            connectionType={selectedConnectionType || (isEdit ? connectionTypeSource : undefined)}
+            setConnectionType={(name: string) => {
+              const obj = connectionTypes.find((c) => c.metadata.name === name);
+              if (!isModified) {
+                setIsModified(true);
+              }
+              changeSelectionType(obj);
+            }}
+            connectionNameDesc={nameDescData}
+            setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
+              if (!isModified) {
+                setIsModified(true);
+              }
+              setNameDescData(key, value);
+            }}
+            connectionValues={connectionValues}
+            onChange={(field, value) => {
+              if (!isModified) {
+                setIsModified(true);
+              }
+              setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
+            }}
+            onValidate={(field, error) =>
+              setConnectionErrors((prev) => ({ ...prev, [field.envVar]: !!error }))
+            }
+          />
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={isEdit ? 'Save' : 'Create'}
           onCancel={onClose}
@@ -151,49 +194,7 @@ export const ManageConnectionModal: React.FC<Props> = ({
           isSubmitLoading={isSaving}
           alertTitle=""
         />
-      }
-    >
-      {isEdit && (
-        <Alert
-          className="pf-v6-u-mb-lg"
-          variant="warning"
-          isInline
-          title="Dependent resources require further action"
-        >
-          Connection changes are not applied to dependent resources until those resources are
-          restarted, redeployed, or otherwise regenerated.
-        </Alert>
-      )}
-      <Form>
-        <ConnectionTypeForm
-          options={!isEdit ? enabledConnectionTypes : undefined}
-          connectionType={selectedConnectionType || (isEdit ? connectionTypeSource : undefined)}
-          setConnectionType={(name: string) => {
-            const obj = connectionTypes.find((c) => c.metadata.name === name);
-            if (!isModified) {
-              setIsModified(true);
-            }
-            changeSelectionType(obj);
-          }}
-          connectionNameDesc={nameDescData}
-          setConnectionNameDesc={(key: keyof K8sNameDescriptionFieldData, value: string) => {
-            if (!isModified) {
-              setIsModified(true);
-            }
-            setNameDescData(key, value);
-          }}
-          connectionValues={connectionValues}
-          onChange={(field, value) => {
-            if (!isModified) {
-              setIsModified(true);
-            }
-            setConnectionValues((prev) => ({ ...prev, [field.envVar]: value }));
-          }}
-          onValidate={(field, error) =>
-            setConnectionErrors((prev) => ({ ...prev, [field.envVar]: !!error }))
-          }
-        />
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/connections/__tests__/ManageConnectionsModal.spec.tsx
@@ -32,7 +32,7 @@ describe('Create connection modal', () => {
       />,
     );
 
-    expect(screen.getByRole('dialog', { name: 'Create connection' })).toBeTruthy();
+    expect(screen.getByRole('dialog')).toBeTruthy();
     expect(screen.getByRole('combobox')).toHaveValue('the only type');
     expect(screen.getByRole('textbox', { name: 'Connection name' })).toBeVisible();
     expect(screen.getByRole('textbox', { name: 'Connection description' })).toBeVisible();
@@ -430,7 +430,7 @@ describe('Edit connection modal', () => {
       />,
     );
 
-    expect(screen.getByRole('dialog', { name: 'Edit connection' })).toBeTruthy();
+    expect(screen.getByRole('dialog')).toBeTruthy();
     expect(screen.getByRole('combobox')).toHaveValue('s3');
     expect(screen.getByRole('textbox', { name: 'Connection name' })).toHaveValue('s3-connection');
     expect(screen.getByRole('textbox', { name: 'Connection description' })).toHaveValue('s3 desc');

--- a/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/BaseStorageModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { PersistentVolumeClaimKind } from '~/k8sTypes';
 import CreateNewStorageSection from '~/pages/projects/screens/spawner/storage/CreateNewStorageSection';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
@@ -81,14 +88,34 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
   };
 
   return (
-    <Modal
-      title={title}
-      description={description}
-      variant="medium"
-      isOpen
-      onClose={() => onClose(false)}
-      showClose
-      footer={
+    <Modal variant="medium" isOpen onClose={() => onClose(false)}>
+      <ModalHeader title={title} description={description} />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          <Stack hasGutter>
+            <StackItem>
+              <CreateNewStorageSection
+                data={createData}
+                setData={setCreateData}
+                currentStatus={existingPvc?.status}
+                autoFocusName
+                onNameChange={onNameChange}
+                setValid={setNameDescValid}
+                hasDuplicateName={hasDuplicateName}
+                disableStorageClassSelect={!!existingPvc}
+                editableK8sName={!existingPvc}
+              />
+            </StackItem>
+            {children}
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel={submitLabel}
           onSubmit={submit}
@@ -97,31 +124,7 @@ const BaseStorageModal: React.FC<BaseStorageModalProps> = ({
           error={error}
           alertTitle="Error creating storage"
         />
-      }
-    >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit();
-        }}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            <CreateNewStorageSection
-              data={createData}
-              setData={setCreateData}
-              currentStatus={existingPvc?.status}
-              autoFocusName
-              onNameChange={onNameChange}
-              setValid={setNameDescValid}
-              hasDuplicateName={hasDuplicateName}
-              disableStorageClassSelect={!!existingPvc}
-              editableK8sName={!existingPvc}
-            />
-          </StackItem>
-          {children}
-        </Stack>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
+++ b/frontend/src/pages/projects/screens/projects/ManageProjectModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Alert, Button, Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  Form,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { createProject, updateProject } from '~/api';
 import { useUser } from '~/redux/selectors';
 import { ProjectKind } from '~/k8sTypes';
@@ -73,12 +82,38 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({ editProjectData
   };
 
   return (
-    <Modal
-      title={editProjectData ? 'Edit project' : 'Create project'}
-      variant="medium"
-      isOpen
-      onClose={() => onBeforeClose()}
-      actions={[
+    <Modal variant="medium" isOpen onClose={() => onBeforeClose()}>
+      <ModalHeader title={editProjectData ? 'Edit project' : 'Create project'} />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submit();
+              }}
+            >
+              <K8sNameDescriptionField
+                autoFocusName
+                dataTestId="manage-project-modal"
+                {...k8sNameDescriptionData}
+              />
+            </Form>
+          </StackItem>
+          {error && (
+            <StackItem>
+              <Alert
+                variant="danger"
+                isInline
+                title={editProjectData ? 'Error updating project' : 'Error creating project'}
+              >
+                {error.message}
+              </Alert>
+            </StackItem>
+          )}
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="confirm"
           variant="primary"
@@ -87,7 +122,7 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({ editProjectData
           onClick={submit}
         >
           {editProjectData ? 'Update' : 'Create'}
-        </Button>,
+        </Button>
         <Button
           key="cancel"
           variant="link"
@@ -99,36 +134,8 @@ const ManageProjectModal: React.FC<ManageProjectModalProps> = ({ editProjectData
           }}
         >
           Cancel
-        </Button>,
-      ]}
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <Form
-            onSubmit={(e) => {
-              e.preventDefault();
-              submit();
-            }}
-          >
-            <K8sNameDescriptionField
-              autoFocusName
-              dataTestId="manage-project-modal"
-              {...k8sNameDescriptionData}
-            />
-          </Form>
-        </StackItem>
-        {error && (
-          <StackItem>
-            <Alert
-              variant="danger"
-              isInline
-              title={editProjectData ? 'Error updating project' : 'Error creating project'}
-            >
-              {error.message}
-            </Alert>
-          </StackItem>
-        )}
-      </Stack>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/connections/DetachConnectionModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/DetachConnectionModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
 
@@ -19,13 +18,23 @@ export const DetachConnectionModal: React.FC<Props> = ({
   onDetach,
   onClose,
 }) => (
-  <Modal
-    isOpen
-    variant="medium"
-    title="Detach connection?"
-    titleIconVariant={isRunning ? 'warning' : undefined}
-    onClose={onClose}
-    actions={[
+  <Modal isOpen variant="medium" onClose={onClose}>
+    <ModalHeader title="Detach connection?" titleIconVariant={isRunning ? 'warning' : undefined} />
+    <ModalBody>
+      {isRunning ? (
+        <>
+          The <b>{getDisplayNameFromK8sResource(connection)}</b> connection will be detached from
+          the workbench. To avoid losing your work, save any recent data in the current workbench,{' '}
+          <b>{notebookDisplayName}</b>.
+        </>
+      ) : (
+        <>
+          The <b>{getDisplayNameFromK8sResource(connection)}</b> connection will be detached from
+          the <b>{notebookDisplayName}</b> workbench.
+        </>
+      )}
+    </ModalBody>
+    <ModalFooter>
       <Button
         key="detach-button"
         variant={isRunning ? 'danger' : 'primary'}
@@ -34,23 +43,10 @@ export const DetachConnectionModal: React.FC<Props> = ({
         }}
       >
         Detach
-      </Button>,
+      </Button>
       <Button key="cancel-button" variant="link" onClick={onClose}>
         Cancel
-      </Button>,
-    ]}
-  >
-    {isRunning ? (
-      <>
-        The <b>{getDisplayNameFromK8sResource(connection)}</b> connection will be detached from the
-        workbench. To avoid losing your work, save any recent data in the current workbench,{' '}
-        <b>{notebookDisplayName}</b>.
-      </>
-    ) : (
-      <>
-        The <b>{getDisplayNameFromK8sResource(connection)}</b> connection will be detached from the{' '}
-        <b>{notebookDisplayName}</b> workbench.
-      </>
-    )}
+      </Button>
+    </ModalFooter>
   </Modal>
 );

--- a/frontend/src/pages/projects/screens/spawner/connections/SelectConnectionsModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/SelectConnectionsModal.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
-import { Button, Flex, FlexItem, Form, FormGroup, Truncate } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Truncate,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { MultiSelection, SelectionOptions } from '~/components/MultiSelection';
 import { Connection, ConnectionTypeConfigMapObj } from '~/concepts/connectionTypes/types';
 import { getDescriptionFromK8sResource, getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
@@ -68,12 +78,34 @@ export const SelectConnectionsModal: React.FC<Props> = ({
   );
 
   return (
-    <Modal
-      isOpen
-      variant="medium"
-      title="Attach existing connections"
-      onClose={onClose}
-      actions={[
+    <Modal isOpen variant="medium" onClose={onClose}>
+      <ModalHeader title="Attach existing connections" />
+      <ModalBody>
+        <Form>
+          {envVarConflicts.length > 0 && (
+            <DuplicateEnvVarWarning envVarConflicts={envVarConflicts} />
+          )}
+          <FormGroup label="Connections" isRequired>
+            <MultiSelection
+              id="select-connection"
+              ariaLabel="Connections"
+              placeholder="Select a connection, or search by keyword or type"
+              isDisabled={connectionsToList.length === 1}
+              value={selectionOptions}
+              setValue={setSelectionOptions}
+              filterFunction={(filterText, options) =>
+                options.filter(
+                  (o) =>
+                    !filterText ||
+                    o.name.toLowerCase().includes(filterText.toLowerCase()) ||
+                    o.data?.toLowerCase().includes(filterText.toLowerCase()),
+                )
+              }
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <Button
           data-testid="attach-button"
           key="attach-button"
@@ -84,33 +116,11 @@ export const SelectConnectionsModal: React.FC<Props> = ({
           }}
         >
           Attach
-        </Button>,
+        </Button>
         <Button key="cancel-button" variant="secondary" onClick={onClose}>
           Cancel
-        </Button>,
-      ]}
-    >
-      <Form>
-        {envVarConflicts.length > 0 && <DuplicateEnvVarWarning envVarConflicts={envVarConflicts} />}
-        <FormGroup label="Connections" isRequired>
-          <MultiSelection
-            id="select-connection"
-            ariaLabel="Connections"
-            placeholder="Select a connection, or search by keyword or type"
-            isDisabled={connectionsToList.length === 1}
-            value={selectionOptions}
-            setValue={setSelectionOptions}
-            filterFunction={(filterText, options) =>
-              options.filter(
-                (o) =>
-                  !filterText ||
-                  o.name.toLowerCase().includes(filterText.toLowerCase()) ||
-                  o.data?.toLowerCase().includes(filterText.toLowerCase()),
-              )
-            }
-          />
-        </FormGroup>
-      </Form>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/connections/__tests__/ConnectionsFormSection.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/connections/__tests__/ConnectionsFormSection.spec.tsx
@@ -117,7 +117,7 @@ describe('ConnectionsFormSection', () => {
     );
 
     act(() => result.getByRole('button', { name: 'Attach existing connections' }).click());
-    const attachModal = result.getByRole('dialog', { name: 'Attach existing connections' });
+    const attachModal = result.getByRole('dialog');
     expect(attachModal).toBeTruthy();
     expect(within(attachModal).getByRole('button', { name: 'Attach' })).toBeDisabled();
     expect(within(attachModal).getByRole('button', { name: 'Cancel' })).toBeEnabled();

--- a/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
@@ -1,5 +1,12 @@
-import { Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Form,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import React from 'react';
 import { ExistingStorageObject, MountPath } from '~/pages/projects/types';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
@@ -36,13 +43,36 @@ const AttachExistingStorageModal: React.FC<AttachExistingStorageModalProps> = ({
   };
 
   return (
-    <Modal
-      title="Attach Existing Storage"
-      variant="medium"
-      onClose={() => onBeforeClose(false)}
-      showClose
-      isOpen
-      footer={
+    <Modal variant="medium" onClose={() => onBeforeClose(false)} isOpen>
+      <ModalHeader title="Attach Existing Storage" />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onBeforeClose(true, data);
+          }}
+        >
+          <Stack hasGutter>
+            <StackItem>
+              <AddExistingStorageField
+                data={data}
+                setData={(existingStorage) =>
+                  setData({ ...data, storage: existingStorage.storage, pvc: existingStorage.pvc })
+                }
+                existingStorageNames={existingStorageNames}
+              />
+            </StackItem>
+            <StackItem>
+              <SpawnerMountPathField
+                mountPath={data.mountPath}
+                inUseMountPaths={existingMountPaths}
+                onChange={(path) => setData({ ...data, mountPath: path })}
+              />
+            </StackItem>
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel="Attach storage"
           onSubmit={() => onBeforeClose(true, data)}
@@ -50,33 +80,7 @@ const AttachExistingStorageModal: React.FC<AttachExistingStorageModalProps> = ({
           isSubmitDisabled={!data.mountPath.value || !!data.mountPath.error}
           alertTitle="Error creating storage"
         />
-      }
-    >
-      <Form
-        onSubmit={(e) => {
-          e.preventDefault();
-          onBeforeClose(true, data);
-        }}
-      >
-        <Stack hasGutter>
-          <StackItem>
-            <AddExistingStorageField
-              data={data}
-              setData={(existingStorage) =>
-                setData({ ...data, storage: existingStorage.storage, pvc: existingStorage.pvc })
-              }
-              existingStorageNames={existingStorageNames}
-            />
-          </StackItem>
-          <StackItem>
-            <SpawnerMountPathField
-              mountPath={data.mountPath}
-              inUseMountPaths={existingMountPaths}
-              onChange={(path) => setData({ ...data, mountPath: path })}
-            />
-          </StackItem>
-        </Stack>
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/storage/ClusterStorageDetachModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/ClusterStorageDetachModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 
 interface ClusterStorageDetachModalProps {
   storageName: string;
@@ -13,20 +12,18 @@ export const ClusterStorageDetachModal: React.FC<ClusterStorageDetachModalProps>
   onConfirm,
   onClose,
 }) => (
-  <Modal
-    isOpen
-    variant={ModalVariant.small}
-    title="Detach storage?"
-    onClose={onClose}
-    actions={[
+  <Modal isOpen variant="small" onClose={onClose}>
+    <ModalHeader title="Detach storage?" />
+    <ModalBody>
+      The <b>{storageName}</b> storage and all of its resources will be detached from the workbench.
+    </ModalBody>
+    <ModalFooter>
       <Button key="confirm" variant="primary" onClick={onConfirm}>
         Detach
-      </Button>,
+      </Button>
       <Button key="cancel" variant="link" onClick={onClose}>
         Cancel
-      </Button>,
-    ]}
-  >
-    The <b>{storageName}</b> storage and all of its resources will be detached from the workbench.
+      </Button>
+    </ModalFooter>
   </Modal>
 );


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-24709
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is the second PR to replace deprecated Modal component with PF6 Modal. Below are the major changes implemented in the PR,

> In PF6, we have separate ModalBody, ModalHeader, ModalFooter components. In the deprecated version, we pass header and footer/actions as props. So we just have to use these new components instead of props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Manually tested the UI for the affected areas of the dashboard to make sure that the new Modal loads correctly with all the right content.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
