### PR TITLE
testManifestLinks: Validate multiple HTTP status code responses

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 
 // @ts-expect-error: Types are not available for this third-party library
 import registerCypressGrep from '@cypress/grep/src/plugin';
@@ -12,10 +12,11 @@ import cypressHighResolution from 'cypress-high-resolution';
 // @ts-ignore no types available
 import { beforeRunHook, afterRunHook } from 'cypress-mochawesome-reporter/lib';
 import { mergeFiles } from 'junit-report-merger';
-import { interceptSnapshotFile } from '~/__tests__/cypress/cypress/utils/snapshotUtils';
-import { setup as setupWebsockets } from '~/__tests__/cypress/cypress/support/websockets';
-import { env, cypressEnv, BASE_URL } from '~/__tests__/cypress/cypress/utils/testConfig';
-import { extractHttpsUrls } from '~/__tests__/cypress/cypress/utils/urlExtractor';
+import { interceptSnapshotFile } from './cypress/utils/snapshotUtils';
+import { setup as setupWebsockets } from './cypress/support/websockets';
+import { env, cypressEnv, BASE_URL } from './cypress/utils/testConfig';
+import { extractHttpsUrls } from './cypress/utils/urlExtractor';
+import { validateHttpsUrls } from './cypress/utils/urlValidator';
 
 const resultsDir = `${env.CY_RESULTS_DIR || 'results'}/${env.CY_MOCK ? 'mocked' : 'e2e'}`;
 
@@ -90,6 +91,9 @@ export default defineConfig({
         },
         extractHttpsUrls(directory: string) {
           return extractHttpsUrls(directory);
+        },
+        validateHttpsUrls(urls: string[]) {
+          return validateHttpsUrls(urls);
         },
         log(message) {
           // eslint-disable-next-line no-console

--- a/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
@@ -1,0 +1,137 @@
+import * as http from 'http';
+import * as https from 'https';
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
+const HttpsProxyAgent: new (options: string | object) => https.Agent = require('https-proxy-agent');
+
+const commonUserAgent =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36';
+const maxRedirects = 5;
+const requestTimeout = 30000; // 30 seconds
+
+const makeRequest = (
+  urlToTest: string,
+  proxyUrlFromTask?: string,
+  redirectCount = 0,
+): Promise<{ url: string; status: number; error?: string }> => {
+  return new Promise((resolve) => {
+    let resolved = false; // Flag to prevent double resolving
+
+    const doResolve = (codeValue: number, errorMessage?: string) => {
+      if (!resolved) {
+        resolved = true;
+        // If an errorMessage is present, it signifies an issue (e.g., network error, timeout)
+        // that prevented obtaining a standard HTTP status, or a specific condition like 'too many redirects'.
+        // In these cases, status will be reported as 0.
+        // Actual HTTP status codes (e.g., 200, 404) are passed as codeValue when errorMessage is undefined.
+        const reportedStatus = errorMessage ? 0 : codeValue;
+        resolve({ url: urlToTest, status: reportedStatus, error: errorMessage });
+      }
+    };
+
+    if (redirectCount > maxRedirects) {
+      doResolve(-2, 'Too many redirects'); // Will set status to 0 due to errorMessage
+      return;
+    }
+
+    const effectiveProxyUrl =
+      proxyUrlFromTask || process.env.https_proxy || process.env.HTTPS_PROXY;
+    let agent: http.Agent | undefined;
+
+    if (effectiveProxyUrl && urlToTest.startsWith('https')) {
+      try {
+        agent = new HttpsProxyAgent(effectiveProxyUrl);
+      } catch (e: unknown) {
+        // Failed to create HttpsProxyAgent.
+        // The request might proceed without a proxy or fail later.
+        // Propagating this as a resolution error.
+        doResolve(0, e instanceof Error ? e.message : 'Failed to create proxy agent');
+        return;
+      }
+    }
+
+    const protocol = urlToTest.startsWith('https') ? https : http;
+    const options: http.RequestOptions = {
+      timeout: requestTimeout,
+      headers: {
+        'User-Agent': commonUserAgent,
+        Accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Accept-Encoding': 'gzip, deflate, br',
+      },
+    };
+    if (agent) {
+      options.agent = agent;
+    }
+
+    const req = protocol.get(urlToTest, options, (res: http.IncomingMessage) => {
+      const statusCode = res.statusCode || 0; // Default to 0 if statusCode is undefined
+      const { location } = res.headers;
+
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        let nextUrl = location;
+        try {
+          const currentUrl = new URL(urlToTest);
+          nextUrl = new URL(location, currentUrl.origin).toString();
+        } catch (e: unknown) {
+          doResolve(-3, e instanceof Error ? e.message : 'Invalid redirect URL'); // Will set status to 0
+          return;
+        }
+        res.resume();
+        makeRequest(nextUrl, proxyUrlFromTask, redirectCount + 1)
+          .then((finalResult) => {
+            if (!resolved) {
+              resolved = true;
+              // Pass through the final result from the redirect chain.
+              // If finalResult has an error, its status (due to doResolve) would be 0.
+              // If it's a success, its status will be the HTTP status.
+              resolve({ url: urlToTest, status: finalResult.status, error: finalResult.error });
+            }
+          })
+          .catch((err) => {
+            // This catch is for promise rejections from the recursive makeRequest call.
+            doResolve(0, err?.message || 'Error in redirect chain'); // Explicitly status 0 for this error
+          });
+      } else {
+        // Consume data to trigger 'end'. This is necessary for the 'end' event to fire.
+        res.on('data', () => {
+          /* consume stream */
+        });
+        res.on('end', () => {
+          doResolve(statusCode); // If no errorMessage, status will be statusCode
+        });
+        res.on('aborted', () => {
+          doResolve(-4, 'Response aborted by the server'); // Will set status to 0
+        });
+      }
+    });
+
+    req.on('error', (err: Error & { code?: string; errors?: Array<Error & { code?: string }> }) => {
+      let clientErrorMessage = err.message;
+      if (err.code) {
+        clientErrorMessage = `Code: ${err.code} - ${err.message}`;
+      }
+      // Check for .errors property if err.name suggests an AggregateError.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (err.name === 'AggregateError' && Array.isArray(err.errors)) {
+        clientErrorMessage = err.errors
+          .map((e) => `(Code: ${e.code || 'N/A'} - ${e.message})`)
+          .join('; ');
+      }
+      doResolve(-5, clientErrorMessage); // Will set status to 0
+    });
+
+    req.on('timeout', () => {
+      req.destroy(); // Important to destroy the request on timeout
+      doResolve(-1, `Request timed out after ${requestTimeout}ms`); // Will set status to 0
+    });
+  });
+};
+
+export async function validateHttpsUrls(
+  urls: string[],
+  proxyUrlFromTask?: string,
+): Promise<{ url: string; status: number; error?: string }[]> {
+  const promises = urls.map((url) => makeRequest(url, proxyUrlFromTask));
+  return Promise.all(promises);
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-9235

## Description
Add support for common successful responses (201, 202, 204), redirects (301, 302, 307, 308), and rate limiting (429) in testManifestLinks.cy.ts.

## How Has This Been Tested?
In Jenkins and locally, the test duration is now 15 - 30 seconds, while previously it was 40 - 100 seconds:

![image](https://github.com/user-attachments/assets/5b783728-c5cf-47f9-a3b4-f579ba758d52)

## Test Impact
E2E test `dashboardNavigation/testManifestLinks.cy.ts`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
