### PR TITLE
Fix pipeline version creation in create run form

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import type {
   ArgoWorkflowPipelineVersion,
+  CreatePipelineVersionKFData,
   ExperimentKF,
   PipelineKF,
   PipelineRecurringRunKF,
@@ -328,13 +329,23 @@ export class CreateRunPage {
     );
   }
 
-  mockCreatePipelineVersion(namespace: string, pipelineId: string): Cypress.Chainable<null> {
+  mockCreatePipelineVersion(
+    namespace: string,
+    params: CreatePipelineVersionKFData,
+  ): Cypress.Chainable<null> {
     return cy.interceptOdh(
-      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
-      { path: { namespace, serviceName: 'dspa', pipelineId }, times: 1 },
-      (req) => {
-        req.reply(buildMockPipelineVersion({ pipeline_id: pipelineId }));
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload_version',
+      {
+        path: { namespace, serviceName: 'dspa' },
+        query: {
+          pipelineid: params.pipeline_id,
+          name: params.display_name,
+          description: params.description,
+        },
+        times: 1,
       },
+
+      buildMockPipelineVersion(params),
     );
   }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -9,7 +9,10 @@ import type {
 } from '~/concepts/pipelines/kfTypes';
 import { buildMockRunKF } from '~/__mocks__';
 import { buildMockPipelines } from '~/__mocks__/mockPipelinesProxy';
-import { buildMockPipelineVersions } from '~/__mocks__/mockPipelineVersionsProxy';
+import {
+  buildMockPipelineVersion,
+  buildMockPipelineVersions,
+} from '~/__mocks__/mockPipelineVersionsProxy';
 import { Contextual } from '~/__tests__/cypress/cypress/pages/components/Contextual';
 import { buildMockRecurringRunKF } from '~/__mocks__/mockRecurringRunKF';
 import { SearchSelector } from '~/__tests__/cypress/cypress/pages/components/subComponents/SearchSelector';
@@ -61,6 +64,10 @@ export class CreateRunPage {
       .findByTestId('pipeline-version-selector-table-list')
       .find('td')
       .contains(name);
+  }
+
+  findPipelineCreateVersionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('import-pipeline-version-button');
   }
 
   findScheduledRunTypeSelector(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -317,6 +324,16 @@ export class CreateRunPage {
           JSON.stringify(recurringRun.runtime_config),
         );
         req.reply(buildMockRecurringRunKF({ ...data, recurring_run_id }));
+      },
+    );
+  }
+
+  mockCreatePipelineVersion(namespace: string, pipelineId: string): Cypress.Chainable<null> {
+    return cy.interceptOdh(
+      'POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+      { path: { namespace, serviceName: 'dspa', pipelineId }, times: 1 },
+      (req) => {
+        req.reply(buildMockPipelineVersion({ pipeline_id: pipelineId }));
       },
     );
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -420,7 +420,11 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: `POST /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/upload_version`,
-          options: { path: { namespace: string; serviceName: string }; times?: number },
+          options: {
+            path: { namespace: string; serviceName: string };
+            query?: { pipelineid: string; name: string; description?: string };
+            times?: number;
+          },
           response: OdhResponse<PipelineVersionKF | GoogleRpcStatusKF>,
         ) => Cypress.Chainable<null>) &
         ((

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -17,6 +17,7 @@ import {
   activeRunsTable,
   createSchedulePage,
   duplicateSchedulePage,
+  pipelineVersionImportModal,
 } from '~/__tests__/cypress/cypress/pages/pipelines';
 import { verifyRelativeURL } from '~/__tests__/cypress/cypress/utils/url';
 import { getCorePipelineSpec } from '~/concepts/pipelines/getCorePipelineSpec';
@@ -557,6 +558,159 @@ describe('Pipeline create runs', () => {
           experiment_id: 'experiment-1',
         });
       });
