### PR TITLE
test : Fix multiModelAdminCreation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -139,6 +139,10 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
         checkReady: true,
         checkLatestDeploymentReady: false,
       });
+      // Usually it takes a little longer to load the status tooltip, so it's faster to Reload the page
+      cy.reload(); 
+      modelMeshRow.findDeployedModelExpansionButton().click();
+      // Click the status tooltip
       attemptToClickTooltip();
 
       //Verify the Model is accessible externally


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-26100

## Description
In this PR there's a fix for the wrong detection of the model served spinner in the e2e tests
Also, we've added some logs in order to try to debug what happens when (sometimes) the response from the modelServingService is not well formed (which makes the test to fail randomly)

## How Has This Been Tested?
Locally against the e2e cluster

## Test Impact
Test fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
