### PR TITLE
Add Serving Runtime Version to Admin Serving Runtime Table

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,4 +1,4 @@
-import { SupportedModelFormats, TemplateKind } from '~/k8sTypes';
+import { K8sDSGResource, SupportedModelFormats, TemplateKind } from '~/k8sTypes';
 import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '~/types';
 
 type MockResourceConfigType = {
@@ -14,6 +14,7 @@ type MockResourceConfigType = {
   containerEnvVars?: { name: string; value: string }[];
   supportedModelFormats?: SupportedModelFormats[];
   annotations?: Record<string, string>;
+  objects?: K8sDSGResource[];
 };
 
 export const mockServingRuntimeTemplateK8sResource = ({
@@ -40,6 +41,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
     },
   ],
   annotations,
+  objects,
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -56,7 +58,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
       ...annotations,
     },
   },
-  objects: [
+  objects: objects || [
     {
       apiVersion: 'serving.kserve.io/v1alpha1',
       kind: 'ServingRuntime',
@@ -64,6 +66,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
         name,
         annotations: {
           'openshift.io/display-name': displayName,
+          'opendatahub.io/runtime-version': '1.0.0',
         },
         labels: {
           'opendatahub.io/dashboard': 'true',

--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -13,6 +13,7 @@ type MockResourceConfigType = {
   containerName?: string;
   containerEnvVars?: { name: string; value: string }[];
   supportedModelFormats?: SupportedModelFormats[];
+  annotations?: Record<string, string>;
 };
 
 export const mockServingRuntimeTemplateK8sResource = ({
@@ -38,6 +39,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
       version: '1',
     },
   ],
+  annotations,
 }: MockResourceConfigType): TemplateKind => ({
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -51,6 +53,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
     annotations: {
       'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
       'opendatahub.io/apiProtocol': apiProtocol,
+      ...annotations,
     },
   },
   objects: [

--- a/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/servingRuntimes.ts
@@ -36,6 +36,10 @@ class ServingRuntimeRow {
     this.find().find('[data-label="API protocol"]').should('include.text', apiProtocol);
     return this;
   }
+
+  findServingRuntimeVersionLabel() {
+    return this.find().findByTestId('serving-runtime-version-label');
+  }
 }
 
 class ServingRuntimes {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
@@ -33,6 +33,13 @@ describe('Custom serving runtimes', () => {
     servingRuntimes.shouldBeSingleModel(true).shouldBeMultiModel(true);
   });
 
+  it('should display serving runtime version label', () => {
+    servingRuntimes.getRowById('template-1').findServingRuntimeVersionLabel().should('exist');
+    servingRuntimes.getRowById('template-2').findServingRuntimeVersionLabel().should('not.exist');
+    servingRuntimes.getRowById('template-3').findServingRuntimeVersionLabel().should('not.exist');
+    servingRuntimes.getRowById('template-4').findServingRuntimeVersionLabel().should('not.exist');
+  });
+
   it('should test pre-installed label', () => {
     servingRuntimes.getRowById('template-3').shouldHavePreInstalledLabel();
     servingRuntimes.getRowById('template-3').find().findKebabAction('Edit').should('not.exist');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimes.cy.ts
@@ -35,9 +35,9 @@ describe('Custom serving runtimes', () => {
 
   it('should display serving runtime version label', () => {
     servingRuntimes.getRowById('template-1').findServingRuntimeVersionLabel().should('exist');
-    servingRuntimes.getRowById('template-2').findServingRuntimeVersionLabel().should('not.exist');
+    servingRuntimes.getRowById('template-2').findServingRuntimeVersionLabel().should('exist');
     servingRuntimes.getRowById('template-3').findServingRuntimeVersionLabel().should('not.exist');
-    servingRuntimes.getRowById('template-4').findServingRuntimeVersionLabel().should('not.exist');
+    servingRuntimes.getRowById('template-4').findServingRuntimeVersionLabel().should('exist');
   });
 
   it('should test pre-installed label', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
@@ -9,6 +9,9 @@ export const customServingRuntimesInitialMock = [
     name: 'template-1',
     displayName: 'Multi Platform',
     platforms: [ServingRuntimePlatform.SINGLE],
+    annotations: {
+      'opendatahub.io/runtime-version': '1.0.0',
+    },
   }),
   mockServingRuntimeTemplateK8sResource({
     name: 'template-2',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/customServingRuntimes/customServingRuntimesUtils.ts
@@ -9,9 +9,6 @@ export const customServingRuntimesInitialMock = [
     name: 'template-1',
     displayName: 'Multi Platform',
     platforms: [ServingRuntimePlatform.SINGLE],
-    annotations: {
-      'opendatahub.io/runtime-version': '1.0.0',
-    },
   }),
   mockServingRuntimeTemplateK8sResource({
     name: 'template-2',
@@ -24,6 +21,19 @@ export const customServingRuntimesInitialMock = [
     displayName: 'OVMS',
     platforms: [ServingRuntimePlatform.MULTI],
     preInstalled: true,
+    // override the objects to leave the runtime version annotation empty
+    objects: [
+      {
+        apiVersion: 'serving.kserve.io/v1alpha1',
+        kind: 'ServingRuntime',
+        metadata: {
+          name: 'template-3',
+          annotations: {
+            'openshift.io/display-name': 'OVMS',
+          },
+        },
+      },
+    ],
   }),
   mockServingRuntimeTemplateK8sResource({
     name: 'template-4',

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
-import { Label } from '@patternfly/react-core';
+import { Label, Split, SplitItem } from '@patternfly/react-core';
 import { TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
@@ -10,6 +10,7 @@ import CustomServingRuntimeEnabledToggle from './CustomServingRuntimeEnabledTogg
 import {
   getServingRuntimeDisplayNameFromTemplate,
   getServingRuntimeNameFromTemplate,
+  getServingRuntimeVersionFromTemplate,
 } from './utils';
 import CustomServingRuntimeAPIProtocolLabel from './CustomServingRuntimeAPIProtocolLabel';
 
@@ -46,7 +47,18 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
         <ResourceNameTooltip resource={template}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
-        {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
+        <Split hasGutter>
+          <SplitItem>
+            {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
+          </SplitItem>
+          {getServingRuntimeVersionFromTemplate(template) && (
+            <SplitItem>
+              <Label data-testid="serving-runtime-version-label" color="blue">
+                {getServingRuntimeVersionFromTemplate(template)}
+              </Label>
+            </SplitItem>
+          )}
+        </Split>
       </Td>
       <Td dataLabel="Enabled">
         <CustomServingRuntimeEnabledToggle template={template} />

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
 import { Label, LabelGroup } from '@patternfly/react-core';
-import { TemplateKind } from '~/k8sTypes';
+import { ServingRuntimeKind, TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
 import { isOOTB, PreInstalledName } from '~/concepts/k8s/utils';
@@ -10,8 +10,9 @@ import ServingRuntimeVersionLabel from '~/pages/modelServing/screens/ServingRunt
 import CustomServingRuntimeEnabledToggle from './CustomServingRuntimeEnabledToggle';
 import {
   getServingRuntimeDisplayNameFromTemplate,
+  getServingRuntimeFromTemplate,
   getServingRuntimeNameFromTemplate,
-  getServingRuntimeVersionFromTemplate,
+  getServingRuntimeVersion,
 } from './utils';
 import CustomServingRuntimeAPIProtocolLabel from './CustomServingRuntimeAPIProtocolLabel';
 
@@ -30,7 +31,8 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
   const navigate = useNavigate();
   const servingRuntimeName = getServingRuntimeNameFromTemplate(template);
   const templateOOTB = isOOTB(template);
-
+  const sr: ServingRuntimeKind | undefined = getServingRuntimeFromTemplate(template);
+  const srVersion: string | undefined = getServingRuntimeVersion(sr);
   return (
     <Tr
       key={rowIndex}
@@ -50,9 +52,7 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
         </ResourceNameTooltip>
         <LabelGroup>
           {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
-          {getServingRuntimeVersionFromTemplate(template) && (
-            <ServingRuntimeVersionLabel version={getServingRuntimeVersionFromTemplate(template)} />
-          )}
+          {srVersion && <ServingRuntimeVersionLabel version={srVersion} />}
         </LabelGroup>
       </Td>
       <Td dataLabel="Enabled">

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -6,6 +6,7 @@ import { TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
 import { isOOTB, PreInstalledName } from '~/concepts/k8s/utils';
+import ServingRuntimeVersionLabel from '~/pages/modelServing/screens/ServingRuntimeVersionLabel';
 import CustomServingRuntimeEnabledToggle from './CustomServingRuntimeEnabledToggle';
 import {
   getServingRuntimeDisplayNameFromTemplate,
@@ -48,14 +49,16 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
         <Split hasGutter>
-          <SplitItem>
-            {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
-          </SplitItem>
+          {templateOOTB && (
+            <SplitItem>
+              <Label data-testid="pre-installed-label">{PreInstalledName}</Label>
+            </SplitItem>
+          )}
           {getServingRuntimeVersionFromTemplate(template) && (
             <SplitItem>
-              <Label data-testid="serving-runtime-version-label" color="blue">
-                {getServingRuntimeVersionFromTemplate(template)}
-              </Label>
+              <ServingRuntimeVersionLabel
+                version={getServingRuntimeVersionFromTemplate(template)}
+              />
             </SplitItem>
           )}
         </Split>

--- a/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
+++ b/frontend/src/pages/modelServing/customServingRuntimes/CustomServingRuntimeTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import { TemplateKind } from '~/k8sTypes';
 import ResourceNameTooltip from '~/components/ResourceNameTooltip';
 import CustomServingRuntimePlatformsLabelGroup from '~/pages/modelServing/customServingRuntimes/CustomServingRuntimePlatformsLabelGroup';
@@ -48,20 +48,12 @@ const CustomServingRuntimeTableRow: React.FC<CustomServingRuntimeTableRowProps> 
         <ResourceNameTooltip resource={template}>
           {getServingRuntimeDisplayNameFromTemplate(template)}
         </ResourceNameTooltip>
-        <Split hasGutter>
-          {templateOOTB && (
-            <SplitItem>
-              <Label data-testid="pre-installed-label">{PreInstalledName}</Label>
-            </SplitItem>
-          )}
+        <LabelGroup>
+          {templateOOTB && <Label data-testid="pre-installed-label">{PreInstalledName}</Label>}
           {getServingRuntimeVersionFromTemplate(template) && (
-            <SplitItem>
-              <ServingRuntimeVersionLabel
-                version={getServingRuntimeVersionFromTemplate(template)}
-              />
-            </SplitItem>
+            <ServingRuntimeVersionLabel version={getServingRuntimeVersionFromTemplate(template)} />
           )}
-        </Split>
+        </LabelGroup>
       </Td>
       <Td dataLabel="Enabled">
         <CustomServingRuntimeEnabledToggle template={template} />

--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   getEnabledPlatformsFromTemplate,
   getServingRuntimeVersionFromTemplate,
   getTemplateEnabledForPlatform,
+  isTemplateKind,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { ServingRuntimePlatform } from '~/types';
 import { mockServingRuntimeTemplateK8sResource } from '~/__mocks__/mockServingRuntimeTemplateK8sResource';
@@ -126,5 +127,16 @@ describe('getServingRuntimeVersionFromTemplate', () => {
   it('should return empty string if annotation is not present', () => {
     const servingRuntime = mockServingRuntimeK8sResource({});
     expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe(undefined);
+  });
+});
+
+describe('isTemplateKind', () => {
+  it('should return true if the resource is a template', () => {
+    const template = mockServingRuntimeTemplateK8sResource({});
+    expect(isTemplateKind(template)).toBe(true);
+  });
+  it('should return false if the resource is not a template', () => {
+    const servingRuntime = mockServingRuntimeK8sResource({});
+    expect(isTemplateKind(servingRuntime)).toBe(false);
   });
 });

--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
@@ -6,7 +6,7 @@ import { ServingRuntimeKind } from '~/k8sTypes';
 import {
   getDisplayNameFromServingRuntimeTemplate,
   getEnabledPlatformsFromTemplate,
-  getServingRuntimeVersionFromTemplate,
+  getServingRuntimeVersion,
   getTemplateEnabledForPlatform,
   isTemplateKind,
 } from '~/pages/modelServing/customServingRuntimes/utils';
@@ -121,12 +121,12 @@ describe('getServingRuntimeVersionFromTemplate', () => {
     servingRuntime.metadata.annotations = {
       'opendatahub.io/runtime-version': '1.0.0',
     };
-    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe('1.0.0');
+    expect(getServingRuntimeVersion(servingRuntime)).toBe('1.0.0');
   });
 
   it('should return empty string if annotation is not present', () => {
     const servingRuntime = mockServingRuntimeK8sResource({});
-    expect(getServingRuntimeVersionFromTemplate(servingRuntime)).toBe(undefined);
+    expect(getServingRuntimeVersion(servingRuntime)).toBe(undefined);
   });
 });
 

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -128,8 +128,14 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
 
 export const getServingRuntimeVersionFromTemplate = (
   resource: ServingRuntimeKind | TemplateKind,
-): string | undefined =>
-  resource.metadata.annotations?.['opendatahub.io/runtime-version'] || undefined;
+): string | undefined => {
+  if (resource.kind === 'Template' && 'objects' in resource) {
+    return (
+      resource.objects[0].metadata.annotations?.['opendatahub.io/runtime-version'] || undefined
+    );
+  }
+  return resource.metadata.annotations?.['opendatahub.io/runtime-version'] || undefined;
+};
 
 export const getEnabledPlatformsFromTemplate = (
   template: TemplateKind,

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -129,13 +129,17 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
 export const getServingRuntimeVersionFromTemplate = (
   resource: ServingRuntimeKind | TemplateKind,
 ): string | undefined => {
-  if (resource.kind === 'Template' && 'objects' in resource) {
+  if (isTemplateKind(resource)) {
     return (
       resource.objects[0].metadata.annotations?.['opendatahub.io/runtime-version'] || undefined
     );
   }
   return resource.metadata.annotations?.['opendatahub.io/runtime-version'] || undefined;
 };
+
+export const isTemplateKind = (
+  resource: ServingRuntimeKind | TemplateKind,
+): resource is TemplateKind => resource.kind === 'Template';
 
 export const getEnabledPlatformsFromTemplate = (
   template: TemplateKind,

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -126,9 +126,12 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';
 };
 
-export const getServingRuntimeVersionFromTemplate = (
-  resource: ServingRuntimeKind | TemplateKind,
+export const getServingRuntimeVersion = (
+  resource: ServingRuntimeKind | TemplateKind | undefined,
 ): string | undefined => {
+  if (!resource) {
+    return undefined;
+  }
   if (isTemplateKind(resource)) {
     return (
       resource.objects[0].metadata.annotations?.['opendatahub.io/runtime-version'] || undefined

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -127,7 +127,7 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
 };
 
 export const getServingRuntimeVersionFromTemplate = (
-  resource: ServingRuntimeKind,
+  resource: ServingRuntimeKind | TemplateKind,
 ): string | undefined =>
   resource.metadata.annotations?.['opendatahub.io/runtime-version'] || undefined;
 

--- a/frontend/src/pages/modelServing/screens/ServingRuntimeVersionLabel.tsx
+++ b/frontend/src/pages/modelServing/screens/ServingRuntimeVersionLabel.tsx
@@ -1,0 +1,18 @@
+import { Label } from '@patternfly/react-core';
+import * as React from 'react';
+
+type ServingRuntimeVersionLabelProps = {
+  version: string | undefined;
+  isCompact?: boolean;
+};
+
+const ServingRuntimeVersionLabel: React.FC<ServingRuntimeVersionLabelProps> = ({
+  version,
+  isCompact,
+}) => (
+  <Label data-testid="serving-runtime-version-label" color="blue" isCompact={isCompact}>
+    {version}
+  </Label>
+);
+
+export default ServingRuntimeVersionLabel;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -1,4 +1,4 @@
-import { Label, LabelGroup } from '@patternfly/react-core';
+import { Label, LabelGroup, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import TypedObjectIcon from '~/concepts/design/TypedObjectIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
@@ -18,30 +18,32 @@ type Props = {
 const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isProjectScoped }) => (
   <>
     {servingRuntime ? (
-      <>
-        {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
-        <LabelGroup>
-          {getServingRuntimeVersion(servingRuntime) && (
-            <ServingRuntimeVersionLabel
-              version={getServingRuntimeVersion(servingRuntime)}
-              isCompact
-            />
-          )}
-          {isProjectScoped &&
-            servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
-              SERVING_RUNTIME_SCOPE.Project && (
-              <Label
-                variant="outline"
-                color="blue"
-                data-testid="project-scoped-label"
+      <Stack>
+        <StackItem>{getDisplayNameFromServingRuntimeTemplate(servingRuntime)}</StackItem>
+        <StackItem>
+          <LabelGroup>
+            {getServingRuntimeVersion(servingRuntime) && (
+              <ServingRuntimeVersionLabel
+                version={getServingRuntimeVersion(servingRuntime)}
                 isCompact
-                icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
-              >
-                Project-scoped
-              </Label>
+              />
             )}
-        </LabelGroup>
-      </>
+            {isProjectScoped &&
+              servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
+                SERVING_RUNTIME_SCOPE.Project && (
+                <Label
+                  variant="outline"
+                  color="blue"
+                  data-testid="project-scoped-label"
+                  isCompact
+                  icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
+                >
+                  Project-scoped
+                </Label>
+              )}
+          </LabelGroup>
+        </StackItem>
+      </Stack>
     ) : (
       'Unknown'
     )}

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -8,6 +8,7 @@ import {
   getServingRuntimeVersionFromTemplate,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
+import ServingRuntimeVersionLabel from '~/pages/modelServing/screens/ServingRuntimeVersionLabel';
 
 type Props = {
   servingRuntime?: ServingRuntimeKind;
@@ -22,14 +23,10 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
         <Split hasGutter>
           {getServingRuntimeVersionFromTemplate(servingRuntime) && (
             <SplitItem>
-              <Label
-                variant="filled"
-                color="blue"
-                data-testid="serving-runtime-version-label"
+              <ServingRuntimeVersionLabel
+                version={getServingRuntimeVersionFromTemplate(servingRuntime)}
                 isCompact
-              >
-                {getServingRuntimeVersionFromTemplate(servingRuntime)}
-              </Label>
+              />
             </SplitItem>
           )}
           {isProjectScoped &&

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -5,7 +5,7 @@ import { ProjectObjectType } from '~/concepts/design/utils';
 import { ServingRuntimeKind } from '~/k8sTypes';
 import {
   getDisplayNameFromServingRuntimeTemplate,
-  getServingRuntimeVersionFromTemplate,
+  getServingRuntimeVersion,
 } from '~/pages/modelServing/customServingRuntimes/utils';
 import { SERVING_RUNTIME_SCOPE } from '~/pages/modelServing/screens/const';
 import ServingRuntimeVersionLabel from '~/pages/modelServing/screens/ServingRuntimeVersionLabel';
@@ -21,9 +21,9 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
       <>
         {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
         <LabelGroup>
-          {getServingRuntimeVersionFromTemplate(servingRuntime) && (
+          {getServingRuntimeVersion(servingRuntime) && (
             <ServingRuntimeVersionLabel
-              version={getServingRuntimeVersionFromTemplate(servingRuntime)}
+              version={getServingRuntimeVersion(servingRuntime)}
               isCompact
             />
           )}

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -1,4 +1,4 @@
-import { Label } from '@patternfly/react-core';
+import { Label, Split, SplitItem } from '@patternfly/react-core';
 import * as React from 'react';
 import TypedObjectIcon from '~/concepts/design/TypedObjectIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
@@ -19,35 +19,35 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
     {servingRuntime ? (
       <>
         {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
-        {getServingRuntimeVersionFromTemplate(servingRuntime) && (
-          <>
-            {' '}
-            <Label
-              variant="filled"
-              color="grey"
-              data-testid="serving-runtime-version-label"
-              isCompact
-            >
-              {getServingRuntimeVersionFromTemplate(servingRuntime)}
-            </Label>
-          </>
-        )}
-        {isProjectScoped &&
-          servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
-            SERVING_RUNTIME_SCOPE.Project && (
-            <>
-              {' '}
+        <Split hasGutter>
+          {getServingRuntimeVersionFromTemplate(servingRuntime) && (
+            <SplitItem>
               <Label
-                variant="outline"
+                variant="filled"
                 color="blue"
-                data-testid="project-scoped-label"
+                data-testid="serving-runtime-version-label"
                 isCompact
-                icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
               >
-                Project-scoped
+                {getServingRuntimeVersionFromTemplate(servingRuntime)}
               </Label>
-            </>
+            </SplitItem>
           )}
+          {isProjectScoped &&
+            servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
+              SERVING_RUNTIME_SCOPE.Project && (
+              <SplitItem>
+                <Label
+                  variant="outline"
+                  color="blue"
+                  data-testid="project-scoped-label"
+                  isCompact
+                  icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
+                >
+                  Project-scoped
+                </Label>
+              </SplitItem>
+            )}
+        </Split>
       </>
     ) : (
       'Unknown'

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceServingRuntime.tsx
@@ -1,4 +1,4 @@
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import * as React from 'react';
 import TypedObjectIcon from '~/concepts/design/TypedObjectIcon';
 import { ProjectObjectType } from '~/concepts/design/utils';
@@ -20,31 +20,27 @@ const InferenceServiceServingRuntime: React.FC<Props> = ({ servingRuntime, isPro
     {servingRuntime ? (
       <>
         {getDisplayNameFromServingRuntimeTemplate(servingRuntime)}
-        <Split hasGutter>
+        <LabelGroup>
           {getServingRuntimeVersionFromTemplate(servingRuntime) && (
-            <SplitItem>
-              <ServingRuntimeVersionLabel
-                version={getServingRuntimeVersionFromTemplate(servingRuntime)}
-                isCompact
-              />
-            </SplitItem>
+            <ServingRuntimeVersionLabel
+              version={getServingRuntimeVersionFromTemplate(servingRuntime)}
+              isCompact
+            />
           )}
           {isProjectScoped &&
             servingRuntime.metadata.annotations?.['opendatahub.io/serving-runtime-scope'] ===
               SERVING_RUNTIME_SCOPE.Project && (
-              <SplitItem>
-                <Label
-                  variant="outline"
-                  color="blue"
-                  data-testid="project-scoped-label"
-                  isCompact
-                  icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
-                >
-                  Project-scoped
-                </Label>
-              </SplitItem>
+              <Label
+                variant="outline"
+                color="blue"
+                data-testid="project-scoped-label"
+                isCompact
+                icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
+              >
+                Project-scoped
+              </Label>
             )}
-        </Split>
+        </LabelGroup>
       </>
     ) : (
       'Unknown'


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-26114](https://issues.redhat.com/browse/RHOAIENG-26114)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
A continuation of [RHOAIENG-25675](https://issues.redhat.com/browse/RHOAIENG-25675) <- where I added the serving runtime version to the model deployment table. 
In this PR I added the runtime version to the runtime templates in the settings > serving runtimes table.

**Before:**
<img width="1187" alt="Screenshot 2025-05-22 at 3 14 09 PM" src="https://github.com/user-attachments/assets/ac660195-f0e4-4958-8903-10357eab511b" />

**After:**
![Screenshot 2025-05-27 at 2 53 49 PM](https://github.com/user-attachments/assets/bd79ed71-b4d3-4a66-9693-48541fc786f2)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and with `npm run test`

To test this:
- Log in as a user thats allowed to see this page
- Go to settings > serving runtimes and notice that there are no version labels
- Duplicate any of the existing serving runtimes
- Now to the OCP search in the `opendatahub` namespace for `template` resources
- You can find the resource name for the templates from the popups in settings > serving runtimes
- It'll be generated, something like `template-r6vhw3` open that, go to the yaml
- Go to `objects[0].metadata.annotations`
- Add `opendatahub.io/runtime-version: v0.5.1` to the annotations in the yaml
- Go back to the dashboard
- Label should be there 👍 
- If you want to see if with the `Pre-installed` label go back to your duplicated serving runtime and in the regular `metadata.annotations` add `platform.opendatahub.io/part-of: modelcontroller`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a cypress test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
