### PR TITLE
'valueFrom' env vars bug fix

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -28,7 +28,11 @@ type MockResourceConfigType = {
   kserveInternalLabel?: boolean;
   additionalLabels?: Record<string, string>;
   args?: string[];
-  env?: Array<{ name: string; value: string }>;
+  env?: Array<{
+    name: string;
+    value?: string;
+    valueFrom?: { secretKeyRef: { name: string; key: string } };
+  }>;
   isKserveRaw?: boolean;
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -928,6 +928,34 @@ describe('Model Serving Global', () => {
     cy.findByTestId('app-page-title').should('have.text', 'Test Inference Service metrics');
   });
 
+  it('Should display env vars from a valueFrom secret', () => {
+    initIntercepts({
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          env: [
+            {
+              name: 'value-from-secret-env-var',
+              valueFrom: { secretKeyRef: { name: 'test-secret', key: 'test-key' } },
+            },
+            {
+              name: 'key-value-env-var',
+              value: 'test-value',
+            },
+          ],
+        }),
+      ],
+    });
+    modelServingGlobal.visit('test-project');
+
+    modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
+    kserveModalEdit.findServingRuntimeEnvVarsValue('0').should('be.disabled');
+    kserveModalEdit
+      .findServingRuntimeEnvVarsValue('0')
+      .should('have.value', '{"secretKeyRef":{"name":"test-secret","key":"test-key"}}');
+    kserveModalEdit.findServingRuntimeEnvVarsValue('1').should('not.be.disabled');
+    kserveModalEdit.findServingRuntimeEnvVarsValue('1').should('have.value', 'test-value');
+  });
+
   describe('Table filter and pagination', () => {
     it('filter by name', () => {
       initIntercepts({});

--- a/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
@@ -17,6 +17,7 @@ import {
   getModelServingCompatibility,
   isModelServingCompatible,
   isValidEnvVar,
+  isValueFromEnvVar,
   ModelServingCompatibleTypes,
   toConnectionTypeConfigMap,
   toConnectionTypeConfigMapObj,
@@ -542,5 +543,30 @@ describe('useTrimInputHandlers', () => {
 
     trimInputOnPaste('', handleChange)(mockEvent);
     expect(handleChange).toHaveBeenCalledWith('foo');
+  });
+});
+
+describe('isValueFrom', () => {
+  it('should return true if the value is from a valueFrom envVar', () => {
+    expect(
+      isValueFromEnvVar({
+        valueFrom: {
+          secretKeyRef: {
+            name: 'test',
+            key: '',
+          },
+        },
+        name: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false if the value is not from a valueFrom envVar', () => {
+    expect(
+      isValueFromEnvVar({
+        value: 'test',
+        name: '',
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/connectionTypes/__tests__/utils.spec.ts
@@ -17,7 +17,6 @@ import {
   getModelServingCompatibility,
   isModelServingCompatible,
   isValidEnvVar,
-  isValueFromEnvVar,
   ModelServingCompatibleTypes,
   toConnectionTypeConfigMap,
   toConnectionTypeConfigMapObj,
@@ -543,30 +542,5 @@ describe('useTrimInputHandlers', () => {
 
     trimInputOnPaste('', handleChange)(mockEvent);
     expect(handleChange).toHaveBeenCalledWith('foo');
-  });
-});
-
-describe('isValueFrom', () => {
-  it('should return true if the value is from a valueFrom envVar', () => {
-    expect(
-      isValueFromEnvVar({
-        valueFrom: {
-          secretKeyRef: {
-            name: 'test',
-            key: '',
-          },
-        },
-        name: '',
-      }),
-    ).toBe(true);
-  });
-
-  it('should return false if the value is not from a valueFrom envVar', () => {
-    expect(
-      isValueFromEnvVar({
-        value: 'test',
-        name: '',
-      }),
-    ).toBe(false);
   });
 });

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { KnownLabels, SecretKind, ServingContainer } from '~/k8sTypes';
+import { KnownLabels, SecretKind } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
 import {
@@ -429,25 +429,6 @@ export const findSectionFields = (
 
   return fields.slice(sectionIndex + 1, nextSectionIndex === -1 ? undefined : nextSectionIndex);
 };
-
-export const VALID_ENV_VARNAME_REGEX = /^[A-Za-z_][A-Za-z0-9_\-.]*$/;
-export const STARTS_WITH_DIGIT_REGEX = /^\d/;
-
-export const validateEnvVarName = (name: string): string | undefined => {
-  if (!name) {
-    return undefined;
-  }
-  if (STARTS_WITH_DIGIT_REGEX.test(name)) {
-    return 'Must not start with a digit.';
-  }
-  if (!VALID_ENV_VARNAME_REGEX.test(name)) {
-    return "Must consist of alphabetic characters, digits, '_', '-', or '.'";
-  }
-  return undefined;
-};
-
-export const isValueFromEnvVar = (envVar: NonNullable<ServingContainer['env']>[number]): boolean =>
-  envVar.valueFrom !== undefined;
 
 export const convertObjectStorageSecretData = (dataConnection: Connection): AWSDataEntry => {
   let convertedData: { key: AwsKeys; value: string }[] = [];

--- a/frontend/src/concepts/connectionTypes/utils.ts
+++ b/frontend/src/concepts/connectionTypes/utils.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { KnownLabels, SecretKind } from '~/k8sTypes';
+import { KnownLabels, SecretKind, ServingContainer } from '~/k8sTypes';
 import { getDisplayNameFromK8sResource, translateDisplayNameForK8s } from '~/concepts/k8s/utils';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
 import {
@@ -445,6 +445,9 @@ export const validateEnvVarName = (name: string): string | undefined => {
   }
   return undefined;
 };
+
+export const isValueFromEnvVar = (envVar: NonNullable<ServingContainer['env']>[number]): boolean =>
+  envVar.valueFrom !== undefined;
 
 export const convertObjectStorageSecretData = (dataConnection: Connection): AWSDataEntry => {
   let convertedData: { key: AwsKeys; value: string }[] = [];

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getProjectModelServingPlatform,
   getUrlFromKserveInferenceService,
   isCurrentServingPlatformEnabled,
+  isValueFromEnvVar,
 } from '~/pages/modelServing/screens/projects/utils';
 import { ServingPlatformStatuses } from '~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '~/types';
@@ -549,5 +550,30 @@ describe('isCurrentServingPlatformEnabled', () => {
 
   it('returns false if currentPlatform is undefined', () => {
     expect(isCurrentServingPlatformEnabled(undefined, baseStatuses)).toBe(false);
+  });
+});
+
+describe('isValueFrom', () => {
+  it('should return true if the value is from a valueFrom envVar', () => {
+    expect(
+      isValueFromEnvVar({
+        valueFrom: {
+          secretKeyRef: {
+            name: 'test',
+            key: '',
+          },
+        },
+        name: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false if the value is not from a valueFrom envVar', () => {
+    expect(
+      isValueFromEnvVar({
+        value: 'test',
+        name: '',
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -23,7 +23,7 @@ import {
 } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
-import { isValueFromEnvVar, validateEnvVarName } from '~/concepts/connectionTypes/utils';
+import { isValueFromEnvVar, validateEnvVarName } from '~/pages/modelServing/screens/projects/utils';
 import { ServingContainer } from '~/k8sTypes';
 
 type EnvironmentVariablesSectionType = {

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/EnvironmentVariablesSection.tsx
@@ -23,7 +23,7 @@ import {
 } from '@patternfly/react-icons';
 import { UpdateObjectAtPropAndValue } from '~/pages/projects/types';
 import { CreatingInferenceServiceObject } from '~/pages/modelServing/screens/types';
-import { validateEnvVarName } from '~/concepts/connectionTypes/utils';
+import { isValueFromEnvVar, validateEnvVarName } from '~/concepts/connectionTypes/utils';
 import { ServingContainer } from '~/k8sTypes';
 
 type EnvironmentVariablesSectionType = {
@@ -145,6 +145,7 @@ const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = (
       <Stack hasGutter>
         {data.servingRuntimeEnvVars?.map((envVar, index) => {
           const error = validateEnvVarName(envVar.name);
+          const isEnvVarValueFrom = isValueFromEnvVar(envVar);
           return (
             <Split hasGutter key={index}>
               <SplitItem isFilled>
@@ -171,14 +172,29 @@ const EnvironmentVariablesSection: React.FC<EnvironmentVariablesSectionType> = (
                 )}
               </SplitItem>
               <SplitItem isFilled>
-                <TextInput
-                  data-testid={`serving-runtime-environment-variables-input-value ${index}`}
-                  aria-label="env var value"
-                  value={envVar.value}
-                  onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
-                    updateEnvVar(index, { value })
+                <Tooltip
+                  trigger={isEnvVarValueFrom ? 'mouseenter' : ''}
+                  content={
+                    <>
+                      <div>{JSON.stringify(envVar.valueFrom)}</div>
+                      <br />
+                      <div>
+                        The value of this variable is defined by a key of a ConfigMap/Secret. It can
+                        only be edited from the OpenShift console.
+                      </div>
+                    </>
                   }
-                />
+                >
+                  <TextInput
+                    data-testid={`serving-runtime-environment-variables-input-value ${index}`}
+                    aria-label="env var value"
+                    value={envVar.value ? envVar.value : JSON.stringify(envVar.valueFrom)}
+                    isDisabled={isEnvVarValueFrom}
+                    onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
+                      updateEnvVar(index, { value })
+                    }
+                  />
+                </Tooltip>
               </SplitItem>
               <SplitItem>
                 <Button

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -15,6 +15,7 @@ import {
   getSubmitServingRuntimeResourcesFn,
   useCreateInferenceServiceObject,
   useCreateServingRuntimeObject,
+  validateEnvVarName,
 } from '~/pages/modelServing/screens/projects/utils';
 import {
   TemplateKind,
@@ -58,7 +59,6 @@ import K8sNameDescriptionField, {
 import { isK8sNameDescriptionDataValid } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import { useProfileIdentifiers } from '~/concepts/hardwareProfiles/utils';
 import { useModelServingPodSpecOptionsState } from '~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
-import { validateEnvVarName } from '~/concepts/connectionTypes/utils';
 import usePrefillModelDeployModal, {
   ModelDeployPrefillInfo,
 } from '~/pages/modelServing/screens/projects/usePrefillModelDeployModal';

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -8,6 +8,7 @@ import {
   PersistentVolumeClaimKind,
   ProjectKind,
   SecretKind,
+  ServingContainer,
   ServingRuntimeKind,
 } from '~/k8sTypes';
 import { NamespaceApplicationCase, UpdateObjectAtPropAndValue } from '~/pages/projects/types';
@@ -742,3 +743,22 @@ export function isCurrentServingPlatformEnabled(
   const mappedKey = platformKeyMap[currentPlatform];
   return statuses[mappedKey].enabled;
 }
+
+export const VALID_ENV_VARNAME_REGEX = /^[A-Za-z_][A-Za-z0-9_\-.]*$/;
+export const STARTS_WITH_DIGIT_REGEX = /^\d/;
+
+export const validateEnvVarName = (name: string): string | undefined => {
+  if (!name) {
+    return undefined;
+  }
+  if (STARTS_WITH_DIGIT_REGEX.test(name)) {
+    return 'Must not start with a digit.';
+  }
+  if (!VALID_ENV_VARNAME_REGEX.test(name)) {
+    return "Must consist of alphabetic characters, digits, '_', '-', or '.'";
+  }
+  return undefined;
+};
+
+export const isValueFromEnvVar = (envVar: NonNullable<ServingContainer['env']>[number]): boolean =>
+  envVar.valueFrom !== undefined;


### PR DESCRIPTION
Closes [RHOAIENG-15595](https://issues.redhat.com/browse/RHOAIENG-15595)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If you had an env variable that pointed to a `Secret` or `ConfigMap` using `valueFrom` then the env value shown in the model deployment would be empty. Upon trying to edit that empty value it would add `value` next to  `valueFrom` and break the whole thing.
Per the ticket, the input now shows the `valueFrom` but is disabled to prevent editing; with a tooltip that explains the value can be edited from the OCP.
<img width="339" alt="Screenshot 2025-05-20 at 3 44 14 PM" src="https://github.com/user-attachments/assets/35a5b017-4ac9-4e87-ae9d-49b1113e3d3a" />


**Previously:**
<img width="818" alt="Screenshot 2025-05-20 at 3 44 21 PM" src="https://github.com/user-attachments/assets/2aeee565-c7b9-407b-bb88-e2c4a8b41696" />

**Now:**
<img width="821" alt="Screenshot 2025-05-20 at 3 56 11 PM" src="https://github.com/user-attachments/assets/6ea4ea48-24ef-4e7c-bafb-3ed4c636d67a" />

**The tooltip:**
<img width="828" alt="Screenshot 2025-05-20 at 3 56 17 PM" src="https://github.com/user-attachments/assets/075236b4-45e0-44cc-a3b3-3d482c220bad" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

**To test this:**
- Go to deploy a kserve model.
- Add a regular env variable. Ex key: `test-variable-key` value: `test-variable-value`.
- Deploy the model.
- Find the deployed inference service in OCP.
- Go to the yaml.
- in `spec.predictor.model.env` add:
```
        - name: console-variable-update
          valueFrom:
            secretKeyRef:
              key: fake-secret-key
              name: fake-secret
```
- Hit save.
- Go back to ODH (might need to refresh the page) and edit the model.
- Find the 'additional environment variables' section and notice that the new envVar is there.
- The key input should be enabled and can be edited but the value input should be disabled and populated with the `valueFrom` with a tooltip showing the content of the input and explaining the value can only be edited from OCP.



## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit and cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
