### PR TITLE
add project search in model registry deploy model

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelCatalogDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelCatalog/modelCatalogDeployModal.ts
@@ -5,13 +5,17 @@ class ModelCatalogDeployModal extends Modal {
     super('Deploy model');
   }
 
-  findProjectSelector() {
-    return this.find().findByTestId('deploy-model-project-selector');
+  private findProjectSelector() {
+    return this.find().findByTestId('deploy-model-project-selector-toggle');
   }
 
   selectProjectByName(name: string) {
     this.findProjectSelector().click();
-    cy.findByRole('option', { name, hidden: true }).click();
+    cy.findByTestId('deploy-model-project-selector-search').fill(name);
+    cy.findByTestId('deploy-model-project-selector-menuList')
+      .contains('button', name)
+      .should('be.visible')
+      .click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -5,13 +5,17 @@ class ModelVersionDeployModal extends Modal {
     super('Deploy model');
   }
 
-  findProjectSelector() {
-    return this.find().findByTestId('deploy-model-project-selector');
+  private findProjectSelector() {
+    return this.find().findByTestId('deploy-model-project-selector-toggle');
   }
 
   selectProjectByName(name: string) {
     this.findProjectSelector().click();
-    cy.findByRole('option', { name, hidden: true }).click();
+    cy.findByTestId('deploy-model-project-selector-search').fill(name);
+    cy.findByTestId('deploy-model-project-selector-menuList')
+      .contains('button', name)
+      .should('be.visible')
+      .click();
   }
 }
 

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ProjectSelector.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Alert, FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, FormGroup, MenuItem, Stack, StackItem, Truncate } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '~/concepts/k8s/utils';
-import { byName, ProjectsContext } from '~/concepts/projects/ProjectsContext';
+import { ProjectsContext } from '~/concepts/projects/ProjectsContext';
 import { KnownLabels, ProjectKind } from '~/k8sTypes';
 import { ProjectSectionID } from '~/pages/projects/screens/detail/types';
-import SimpleSelect from '~/components/SimpleSelect';
+import SearchSelector from '~/components/searchSelector/SearchSelector';
 
 type ProjectSelectorProps = {
   selectedProject: ProjectKind | null;
@@ -28,7 +28,16 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       !project.metadata.labels?.[KnownLabels.MODEL_SERVING_PROJECT] ||
       project.metadata.labels[KnownLabels.MODEL_SERVING_PROJECT] === 'false',
   );
+  const [searchText, setSearchText] = React.useState('');
+  const bySearchText = React.useCallback(
+    (project: ProjectKind) =>
+      !searchText ||
+      getDisplayNameFromK8sResource(project).toLowerCase().includes(searchText.toLowerCase()),
+    [searchText],
+  );
 
+  const filteredProjects = isOciModel ? kserveProjects : projects;
+  const visibleProjects = filteredProjects.filter(bySearchText);
   const projectLinkUrlParams = new URLSearchParams();
   projectLinkUrlParams.set('section', ProjectSectionID.MODEL_SERVER);
   if (projectLinkExtraUrlParams) {
@@ -43,31 +52,35 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     <FormGroup label="Project" fieldId="deploy-model-project-selector" isRequired>
       <Stack hasGutter>
         <StackItem>
-          <SimpleSelect
+          <SearchSelector
             isFullWidth
-            isScrollable
-            onChange={(selection) => {
-              const foundProject = projects.find(byName(selection));
-              if (foundProject) {
-                setSelectedProject(foundProject);
-              } else {
-                setSelectedProject(null);
-              }
-            }}
-            value={selectedProject?.metadata.name}
-            options={(isOciModel ? kserveProjects : projects).map((project) => ({
-              key: project.metadata.name,
-              value: project.metadata.name,
-              label: getDisplayNameFromK8sResource(project),
-            }))}
+            onSearchChange={(value) => setSearchText(value)}
+            onSearchClear={() => setSearchText('')}
+            searchValue={searchText}
             dataTestId="deploy-model-project-selector"
-            toggleLabel={
+            toggleContent={
               selectedProject
                 ? getDisplayNameFromK8sResource(selectedProject)
                 : 'Select target project'
             }
-            toggleProps={{ id: 'deploy-model-project-selector' }}
-          />
+            searchPlaceholder="Project name"
+          >
+            {visibleProjects.length === 0 && <MenuItem isDisabled>No matching results</MenuItem>}
+            {visibleProjects.map((project) => (
+              <MenuItem
+                key={project.metadata.name}
+                isSelected={project.metadata.name === selectedProject?.metadata.name}
+                onClick={() => {
+                  setSearchText('');
+                  setSelectedProject(project);
+                }}
+              >
+                <Truncate content={getDisplayNameFromK8sResource(project)}>
+                  {getDisplayNameFromK8sResource(project)}
+                </Truncate>
+              </MenuItem>
+            ))}
+          </SearchSelector>
         </StackItem>
         {error && selectedProject && (
           <StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-24694

## Description
Added project search to deploy model modal

https://github.com/user-attachments/assets/ca9c2222-60df-4072-9056-e35e3d9185cc




<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?

- Deploy a model either from model registry or directly from model catalog
- Verify you can now see a project search to search the project by name

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated the cypress test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
cc @yannnz 