### PR TITLE
Fix for default character limit message

### DIFF
--- a/frontend/src/components/CharLimitHelperText.tsx
+++ b/frontend/src/components/CharLimitHelperText.tsx
@@ -7,6 +7,8 @@ interface CharLimitHelperTextProps {
 
 export const CharLimitHelperText: React.FC<CharLimitHelperTextProps> = ({ limit }) => (
   <HelperText>
-    <HelperTextItem>{`Cannot exceed ${limit} characters`}</HelperTextItem>
+    <HelperTextItem>
+      <strong>{`Cannot exceed ${limit} characters`}</strong>
+    </HelperTextItem>
   </HelperText>
 );

--- a/frontend/src/concepts/k8s/NameDescriptionField.tsx
+++ b/frontend/src/concepts/k8s/NameDescriptionField.tsx
@@ -31,6 +31,7 @@ type NameDescriptionFieldProps = {
   nameHelperText?: React.ReactNode;
   hasNameError?: boolean;
   onNameChange?: (value: string) => void;
+  onValidationChange?: (isValid: boolean) => void;
 };
 
 /**
@@ -50,9 +51,9 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
   disableK8sName,
   maxLengthName,
   maxLengthDesc,
-  nameHelperText,
   hasNameError,
   onNameChange,
+  onValidationChange,
 }) => {
   const k8sName = React.useMemo(() => {
     if (showK8sName) {
@@ -61,6 +62,12 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
 
     return '';
   }, [showK8sName, data.name]);
+
+  React.useEffect(() => {
+    const isNameValid = !hasNameError && (!maxLengthName || data.name.length <= maxLengthName);
+    const isDescValid = !maxLengthDesc || data.description.length <= maxLengthDesc;
+    onValidationChange?.(isNameValid && isDescValid);
+  }, [data.name, data.description, maxLengthName, maxLengthDesc, hasNameError, onValidationChange]);
 
   return (
     <Stack hasGutter>
@@ -82,11 +89,21 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
                   }
                 : undefined
             }
-            maxLength={maxLengthName}
-            validated={hasNameError ? 'error' : 'default'}
+            validated={
+              hasNameError || (maxLengthName && data.name.length > maxLengthName)
+                ? 'error'
+                : 'default'
+            }
           />
-          {nameHelperText}
-          {maxLengthName && <CharLimitHelperText limit={maxLengthName} />}
+          {maxLengthName && data.name.length > maxLengthName && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  <CharLimitHelperText limit={maxLengthName} />
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
       </StackItem>
       {showK8sName && (
@@ -142,10 +159,20 @@ const NameDescriptionField: React.FC<NameDescriptionFieldProps> = ({
             name={descriptionFieldId}
             value={data.description}
             onChange={setData ? (e, description) => setData({ ...data, description }) : undefined}
-            maxLength={maxLengthDesc}
+            validated={
+              maxLengthDesc && data.description.length > maxLengthDesc ? 'error' : 'default'
+            }
           />
 
-          {maxLengthDesc && <CharLimitHelperText limit={maxLengthDesc} />}
+          {maxLengthDesc && data.description.length > maxLengthDesc && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  <CharLimitHelperText limit={maxLengthDesc} />
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
       </StackItem>
     </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -36,9 +36,15 @@ type RunFormProps = {
   data: RunFormData;
   onValueChange: (key: keyof RunFormData, value: ValueOf<RunFormData>) => void;
   isDuplicated: boolean;
+  onValidationChange?: (isValid: boolean) => void;
 };
 
-const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) => {
+const RunForm: React.FC<RunFormProps> = ({
+  data,
+  onValueChange,
+  isDuplicated,
+  onValidationChange,
+}) => {
   const { api } = usePipelinesAPI();
   const [latestVersion, latestVersionLoaded] = useLatestPipelineVersion(data.pipeline?.pipeline_id);
   // Use this state to avoid the pipeline version being set as the latest version at the initial load
@@ -136,6 +142,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
             setHasDuplicateName(false);
             checkForDuplicateName(value);
           }}
+          onValidationChange={onValidationChange}
           nameHelperText={hasDuplicateName ? <DuplicateNameHelperText name={name} /> : undefined}
         />
 

--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -102,6 +102,8 @@ const RunPage: React.FC<RunPageProps> = ({
     experiment: locationExperiment || contextExperiment || defaultExperiment,
   });
 
+  const [isNameValid, setIsNameValid] = React.useState(true);
+
   const onValueChange = React.useCallback(
     (key: keyof RunFormData, value: ValueOf<RunFormData>) => setFormDataValue(key, value),
     [setFormDataValue],
@@ -111,11 +113,16 @@ const RunPage: React.FC<RunPageProps> = ({
     <div data-testid={testId}>
       <PageSection hasBodyWrapper={false} isFilled>
         <GenericSidebar sections={jumpToSections} titles={runPageSectionTitles} maxWidth={175}>
-          <RunForm isDuplicated={!!duplicateRun} data={formData} onValueChange={onValueChange} />
+          <RunForm
+            isDuplicated={!!duplicateRun}
+            data={formData}
+            onValueChange={onValueChange}
+            onValidationChange={setIsNameValid}
+          />
         </GenericSidebar>
       </PageSection>
       <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
-        <RunPageFooter data={formData} contextPath={contextPath} />
+        <RunPageFooter data={formData} contextPath={contextPath} isCreateDisabled={!isNameValid} />
       </PageSection>
     </div>
   );

--- a/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPageFooter.tsx
@@ -15,10 +15,11 @@ import {
 type RunPageFooterProps = {
   data: RunFormData;
   contextPath: string;
+  isCreateDisabled?: boolean;
 };
 
 const eventName = 'Pipeline Run Triggered';
-const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
+const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath, isCreateDisabled }) => {
   const { api } = usePipelinesAPI();
   const runType = data.runType.type;
   const navigate = useNavigate();
@@ -42,7 +43,7 @@ const RunPageFooter: React.FC<RunPageFooterProps> = ({ data, contextPath }) => {
             <Button
               variant="primary"
               data-testid="run-page-submit-button"
-              isDisabled={!canSubmit || isSubmitting}
+              isDisabled={!canSubmit || isSubmitting || isCreateDisabled}
               onClick={() => {
                 setSubmitting(true);
                 setError(null);


### PR DESCRIPTION
Closes: [RHOAIENG-24109](https://issues.redhat.com/browse/RHOAIENG-24109)

## Description
Removes the static character limit message and updates it to follow the existing pattern. Now when the user exceeds the character limit, the message will pop up with a warning icon, and the create run button will be disabled. 

## How Has This Been Tested?
Tested locally

- Navigate to Data science projects > Runs
- Click create run 
- Scroll to Run details, and put a name or description that’s larger than 255 characters to see the warning.

## Test Impact
No tests changed

## Screenshots
Before:
<img width="571" alt="Screenshot 2025-05-14 at 9 43 32 AM" src="https://github.com/user-attachments/assets/e01b58f1-5d96-4155-a2e9-ce442058e222" />

After:

https://github.com/user-attachments/assets/67fe8319-b538-41b8-8115-cfd56b57d195 


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
