### PR TITLE
Prefill connection name when project has no connections

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -530,6 +530,35 @@ describe('Deploy model version', () => {
     kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
   });
 
+  it('Selects Create Connection in case of no connections in project', () => {
+    initIntercepts({});
+    cy.visit(`/modelRegistry/modelregistry-sample/registeredModels/1/versions`);
+    const modelVersionRow = modelRegistry.getModelVersionRow(modelVersionMocked2.name);
+    modelVersionRow.findKebabAction('Deploy').click();
+    modelVersionDeployModal.selectProjectByName('KServe project');
+
+    // Validate name input field
+    kserveModal.findModelNameInput().should('exist');
+
+    // Validate model framework section
+    kserveModal.findModelFrameworkSelect().should('be.disabled');
+    cy.findByText('The format of the source model is').should('not.exist');
+    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Multi Platform').click();
+    kserveModal.findModelFrameworkSelect().should('be.enabled');
+    cy.findByText(
+      `The format of the source model is ${modelArtifactMocked.modelFormatName ?? ''} - ${
+        modelArtifactMocked.modelFormatVersion ?? ''
+      }`,
+    ).should('exist');
+
+    // Validate connection section
+    kserveModal.findConnectionNameInput().should('have.value', 'test storage key');
+    kserveModal.findLocationBucketInput().should('have.value', 'test-bucket');
+    kserveModal.findLocationEndpointInput().should('have.value', 'test-endpoint');
+    kserveModal.findLocationRegionInput().should('have.value', 'test-region');
+    kserveModal.findLocationPathInput().should('have.value', 'demo-models/test-path');
+  });
+
   it('Selects Create Connection in case of no matching URI connections', () => {
     initIntercepts({});
     cy.interceptK8sList(

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -426,6 +426,7 @@ export const ConnectionSection: React.FC<Props> = ({
               setData={setData}
               initialNewConnectionType={initialNewConnectionType}
               initialNewConnectionValues={initialNewConnectionValues}
+              initialConnectionName={data.storage.dataConnection}
               setNewConnection={setConnection}
               modelUri={data.storage.uri}
               setModelUri={(uri) => setData('storage', { ...data.storage, uri })}

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/usePrefillModelDeployModal.spec.ts
@@ -659,7 +659,7 @@ describe('usePrefillModelDeployModal', () => {
               { key: 'AWS_S3_ENDPOINT', value: '' },
               { key: 'AWS_DEFAULT_REGION', value: '' },
             ],
-            dataConnection: '',
+            dataConnection: 'test-key',
             path: '',
             type: 'new-storage',
             uri: 'oci://test.io/test/private:test',

--- a/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
+++ b/frontend/src/pages/modelServing/screens/projects/usePrefillModelDeployModal.ts
@@ -88,6 +88,8 @@ const usePrefillModelDeployModal = (
         (dataConnection) => dataConnection.isRecommended,
       );
 
+      const connectionName = modelDeployPrefillInfo.initialConnectionName || '';
+
       if (!modelLocation) {
         setCreateData('storage', {
           awsData: EMPTY_AWS_SECRET_DATA,
@@ -103,7 +105,7 @@ const usePrefillModelDeployModal = (
           AwsKeys.DEFAULT_REGION,
         ];
         const prefilledAWSData = [
-          { key: AwsKeys.NAME, value: modelDeployPrefillInfo.initialConnectionName || '' },
+          { key: AwsKeys.NAME, value: connectionName },
           { key: AwsKeys.AWS_S3_BUCKET, value: modelLocation.s3Fields.bucket },
           { key: AwsKeys.S3_ENDPOINT, value: modelLocation.s3Fields.endpoint },
           { key: AwsKeys.DEFAULT_REGION, value: modelLocation.s3Fields.region || '' },
@@ -112,7 +114,7 @@ const usePrefillModelDeployModal = (
         if (recommendedConnections.length === 0) {
           setCreateData('storage', {
             awsData: prefilledAWSData,
-            dataConnection: modelDeployPrefillInfo.initialConnectionName || '',
+            dataConnection: connectionName,
             path: modelLocation.s3Fields.path,
             type: InferenceServiceStorageType.NEW_STORAGE,
             alert,
@@ -147,7 +149,7 @@ const usePrefillModelDeployModal = (
           setCreateData('storage', {
             awsData: EMPTY_AWS_SECRET_DATA,
             uri: '',
-            dataConnection: modelDeployPrefillInfo.initialConnectionName || '',
+            dataConnection: connectionName,
             path: '',
             type: InferenceServiceStorageType.NEW_STORAGE,
             alert,
@@ -192,7 +194,7 @@ const usePrefillModelDeployModal = (
           setCreateData('storage', {
             awsData: EMPTY_AWS_SECRET_DATA,
             uri: modelLocation.ociUri,
-            dataConnection: '',
+            dataConnection: connectionName,
             path: '',
             type: InferenceServiceStorageType.NEW_STORAGE,
             alert,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow up #4106 

The ticket `Failed_QA` while verification as it was not handling projects with no connections

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Try deploying `mdas-uri-test`(for URI) and `mdas-prefill-model`(for S3) version `v1` to any project(you can try 'mdas-new` project that has no connections in `ui-green` cluster) that has Kserve platform selected to deploy and has no connections, the connection name should still be present in the "Connection name" field

<img width="656" alt="Screenshot 2025-05-13 at 8 58 12 PM" src="https://github.com/user-attachments/assets/f3186f08-1683-4df8-b9a0-5eb83a544ab0" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As mentioned in the description

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added Cypress tests for this specific use case

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
