### PR TITLE
fix: testProjectAdminPermissions test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
@@ -85,7 +85,9 @@ class PermissionTable extends Contextual<HTMLElement> {
   addGroupName(name: string) {
     const userNameCell = permissions.getGroupTable().find().find('[data-label="Username"]');
     userNameCell.find('input[role="combobox"]').type(name);
-    cy.findByRole('listbox').findByRole('option', { name: `Select "${name}"` }).click();
+    cy.findByRole('listbox')
+      .findByRole('option', { name: `Select "${name}"` })
+      .click();
   }
 
   selectAdminOption() {

--- a/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/permissions.ts
@@ -84,10 +84,8 @@ class PermissionTable extends Contextual<HTMLElement> {
 
   addGroupName(name: string) {
     const userNameCell = permissions.getGroupTable().find().find('[data-label="Username"]');
-    userNameCell.findByRole('button', { name: 'Typeahead menu toggle' }).should('exist').click();
-    userNameCell.children().first().type(`${name}`);
-    //have to do this at top level `cy` because it goes to top of dom
-    cy.findByRole('option', { name: `Select "${name}"` }).click();
+    userNameCell.find('input[role="combobox"]').type(name);
+    cy.findByRole('listbox').findByRole('option', { name: `Select "${name}"` }).click();
   }
 
   selectAdminOption() {
@@ -96,7 +94,7 @@ class PermissionTable extends Contextual<HTMLElement> {
       .find()
       .find('[data-label="Permission"]')
       .children()
-      .first()
+      .last()
       .findSelectOption('Admin Edit the project and manage user access')
       .click();
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-26151

## Description
Fix the issues found in last RHOAI nightly (dashboard-tests/1587) regarding the testProjectAdminPermissions tests

## How Has This Been Tested?
Locally:
`$ npx cypress run --browser chrome --project src/__tests__/cypress --spec **/testProjectAdminPermissions.cy.ts`
![image](https://github.com/user-attachments/assets/768b2fb0-4ce0-4c00-87c9-dd16c9bb7391)

## Test Impact
Fix for testProjectAdminPermissions

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