+      // Should be redirected to the run details page
+      verifyRelativeURL(`/pipelineRuns/${projectName}/runs/${createRunParams.run_id}`);
+    });
+
+    it('should not redirect user after creating a new pipeline version', () => {
+      pipelineRunsGlobal.visit(projectName);
+
+      const createRunParams = {
+        display_name: 'New run',
+        description: 'New run description',
+        run_id: 'new-run-id',
+        runtime_config: {
+          parameters: {
+            string_param: 'String default value',
+            int_param: 1,
+            struct_param: { default: 'value' },
+            list_param: [{ default: 'value' }],
+            bool_param: true,
+          },
+        },
+      } satisfies Partial<PipelineRunKF>;
+
+      const newPipelineVersion = {
+        pipeline_id: mockPipeline.pipeline_id,
+        display_name: 'New pipeline version',
+        pipeline_version_id: 'new-pipeline-version',
+      };
+
+      // Mock experiements, pipelines, and versions
+      createRunPage.mockGetExperiments(projectName, mockExperiments);
+      createRunPage.mockGetPipelines(projectName, [mockPipeline]);
+      createRunPage.mockGetPipelineVersions(
+        projectName,
+        [
+          {
+            ...mockPipelineVersion,
+            pipeline_spec: {
+              components: {},
+              deploymentSpec: { executors: {} },
+              pipelineInfo: { name: '' },
+              schemaVersion: '',
+              sdkVersion: '',
+              ...getCorePipelineSpec(mockPipelineVersion.pipeline_spec),
+              root: {
+                dag: { tasks: {} },
+                inputDefinitions: {
+                  parameters: {
+                    string_param: {
+                      parameterType: InputDefinitionParameterType.STRING,
+                      defaultValue: 'String default value',
+                      description: 'Some string helper text',
+                    },
+                    double_param: {
+                      parameterType: InputDefinitionParameterType.DOUBLE,
+                      defaultValue: 7.0,
+                      description: 'Some double helper text',
+                      isOptional: true,
+                    },
+                    int_param: {
+                      parameterType: InputDefinitionParameterType.INTEGER,
+                      defaultValue: 1,
+                    },
+                    struct_param: {
+                      parameterType: InputDefinitionParameterType.STRUCT,
+                      defaultValue: { default: 'value' },
+                    },
+                    list_param: {
+                      parameterType: InputDefinitionParameterType.LIST,
+                      defaultValue: [{ default: 'value' }],
+                    },
+                    bool_param: {
+                      parameterType: InputDefinitionParameterType.BOOLEAN,
+                      defaultValue: true,
+                    },
+                    optional_string_param: {
+                      parameterType: InputDefinitionParameterType.STRING,
+                      isOptional: true,
+                      description: 'Some string helper text',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        mockPipelineVersion.pipeline_id,
+      );
+
+      // Navigate to the 'Create run' page
+      pipelineRunsGlobal.findCreateRunButton().click();
+      verifyRelativeURL(`/pipelineRuns/${projectName}/runs/create`);
+      createRunPage.find();
+
+      // Fill required fields
+      createRunPage.fillName('New run');
+      createRunPage.experimentSelect.findToggleButton().click();
+      createRunPage.selectExperimentByName('Test experiment 1');
+      createRunPage.pipelineSelect.findToggleButton().click();
+      createRunPage.selectPipelineByName('Test pipeline');
+
+      // Create new pipeline version
+      createRunPage
+        .mockCreatePipelineVersion(projectName, mockPipeline.pipeline_id)
+        .as('createPipelineVersion');
+
+      // Mock versions fetch after creation
+      createRunPage.mockGetPipelineVersions(
+        projectName,
+        [buildMockPipelineVersion(newPipelineVersion), mockPipelineVersion],
+        mockPipelineVersion.pipeline_id,
+      );
+
+      pipelineVersionImportModal.find();
+      pipelineVersionImportModal.fillVersionName('Newly created version');
+      pipelineVersionImportModal.fillVersionDescription('New version description');
+      pipelineVersionImportModal.uploadPipelineYaml('../mock-upload-pipeline.yaml');
+
+      // Verify default parameter values & helper text
+      const paramsSection = createRunPage.getParamsSection();
+      paramsSection.findParamById('string_param').should('have.value', 'String default value');
+      cy.findByTestId('string_param-helper-text').should('have.text', 'Some string helper text');
+
+      paramsSection.findParamById('double_param').should('have.value', '7.0');
+      cy.findByTestId('double_param-form-group').should('not.have.text', '*', { exact: false });
+      cy.findByTestId('double_param-helper-text').should('have.text', 'Some double helper text');
+
+      paramsSection.findParamById('int_param').find('input').should('have.value', '1');
+      paramsSection.findParamById('struct_param').should('have.value', '{"default":"value"}');
+      paramsSection.findParamById('list_param').should('have.value', '[{"default":"value"}]');
+      paramsSection.findParamById('radio-bool_param-true').should('be.checked');
+      paramsSection.findParamById('optional_string_param').should('have.value', '');
+
+      // Clear optional parameter then submit
+      paramsSection.findParamById('double_param').clear();
+      createRunPage
+        .mockCreateRun(projectName, mockPipelineVersion, createRunParams)
+        .as('createRuns');
+      createRunPage.submit();
+
+      cy.wait('@createRuns').then((interception) => {
+        expect(interception.request.body).to.eql({
+          display_name: 'New run',
+          description: '',
+          pipeline_version_reference: {
+            pipeline_id: 'test-pipeline',
+            pipeline_version_id: 'test-pipeline-version',
+          },
+          runtime_config: createRunParams.runtime_config,
+          service_account: '',
+          experiment_id: 'experiment-1',
+        });
+      });
+
       // Should be redirected to the run details page
       verifyRelativeURL(`/pipelineRuns/${projectName}/runs/${createRunParams.run_id}`);
     });

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -69,6 +69,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
           </StackItem>
           <StackItem>
             <ImportPipelineButton
+              data-testid="import-pipeline-version-button"
               variant="link"
               icon={<PlusCircleIcon />}
               onCreate={onPipelineChange}

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -69,7 +69,6 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
           </StackItem>
           <StackItem>
             <ImportPipelineButton
-              data-testid="import-pipeline-version-button"
               variant="link"
               icon={<PlusCircleIcon />}
               onCreate={onPipelineChange}
@@ -105,13 +104,13 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
             </StackItem>
             <StackItem>
               <ImportPipelineVersionButton
+                data-testid="import-pipeline-version-button"
                 selectedPipeline={pipeline}
                 variant="link"
                 icon={<PlusCircleIcon />}
                 onCreate={(value) => {
                   onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
                 }}
-                redirectAfterImport={false}
               />
             </StackItem>
           </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -110,6 +110,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
                 onCreate={(value) => {
                   onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
                 }}
+                redirectAfterImport={false}
               />
             </StackItem>
           </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineSection.tsx
@@ -111,6 +111,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({
                 onCreate={(value) => {
                   onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
                 }}
+                redirectAfterImport={false}
               />
             </StackItem>
           </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
@@ -124,7 +124,6 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                           refreshAllAPI();
                         }
                       }}
-                      redirectAfterImport={false}
                     />
                   )}
                 </>
@@ -163,6 +162,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                     </StackItem>
                     <StackItem>
                       <ImportPipelineVersionButton
+                        data-testid="import-pipeline-version-radio-button"
                         selectedPipeline={pipeline}
                         variant="link"
                         icon={<PlusCircleIcon />}
@@ -172,7 +172,6 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                             versionToUse: PipelineVersionToUse.PROVIDED,
                           });
                         }}
