### PR TITLE
Fix duplicate name issue with workbench images

### DIFF
--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -31,6 +31,7 @@ type MockResourceConfigType = {
   additionalVolumes?: Volume[];
   hardwareProfileName?: string;
   hardwareProfileNamespace?: string | null;
+  workbenchImageNamespace?: string | null;
 };
 
 export const mockNotebookK8sResource = ({
@@ -57,6 +58,7 @@ export const mockNotebookK8sResource = ({
   additionalVolumes = [],
   hardwareProfileName = '',
   hardwareProfileNamespace = null,
+  workbenchImageNamespace = null,
 }: MockResourceConfigType): NotebookKind =>
   _.merge(
     {
@@ -76,6 +78,7 @@ export const mockNotebookK8sResource = ({
           'openshift.io/display-name': displayName,
           'opendatahub.io/hardware-profile-name': hardwareProfileName,
           'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
+          'opendatahub.io/workbench-image-namespace': workbenchImageNamespace,
         },
         creationTimestamp: '2023-02-14T21:44:13Z',
         generation: 4,

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -95,12 +95,12 @@ export const assembleNotebook = (
     volumeMounts.push(getshmVolumeMount());
   }
 
-  let hardwareProfileNamespace: Record<string, string | null> | null = {
-    'opendatahub.io/hardware-profile-namespace': null,
-  };
-  if (selectedHardwareProfile?.metadata.namespace === projectName) {
-    hardwareProfileNamespace = { 'opendatahub.io/hardware-profile-namespace': data.projectName };
-  }
+  const hardwareProfileNamespace: Record<string, string | null> | null =
+    selectedHardwareProfile?.metadata.namespace === projectName
+      ? { 'opendatahub.io/hardware-profile-namespace': projectName }
+      : {
+          'opendatahub.io/hardware-profile-namespace': null,
+        };
 
   const resource: NotebookKind = {
     apiVersion: 'kubeflow.org/v1',
@@ -203,6 +203,8 @@ export const assembleNotebook = (
     resource.metadata.annotations['opendatahub.io/image-display-name'] = getImageStreamDisplayName(
       image.imageStream,
     );
+    resource.metadata.annotations['opendatahub.io/workbench-image-namespace'] =
+      image.imageStream.metadata.namespace === projectName ? projectName : null;
   }
 
   return resource;

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -149,7 +149,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     return formattedOptions;
   }, [hardwareProfiles, initialHardwareProfile, allowExistingSettings, isHardwareProfileSupported]);
 
-  const getHardwareProfiles = () => {
+  const getProjectHardwareProfiles = () => {
     const currentProjectEnabledProfiles = currentProjectHardwareProfiles
       .filter((hp) => hp.spec.enabled)
       .toSorted((a, b) => {
@@ -303,18 +303,22 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
               )}
             </Stack>
           }
-          icon={<GlobalIcon />}
           onClick={() => {
             onChange(profile);
           }}
         >
-          <Split>
-            <SplitItem>{displayName}</SplitItem>
-            <SplitItem isFilled />
-            <SplitItem>
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <FlexItem>
+              <GlobalIcon />
+            </FlexItem>
+            <FlexItem>{displayName}</FlexItem>
+            <FlexItem align={{ default: 'alignRight' }}>
               {isHardwareProfileSupported(profile) && <Label color="blue">Compatible</Label>}
-            </SplitItem>
-          </Split>
+            </FlexItem>
+          </Flex>
         </MenuItem>
       );
     });
@@ -341,7 +345,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     return <Skeleton />;
   }
 
-  const filteredHardwareProfiles = getHardwareProfiles();
+  const filteredHardwareProfiles = getProjectHardwareProfiles();
   const filteredDashboardHardwareProfiles = getDashboardHardwareProfiles();
 
   return (

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -113,6 +113,7 @@ export type NotebookAnnotations = Partial<{
   'opendatahub.io/image-display-name': string; // the display name of the image
   'notebooks.opendatahub.io/last-image-version-git-commit-selection': string; // the build commit of the last image they selected
   'opendatahub.io/hardware-profile-namespace': string | null; // the namespace of the hardware profile used
+  'opendatahub.io/workbench-image-namespace': string | null; // namespace of the
 }>;
 
 export type DashboardLabels = {

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -118,7 +118,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
           .toLocaleLowerCase()
           .includes(searchServingRuntime.toLocaleLowerCase()),
       ) || [];
-    const filteredScopedTemplates = filteredTemplates.filter((template) =>
+    const filteredGlobalScopedTemplates = filteredTemplates.filter((template) =>
       getServingRuntimeDisplayNameFromTemplate(template)
         .toLocaleLowerCase()
         .includes(searchServingRuntime.toLocaleLowerCase()),
@@ -170,7 +170,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
                   spaceItems={{ default: 'spaceItemsXs' }}
                   alignItems={{ default: 'alignItemsCenter' }}
                 >
-                  <FlexItem style={{ display: 'flex' }}>
+                  <FlexItem>
                     <TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />
                   </FlexItem>
                   <FlexItem>
@@ -191,10 +191,10 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
             ))}
           </MenuGroup>
         )}
