### PR TITLE
removed inline kubeflow link

### DIFF
--- a/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineUploadRadio.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Alert,
-  AlertActionLink,
   FormGroup,
   FormHelperText,
   HelperText,
@@ -13,8 +12,7 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { COMPILE_PIPELINE_DOCUMENTATION_URL, PipelineUploadOption } from './utils';
+import { PipelineUploadOption } from './utils';
 import PipelineFileUpload from './PipelineFileUpload';
 
 type PipelineFileUploadProps = {
@@ -70,23 +68,6 @@ const PipelineUploadRadio: React.FC<PipelineFileUploadProps> = ({
         variant="info"
         title="For expected file format, refer to Compile Pipeline Documentation."
         isInline
-        actionLinks={
-          <>
-            <AlertActionLink
-              component="a"
-              href={COMPILE_PIPELINE_DOCUMENTATION_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Split hasGutter>
-                <SplitItem>View documentation</SplitItem>
-                <SplitItem>
-                  <ExternalLinkAltIcon />
-                </SplitItem>
-              </Split>
-            </AlertActionLink>
-          </>
-        }
       />
     </StackItem>
     <StackItem>

--- a/frontend/src/concepts/pipelines/content/import/utils.ts
+++ b/frontend/src/concepts/pipelines/content/import/utils.ts
@@ -4,9 +4,6 @@ import { PipelineKF } from '~/concepts/pipelines/kfTypes';
 export const generatePipelineVersionName = (pipeline?: PipelineKF | null): string =>
   pipeline ? `${pipeline.display_name}_version_at_${new Date().toISOString()}` : '';
 
-export const COMPILE_PIPELINE_DOCUMENTATION_URL =
-  'https://www.kubeflow.org/docs/components/pipelines/v2/compile-a-pipeline/';
-
 export enum PipelineUploadOption {
   URL_IMPORT,
   FILE_UPLOAD,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-11161

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1724" alt="Screenshot 2025-05-19 at 2 39 40 PM" src="https://github.com/user-attachments/assets/033daec3-9c35-404c-a034-34c7f0970e21" />
Removed inline kubeflow link, as mentioned in the issue comments

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to the import pipeline modal. The link should not be there anymore.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A, micro copy update

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