-                        redirectAfterImport={false}
                       />
                     </StackItem>
                   </Stack>
@@ -196,14 +195,13 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
           </StackItem>
           <StackItem>
             <ImportPipelineVersionButton
-              data-testid="import-pipeline-version-button"
+              data-testid="import-pipeline-version-radio-none-available-button"
               selectedPipeline={pipeline}
               variant="link"
               icon={<PlusCircleIcon />}
               onCreate={(value) => {
                 onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
               }}
-              redirectAfterImport={false}
             />
           </StackItem>
         </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
@@ -124,6 +124,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                           refreshAllAPI();
                         }
                       }}
+                      redirectAfterImport={false}
                     />
                   )}
                 </>
@@ -171,6 +172,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                             versionToUse: PipelineVersionToUse.PROVIDED,
                           });
                         }}
+                        redirectAfterImport={false}
                       />
                     </StackItem>
                   </Stack>
@@ -201,6 +203,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
               onCreate={(value) => {
                 onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
               }}
+              redirectAfterImport={false}
             />
           </StackItem>
         </Stack>

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
@@ -195,7 +195,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
           </StackItem>
           <StackItem>
             <ImportPipelineVersionButton
-              data-testid="import-pipeline-version-radio-none-available-button"
+              data-testid="import-pipeline-version-button"
               selectedPipeline={pipeline}
               variant="link"
               icon={<PlusCircleIcon />}

