### PR TITLE
test: Add retry when 429 after request

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
@@ -59,8 +59,12 @@ describe('Verify that all the URLs referenced in the Manifest directory are oper
                 return;
               }
 
-              const logMessage =
-                status === 200 ? `✅ ${url} - Status: ${status}` : `❌ ${url} - Status: ${status}`;
+              // Define valid status codes
+              const validStatusCodes = [200, 201, 202, 204, 301, 302, 307, 308];
+              const isSuccess = validStatusCodes.includes(status);
+              const logMessage = isSuccess
+                ? `✅ ${url} - Status: ${status}`
+                : `❌ ${url} - Status: ${status}`;
               cy.log(logMessage);
               results.push({ url, status });
             });
@@ -72,7 +76,13 @@ describe('Verify that all the URLs referenced in the Manifest directory are oper
         // Wait for all requests to complete
         cy.wrap(null).then(() => {
           results.forEach(({ url, status }) => {
-            expect(status).to.eq(200, `URL ${url} should return 200`);
+            const validStatusCodes = [200, 201, 202, 204, 301, 302, 307, 308];
+            expect(validStatusCodes).to.include(
+              status,
+              `URL ${url} should return one of the valid status codes: ${validStatusCodes.join(
+                ', ',
+              )}`,
+            );
           });
         });
       });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-25710 

## Description
In case of getting a 429, wait 5 seconds and retry the request

## How Has This Been Tested?
Command:  `$ npx cypress run --browser chrome --project src/__tests__/cypress --spec **/testManifestLinks.cy.ts`
Result:
![image](https://github.com/user-attachments/assets/105a8857-b925-4218-b2a3-3a90327a0266)

Example of retry: 
![Screenshot From 2025-05-19 07-54-59](https://github.com/user-attachments/assets/e0cb1f8c-7ee4-44c0-b351-173e51c2fcc9)


## Test Impact
Modify (fix) one of the tests

## Request review criteria:
Run the testManifestLinks test

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
