### PR TITLE
added byon checking

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -150,6 +150,20 @@ const initIntercepts = ({
         },
       },
     }),
+    mockNotebookK8sResource({
+      name: 'mismatch-commit-byon-notebook',
+      displayName: 'BYON Notebook',
+      image: 'test-6:2024.2',
+      envFrom,
+      opts: {
+        metadata: {
+          name: 'mismatch-commit-byon-notebook',
+          labels: {
+            'opendatahub.io/notebook-image': 'true',
+          },
+        },
+      },
+    }),
   ],
 }: HandlersProps) => {
   cy.interceptK8sList(StorageClassModel, mockStorageClassList());
@@ -207,6 +221,52 @@ const initIntercepts = ({
         namespace: 'opendatahub',
         name: 'test-6',
         displayName: 'Test image 6',
+        opts: {
+          metadata: {
+            name: 'test-6',
+            labels: {
+              'component.opendatahub.io/name': 'notebooks',
+              'opendatahub.io/component': 'true',
+              'opendatahub.io/notebook-image': 'true',
+              'app.kubernetes.io/created-by': 'byon',
+            },
+          },
+          spec: {
+            tags: [
+              {
+                name: '2024.2',
+                annotations: {
+                  'opendatahub.io/notebook-python-dependencies':
+                    '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]',
+                  'opendatahub.io/notebook-software': '[{"name":"Python","version":"v3.8"}]',
+                },
+                from: {
+                  kind: 'DockerImage',
+                  name: 'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+                },
+              },
+            ],
+          },
+          status: {
+            dockerImageRepository:
+              'image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-notebook',
+            tags: [
+              {
+                tag: '2024.2',
+                items: [
+                  {
+                    created: '2023-06-30T15:07:36Z',
+                    dockerImageReference:
+                      'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+                    image:
+                      'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
+                    generation: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        },
       }),
       mockImageStreamK8sResource({
         namespace: 'opendatahub',
@@ -829,10 +889,14 @@ describe('Workbench page', () => {
     initIntercepts({});
     cy.interceptK8sList(
       PVCModel,
-      mockK8sResourceList([mockPVCK8sResource({ name: 'mismatch-commit-notebook' })]),
+      mockK8sResourceList([
+        mockPVCK8sResource({ name: 'mismatch-commit-notebook' }),
+        mockPVCK8sResource({ name: 'mismatch-commit-byon-notebook' }),
+      ]),
     );
     cy.interceptK8s(RouteModel, mockRouteK8sResource({ notebookName: 'mismatch-commit-notebook' }));
     workbenchPage.visit('test-project');
+    workbenchPage.getNotebookRow('BYON Notebook').findNotebookImageLabel().should('not.exist');
     workbenchPage.getNotebookRow('Deleted Notebook').findNotebookImageLabel().click();
     cy.contains('Notebook image deleted');
   });

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -3,7 +3,10 @@ import { ImageStreamKind, ImageStreamSpecTagType, NotebookKind } from '~/k8sType
 import useNamespaces from '~/pages/notebookController/useNamespaces';
 import useImageStreams from '~/pages/projects/screens/spawner/useImageStreams';
 import { PodContainer } from '~/types';
-import { getImageStreamDisplayName } from '~/pages/projects/screens/spawner/spawnerUtils';
+import {
+  getImageStreamDisplayName,
+  isBYONImageStream,
+} from '~/pages/projects/screens/spawner/spawnerUtils';
 import { NotebookImageAvailability, NotebookImageStatus } from './const';
 import { NotebookImageData } from './types';
 
@@ -115,7 +118,10 @@ const getNotebookImageInternalRegistry = (
 ): NotebookImageData[0] => {
   const imageStream = images.find((image) => image.metadata.name === imageName);
 
-  if (!imageStream || !findNotebookImageCommit(notebook, images)) {
+  if (
+    !imageStream ||
+    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
+  ) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],
@@ -155,7 +161,10 @@ const getNotebookImageNoInternalRegistry = (
       image.spec.tags?.find((version) => version.from?.name === containerImage),
   );
 
-  if (!imageStream || !findNotebookImageCommit(notebook, images)) {
+  if (
+    !imageStream ||
+    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
+  ) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],
@@ -197,7 +206,10 @@ const getNotebookImageNoInternalRegistryNoSHA = (
     ),
   );
 
-  if (!imageStream || !findNotebookImageCommit(notebook, images)) {
+  if (
+    !imageStream ||
+    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
+  ) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -118,10 +118,7 @@ const getNotebookImageInternalRegistry = (
 ): NotebookImageData[0] => {
   const imageStream = images.find((image) => image.metadata.name === imageName);
 
-  if (
-    !imageStream ||
-    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
-  ) {
+  if (!imageStream || isNotebookImageDeleted(notebook, imageStream)) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],
@@ -161,10 +158,7 @@ const getNotebookImageNoInternalRegistry = (
       image.spec.tags?.find((version) => version.from?.name === containerImage),
   );
 
-  if (
-    !imageStream ||
-    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
-  ) {
+  if (!imageStream || isNotebookImageDeleted(notebook, imageStream)) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],
@@ -206,10 +200,7 @@ const getNotebookImageNoInternalRegistryNoSHA = (
     ),
   );
 
-  if (
-    !imageStream ||
-    (!findNotebookImageCommit(notebook, images) && !isBYONImageStream(imageStream))
-  ) {
+  if (!imageStream || isNotebookImageDeleted(notebook, imageStream)) {
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],
@@ -259,17 +250,16 @@ const getImageStatus = (imageVersion: ImageStreamSpecTagType): NotebookImageStat
   return undefined;
 };
 
-const findNotebookImageCommit = (notebook: NotebookKind, images: ImageStreamKind[]) =>
-  images.some(
-    (image) =>
-      image.spec.tags &&
-      image.spec.tags.some(
-        (imageTags) =>
-          imageTags.annotations?.['opendatahub.io/notebook-build-commit'] ===
-          notebook.metadata.annotations?.[
-            'notebooks.opendatahub.io/last-image-version-git-commit-selection'
-          ],
-      ),
+const isNotebookImageDeleted = (notebook: NotebookKind, imageStream: ImageStreamKind) =>
+  !findNotebookImageCommit(notebook, imageStream) && !isBYONImageStream(imageStream);
+
+const findNotebookImageCommit = (notebook: NotebookKind, imageStream: ImageStreamKind) =>
+  imageStream.spec.tags?.some(
+    (imageTags) =>
+      imageTags.annotations?.['opendatahub.io/notebook-build-commit'] ===
+      notebook.metadata.annotations?.[
+        'notebooks.opendatahub.io/last-image-version-git-commit-selection'
+      ],
   );
 
 export default useNotebookImageData;

--- a/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
+++ b/frontend/src/pages/projects/screens/spawner/spawnerUtils.ts
@@ -347,16 +347,16 @@ export const checkRequiredFieldsForNotebookStart = (
   return isNotebookDataValid && isEnvVariableDataValid(envVariables);
 };
 
+export const isBYONImageStream = (imageStream: ImageStreamKind): boolean =>
+  imageStream.metadata.labels?.['app.kubernetes.io/created-by'] === 'byon';
+
 export const isInvalidBYONImageStream = (imageStream: ImageStreamKind): boolean => {
   // there will be always only 1 tag in the spec for BYON images
   // status tags could be more than one
   const activeTag = imageStream.status?.tags?.find(
     (statusTag) => statusTag.tag === imageStream.spec.tags?.[0].name,
   );
-  return (
-    imageStream.metadata.labels?.['app.kubernetes.io/created-by'] === 'byon' &&
-    (activeTag === undefined || activeTag.items === null)
-  );
+  return isBYONImageStream(imageStream) && (activeTag === undefined || activeTag.items === null);
 };
 
 export const getPvcVolumeDetails = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-25679

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Added a check, where an image can only be deleted if the build commit is not found AND it is not a BYON image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Create a byon image
2. Go to the notebook list. It should not show as deleted.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
