### PR TITLE
fix: clusterStorage bug during provision

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -13,6 +13,7 @@ import {
   deleteOpenShiftProject,
   addUserToProject,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { createCleanProject } from './projectChecker';
 
 /**
  * Provision (using oc) all necessary resources for the Storage Class testing feature
@@ -71,7 +72,7 @@ export const tearDownStorageClassFeature = (createdSC: string[]): void => {
  */
 export const provisionClusterStorageSCFeature = (projectName: string, userName: string): void => {
   // Provision a Project
-  createOpenShiftProject(projectName);
+  createCleanProject(projectName);
   addUserToProject(projectName, userName);
 };
 

--- a/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/storageClass.ts
@@ -9,7 +9,6 @@ import {
   getStorageClassConfig,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
 import {
-  createOpenShiftProject,
   deleteOpenShiftProject,
   addUserToProject,
 } from '~/__tests__/cypress/cypress/utils/oc_commands/project';


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-25189
## Description
Fix ClusterStorage provision bug found during the nightly exectution.

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/feea9b65-70d5-4ac5-b200-44bcb5e78e4d)
Command used:
`$ npx cypress run --browser chrome --project src/__tests__/cypress --spec src/__tests__/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts`
It does not make sense to run a pipeline in this case, as for checking that the error is not happening anymore there's a setup needed
So I've tested both cases: With the setup (green) and a regular execution (green too)

## Test Impact
Total impact as it's a fix for a test.

## Request review criteria:
Run the tests locally

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
