### PR TITLE
Fix model serving service account when isvc and sr have different names

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -562,6 +562,9 @@ export type InferenceServiceKind = K8sResourceCommon & {
   };
 };
 
+export const isInferenceServiceKind = (obj: K8sResourceCommon): obj is InferenceServiceKind =>
+  obj.kind === 'InferenceService';
+
 export type RoleBindingSubject = {
   kind: string;
   apiGroup?: string;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -142,7 +142,9 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
                     ),
                     secrets: [],
                   },
-                  secrets: filterTokens ? filterTokens(editInferenceService.metadata.name) : [],
+                  secrets: filterTokens
+                    ? filterTokens(editInferenceService.spec.predictor.model?.runtime)
+                    : [],
                 }}
                 onClose={(edited) => {
                   if (edited) {

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -89,7 +89,9 @@ const KServeInferenceServiceTable: React.FC = () => {
               secrets: [],
             },
             inferenceServiceEditInfo: editKserveResources.inferenceService,
-            secrets: filterTokens(editKserveResources.inferenceService.metadata.name),
+            secrets: filterTokens(
+              editKserveResources.inferenceService.spec.predictor.model?.runtime,
+            ),
           }}
           onClose={(submit: boolean) => {
             setEditKServeResources(undefined);

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
@@ -3,7 +3,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import { Table } from '~/components/table';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { tokenColumns } from '~/pages/modelServing/screens/global/data';
-import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, isInferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import ServingRuntimeTokenTableRow from '~/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokenTableRow';
 
 type ServingRuntimeTokensTableProps = {
@@ -20,7 +20,9 @@ const ServingRuntimeTokensTable: React.FC<ServingRuntimeTokensTableProps> = ({
     filterTokens,
   } = React.useContext(ProjectDetailsContext);
 
-  const tokens = filterTokens(obj.metadata.name);
+  const name = isInferenceServiceKind(obj) ? obj.spec.predictor.model?.runtime : obj.metadata.name;
+
+  const tokens = filterTokens(name);
 
   if (!isTokenEnabled) {
     return (

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -288,8 +288,8 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     const submitInferenceServiceResource = getSubmitInferenceServiceResourceFn(
       createDataInferenceService,
       editInfo?.inferenceServiceEditInfo,
-      servingRuntimeName,
-      inferenceServiceName,
+      editInfo?.servingRuntimeEditInfo?.servingRuntime?.metadata.name || servingRuntimeName,
+      editInfo?.inferenceServiceEditInfo?.metadata.name || inferenceServiceName,
       false,
       podSpecOptionsState.podSpecOptions,
       allowCreate,

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -99,7 +99,6 @@ const ProjectDetailsContextProvider: React.FC = () => {
       if (!namespace || !servingRuntimeName) {
         return [];
       }
-
       const { serviceAccountName } = getTokenNames(servingRuntimeName, namespace);
 
       const secrets = serverSecrets.data.filter(
@@ -107,6 +106,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
           secret.metadata.annotations?.['kubernetes.io/service-account.name'] ===
           serviceAccountName,
       );
+
       return secrets;
     },
     [namespace, serverSecrets],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-23800
## Description
When you have an ISVC and a SR that have different names, the token created in the kserve modal will not display. I had to revert one change from a recent PR that will need testing from the NIM team.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Select single model serving
2. Create an ISVC and a SR with different names
3. Go to edit the model
4. Require token authentication
5. Redeploy
6. Edit the model again
7. The service account input field should be visible
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Going to add tests in a separate PR
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
