### PR TITLE
Update model serving plugin linting

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -427,7 +427,7 @@ module.exports = {
       },
     },
     {
-      files: ['src/plugins/extensions/**'],
+      files: ["src/plugins/extensions/**", "packages/**/extensions.ts", "packages/**/extension-points/*.{ts,tsx,js,jsx}"],
       rules: {
         '@typescript-eslint/consistent-type-imports': 'error',
         'no-restricted-syntax': [
@@ -458,7 +458,7 @@ function srcRulesOverrides() {
         'import/no-extraneous-dependencies': [
           'error',
           {
-            packageDir: ['.','./src'],
+            packageDir: ['.', './src'],
           },
         ],
       },

--- a/frontend/packages/kserve/extensions.ts
+++ b/frontend/packages/kserve/extensions.ts
@@ -1,10 +1,10 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line no-restricted-syntax
 import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types';
 import type {
   ModelServingPlatformExtension,
   ModelServingDeploymentsTableExtension,
 } from '@odh-dashboard/model-serving/extension-points';
-import { KServeDeployment } from './src/deployments';
+import type { KServeDeployment } from './src/deployments';
 
 export const KSERVE_ID = 'kserve';
 

--- a/frontend/packages/kserve/src/deployments.ts
+++ b/frontend/packages/kserve/src/deployments.ts
@@ -1,21 +1,16 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   InferenceServiceKind,
   K8sAPIOptions,
   ProjectKind,
   ServingRuntimeKind,
 } from '@odh-dashboard/internal/k8sTypes';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   InferenceServiceModel,
   ServingRuntimeModel,
 } from '@odh-dashboard/internal/api/models/kserve';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 import { Deployment } from '@odh-dashboard/model-serving/extension-points';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';

--- a/frontend/packages/modelServing/extension-points/index.ts
+++ b/frontend/packages/modelServing/extension-points/index.ts
@@ -1,11 +1,8 @@
-import { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types';
-import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { SortableData } from '@odh-dashboard/internal/components/table/types';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { K8sAPIOptions, ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+import type { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types';
+import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import type { SortableData } from '@odh-dashboard/internal/components/table/types';
+import type { K8sAPIOptions, ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 
 //// Model serving platform extension
 

--- a/frontend/packages/modelServing/extensions.ts
+++ b/frontend/packages/modelServing/extensions.ts
@@ -1,6 +1,6 @@
 import type { ProjectDetailsTab } from '@odh-dashboard/plugin-core/extension-points';
 // Allow this import as it consists of types and enums only.
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 
 const projectDetailsTabs: ProjectDetailsTab[] = [

--- a/frontend/packages/modelServing/src/components/projectDetails/DeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/DeploymentsTable.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   SortableData,
   Table,
   TableRowTitleDescription,
 } from '@odh-dashboard/internal/components/table/index';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import { ActionsColumn, Td } from '@patternfly/react-table';
 import { useResolvedPlatformExtension } from '../../concepts/extensionUtils';

--- a/frontend/packages/modelServing/src/components/projectDetails/ModelsProjectDetailsView.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/ModelsProjectDetailsView.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import DetailsSection from '@odh-dashboard/internal/pages/projects/screens/detail/DetailsSection';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ProjectSectionID } from '@odh-dashboard/internal/pages/projects/screens/detail/types';
 import { Button, Flex, Label, Popover } from '@patternfly/react-core';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import DashboardPopupIconButton from '@odh-dashboard/internal/concepts/dashboard/DashboardPopupIconButton';
 import { OutlinedQuestionCircleIcon, PencilAltIcon } from '@patternfly/react-icons';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
 import { SelectPlatformView } from './SelectPlatformView';
 import { NoModelsView } from './NoModelsView';

--- a/frontend/packages/modelServing/src/components/projectDetails/NoModelsView.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/NoModelsView.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import EmptyDetailsView from '@odh-dashboard/internal/components/EmptyDetailsView';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ProjectObjectType, typedEmptyImage } from '@odh-dashboard/internal/concepts/design/utils';
 import { ModelServingPlatform } from '../../concepts/modelServingPlatforms';
 import { DeployButton } from '../deploy/DeployButton';

--- a/frontend/packages/modelServing/src/components/projectDetails/SelectPlatformView.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/SelectPlatformView.tsx
@@ -16,11 +16,8 @@ import {
   Button,
   ContentVariants,
 } from '@patternfly/react-core';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import EmptyDetailsView from '@odh-dashboard/internal/components/EmptyDetailsView';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ProjectObjectType, typedEmptyImage } from '@odh-dashboard/internal/concepts/design/utils';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import EmptyModelServingPlatform from '@odh-dashboard/internal/pages/modelServing/screens/projects/EmptyModelServingPlatform';
 import { ModelServingPlatform } from '../../concepts/modelServingPlatforms';
 

--- a/frontend/packages/modelServing/src/concepts/ModelDeploymentsContext.tsx
+++ b/frontend/packages/modelServing/src/concepts/ModelDeploymentsContext.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { ModelServingPlatform } from './modelServingPlatforms';
 import { Deployment } from '../../extension-points';

--- a/frontend/packages/modelServing/src/concepts/ModelServingPlatformContext.tsx
+++ b/frontend/packages/modelServing/src/concepts/ModelServingPlatformContext.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';

--- a/frontend/packages/modelServing/src/concepts/extensionUtils.ts
+++ b/frontend/packages/modelServing/src/concepts/extensionUtils.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import {
   Extension,

--- a/frontend/packages/modelServing/src/concepts/modelServingPlatforms.ts
+++ b/frontend/packages/modelServing/src/concepts/modelServingPlatforms.ts
@@ -1,9 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { addSupportServingPlatformProject } from '@odh-dashboard/internal/api/k8s/projects';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types';
 import { ModelServingPlatformExtension } from '../../extension-points';
 

--- a/frontend/packages/plugin-core/src/extension-points/project-details.ts
+++ b/frontend/packages/plugin-core/src/extension-points/project-details.ts
@@ -1,5 +1,5 @@
-import { Extension } from '@openshift/dynamic-plugin-sdk';
-import { ComponentCodeRef } from './types';
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import type { ComponentCodeRef } from './types';
 
 export type ProjectDetailsTab = Extension<
   'app.project-details/tab',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Based off https://github.com/opendatahub-io/odh-dashboard/pull/4191
Closes https://issues.redhat.com/browse/RHOAIENG-26246

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Removes the `// eslint-disable-next-line import/no-extraneous-dependenc` lines and also fix the path checking to forces type imports for extension specific files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run `npm run test:lint`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests needed because it's linting only changes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