--- a/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/contentSections/PipelineVersionRadioGroup.tsx
@@ -113,6 +113,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                   </Popover>
                   {isUploadPipelineVersionModalOpen && (
                     <PipelineVersionImportModal
+                      redirectAfterImport={false}
                       existingPipeline={pipeline}
                       onClose={(value) => {
                         setIsUploadPipelineVersionModalOpen(false);
@@ -172,6 +173,7 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
                             versionToUse: PipelineVersionToUse.PROVIDED,
                           });
                         }}
+                        redirectAfterImport={false}
                       />
                     </StackItem>
                   </Stack>
@@ -195,13 +197,13 @@ const PipelineVersionRadioGroup: React.FC<PipelineVersionRadioGroupProps> = ({
           </StackItem>
           <StackItem>
             <ImportPipelineVersionButton
-              data-testid="import-pipeline-version-button"
               selectedPipeline={pipeline}
               variant="link"
               icon={<PlusCircleIcon />}
               onCreate={(value) => {
                 onVersionChange({ value, versionToUse: PipelineVersionToUse.PROVIDED });
               }}
+              redirectAfterImport={false}
             />
           </StackItem>
         </Stack>

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
@@ -7,12 +7,14 @@ import PipelineVersionImportModal from '~/concepts/pipelines/content/import/Pipe
 type ImportPipelineVersionButtonProps = {
   selectedPipeline: PipelineKF | null;
   onCreate?: (pipelineVersion: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
+  redirectAfterImport?: boolean;
 } & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
 
 const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = ({
   selectedPipeline,
   onCreate,
   children,
+  redirectAfterImport,
   ...buttonProps
 }) => {
   const { apiAvailable, refreshAllAPI } = usePipelinesAPI();
@@ -21,6 +23,7 @@ const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = 
   return (
     <>
       <Button
+        data-testid="import-pipeline-version-button"
         {...buttonProps}
         isDisabled={!apiAvailable || buttonProps.isDisabled}
         onClick={() => setOpen(true)}
@@ -29,6 +32,7 @@ const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = 
       </Button>
       {open && (
         <PipelineVersionImportModal
+          redirectAfterImport={redirectAfterImport}
           existingPipeline={selectedPipeline}
           onClose={(pipelineVersion, pipeline) => {
             setOpen(false);

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
@@ -7,14 +7,12 @@ import PipelineVersionImportModal from '~/concepts/pipelines/content/import/Pipe
 type ImportPipelineVersionButtonProps = {
   selectedPipeline: PipelineKF | null;
   onCreate?: (pipelineVersion: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
-  redirectAfterImport?: boolean;
 } & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
 
 const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = ({
   selectedPipeline,
   onCreate,
   children,
-  redirectAfterImport = true,
   ...buttonProps
 }) => {
   const { apiAvailable, refreshAllAPI } = usePipelinesAPI();
@@ -41,7 +39,6 @@ const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = 
               refreshAllAPI();
             }
           }}
-          redirectAfterImport={redirectAfterImport}
         />
       )}
     </>

--- a/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
+++ b/frontend/src/concepts/pipelines/content/import/ImportPipelineVersionButton.tsx
@@ -7,12 +7,14 @@ import PipelineVersionImportModal from '~/concepts/pipelines/content/import/Pipe
 type ImportPipelineVersionButtonProps = {
   selectedPipeline: PipelineKF | null;
   onCreate?: (pipelineVersion: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
+  redirectAfterImport?: boolean;
 } & Omit<React.ComponentProps<typeof Button>, 'onClick'>;
 
 const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = ({
   selectedPipeline,
   onCreate,
   children,
+  redirectAfterImport = true,
   ...buttonProps
 }) => {
   const { apiAvailable, refreshAllAPI } = usePipelinesAPI();
@@ -39,6 +41,7 @@ const ImportPipelineVersionButton: React.FC<ImportPipelineVersionButtonProps> = 
               refreshAllAPI();
             }
           }}
+          redirectAfterImport={redirectAfterImport}
         />
       )}
     </>

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
 import { FormGroup, StackItem } from '@patternfly/react-core';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
@@ -9,10 +9,6 @@ import { getNameEqualsFilter } from '~/concepts/pipelines/utils';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 import { pipelineVersionDetailsRoute } from '~/routes/pipelines/global';
-import {
-  globalCreatePipelineRecurringRunRoute,
-  globalCreatePipelineRunRoute,
-} from '~/routes/pipelines/runs';
 import { generatePipelineVersionName, PipelineUploadOption } from './utils';
 import { usePipelineVersionImportModalData } from './useImportModalData';
 import PipelineImportBase from './PipelineImportBase';
@@ -20,6 +16,7 @@ import PipelineImportBase from './PipelineImportBase';
 type PipelineVersionImportModalProps = {
   existingPipeline?: PipelineKF | null;
   onClose: (pipelineVersion?: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
+  redirectAfterImport?: boolean;
 };
 
 const eventName = 'Pipeline Version Updated';
@@ -27,10 +24,10 @@ const eventName = 'Pipeline Version Updated';
 const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   existingPipeline,
   onClose,
+  redirectAfterImport = true,
 }) => {
   const { api, namespace } = usePipelinesAPI();
   const navigate = useNavigate();
-  const location = useLocation();
   const [modalData, setData, resetData] = usePipelineVersionImportModalData(existingPipeline);
 
   const handleClose = React.useCallback(
@@ -41,11 +38,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
 
       if (result && 'pipeline_version_id' in result && pipeline) {
         onClose(result, pipeline);
-        const noRedirectPaths = [
-          globalCreatePipelineRunRoute(namespace),
-          globalCreatePipelineRecurringRunRoute(namespace),
-        ];
-        if (!noRedirectPaths.includes(location.pathname)) {
+        if (redirectAfterImport) {
           navigate(
             pipelineVersionDetailsRoute(
               namespace,
@@ -58,7 +51,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
         onClose();
       }
     },
-    [namespace, navigate, onClose, location],
+    [namespace, navigate, onClose, redirectAfterImport],
   );
 
   const checkForDuplicateName = React.useCallback(

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -16,12 +16,14 @@ import PipelineImportBase from './PipelineImportBase';
 type PipelineVersionImportModalProps = {
   existingPipeline?: PipelineKF | null;
   onClose: (pipelineVersion?: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
+  redirectAfterImport?: boolean;
 };
 
 const eventName = 'Pipeline Version Updated';
 const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   existingPipeline,
   onClose,
+  redirectAfterImport = true,
 }) => {
   const { api, namespace } = usePipelinesAPI();
   const navigate = useNavigate();
@@ -35,14 +37,20 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
 
       if (result && 'pipeline_version_id' in result && pipeline) {
         onClose(result, pipeline);
-        navigate(
-          pipelineVersionDetailsRoute(namespace, pipeline.pipeline_id, result.pipeline_version_id),
-        );
+        if (redirectAfterImport) {
+          navigate(
+            pipelineVersionDetailsRoute(
+              namespace,
+              pipeline.pipeline_id,
+              result.pipeline_version_id,
+            ),
+          );
+        }
       } else {
         onClose();
       }
     },
-    [namespace, navigate, onClose],
+    [namespace, navigate, onClose, redirectAfterImport],
   );
 
   const checkForDuplicateName = React.useCallback(

--- a/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
+++ b/frontend/src/concepts/pipelines/content/import/PipelineVersionImportModal.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
 import { FormGroup, StackItem } from '@patternfly/react-core';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { usePipelinesAPI } from '~/concepts/pipelines/context';
 import { PipelineKF, PipelineVersionKF } from '~/concepts/pipelines/kfTypes';
 import PipelineSelector from '~/concepts/pipelines/content/pipelineSelector/PipelineSelector';
@@ -9,6 +9,10 @@ import { getNameEqualsFilter } from '~/concepts/pipelines/utils';
 import { fireFormTrackingEvent } from '~/concepts/analyticsTracking/segmentIOUtils';
 import { TrackingOutcome } from '~/concepts/analyticsTracking/trackingProperties';
 import { pipelineVersionDetailsRoute } from '~/routes/pipelines/global';
+import {
+  globalCreatePipelineRecurringRunRoute,
+  globalCreatePipelineRunRoute,
+} from '~/routes/pipelines/runs';
 import { generatePipelineVersionName, PipelineUploadOption } from './utils';
 import { usePipelineVersionImportModalData } from './useImportModalData';
 import PipelineImportBase from './PipelineImportBase';
@@ -16,17 +20,17 @@ import PipelineImportBase from './PipelineImportBase';
 type PipelineVersionImportModalProps = {
   existingPipeline?: PipelineKF | null;
   onClose: (pipelineVersion?: PipelineVersionKF, pipeline?: PipelineKF | null) => void;
-  redirectAfterImport?: boolean;
 };
 
 const eventName = 'Pipeline Version Updated';
+
 const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
   existingPipeline,
   onClose,
-  redirectAfterImport = true,
 }) => {
   const { api, namespace } = usePipelinesAPI();
   const navigate = useNavigate();
+  const location = useLocation();
   const [modalData, setData, resetData] = usePipelineVersionImportModalData(existingPipeline);
 
   const handleClose = React.useCallback(
@@ -37,7 +41,11 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
 
       if (result && 'pipeline_version_id' in result && pipeline) {
         onClose(result, pipeline);
-        if (redirectAfterImport) {
+        const noRedirectPaths = [
+          globalCreatePipelineRunRoute(namespace),
+          globalCreatePipelineRecurringRunRoute(namespace),
+        ];
+        if (!noRedirectPaths.includes(location.pathname)) {
           navigate(
             pipelineVersionDetailsRoute(
               namespace,
@@ -50,7 +58,7 @@ const PipelineVersionImportModal: React.FC<PipelineVersionImportModalProps> = ({
         onClose();
       }
     },
-    [namespace, navigate, onClose, redirectAfterImport],
+    [namespace, navigate, onClose, location],
   );
 
   const checkForDuplicateName = React.useCallback(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-24479 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Previously, in the Data science pipelines > Runs > Create run form, if a new pipeline version was created within that form, the user would be redirected to the newly created pipeline's page instead of closing the modal and going back to the create run form. This change makes it so that the user is returned back to the create run form so that the user does not lose their inputted data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the existing cypress and unit tests which already test the pipeline version creation modal and the create run form. These tests ensured that the change is localized within the create run flow and does not affect flows such as creating a new pipeline version from the Pipelines tab.

To see the changes
1. Go to Data science pipelines > Runs > Create run
2. Populate name and pipeline field with arbitrary values
3. Click "Upload new version" under the pipeline version section
4. Populate the upload new version modal with arbitrary values
5. Click "Upload"
The user should be returned back to the Create Run form with the newly created version as a selection.

![Screen Recording 2025-05-28 at 4 57 40 PM(1)](https://github.com/user-attachments/assets/67136909-c56b-4c2b-82d0-fc43e3544038)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a test within pipelineCreateRuns.cy.ts that covers the creation of a pipeline and asserts that the url does not change, the pipeline creation modal is closed, and that the new version is selected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
