### PR TITLE
Trim Whitespace Bug Fix

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionOciPathField.tsx
@@ -11,7 +11,7 @@ import {
   FormSection,
   Alert,
 } from '@patternfly/react-core';
-import { trimInputOnBlur, trimInputOnPaste } from '~/concepts/connectionTypes/utils';
+import { trimInputOnPaste } from '~/concepts/connectionTypes/utils';
 
 type ConnectionOciPathFieldProps = {
   ociHost?: string;
@@ -73,10 +73,8 @@ const ConnectionOciPathField: React.FC<ConnectionOciPathFieldProps> = ({
                 onChange={(e, value: string) => {
                   setModelUri(value);
                 }}
-                onBlur={(e) => {
-                  trimInputOnBlur(modelUri, (trimmedValue) => {
-                    setModelUri(addUriPrefix(hideUriPrefix(trimmedValue)));
-                  })(e);
+                onBlur={() => {
+                  setModelUri(addUriPrefix(hideUriPrefix(modelUri?.trim())));
                 }}
                 onPaste={(e) => trimInputOnPaste(modelUri, setModelUri)(e)}
               />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Related to [RHOAIENG-2545](https://issues.redhat.com/browse/RHOAIENG-2545)
Fixes [RHOAIENG-25342](https://issues.redhat.com/browse/RHOAIENG-25342)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There was a bug causing problems with deploying an OCI model the new field trimming behavior was not always triggering on this field and was sometimes resulting in the modelUri lacking the `oci://` prefix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test yourself:
- go to a project with kserve enabled
- deploy a model with oci, use any of the options below typed or pasted into the input field for "Model URI" (the ___ are spaces, github was trimming them)
- Either look for the inference service in the network tab or go look at the inference service yaml in openshift
- `spec: predictor: storageUri:` should have the correct `oci://` prefix

**Tested Scenarios:**
- [x] Paste in “_____ registry.redhat.io/fake/model _____“
- [x] Paste in “__ oci://registry.redhat.io/fake/model __“
- [x] Paste in “__ http://registry.redhat.io/fake/model ___ “
- [x] Paste in “registry.redhat.io/fake/model”
- [x] Paste in “oci://registry.redhat.io/fake/model”
- [x] Paste in “http://registry.redhat.io/fake/model”
- [x] Type in “___ registry.redhat.io/fake/model ____“
- [x] Type in “  ____oci://registry.redhat.io/fake/model   ______      “
- [x] Type in “    _____ http://registry.redhat.io/fake/model      _______   “
- [x] Type in “registry.redhat.io/fake/model”
- [x] Type in “oci://registry.redhat.io/fake/model”
- [x] Type in “http://registry.redhat.io/fake/model”

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed for now but more specific tests should be added for the above scenarios.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
