### PR TITLE
Modified cypress test for registered from catalog in modelVersionDetails

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -24,6 +24,10 @@ class ModelVersionDetails {
     return cy.findByTestId('registered-from-catalog');
   }
 
+  findRegisteredFromTitle() {
+    return cy.findByTestId('registered-from-title');
+  }
+
   findRegisteredFromPipeline() {
     return cy.findByTestId('registered-from-pipeline');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -293,8 +293,8 @@ describe('Model version details', () => {
       initIntercepts(false, true, false);
       modelVersionDetails.visit();
       modelVersionDetails.findVersionId().contains('1');
-      cy.findByTestId('registered-from-catalog').should('exist');
-      cy.findByTestId('registered-from-title').should('exist');
+      modelVersionDetails.findRegisteredFromCatalog().should('exist');
+      modelVersionDetails.findRegisteredFromTitle().should('exist');
     });
 
     it('Model version details page header', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -278,13 +278,12 @@ describe('Model version details', () => {
     it('Model version details registered from catalog', () => {
       initIntercepts(false, true, true);
       modelVersionDetails.visit();
-      cy.findByTestId('model-version-id').contains('1');
-      cy.findByTestId('registered-from-catalog').should('exist');
-      cy.findByTestId('registered-from-catalog').should(
-        'have.text',
-        'test-catalog-model (test-catalog-tag)',
-      );
-      cy.findByTestId('registered-from-catalog').click();
+      modelVersionDetails.findVersionId().contains('1');
+      modelVersionDetails.findRegisteredFromCatalog().should('exist');
+      modelVersionDetails
+        .findRegisteredFromCatalog()
+        .should('have.text', 'test-catalog-model (test-catalog-tag)');
+      modelVersionDetails.findRegisteredFromCatalog().click();
       verifyRelativeURL(
         '/modelCatalog/test-catalog-source/test-catalog-repo/test-catalog-model/test-catalog-tag',
       );
@@ -293,8 +292,9 @@ describe('Model version details', () => {
     it('Model version details registered from catalog with model catalog unavailable', () => {
       initIntercepts(false, true, false);
       modelVersionDetails.visit();
-      cy.findByTestId('model-version-id').contains('1');
-      cy.findByTestId('registered-from-catalog').should('not.exist');
+      modelVersionDetails.findVersionId().contains('1');
+      cy.contains('test-catalog-model (test-catalog-tag) in Model catalog').should('exist');
+      modelVersionDetails.findRegisteredFromCatalog().should('not.exist');
       cy.contains('Registered from').should('exist');
     });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -294,7 +294,6 @@ describe('Model version details', () => {
       modelVersionDetails.visit();
       modelVersionDetails.findVersionId().contains('1');
       cy.findByTestId('registered-from-catalog').should('not.exist');
-      modelVersionDetails.findRegisteredFromCatalog().should('not.exist');
       cy.findByTestId('registered-from-title').should('not.exist');
     });
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -293,9 +293,9 @@ describe('Model version details', () => {
       initIntercepts(false, true, false);
       modelVersionDetails.visit();
       modelVersionDetails.findVersionId().contains('1');
-      cy.contains('test-catalog-model (test-catalog-tag) in Model catalog').should('exist');
+      cy.findByTestId('registered-from-catalog').should('not.exist');
       modelVersionDetails.findRegisteredFromCatalog().should('not.exist');
-      cy.contains('Registered from').should('exist');
+      cy.findByTestId('registered-from-title').should('not.exist');
     });
 
     it('Model version details page header', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -293,8 +293,8 @@ describe('Model version details', () => {
       initIntercepts(false, true, false);
       modelVersionDetails.visit();
       modelVersionDetails.findVersionId().contains('1');
-      cy.findByTestId('registered-from-catalog').should('not.exist');
-      cy.findByTestId('registered-from-title').should('not.exist');
+      cy.findByTestId('registered-from-catalog').should('exist');
+      cy.findByTestId('registered-from-title').should('exist');
     });
 
     it('Model version details page header', () => {

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredFromLink.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredFromLink.tsx
@@ -139,7 +139,9 @@ const ModelVersionRegisteredFromLink: React.FC<ModelVersionRegisteredFromLinkPro
   }
 
   return (
-    <DashboardDescriptionListGroup title="Registered from">{content}</DashboardDescriptionListGroup>
+    <DashboardDescriptionListGroup title="Registered from" data-testid="registered-from-title">
+      {content}
+    </DashboardDescriptionListGroup>
   );
 };
 

--- a/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredFromLink.tsx
+++ b/frontend/src/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredFromLink.tsx
@@ -29,7 +29,7 @@ const ModelVersionRegisteredFromLink: React.FC<ModelVersionRegisteredFromLinkPro
   const registeredFromPipelineDetails = modelSourcePropertiesToPipelineRunRef(modelArtifact);
 
   const registeredfromText = (
-    <span className="pf-v6-u-font-weight-bold">
+    <span className="pf-v6-u-font-weight-bold" data-testid="registered-from-catalog">
       {registeredFromCatalogDetails?.modelName} ({registeredFromCatalogDetails?.tag})
     </span>
   );
@@ -119,9 +119,7 @@ const ModelVersionRegisteredFromLink: React.FC<ModelVersionRegisteredFromLinkPro
       return (
         <>
           {isModelCatalogAvailable ? (
-            <Link to={catalogModelUrl} data-testid="registered-from-catalog">
-              {registeredfromText}
-            </Link>
+            <Link to={catalogModelUrl}>{registeredfromText}</Link>
           ) : (
             registeredfromText
           )}{' '}
@@ -139,7 +137,7 @@ const ModelVersionRegisteredFromLink: React.FC<ModelVersionRegisteredFromLinkPro
   }
 
   return (
-    <DashboardDescriptionListGroup title="Registered from" data-testid="registered-from-title">
+    <DashboardDescriptionListGroup title="Registered from" groupTestId="registered-from-title">
       {content}
     </DashboardDescriptionListGroup>
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-23477

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Modified cypress test for registered from catalog in modelVersionDetails

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
all cypress tests are passing.
<img width="672" alt="Screenshot 2025-05-08 at 11 40 37" src="https://github.com/user-attachments/assets/e6b8e03a-9470-4449-9a83-5036eff785a9" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
