### PR TITLE
Custom Model Serving Size Deploy Button Fix

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -456,6 +456,26 @@ class ServingRuntimeModal extends Modal {
     return this.find().findByTestId('model-server-size-selection');
   }
 
+  findModelServerSizeSelectOption(name: string) {
+    return cy.findByTestId(`model-server-size-select-option-${name}`);
+  }
+
+  findCPURequestInput() {
+    return this.find().findByTestId('cpu-request-input');
+  }
+
+  findCPULimitInput() {
+    return this.find().findByTestId('cpu-limit-input');
+  }
+
+  findMemoryRequestInput() {
+    return this.find().findByTestId('memory-request-input');
+  }
+
+  findMemoryLimitInput() {
+    return this.find().findByTestId('memory-limit-input');
+  }
+
   findDeployedModelRouteCheckbox() {
     return this.find().findByTestId('alt-form-checkbox-route');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -896,6 +896,25 @@ describe('Serving Runtime List', () => {
       kserveModal.findServingRuntimeEnvVarsValue('0').type('test-value');
       kserveModal.findSubmitButton().should('be.enabled');
 
+      // test model server size select
+      kserveModal.findModelServerSizeSelect().click();
+      kserveModal.findModelServerSizeSelectOption('Medium').find('button').click();
+      kserveModal.findSubmitButton().should('be.enabled');
+      kserveModal.findModelServerSizeSelect().click();
+      kserveModal.findModelServerSizeSelectOption('Custom').find('button').click();
+      kserveModal.findSubmitButton().should('be.enabled');
+
+      // test custom cpu and memory
+      kserveModal.findCPURequestInput().clear().type('3');
+      kserveModal.findCPULimitInput().clear().type('2');
+      kserveModal.findMemoryRequestInput().clear().type('4Gi');
+      kserveModal.findMemoryLimitInput().clear().type('3Gi');
+      kserveModal.findSubmitButton().should('be.disabled');
+
+      kserveModal.findModelServerSizeSelect().click();
+      kserveModal.findModelServerSizeSelectOption('Small').find('button').click();
+      kserveModal.findSubmitButton().should('be.enabled');
+
       // test submitting form, the modal should close to indicate success.
       kserveModal.findSubmitButton().click();
       kserveModal.shouldBeOpen(false);

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeExpandedField.tsx
@@ -32,31 +32,45 @@ const ServingRuntimeSizeExpandedField = ({
       },
     });
   };
+  const setInitialValue = (
+    type: ContainerResourceAttributes,
+    variant: ResourceKeys,
+  ): string | number => {
+    if (data.resources[variant]?.[type] === undefined) {
+      handleChange(type, variant, '1');
+      return '1';
+    }
+    return data.resources[variant][type];
+  };
 
   return (
     <Grid hasGutter md={6}>
       <FormGroup label="CPUs requested">
         <CPUField
           onChange={(value) => handleChange(ContainerResourceAttributes.CPU, 'requests', value)}
-          value={data.resources.requests?.cpu}
+          value={setInitialValue(ContainerResourceAttributes.CPU, 'requests')}
+          dataTestId="cpu-request"
         />
       </FormGroup>
       <FormGroup label="Memory requested">
         <MemoryField
           onChange={(value) => handleChange(ContainerResourceAttributes.MEMORY, 'requests', value)}
-          value={data.resources.requests?.memory}
+          value={setInitialValue(ContainerResourceAttributes.MEMORY, 'requests')}
+          dataTestId="memory-request"
         />
       </FormGroup>
       <FormGroup label="CPU limit">
         <CPUField
           onChange={(value) => handleChange(ContainerResourceAttributes.CPU, 'limits', value)}
-          value={data.resources.limits?.cpu}
+          value={setInitialValue(ContainerResourceAttributes.CPU, 'limits')}
+          dataTestId="cpu-limit"
         />
       </FormGroup>
       <FormGroup label="Memory limit">
         <MemoryField
           onChange={(value) => handleChange(ContainerResourceAttributes.MEMORY, 'limits', value)}
-          value={data.resources.limits?.memory}
+          value={setInitialValue(ContainerResourceAttributes.MEMORY, 'limits')}
+          dataTestId="memory-limit"
         />
       </FormGroup>
     </Grid>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -53,6 +53,7 @@ const ServingRuntimeSizeSection = ({
   const sizeOptions = () =>
     sizeCustom.map((size) => {
       const { name } = size;
+      const dataTestId = `model-server-size-select-option-${name}`;
       const desc =
         name !== 'Custom'
           ? `Limits: ${size.resources.limits?.cpu || '??'} CPU, ` +
@@ -60,7 +61,7 @@ const ServingRuntimeSizeSection = ({
             `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
             `${formatMemory(size.resources.requests?.memory) || '??'} Memory`
           : '';
-      return { key: name, label: name, description: desc };
+      return { key: name, label: name, description: desc, dataTestId };
     });
 
   const isHardwareProfileSupported = React.useCallback(


### PR DESCRIPTION
Closes [RHOAIENG-25034](https://issues.redhat.com/browse/RHOAIENG-25034)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If you went to deploy a kserve model and set the model serving size to `custom` the deploy button would disable. You would need to edit each of the inputs for CPU and memory to reenable it.


This is really only a problem if the `Custom` size hasn't been edited or given initial values. You can check this in the hardware profiles section under the `Legacy Profiles` menu.
<img width="1166" alt="Screenshot 2025-05-22 at 11 30 45 AM" src="https://github.com/user-attachments/assets/303e2339-0174-404f-b765-4aca77cc2ca0" />

but its clearer if you go to the OCP and in the `opendatahub` namespace search for the `OdhDashboardConfig` resource type then go to the yaml and see the `modelServerSizes` as well as `notebookSizes`.
<img width="1224" alt="Screenshot 2025-05-22 at 11 32 47 AM" src="https://github.com/user-attachments/assets/c8cc4895-8b79-40ce-809e-159d584c5c98" />

If you have values in `Custom` this bug doesn't happen. But it takes a couple minutes to register in the dashboard.
```
    - name: Custom
      resources:
        limits:
          cpu: '2'
          memory: 2Gi
        requests:
          cpu: '2'
          memory: 2Gi
```
the bug also doesn't happen if you have hardware profiles enabled. So if you're testing and want to recreate the bug make sure it's disabled. But anyway I added a little function to set initial values to 1 if the values are undefined from `OdhDashboardConfig`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

To recreate the bug:
- Use the main branch so you don't have these changes
- Make sure hardware profiles are disabled (by default they should be)
- Go check out the `OdhDashboardConfig` yaml in the `opendatahub` namespace and see that `Custom` (under `modelServerSizes` looks something like this:
 ```
    - name: Custom
      resources:
        limits: {}
        requests: {}
```
- Go back to the dashboard
- Go to deploy a kServe model
- Fill out everything so the deploy button enables but don't touch model server size yet
- Select `Custom` model server size and the deploy button should disable and only reenable once you've edited all of the fields

To test this fix:
- Use this branch and repeat the steps above except the button shouldn't disable

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added to a cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
