### PR TITLE
Add Feature flag for LMEval

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -40,6 +40,7 @@ export type MockDashboardConfigType = {
   disableFineTuning?: boolean;
   disableLlamaStackChatBot?: boolean;
   modelServerSizes?: ModelServingSize[];
+  disableLMEval?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -75,6 +76,7 @@ export const mockDashboardConfig = ({
   disableNotebookController = false,
   disableNIMModelServing = false,
   disableLlamaStackChatBot = false,
+  disableLMEval = true,
   modelServerSizes = [
     {
       name: 'Small',
@@ -232,6 +234,7 @@ export const mockDashboardConfig = ({
       disableFineTuning,
       disableModelServingPlugin: true,
       disableLlamaStackChatBot,
+      disableLMEval,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -181,7 +181,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.LM_EVAL]: {
     featureFlags: ['disableLMEval'],
-    //TODO: Discuss with the team regarding reliant areas.
     reliantAreas: [SupportedArea.MODEL_REGISTRY, SupportedArea.MODEL_SERVING],
   },
 };

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -44,6 +44,7 @@ export const allFeatureFlags: string[] = Object.keys({
   disableFineTuning: true,
   disableModelServingPlugin: true, // internal dev only
   disableLlamaStackChatBot: true, // internal dev only
+  disableLMEval: true, // internal dev only
 } satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
@@ -177,6 +178,11 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     featureFlags: ['disableLlamaStackChatBot'],
     reliantAreas: [SupportedArea.MODEL_SERVING],
     //TODO: Add Llama Stack component when details known.
+  },
+  [SupportedArea.LM_EVAL]: {
+    featureFlags: ['disableLMEval'],
+    //TODO: Discuss with the team regarding reliant areas.
+    reliantAreas: [SupportedArea.MODEL_REGISTRY, SupportedArea.MODEL_SERVING],
   },
 };
 

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -76,6 +76,9 @@ export enum SupportedArea {
 
   /* RAG & Agentic */
   LLAMA_STACK_CHAT_BOT = 'llama-stack-chat-bot',
+
+  /* LM Eval */
+  LM_EVAL = 'lm-eval',
 }
 
 /** Components deployed by the Operator. Part of the DSC Status. */

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1227,6 +1227,7 @@ export type DashboardCommonConfig = {
   disableFineTuning: boolean;
   disableModelServingPlugin: boolean;
   disableLlamaStackChatBot: boolean;
+  disableLMEval: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Added feature flag for LMEval

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
<img width="1099" alt="Screenshot 2025-05-21 at 13 29 16" src="https://github.com/user-attachments/assets/8b982158-3d5b-4101-8c12-eeb945eba24d" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
