### PR TITLE
Handle duplicate names in different namespaces for project-scoped accelerator profiles

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -21,6 +21,7 @@ type MockResourceConfigType = {
   isProjectScoped?: boolean;
   scope?: string;
   hardwareProfileNamespace?: string;
+  acceleratorProfileNamespace?: string;
   isNonDashboardItem?: boolean;
 };
 
@@ -110,6 +111,7 @@ export const mockServingRuntimeK8sResource = ({
   route = false,
   displayName = 'OVMS Model Serving',
   acceleratorName = '',
+  acceleratorProfileNamespace = undefined,
   hardwareProfileName = '',
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   resources = {
@@ -156,6 +158,7 @@ export const mockServingRuntimeK8sResource = ({
       ...(isProjectScoped && { 'opendatahub.io/serving-runtime-scope': scope }),
       ...(hardwareProfileNamespace && {
         'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
+        'opendatahub.io/accelerator-profile-namespace': acceleratorProfileNamespace,
       }),
     },
     name,

--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -158,6 +158,8 @@ export const mockServingRuntimeK8sResource = ({
       ...(isProjectScoped && { 'opendatahub.io/serving-runtime-scope': scope }),
       ...(hardwareProfileNamespace && {
         'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
+      }),
+      ...(acceleratorProfileNamespace && {
         'opendatahub.io/accelerator-profile-namespace': acceleratorProfileNamespace,
       }),
     },

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -850,6 +850,24 @@ describe('Model Serving Global', () => {
     kserveModalEdit.findProjectScopedLabel().should('exist');
   });
 
+  it('Display Existing settings for deleted accelerator profile selection on Edit', () => {
+    initIntercepts({
+      projectEnableModelMesh: false,
+      disableServingRuntimeParamsConfig: false,
+      disableProjectScoped: false,
+      servingRuntimes: [
+        mockServingRuntimeK8sResource({
+          acceleratorName: 'large-profile-2',
+        }),
+      ],
+    });
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
+    acceleratorProfileSection
+      .findAcceleratorProfileSearchSelector()
+      .should('contain.text', 'Existing settings');
+  });
+
   it('Display global scoped label on serving runtime selection', () => {
     initIntercepts({
       projectEnableModelMesh: false,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -838,6 +838,7 @@ describe('Model Serving Global', () => {
       servingRuntimes: [
         mockServingRuntimeK8sResource({
           acceleratorName: 'large-profile-1',
+          acceleratorProfileNamespace: 'test-project',
         }),
       ],
     });

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -101,6 +101,15 @@ export const assembleNotebook = (
           'opendatahub.io/hardware-profile-namespace': null,
         };
 
+  let acceleratorProfileNamespace: Record<string, string | null> | null = {
+    'opendatahub.io/accelerator-profile-namespace': null,
+  };
+  if (selectedAcceleratorProfile?.metadata.namespace === projectName) {
+    acceleratorProfileNamespace = {
+      'opendatahub.io/accelerator-profile-namespace': data.projectName,
+    };
+  }
+
   const resource: NotebookKind = {
     apiVersion: 'kubeflow.org/v1',
     kind: 'Notebook',
@@ -113,6 +122,7 @@ export const assembleNotebook = (
       },
       annotations: {
         ...hardwareProfileNamespace,
+        ...acceleratorProfileNamespace,
         'openshift.io/display-name': notebookName.trim(),
         'openshift.io/description': description || '',
         'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -94,14 +94,14 @@ export const assembleNotebook = (
     volumeMounts.push(getshmVolumeMount());
   }
 
-  const hardwareProfileNamespace: Record<string, string | null> | null =
+  const hardwareProfileNamespace: Record<string, string | null> =
     selectedHardwareProfile?.metadata.namespace === projectName
       ? { 'opendatahub.io/hardware-profile-namespace': projectName }
       : {
           'opendatahub.io/hardware-profile-namespace': null,
         };
 
-  let acceleratorProfileNamespace: Record<string, string | null> | null = {
+  let acceleratorProfileNamespace: Record<string, string | null> = {
     'opendatahub.io/accelerator-profile-namespace': null,
   };
   if (selectedAcceleratorProfile?.metadata.namespace === projectName) {

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -73,6 +73,12 @@ export const assembleServingRuntime = (
     annotations['opendatahub.io/hardware-profile-namespace'] = undefined;
   }
 
+  if (podSpecOptions.selectedAcceleratorProfile?.metadata.namespace === namespace) {
+    annotations['opendatahub.io/accelerator-profile-namespace'] = namespace;
+  } else {
+    annotations['opendatahub.io/accelerator-profile-namespace'] = undefined;
+  }
+
   // TODO: Enable GRPC
   if (!isEditing) {
     updatedServingRuntime.metadata = {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -114,6 +114,7 @@ export type NotebookAnnotations = Partial<{
   'notebooks.opendatahub.io/last-image-version-git-commit-selection': string; // the build commit of the last image they selected
   'opendatahub.io/hardware-profile-namespace': string | null; // the namespace of the hardware profile used
   'opendatahub.io/workbench-image-namespace': string | null; // namespace of the
+  'opendatahub.io/accelerator-profile-namespace': string | undefined; // the namespace of the accelerator profile used
 }>;
 
 export type DashboardLabels = {
@@ -143,6 +144,7 @@ export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/apiProtocol': string;
   'opendatahub.io/serving-runtime-scope': string;
   'opendatahub.io/hardware-profile-namespace': string | undefined;
+  'opendatahub.io/accelerator-profile-namespace': string | undefined;
   'enable-route': string;
   'enable-auth': string;
   'modelmesh-enabled': 'true' | 'false';

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
@@ -17,12 +17,15 @@ const useServingAcceleratorProfileFormState = (
     inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const namespace = servingRuntime?.metadata.namespace;
+  const acceleratorProfileNamespace =
+    servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-profile-namespace'];
 
   return useAcceleratorProfileFormState(
     resources,
     tolerations,
     acceleratorProfileName,
     isProjectScopedAvailable ? namespace : undefined,
+    acceleratorProfileNamespace,
   );
 };
 

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -187,18 +187,18 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     <>
       <MenuItem
         key="none"
-        isSelected={!formData.profile}
+        isSelected={!formData.profile && !formData.useExistingSettings}
         onClick={() => {
           setFormData('profile', undefined);
         }}
       >
         None
       </MenuItem>
-      {initialState.unknownProfileDetected ? (
+      {formData.useExistingSettings ? (
         <MenuItem
           key="unknown-existing"
           description="Use the existing accelerator settings from the notebook server"
-          isSelected={!formData.profile}
+          isSelected={formData.useExistingSettings}
           onClick={() => {
             setFormData('profile', undefined);
           }}
@@ -348,7 +348,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 isFullWidth
                 extraMenuItems={extraMenuItems}
               />
-              {initialState.unknownProfileDetected
+              {formData.useExistingSettings
                 ? 'Use existing resource requests/limits, tolerations, and node selectors.'
                 : null}
               {currentProjectAcceleratorProfilesError && (

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfileFormState.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookAcceleratorProfileFormState.ts
@@ -15,11 +15,15 @@ const useNotebookAcceleratorProfileFormState = (
   const tolerations = notebook?.spec.template.spec.tolerations;
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const namespace = notebook?.metadata.namespace;
+  const acceleratorProfileNamespace =
+    notebook?.metadata.annotations?.['opendatahub.io/accelerator-profile-namespace'];
+
   return useAcceleratorProfileFormState(
     resources,
     tolerations,
     name,
     isProjectScopedAvailable ? namespace : undefined,
+    acceleratorProfileNamespace,
   );
 };
 

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -77,16 +77,14 @@ const useAcceleratorProfileFormState = (
       let acceleratorProfile: AcceleratorProfileKind | undefined;
       if (existingAcceleratorProfileName && acceleratorProfileNamespace) {
         // Look for the profile by both name and namespace in all available profiles
-        acceleratorProfile = allProfiles.find(
+        acceleratorProfile = projectProfiles.find(
           (ap) =>
             ap.metadata.name === existingAcceleratorProfileName &&
             ap.metadata.namespace === acceleratorProfileNamespace,
         );
       } else if (existingAcceleratorProfileName) {
         // Fallback: look by name only if no namespace is specified
-        acceleratorProfile =
-          projectScopedInitialState.acceleratorProfile ||
-          globalScopedInitialState.acceleratorProfile;
+        acceleratorProfile = globalScopedInitialState.acceleratorProfile;
       }
 
       // Check for deleted profile: we have profile reference but can't find it

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -46,6 +46,26 @@ const useAcceleratorProfileFormState = (
     : globalScopedLoadError;
 
   const initialState = React.useMemo(() => {
+    // Check if project-scoped feature flag is off but workbench has project-scoped profile
+    // Only apply this if acceleratorProfileNamespace is NOT the global dashboard namespace
+    if (
+      !namespace &&
+      existingAcceleratorProfileName &&
+      acceleratorProfileNamespace &&
+      acceleratorProfileNamespace !==
+        globalScopedInitialState.acceleratorProfiles[0]?.metadata.namespace
+    ) {
+      // Feature flag is off (no namespace) but workbench has project-scoped profile
+      // Show "Existing settings" instead of searching for global profile with same name
+      const state: AcceleratorProfileState = {
+        acceleratorProfiles: globalScopedInitialState.acceleratorProfiles,
+        acceleratorProfile: undefined,
+        count: 1,
+        unknownProfileDetected: true,
+      };
+      return state;
+    }
+
     // If we have a namespace, use project-scoped state but include global profiles
     if (namespace) {
       // Keep project and global profiles separate

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -27,11 +27,18 @@ const useAcceleratorProfileFormState = (
   tolerations?: Toleration[],
   existingAcceleratorProfileName?: string,
   namespace?: string,
+  acceleratorProfileNamespace?: string,
 ): UseAcceleratorProfileFormResult => {
   const [globalScopedInitialState, globalScopedLoaded, globalScopedLoadError, refresh] =
     useReadAcceleratorState(resources, tolerations, existingAcceleratorProfileName);
   const [projectScopedInitialState, projectScopedLoaded, projectScopedLoadError] =
-    useReadAcceleratorState(resources, tolerations, existingAcceleratorProfileName, namespace);
+    useReadAcceleratorState(
+      resources,
+      tolerations,
+      existingAcceleratorProfileName,
+      namespace,
+      acceleratorProfileNamespace,
+    );
 
   const loaded = namespace ? projectScopedLoaded && globalScopedLoaded : globalScopedLoaded;
   const loadError = namespace

--- a/frontend/src/utilities/useReadAcceleratorState.ts
+++ b/frontend/src/utilities/useReadAcceleratorState.ts
@@ -68,6 +68,17 @@ const useReadAcceleratorState = (
         });
       }
 
+      // Check if we have a profile name reference but can't find the profile
+      // This indicates the profile was deleted
+      if (existingAcceleratorProfileName) {
+        return Promise.resolve({
+          acceleratorProfiles,
+          acceleratorProfile: undefined,
+          count: 1, // Default count when profile is missing
+          unknownProfileDetected: true,
+        });
+      }
+
       // check if there is accelerator usage in the container
       // this is to handle the case where the accelerator is disabled, deleted, or empty
       const possibleAcceleratorRequests = Object.entries(resources.requests ?? {})

--- a/frontend/src/utilities/useReadAcceleratorState.ts
+++ b/frontend/src/utilities/useReadAcceleratorState.ts
@@ -47,13 +47,13 @@ const useReadAcceleratorState = (
     // Exit early if no resources = not in edit mode
     if (resources) {
       let acceleratorProfile: AcceleratorProfileKind | undefined;
-      if (namespace && acceleratorProfileNamespace) {
+      if (namespace) {
         acceleratorProfile = acceleratorProfiles.find(
           (cr) =>
             cr.metadata.name === existingAcceleratorProfileName &&
             cr.metadata.namespace === acceleratorProfileNamespace,
         );
-      } else if (existingAcceleratorProfileName) {
+      } else {
         acceleratorProfile = acceleratorProfiles.find(
           (cr) => cr.metadata.name === existingAcceleratorProfileName,
         );
@@ -65,17 +65,6 @@ const useReadAcceleratorState = (
           acceleratorProfile,
           count: getAcceleratorProfileCount(acceleratorProfile, resources),
           unknownProfileDetected: false,
-        });
-      }
-
-      // Check if we have an existing profile name but couldn't find the profile
-      // This indicates the profile was deleted
-      if (existingAcceleratorProfileName) {
-        return Promise.resolve({
-          acceleratorProfiles,
-          acceleratorProfile: undefined,
-          count: 1, // Default count since we can't determine from missing resources
-          unknownProfileDetected: true,
         });
       }
 

--- a/frontend/src/utilities/useReadAcceleratorState.ts
+++ b/frontend/src/utilities/useReadAcceleratorState.ts
@@ -28,6 +28,7 @@ const useReadAcceleratorState = (
   tolerations?: Toleration[],
   existingAcceleratorProfileName?: string,
   namespace?: string,
+  acceleratorProfileNamespace?: string,
 ): FetchState<AcceleratorProfileState> => {
   const { dashboardNamespace } = useDashboardNamespace();
   const [acceleratorProfiles, loaded, loadError] = useAcceleratorProfiles(
@@ -45,9 +46,18 @@ const useReadAcceleratorState = (
     }
     // Exit early if no resources = not in edit mode
     if (resources) {
-      const acceleratorProfile = acceleratorProfiles.find(
-        (cr) => cr.metadata.name === existingAcceleratorProfileName,
-      );
+      let acceleratorProfile: AcceleratorProfileKind | undefined;
+      if (namespace) {
+        acceleratorProfile = acceleratorProfiles.find(
+          (cr) =>
+            cr.metadata.name === existingAcceleratorProfileName &&
+            cr.metadata.namespace === acceleratorProfileNamespace,
+        );
+      } else {
+        acceleratorProfile = acceleratorProfiles.find(
+          (cr) => cr.metadata.name === existingAcceleratorProfileName,
+        );
+      }
 
       if (acceleratorProfile) {
         return Promise.resolve({
@@ -139,7 +149,9 @@ const useReadAcceleratorState = (
     loadError,
     resources,
     acceleratorProfiles,
+    namespace,
     existingAcceleratorProfileName,
+    acceleratorProfileNamespace,
     tolerations,
     dashboardNamespace,
   ]);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes: [RHOAIENG-25733](https://issues.redhat.com/browse/RHOAIENG-25733)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
1. Handle duplicate names in different namespace(namely project and global namespace).
2. Show and select "Existing settings" when a deleted project-scoped and global accelerator profile is being used on Edit page of Workbenches/kserve/model-mesh/training hardware field in Ilab form

<img width="621" alt="Screenshot 2025-06-03 at 6 30 28 PM" src="https://github.com/user-attachments/assets/afce4ff2-4905-475b-9ed4-8c2d311ecbf2" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create/copy the same `AcceleratorProfile` from `opendatahub` and just change the namespace(not the name) to a project when you want to create this item. Change from the project-scoped to the global-scoped accelerator profile and check whether the label reflects properly.
2. Make sure "Existing settings" is showed and selected when a deleted project-scoped and global accelerator profile is being used on Edit page of Workbenches/kserve/model-mesh/training hardware field in Ilab form

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed existing Cypress test failures introduced due to this new change

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
