### PR TITLE
Hardware guard deletion: show a dialog when deleting the *last* CPU or memory for a hardware profile

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
@@ -322,6 +322,18 @@ class ManageHardwareProfile {
     return cy.findByTestId('node-resource-table-alert');
   }
 
+  findNodeResourceDeletionDialog() {
+    return cy.findByTestId('delete-node-resource-modal');
+  }
+
+  findNodeResourceDeletionDialogDeleteButton() {
+    return cy.findByTestId('delete-node-resource-modal-delete-btn');
+  }
+
+  findNodeResourceDeletionDialogCancelButton() {
+    return cy.findByTestId('delete-node-resource-modal-cancel-btn');
+  }
+
   getTolerationTableRow(name: string) {
     return new TolerationRow(() =>
       this.findTolerationTable().find(`[data-label=Key]`).contains(name).parents('tr'),
@@ -341,6 +353,18 @@ class ManageHardwareProfile {
         .contains(name)
         .parents('tr'),
     );
+  }
+
+  hasNodeResourceRow(name: string): Cypress.Chainable<boolean> {
+    // Use .then to transform the result into a boolean
+    return cy.document().then(() => {
+      // Create a wrapped jQuery selector that won't fail if the element doesn't exist
+      return cy.wrap(
+        Cypress.$(
+          `[data-testid="hardware-profile-node-resources-table"] [data-label="Resource identifier"]:contains("${name}")`,
+        ).length > 0,
+      );
+    });
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -226,7 +226,6 @@ describe('Manage Hardware Profile', () => {
 
     // test deleting the last CPU trigger the alert shown
     createHardwareProfile.getNodeResourceTableRow('cpu').findDeleteAction().click();
-    // debugger;
     createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
     createHardwareProfile.findNodeResourceDeletionDialogDeleteButton().click();
     createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -151,6 +151,26 @@ describe('Manage Hardware Profile', () => {
     // test that values were added correctly
     createHardwareProfile.getNodeResourceTableRow('test-gpu').shouldHaveResourceLabel('Test GPU');
 
+    // make a new one; a test-ack that should be deletable - no dialog should show up
+    createHardwareProfile.findAddNodeResourceButton().click();
+    // fill in form required fields
+    createNodeResourceModal.findNodeResourceSubmitButton().should('be.disabled');
+    createNodeResourceModal.findNodeResourceLabelInput().fill('Test Ack');
+    createNodeResourceModal.findNodeResourceIdentifierInput().fill('test-ack');
+    createNodeResourceModal.findNodeResourceTypeSelect().should('contain.text', 'Other');
+    createNodeResourceModal.findNodeResourceSubmitButton().should('be.enabled');
+    createNodeResourceModal.findNodeResourceSubmitButton().click();
+    // test that values were added correctly
+    createHardwareProfile.getNodeResourceTableRow('test-ack').shouldHaveResourceLabel('Test Ack');
+
+    // now; delete it; no dialog should show:
+    createHardwareProfile.getNodeResourceTableRow('test-ack').findDeleteAction().click();
+    createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');
+    createHardwareProfile.findNodeResourceTableAlert().should('not.exist');
+
+    // Assert that the row does not exist
+    createHardwareProfile.hasNodeResourceRow('test-ack').should('be.false');
+
     // test edit node resource
     createHardwareProfile.getNodeResourceTableRow('cpu').findEditAction().click();
     editNodeResourceModal.findNodeResourceTypeSelect().should('contain.text', 'CPU');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -206,6 +206,11 @@ describe('Manage Hardware Profile', () => {
 
     // test deleting the last CPU trigger the alert shown
     createHardwareProfile.getNodeResourceTableRow('cpu').findDeleteAction().click();
+    // debugger;
+    createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
+    createHardwareProfile.findNodeResourceDeletionDialogDeleteButton().click();
+    createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');
+
     createHardwareProfile.findNodeResourceTableAlert().should('exist');
     createHardwareProfile.findAddNodeResourceButton().click();
     createNodeResourceModal.findNodeResourceLabelInput().fill('CPU');
@@ -216,8 +221,39 @@ describe('Manage Hardware Profile', () => {
 
     createHardwareProfile.findNodeResourceTableAlert().should('not.exist');
 
-    // test deleting the last Memory trigger the alert shown
+    // add an extra memory:
+    createHardwareProfile.findAddNodeResourceButton().click();
+    createNodeResourceModal.findNodeResourceLabelInput().fill('extra-memory');
+    createNodeResourceModal.findNodeResourceIdentifierInput().fill('extra-memory');
+    createNodeResourceModal.findNodeResourceTypeSelect().findSelectOption('Memory').click();
+    createNodeResourceModal.findNodeResourceSubmitButton().should('be.enabled');
+    createNodeResourceModal.findNodeResourceSubmitButton().click();
+
+    createHardwareProfile.hasNodeResourceRow('extra-memory').should('be.true');
+
+    // test deleting one of the two memory slots does NOT trigger an alert (or the dialog):
+    createHardwareProfile.getNodeResourceTableRow('extra-memory').findDeleteAction().click();
+
+    createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');
+    createHardwareProfile.findNodeResourceTableAlert().should('not.exist');
+    // Assert that the row does not exist
+    createHardwareProfile.hasNodeResourceRow('extra-memory').should('be.false');
+
+    // now: test deleting the last Memory trigger the alert shown
     createHardwareProfile.getNodeResourceTableRow('memory').findDeleteAction().click();
+    createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
+
+    // first; cancel; should be a no-op (row still there, no alert shown)
+    createHardwareProfile.findNodeResourceDeletionDialogCancelButton().click();
+    createHardwareProfile.hasNodeResourceRow('memory').should('be.true');
+    createHardwareProfile.findNodeResourceTableAlert().should('not.exist');
+
+    // now; do it again and actually delete it:
+    createHardwareProfile.getNodeResourceTableRow('memory').findDeleteAction().click();
+    createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
+    createHardwareProfile.findNodeResourceDeletionDialogDeleteButton().click();
+    createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');
+
     createHardwareProfile.findNodeResourceTableAlert().should('exist');
     createHardwareProfile.findAddNodeResourceButton().click();
     createNodeResourceModal.findNodeResourceLabelInput().fill('MEMORY');

--- a/frontend/src/pages/hardwareProfiles/const.tsx
+++ b/frontend/src/pages/hardwareProfiles/const.tsx
@@ -156,3 +156,6 @@ export const DEFAULT_HARDWARE_PROFILE_SPEC: HardwareProfileKind['spec'] = {
     },
   ],
 };
+
+export const CPU_MEMORY_MISSING_WARNING =
+  'It is not recommended to remove the last CPU or Memory resource. Resources that use this hardware profile will schedule, but will be very unstable due to not having any lower or upper resource bounds.';

--- a/frontend/src/pages/hardwareProfiles/manage/ManageNodeResourceSection.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageNodeResourceSection.tsx
@@ -5,7 +5,10 @@ import { useSearchParams } from 'react-router-dom';
 import { Identifier, IdentifierResourceType } from '~/types';
 import NodeResourceTable from '~/pages/hardwareProfiles/nodeResource/NodeResourceTable';
 import ManageNodeResourceModal from '~/pages/hardwareProfiles/nodeResource/ManageNodeResourceModal';
-import { ManageHardwareProfileSectionTitles } from '~/pages/hardwareProfiles/const';
+import {
+  ManageHardwareProfileSectionTitles,
+  CPU_MEMORY_MISSING_WARNING,
+} from '~/pages/hardwareProfiles/const';
 import { ManageHardwareProfileSectionID } from '~/pages/hardwareProfiles/manage/types';
 import {
   DEFAULT_CPU_IDENTIFIER,
@@ -86,9 +89,7 @@ const ManageNodeResourceSection: React.FC<ManageNodeResourceSectionProps> = ({
             variant={AlertVariant.warning}
             data-testid="node-resource-table-alert"
           >
-            It is not recommended to remove the CPU or Memory. The resources that use this hardware
-            profile will schedule, but will be very unstable due to not having any lower or upper
-            resource bounds.
+            {CPU_MEMORY_MISSING_WARNING}
           </Alert>
         )}
         {!isEmpty && (

--- a/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
-import { Alert, Button, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  Stack,
+  StackItem,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@patternfly/react-core';
 import { Identifier } from '~/types';
 import { CPU_MEMORY_MISSING_WARNING } from '~/pages/hardwareProfiles/const';
 
@@ -21,17 +29,34 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
 
   return (
     <Modal
-      title={deleteTitle}
-      onClose={() => onBeforeClose(false)}
       isOpen
-      actions={[
+      data-testid="delete-node-resource-modal"
+      variant="small"
+      onClose={() => onBeforeClose(false)}
+    >
+      <ModalHeader title={deleteTitle} />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
+              {CPU_MEMORY_MISSING_WARNING}
+            </Alert>
+          </StackItem>
+          <StackItem>
+            <p>
+              The resource: <strong>{identifier.displayName}</strong> will be deleted.
+            </p>
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="delete-button"
           data-testid="delete-node-resource-modal-delete-btn"
           onClick={() => onBeforeClose(true)}
         >
           Delete
-        </Button>,
+        </Button>
         <Button
           key="cancel-button"
           data-testid="delete-node-resource-modal-cancel-btn"
@@ -39,23 +64,8 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
           onClick={() => onBeforeClose(false)}
         >
           Cancel
-        </Button>,
-      ]}
-      variant="small"
-      data-testid="delete-node-resource-modal"
-    >
-      <Stack hasGutter>
-        <StackItem>
-          <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
-            {CPU_MEMORY_MISSING_WARNING}
-          </Alert>
-        </StackItem>
-        <StackItem>
-          <p>
-            The resource: <strong>{identifier.displayName}</strong> will be deleted.
-          </p>
-        </StackItem>
-      </Stack>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
@@ -25,10 +25,19 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
       onClose={() => onBeforeClose(false)}
       isOpen
       actions={[
-        <Button key="delete-button" onClick={() => onBeforeClose(true)}>
+        <Button
+          key="delete-button"
+          data-testid="delete-node-resource-modal-delete-btn"
+          onClick={() => onBeforeClose(true)}
+        >
           Delete
         </Button>,
-        <Button key="cancel-button" variant="link" onClick={() => onBeforeClose(false)}>
+        <Button
+          key="cancel-button"
+          data-testid="delete-node-resource-modal-cancel-btn"
+          variant="link"
+          onClick={() => onBeforeClose(false)}
+        >
           Cancel
         </Button>,
       ]}

--- a/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Alert, Button, Stack, StackItem } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { Identifier } from '~/types';
+import { CPU_MEMORY_MISSING_WARNING } from '~/pages/hardwareProfiles/const';
 
 type DeleteNodeResourceModalProps = {
   identifier: Identifier;
@@ -12,8 +13,8 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
   identifier,
   onClose,
 }) => {
-  const onBeforeClose = (deleted = false) => {
-    onClose(deleted);
+  const onBeforeClose = (shouldDoDeletion: boolean) => {
+    onClose(shouldDoDeletion);
   };
 
   const deleteTitle = `Delete resource: ${identifier.displayName}`;
@@ -37,9 +38,7 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
       <Stack hasGutter>
         <StackItem>
           <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
-            It is not recommended to remove the last CPU or Memory resource. Resources that use this
-            hardware profile will schedule, but will be very unstable due to not having any lower or
-            upper resource bounds.
+            {CPU_MEMORY_MISSING_WARNING}
           </Alert>
         </StackItem>
         <StackItem>

--- a/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
+import { Identifier } from '~/types';
+import DeleteModal from '~/pages/projects/components/DeleteModal';
+
+type DeleteNodeResourceModalProps = {
+  identifier: Identifier;
+  onClose: (deleted: boolean) => void;
+};
+
+const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
+  identifier,
+  onClose,
+}) => {
+  const onBeforeClose = (deleted = false) => {
+    onClose(deleted);
+  };
+
+  const deleteTitle = `Delete resource: ${identifier.displayName}`;
+
+  // todo: figure out how to use the 'deleting' status; set to false for now! TODO
+  return (
+    <DeleteModal
+      title={deleteTitle}
+      onClose={onBeforeClose}
+      onDelete={() => {
+        onBeforeClose(true);
+      }}
+      deleting={false}
+      submitButtonLabel="Delete"
+      deleteName={identifier.displayName}
+      testId="delete-node-resource-modal"
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
+            It is not recommended to remove the last CPU or Memory resource. Resources that use this
+            hardware profile will schedule, but will be very unstable due to not having any lower or
+            upper resource bounds.
+          </Alert>
+        </StackItem>
+        <StackItem>
+          <p>
+            Are you sure you want to delete the resource: <strong>{identifier.displayName}</strong>?
+          </p>
+        </StackItem>
+      </Stack>
+    </DeleteModal>
+  );
+};
+
+export default DeleteNodeResourceModal;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/DeleteNodeResourceModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Alert, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, Button, Stack, StackItem } from '@patternfly/react-core';
+import { Modal } from '@patternfly/react-core/deprecated';
 import { Identifier } from '~/types';
-import DeleteModal from '~/pages/projects/components/DeleteModal';
 
 type DeleteNodeResourceModalProps = {
   identifier: Identifier;
@@ -18,18 +18,21 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
 
   const deleteTitle = `Delete resource: ${identifier.displayName}`;
 
-  // todo: figure out how to use the 'deleting' status; set to false for now! TODO
   return (
-    <DeleteModal
+    <Modal
       title={deleteTitle}
-      onClose={onBeforeClose}
-      onDelete={() => {
-        onBeforeClose(true);
-      }}
-      deleting={false}
-      submitButtonLabel="Delete"
-      deleteName={identifier.displayName}
-      testId="delete-node-resource-modal"
+      onClose={() => onBeforeClose(false)}
+      isOpen
+      actions={[
+        <Button key="delete-button" onClick={() => onBeforeClose(true)}>
+          Delete
+        </Button>,
+        <Button key="cancel-button" variant="link" onClick={() => onBeforeClose(false)}>
+          Cancel
+        </Button>,
+      ]}
+      variant="small"
+      data-testid="delete-node-resource-modal"
     >
       <Stack hasGutter>
         <StackItem>
@@ -41,11 +44,11 @@ const DeleteNodeResourceModal: React.FC<DeleteNodeResourceModalProps> = ({
         </StackItem>
         <StackItem>
           <p>
-            Are you sure you want to delete the resource: <strong>{identifier.displayName}</strong>?
+            The resource: <strong>{identifier.displayName}</strong> will be deleted.
           </p>
         </StackItem>
       </Stack>
-    </DeleteModal>
+    </Modal>
   );
 };
 

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
@@ -25,7 +25,8 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
       identifier.resourceType === IdentifierResourceType.MEMORY ||
       identifier.identifier === DEFAULT_MEMORY_IDENTIFIER;
 
-    if (!isCPU && !isMemory) {
+    // if it's not cpu or memory, guard not applicable, can just remove it
+    if (!(isCPU || isMemory)) {
       return false;
     }
 
@@ -36,14 +37,12 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
           r.resourceType === IdentifierResourceType.CPU || r.identifier === DEFAULT_CPU_IDENTIFIER,
       );
     }
-    if (isMemory) {
-      return !remainingResources.some(
-        (r) =>
-          r.resourceType === IdentifierResourceType.MEMORY ||
-          r.identifier === DEFAULT_MEMORY_IDENTIFIER,
-      );
-    }
-    return false;
+    // has to be memory; all that is left
+    return !remainingResources.some(
+      (r) =>
+        r.resourceType === IdentifierResourceType.MEMORY ||
+        r.identifier === DEFAULT_MEMORY_IDENTIFIER,
+    );
   };
 
   const handleDelete = (rowIndex: number) => {

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
@@ -47,7 +47,6 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
   };
 
   const handleDelete = (rowIndex: number) => {
-    console.log('handleDelete', rowIndex);
     const identifierToDelete = nodeResources[rowIndex];
 
     if (wouldRemoveLastCPUorMemory(identifierToDelete, nodeResources)) {
@@ -60,8 +59,8 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
     }
   };
 
-  const handleDeleteConfirm = (deleted: boolean) => {
-    if (deleted && deleteIdentifier) {
+  const handleDeleteConfirm = (shouldDoDeletion: boolean) => {
+    if (shouldDoDeletion && deleteIdentifier) {
       const updatedIdentifiers = nodeResources.filter((r) => r !== deleteIdentifier);
       onUpdate?.(updatedIdentifiers);
     }

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
@@ -111,10 +111,7 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
         />
       ) : null}
       {deleteIdentifier && (
-        <>
-          <div> ack ack ack 44a</div>
-          <DeleteNodeResourceModal identifier={deleteIdentifier} onClose={handleDeleteConfirm} />
-        </>
+        <DeleteNodeResourceModal identifier={deleteIdentifier} onClose={handleDeleteConfirm} />
       )}
     </>
   );

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { Alert, Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { TableBase } from '~/components/table';
-import { Identifier } from '~/types';
-import { nodeResourceColumns } from './const';
+import { Identifier, IdentifierResourceType } from '~/types';
+import { hasCPUandMemory } from '~/pages/hardwareProfiles/manage/ManageNodeResourceSection';
+import { nodeResourceColumns, DEFAULT_CPU_IDENTIFIER, DEFAULT_MEMORY_IDENTIFIER } from './const';
 import NodeResourceTableRow from './NodeResourceTableRow';
 import ManageNodeResourceModal from './ManageNodeResourceModal';
 
@@ -14,6 +16,70 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
   const viewOnly = !onUpdate;
   const [editIdentifier, setEditIdentifier] = React.useState<Identifier | undefined>();
   const [currentIndex, setCurrentIndex] = React.useState<number | undefined>();
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false);
+  const [pendingDeleteIndex, setPendingDeleteIndex] = React.useState<number | undefined>();
+
+  const isCPUorMemory = (identifier: Identifier): boolean =>
+    identifier.resourceType === IdentifierResourceType.CPU ||
+    identifier.identifier === DEFAULT_CPU_IDENTIFIER ||
+    identifier.resourceType === IdentifierResourceType.MEMORY ||
+    identifier.identifier === DEFAULT_MEMORY_IDENTIFIER;
+
+  const wouldRemoveLastCPUorMemory = (identifier: Identifier, resources: Identifier[]): boolean => {
+    const isCPU =
+      identifier.resourceType === IdentifierResourceType.CPU ||
+      identifier.identifier === DEFAULT_CPU_IDENTIFIER;
+    const isMemory =
+      identifier.resourceType === IdentifierResourceType.MEMORY ||
+      identifier.identifier === DEFAULT_MEMORY_IDENTIFIER;
+
+    if (!isCPU && !isMemory) {
+      return false;
+    }
+
+    const remainingResources = resources.filter((r) => r !== identifier);
+    if (isCPU) {
+      return !remainingResources.some(
+        (r) =>
+          r.resourceType === IdentifierResourceType.CPU || r.identifier === DEFAULT_CPU_IDENTIFIER,
+      );
+    }
+    if (isMemory) {
+      return !remainingResources.some(
+        (r) =>
+          r.resourceType === IdentifierResourceType.MEMORY ||
+          r.identifier === DEFAULT_MEMORY_IDENTIFIER,
+      );
+    }
+    return false;
+  };
+
+  const handleDelete = (rowIndex: number) => {
+    console.log('handleDelete', rowIndex);
+    const identifierToDelete = nodeResources[rowIndex];
+
+    if (wouldRemoveLastCPUorMemory(identifierToDelete, nodeResources)) {
+      setPendingDeleteIndex(rowIndex);
+      setDeleteConfirmOpen(true);
+      return;
+    }
+
+    // If not CPU/memory or not the last one, proceed with delete
+    const updatedIdentifiers = [...nodeResources];
+    updatedIdentifiers.splice(rowIndex, 1);
+    onUpdate?.(updatedIdentifiers);
+  };
+
+  const confirmDelete = () => {
+    if (pendingDeleteIndex !== undefined) {
+      const updatedIdentifiers = [...nodeResources];
+      updatedIdentifiers.splice(pendingDeleteIndex, 1);
+      onUpdate?.(updatedIdentifiers);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteIndex(undefined);
+  };
+
   return (
     <>
       <TableBase
@@ -34,11 +100,7 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
               setEditIdentifier(newIdentifier);
               setCurrentIndex(rowIndex);
             }}
-            onDelete={() => {
-              const updatedIdentifiers = [...nodeResources];
-              updatedIdentifiers.splice(rowIndex, 1);
-              onUpdate?.(updatedIdentifiers);
-            }}
+            onDelete={() => handleDelete(rowIndex)}
             showActions={!viewOnly}
           />
         )}
@@ -60,6 +122,40 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
           nodeResources={nodeResources}
         />
       ) : null}
+      {deleteConfirmOpen && (
+        <>
+          <div>hi there delete would be open here</div>
+          <Modal
+            variant={ModalVariant.small}
+            title="Remove resource"
+            onClose={() => {
+              setDeleteConfirmOpen(false);
+              setPendingDeleteIndex(undefined);
+            }}
+          >
+            <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
+              It is not recommended to remove the last CPU or Memory resource. Resources that use
+              this hardware profile will schedule, but will be very unstable due to not having any
+              lower or upper resource bounds.
+            </Alert>
+            <div className="pf-v6-u-mt-md">
+              <Button variant="danger" onClick={confirmDelete}>
+                Remove
+              </Button>
+              <Button
+                variant="link"
+                onClick={() => {
+                  setDeleteConfirmOpen(false);
+                  setPendingDeleteIndex(undefined);
+                }}
+                className="pf-v6-u-ml-sm"
+              >
+                Cancel
+              </Button>
+            </div>
+          </Modal>
+        </>
+      )}
     </>
   );
 };

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTable.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Alert, Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { TableBase } from '~/components/table';
 import { Identifier, IdentifierResourceType } from '~/types';
-import { hasCPUandMemory } from '~/pages/hardwareProfiles/manage/ManageNodeResourceSection';
 import { nodeResourceColumns, DEFAULT_CPU_IDENTIFIER, DEFAULT_MEMORY_IDENTIFIER } from './const';
 import NodeResourceTableRow from './NodeResourceTableRow';
 import ManageNodeResourceModal from './ManageNodeResourceModal';
+import DeleteNodeResourceModal from './DeleteNodeResourceModal';
 
 type NodeResourceTableProps = {
   nodeResources: Identifier[];
@@ -16,14 +15,7 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
   const viewOnly = !onUpdate;
   const [editIdentifier, setEditIdentifier] = React.useState<Identifier | undefined>();
   const [currentIndex, setCurrentIndex] = React.useState<number | undefined>();
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = React.useState(false);
-  const [pendingDeleteIndex, setPendingDeleteIndex] = React.useState<number | undefined>();
-
-  const isCPUorMemory = (identifier: Identifier): boolean =>
-    identifier.resourceType === IdentifierResourceType.CPU ||
-    identifier.identifier === DEFAULT_CPU_IDENTIFIER ||
-    identifier.resourceType === IdentifierResourceType.MEMORY ||
-    identifier.identifier === DEFAULT_MEMORY_IDENTIFIER;
+  const [deleteIdentifier, setDeleteIdentifier] = React.useState<Identifier | undefined>();
 
   const wouldRemoveLastCPUorMemory = (identifier: Identifier, resources: Identifier[]): boolean => {
     const isCPU =
@@ -59,25 +51,21 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
     const identifierToDelete = nodeResources[rowIndex];
 
     if (wouldRemoveLastCPUorMemory(identifierToDelete, nodeResources)) {
-      setPendingDeleteIndex(rowIndex);
-      setDeleteConfirmOpen(true);
-      return;
-    }
-
-    // If not CPU/memory or not the last one, proceed with delete
-    const updatedIdentifiers = [...nodeResources];
-    updatedIdentifiers.splice(rowIndex, 1);
-    onUpdate?.(updatedIdentifiers);
-  };
-
-  const confirmDelete = () => {
-    if (pendingDeleteIndex !== undefined) {
+      setDeleteIdentifier(identifierToDelete);
+    } else {
+      // If not CPU/memory or not the last one, proceed with delete
       const updatedIdentifiers = [...nodeResources];
-      updatedIdentifiers.splice(pendingDeleteIndex, 1);
+      updatedIdentifiers.splice(rowIndex, 1);
       onUpdate?.(updatedIdentifiers);
     }
-    setDeleteConfirmOpen(false);
-    setPendingDeleteIndex(undefined);
+  };
+
+  const handleDeleteConfirm = (deleted: boolean) => {
+    if (deleted && deleteIdentifier) {
+      const updatedIdentifiers = nodeResources.filter((r) => r !== deleteIdentifier);
+      onUpdate?.(updatedIdentifiers);
+    }
+    setDeleteIdentifier(undefined);
   };
 
   return (
@@ -122,38 +110,10 @@ const NodeResourceTable: React.FC<NodeResourceTableProps> = ({ nodeResources, on
           nodeResources={nodeResources}
         />
       ) : null}
-      {deleteConfirmOpen && (
+      {deleteIdentifier && (
         <>
-          <div>hi there delete would be open here</div>
-          <Modal
-            variant={ModalVariant.small}
-            title="Remove resource"
-            onClose={() => {
-              setDeleteConfirmOpen(false);
-              setPendingDeleteIndex(undefined);
-            }}
-          >
-            <Alert variant="warning" isInline title="Removing the last CPU or Memory resource">
-              It is not recommended to remove the last CPU or Memory resource. Resources that use
-              this hardware profile will schedule, but will be very unstable due to not having any
-              lower or upper resource bounds.
-            </Alert>
-            <div className="pf-v6-u-mt-md">
-              <Button variant="danger" onClick={confirmDelete}>
-                Remove
-              </Button>
-              <Button
-                variant="link"
-                onClick={() => {
-                  setDeleteConfirmOpen(false);
-                  setPendingDeleteIndex(undefined);
-                }}
-                className="pf-v6-u-ml-sm"
-              >
-                Cancel
-              </Button>
-            </div>
-          </Modal>
+          <div> ack ack ack 44a</div>
+          <DeleteNodeResourceModal identifier={deleteIdentifier} onClose={handleDeleteConfirm} />
         </>
       )}
     </>


### PR DESCRIPTION
for: https://issues.redhat.com/browse/RHOAIENG-22692

## Description
show a dialog when deleting the *last* CPU or memory for a hardware profile.

previously, the warning happened on the page *after* the deletion happened.  
Now; the warning is still there; but there is a confirmation dialog that pops up if and only if the user is trying to delete the last CPU or memory resource.

if there are multiple cpu or memory resources; then the deletion just happens without a dialog.

Note:  normally hardware profiles are not visible to the user; the feature flag for hiding the hardware profiles has to be unchecked. see this video: (it has audio)


https://github.com/user-attachments/assets/da2c5440-bbae-459a-9739-58d8be34a06d



## How Has This Been Tested?
tested this manually, see the video up above.  tested while editing and while creating a hardware profile.  the dialog *only* shows if the item being deleted is the only cpu or memory in the profile; the dialog does not show/get used at all if there are multiple of the cpus or memories, or if the type is not cpu or memory.

Originally, thought was to add a generic deletion dialog; but a deletion modal already exists for more destructive operations; and no where else needed this.  so is not necessary. 

## Test Impact
 no tests needed; this is very minor. manual testing is sufficient.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
