### PR TITLE
Cypress e2e Test - Verify models can be registered in a model registry

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testRegisterModel.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testRegisterModel.yaml
@@ -1,0 +1,5 @@
+# Test data for model registry registration tests
+registryNamePrefix: "test-model-registry"
+objectStorageModelName: "test-object-storage-model"
+uriModelName: "test-uri-model"
+  

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/model_registry.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/model_registry.yaml
@@ -1,0 +1,36 @@
+apiVersion: modelregistry.opendatahub.io/v1alpha1
+kind: ModelRegistry
+metadata:
+  name: {{REGISTRY_NAME}}
+  namespace: {{NAMESPACE}}
+  annotations:
+    openshift.io/display-name: {{REGISTRY_NAME}}
+    openshift.io/description: E2E test model registry
+spec:
+  grpc:
+    port: 9090
+  rest:
+    port: 8080
+    serviceRoute: disabled
+  istio:
+    gateway:
+      grpc:
+        gatewayRoute: enabled
+        port: 443
+        tls:
+          mode: SIMPLE
+      rest:
+        gatewayRoute: enabled
+        port: 443
+        tls:
+          mode: SIMPLE
+    tlsMode: ISTIO_MUTUAL
+  mysql:
+    host: model-registry-db
+    port: 3306
+    database: model_registry
+    username: mlmduser
+    skipDBCreation: false
+    passwordSecret:
+      name: model-registry-db
+      key: database-password 

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage.ts
@@ -25,11 +25,23 @@ class RegisterModelPage {
     this.wait();
   }
 
