### PR TITLE
Fix Cypress URL extraction regex

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dashboardNavigation/testManifestLinks.cy.ts
@@ -90,19 +90,12 @@ describe('Verify that all the URLs referenced in the Manifest directory are oper
           // Filter out Sample/Test URLs in a single pass
           const filteredUrls = urls.filter((url) => url && !isUrlExcluded(url, excludedSubstrings));
 
-          cy.log(`Found ${urls.length} total URLs, filtered to ${filteredUrls.length} URLs`);
-
-          // Log filtered URLs for debugging
-          filteredUrls.forEach((url) => {
-            cy.log(`[PRE-CHECK UI LOG] URL to check: ${url}`);
-          });
-
-          cy.task(
-            'log',
-            `[Step] Verifying URLs against valid status codes: ${Array.from(
-              VALID_STATUS_CODES,
-            ).join(', ')}`,
-            { log: false },
+          cy.log(
+            `Found ${urls.length} total URLs, filtered to ${
+              filteredUrls.length
+            } URLs.\nValid status codes to check: ${Array.from(VALID_STATUS_CODES).join(
+              ', ',
+            )}\n\nURLs to verify:\n${filteredUrls.join('\n')}`,
           );
 
           return cy.task<UrlValidationResult[]>('validateHttpsUrls', filteredUrls);

--- a/frontend/src/__tests__/cypress/cypress/utils/urlExtractor.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/urlExtractor.ts
@@ -38,7 +38,7 @@ type YamlArray = YamlValue[];
  */
 function extractUrlsFromValue(value: YamlValue, urlSet: Set<string>): void {
   if (typeof value === 'string') {
-    const urlRegex = /https?:\/\/[^\s\](),"'}*]*(?=[\s\](),"'}*]|$)/g; // Matches both HTTP and HTTPS
+    const urlRegex = /^(?:https?:\/\/)[^\s\](),"'}*]*(?=[\s\](),"'}*]|$)/g; // Matches only http:// or https:// exactly
     const matches = value.match(urlRegex);
     if (matches) {
       matches.forEach((url) => {

--- a/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/urlValidator.ts
@@ -24,10 +24,10 @@ const commonUserAgent =
 const maxRedirects = 5;
 
 /** Request timeout in milliseconds */
-const requestTimeout = 30000;
+const requestTimeout = 50000;
 
 /** Maximum number of retries for network errors */
-const maxRetries = 3;
+const maxRetries = 5;
 
 /** Initial retry delay in milliseconds */
 const initialRetryDelay = 1000;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
The regex in `frontend/src/__tests__/cypress/cypress/utils/urlExtractor.ts` was extracting some manifests URLs with a wrong protocol `httpss`:
![image](https://github.com/user-attachments/assets/f6b152c2-cad9-431a-821e-da38b7f270a5)

This PR is to fix the regex pattern used.

## How Has This Been Tested?
E2E on Jenkins:
![image](https://github.com/user-attachments/assets/4cb831f7-b59b-4f3b-99e7-8b3d84092270)


## Test Impact
dashboardNavigation/testManifestLinks.cy.ts

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