-        {filteredProjectScopedTemplates.length > 0 && filteredScopedTemplates.length > 0 && (
+        {filteredProjectScopedTemplates.length > 0 && filteredGlobalScopedTemplates.length > 0 && (
           <Divider component="li" />
         )}
-        {filteredScopedTemplates.length > 0 && (
+        {filteredGlobalScopedTemplates.length > 0 && (
           <MenuGroup
             data-testid="global-scoped-serving-runtimes"
             label={
@@ -213,7 +213,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
               </Flex>
             }
           >
-            {filteredScopedTemplates.map((template, index) => (
+            {filteredGlobalScopedTemplates.map((template, index) => (
               <MenuItem
                 key={`servingRuntime-${index}`}
                 data-testid={`servingRuntime ${getServingRuntimeNameFromTemplate(template)}`}
@@ -232,13 +232,18 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
                     resetModelFormat,
                   })
                 }
-                icon={<GlobalIcon />}
               >
-                <Split>
-                  <SplitItem isFilled>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem>
+                    <GlobalIcon />
+                  </FlexItem>
+                  <FlexItem>
                     <Truncate content={getServingRuntimeDisplayNameFromTemplate(template)} />
-                  </SplitItem>
-                  <SplitItem>
+                  </FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>
                     {compatibleIdentifiers?.some((identifier) =>
                       isCompatibleWithIdentifier(identifier, template.objects[0]),
                     ) && (
@@ -247,15 +252,16 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
                         {isHardwareProfilesAvailable ? 'hardware profile' : 'accelerator'}
                       </Label>
                     )}
-                  </SplitItem>
-                </Split>
+                  </FlexItem>
+                </Flex>
               </MenuItem>
             ))}
           </MenuGroup>
         )}
-        {filteredProjectScopedTemplates.length === 0 && filteredScopedTemplates.length === 0 && (
-          <MenuItem isDisabled>No results found</MenuItem>
-        )}
+        {filteredProjectScopedTemplates.length === 0 &&
+          filteredGlobalScopedTemplates.length === 0 && (
+            <MenuItem isDisabled>No results found</MenuItem>
+          )}
       </>
     );
   };

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -205,18 +205,22 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
             formData.profile?.metadata.name === profile.metadata.name &&
             formData.profile.metadata.namespace === profile.metadata.namespace
           }
-          icon={<GlobalIcon />}
           onClick={() => {
             setFormData('profile', profile);
           }}
         >
-          <Split>
-            <SplitItem>{profile.spec.displayName}</SplitItem>
-            <SplitItem isFilled />
-            <SplitItem>
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <FlexItem>
+              <GlobalIcon />
+            </FlexItem>
+            <FlexItem>{profile.spec.displayName}</FlexItem>
+            <FlexItem align={{ default: 'alignRight' }}>
               {isAcceleratorProfileSupported(profile) && <Label color="blue">Compatible</Label>}
-            </SplitItem>
-          </Split>
+            </FlexItem>
+          </Flex>
         </MenuItem>
       ));
 

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -34,11 +34,12 @@ import {
 } from '#~/pages/projects/screens/spawner/spawnerUtils';
 import { NotebookState } from '#~/pages/projects/notebook/types';
 import UnderlinedTruncateButton from '#~/components/UnderlinedTruncateButton';
