### PR TITLE
Small update to remove documentation link

### DIFF
--- a/frontend/src/pages/clusterSettings/TelemetrySettings.tsx
+++ b/frontend/src/pages/clusterSettings/TelemetrySettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox, Content, ContentVariants } from '@patternfly/react-core';
+import { Checkbox } from '@patternfly/react-core';
 import SettingSection from '~/components/SettingSection';
 
 type TelemetrySettingsProps = {
@@ -20,22 +20,7 @@ const TelemetrySettings: React.FC<TelemetrySettingsProps> = ({
   }, [initialValue, setEnabled]);
 
   return (
-    <SettingSection
-      title="Usage data collection"
-      footer={
-        <Content component={ContentVariants.small}>
-          For more information see the{' '}
-          <Content
-            component={ContentVariants.a}
-            href="https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/managing_resources/managing-collection-of-usage-data"
-            target="_blank"
-          >
-            documentation
-          </Content>
-          .
-        </Content>
-      }
-    >
+    <SettingSection title="Usage data collection">
       <Checkbox
         label="Allow collection of usage data"
         isChecked={enabled}


### PR DESCRIPTION
Closes: [RHOAIENG-1198](https://issues.redhat.com/browse/RHOAIENG-1198)

## Description
Small update to remove the documentation link from usage data collection.

## How Has This Been Tested?
Tested locally. 

- Ensure that the disableTracking feature flag is unchecked.
- Navigate to cluster settings. 
- Towards the bottom, under usage data collection, there should no longer be a documentation link

## Test Impact
No tests changed

## Screenshots
Before:
<img width="365" alt="Screenshot 2025-05-12 at 2 30 08 PM" src="https://github.com/user-attachments/assets/3ad203e1-e86a-48fc-8280-87575f56722e" />

After:
<img width="309" alt="Screenshot 2025-05-12 at 2 29 53 PM" src="https://github.com/user-attachments/assets/5070e490-9786-409f-a387-ad4c9f008be1" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
