### PR TITLE
Workbench Cancel Button Bug Fix

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -385,6 +385,14 @@ class CreateSpawnerPage {
     return cy.findByTestId('submit-button');
   }
 
+  findCancelButton() {
+    return cy.findByTestId('cancel-button');
+  }
+
+  findSideBarItems(section: string) {
+    return cy.findByTestId(`${section}-jump-link`).find('a');
+  }
+
   getEnvironmentVariableTypeField(index: number) {
     return new EnvironmentVariableTypeField(() =>
       cy.findAllByTestId('environment-variable-field').eq(index),

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -43,6 +43,7 @@ import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 import { mockConnectionTypeConfigMap } from '~/__mocks__/mockConnectionType';
 import type { NotebookKind, PodKind } from '~/k8sTypes';
 import type { EnvironmentFromVariable } from '~/pages/projects/types';
+import { SpawnerPageSectionID } from '~/pages/projects/screens/spawner/types';
 
 const configYamlPath = '../../__mocks__/mock-upload-configmap.yaml';
 
@@ -352,6 +353,26 @@ describe('Workbench page', () => {
     workbenchPage.visit('test-project');
     workbenchPage.findEmptyState().should('exist');
     workbenchPage.findCreateButton().should('be.enabled');
+  });
+
+  it('Cancel button', () => {
+    initIntercepts({ isEmpty: true });
+    workbenchPage.visit('test-project');
+    //cancel button should work
+    workbenchPage.findCreateButton().click();
+    createSpawnerPage.findCancelButton().click();
+    verifyRelativeURL('/projects/test-project?section=workbenches');
+
+    //cancel button should work after clicking on sidebar items
+    workbenchPage.findCreateButton().click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.NAME_DESCRIPTION).click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.WORKBENCH_IMAGE).click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.DEPLOYMENT_SIZE).click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.ENVIRONMENT_VARIABLES).click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.CLUSTER_STORAGE).click();
+    createSpawnerPage.findSideBarItems(SpawnerPageSectionID.CONNECTIONS).click();
+    createSpawnerPage.findCancelButton().click();
+    verifyRelativeURL('/projects/test-project?section=workbenches');
   });
 
   it('Create workbench', () => {

--- a/frontend/src/components/GenericSidebar.tsx
+++ b/frontend/src/components/GenericSidebar.tsx
@@ -42,6 +42,7 @@ const GenericSidebar: React.FC<GenericSidebarProps> = ({
           <JumpLinksItem
             key={section}
             href={`#${section}`}
+            data-testid={`${section}-jump-link`}
             onClick={onJumpLinksItemClick ? () => onJumpLinksItemClick(section) : undefined}
           >
             {titles[section]}

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -55,7 +55,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   canEnablePipelines,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
-
+  const isWorkbenchesAvailable = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
   const {
     notebooks: { data: notebooks, refresh: refreshNotebooks },
     connections: { data: projectConnections, refresh: refreshConnections },
@@ -300,11 +300,16 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
             <Button
               variant="link"
               id="cancel-button"
+              data-testid="cancel-button"
               onClick={() => {
                 fireFormTrackingEvent(`Workbench ${editNotebook ? 'Updated' : 'Created'}`, {
                   outcome: TrackingOutcome.cancel,
                 });
-                navigate(-1);
+                navigate(
+                  isWorkbenchesAvailable
+                    ? `/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`
+                    : '/',
+                );
               }}
             >
               Cancel

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -55,7 +55,6 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   canEnablePipelines,
 }) => {
   const [error, setError] = React.useState<K8sStatusError>();
-  const isWorkbenchesAvailable = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
   const {
     notebooks: { data: notebooks, refresh: refreshNotebooks },
     connections: { data: projectConnections, refresh: refreshConnections },
@@ -305,11 +304,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
                 fireFormTrackingEvent(`Workbench ${editNotebook ? 'Updated' : 'Created'}`, {
                   outcome: TrackingOutcome.cancel,
                 });
-                navigate(
-                  isWorkbenchesAvailable
-                    ? `/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`
-                    : `/projects/${projectName}?section=${ProjectSectionID.OVERVIEW}`,
-                );
+                navigate(`/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`);
               }}
             >
               Cancel

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -308,7 +308,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
                 navigate(
                   isWorkbenchesAvailable
                     ? `/projects/${projectName}?section=${ProjectSectionID.WORKBENCHES}`
-                    : '/',
+                    : `/projects/${projectName}?section=${ProjectSectionID.OVERVIEW}`,
                 );
               }}
             >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-17334](https://issues.redhat.com/browse/RHOAIENG-17334)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There was a bug where if you clicked the sidebar items when creating/editing a workbench and then hit cancel, you'd have to hit cancel however many times as sidebar items clicked +1 to get back to the workbenches tab.
(there's a video of it in the ticket)
The navigation was fixed and I added some cypress tests for testing the cancel button.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress tests

**If you want to test:**
- On a branch or cluster without this fix, go make/edit a workbench and click around the sidebar items and then try to hit cancel -> it'll take a few clicks to actually cancel.
- Now go to this branch with the fix, go make/edit a workbench and click around the sidebar items and then try to cancel -> should take you right back to the workbenches tab.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
