### PR TITLE
RHOAIENG-24710: Part 5: Replace Deprecated Modal Instances with PF6 Modal 

### DIFF
--- a/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/RegisterModel/ConnectionModal.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Button, FormGroup, HelperText, Form, FormHelperText } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  FormGroup,
+  HelperText,
+  Form,
+  FormHelperText,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import ProjectSelector from '~/concepts/projects/ProjectSelector';
 import { Connection } from '~/concepts/connectionTypes/types';
 import { ConnectionDropdown } from './ConnectionDropdown';
@@ -20,14 +29,47 @@ export const ConnectionModal: React.FC<{
       isOpen
       data-testid="connection-autofill-modal"
       variant="medium"
-      title="Autofill from connection"
-      description={`Select a project to list its ${modelLocationType} connections. Select a connection to autofill the model location.`}
       onClose={() => {
         setProject(undefined);
         setConnection(undefined);
         onClose();
       }}
-      actions={[
+    >
+      <ModalHeader
+        title="Autofill from connection"
+        description={`Select a project to list its ${modelLocationType} connections. Select a connection to autofill the model location.`}
+      />
+      <ModalBody>
+        <Form>
+          <FormGroup label="Project" isRequired fieldId="autofillProject">
+            <ProjectSelector
+              isFullWidth
+              onSelection={(projectName: string) => {
+                setProject(projectName);
+                setConnection(undefined);
+              }}
+              namespace={project || ''}
+              invalidDropdownPlaceholder="Select project"
+            />
+          </FormGroup>
+          <FormGroup label="Connection name" isRequired fieldId="autofillConnection">
+            <ConnectionDropdown
+              type={type}
+              onSelect={setConnection}
+              selectedConnection={connection}
+              project={project}
+            />
+            <FormHelperText>
+              <HelperText>
+                {modelLocationType !== 'URI'
+                  ? `Connection list includes only ${modelLocationType} types that contain a bucket.`
+                  : `Connection list includes only ${modelLocationType} types.`}
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <Button
           isDisabled={!connection}
           data-testid="autofill-modal-button"
@@ -39,40 +81,11 @@ export const ConnectionModal: React.FC<{
           }}
         >
           Autofill
-        </Button>,
+        </Button>
         <Button key="cancel" variant="link" onClick={onClose}>
           Cancel
-        </Button>,
-      ]}
-    >
-      <Form>
-        <FormGroup label="Project" isRequired fieldId="autofillProject">
-          <ProjectSelector
-            isFullWidth
-            onSelection={(projectName: string) => {
-              setProject(projectName);
-              setConnection(undefined);
-            }}
-            namespace={project || ''}
-            invalidDropdownPlaceholder="Select project"
-          />
-        </FormGroup>
-        <FormGroup label="Connection name" isRequired fieldId="autofillConnection">
-          <ConnectionDropdown
-            type={type}
-            onSelect={setConnection}
-            selectedConnection={connection}
-            project={project}
-          />
-          <FormHelperText>
-            <HelperText>
-              {modelLocationType !== 'URI'
-                ? `Connection list includes only ${modelLocationType} types that contain a bucket.`
-                : `Connection list includes only ${modelLocationType} types.`}
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-      </Form>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/components/ArchiveModelVersionModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/ArchiveModelVersionModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Flex, FlexItem, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import useNotification from '~/utilities/useNotification';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -63,13 +72,36 @@ export const ArchiveModelVersionModal: React.FC<ArchiveModelVersionModalProps> =
   }, [onSubmit, onClose, notification, modelVersionName]);
 
   return (
-    <Modal
-      isOpen
-      title="Archive model version?"
-      titleIconVariant="warning"
-      variant="small"
-      onClose={onCancelClose}
-      footer={
+    <Modal isOpen variant="small" onClose={onCancelClose} data-testid="archive-model-version-modal">
+      <ModalHeader title="Archive model version?" titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <b>{modelVersionName}</b> will be archived and unavailable for use unless it is
+            restored.
+          </StackItem>
+          <StackItem>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                Type <strong>{modelVersionName}</strong> to confirm archiving:
+              </FlexItem>
+              <TextInput
+                id="confirm-archive-input"
+                data-testid="confirm-archive-input"
+                aria-label="confirm archive input"
+                value={confirmInputValue}
+                onChange={(_e, newValue) => setConfirmInputValue(newValue)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !isDisabled) {
+                    onConfirm();
+                  }
+                }}
+              />
+            </Flex>
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onCancelClose}
           onSubmit={onConfirm}
