### PR TITLE
Remove legacy functionality

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -89,22 +89,6 @@ const fetchOrCreateDashboardCR = async (fastify: KubeFastifyInstance): Promise<D
     )
     .then((res) => {
       const dashboardCR = res?.body as DashboardConfig;
-      if (
-        dashboardCR &&
-        dashboardCR.spec.dashboardConfig &&
-        dashboardCR.spec.dashboardConfig.disableKServe === undefined &&
-        dashboardCR.spec.dashboardConfig.disableModelMesh === undefined
-      ) {
-        // return a merge between dashboardCR and blankDashboardCR but changing spec.disableKServe to true and spec.disableModelMesh to false
-        return _.merge({}, blankDashboardCR, dashboardCR, {
-          spec: {
-            dashboardConfig: {
-              disableKServe: true,
-              disableModelMesh: false,
-            },
-          },
-        });
-      }
       return _.merge({}, blankDashboardCR, dashboardCR); // merge with blank CR to prevent any missing values
     })
     .catch((e) => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25122

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In ODH -- no flags are set, the check failed to be hit, no issues.

In RHOAI -- the one flag is set, neither kserve or modelmesh, so it assumes we are still in v1 days and trying to migrate settings for new KServe option. Configures things weirdly & breaks tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Remove any kserve & model mesh feature flags in the OdhDashboardConfig

* Delete the contents of `dashboardConfig` item from your OdhDashboardConfig
    * Should be set to something like this: `dashboardConfig: {}`
* Navigate to the Cluster Settings page
* Disable the Operator deployment
* (scale the Dashboard replicas to 1)
* Modify the image for the Dashboard pod and set the image tag to `pr-4183`
* Wait 2 mins -- refresh the Cluster Settings page
* Do it again, with the `main` tag

Looking out for the `Single Model Serving` flag on the Cluster Settings page. 
* With my PR: both should be selected
* With `main`: Model Mesh (multi-model) serving should be the only one selected

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A -- Test are accurate, this was caught via them. Needs to be RHOAI e2e tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
