### PR TITLE
added unit tests for useModelArtifactsByVersionId.ts

### DIFF
--- a/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelArtifactsByVersionId.spec.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/__tests__/useModelArtifactsByVersionId.spec.ts
@@ -1,0 +1,131 @@
+import { testHook, standardUseFetchState } from '~/__tests__/unit/testUtils/hooks';
+import useModelArtifactsByVersionId from '~/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId';
+import { ModelArtifactList } from '~/concepts/modelRegistry/types';
+import { useModelRegistryAPI } from '~/concepts/modelRegistry/context/ModelRegistryContext';
+import { mockModelArtifactList } from '~/__mocks__/mockModelArtifactList';
+
+// Mock the useModelRegistryAPI hook
+jest.mock('~/concepts/modelRegistry/context/ModelRegistryContext', () => ({
+  useModelRegistryAPI: jest.fn(),
+}));
+
+const mockUseModelRegistryAPI = jest.mocked(useModelRegistryAPI);
+
+describe('useModelArtifactsByVersionId', () => {
+  const mockGetModelArtifactsByModelVersion = jest.fn();
+  const defaultEmptyState: ModelArtifactList = {
+    items: [],
+    size: 0,
+    pageSize: 0,
+    nextPageToken: '',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: {
+        getModelArtifactsByModelVersion: mockGetModelArtifactsByModelVersion,
+      },
+      apiAvailable: true,
+    } as unknown as ReturnType<typeof useModelRegistryAPI>);
+  });
+
+  it('should fetch model artifacts when modelVersionId is provided and api available', async () => {
+    mockGetModelArtifactsByModelVersion.mockResolvedValue(mockModelArtifactList({}));
+
+    const renderResult = testHook(useModelArtifactsByVersionId)('test-version-id');
+
+    // Initial state
+    expect(renderResult.result.current).toStrictEqual(
+      standardUseFetchState({ items: [], size: 0, pageSize: 0, nextPageToken: '' }),
+    );
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    // Wait for data to be fetched
+    await renderResult.waitForNextUpdate();
+
+    // State after data fetched
+    expect(renderResult.result.current).toStrictEqual(
+      standardUseFetchState(mockModelArtifactList({}), true),
+    );
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(mockGetModelArtifactsByModelVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle NotReadyError when modelVersionId is not provided', async () => {
+    const renderResult = testHook(useModelArtifactsByVersionId)();
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(defaultEmptyState));
+    expect(mockGetModelArtifactsByModelVersion).not.toHaveBeenCalled();
+  });
+
+  it('should fetch model artifacts when modelVersionId is provided', async () => {
+    const modelVersionId = 'test-version-id';
+
+    mockGetModelArtifactsByModelVersion.mockResolvedValue(mockModelArtifactList({}));
+    const renderResult = testHook(useModelArtifactsByVersionId)(modelVersionId);
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(defaultEmptyState));
+
+    // Wait for data to be fetched
+    await renderResult.waitForNextUpdate();
+
+    // Verify API was called with correct parameters
+    expect(mockGetModelArtifactsByModelVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+      modelVersionId,
+    );
+
+    // Verify state was updated correctly
+    expect(renderResult.result.current).toStrictEqual(
+      standardUseFetchState(mockModelArtifactList({}), true),
+    );
+  });
+
+  it('should handle errors when fetching model artifacts', async () => {
+    const modelVersionId = 'test-version-id';
+    const mockError = new Error('Failed to fetch model artifacts');
+
+    mockGetModelArtifactsByModelVersion.mockRejectedValue(mockError);
+
+    const renderResult = testHook(useModelArtifactsByVersionId)(modelVersionId);
+
+    // Initial state before async update
+    expect(renderResult.result.current).toStrictEqual(standardUseFetchState(defaultEmptyState));
+
+    // Wait for error to be caught
+    await renderResult.waitForNextUpdate();
+
+    // Verify API was called with correct parameters
+    expect(mockGetModelArtifactsByModelVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+      modelVersionId,
+    );
+
+    // Verify error state was set correctly
+    expect(renderResult.result.current).toStrictEqual(
+      standardUseFetchState(defaultEmptyState, false, mockError),
+    );
+  });
+
+  it('should not make API calls when API is not available', () => {
+    jest.resetModules();
+    // Set up the mocks to return a non-API state
+    mockUseModelRegistryAPI.mockReturnValue({
+      api: {
+        getModelArtifactsByModelVersion: mockGetModelArtifactsByModelVersion,
+      },
+      apiAvailable: false,
+    } as unknown as ReturnType<typeof useModelRegistryAPI>);
+    const modelVersionId = 'test-version-id';
+    const renderResult = testHook(useModelArtifactsByVersionId)(modelVersionId);
+
+    // Verify the hook returned the initial state
+    expect(renderResult.result.current[0]).toEqual(defaultEmptyState);
+
+    // Verify the API was not called
+    expect(mockGetModelArtifactsByModelVersion).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId.ts
+++ b/frontend/src/concepts/modelRegistry/apiHooks/useModelArtifactsByVersionId.ts
@@ -8,15 +8,19 @@ import { ModelArtifactList } from '~/concepts/modelRegistry/types';
 import { useModelRegistryAPI } from '~/concepts/modelRegistry/context/ModelRegistryContext';
 
 const useModelArtifactsByVersionId = (modelVersionId?: string): FetchState<ModelArtifactList> => {
-  const { api } = useModelRegistryAPI();
+  const { api, apiAvailable } = useModelRegistryAPI();
   const callback = React.useCallback<FetchStateCallbackPromise<ModelArtifactList>>(
     (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new NotReadyError('API not yet available'));
+      }
       if (!modelVersionId) {
         return Promise.reject(new NotReadyError('No model registeredModel id'));
       }
+
       return api.getModelArtifactsByModelVersion(opts, modelVersionId);
     },
-    [api, modelVersionId],
+    [api, apiAvailable, modelVersionId],
   );
 
   return useFetchState(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-24225
## Description
added test for useModelArtifactsByVersionId

<img width="1301" alt="Screenshot 2025-05-13 at 1 35 19 PM" src="https://github.com/user-attachments/assets/fa24f5d4-8eff-4663-8ccd-d19dd34541af" />

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
run the jest test check for coverage and test pass
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added jest test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
