### PR TITLE
Fix typos in documentation files and broken links in dev-setup.md

### DIFF
--- a/docs/admin-dashboard.md
+++ b/docs/admin-dashboard.md
@@ -23,7 +23,7 @@ spec:
 
 ```
 
-2. A part from that, we should have one or several `Groups` with the same name as the one mentioned above, here we should have all of our **admin users**.
+2. Apart from that, we should have one or several `Groups` with the same name as the one mentioned above, here we should have all of our **admin users**.
 
 ```yaml
 apiVersion: user.openshift.io/v1

--- a/docs/byon.md
+++ b/docs/byon.md
@@ -12,7 +12,7 @@ Once you have completed both steps you will see a section called `Notebook Image
 
 ## Minimum requirements for BYON
 
-For image to be spawneable via Jupyter Spawner, it is required to meet the following criteria:
+For image to be spawnable via Jupyter Spawner, it is required to meet the following criteria:
 
 * It needs to include Python runtime,  >= 3.8.
 * Python packages `jupyter` and `jupyterlab` need to be installed.

--- a/docs/dashboard-config.md
+++ b/docs/dashboard-config.md
@@ -2,11 +2,11 @@
 
 # Dashboard Config
 
-By default the ODH Dashboard comes with a set of core features enabled that are design to work for most scenarios. The dashboard can be configured from its OdhDashboard CR, `odh-dashboard-config`.
+By default the ODH Dashboard comes with a set of core features enabled that are designed to work for most scenarios. The dashboard can be configured from its OdhDashboard CR, `odh-dashboard-config`.
 
 ## Features
 
-The following are a list of features that are supported, along with there default settings.
+The following are a list of features that are supported, along with their default settings.
 
 | Feature                      | Default | Description                                                                                          |
 | ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -88,10 +88,10 @@ The [nightly](https://quay.io/opendatahub/odh-dashboard:nightly) tag is a floati
 
 ### Deploy using kustomize
 
-The [manifests](./manifests) folder contains a [kustomize](https://kustomize.io) manifest that can be used with `kustomize build`.
+The [manifests](../manifests) folder contains a [kustomize](https://kustomize.io) manifest that can be used with `kustomize build`.
 
 ### Deploy using a kfdef
 
 > Note: This flow is deprecated, deploy v2 [Operator](https://github.com/opendatahub-io/opendatahub-operator) with their custom CR.
 
-The [manifests/kfdef](./manifests/kfdef) folder contains an example kfdef to deploy ODH Dashboard with the Notebook Controller backend is located in [odh-dashboard-kfnbc-test.yaml](manifests/kfdef/odh-dashboard-kfnbc-test.yaml).
+The [manifests/kfdef](../manifests/kfdef) folder contains an example kfdef to deploy ODH Dashboard with the Notebook Controller backend is located in [odh-dashboard-kfnbc-test.yaml](../manifests/kfdef/odh-dashboard-kfnbc-test.yaml).


### PR DESCRIPTION
Typo and broken link fixes found with the help of Cursor