+  visitWithRegistry(registryName: string) {
+    cy.visitWithLogin(`/modelRegistry/${registryName}/registerModel`);
+    this.waitWithRegistry(registryName);
+  }
+
   private wait() {
     const preferredModelRegistry = 'modelregistry-sample';
     cy.findByTestId('app-page-title').should('exist');
     cy.findByTestId('app-page-title').contains('Register model');
     cy.findByText(`Model registry - ${preferredModelRegistry}`).should('exist');
+    cy.testA11y();
+  }
+
+  private waitWithRegistry(registryName: string) {
+    cy.findByTestId('app-page-title').should('exist');
+    cy.findByTestId('app-page-title').contains('Register model');
+    cy.findByText(`Model registry - ${registryName}`).should('exist');
     cy.testA11y();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
@@ -1,0 +1,148 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  FormFieldSelector,
+  registerModelPage,
+} from '~/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage';
+import { modelRegistry } from '~/__tests__/cypress/cypress/pages/modelRegistry';
+import { retryableBeforeEach } from '~/__tests__/cypress/cypress/utils/retryableHooks';
+import {
+  checkModelRegistry,
+  checkModelRegistryAvailable,
+  cleanupRegisteredModelsFromDatabase,
+  createModelRegistryViaYAML,
+  deleteModelRegistry,
+} from '~/__tests__/cypress/cypress/utils/oc_commands/modelRegistry';
+import { loadRegisterModelFixture } from '~/__tests__/cypress/cypress/utils/dataLoader';
+import { generateTestUUID } from '~/__tests__/cypress/cypress/utils/uuidGenerator';
+import type { RegisterModelTestData } from '~/__tests__/cypress/cypress/types';
+import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
+
+describe('Verify models can be registered in a model registry', () => {
+  let testData: RegisterModelTestData;
+  let registryName: string;
+  const uuid = generateTestUUID();
+
+  before(() => {
+    cy.step('Load test data from fixture');
+    loadRegisterModelFixture('e2e/modelRegistry/testRegisterModel.yaml').then((fixtureData) => {
+      testData = fixtureData;
+      registryName = `${testData.registryNamePrefix}-${uuid}`;
+
+      // creates a model registry
+      cy.step('Create a model registry using YAML');
+      createModelRegistryViaYAML(registryName);
+
+      cy.step('Verify model registry is created');
+      checkModelRegistry(registryName).should('be.true');
+
+      cy.step('Wait for model registry to be in Available state');
+      checkModelRegistryAvailable(registryName).should('be.true');
+    });
+  });
+
+  retryableBeforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+
+  it(
+    'Registers models via model registry using object storage and URI',
+    { tags: ['@Maintain', '@ModelRegistry', '@NonConcurrent'] },
+    () => {
+      cy.step('Login as an Admin');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Navigate to Model Registry');
+      appChrome.findNavItem('Model registry', 'Models').click();
+
+      cy.step('Select the created model registry');
+      modelRegistry.findModelRegistry().click();
+      cy.findByTestId(registryName).click();
+
+      cy.step('Register a model using object storage');
+      modelRegistry.findRegisterModelButton().click();
+
+      // Fill in model details for object storage
+      registerModelPage
+        .findFormField(FormFieldSelector.MODEL_NAME)
+        .type(testData.objectStorageModelName);
+      registerModelPage
+        .findFormField(FormFieldSelector.MODEL_DESCRIPTION)
+        .type('E2E test model using object storage');
+      registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('v1.0');
+      registerModelPage
+        .findFormField(FormFieldSelector.VERSION_DESCRIPTION)
+        .type('First version of the test model');
+      registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT).type('onnx');
+      registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT_VERSION).type('1.0');
+
+      // Configure object storage location
+      registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_OBJECT_STORAGE).click();
+      registerModelPage
+        .findFormField(FormFieldSelector.LOCATION_ENDPOINT)
+        .type('http://minio.example.com:9000');
+      registerModelPage.findFormField(FormFieldSelector.LOCATION_BUCKET).type('test-models');
+      registerModelPage.findFormField(FormFieldSelector.LOCATION_REGION).type('us-east-1');
+      registerModelPage
+        .findFormField(FormFieldSelector.LOCATION_PATH)
+        .type('models/test-model/v1.0');
+
+      registerModelPage.findSubmitButton().click();
+
+      cy.step('Verify the object storage model was registered');
+      cy.url().should('include', '/modelRegistry');
+      cy.contains(testData.objectStorageModelName, { timeout: 10000 }).should('be.visible');
+
+      cy.step('Navigate back to register another model using direct URL');
+      registerModelPage.visitWithRegistry(registryName);
+
+      cy.step('Register a model using URI');
+      // Fill in model details for URI
+      registerModelPage.findFormField(FormFieldSelector.MODEL_NAME).type(testData.uriModelName);
+      registerModelPage
+        .findFormField(FormFieldSelector.MODEL_DESCRIPTION)
+        .type('E2E test model using URI');
+      registerModelPage.findFormField(FormFieldSelector.VERSION_NAME).type('v1.0');
+      registerModelPage
+        .findFormField(FormFieldSelector.VERSION_DESCRIPTION)
+        .type('First version of the URI test model');
+      registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT).type('pytorch');
+      registerModelPage.findFormField(FormFieldSelector.SOURCE_MODEL_FORMAT_VERSION).type('2.0');
+
+      // Configure URI location
+      registerModelPage.findFormField(FormFieldSelector.LOCATION_TYPE_URI).click();
+      registerModelPage
+        .findFormField(FormFieldSelector.LOCATION_URI)
+        .type(
+          's3://test-bucket/models/pytorch-model?endpoint=http%3A%2F%2Fminio.example.com%3A9000&defaultRegion=us-east-1',
+        );
+
+      registerModelPage.findSubmitButton().click();
+
+      cy.step('Verify the URI model was registered');
+      cy.url().should('include', '/modelRegistry');
+      cy.contains(testData.uriModelName, { timeout: 10000 }).should('be.visible');
+
+      cy.step('Navigate back to model registry to verify both models');
+      cy.visitWithLogin(`/modelRegistry/${registryName}`, HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Verify both models are visible in the registry');
+      cy.contains(testData.objectStorageModelName, { timeout: 10000 }).should('be.visible');
+      cy.contains(testData.uriModelName, { timeout: 10000 }).should('be.visible');
+    },
+  );
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+
+    cy.step('Clean up registered models from database');
+    cleanupRegisteredModelsFromDatabase([testData.objectStorageModelName, testData.uriModelName]);
+
+    cy.step('Delete the model registry');
+    deleteModelRegistry(registryName);
+
+    cy.step('Verify model registry is removed from the backend');
+    checkModelRegistry(registryName).should('be.false');
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -303,3 +303,9 @@ export type NotebookTolerationsTestData = {
   tolerationValue: string;
   hardwareProfileDeploymentSize: string;
 };
