### PR TITLE
Print cy.step() into terminal at real time

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -27,6 +27,21 @@ import { addCommands as webSocketsAddCommands } from './websockets';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const softAssert = require('soft-assert');
 
+// Track step counter
+let stepCounter: number;
+
+// Enhance cy.step() to print real-time steps with counter in the terminal
+Cypress.Commands.overwrite('step', (originalFn, message: string) => {
+  stepCounter++;
+  cy.task('log', `[STEP ${stepCounter}] ${message}`);
+  return originalFn(message);
+});
+
+// Reset step counter before each test
+beforeEach(() => {
+  stepCounter = 0;
+});
+
 // ============================
 // Type Definitions
 // ============================


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Added real-time logging of Cypress test steps to the terminal during test execution. This enhancement improves test debugging and monitoring capabilities by adding a step counter and printing each step with its counter number to the terminal.

## How Has This Been Tested?
Tested locally by running Cypress test suites
Verified that steps are printed to the terminal in real-time with proper counter formatting
Confirmed that the step counter resets correctly between tests

![image](https://github.com/user-attachments/assets/5356896c-692a-4d4d-888e-f875868cc82c)


## Test Impact
The changes are focused on test infrastructure and logging. The implementation enhances the existing Cypress test framework with logging functionality without modifying test behavior.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an x in all the boxes that apply. -->

Self checklist (all need to be checked):
[x] The developer has manually tested the changes and verified that the changes work
[x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
[x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes:
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
[ ] Included any necessary screenshots or gifs if it was a UI change.
[ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
[ ] The developer has tested their solution on a cluster by using the image produced by the PR to main