### PR TITLE
Fix cypress app nav utility to address failures in e2e tests

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/appChrome.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/appChrome.ts
@@ -33,17 +33,7 @@ class AppChrome {
   }
 
   findNavItem(name: string, section?: string) {
-    if (section) {
-      this.findNavSection(section)
-        // do not fail if the section is not found
-        .should('have.length.at.least', 0)
-        .then(($el) => {
-          if ($el.attr('aria-expanded') === 'false') {
-            cy.wrap($el).click();
-          }
-        });
-    }
-    return this.findSideBar().findByRole('link', { name });
+    return this.findSideBar().findAppNavItem(name, section);
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/application.ts
@@ -26,6 +26,14 @@ declare global {
       ) => Cypress.Chainable<void>;
 
       /**
+       * Finds a app nav item relative to the subject element.
+       *
+       * @param name the name of the item
+       * @param section the section of the item
+       */
+      findAppNavItem: (name: string, section?: string) => Cypress.Chainable<JQuery>;
+
+      /**
        * Find a patternfly kebab toggle button.
        *
        * @param isDropdownToggle - True to indicate that it is a dropdown toggle instead of table kebab actions
@@ -179,6 +187,31 @@ declare global {
     }
   }
 }
+
+Cypress.Commands.addQuery('findAppNavItem', (name: string, section?: string) => {
+  Cypress.log({
+    displayName: 'findAppNavItem',
+    message: `name: ${name}, section: ${section ?? 'none'}`,
+  });
+
+  return (subject) => {
+    Cypress.ensure.isElement(subject, 'findAppNavItem', cy);
+    const $el: JQuery<HTMLElement> = subject;
+
+    let $parent = $el;
+    if (section) {
+      const $section = $el.find(`:contains('${section}')`).closest('button');
+      if ($section.length) {
+        $parent = $section.parent();
+        if ($section.attr('aria-expanded') === 'false') {
+          $section.trigger('click');
+        }
+      }
+    }
+
+    return $parent.find(`:contains('${name}')`).closest('a');
+  };
+});
 
 Cypress.Commands.add('visitWithLogin', (relativeUrl, credentials = HTPASSWD_CLUSTER_ADMIN_USER) => {
   if (Cypress.env('MOCK')) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Convert `findAppNavItem` to a custom query. This will allow cypress to retry the query until it succeeds. This is necessary because async behavior of nav item loading due to the evaluation of access review checks can fail due to timing issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cypress tests.
https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/cypress/job/dashboard-tests/1434/

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
