### PR TITLE
Fix PVC update logic for externally created PVCs

### DIFF
--- a/frontend/src/api/k8s/pvcs.ts
+++ b/frontend/src/api/k8s/pvcs.ts
@@ -82,10 +82,23 @@ export const updatePvc = (
   existingData: PersistentVolumeClaimKind,
   namespace: string,
   opts?: K8sAPIOptions,
+  excludeSpec?: boolean,
 ): Promise<PersistentVolumeClaimKind> => {
   const pvc = assemblePvc(data, namespace, existingData.metadata.name);
+  const newData = excludeSpec
+    ? {
+        ...pvc,
+        spec: {
+          resources: {
+            requests: {
+              storage: pvc.spec.resources.requests.storage,
+            },
+          },
+        },
+      }
+    : pvc;
 
-  const pvcResource = _.merge({}, existingData, pvc);
+  const pvcResource = _.merge({}, existingData, newData);
   if (!data.description && pvcResource.metadata.annotations?.['openshift.io/description']) {
     pvcResource.metadata.annotations['openshift.io/description'] = undefined;
   }

--- a/frontend/src/pages/projects/screens/detail/storage/utils.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/utils.ts
@@ -24,7 +24,7 @@ export const isPvcUpdateRequired = (
   storageData: StorageData,
 ): boolean =>
   getDisplayNameFromK8sResource(existingPvc) !== storageData.name ||
-  getDescriptionFromK8sResource(existingPvc) !== storageData.description ||
+  getDescriptionFromK8sResource(existingPvc) !== (storageData.description ?? '') ||
   existingPvc.spec.resources.requests.storage !== storageData.size ||
   existingPvc.spec.storageClassName !== storageData.storageClassName;
 

--- a/frontend/src/pages/projects/screens/spawner/service.ts
+++ b/frontend/src/pages/projects/screens/spawner/service.ts
@@ -58,7 +58,7 @@ export const updatePvcDataForNotebook = async (
 
   if (existingPvc && storageData.storageType === StorageType.EXISTING_PVC) {
     if (isPvcUpdateRequired(existingPvc, storageData)) {
-      await updatePvc(storageData, existingPvc, projectName, { dryRun });
+      await updatePvc(storageData, existingPvc, projectName, { dryRun }, true);
     }
     const { name } = existingPvc.metadata;
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-23113

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The PVC update logic has issues handling PVCs created outside the dashboard UI, leading to unnecessary updates and invalid spec modifications.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Steps:
* Create a PVC manually through the console. Make sure to add the following to the yaml to see it in the UI:
```
metadata:
  labels:
    opendatahub.io/dashboard: 'true'
```
* Edit a preexisting workbench and replace the storage with the manually created storage 
* You’ll see that the description of the storageData update will be undefined

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
