### PR TITLE
Add min/max selector to advanced deploy model

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/NIMDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/NIMDeployModal.ts
@@ -33,12 +33,28 @@ class NIMDeployModal extends Modal {
     return cy.get('[data-testid="model-server-replicas"] input');
   }
 
-  findNimModelReplicasMinusButton() {
-    return this.find().find('button[aria-label="Minus"]').eq(1);
+  findMinReplicasInput() {
+    return this.find().findByTestId('min-replicas').find('input');
   }
 
-  findNimModelReplicasPlusButton() {
-    return this.find().find('button[aria-label="Plus"]').eq(1);
+  findMaxReplicasInput() {
+    return this.find().findByTestId('max-replicas').find('input');
+  }
+
+  findMinReplicasPlusButton() {
+    return this.find().findByTestId('min-replicas').findByRole('button', { name: 'Plus' });
+  }
+
+  findMinReplicasMinusButton() {
+    return this.find().findByTestId('min-replicas').findByRole('button', { name: 'Minus' });
+  }
+
+  findMaxReplicasPlusButton() {
+    return this.find().findByTestId('max-replicas').findByRole('button', { name: 'Plus' });
+  }
+
+  findMaxReplicasMinusButton() {
+    return this.find().findByTestId('max-replicas').findByRole('button', { name: 'Minus' });
   }
 
   shouldDisplayError(msg: string): void {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -490,6 +490,30 @@ class KServeModal extends InferenceServiceModal {
   constructor(private edit = false) {
     super(edit);
   }
+
+  findMinReplicasInput() {
+    return this.find().findByTestId('min-replicas').find('input');
+  }
+
+  findMaxReplicasInput() {
+    return this.find().findByTestId('max-replicas').find('input');
+  }
+
+  findMinReplicasPlusButton() {
+    return this.find().findByTestId('min-replicas').findByRole('button', { name: 'Plus' });
+  }
+
+  findMinReplicasMinusButton() {
+    return this.find().findByTestId('min-replicas').findByRole('button', { name: 'Minus' });
+  }
+
+  findMaxReplicasPlusButton() {
+    return this.find().findByTestId('max-replicas').findByRole('button', { name: 'Plus' });
+  }
+
+  findMaxReplicasMinusButton() {
+    return this.find().findByTestId('max-replicas').findByRole('button', { name: 'Minus' });
+  }
 }
 mixin(KServeModal, [ServingRuntimeModal, InferenceServiceModal]);
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1503,6 +1503,21 @@ describe('Serving Runtime List', () => {
       kserveModal.findSubmitButton().should('be.enabled');
       // raw
       kserveModal.findDeploymentModeSelect().should('contain.text', 'Advanced');
+
+      // Test advanced mode replica settings
+      kserveModal.findMinReplicasInput().should('have.value', '1');
+      kserveModal.findMinReplicasPlusButton().should('be.disabled');
+      kserveModal.findMaxReplicasInput().should('have.value', '1');
+      kserveModal.findMaxReplicasMinusButton().should('be.disabled');
+      kserveModal.findMaxReplicasPlusButton().click();
+      kserveModal.findMaxReplicasInput().should('have.value', '2');
+      kserveModal.findMinReplicasPlusButton().click();
+      kserveModal.findMinReplicasInput().should('have.value', '2');
+
+      // Test max limit of 99
+      kserveModal.findMaxReplicasInput().clear().type('100');
+      kserveModal.findMaxReplicasInput().should('have.value', '99');
+      kserveModal.findMaxReplicasPlusButton().should('be.disabled');
       kserveModal.findDeploymentModeSelect().findSelectOption('Standard').click();
 
       // test submitting form, the modal should close to indicate success.
@@ -1564,8 +1579,8 @@ describe('Serving Runtime List', () => {
           },
           spec: {
             predictor: {
-              minReplicas: 1,
-              maxReplicas: 1,
+              minReplicas: 2,
+              maxReplicas: 2,
               model: {
                 modelFormat: { name: 'onnx', version: '1' },
                 runtime: 'test-name',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
@@ -73,15 +73,16 @@ describe('NIM Model Serving', () => {
       nimDeployModal.findNimStorageSizeInput().should('have.value', '30');
 
       // Validate model replicas
-      nimDeployModal.findNimModelReplicas().should('have.value', '1');
-
-      cy.get('button[aria-label="Plus"]').eq(1).should('exist').should('be.visible').click();
-
-      nimDeployModal.findNimModelReplicas().should('have.value', '2');
-
-      cy.get('button[aria-label="Minus"]').eq(1).should('exist').should('be.visible').click();
-
-      nimDeployModal.findNimModelReplicas().should('have.value', '1');
+      nimDeployModal.findMinReplicasInput().should('have.value', '1');
+      nimDeployModal.findMinReplicasPlusButton().should('be.disabled');
+      nimDeployModal.findMaxReplicasInput().should('have.value', '1');
+      nimDeployModal.findMaxReplicasMinusButton().should('be.disabled');
+      nimDeployModal.findMaxReplicasPlusButton().click();
+      nimDeployModal.findMaxReplicasInput().should('have.value', '2');
+      nimDeployModal.findMinReplicasPlusButton().click();
+      nimDeployModal.findMinReplicasInput().should('have.value', '2');
+      nimDeployModal.findMinReplicasMinusButton().click();
+      nimDeployModal.findMaxReplicasMinusButton().click();
 
       nimDeployModal.findSubmitButton().click();
 

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
-import { FormGroup, Popover, Icon } from '@patternfly/react-core';
+import { FormGroup, Popover, Icon, Flex, FlexItem } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import NumberInputWrapper from '~/components/NumberInputWrapper';
 import { normalizeBetween } from '~/utilities/utils';
 
 const MIN_SIZE = 0;
 const MAX_SIZE = 999;
+const ADVANCED_MAX_SIZE = 99;
 
 type ReplicaSectionProps = {
   value: number;
   onChange: (value: number) => void;
   infoContent?: string;
   isRequired?: boolean;
+  isRaw: boolean;
+  maxValue: number;
+  onMaxChange?: (value: number) => void;
 };
 
 const ReplicaSection: React.FC<ReplicaSectionProps> = ({
@@ -19,34 +23,87 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
   onChange,
   infoContent,
   isRequired = false,
-}) => (
-  <FormGroup
-    label="Number of model server replicas to deploy"
-    data-testid="model-server-replicas"
-    labelHelp={
-      infoContent ? (
-        <Popover bodyContent={<div>{infoContent}</div>}>
-          <Icon aria-label="Model server replicas info" role="button">
-            <OutlinedQuestionCircleIcon />
-          </Icon>
-        </Popover>
-      ) : undefined
-    }
-    fieldId="model-server-replicas"
-    isRequired={isRequired}
-  >
-    <NumberInputWrapper
-      min={MIN_SIZE}
-      max={MAX_SIZE}
-      value={value}
-      onChange={(val) => {
-        const newSize = Number(val);
-        if (!Number.isNaN(newSize) && newSize <= MAX_SIZE) {
-          onChange(normalizeBetween(newSize, MIN_SIZE, MAX_SIZE));
-        }
-      }}
-    />
-  </FormGroup>
-);
+  isRaw = true,
+  maxValue,
+  onMaxChange,
+}) => {
+  const maxLimit = isRaw ? MAX_SIZE : maxValue;
+
+  return (
+    <FormGroup
+      label="Number of model server replicas to deploy"
+      data-testid="model-server-replicas"
+      labelHelp={
+        infoContent ? (
+          <Popover bodyContent={<div>{infoContent}</div>}>
+            <Icon aria-label="Model server replicas info" role="button">
+              <OutlinedQuestionCircleIcon />
+            </Icon>
+          </Popover>
+        ) : undefined
+      }
+      fieldId="model-server-replicas"
+      isRequired={isRequired}
+    >
+      <Flex>
+        <FlexItem>
+          {!isRaw && (
+            <FormGroup
+              label={<span style={{ fontWeight: 'normal' }}>Minimum replicas</span>}
+              fieldId="min-replicas"
+              data-testid="min-replicas"
+            >
+              <NumberInputWrapper
+                min={MIN_SIZE}
+                max={maxLimit}
+                value={value}
+                onChange={(val) => {
+                  const newSize = val === undefined ? 0 : Number(val);
+                  if (!Number.isNaN(newSize) && newSize <= maxLimit) {
+                    onChange(normalizeBetween(newSize, MIN_SIZE, maxLimit));
+                  }
+                }}
+              />
+            </FormGroup>
+          )}
+          {isRaw && (
+            <NumberInputWrapper
+              min={MIN_SIZE}
+              max={MAX_SIZE}
+              value={value}
+              onChange={(val) => {
+                const newSize = val === undefined ? 0 : Number(val);
+                if (!Number.isNaN(newSize) && newSize <= MAX_SIZE) {
+                  onChange(normalizeBetween(newSize, MIN_SIZE, MAX_SIZE));
+                }
+              }}
+            />
+          )}
+        </FlexItem>
+        {!isRaw && onMaxChange && (
+          <FlexItem>
+            <FormGroup
+              label={<span style={{ fontWeight: 'normal' }}>Maximum replicas</span>}
+              fieldId="max-replicas"
+              data-testid="max-replicas"
+            >
+              <NumberInputWrapper
+                min={value}
+                max={ADVANCED_MAX_SIZE}
+                value={maxValue}
+                onChange={(val) => {
+                  const newSize = val === undefined ? 0 : Number(val);
+                  if (!Number.isNaN(newSize) && newSize <= ADVANCED_MAX_SIZE && newSize >= value) {
+                    onMaxChange(normalizeBetween(newSize, value, ADVANCED_MAX_SIZE));
+                  }
+                }}
+              />
+            </FormGroup>
+          </FlexItem>
+        )}
+      </Flex>
+    </FormGroup>
+  );
+};
 
 export default ReplicaSection;

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -4,30 +4,29 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import NumberInputWrapper from '~/components/NumberInputWrapper';
 import { normalizeBetween } from '~/utilities/utils';
 
-const MIN_SIZE = 0;
-const MAX_SIZE = 999;
-const ADVANCED_MAX_SIZE = 99;
+const lowerLimit = 0;
+const upperLimit = 99;
 
 type ReplicaSectionProps = {
   value: number;
   onChange: (value: number) => void;
   infoContent?: string;
   isRequired?: boolean;
-  isRaw: boolean;
+  showMinMax: boolean;
   maxValue: number;
   onMaxChange?: (value: number) => void;
 };
 
-const ReplicaSection: React.FC<ReplicaSectionProps> = ({
+const ReplicaFormGroup: React.FC<ReplicaSectionProps> = ({
   value,
   onChange,
   infoContent,
   isRequired = false,
-  isRaw = true,
+  showMinMax = true,
   maxValue,
   onMaxChange,
 }) => {
-  const maxLimit = isRaw ? MAX_SIZE : maxValue;
+  const maxLimit = showMinMax ? upperLimit : maxValue;
 
   return (
     <FormGroup
@@ -47,40 +46,40 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
     >
       <Flex>
         <FlexItem>
-          {!isRaw && (
+          {!showMinMax && (
             <FormGroup
               label={<span style={{ fontWeight: 'normal' }}>Minimum replicas</span>}
               fieldId="min-replicas"
               data-testid="min-replicas"
             >
               <NumberInputWrapper
-                min={MIN_SIZE}
+                min={lowerLimit}
                 max={maxLimit}
                 value={value}
                 onChange={(val) => {
                   const newSize = val === undefined ? 0 : Number(val);
                   if (!Number.isNaN(newSize) && newSize <= maxLimit) {
-                    onChange(normalizeBetween(newSize, MIN_SIZE, maxLimit));
+                    onChange(normalizeBetween(newSize, lowerLimit, maxLimit));
                   }
                 }}
               />
             </FormGroup>
           )}
-          {isRaw && (
+          {showMinMax && (
             <NumberInputWrapper
-              min={MIN_SIZE}
-              max={MAX_SIZE}
+              min={lowerLimit}
+              max={upperLimit}
               value={value}
               onChange={(val) => {
                 const newSize = val === undefined ? 0 : Number(val);
-                if (!Number.isNaN(newSize) && newSize <= MAX_SIZE) {
-                  onChange(normalizeBetween(newSize, MIN_SIZE, MAX_SIZE));
+                if (!Number.isNaN(newSize) && newSize <= upperLimit) {
+                  onChange(normalizeBetween(newSize, lowerLimit, upperLimit));
                 }
               }}
             />
           )}
         </FlexItem>
-        {!isRaw && onMaxChange && (
+        {!showMinMax && onMaxChange && (
           <FlexItem>
             <FormGroup
               label={<span style={{ fontWeight: 'normal' }}>Maximum replicas</span>}
@@ -89,12 +88,12 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
             >
               <NumberInputWrapper
                 min={value}
-                max={ADVANCED_MAX_SIZE}
+                max={upperLimit}
                 value={maxValue}
                 onChange={(val) => {
                   const newSize = val === undefined ? 0 : Number(val);
-                  if (!Number.isNaN(newSize) && newSize <= ADVANCED_MAX_SIZE && newSize >= value) {
-                    onMaxChange(normalizeBetween(newSize, value, ADVANCED_MAX_SIZE));
+                  if (!Number.isNaN(newSize) && newSize <= upperLimit && newSize >= value) {
+                    onMaxChange(normalizeBetween(newSize, value, upperLimit));
                   }
                 }}
               />
@@ -106,4 +105,4 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
   );
 };
 
-export default ReplicaSection;
+export default ReplicaFormGroup;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
@@ -20,7 +20,7 @@ const ServingRuntimeReplicaSection: React.FC<ServingRuntimeReplicaSectionProps> 
       infoContent={infoContent}
       onChange={(value) => setData('numReplicas', value)}
       value={data.numReplicas}
-      isRaw
+      showMinMax
       maxValue={data.numReplicas}
     />
   </FormSection>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeReplicaSection.tsx
@@ -20,6 +20,8 @@ const ServingRuntimeReplicaSection: React.FC<ServingRuntimeReplicaSectionProps> 
       infoContent={infoContent}
       onChange={(value) => setData('numReplicas', value)}
       value={data.numReplicas}
+      isRaw
+      maxValue={data.numReplicas}
     />
   </FormSection>
 );

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
@@ -19,9 +19,21 @@ const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionPro
     isRequired
     onChange={(value) => {
       setData('minReplicas', value);
-      setData('maxReplicas', value);
+      if (data.isKServeRawDeployment) {
+        setData('maxReplicas', value);
+      } else if (value > data.maxReplicas) {
+        setData('maxReplicas', value);
+      }
     }}
     value={data.minReplicas}
+    isRaw={!!data.isKServeRawDeployment}
+    maxValue={data.maxReplicas}
+    onMaxChange={(value) => {
+      setData('maxReplicas', value);
+      if (value < data.minReplicas) {
+        setData('minReplicas', value);
+      }
+    }}
   />
 );
 

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
@@ -26,7 +26,7 @@ const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionPro
       }
     }}
     value={data.minReplicas}
-    isRaw={!!data.isKServeRawDeployment}
+    showMinMax={!!data.isKServeRawDeployment}
     maxValue={data.maxReplicas}
     onMaxChange={(value) => {
       setData('maxReplicas', value);

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -413,9 +413,15 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                 {isRawAvailable && isServerlessAvailable && (
                   <KServeDeploymentModeDropdown
                     isRaw={!!createDataInferenceService.isKServeRawDeployment}
-                    setIsRaw={(isRaw) =>
-                      setCreateDataInferenceService('isKServeRawDeployment', isRaw)
-                    }
+                    setIsRaw={(isRaw) => {
+                      setCreateDataInferenceService('isKServeRawDeployment', isRaw);
+                      if (isRaw) {
+                        setCreateDataInferenceService(
+                          'maxReplicas',
+                          createDataInferenceService.minReplicas,
+                        );
+                      }
+                    }}
                     isDisabled={!!editInfo}
                   />
                 )}


### PR DESCRIPTION
Closes [RHOAIENG-24712](https://issues.redhat.com/browse/RHOAIENG-24712)

## Description
Changes the Advanced deployment option to require a minimum and maximum number of model servers to deploy. 
The numbers are capped at 99, and the inputs won't allow the min to be higher than the max. 

## How Has This Been Tested?
To test this:

- Go to your project and to models > deploy model
- Scroll to deployment mode and ensure 'Advanced' is selected 
- Modify the min and max numbers and deploy the model. The numbers can be equal, but min can't be higher than max and vice versa 
- Go to your OpenShift console, and select your project
- Under your project, search for 'InferenceServices' and open the yaml
- Under `spec:`, you should see your maxReplicas and minReplicas.

## Test Impact
Added additional cypress tests to check the functionality of the advanced selectors.

## Screenshots
Before:
<img width="567" alt="Screenshot 2025-05-21 at 9 49 26 AM" src="https://github.com/user-attachments/assets/8d25b89e-c383-4c3e-ac55-496a5df320d0" />

After:

https://github.com/user-attachments/assets/33284ca0-c2ff-413f-b1e0-db0ff9e7eeef

- - - -
<img width="749" alt="Screenshot 2025-05-21 at 9 47 01 AM" src="https://github.com/user-attachments/assets/5da5380c-90c1-4448-bcfe-6c0bd5f01715" />



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