@@ -79,33 +111,7 @@ export const ArchiveModelVersionModal: React.FC<ArchiveModelVersionModalProps> =
           error={error}
           alertTitle="Error"
         />
-      }
-      data-testid="archive-model-version-modal"
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <b>{modelVersionName}</b> will be archived and unavailable for use unless it is restored.
-        </StackItem>
-        <StackItem>
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              Type <strong>{modelVersionName}</strong> to confirm archiving:
-            </FlexItem>
-            <TextInput
-              id="confirm-archive-input"
-              data-testid="confirm-archive-input"
-              aria-label="confirm archive input"
-              value={confirmInputValue}
-              onChange={(_e, newValue) => setConfirmInputValue(newValue)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && !isDisabled) {
-                  onConfirm();
-                }
-              }}
-            />
-          </Flex>
-        </StackItem>
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { Flex, FlexItem, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  TextInput,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import useNotification from '~/utilities/useNotification';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -65,11 +74,39 @@ export const ArchiveRegisteredModelModal: React.FC<ArchiveRegisteredModelModalPr
   return (
     <Modal
       isOpen
-      title="Archive model?"
-      titleIconVariant="warning"
       variant="small"
       onClose={onCancelClose}
-      footer={
+      data-testid="archive-registered-model-modal"
+    >
+      <ModalHeader title="Archive model?" titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <b>{registeredModelName}</b> and all of its versions will be archived and unavailable
+            for use unless it is restored.
+          </StackItem>
+          <StackItem>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                Type <strong>{registeredModelName}</strong> to confirm archiving:
+              </FlexItem>
+              <TextInput
+                id="confirm-archive-input"
+                data-testid="confirm-archive-input"
+                aria-label="confirm archive input"
+                value={confirmInputValue}
+                onChange={(_e, newValue) => setConfirmInputValue(newValue)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !isDisabled) {
+                    onConfirm();
+                  }
+                }}
+              />
+            </Flex>
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onCancelClose}
           onSubmit={onConfirm}
@@ -79,34 +116,7 @@ export const ArchiveRegisteredModelModal: React.FC<ArchiveRegisteredModelModalPr
           error={error}
           alertTitle="Error"
         />
-      }
-      data-testid="archive-registered-model-modal"
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <b>{registeredModelName}</b> and all of its versions will be archived and unavailable for
-          use unless it is restored.
-        </StackItem>
-        <StackItem>
-          <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <FlexItem>
-              Type <strong>{registeredModelName}</strong> to confirm archiving:
-            </FlexItem>
-            <TextInput
-              id="confirm-archive-input"
-              data-testid="confirm-archive-input"
-              aria-label="confirm archive input"
-              value={confirmInputValue}
-              onChange={(_e, newValue) => setConfirmInputValue(newValue)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && !isDisabled) {
-                  onConfirm();
-                }
-              }}
-            />
-          </Flex>
-        </StackItem>
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/components/ModelLabels.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/ModelLabels.tsx
@@ -1,5 +1,15 @@
-import { Button, Label, LabelGroup, Popover, SearchInput, Content } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Label,
+  LabelGroup,
+  Popover,
+  SearchInput,
+  Content,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import React from 'react';
 import { ModelVersion, RegisteredModel } from '~/concepts/modelRegistry/types';
 import useDebounceCallback from '~/utilities/useDebounceCallback';
