### PR TITLE
Add serving runtime version to deployment table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -108,6 +108,10 @@ class ModelServingGlobal {
   findServingRuntime(name: string) {
     return this.findModelsTable().find(`[data-label=Serving Runtime]`).contains(name);
   }
+
+  findServingRuntimeVersionLabel() {
+    return cy.findByTestId('serving-runtime-version-label');
+  }
 }
 
 class ServingRuntimeGroup extends Contextual<HTMLElement> {}

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -927,6 +927,31 @@ describe('Model Serving Global', () => {
     modelServingGlobal.getModelMetricLink('Test Inference Service').click();
     cy.findByTestId('app-page-title').should('have.text', 'Test Inference Service metrics');
   });
+  it('Display the version label if the annotation is present', () => {
+    const servingRuntimeWithVersion = mockServingRuntimeK8sResource({});
+    servingRuntimeWithVersion.metadata.annotations =
+      servingRuntimeWithVersion.metadata.annotations || {};
+    servingRuntimeWithVersion.metadata.annotations['opendatahub.io/runtime-version'] = '1.2.3';
+
+    initIntercepts({
+      servingRuntimes: [servingRuntimeWithVersion],
+    });
+
+    modelServingGlobal.visit();
+    modelServingGlobal.findServingRuntimeVersionLabel().should('exist');
+    modelServingGlobal.findServingRuntimeVersionLabel().should('contain.text', '1.2.3');
+  });
+
+  it('Not display the version label if the annotation is absent', () => {
+    const servingRuntimeWithoutVersion = mockServingRuntimeK8sResource({});
+
+    initIntercepts({
+      servingRuntimes: [servingRuntimeWithoutVersion],
+    });
+
+    modelServingGlobal.visit();
+    modelServingGlobal.findServingRuntimeVersionLabel().should('not.exist');
+  });
 
   describe('Table filter and pagination', () => {
     it('filter by name', () => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
@@ -125,6 +125,6 @@ describe('getServingRuntimeVersionFromTemplate', () => {
 
   it('should return empty string if annotation is not present', () => {
     const servingRuntime = mockServingRuntimeK8sResource({});
-    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe('');
+    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe(undefined);
   });
 });

--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
@@ -6,6 +6,7 @@ import { ServingRuntimeKind } from '~/k8sTypes';
 import {
   getDisplayNameFromServingRuntimeTemplate,
   getEnabledPlatformsFromTemplate,
+  getServingRuntimeVersionFromTemplate,
   getTemplateEnabledForPlatform,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { ServingRuntimePlatform } from '~/types';
@@ -110,5 +111,20 @@ describe('getEnabledPlatformsFromTemplate', () => {
       ServingRuntimePlatform.SINGLE,
       ServingRuntimePlatform.MULTI,
     ]);
+  });
+});
+
+describe('getServingRuntimeVersionFromTemplate', () => {
+  it('should return the version from the annotation', () => {
+    const servingRuntime = mockServingRuntimeK8sResource({});
+    servingRuntime.metadata.annotations = {
+      'opendatahub.io/runtime-version': '1.0.0',
+    };
+    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe('1.0.0');
+  });
+
+  it('should return empty string if annotation is not present', () => {
+    const servingRuntime = mockServingRuntimeK8sResource({});
+    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe('');
   });
 });

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -126,6 +126,9 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';
 };
 
+export const getServingRuntimeVersionFromTemplate = (resource: ServingRuntimeKind): string =>
+  resource.metadata.annotations?.['opendatahub.io/runtime-version'] || '';
+
 export const getEnabledPlatformsFromTemplate = (
   template: TemplateKind,
 ): ServingRuntimePlatform[] => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -126,8 +126,10 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';
 };
 
-export const getServingRuntimeVersionFromTemplate = (resource: ServingRuntimeKind): string =>
-  resource.metadata.annotations?.['opendatahub.io/runtime-version'] || '';
+export const getServingRuntimeVersionFromTemplate = (
+  resource: ServingRuntimeKind,
+): string | undefined =>
+  resource.metadata.annotations?.['opendatahub.io/runtime-version'] || undefined;
 
 export const getEnabledPlatformsFromTemplate = (
   template: TemplateKind,

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -3,7 +3,10 @@ import * as React from 'react';
 import TypedObjectIcon from '~/concepts/design/TypedObjectIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
 import { ServingRuntimeKind } from '~/k8sTypes';
-import { getDisplayNameFromServingRuntimeTemplate } from '~/pages/modelServing/customServingRuntimes/utils';
+import {
+  getDisplayNameFromServingRuntimeTemplate,
+  getServingRuntimeVersionFromTemplate,
+} from '~/pages/modelServing/customServingRuntimes/utils';
 import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
 
 type Props = {
@@ -16,6 +19,19 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
     {servingRuntime ? (
       <>
         {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
+        {getServingRuntimeVersionFromTemplate(servingRuntime) && (
+          <>
+            {' '}
+            <Label
+              variant="filled"
+              color="grey"
+              data-testid="serving-runtime-version-label"
+              isCompact
+            >
+              {getServingRuntimeVersionFromTemplate(servingRuntime)}
+            </Label>
+          </>
+        )}
         {isProjectScoped &&
           servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
             SERVING_RUNTIME_SCOPE.Project && (
@@ -38,5 +54,4 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
     )}
   </>
 );
-
 export default InferenceServiceServingRuntime;


### PR DESCRIPTION
Closes [RHOAIENG-25675](https://issues.redhat.com/browse/RHOAIENG-25675)

## Description
If the runtime version annotation exists in the serving runtime then it will show in the model deployments table

**Before:**
![Screenshot 2025-05-19 at 2 47 13 PM](https://github.com/user-attachments/assets/b9a6ad41-fd9a-46b0-98bb-1c52a2e3a732)


**After:**
![Screenshot 2025-05-19 at 2 39 29 PM](https://github.com/user-attachments/assets/c598fd47-e6a4-4020-b7c0-c0358103d35c)


## How Has This Been Tested?
Tested locally and with `npm run test`

To test this:
- Deploy a model.
- Go to the model serving global page.
- Note that there is no version for the serving runtime.
- Go to openshift console and search in the project for the `ServingRuntime` for the model you deployed.
- Go to the yaml.
- Add this to the annotations -> `opendatahub.io/runtime-version: 'v0.5.1'`.
- Go back to the dashboard and refresh the page.
- If you want to see it with the project scoped label as well you can add `opendatahub.io/serving-runtime-scope: project` to the annotations as well.
- (shows in the deployment table in global and in the project section)

## Test Impact
Added unit and cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
