### PR TITLE
Use download URL instead of render URL for system.Artifact type

### DIFF
--- a/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
+++ b/frontend/src/concepts/pipelines/content/artifacts/ArtifactUriLink.tsx
@@ -17,7 +17,8 @@ export const ArtifactUriLink: React.FC<ArtifactUriLinkProps> = ({ artifact }) =>
     artifact.getType() === ArtifactType.METRICS ||
     artifact.getType() === ArtifactType.SLICED_CLASSIFICATION_METRICS;
 
-  const isDownloadableOnly = artifact.getType() === ArtifactType.MODEL;
+  const isDownloadableOnly =
+    artifact.getType() === ArtifactType.MODEL || artifact.getType() === ArtifactType.ARTIFACT;
   const { getStorageObjectDownloadUrl, getStorageObjectRenderUrl } = useArtifactStorage();
   const [loading, setLoading] = React.useState<boolean>(false);
   const notification = useNotification();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow-up fix for [RHOAIENG-11412](https://issues.redhat.com/browse/RHOAIENG-11412)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The `system.Artifact` type should also fetch the download URL like `system.Model`, but not the render URL. This PR updated that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the ilab shared cluster, check the artifacts list. Make sure you can download the file when clicking on the S3 URL of the artifacts that have the `system.Artifact` type.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
