### PR TITLE
User can lose unsaved edits without warning on model registry details pages

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails.ts
@@ -1,4 +1,5 @@
 import { TableRow } from '~/__tests__/cypress/cypress/pages/components/table';
+import { Modal } from '~/__tests__/cypress/cypress/pages/components/Modal';
 
 class ModelVersionDetails {
   visit() {
@@ -197,6 +198,25 @@ class ModelVersionDetails {
   }
 }
 
+class NavigationBlockerModal extends Modal {
+  constructor() {
+    super('Discard unsaved changes?');
+  }
+
+  findDiscardButton() {
+    return cy.findByTestId('confirm-discard-changes');
+  }
+
+  findCloseModal() {
+    return cy.findByTestId('cancel-discard-changes');
+  }
+
+  findDiscardUnsavedChanges() {
+    return cy.findByText('Discard unsaved changes?');
+  }
+}
+
 class PropertyRow extends TableRow {}
 
 export const modelVersionDetails = new ModelVersionDetails();
+export const navigationBlockerModal = new NavigationBlockerModal();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -22,7 +22,10 @@ import {
   ServingRuntimeModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
-import { modelVersionDetails } from '~/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails';
+import {
+  modelVersionDetails,
+  navigationBlockerModal,
+} from '~/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails';
 import { InferenceServiceModelState } from '~/pages/modelServing/screens/types';
 import { modelServingGlobal } from '~/__tests__/cypress/cypress/pages/modelServing';
 import {
@@ -526,6 +529,38 @@ describe('Model version details', () => {
       modelVersionDetails.findPipelineRunLink().should('contain.text', 'pipeline-run-test');
       modelVersionDetails.findProjectAccessInfoButton().click();
       modelVersionDetails.shouldHaveProjectAccessInfo();
+    });
+  });
+
+  describe('Discard unsaved changes', () => {
+    beforeEach(() => {
+      initIntercepts();
+      modelVersionDetails.visit();
+    });
+
+    it('should show discard modal when editing and moving to Deployments tab', () => {
+      modelVersionDetails.findEditLabelsButton().click();
+      modelVersionDetails.findAddLabelButton().click();
+      cy.findByTestId('editable-label-group').within(() => {
+        cy.contains('New Label').should('exist').click();
+      });
+
+      modelVersionDetails.findRegisteredDeploymentsTab().click();
+      navigationBlockerModal.findDiscardUnsavedChanges().should('exist');
+      navigationBlockerModal.findDiscardButton().click();
+      modelVersionDetails.findDetailsTab().click();
+    });
+
+    it('should continue editing when clicking cancel', () => {
+      modelVersionDetails.findEditLabelsButton().click();
+      modelVersionDetails.findAddLabelButton().click();
+      cy.findByTestId('editable-label-group').within(() => {
+        cy.contains('New Label').should('exist').click();
+      });
+
+      modelVersionDetails.findRegisteredDeploymentsTab().click();
+      navigationBlockerModal.findCloseModal().click();
+      cy.findByTestId('editable-labels-group-save').should('exist');
     });
   });
 

--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { sdkStore, store } from './redux/store/store';
 import App from './app/App';
@@ -10,7 +10,22 @@ import { BrowserStorageContextProvider } from './components/browserStorage/Brows
 import ErrorBoundary from './components/error/ErrorBoundary';
 import { ReduxContext } from './redux/context';
 
-/**
+// Creates a data router using createBrowserRouter
+const router = createBrowserRouter([
+  {
+    path: '*',
+    element: (
+      <SDKInitialize>
+        <BrowserStorageContextProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </BrowserStorageContextProvider>
+      </SDKInitialize>
+    ),
+  },
+]);
+
 /**
  * Main function
  */
@@ -23,15 +38,7 @@ root.render(
     <ErrorBoundary>
       <Provider store={sdkStore}>
         <Provider store={store} context={ReduxContext}>
-          <Router>
-            <SDKInitialize>
-              <BrowserStorageContextProvider>
-                <ThemeProvider>
-                  <App />
-                </ThemeProvider>
-              </BrowserStorageContextProvider>
-            </SDKInitialize>
-          </Router>
+          <RouterProvider router={router} />
         </Provider>
       </Provider>
     </ErrorBoundary>

--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -147,7 +147,12 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
           {isEditing ? contentWhenEditing : isEmpty ? contentWhenEmpty : children}
         </DescriptionListDescription>
       </DescriptionListGroup>
-      {hasUnsavedChanges && <NavigationBlockerModal hasUnsavedChanges={hasUnsavedChanges} />}
+      {hasUnsavedChanges && (
+        <NavigationBlockerModal
+          hasUnsavedChanges={hasUnsavedChanges}
+          onDiscardEditsClick={onDiscardEditsClick}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -19,9 +19,10 @@ import {
   TimesIcon,
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
+import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
 
 import './DashboardDescriptionListGroup.scss';
-import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconButton';
+import { useBrowserUnloadBlocker } from '~/utilities/useBrowserUnloadBlocker';
 
 type EditableProps = {
   isEditing: boolean;
@@ -68,6 +69,9 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
     cancelButtonTestId,
     isSaveDisabled,
   } = props;
+
+  useBrowserUnloadBlocker(!!(isEditable && isEditing));
+
   return (
     <DescriptionListGroup data-testid={groupTestId}>
       {action || isEditable ? (

--- a/frontend/src/components/DashboardDescriptionListGroup.tsx
+++ b/frontend/src/components/DashboardDescriptionListGroup.tsx
@@ -23,6 +23,7 @@ import DashboardPopupIconButton from '~/concepts/dashboard/DashboardPopupIconBut
 
 import './DashboardDescriptionListGroup.scss';
 import { useBrowserUnloadBlocker } from '~/utilities/useBrowserUnloadBlocker';
+import NavigationBlockerModal from './NavigationBlockerModal';
 
 type EditableProps = {
   isEditing: boolean;
@@ -70,79 +71,84 @@ const DashboardDescriptionListGroup: React.FC<DashboardDescriptionListGroupProps
     isSaveDisabled,
   } = props;
 
-  useBrowserUnloadBlocker(!!(isEditable && isEditing));
+  const hasUnsavedChanges = !!(isEditable && isEditing);
+
+  useBrowserUnloadBlocker(hasUnsavedChanges);
 
   return (
-    <DescriptionListGroup data-testid={groupTestId}>
-      {action || isEditable ? (
-        <DescriptionListTerm className="odh-custom-description-list-term-with-action">
-          <Split>
-            <SplitItem isFilled>{title}</SplitItem>
-            <SplitItem>
-              {action ||
-                (isEditing ? (
-                  <ActionList isIconList>
-                    <ActionListItem>
-                      <Button
-                        data-testid={saveButtonTestId}
-                        icon={<CheckIcon />}
-                        aria-label={`Save edits to ${title}`}
-                        variant="link"
-                        onClick={onSaveEditsClick}
-                        isDisabled={isSavingEdits || isSaveDisabled}
-                      />
-                    </ActionListItem>
-                    <ActionListItem>
-                      <Button
-                        data-testid={cancelButtonTestId}
-                        icon={<TimesIcon />}
-                        aria-label={`Discard edits to ${title} `}
-                        variant="plain"
-                        onClick={onDiscardEditsClick}
-                        isDisabled={isSavingEdits}
-                      />
-                    </ActionListItem>
-                  </ActionList>
-                ) : (
-                  <Button
-                    data-testid={editButtonTestId}
-                    aria-label={`Edit ${title}`}
-                    variant="link"
-                    icon={<PencilAltIcon />}
-                    iconPosition="start"
-                    onClick={onEditClick}
-                  >
-                    Edit
-                  </Button>
-                ))}
-            </SplitItem>
-          </Split>
-        </DescriptionListTerm>
-      ) : (
-        <DescriptionListTerm>
-          <Flex
-            spaceItems={{ default: 'spaceItemsNone' }}
-            alignItems={{ default: 'alignItemsCenter' }}
-          >
-            <FlexItem>{title}</FlexItem>
-            {popover && (
-              <Popover bodyContent={popover}>
-                <DashboardPopupIconButton
-                  icon={<OutlinedQuestionCircleIcon />}
-                  aria-label="More info"
-                />
-              </Popover>
-            )}
-          </Flex>
-        </DescriptionListTerm>
-      )}
-      <DescriptionListDescription
-        className={isEmpty && !isEditing ? text.textColorDisabled : ''}
-        aria-disabled={!!(isEmpty && !isEditing)}
-      >
-        {isEditing ? contentWhenEditing : isEmpty ? contentWhenEmpty : children}
-      </DescriptionListDescription>
-    </DescriptionListGroup>
+    <>
+      <DescriptionListGroup data-testid={groupTestId}>
+        {action || isEditable ? (
+          <DescriptionListTerm className="odh-custom-description-list-term-with-action">
+            <Split>
+              <SplitItem isFilled>{title}</SplitItem>
+              <SplitItem>
+                {action ||
+                  (isEditing ? (
+                    <ActionList isIconList>
+                      <ActionListItem>
+                        <Button
+                          data-testid={saveButtonTestId}
+                          icon={<CheckIcon />}
+                          aria-label={`Save edits to ${title}`}
+                          variant="link"
+                          onClick={onSaveEditsClick}
+                          isDisabled={isSavingEdits || isSaveDisabled}
+                        />
+                      </ActionListItem>
+                      <ActionListItem>
+                        <Button
+                          data-testid={cancelButtonTestId}
+                          icon={<TimesIcon />}
+                          aria-label={`Discard edits to ${title} `}
+                          variant="plain"
+                          onClick={onDiscardEditsClick}
+                          isDisabled={isSavingEdits}
+                        />
+                      </ActionListItem>
+                    </ActionList>
+                  ) : (
+                    <Button
+                      data-testid={editButtonTestId}
+                      aria-label={`Edit ${title}`}
+                      variant="link"
+                      icon={<PencilAltIcon />}
+                      iconPosition="start"
+                      onClick={onEditClick}
+                    >
+                      Edit
+                    </Button>
+                  ))}
+              </SplitItem>
+            </Split>
+          </DescriptionListTerm>
+        ) : (
+          <DescriptionListTerm>
+            <Flex
+              spaceItems={{ default: 'spaceItemsNone' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <FlexItem>{title}</FlexItem>
+              {popover && (
+                <Popover bodyContent={popover}>
+                  <DashboardPopupIconButton
+                    icon={<OutlinedQuestionCircleIcon />}
+                    aria-label="More info"
+                  />
+                </Popover>
+              )}
+            </Flex>
+          </DescriptionListTerm>
+        )}
+        <DescriptionListDescription
+          className={isEmpty && !isEditing ? text.textColorDisabled : ''}
+          aria-disabled={!!(isEmpty && !isEditing)}
+        >
+          {isEditing ? contentWhenEditing : isEmpty ? contentWhenEmpty : children}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      {hasUnsavedChanges && <NavigationBlockerModal hasUnsavedChanges={hasUnsavedChanges} />}
+    </>
   );
 };
 

--- a/frontend/src/components/NavigationBlockerModal.tsx
+++ b/frontend/src/components/NavigationBlockerModal.tsx
@@ -5,50 +5,71 @@ import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 interface NavigationBlockerModalProps {
   hasUnsavedChanges: boolean;
+  onDiscardEditsClick?: () => void;
 }
 
 /**
  * A modal that warns users they have unsaved changes when they try to navigate away.
  * Uses React Router's useBlocker hook to detect navigation attempts.
  */
-const NavigationBlockerModal: React.FC<NavigationBlockerModalProps> = ({ hasUnsavedChanges }) => {
+const NavigationBlockerModal: React.FC<NavigationBlockerModalProps> = ({
+  hasUnsavedChanges,
+  onDiscardEditsClick,
+}) => {
   const [showModal, setShowModal] = React.useState(false);
-  const [callbacks, setCallbacks] = React.useState<{
-    proceed?: () => void;
-    reset?: () => void;
-  }>({});
+
+  const proceedRef = React.useRef<() => void>();
+  const resetRef = React.useRef<() => void>();
+  const handlingRef = React.useRef(false);
 
   const blocker = useBlocker(
     React.useCallback(
       ({ currentLocation, nextLocation }: { currentLocation: Location; nextLocation: Location }) =>
-        hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname,
+        hasUnsavedChanges &&
+        currentLocation.pathname !== nextLocation.pathname &&
+        !handlingRef.current,
       [hasUnsavedChanges],
     ),
   );
 
   React.useEffect(() => {
-    if (blocker.state === 'blocked') {
-      setShowModal(true);
-      setCallbacks({
-        proceed: blocker.proceed,
-        reset: blocker.reset,
-      });
+    if (!hasUnsavedChanges && showModal && proceedRef.current) {
+      handlingRef.current = true;
+      proceedRef.current();
+      setShowModal(false);
+    }
+  }, [hasUnsavedChanges, showModal]);
+
+  React.useEffect(() => {
+    switch (blocker.state) {
+      case 'blocked':
+        proceedRef.current = blocker.proceed;
+        resetRef.current = blocker.reset;
+        setShowModal(true);
+        break;
+      case 'proceeding':
+        handlingRef.current = true;
+        setShowModal(false);
+        break;
+      default:
+        handlingRef.current = false;
     }
   }, [blocker]);
 
-  const handleConfirm = React.useCallback(() => {
+  const handleConfirm = () => {
+    handlingRef.current = true;
+    onDiscardEditsClick?.();
     setShowModal(false);
-    if (callbacks.proceed) {
-      callbacks.proceed();
-    }
-  }, [callbacks]);
+    proceedRef.current?.();
+  };
 
-  const handleCancel = React.useCallback(() => {
+  const handleCancel = () => {
     setShowModal(false);
-    if (callbacks.reset) {
-      callbacks.reset();
-    }
-  }, [callbacks]);
+    resetRef.current?.();
+    setTimeout(() => {
+      handlingRef.current = false;
+    }, 100);
+  };
 
   if (!showModal) {
     return null;

--- a/frontend/src/components/NavigationBlockerModal.tsx
+++ b/frontend/src/components/NavigationBlockerModal.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { useBlocker, Location } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
+import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+
+interface NavigationBlockerModalProps {
+  hasUnsavedChanges: boolean;
+}
+
+/**
+ * A modal that warns users they have unsaved changes when they try to navigate away.
+ * Uses React Router's useBlocker hook to detect navigation attempts.
+ */
+const NavigationBlockerModal: React.FC<NavigationBlockerModalProps> = ({ hasUnsavedChanges }) => {
+  const [showModal, setShowModal] = React.useState(false);
+  const [callbacks, setCallbacks] = React.useState<{
+    proceed?: () => void;
+    reset?: () => void;
+  }>({});
+
+  const blocker = useBlocker(
+    React.useCallback(
+      ({ currentLocation, nextLocation }: { currentLocation: Location; nextLocation: Location }) =>
+        hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname,
+      [hasUnsavedChanges],
+    ),
+  );
+
+  React.useEffect(() => {
+    if (blocker.state === 'blocked') {
+      setShowModal(true);
+      setCallbacks({
+        proceed: blocker.proceed,
+        reset: blocker.reset,
+      });
+    }
+  }, [blocker]);
+
+  const handleConfirm = React.useCallback(() => {
+    setShowModal(false);
+    if (callbacks.proceed) {
+      callbacks.proceed();
+    }
+  }, [callbacks]);
+
+  const handleCancel = React.useCallback(() => {
+    setShowModal(false);
+    if (callbacks.reset) {
+      callbacks.reset();
+    }
+  }, [callbacks]);
+
+  if (!showModal) {
+    return null;
+  }
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Discard unsaved changes?"
+      isOpen
+      onClose={handleCancel}
+      actions={[
+        <Button
+          key="confirm"
+          variant="primary"
+          onClick={handleConfirm}
+          data-testid="confirm-discard-changes"
+        >
+          Discard
+        </Button>,
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={handleCancel}
+          data-testid="cancel-discard-changes"
+        >
+          Cancel
+        </Button>,
+      ]}
+    >
+      One or more of your changes on this page are not saved yet. Discard your changes and leave
+      this page, or cancel to continue editing.
+    </Modal>
+  );
+};
+
+export default NavigationBlockerModal;

--- a/frontend/src/components/__tests__/DashboardDescriptionListGroup.spec.tsx
+++ b/frontend/src/components/__tests__/DashboardDescriptionListGroup.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import * as BrowserUnloadBlocker from '~/utilities/useBrowserUnloadBlocker';
+import DashboardDescriptionListGroup from '~/components/DashboardDescriptionListGroup';
+import '@testing-library/jest-dom';
+
+jest.mock('~/components/NavigationBlockerModal', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(({ hasUnsavedChanges }) =>
+      hasUnsavedChanges ? (
+        <div data-testid="navigation-blocker">Navigation Blocker Modal</div>
+      ) : null,
+    ),
+}));
+
+jest.mock('~/utilities/useBrowserUnloadBlocker', () => ({
+  useBrowserUnloadBlocker: jest.fn(),
+}));
+
+describe('DashboardDescriptionListGroup', () => {
+  const defaultProps = {
+    title: 'Test Title',
+    children: <div>Test Content</div>,
+  };
+
+  const editableProps = {
+    ...defaultProps,
+    isEditable: true,
+    isEditing: false,
+    contentWhenEditing: <div>Editing Content</div>,
+    onEditClick: jest.fn(),
+    onSaveEditsClick: jest.fn(),
+    onDiscardEditsClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly with basic props', () => {
+    render(<DashboardDescriptionListGroup {...defaultProps} />);
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should render edit button when isEditable is true', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} />);
+
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  it('should render save and cancel buttons when isEditing is true', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} isEditing />);
+
+    expect(screen.getByLabelText(/Save edits to/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Discard edits to/)).toBeInTheDocument();
+  });
+
+  it('should not render NavigationBlockerModal when not editing', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} />);
+    expect(screen.queryByTestId('navigation-blocker')).not.toBeInTheDocument();
+  });
+
+  it('should render NavigationBlockerModal when editing', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} isEditing />);
+    expect(screen.getByTestId('navigation-blocker')).toBeInTheDocument();
+  });
+
+  it('should call useBrowserUnloadBlocker with true when editing', () => {
+    const useBrowserUnloadBlockerSpy = jest.spyOn(BrowserUnloadBlocker, 'useBrowserUnloadBlocker');
+
+    render(<DashboardDescriptionListGroup {...editableProps} isEditing />);
+    expect(useBrowserUnloadBlockerSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('should call useBrowserUnloadBlocker with false when not editing', () => {
+    const useBrowserUnloadBlockerSpy = jest.spyOn(BrowserUnloadBlocker, 'useBrowserUnloadBlocker');
+
+    render(<DashboardDescriptionListGroup {...editableProps} />);
+    expect(useBrowserUnloadBlockerSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('should call onEditClick when edit button is clicked', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} />);
+    fireEvent.click(screen.getByText('Edit'));
+    expect(editableProps.onEditClick).toHaveBeenCalled();
+  });
+
+  it('should call onSaveEditsClick when save button is clicked', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Save edits to/));
+    expect(editableProps.onSaveEditsClick).toHaveBeenCalled();
+  });
+
+  it('should call onDiscardEditsClick when cancel button is clicked', () => {
+    render(<DashboardDescriptionListGroup {...editableProps} isEditing />);
+    fireEvent.click(screen.getByLabelText(/Discard edits to/));
+    expect(editableProps.onDiscardEditsClick).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/NavigationBlockerModal.spec.tsx
+++ b/frontend/src/components/__tests__/NavigationBlockerModal.spec.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import * as ReactRouterDom from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Location, Blocker } from 'react-router-dom';
+import NavigationBlockerModal from '~/components/NavigationBlockerModal';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useBlocker: jest.fn(),
+}));
+
+describe('NavigationBlockerModal', () => {
+  const mockProceed = jest.fn();
+  const mockReset = jest.fn();
+
+  const mockLocation: Location = {
+    pathname: '/some-path',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'default',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render when navigation is not blocked', () => {
+    const mockBlocker = {
+      state: 'unblocked',
+    } as Blocker;
+    jest.spyOn(ReactRouterDom, 'useBlocker').mockReturnValue(mockBlocker);
+
+    render(<NavigationBlockerModal hasUnsavedChanges />);
+    expect(screen.queryByText('Discard unsaved changes?')).not.toBeInTheDocument();
+  });
+
+  it('should render when navigation is blocked', () => {
+    const mockBlocker = {
+      state: 'blocked',
+      location: mockLocation,
+      proceed: mockProceed,
+      reset: mockReset,
+    } as Blocker;
+    jest.spyOn(ReactRouterDom, 'useBlocker').mockReturnValue(mockBlocker);
+
+    render(<NavigationBlockerModal hasUnsavedChanges />);
+
+    expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument();
+    expect(
+      screen.getByText(/One or more of your changes on this page are not saved yet/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Discard')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('should call proceed when discard button is clicked', () => {
+    const mockBlocker = {
+      state: 'blocked',
+      location: mockLocation,
+      proceed: mockProceed,
+      reset: mockReset,
+    } as Blocker;
+    jest.spyOn(ReactRouterDom, 'useBlocker').mockReturnValue(mockBlocker);
+
+    render(<NavigationBlockerModal hasUnsavedChanges />);
+    fireEvent.click(screen.getByText('Discard'));
+    expect(mockProceed).toHaveBeenCalled();
+  });
+
+  it('should call reset when cancel button is clicked', () => {
+    const mockBlocker = {
+      state: 'blocked',
+      location: mockLocation,
+      proceed: mockProceed,
+      reset: mockReset,
+    } as Blocker;
+    jest.spyOn(ReactRouterDom, 'useBlocker').mockReturnValue(mockBlocker);
+
+    render(<NavigationBlockerModal hasUnsavedChanges />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  describe('navigation blocking conditions', () => {
+    type BlockerCallbackArg = {
+      currentLocation: Location;
+      nextLocation: Location;
+    };
+    type BlockerCallbackFn = (arg: BlockerCallbackArg) => boolean;
+
+    let capturedCallback: BlockerCallbackFn | null = null;
+
+    beforeEach(() => {
+      capturedCallback = null;
+      jest.spyOn(ReactRouterDom, 'useBlocker').mockImplementation((callback) => {
+        capturedCallback = callback as BlockerCallbackFn;
+        return {
+          state: 'unblocked',
+        } as Blocker;
+      });
+    });
+
+    it('should not block navigation when hasUnsavedChanges is false', () => {
+      render(<NavigationBlockerModal hasUnsavedChanges={false} />);
+      expect(capturedCallback).not.toBeNull();
+
+      if (capturedCallback) {
+        const result = capturedCallback({
+          currentLocation: { ...mockLocation, pathname: '/current' },
+          nextLocation: { ...mockLocation, pathname: '/next' },
+        });
+
+        expect(result).toBe(false);
+      }
+    });
+
+    it('should block navigation when hasUnsavedChanges is true and paths are different', () => {
+      render(<NavigationBlockerModal hasUnsavedChanges />);
+
+      expect(capturedCallback).not.toBeNull();
+
+      if (capturedCallback) {
+        const result = capturedCallback({
+          currentLocation: { ...mockLocation, pathname: '/current' },
+          nextLocation: { ...mockLocation, pathname: '/next' },
+        });
+
+        expect(result).toBe(true);
+      }
+    });
+
+    it('should not block navigation when hasUnsavedChanges is true and paths are the same', () => {
+      render(<NavigationBlockerModal hasUnsavedChanges />);
+
+      expect(capturedCallback).not.toBeNull();
+
+      if (capturedCallback) {
+        const result = capturedCallback({
+          currentLocation: { ...mockLocation, pathname: '/same' },
+          nextLocation: { ...mockLocation, pathname: '/same' },
+        });
+
+        expect(result).toBe(false);
+      }
+    });
+  });
+});

--- a/frontend/src/utilities/__tests__/useBrowserUnloadBlocker.spec.ts
+++ b/frontend/src/utilities/__tests__/useBrowserUnloadBlocker.spec.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { useBrowserUnloadBlocker } from '~/utilities/useBrowserUnloadBlocker';
+
+describe('useBrowserUnloadBlocker', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+  let preventDefaultSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+    preventDefaultSpy = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should add beforeunload event listener when shouldBlock is true', () => {
+    renderHook(() => useBrowserUnloadBlocker(true));
+    expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('should not add beforeunload event listener when shouldBlock is false', () => {
+    renderHook(() => useBrowserUnloadBlocker(false));
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should remove event listener on unmount when shouldBlock is true', () => {
+    const { unmount } = renderHook(() => useBrowserUnloadBlocker(true));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('should prevent default and set returnValue when beforeunload is triggered', () => {
+    renderHook(() => useBrowserUnloadBlocker(true));
+
+    const [[, handler]] = addEventListenerSpy.mock.calls;
+
+    const event = {
+      preventDefault: preventDefaultSpy,
+      returnValue: '',
+    };
+
+    handler(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  it('should cleanup properly when shouldBlock changes from true to false', () => {
+    const { rerender } = renderHook(({ shouldBlock }) => useBrowserUnloadBlocker(shouldBlock), {
+      initialProps: { shouldBlock: true },
+    });
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ shouldBlock: false });
+
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utilities/useBrowserUnloadBlocker.tsx
+++ b/frontend/src/utilities/useBrowserUnloadBlocker.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useCallback } from 'react';
+
+/**
+ * Use this hook to block the browser from unloading when the user has unsaved changes.
+ * @param shouldBlock - Whether to block the browser from unloading.
+ */
+export function useBrowserUnloadBlocker(shouldBlock: boolean): void {
+  const handleBeforeUnload = useCallback(
+    (e: BeforeUnloadEvent) => {
+      if (shouldBlock) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    },
+    [shouldBlock],
+  );
+
+  useEffect(() => {
+    if (!shouldBlock) {
+      return;
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [shouldBlock, handleBeforeUnload]);
+}


### PR DESCRIPTION
[RHOAIENG-13914](https://issues.redhat.com/browse/RHOAIENG-13914)

## Description
* Added useBrowserUnloadBlocker to simplify navigation blocking to browser unload events
* Users now will get error if they try to navigate during editing in Model registry and model version details page.

Browser warning
https://github.com/user-attachments/assets/dc6ead44-f44a-4c0e-8164-dd286321b3b6

![Screenshot 2025-05-14 at 2 22 39 PM](https://github.com/user-attachments/assets/c195eb9e-051b-4389-ad04-1330fe5ac9e4)

Dashboard navigation warning modal
https://github.com/user-attachments/assets/020e0829-926a-40a2-986d-8bb4f55ba270

![Screenshot 2025-05-14 at 2 21 54 PM](https://github.com/user-attachments/assets/ce9a919a-ac60-41c8-8528-9a8a2bafaa50)


## How Has This Been Tested?
1. Navigate to details page of model regisrty or model version.
2. Try edit something and click on refresh or try clicking somewhere on the dashboard.
3. You'll get warning modal.

## Test Impact
Added unit test for the hook.
Added cypress test to check discard modal in model version details page.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
@yih-wang 