### PR TITLE
Add project-scoped items for model mesh

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -30,6 +30,7 @@ type MockResourceConfigType = {
   additionalVolumeMounts?: VolumeMount[];
   additionalVolumes?: Volume[];
   hardwareProfileName?: string;
+  hardwareProfileNamespace?: string | null;
 };
 
 export const mockNotebookK8sResource = ({
@@ -55,6 +56,7 @@ export const mockNotebookK8sResource = ({
   additionalVolumeMounts = [],
   additionalVolumes = [],
   hardwareProfileName = '',
+  hardwareProfileNamespace = null,
 }: MockResourceConfigType): NotebookKind =>
   _.merge(
     {
@@ -73,6 +75,7 @@ export const mockNotebookK8sResource = ({
           'openshift.io/description': description,
           'openshift.io/display-name': displayName,
           'opendatahub.io/hardware-profile-name': hardwareProfileName,
+          'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
         },
         creationTimestamp: '2023-02-14T21:44:13Z',
         generation: 4,

--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -20,6 +20,7 @@ type MockResourceConfigType = {
   templateDisplayName?: string;
   isProjectScoped?: boolean;
   scope?: string;
+  hardwareProfileNamespace?: string;
 };
 
 export const mockServingRuntimeK8sResourceLegacy = ({
@@ -128,6 +129,7 @@ export const mockServingRuntimeK8sResource = ({
   templateDisplayName = 'OpenVINO Serving Runtime (Supports GPUs)',
   isProjectScoped = false,
   scope,
+  hardwareProfileNamespace = undefined,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
@@ -141,6 +143,7 @@ export const mockServingRuntimeK8sResource = ({
       'opendatahub.io/template-display-name': templateDisplayName,
       'opendatahub.io/accelerator-name': acceleratorName,
       'opendatahub.io/hardware-profile-name': hardwareProfileName,
+
       'opendatahub.io/template-name': 'ovms',
       'openshift.io/display-name': displayName,
       'opendatahub.io/apiProtocol': apiProtocol,
@@ -149,6 +152,9 @@ export const mockServingRuntimeK8sResource = ({
         'enable-route': route ? 'true' : 'false',
       }),
       ...(isProjectScoped && { 'opendatahub.io/serving-runtime-scope': scope }),
+      ...(hardwareProfileNamespace && {
+        'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
+      }),
     },
     name,
     namespace,

--- a/frontend/src/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection.ts
@@ -1,0 +1,45 @@
+import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Contextual';
+
+class AcceleratorProfileGroup extends Contextual<HTMLElement> {}
+
+export class AcceleratorProfileSection {
+  findSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('accelerator-profile-select');
+  }
+
+  findAcceleratorProfileSearchSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('accelerator-profile-selection-toggle');
+  }
+
+  findAcceleratorProfileSearchInput(): Cypress.Chainable<JQuery<HTMLInputElement>> {
+    return cy.findByTestId('accelerator-profile-selection-search').find('input');
+  }
+
+  findGlobalAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
+    return cy.get('body').contains('Global accelerator profiles');
+  }
+
+  getProjectScopedAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
+    return cy.get('body').contains('Project-scoped accelerator profiles');
+  }
+
+  findProjectScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-scoped-label');
+  }
+
+  findGlobalScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('global-scoped-label');
+  }
+
+  getProjectScopedAcceleratorProfile(): Contextual<HTMLElement> {
+    return new AcceleratorProfileGroup(() =>
+      cy.findByTestId('project-scoped-accelerator-profiles'),
+    );
+  }
+
+  getGlobalScopedAcceleratorProfile(): Contextual<HTMLElement> {
+    return new AcceleratorProfileGroup(() => cy.findByTestId('global-scoped-accelerator-profiles'));
+  }
+}
+
+export const acceleratorProfileSection = new AcceleratorProfileSection();

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -111,7 +111,7 @@ class ModelServingGlobal {
 }
 
 class ServingRuntimeGroup extends Contextual<HTMLElement> {}
-class AcceleratorProfileGroup extends Contextual<HTMLElement> {}
+
 class InferenceServiceModal extends Modal {
   k8sNameDescription = new K8sNameDescriptionField('inference-service');
 
@@ -227,28 +227,6 @@ class InferenceServiceModal extends Modal {
 
   findExistingConnectionOption() {
     return this.find().findByTestId('existing-connection-radio');
-  }
-
-  findAcceleratorProfileSearchSelector() {
-    return this.find().findByTestId('accelerator-profile-selection-toggle');
-  }
-
-  getGlobalAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Global accelerator profiles');
-  }
-
-  getProjectScopedAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Project-scoped accelerator profiles');
-  }
-
-  getProjectScopedAcceleratorProfile(): Contextual<HTMLElement> {
-    return new AcceleratorProfileGroup(() =>
-      cy.findByTestId('project-scoped-accelerator-profiles'),
-    );
-  }
-
-  getGlobalScopedAcceleratorProfile(): Contextual<HTMLElement> {
-    return new AcceleratorProfileGroup(() => cy.findByTestId('global-scoped-accelerator-profiles'));
   }
 
   findExternalRouteError() {
@@ -619,6 +597,10 @@ class ModelServingSection {
     return cy.findByTestId('section-model-server');
   }
 
+  findDescriptionListItem(itemName: string) {
+    return this.find().next('tr').find(`dt:contains("${itemName}")`);
+  }
+
   private findKServeTable() {
     return this.find().findByTestId('kserve-inference-service-table');
   }
@@ -629,6 +611,18 @@ class ModelServingSection {
 
   findModelServerName(name: string) {
     return this.find().findByTestId(`metrics-link-${name}`);
+  }
+
+  findModelServer() {
+    return this.find().findByTestId('model-server-name');
+  }
+
+  findHardwareSection() {
+    return this.find().findByTestId('hardware-section');
+  }
+
+  findAcceleratorSection() {
+    return this.find().findByTestId('accelerator-section');
   }
 
   findStatusTooltip() {

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm.ts
@@ -1,6 +1,5 @@
 import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Contextual';
-
-class AcceleratorProfileGroup extends Contextual<HTMLElement> {}
+import { AcceleratorProfileSection } from '~/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection';
 
 class ModelCustomizationFormGlobal {
   visit(projectName: string, empty = false) {
@@ -176,39 +175,9 @@ class HardwareSection {
   }
 }
 
-class AcceleratorProfileSection {
+class ModelCustomizationAcceleratorProfileSection extends AcceleratorProfileSection {
   find() {
     return cy.findByTestId('fine-tune-section-training-hardware');
-  }
-
-  findAcceleratorProfileSearchSelector() {
-    return this.find().findByTestId('accelerator-profile-selection-toggle');
-  }
-
-  getGlobalAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Global accelerator profiles');
-  }
-
-  getProjectScopedAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Project-scoped accelerator profiles');
-  }
-
-  getProjectScopedAcceleratorProfile(): Contextual<HTMLElement> {
-    return new AcceleratorProfileGroup(() =>
-      cy.findByTestId('project-scoped-accelerator-profiles'),
-    );
-  }
-
-  getGlobalScopedAcceleratorProfile(): Contextual<HTMLElement> {
-    return new AcceleratorProfileGroup(() => cy.findByTestId('global-scoped-accelerator-profiles'));
-  }
-
-  findProjectScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('project-scoped-label');
-  }
-
-  findGlobalScopedLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('global-scoped-label');
   }
 }
 
@@ -317,7 +286,8 @@ export const baseModelSection = new BaseModelSection();
 export const judgeModelSection = new JudgeModelSection();
 export const taxonomySection = new TaxonomySection();
 export const hardwareSection = new HardwareSection();
-export const acceleratorProfileSection = new AcceleratorProfileSection();
+export const acceleratorProfileSectionModelCustomization =
+  new ModelCustomizationAcceleratorProfileSection();
 export const dataScienceProjectSection = new DataScienceProjectSection();
 export const pipelineSection = new PipelineSection();
 export const hyperparameterSection = new HyperparameterSection();

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -399,18 +399,6 @@ class CreateSpawnerPage {
     );
   }
 
-  findAcceleratorProfileSearchSelector() {
-    return cy.findByTestId('accelerator-profile-selection-toggle');
-  }
-
-  getGlobalAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Global accelerator profiles');
-  }
-
-  getProjectScopedAcceleratorProfileLabel(): Cypress.Chainable<JQuery<HTMLBodyElement>> {
-    return cy.get('body').contains('Project-scoped accelerator profiles');
-  }
-
   findAcceleratorProfile(name: string) {
     return cy.findByRole('menuitem', {
       name,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -245,6 +245,7 @@ describe('Workbench Hardware Profiles', () => {
         mockNotebookK8sResource({
           hardwareProfileName: 'large-profile-1',
           displayName: 'Test Notebook',
+          hardwareProfileNamespace: 'test-project',
         }),
       ]),
     );
@@ -363,6 +364,7 @@ describe('Workbench Hardware Profiles', () => {
           mockNotebookK8sResource({
             hardwareProfileName: 'large-profile-1',
             displayName: 'Test Notebook',
+            hardwareProfileNamespace: 'test-project',
           }),
         ]),
       );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -29,6 +29,7 @@ import {
   mockGlobalScopedAcceleratorProfiles,
   mockProjectScopedAcceleratorProfiles,
 } from '~/__mocks__/mockAcceleratorProfile';
+import { acceleratorProfileSection } from '~/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection';
 
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
 
@@ -378,7 +379,7 @@ describe('Deploy model version', () => {
 
     // Check for project specific serving runtimes
     projectScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
-    kserveModal.findProjectScopedLabel().should('exist');
+    acceleratorProfileSection.findProjectScopedLabel().should('exist');
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
     cy.findByText(
@@ -391,7 +392,7 @@ describe('Deploy model version', () => {
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
     const globalScopedSR = kserveModal.getGlobalScopedServingRuntime();
     globalScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
-    kserveModal.findGlobalScopedLabel().should('exist');
+    acceleratorProfileSection.findGlobalScopedLabel().should('exist');
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
     cy.findByText(
@@ -461,11 +462,12 @@ describe('Deploy model version', () => {
     kserveModal.findModelNameInput().should('exist');
 
     // Verify accelerator profile section exists
-    kserveModal.findAcceleratorProfileSearchSelector().should('exist');
-    kserveModal.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().should('exist');
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
 
     // verify available project-scoped accelerator profile
-    const projectScopedAcceleratorProfile = kserveModal.getProjectScopedAcceleratorProfile();
+    const projectScopedAcceleratorProfile =
+      acceleratorProfileSection.getProjectScopedAcceleratorProfile();
     projectScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -473,11 +475,12 @@ describe('Deploy model version', () => {
         hidden: true,
       })
       .click();
-    kserveModal.findProjectScopedLabel().should('exist');
+    acceleratorProfileSection.findProjectScopedLabel().should('exist');
 
     // verify available global-scoped accelerator profile
-    kserveModal.findAcceleratorProfileSearchSelector().click();
-    const globalScopedAcceleratorProfile = kserveModal.getGlobalScopedAcceleratorProfile();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
+    const globalScopedAcceleratorProfile =
+      acceleratorProfileSection.getGlobalScopedAcceleratorProfile();
     globalScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -485,7 +488,7 @@ describe('Deploy model version', () => {
         hidden: true,
       })
       .click();
-    kserveModal.findGlobalScopedLabel().should('exist');
+    acceleratorProfileSection.findGlobalScopedLabel().should('exist');
   });
 
   it('Selects Create Connection in case of no matching connections', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -49,6 +49,7 @@ import {
   mockGlobalScopedAcceleratorProfiles,
   mockProjectScopedAcceleratorProfiles,
 } from '~/__mocks__/mockAcceleratorProfile';
+import { acceleratorProfileSection } from '~/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -777,6 +778,7 @@ describe('Model Serving Global', () => {
       servingRuntimes: [
         mockServingRuntimeK8sResource({
           hardwareProfileName: 'large-profile-1',
+          hardwareProfileNamespace: 'test-project',
         }),
       ],
     });
@@ -799,11 +801,12 @@ describe('Model Serving Global', () => {
     kserveModal.findModelNameInput().should('exist');
 
     // Verify accelerator profile section exists
-    kserveModal.findAcceleratorProfileSearchSelector().should('exist');
-    kserveModal.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().should('exist');
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
 
     // verify available project-scoped accelerator profile
-    const projectScopedAcceleratorProfile = kserveModal.getProjectScopedAcceleratorProfile();
+    const projectScopedAcceleratorProfile =
+      acceleratorProfileSection.getProjectScopedAcceleratorProfile();
     projectScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -814,8 +817,9 @@ describe('Model Serving Global', () => {
     kserveModal.findProjectScopedLabel().should('exist');
 
     // verify available global-scoped accelerator profile
-    kserveModal.findAcceleratorProfileSearchSelector().click();
-    const globalScopedAcceleratorProfile = kserveModal.getGlobalScopedAcceleratorProfile();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
+    const globalScopedAcceleratorProfile =
+      acceleratorProfileSection.getGlobalScopedAcceleratorProfile();
     globalScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -839,7 +843,7 @@ describe('Model Serving Global', () => {
     });
     modelServingGlobal.visit('test-project');
     modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
-    kserveModalEdit
+    acceleratorProfileSection
       .findAcceleratorProfileSearchSelector()
       .should('contain.text', 'Large Profile-1');
     kserveModalEdit.findProjectScopedLabel().should('exist');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/modelCustomizationForm.cy.ts
@@ -10,7 +10,7 @@ import {
   dataScienceProjectSection,
   pipelineSection,
   hyperparameterSection,
-  acceleratorProfileSection,
+  acceleratorProfileSectionModelCustomization,
 } from '~/__tests__/cypress/cypress/pages/pipelines/modelCustomizationForm';
 import {
   buildMockPipeline,
@@ -239,12 +239,14 @@ describe('Model Customization Form', () => {
     cy.wait('@getPipelineVersions');
 
     // Verify accelerator profile section exists
-    acceleratorProfileSection.findAcceleratorProfileSearchSelector().should('exist');
-    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSectionModelCustomization
+      .findAcceleratorProfileSearchSelector()
+      .should('exist');
+    acceleratorProfileSectionModelCustomization.findAcceleratorProfileSearchSelector().click();
 
     // verify available project-scoped hardware profile
     const projectScopedAcceleratorProfile =
-      acceleratorProfileSection.getProjectScopedAcceleratorProfile();
+      acceleratorProfileSectionModelCustomization.getProjectScopedAcceleratorProfile();
     projectScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -252,12 +254,12 @@ describe('Model Customization Form', () => {
         hidden: true,
       })
       .click();
-    acceleratorProfileSection.findProjectScopedLabel().should('exist');
+    acceleratorProfileSectionModelCustomization.findProjectScopedLabel().should('exist');
 
     // verify available global-scoped hardware profile
-    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSectionModelCustomization.findAcceleratorProfileSearchSelector().click();
     const globalScopedAcceleratorProfile =
-      acceleratorProfileSection.getGlobalScopedAcceleratorProfile();
+      acceleratorProfileSectionModelCustomization.getGlobalScopedAcceleratorProfile();
     globalScopedAcceleratorProfile
       .find()
       .findByRole('menuitem', {
@@ -265,7 +267,7 @@ describe('Model Customization Form', () => {
         hidden: true,
       })
       .click();
-    acceleratorProfileSection.findGlobalScopedLabel().should('exist');
+    acceleratorProfileSectionModelCustomization.findGlobalScopedLabel().should('exist');
   });
 
   it('Should submit', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -48,6 +48,7 @@ import { mockConnectionTypeConfigMap } from '~/__mocks__/mockConnectionType';
 import type { NotebookKind, PodKind } from '~/k8sTypes';
 import type { EnvironmentFromVariable } from '~/pages/projects/types';
 import { SpawnerPageSectionID } from '~/pages/projects/screens/spawner/types';
+import { acceleratorProfileSection } from '~/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection';
 
 const configYamlPath = '../../__mocks__/mock-upload-configmap.yaml';
 
@@ -606,15 +607,15 @@ describe('Workbench page', () => {
     verifyRelativeURL('/projects/test-project/spawner');
 
     // Verify accelerator profile section exists
-    createSpawnerPage.findAcceleratorProfileSearchSelector().should('exist');
-    createSpawnerPage.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().should('exist');
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
 
     // verify available project-scoped accelerator profile
     createSpawnerPage.findAcceleratorProfile('Small Profile nvidia.com/gpu').click();
     createSpawnerPage.findProjectScopedLabel().should('exist');
 
     // verify available global-scoped accelerator profile
-    createSpawnerPage.findAcceleratorProfileSearchSelector().click();
+    acceleratorProfileSection.findAcceleratorProfileSearchSelector().click();
     createSpawnerPage.findAcceleratorProfile('Small Profile Global nvidia.com/gpu').click();
     createSpawnerPage.findGlobalScopedLabel().should('exist');
   });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -95,6 +95,13 @@ export const assembleNotebook = (
     volumeMounts.push(getshmVolumeMount());
   }
 
+  let hardwareProfileNamespace: Record<string, string | null> | null = {
+    'opendatahub.io/hardware-profile-namespace': null,
+  };
+  if (selectedHardwareProfile?.metadata.namespace === projectName) {
+    hardwareProfileNamespace = { 'opendatahub.io/hardware-profile-namespace': data.projectName };
+  }
+
   const resource: NotebookKind = {
     apiVersion: 'kubeflow.org/v1',
     kind: 'Notebook',
@@ -106,6 +113,7 @@ export const assembleNotebook = (
         [KnownLabels.DASHBOARD_RESOURCE]: 'true',
       },
       annotations: {
+        ...hardwareProfileNamespace,
         'openshift.io/display-name': notebookName.trim(),
         'openshift.io/description': description || '',
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
@@ -294,7 +302,6 @@ export const updateNotebook = (
   opts?: K8sAPIOptions,
 ): Promise<NotebookKind> => {
   const notebook = assembleNotebook(assignableData, username);
-
   const oldNotebook = structuredClone(existingNotebook);
   const container = oldNotebook.spec.template.spec.containers[0];
 

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -67,6 +67,12 @@ export const assembleServingRuntime = (
     annotations['opendatahub.io/serving-runtime-scope'] = scope;
   }
 
+  if (podSpecOptions.selectedHardwareProfile?.metadata.namespace === namespace) {
+    annotations['opendatahub.io/hardware-profile-namespace'] = namespace;
+  } else {
+    annotations['opendatahub.io/hardware-profile-namespace'] = undefined;
+  }
+
   // TODO: Enable GRPC
   if (!isEditing) {
     updatedServingRuntime.metadata = {

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -421,29 +421,27 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                   {filteredHardwareProfiles.length > 0 &&
                     filteredDashboardHardwareProfiles.length > 0 && <Divider component="li" />}
                   {filteredDashboardHardwareProfiles.length > 0 && (
-                    <>
-                      <MenuGroup
-                        key="global-scoped"
-                        data-testid="global-scoped-hardware-profiles"
-                        label={
-                          <Flex
-                            spaceItems={{ default: 'spaceItemsXs' }}
-                            alignItems={{ default: 'alignItemsCenter' }}
-                            style={{ paddingBottom: '5px' }}
+                    <MenuGroup
+                      key="global-scoped"
+                      data-testid="global-scoped-hardware-profiles"
+                      label={
+                        <Flex
+                          spaceItems={{ default: 'spaceItemsXs' }}
+                          alignItems={{ default: 'alignItemsCenter' }}
+                          style={{ paddingBottom: '5px' }}
+                        >
+                          <FlexItem
+                            style={{ display: 'flex', paddingLeft: '12px' }}
+                            data-testid="ds-project-image"
                           >
-                            <FlexItem
-                              style={{ display: 'flex', paddingLeft: '12px' }}
-                              data-testid="ds-project-image"
-                            >
-                              <GlobalIcon style={{ height: '12px', width: '12px' }} />
-                            </FlexItem>
-                            <FlexItem>Global hardware profiles</FlexItem>
-                          </Flex>
-                        }
-                      >
-                        {filteredDashboardHardwareProfiles}
-                      </MenuGroup>
-                    </>
+                            <GlobalIcon style={{ height: '12px', width: '12px' }} />
+                          </FlexItem>
+                          <FlexItem>Global hardware profiles</FlexItem>
+                        </Flex>
+                      }
+                    >
+                      {filteredDashboardHardwareProfiles}
+                    </MenuGroup>
                   )}
                   {filteredHardwareProfiles.length === 0 &&
                     filteredDashboardHardwareProfiles.length === 0 && (

--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -105,6 +105,7 @@ export const useHardwareProfileConfig = (
   nodeSelector?: NodeSelector,
   visibleIn?: HardwareProfileFeatureVisibility[],
   namespace?: string,
+  hardwareProfileNamespace?: string | null,
 ): UseHardwareProfileConfigResult => {
   const [dashboardProfiles, dashboardProfilesLoaded, dashboardProfilesLoadError] =
     useHardwareProfilesByFeatureVisibility(visibleIn);
@@ -143,9 +144,17 @@ export const useHardwareProfileConfig = (
       if (resources) {
         // try to match to existing profile
         if (existingHardwareProfileName) {
-          selectedProfile = profiles.find(
-            (profile) => profile.metadata.name === existingHardwareProfileName,
-          );
+          if (hardwareProfileNamespace) {
+            selectedProfile = projectScopedProfiles.find(
+              (profile) =>
+                profile.metadata.name === existingHardwareProfileName &&
+                profile.metadata.namespace === hardwareProfileNamespace,
+            );
+          } else {
+            selectedProfile = dashboardProfiles.find(
+              (profile) => profile.metadata.name === existingHardwareProfileName,
+            );
+          }
         } else {
           selectedProfile = matchToHardwareProfile(profiles, resources, tolerations, nodeSelector);
         }
@@ -175,6 +184,9 @@ export const useHardwareProfileConfig = (
     nodeSelector,
     formData.resources,
     formData.selectedProfile,
+    hardwareProfileNamespace,
+    projectScopedProfiles,
+    dashboardProfiles,
   ]);
 
   return {

--- a/frontend/src/concepts/hardwareProfiles/useNotebookHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useNotebookHardwareProfileConfig.ts
@@ -17,6 +17,8 @@ const useNotebookHardwareProfileConfig = (
   const nodeSelector = notebook?.spec.template.spec.nodeSelector;
   const namespace = notebook?.metadata.namespace;
   const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+  const hardwareProfileNamespace =
+    notebook?.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'];
 
   return useHardwareProfileConfig(
     name,
@@ -25,6 +27,7 @@ const useNotebookHardwareProfileConfig = (
     nodeSelector,
     [HardwareProfileFeatureVisibility.WORKBENCH],
     isProjectScoped ? namespace : undefined,
+    hardwareProfileNamespace,
   );
 };
 

--- a/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
@@ -23,6 +23,8 @@ const useServingHardwareProfileConfig = (
     inferenceService?.spec.predictor.nodeSelector || servingRuntime?.spec.nodeSelector;
   const namespace = servingRuntime?.metadata.namespace;
   const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+  const hardwareProfileNamespace =
+    servingRuntime?.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'];
 
   return useHardwareProfileConfig(
     name,
@@ -31,6 +33,7 @@ const useServingHardwareProfileConfig = (
     nodeSelector,
     [HardwareProfileFeatureVisibility.MODEL_SERVING],
     isProjectScoped ? namespace : undefined,
+    hardwareProfileNamespace,
   );
 };
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -110,6 +110,7 @@ export type NotebookAnnotations = Partial<{
   'opendatahub.io/hardware-profile-name': string; // the hardware profile attached to the notebook
   'opendatahub.io/image-display-name': string; // the display name of the image
   'notebooks.opendatahub.io/last-image-version-git-commit-selection': string; // the build commit of the last image they selected
+  'opendatahub.io/hardware-profile-namespace': string | null; // the namespace of the hardware profile used
 }>;
 
 export type DashboardLabels = {
@@ -138,6 +139,7 @@ export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/accelerator-name': string;
   'opendatahub.io/apiProtocol': string;
   'opendatahub.io/serving-runtime-scope': string;
+  'opendatahub.io/hardware-profile-namespace': string | undefined;
   'enable-route': string;
   'enable-auth': string;
   'modelmesh-enabled': 'true' | 'false';

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -4,6 +4,8 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Flex,
+  FlexItem,
   Label,
   List,
   ListItem,
@@ -72,19 +74,38 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
       {isHardwareProfileAvailable ? (
         <DescriptionListGroup>
           <DescriptionListTerm>Hardware profile</DescriptionListTerm>
-          <DescriptionListDescription>
-            {hardwareProfile.initialHardwareProfile
-              ? `${hardwareProfile.initialHardwareProfile.spec.displayName}${
-                  !hardwareProfile.initialHardwareProfile.spec.enabled ? ' (disabled)' : ''
-                }`
-              : hardwareProfile.formData.useExistingSettings
-              ? 'Unknown'
-              : 'No hardware profile selected'}
+          <DescriptionListDescription data-testid="hardware-section">
+            {hardwareProfile.initialHardwareProfile ? (
+              <Flex gap={{ default: 'gapSm' }}>
+                <FlexItem>{hardwareProfile.initialHardwareProfile.spec.displayName}</FlexItem>
+                <FlexItem>
+                  {isProjectScopedAvailable &&
+                    hardwareProfile.initialHardwareProfile.metadata.namespace === project && (
+                      <Label
+                        variant="outline"
+                        color="blue"
+                        data-testid="project-scoped-label"
+                        isCompact
+                        icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
+                      >
+                        Project-scoped
+                      </Label>
+                    )}
+                </FlexItem>
+                <Flex>
+                  {!hardwareProfile.initialHardwareProfile.spec.enabled ? '(disabled)' : ''}
+                </Flex>
+              </Flex>
+            ) : hardwareProfile.formData.useExistingSettings ? (
+              'Unknown'
+            ) : (
+              'No hardware profile selected'
+            )}
           </DescriptionListDescription>
         </DescriptionListGroup>
       ) : (
         <>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="accelerator-section">
             <DescriptionListTerm>Accelerator</DescriptionListTerm>
             <DescriptionListDescription>
               {initialAcceleratorProfileState.acceleratorProfile ? (

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableExpandedSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableExpandedSection.tsx
@@ -16,12 +16,14 @@ type ServingRuntimeTableExpandedSectionProps = {
   activeColumn?: ServingRuntimeTableTabs;
   onClose: () => void;
   obj: ServingRuntimeKind;
+  project: string;
 };
 
 const ServingRuntimeTableExpandedSection: React.FC<ServingRuntimeTableExpandedSectionProps> = ({
   activeColumn,
   onClose,
   obj,
+  project,
 }) => {
   const {
     inferenceServices: { data: inferenceServices, refresh: refreshInferenceServices },
@@ -34,7 +36,7 @@ const ServingRuntimeTableExpandedSection: React.FC<ServingRuntimeTableExpandedSe
       <>
         <Td dataLabel="Type expansion" colSpan={7}>
           <ExpandableRowContent>
-            <ServingRuntimeDetails obj={obj} />
+            <ServingRuntimeDetails obj={obj} project={project} />
           </ExpandableRowContent>
         </Td>
       </>

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTableRow.tsx
@@ -93,6 +93,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
       <Tr isControlRow>
         <EmptyTableCellForAlignment />
         <Td
+          data-testid="model-server-name"
           dataLabel="Model Server Name"
           compoundExpand={compoundExpandParams(ServingRuntimeTableTabs.TYPE, false)}
         >
@@ -229,6 +230,7 @@ const ServingRuntimeTableRow: React.FC<ServingRuntimeTableRowProps> = ({
           activeColumn={expandedColumn}
           obj={obj}
           onClose={() => setExpandedColumn(undefined)}
+          project={currentProject.metadata.name}
         />
       </Tr>
     </Tbody>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -225,6 +225,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               servingRuntimeSelected={servingRuntimeSelected}
               infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
               isEditing={!!editInfo}
+              projectName={currentProject.metadata.name}
             />
             <AuthServingRuntimeSection
               data={createData}

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -312,15 +312,22 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     options.push(formatOption(formData.profile));
   }
 
-  // if there is more than a none option, show the dropdown
-  if (options.length === 1) {
-    return null;
-  }
-
   const filteredAcceleratorProfiles = getAcceleratorProfiles();
   const filteredDashboardAcceleratorProfiles = getDashboardAcceleratorProfiles();
   const hasProjectScopedAccelerators =
     isProjectScopedAvailable && currentProjectAcceleratorProfiles.length > 0;
+
+  // if there is more than a none option, show the dropdown
+  if (!isProjectScopedAvailable && options.length === 1) {
+    return null;
+  }
+  if (
+    isProjectScopedAvailable &&
+    filteredAcceleratorProfiles.length === 0 &&
+    filteredDashboardAcceleratorProfiles.length === 1
+  ) {
+    return null;
+  }
 
   return (
     <Stack hasGutter>
@@ -430,7 +437,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                     </>
                   )}
                   {filteredDashboardAcceleratorProfiles.length > 0 &&
-                    filteredDashboardAcceleratorProfiles.length > 0 && <Divider component="li" />}
+                    filteredAcceleratorProfiles.length > 0 && <Divider component="li" />}
                   {filteredDashboardAcceleratorProfiles.length > 0 && (
                     <>
                       <MenuGroup

--- a/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareProfileFormSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingHardwareProfileFormSection.tsx
@@ -86,12 +86,11 @@ const TrainingHardwareProfileFormSection: React.FC<TrainingHardwareProfileFormSe
                       projectScopedHardwareProfiles['0'].length > 0 && (
                         <List>
                           <ListItem>
-                            <b>Project-scoped</b> hardware profiles are accessible only within this
+                            <b>Project-scoped hardware profiles</b> are accessible only within this
                             project.
                           </ListItem>
                           <ListItem>
-                            <b>Global-scoped</b> hardware profiles are accessible within all
-                            projects.
+                            <b>Global hardware profiles</b> are accessible within all projects.
                           </ListItem>
                         </List>
                       )}


### PR DESCRIPTION
Closes: [RHOAIENG-24572](https://issues.redhat.com/browse/RHOAIENG-24572)

## Description
This PR aims to support project-scoped serving runtime, hardware profile and accelerator profile for model mesh. Also create a re-usable component for acceleratorprofile-section.

1. Add model server with project-scoped Accelerator profile.

https://github.com/user-attachments/assets/5ae3af98-63ac-4af7-acc4-992df566ff77


<img width="1136" alt="Screenshot 2025-05-16 at 2 30 15 PM" src="https://github.com/user-attachments/assets/363bd802-57b0-4465-a422-5ae6d15d96f0" />



<img width="1054" alt="Screenshot 2025-05-13 at 1 32 53 PM" src="https://github.com/user-attachments/assets/c08eecb0-242b-4f85-88b7-7bbd8d5bd1fc" />

2. with hardware profile

https://github.com/user-attachments/assets/915def47-3ba3-47f9-a635-d09f9b644de8

<img width="845" alt="Screenshot 2025-05-12 at 2 19 22 PM" src="https://github.com/user-attachments/assets/010e8605-8278-44a6-80c7-4c2b8af3f53c" />


<img width="1090" alt="Screenshot 2025-05-12 at 2 17 56 PM" src="https://github.com/user-attachments/assets/4a6e0061-ae2a-4444-bbd1-c3f5681e5e43" />




## How Has This Been Tested?
Try to add model server with project-scoped items(serving runtime, hardware profile and accelerator profile)

## Test Impact
Added cypress tests for the same. will be adding more for few edge cases in follow-up PR.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


