### PR TITLE
Cypress e2e Test - Verify a notification is shown when a user group is removed

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/userManagement.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/userManagement.ts
@@ -46,6 +46,16 @@ class GroupSettingSection extends Contextual<HTMLElement> {
     this.findMultiGroupSelectButton().click();
     this.findMultiGroupOptions(name).click();
   }
+
+  findWarningAlert(groupName: string) {
+    this.find()
+      .find('.pf-v6-c-alert.pf-m-inline.pf-m-warning')
+      .should('exist')
+      .contains(
+        `The group ${groupName} no longer exists in OpenShift and has been removed from the selected group list.`,
+      );
+    return this;
+  }
 }
 class UserManagement {
   visit(wait = true) {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/userManagement/testUserGroupRemovedNotification.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/userManagement/testUserGroupRemovedNotification.cy.ts
@@ -17,7 +17,7 @@ describe('Verify a notification is shown when a user group is removed', () => {
 
   it(
     'Deletes a user group that has admin privileges and verifies a notification is shown',
-    { tags: ['@Dashboard', '@Destructive', '@ODS-1816', '@Tier1', '@NonConcurrent'] },
+    { tags: ['@Dashboard', '@Destructive', '@ODS-1686', '@Tier1', '@NonConcurrent'] },
     () => {
       cy.step('Create a new group using oc command');
       createGroup(GROUP_NAME).then((result) => {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/userManagement/testUserGroupRemovedNotification.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/userManagement/testUserGroupRemovedNotification.cy.ts
@@ -1,0 +1,78 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import { retryableBeforeEach } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import {
+  createGroup,
+  deleteGroup,
+  groupExists,
+} from '~/__tests__/cypress/cypress/utils/oc_commands/groups';
+import { userManagement } from '~/__tests__/cypress/cypress/pages/userManagement';
+
+describe('Verify a notification is shown when a user group is removed', () => {
+  const GROUP_NAME = 'test-admin-group';
+
+  retryableBeforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+
+  it(
+    'Deletes a user group that has admin privileges and verifies a notification is shown',
+    { tags: ['@Dashboard', '@Destructive', '@ODS-1816', '@Tier1', '@NonConcurrent'] },
+    () => {
+      cy.step('Create a new group using oc command');
+      createGroup(GROUP_NAME).then((result) => {
+        cy.log(`Group creation result: ${result.stdout}`);
+
+        cy.step('Verify group was created');
+        groupExists(GROUP_NAME).should('be.true');
+
+        // Authentication and navigation
+        cy.step('Login as an Admin');
+        cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+        cy.step('Navigate to User Management');
+        userManagement.navigate();
+
+        cy.step('Add the group to administrators');
+        const administratorGroupSection = userManagement.getAdministratorGroupSection();
+        administratorGroupSection.findMultiGroupSelectButton().click();
+        administratorGroupSection.findMultiGroupOptions(GROUP_NAME).click();
+        userManagement.findSubmitButton().click();
+        userManagement.shouldHaveSuccessAlertMessage();
+
+        cy.step('Delete the group using oc command');
+        deleteGroup(GROUP_NAME).then((deleteResult) => {
+          cy.log(`Group deletion result: ${deleteResult.stdout}`);
+
+          cy.step('Verify group was deleted');
+          groupExists(GROUP_NAME).should('be.false');
+
+          cy.step('Reload the page and verify notification');
+          cy.reload();
+
+          administratorGroupSection.findWarningAlert(GROUP_NAME);
+        });
+      });
+    },
+  );
+
+  after(() => {
+    cy.step('recreate group, remove from admins, then delete it');
+
+    // recreate group
+    createGroup(GROUP_NAME);
+
+    // remove from admins
+    cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+    userManagement.navigate();
+
+    // remove the group from admins
+    cy.get(`[aria-label="Close ${GROUP_NAME}"]`).click();
+    userManagement.findSubmitButton().click();
+    userManagement.shouldHaveSuccessAlertMessage();
+
+    deleteGroup(GROUP_NAME);
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/groups.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/groups.ts
@@ -1,0 +1,57 @@
+import type { CommandLineResult } from '~/__tests__/cypress/cypress/types';
+
+/**
+ * Creates a new OpenShift group
+ * @param groupName Name of the group to create
+ * @returns A Cypress chainable that resolves to the command result
+ * @throws Error if the command fails
+ */
+export const createGroup = (groupName: string): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc adm groups new ${groupName} --dry-run=client -o yaml | oc apply --validate=false -f -`;
+  cy.log(`Creating group with command: ${ocCommand}`);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR creating group ${groupName}
+              stdout: ${result.stdout}
+              stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};
+
+/**
+ * Deletes an OpenShift group
+ * @param groupName Name of the group to delete
+ * @returns A Cypress chainable that resolves to the command result
+ * @throws Error if the command fails
+ */
+export const deleteGroup = (groupName: string): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc delete group ${groupName} --ignore-not-found`;
+  cy.log(`Deleting group with command: ${ocCommand}`);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      cy.log(`ERROR deleting group ${groupName}
+              stdout: ${result.stdout}
+              stderr: ${result.stderr}`);
+      throw new Error(`Command failed with code ${result.code}`);
+    }
+    return result;
+  });
+};
+
+/**
+ * Checks if a group exists
+ * @param groupName Name of the group to check
+ * @returns A Cypress chainable that resolves to true if the group exists, false otherwise
+ */
+export const groupExists = (groupName: string): Cypress.Chainable<boolean> => {
+  const ocCommand = `oc get group ${groupName}`;
+  cy.log(`Checking group existence with command: ${ocCommand}`);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+    return result.code === 0;
+  });
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22506

## Description
Migrates ODS-1686 Tier 1 to Cypress
Test is now added to the test script 'testUserGroupRemovedNotification.cy.ts'

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Tested against ODH-Nightly & RHOAI nightly

![image](https://github.com/user-attachments/assets/42c2cb05-6516-4056-a056-445d23e3a8a5)

- Tested via Jenkins pipeline https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/cypress/job/dashboard-tests/1464/Test_20Reports/ 


## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend and run the command npm run cypress:open . This will open the Cypress UI where testUserGroupRemovedNotification.cy.ts can be run.

Headless
Go to odh-dashboard/frontend and run the command npm run cypress:run -- --spec "src/__tests__/cypress/cypress/tests/e2e/settings/userManagement/testUserGroupRemovedNotification.cy.ts"

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`