@@ -66,17 +76,30 @@ const ModelLabels: React.FC<ModelLabelsProps> = ({ name, customProperties }) => 
   );
 
   const labelModal = isLabelModalOpen ? (
-    <Modal
-      variant={ModalVariant.small}
-      title="Labels"
-      isOpen
-      onClose={() => setIsLabelModalOpen(false)}
-      description={
-        <Content component="p">
-          The following are all the labels of <strong>{name}</strong>
-        </Content>
-      }
-      actions={[
+    <Modal variant="small" isOpen onClose={() => setIsLabelModalOpen(false)}>
+      <ModalHeader
+        title="Labels"
+        description={
+          <Content component="p">
+            The following are all the labels of <strong>{name}</strong>
+          </Content>
+        }
+      />
+      <ModalBody>
+        <SearchInput
+          aria-label="Label modal search"
+          data-testid="label-modal-search"
+          placeholder="Find a label"
+          value={searchValue}
+          onChange={(_event, value) => doSetSearchDebounced(value)}
+          onClear={() => setSearchValue('')}
+        />
+        <br />
+        <LabelGroup data-testid="modal-label-group" numLabels={allLabels.length}>
+          {labelsComponent(filteredLabels, '50ch')}
+        </LabelGroup>
+      </ModalBody>
+      <ModalFooter>
         <Button
           data-testid="close-modal"
           key="close"
@@ -84,21 +107,8 @@ const ModelLabels: React.FC<ModelLabelsProps> = ({ name, customProperties }) => 
           onClick={() => setIsLabelModalOpen(false)}
         >
           Close
-        </Button>,
-      ]}
-    >
-      <SearchInput
-        aria-label="Label modal search"
-        data-testid="label-modal-search"
-        placeholder="Find a label"
-        value={searchValue}
-        onChange={(_event, value) => doSetSearchDebounced(value)}
-        onClear={() => setSearchValue('')}
-      />
-      <br />
-      <LabelGroup data-testid="modal-label-group" numLabels={allLabels.length}>
-        {labelsComponent(filteredLabels, '50ch')}
-      </LabelGroup>
+        </Button>
+      </ModalFooter>
     </Modal>
   ) : null;
 