+import { NotebookKind } from '#~/k8sTypes';
 import { NotebookImageAvailability, NotebookImageStatus } from './const';
 import { NotebookImage } from './types';
 
 type NotebookImageDisplayNameProps = {
-  isImageStreamProjectScoped: boolean;
+  notebook: NotebookKind;
   notebookImage: NotebookImage | null;
   notebookState: NotebookState;
   loaded: boolean;
@@ -50,7 +51,7 @@ type NotebookImageDisplayNameProps = {
 };
 
 export const NotebookImageDisplayName = ({
-  isImageStreamProjectScoped,
+  notebook,
   notebookImage,
   notebookState,
   loaded,
@@ -235,7 +236,7 @@ export const NotebookImageDisplayName = ({
           {notebookImage.imageStatus !== NotebookImageStatus.DELETED &&
             notebookImage.imageAvailability === NotebookImageAvailability.ENABLED &&
             isProjectScopedAvailable &&
-            isImageStreamProjectScoped && (
+            notebook.metadata.annotations?.['opendatahub.io/workbench-image-namespace'] && (
               <Label
                 isCompact
                 variant="outline"

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -32,7 +32,6 @@ import NotebookSizeDetails from './NotebookSizeDetails';
 import useNotebookImage from './useNotebookImage';
 import useNotebookDeploymentSize from './useNotebookDeploymentSize';
 import { extractAcceleratorResources } from './utils';
-import useNotebookImageData from './useNotebookImageData';
 import NotebookUpdateImageModal from './NotebookUpdateImageModal';
 
 type NotebookTableRowProps = {
@@ -65,14 +64,8 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
       requests: {},
     },
   };
-  const [notebookImage, loaded, loadError] = useNotebookImage(
-    obj.notebook,
-    currentProject.metadata.name,
-  );
-  const [data, notebookImageStreamLoaded] = useNotebookImageData(
-    currentProject.metadata.name,
-    obj.notebook,
-  );
+  const [notebookImage, loaded, loadError] = useNotebookImage(obj.notebook);
+
   const podSpecOptionsState = useNotebookKindPodSpecOptionsState(obj.notebook);
   const [dontShowModalValue] = useStopNotebookModalAvailability();
   const { dashboardConfig } = useAppContext();
@@ -159,11 +152,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           <Split>
             <SplitItem>
               <NotebookImageDisplayName
-                isImageStreamProjectScoped={
-                  notebookImageStreamLoaded &&
-                  data.imageStatus !== NotebookImageStatus.DELETED &&
-                  data.imageStream.metadata.namespace === currentProject.metadata.name
-                }
+                notebook={obj.notebook}
                 notebookImage={notebookImage}
                 notebookState={obj}
                 loaded={loaded}

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
@@ -10,11 +10,10 @@ import { NotebookImage } from './types';
 
 const useNotebookImage = (
   notebook: NotebookKind | undefined,
-  project: string,
 ):
   | [notebookImage: null, loaded: false, loadError?: Error]
   | [notebookImage: NotebookImage, loaded: true, loadError: undefined] => {
-  const [data, loaded, loadError] = useNotebookImageData(project, notebook);
+  const [data, loaded, loadError] = useNotebookImageData(notebook);
 
   if (!notebook || !loaded) {
     return [null, false, loadError];

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -18,7 +18,6 @@ export const getNotebookImageData = (
     (currentContainer) => currentContainer.name === notebook.metadata.name,
   );
   const imageTag = container?.image.split('/').at(-1)?.split(':');
-
   // if image could not be parsed from the container, consider it deleted because the image tag is invalid
   if (!imageTag || imageTag.length < 2 || !container) {
     return {
@@ -76,38 +75,26 @@ export const getNotebookImageData = (
   };
 };
 
-const useNotebookImageData = (project: string, notebook?: NotebookKind): NotebookImageData => {
+const useNotebookImageData = (notebook?: NotebookKind): NotebookImageData => {
   const { dashboardNamespace } = useNamespaces();
-
-  const [dashboardImages, dashboardLoaded, dashboardLoadError] = useImageStreams(
-    dashboardNamespace,
-    true,
-  );
-
-  const [projectImages, projectLoaded, projectLoadError] = useImageStreams(project, true);
+  const namespace = notebook?.metadata.annotations?.['opendatahub.io/workbench-image-namespace']
+    ? notebook.metadata.annotations['opendatahub.io/workbench-image-namespace']
+    : dashboardNamespace;
+  const [images, loaded, loadError] = useImageStreams(namespace, true);
 
   return React.useMemo(() => {
-    if (!notebook || !dashboardLoaded || !projectLoaded) {
-      return [null, false, dashboardLoadError || projectLoadError];
+    if (!notebook || !loaded) {
+      return [null, false, loadError];
     }
-    const allImages = [...projectImages, ...dashboardImages];
 
-    const data = getNotebookImageData(notebook, allImages);
+    const data = getNotebookImageData(notebook, images);
 
     if (data === null) {
-      return [null, false, dashboardLoadError || projectLoadError];
+      return [null, false, loadError];
     }
 
     return [data, true, undefined];
-  }, [
-    notebook,
-    dashboardLoaded,
-    projectLoaded,
-    dashboardImages,
-    dashboardLoadError,
-    projectLoadError,
-    projectImages,
-  ]);
+  }, [notebook, loaded, images, loadError]);
 };
 
 const getNotebookImageInternalRegistry = (

--- a/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerFooter.tsx
@@ -65,6 +65,7 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   );
 
   const hardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
+  const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
 
   const editNotebook = notebookState?.notebook;
   const { projectName } = startNotebookData;
@@ -80,7 +81,10 @@ const SpawnerFooter: React.FC<SpawnerFooterProps> = ({
   const isButtonDisabled =
     createInProgress ||
     !checkRequiredFieldsForNotebookStart(startNotebookData, envVariables) ||
-    !isHardwareProfileValid;
+    !isHardwareProfileValid ||
+    (!isProjectScopedAvailable &&
+      startNotebookData.image.imageStream?.metadata.namespace === projectName);
+
   const { username } = useUser();
 
   const afterStart = (name: string, type: 'created' | 'updated') => {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -29,10 +29,7 @@ import {
   NotebookImageStatus,
 } from '#~/pages/projects/screens/detail/notebooks/const';
 import useProjectPvcs from '#~/pages/projects/screens/detail/storage/useProjectPvcs';
-import {
-  getDisplayNameFromK8sResource,
-  getResourceNameFromK8sResource,
-} from '#~/concepts/k8s/utils';
+import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
@@ -179,10 +176,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     ...notebooksUsingPVCsWithSizeChanges,
   ]);
 
-  const [data, loaded, loadError] = useNotebookImageData(
-    getResourceNameFromK8sResource(currentProject),
-    existingNotebook,
-  );
+  const [data, loaded, loadError] = useNotebookImageData(existingNotebook);
 
   React.useEffect(() => {
     if (loaded) {

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -40,17 +40,21 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
   const imageStreamsLoaded = isProjectScopedAvailable
     ? loaded && currentProjectImageStreamsLoaded
     : loaded;
+
   const imageVersionData = React.useMemo(() => {
     const { imageStream } = selectedImage;
-    if (!imageStream) {
-      return { buildStatuses, imageStream, imageVersions: [] };
+    if (
+      (!isProjectScopedAvailable && imageStream?.metadata.namespace === currentProject) ||
+      !imageStream
+    ) {
+      return { buildStatuses, imageStream: undefined, imageVersions: [] };
     }
     return {
       buildStatuses,
       imageStream,
       imageVersions: getExistingVersionsForImageStream(imageStream),
     };
-  }, [selectedImage, buildStatuses]);
+  }, [selectedImage, buildStatuses, currentProject, isProjectScopedAvailable]);
 
   const onImageStreamSelect = (newImageStream: ImageStreamKind) => {
     const version = getDefaultVersionForImageStream(newImageStream, buildStatuses);
@@ -97,7 +101,14 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
         }
         selectedImageVersion={selectedImage.imageVersion}
       />
-      <ImageStreamPopover selectedImage={selectedImage} />
+      <ImageStreamPopover
+        selectedImage={
+          !isProjectScopedAvailable &&
+          selectedImage.imageStream?.metadata.namespace === currentProject
+            ? {}
+            : selectedImage
+        }
+      />
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageStreamSelector.tsx
@@ -91,12 +91,16 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                   selectedImageStream.metadata.namespace === imageStream.metadata.namespace
                 }
                 onClick={() => onImageStreamSelect(imageStream)}
-                icon={<TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />}
               >
-                <Split>
-                  {getImageStreamDisplayName(imageStream)}
-                  <SplitItem isFilled />
-                  <SplitItem>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem>
+                    <TypedObjectIcon alt="" resourceType={ProjectObjectType.project} />
+                  </FlexItem>
+                  <FlexItem>{getImageStreamDisplayName(imageStream)}</FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>
                     {compatibleIdentifiers?.some((identifier) =>
                       isCompatibleWithIdentifier(identifier, imageStream),
                     ) && (
@@ -105,8 +109,8 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                         {isHardwareProfilesAvailable ? ' hardware profile' : ' accelerator'}
                       </Label>
                     )}
-                  </SplitItem>
-                </Split>
+                  </FlexItem>
+                </Flex>
               </MenuItem>
             ))}
           </MenuGroup>
@@ -139,12 +143,16 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                   selectedImageStream.metadata.namespace === imageStream.metadata.namespace
                 }
                 onClick={() => onImageStreamSelect(imageStream)}
-                icon={<GlobalIcon />}
               >
-                <Split>
-                  {getImageStreamDisplayName(imageStream)}
-                  <SplitItem isFilled />
-                  <SplitItem>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem>
+                    <GlobalIcon />
+                  </FlexItem>
+                  <FlexItem>{getImageStreamDisplayName(imageStream)}</FlexItem>
+                  <FlexItem align={{ default: 'alignRight' }}>
                     {compatibleIdentifiers?.some((identifier) =>
                       isCompatibleWithIdentifier(identifier, imageStream),
                     ) && (
@@ -153,8 +161,8 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
                         {isHardwareProfilesAvailable ? ' hardware profile' : ' accelerator'}
                       </Label>
                     )}
-                  </SplitItem>
-                </Split>
+                  </FlexItem>
+                </Flex>
               </MenuItem>
             ))}
           </MenuGroup>
@@ -258,7 +266,11 @@ const ImageStreamSelector: React.FC<ImageStreamSelectorProps> = ({
           aria-label="Select an image"
           options={options}
           placeholder="Select one"
-          value={selectedImageStream?.metadata.name}
+          value={
+            selectedImageStream?.metadata.namespace !== currentProject
+              ? selectedImageStream?.metadata.name
+              : ''
+          }
           popperProps={{ appendTo: 'inline' }}
           onChange={(key) => {
             const imageStream = imageStreams.find(


### PR DESCRIPTION
Closes: [RHOAIENG-25734](https://issues.redhat.com/browse/RHOAIENG-25734)

## Description
This PR aims to fix duplicate name issue with workbench images. We have introduced an annotation to identify whether a workbench image is project-scoped or global-scoped. 
Also, minor changes around the dropdown items of search selector.

## How Has This Been Tested?
disbaleProjectScoped feature flag should be on.
1. Create same workbench image in opendatahub and any namespace in which, you are going to create a workbench.
2. Make sure the edit page and the table will show the correct label (Project-scoped/global-scoped).
3. Also, turn off the feature flag after creating a workbench with the project-scoped image, go to edit page - you will see the placeholder text in image selector and update workbench button will be disabled.

## Test Impact
Added cypress test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