+
+export type RegisterModelTestData = {
+  registryNamePrefix: string;
+  objectStorageModelName: string;
+  uriModelName: string;
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
@@ -12,6 +12,7 @@ import type {
   WBImagesTestData,
   DeployOCIModelData,
   ModelTolerationsTestData,
+  RegisterModelTestData,
 } from '~/__tests__/cypress/cypress/types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -114,6 +115,16 @@ export const loadModelTolerationsFixture = (
 ): Cypress.Chainable<ModelTolerationsTestData> => {
   return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelTolerationsTestData;
+
+    return data;
+  });
+};
+
+export const loadRegisterModelFixture = (
+  fixturePath: string,
+): Cypress.Chainable<RegisterModelTestData> => {
+  return cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as RegisterModelTestData;
 
     return data;
   });

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -2,6 +2,25 @@
  * Utility functions for Model Registry OC commands
  */
 
+import type { CommandLineResult } from '~/__tests__/cypress/cypress/types';
+import { applyOpenShiftYaml } from '~/__tests__/cypress/cypress/utils/oc_commands/baseCommands';
+import { replacePlaceholdersInYaml } from '~/__tests__/cypress/cypress/utils/yaml_files';
+
+/**
+ * Get the model registry namespace based on the environment
+ * @returns The appropriate namespace for model registries
+ */
+export const getModelRegistryNamespace = (): string => {
+  const applicationsNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
+
+  // For RHOAI use rhoai-model-registries, for ODH use odh-model-registries
+  if (applicationsNamespace === 'redhat-ods-applications') {
+    return 'rhoai-model-registries';
+  }
+  // Handle both 'opendatahub' and any other namespace as ODH
+  return 'odh-model-registries';
+};
+
 /**
  * Check if a model registry exists in any namespace
  * @param registryName Name of the model registry to check
@@ -10,10 +29,126 @@
 export const checkModelRegistry = (registryName: string): Cypress.Chainable<boolean> => {
   const command = `oc get modelregistry.modelregistry.opendatahub.io --all-namespaces | grep ${registryName}`;
   cy.log(`Running command: ${command}`);
-  return cy.exec(command, { failOnNonZeroExit: false }).then((result: Cypress.Exec) => {
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
     if (result.stdout) {
       cy.log(`Command output: ${result.stdout}`);
     }
     return cy.wrap(result.code === 0);
   });
+};
+
+/**
+ * Check if a model registry exists and is in Available state
+ * @param registryName Name of the model registry to check
+ * @returns Cypress.Chainable<boolean> that resolves to true if the registry exists and is available
+ */
+export const checkModelRegistryAvailable = (registryName: string): Cypress.Chainable<boolean> => {
+  const targetNamespace = getModelRegistryNamespace();
+  const command = `oc wait --for=condition=Available modelregistry.modelregistry.opendatahub.io/${registryName} -n ${targetNamespace} --timeout=60s`;
+  cy.log(`Waiting for model registry ${registryName} to be available...`);
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.stdout) {
+      cy.log(`Wait result: ${result.stdout}`);
+    }
+    if (result.stderr) {
+      cy.log(`Wait stderr: ${result.stderr}`);
+    }
+    return cy.wrap(result.code === 0);
+  });
+};
+
+/**
+ * Create a model registry using YAML fixtures
+ * @param registryName Name of the model registry to create
+ * @returns Cypress.Chainable<void>
+ */
+export const createModelRegistryViaYAML = (registryName: string): Cypress.Chainable<void> => {
+  const targetNamespace = getModelRegistryNamespace();
+
+  const registryReplacements = {
+    REGISTRY_NAME: registryName,
+    NAMESPACE: targetNamespace,
+  };
+
+  cy.log(
+    `Creating model registry ${registryName} in namespace ${targetNamespace} using existing secret model-registry-db`,
+  );
+
+  return cy
+    .fixture('resources/yaml/model_registry.yaml')
+    .then((registryYamlContent) => {
+      const modifiedRegistryYaml = replacePlaceholdersInYaml(
+        registryYamlContent,
+        registryReplacements,
+      );
+      return applyOpenShiftYaml(modifiedRegistryYaml);
+    })
+    .then(() => {
+      cy.log(`Model registry ${registryName} created successfully in namespace ${targetNamespace}`);
+    });
+};
+
+/**
+ * Delete a model registry
+ * @param registryName Name of the model registry to delete
+ * @returns Cypress.Chainable<void>
+ */
+export const deleteModelRegistry = (registryName: string): Cypress.Chainable<void> => {
+  const targetNamespace = getModelRegistryNamespace();
+  const registryCommand = `oc delete modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace}`;
+
+  cy.log(`Deleting model registry ${registryName} from namespace ${targetNamespace}`);
+
+  return cy.exec(registryCommand, { failOnNonZeroExit: false }).then(() => {
+    cy.log(`Model registry ${registryName} deleted from namespace ${targetNamespace}`);
+  });
+};
+
+/**
+ * Clean up registered models from the database
+ * @param modelNames Array of model names to delete from the database
+ * @returns Cypress.Chainable<void>
+ */
+export const cleanupRegisteredModelsFromDatabase = (
+  modelNames: string[],
+): Cypress.Chainable<void> => {
+  const targetNamespace = getModelRegistryNamespace();
+
+  // Find MySQL pod
+  const findPodCommand = `oc get pods -n ${targetNamespace} -o name | grep model-registry-db | head -1 | cut -d'/' -f2`;
+
+  return cy
+    .exec(findPodCommand, { failOnNonZeroExit: false })
+    .then((podResult: CommandLineResult) => {
+      if (podResult.code !== 0 || !podResult.stdout.trim()) {
+        cy.log('No MySQL pod found, skipping database cleanup');
+        return;
+      }
+
+      const podName = podResult.stdout.trim();
+
+      // SQL commands to clean up contexts for the specified registeredmodels
+      const modelNamesStr = modelNames.map((name) => `'${name}'`).join(', ');
+      const sqlCommands = [
+        `DELETE cp FROM ContextProperty cp JOIN Context c ON cp.context_id = c.id WHERE c.name IN (${modelNamesStr});`,
+        `DELETE pc FROM ParentContext pc JOIN Context c ON pc.context_id = c.id OR pc.parent_context_id = c.id WHERE c.name IN (${modelNamesStr});`,
+        `DELETE a FROM Association a JOIN Context c ON a.context_id = c.id WHERE c.name IN (${modelNamesStr});`,
+        `DELETE at FROM Attribution at JOIN Context c ON at.context_id = c.id WHERE c.name IN (${modelNamesStr});`,
+        `DELETE FROM Context WHERE name IN (${modelNamesStr});`,
+      ].join(' ');
+
+      const cleanupCommand = `oc exec ${podName} -n ${targetNamespace} -- mysql -u mlmduser -pTheBlurstOfTimes model_registry -e "${sqlCommands}"`;
+
+      cy.log(`Cleaning up registered models: ${modelNames.join(', ')}`);
+
+      return cy
+        .exec(cleanupCommand, { failOnNonZeroExit: false })
+        .then((cleanupResult: CommandLineResult) => {
+          if (cleanupResult.code === 0) {
+            cy.log('Database cleanup completed successfully');
+          } else {
+            cy.log(`Database cleanup failed: ${cleanupResult.stderr}`);
+          }
+        });
+    });
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22447

## Description
Creates a new Model Registry test. Test is now added to the test script 'testRegisterModel.cy.ts'
All Model Registry e2e tests will be executed using a preconfigured cluster `ui-green`.

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Prerequisites: 
  - modelregistry:
      managementState: Managed (via the DSC)
  - mysql MR Database preinstalled on the cluster

- Tested against RHOAI-Nightly & ODH nightly via the `ui-green` cluster

![image](https://github.com/user-attachments/assets/761cd32a-b21b-4b5e-8d9c-3d660767ca0c)
- Tested via Jenkins pipeline cypress/job/dashboard-tests/1637/Test_20Reports/ 


## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend and run the command npm run cypress:open . This will open the Cypress UI where testRegisterModel.cy.ts can be run.

Headless
Go to odh-dashboard/frontend and run the command npm run cypress:run -- --spec src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`