--- a/frontend/src/pages/modelRegistry/screens/components/RestoreModelVersionModal.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/RestoreModelVersionModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import useNotification from '~/utilities/useNotification';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -56,12 +56,12 @@ export const RestoreModelVersionModal: React.FC<RestoreModelVersionModalProps> =
   }, [onSubmit, onClose, notification, modelVersionName]);
 
   return (
-    <Modal
-      isOpen
-      title="Restore model version?"
-      variant="small"
-      onClose={onCancelClose}
-      footer={
+    <Modal isOpen variant="small" onClose={onCancelClose} data-testid="restore-model-version-modal">
+      <ModalHeader title="Restore model version?" />
+      <ModalBody>
+        <b>{modelVersionName}</b> will be restored and returned to the versions list.
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onCancelClose}
           onSubmit={onConfirm}
@@ -71,10 +71,7 @@ export const RestoreModelVersionModal: React.FC<RestoreModelVersionModalProps> =
           alertTitle="Error"
           isSubmitDisabled={isSubmitting}
         />
-      }
-      data-testid="restore-model-version-modal"
-    >
-      <b>{modelVersionName}</b> will be restored and returned to the versions list.
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelRegistry/screens/components/RestoreRegisteredModel.tsx
+++ b/frontend/src/pages/modelRegistry/screens/components/RestoreRegisteredModel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader, ModalFooter } from '@patternfly/react-core';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import useNotification from '~/utilities/useNotification';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
@@ -58,10 +58,16 @@ export const RestoreRegisteredModelModal: React.FC<RestoreRegisteredModelModalPr
   return (
     <Modal
       isOpen
-      title="Restore model?"
       variant="small"
       onClose={onCancelClose}
-      footer={
+      data-testid="restore-registered-model-modal"
+    >
+      <ModalHeader title="Restore model?" />
+      <ModalBody>
+        <b>{registeredModelName}</b> and all of its versions will be restored and returned to the
+        registered models list.
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           onCancel={onCancelClose}
           onSubmit={onConfirm}
@@ -71,11 +77,7 @@ export const RestoreRegisteredModelModal: React.FC<RestoreRegisteredModelModalPr
           alertTitle="Error"
           isSubmitDisabled={isSubmitting}
         />
-      }
-      data-testid="restore-registered-model-modal"
-    >
-      <b>{registeredModelName}</b> and all of its versions will be restored and returned to the
-      registered models list.
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/modelRegistrySettings/DeleteModelRegistryModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/DeleteModelRegistryModal.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
-import { Content, TextInput, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Content,
+  TextInput,
+  Stack,
+  StackItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { ModelRegistryKind } from '~/k8sTypes';
 import DashboardModalFooter from '~/concepts/dashboard/DashboardModalFooter';
 import { deleteModelRegistryBackend } from '~/services/modelRegistrySettingsService';
@@ -63,14 +71,39 @@ const DeleteModelRegistryModal: React.FC<DeleteModelRegistryModalProps> = ({
   };
 
   return (
-    <Modal
-      data-testid="delete-mr-modal"
-      titleIconVariant="warning"
-      title="Delete model registry?"
-      isOpen
-      onClose={onClose}
-      variant="medium"
-      footer={
+    <Modal data-testid="delete-mr-modal" isOpen onClose={onClose} variant="medium">
+      <ModalHeader title="Delete model registry?" titleIconVariant="warning" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Content>
+              <Content component="p">
+                The <strong>{mr.metadata.name}</strong> model registry, its default group, and any
+                permissions associated with it will be deleted. Data located in the database
+                connected to the registry will be unaffected.
+              </Content>
+              <Content component="p">
+                Type <strong>{mr.metadata.name}</strong> to confirm deletion:
+              </Content>
+            </Content>
+          </StackItem>
+          <StackItem>
+            <TextInput
+              id="confirm-delete-input"
+              data-testid="confirm-delete-input"
+              aria-label="Confirm delete input"
+              value={confirmInputValue}
+              onChange={(_e, newValue) => setConfirmInputValue(newValue)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !isDisabled) {
+                  onConfirm();
+                }
+              }}
+            />
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <DashboardModalFooter
           submitLabel="Delete model registry"
           submitButtonVariant="danger"
@@ -81,36 +114,7 @@ const DeleteModelRegistryModal: React.FC<DeleteModelRegistryModalProps> = ({
           error={error}
           alertTitle="Error deleting model registry"
         />
-      }
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <Content>
-            <Content component="p">
-              The <strong>{mr.metadata.name}</strong> model registry, its default group, and any
-              permissions associated with it will be deleted. Data located in the database connected
-              to the registry will be unaffected.
-            </Content>
-            <Content component="p">
-              Type <strong>{mr.metadata.name}</strong> to confirm deletion:
-            </Content>
-          </Content>
-        </StackItem>
-        <StackItem>
-          <TextInput
-            id="confirm-delete-input"
-            data-testid="confirm-delete-input"
-            aria-label="Confirm delete input"
-            value={confirmInputValue}
-            onChange={(_e, newValue) => setConfirmInputValue(newValue)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !isDisabled) {
-                onConfirm();
-              }
-            }}
-          />
-        </StackItem>
-      </Stack>
+      </ModalFooter>
     </Modal>
   );
 };


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-24710
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This is the second PR to replace deprecated Modal component with PF6 Modal. Below are the major changes implemented in the PR,

> In PF6, we have separate ModalBody, ModalHeader, ModalFooter components. In the deprecated version, we pass header and footer/actions as props. So we just have to use these new components instead of props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Manually tested the UI for the affected areas of the dashboard to make sure that the new Modal loads correctly with all the right content.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
