### PR TITLE
Add version for serving runtime dropdown

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -116,41 +116,25 @@ class ModelServingGlobal {
 
 class ServingRuntimeGroup extends Contextual<HTMLElement> {}
 
-class InferenceServiceModal extends Modal {
-  k8sNameDescription = new K8sNameDescriptionField('inference-service');
-
-  constructor(private edit = false) {
-    super(`${edit ? 'Edit' : 'Deploy'} model`);
-  }
-
-  findConnectionType(name: string | RegExp) {
-    return this.findExistingConnectionSelect()
-      .findByRole('button', { name: 'Typeahead menu toggle' })
-      .findSelectOption(name);
-  }
-
-  findSubmitButton() {
-    return this.findFooter().findByTestId('modal-submit-button');
-  }
-
-  findModelNameInput() {
-    return this.k8sNameDescription.findDisplayNameInput();
-  }
-
-  findSpinner() {
-    return this.find().findByTestId('spinner');
-  }
-
-  findServingRuntimeSelect() {
-    return this.find().findByTestId('inference-service-model-selection');
-  }
-
+class ServingModal extends Modal {
   findServingRuntimeTemplateSearchSelector() {
     return this.find().findByTestId('serving-runtime-template-selection-toggle');
   }
 
   findServingRuntimeTemplateSearchInput() {
     return cy.findByTestId('serving-runtime-template-selection-search').find('input');
+  }
+
+  findGlobalScopedTemplateOption(name: string) {
+    return this.getGlobalScopedServingRuntime()
+      .find()
+      .findByRole('menuitem', { name: new RegExp(name), hidden: true });
+  }
+
+  findProjectScopedTemplateOption(name: string) {
+    return this.getProjectScopedServingRuntime()
+      .find()
+      .findByRole('menuitem', { name: new RegExp(name), hidden: true });
   }
 
   getGlobalServingRuntimesLabel() {
@@ -177,20 +161,38 @@ class InferenceServiceModal extends Modal {
     return new ServingRuntimeGroup(() => cy.findByTestId('global-scoped-serving-runtimes'));
   }
 
-  findServingRuntimeTemplate() {
-    return this.find().findByTestId('serving-runtime-template-selection');
+  findServingRuntimeVersionLabel() {
+    return cy.findByTestId('serving-runtime-version-label');
+  }
+}
+
+class InferenceServiceModal extends ServingModal {
+  k8sNameDescription = new K8sNameDescriptionField('inference-service');
+
+  constructor(private edit = false) {
+    super(`${edit ? 'Edit' : 'Deploy'} model`);
   }
 
-  findCalkitStandaloneServingRuntime() {
-    return this.find().findByTestId('caikit-standalone-runtime');
+  findConnectionType(name: string | RegExp) {
+    return this.findExistingConnectionSelect()
+      .findByRole('button', { name: 'Typeahead menu toggle' })
+      .findSelectOption(name);
   }
 
-  findCalkitTGISServingRuntime() {
-    return this.find().findByTestId('caikit-tgis-runtime');
+  findSubmitButton() {
+    return this.findFooter().findByTestId('modal-submit-button');
   }
 
-  findOpenVinoServingRuntime() {
-    return this.find().findByTestId('kserve-ovms');
+  findModelNameInput() {
+    return this.k8sNameDescription.findDisplayNameInput();
+  }
+
+  findSpinner() {
+    return this.find().findByTestId('spinner');
+  }
+
+  findServingRuntimeSelect() {
+    return this.find().findByTestId('inference-service-model-selection');
   }
 
   findModelFrameworkSelect() {
@@ -373,7 +375,7 @@ class InferenceServiceModal extends Modal {
   }
 }
 
-class ServingRuntimeModal extends Modal {
+class ServingRuntimeModal extends ServingModal {
   k8sNameDescription = new K8sNameDescriptionField('serving-runtime');
 
   constructor(private edit = false) {
@@ -398,14 +400,6 @@ class ServingRuntimeModal extends Modal {
 
   findServingRuntimeTemplateHelptext() {
     return this.find().findByTestId('serving-runtime-template-helptext');
-  }
-
-  findServingRuntimeTemplateDropdown() {
-    return this.find().findByTestId('serving-runtime-template-selection');
-  }
-
-  findOpenVinoModelServer() {
-    return this.find().findByTestId('ovms');
   }
 
   findPredefinedArgsButton() {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -83,8 +83,8 @@ describe(
         modelServingGlobal.findSingleServingModelButton().click();
         modelServingGlobal.findDeployModelButton().click();
         inferenceServiceModal.findModelNameInput().type(modelDeploymentName);
-        inferenceServiceModal.findServingRuntimeTemplate().click();
-        inferenceServiceModal.findOpenVinoServingRuntime().click();
+        inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+        inferenceServiceModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
         inferenceServiceModal.findModelFrameworkSelect().click();
         inferenceServiceModal.findOpenVinoOnnx().click();
         inferenceServiceModal.findOCIModelURI().type(modelDeploymentURI);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -89,18 +89,9 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
       modelServingGlobal.findMultiModelButton().click();
       modelServingSection.findAddModelServerButton().click();
       createServingRuntimeModal.findModelServerName().type(testData.multiModelAdminName);
-      // Check if Serving Runtime is selectable, if it is then select OpenVino Model Server
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .should('be.visible')
-        .then(($element) => {
-          if ($element.is(':visible') && !$element.prop('disabled')) {
-            cy.wrap($element).click();
-            createServingRuntimeModal.findOpenVinoModelServer().click();
-          } else {
-            cy.log('Serving Runtime Template dropdown is not clickable. Skipping this step.');
-          }
-        });
+      // Select the OpenVino serving runtime template
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
 
       // Click the deployed model route checkbox and confirm it's checked
       cy.step('Allow Model to be accessed from an External route without Authentication');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -84,8 +84,8 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
       // Launch a Single Serving Model and select the required entries
       cy.step('Launch a Single Serving Model using Openvino');
       inferenceServiceModal.findModelNameInput().type(testData.singleModelAdminName);
-      inferenceServiceModal.findServingRuntimeTemplate().click();
-      inferenceServiceModal.findOpenVinoServingRuntime().click();
+      inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+      inferenceServiceModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
       inferenceServiceModal.findModelFrameworkSelect().click();
       inferenceServiceModal.findOpenVinoIROpSet13().click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -89,8 +89,10 @@ describe('Verify Model Creation and Validation using the UI', () => {
       // Launch a Single Serving Model and select the required entries
       cy.step('Launch a Single Serving Model using Caikit TGIS ServingRuntime for KServe');
       inferenceServiceModal.findModelNameInput().type(testData.singleModelName);
-      inferenceServiceModal.findServingRuntimeTemplate().click();
-      inferenceServiceModal.findCalkitTGISServingRuntime().click();
+      inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+      inferenceServiceModal
+        .findGlobalScopedTemplateOption('Caikit TGIS ServingRuntime for KServe')
+        .click();
 
       inferenceServiceModal.findLocationPathInput().type(modelFilePath);
       inferenceServiceModal.findSubmitButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -122,8 +122,10 @@ describe('Notebooks - tolerations tests', () => {
         'Launch a Single Serving Model using Caikit TGIS ServingRuntime for KServe and by selecting the Hardware Profile',
       );
       inferenceServiceModal.findModelNameInput().type(modelName);
-      inferenceServiceModal.findServingRuntimeTemplate().click();
-      inferenceServiceModal.findCalkitTGISServingRuntime().click();
+      inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+      inferenceServiceModal
+        .findGlobalScopedTemplateOption('Caikit TGIS ServingRuntime for KServe')
+        .click();
 
       inferenceServiceModal.selectPotentiallyDisabledProfile(
         testData.hardwareProfileDeploymentSize,

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDeploy.cy.ts
@@ -355,7 +355,6 @@ describe('Deploy model version', () => {
     kserveModal.findModelNameInput().should('exist');
 
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    const projectScopedSR = kserveModal.getProjectScopedServingRuntime();
 
     // Verify both groups are initially visible
     cy.contains('Project-scoped serving runtimes').should('be.visible');
@@ -378,7 +377,7 @@ describe('Deploy model version', () => {
     kserveModal.findServingRuntimeTemplateSearchInput().should('be.visible').clear();
 
     // Check for project specific serving runtimes
-    projectScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
+    kserveModal.findProjectScopedTemplateOption('Caikit').click();
     acceleratorProfileSection.findProjectScopedLabel().should('exist');
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
@@ -390,8 +389,7 @@ describe('Deploy model version', () => {
 
     // Check for global specific serving runtimes
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    const globalScopedSR = kserveModal.getGlobalScopedServingRuntime();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     acceleratorProfileSection.findGlobalScopedLabel().should('exist');
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
@@ -403,16 +401,16 @@ describe('Deploy model version', () => {
 
     // check model framework selection when serving runtime changes
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     kserveModal.findModelFrameworkSelect().should('have.text', 'onnx - 1');
 
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Caikit').click();
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'Select a framework');
 
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    projectScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
+    kserveModal.findProjectScopedTemplateOption('Caikit').click();
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
   });
@@ -517,7 +515,8 @@ describe('Deploy model version', () => {
     // Validate model framework section
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     cy.findByText('The format of the source model is').should('not.exist');
-    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Multi Platform').click();
+    kserveModal.findServingRuntimeTemplateSearchSelector().click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     cy.findByText(
       `The format of the source model is ${modelArtifactMocked.modelFormatName ?? ''} - ${
@@ -547,7 +546,8 @@ describe('Deploy model version', () => {
     // Validate model framework section
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     cy.findByText('The format of the source model is').should('not.exist');
-    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Multi Platform').click();
+    kserveModal.findServingRuntimeTemplateSearchSelector().click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     cy.findByText(
       `The format of the source model is ${modelArtifactMocked.modelFormatName ?? ''} - ${

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -662,7 +662,8 @@ describe('Model Serving Global', () => {
 
     kserveModal.shouldBeOpen();
     kserveModal.findServingRuntimeTemplateHelptext().should('not.exist');
-    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findServingRuntimeTemplateSearchSelector().click();
+    kserveModal.findGlobalScopedTemplateOption('Caikit').click();
     kserveModal.findServingRuntimeTemplateHelptext().should('exist');
   });
 
@@ -680,29 +681,27 @@ describe('Model Serving Global', () => {
 
     // Check for project specific serving runtimes
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    const projectScopedSR = kserveModal.getProjectScopedServingRuntime();
-    projectScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
+    kserveModal.findProjectScopedTemplateOption('Multi Platform').click();
     kserveModal.findProjectScopedLabel().should('exist');
 
     // Check for global specific serving runtimes
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    const globalScopedSR = kserveModal.getGlobalScopedServingRuntime();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     kserveModal.findGlobalScopedLabel().should('exist');
     kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
 
     // check model framework selection when serving runtime changes
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Multi Platform', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
     kserveModal.findModelFrameworkSelect().should('have.text', 'onnx - 1');
 
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    globalScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
+    kserveModal.findGlobalScopedTemplateOption('Caikit').click();
     kserveModal.findModelFrameworkSelect().should('be.enabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'Select a framework');
 
     kserveModal.findServingRuntimeTemplateSearchSelector().click();
-    projectScopedSR.find().findByRole('menuitem', { name: 'Caikit', hidden: true }).click();
+    kserveModal.findProjectScopedTemplateOption('Caikit').click();
     kserveModal.findModelFrameworkSelect().should('be.disabled');
     kserveModal.findModelFrameworkSelect().should('have.text', 'openvino_ir - opset1');
   });
@@ -884,7 +883,8 @@ describe('Model Serving Global', () => {
     kserveModal.findPredefinedArgsButton().click();
     kserveModal.findPredefinedArgsList().should('not.exist');
     kserveModal.findPredefinedArgsTooltip().should('exist');
-    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findServingRuntimeTemplateSearchSelector().click();
+    kserveModal.findGlobalScopedTemplateOption('Caikit').click();
     kserveModal.findPredefinedArgsButton().click();
     kserveModal.findPredefinedArgsList().should('exist');
     kserveModal.findPredefinedArgsTooltip().should('not.exist');
@@ -904,7 +904,8 @@ describe('Model Serving Global', () => {
     kserveModal.findPredefinedVarsButton().click();
     kserveModal.findPredefinedVarsList().should('not.exist');
     kserveModal.findPredefinedVarsTooltip().should('exist');
-    kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+    kserveModal.findServingRuntimeTemplateSearchSelector().click();
+    kserveModal.findGlobalScopedTemplateOption('Caikit').click();
     kserveModal.findPredefinedVarsButton().click();
     kserveModal.findPredefinedVarsList().should('exist');
     kserveModal.findPredefinedVarsTooltip().should('not.exist');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -869,7 +869,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       // check external route, token should be checked and no alert
@@ -1056,7 +1057,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       // check external route, token should be checked and no alert
@@ -1142,7 +1144,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findExistingConnectionSelect().should('have.attr', 'disabled');
       kserveModal.findNewConnectionOption().click();
@@ -1419,7 +1422,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       kserveModal.findNewConnectionOption().click();
@@ -1516,7 +1520,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       // misc.
@@ -1679,7 +1684,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       // misc.
@@ -1816,7 +1822,8 @@ describe('Serving Runtime List', () => {
       kserveModal.shouldBeOpen();
 
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findExistingConnectionOption().click();
       kserveModal.findLocationPathInput().type('test-model/');
@@ -1884,10 +1891,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // test invalid resource name
@@ -2309,10 +2314,8 @@ describe('Serving Runtime List', () => {
 
       // fill in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // test submitting form, the modal should close to indicate success.
@@ -2363,10 +2366,8 @@ describe('Serving Runtime List', () => {
 
       // fill in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // test submitting form, an error should appear
@@ -2413,10 +2414,8 @@ describe('Serving Runtime List', () => {
 
       // fill in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // test submitting form, the modal should close to indicate success.
@@ -2476,10 +2475,8 @@ describe('Serving Runtime List', () => {
 
       // fill in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // enable auth
@@ -2550,10 +2547,8 @@ describe('Serving Runtime List', () => {
 
       // fill in minimum required fields
       createServingRuntimeModal.k8sNameDescription.findDisplayNameInput().type('Test Name');
-      createServingRuntimeModal
-        .findServingRuntimeTemplateDropdown()
-        .findSelectOption('New OVMS Server')
-        .click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('New OVMS Server').click();
       createServingRuntimeModal.findSubmitButton().should('be.enabled');
 
       // enable auth
@@ -2858,7 +2853,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       kserveModal.findExistingConnectionOption().click();
@@ -2897,7 +2893,8 @@ describe('Serving Runtime List', () => {
 
       // test filling in minimum required fields
       kserveModal.findModelNameInput().type('Test Name');
-      kserveModal.findServingRuntimeTemplateDropdown().findSelectOption('Caikit').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Caikit').click();
       kserveModal.findModelFrameworkSelect().findSelectOption('onnx - 1').click();
       kserveModal.findSubmitButton().should('be.disabled');
       kserveModal.findExistingConnectionOption().click();
@@ -3183,6 +3180,47 @@ describe('Serving Runtime List', () => {
         .findInternalServicePopover()
         .findByText('Could not find any internal service enabled')
         .should('exist');
+    });
+  });
+  describe('Serving Runtime Template Selection', () => {
+    it('displays label in search selector when multi-model serving is selected', () => {
+      initIntercepts({
+        projectEnableModelMesh: true,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+      modelServingSection.findAddModelServerButton().click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().should('exist');
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().click();
+      createServingRuntimeModal.findGlobalScopedTemplateOption('Multi Platform').within(() => {
+        createServingRuntimeModal.findServingRuntimeVersionLabel().should('exist');
+      });
+      createServingRuntimeModal.findGlobalScopedTemplateOption('Multi Platform').click();
+      createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().within(() => {
+        createServingRuntimeModal.findServingRuntimeVersionLabel().should('exist');
+      });
+    });
+
+    it('displays label in search selector when single-model serving is selected', () => {
+      initIntercepts({
+        projectEnableModelMesh: false,
+        disableKServeConfig: false,
+        disableModelMeshConfig: false,
+      });
+
+      projectDetails.visitSection('test-project', 'model-server');
+      modelServingSection.findDeployModelButton().click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().should('exist');
+      kserveModal.findServingRuntimeTemplateSearchSelector().click();
+      kserveModal.findGlobalScopedTemplateOption('Multi Platform').within(() => {
+        kserveModal.findServingRuntimeVersionLabel().should('exist');
+      });
+      kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
+      kserveModal.findServingRuntimeTemplateSearchSelector().within(() => {
+        kserveModal.findServingRuntimeVersionLabel().should('exist');
+      });
     });
   });
 });

--- a/frontend/src/components/searchSelector/ProjectScopedToggleContent.tsx
+++ b/frontend/src/components/searchSelector/ProjectScopedToggleContent.tsx
@@ -13,6 +13,7 @@ export type ProjectScopedToggleContentProps = {
   color?: ScopedLabelColor;
   isCompact?: boolean;
   fallback?: React.ReactNode;
+  additionalContent?: React.ReactNode;
 };
 
 const ProjectScopedToggleContent: React.FC<ProjectScopedToggleContentProps> = ({
@@ -25,6 +26,7 @@ const ProjectScopedToggleContent: React.FC<ProjectScopedToggleContentProps> = ({
   color = 'blue',
   isCompact = true,
   fallback = 'Select one',
+  additionalContent,
 }) => {
   if (!displayName) {
     return <>{fallback}</>;
@@ -32,6 +34,7 @@ const ProjectScopedToggleContent: React.FC<ProjectScopedToggleContentProps> = ({
   return (
     <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>{displayName}</FlexItem>
+      {additionalContent && <FlexItem>{additionalContent}</FlexItem>}
       <FlexItem>
         <ScopedLabel
           isProject={isProject}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25676
## Description
This adds the Runtime Version Label to the dropdown when selecting your serving runtime in both multi and single serving modals. It replaces the SimpleSelect with the SearchSelector full time (something we only did when there were project specific templates). If there are no project specific templates you'll see the normal ones under global.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Create a Serving Runtime Template and add the annotation under the Serving Runtime 
```
opendatahub.io/runtime-version: 'v0.5.1'
```
Go to deploy single and multi models
In the modal go to select a template and see the version label next to your template item
Once selected it should show the label in the selector's place holder.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added a couple mock tests
Created a new base ServingModal that is inherited by the ServingRuntimeModal and InferenceServiceModal to host anything shared between the two (in this case the template selector)
Updated tests that relied on the SimpleSelect that was removed
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
With my changes we will now always show the search selector for serving runtimes. Before it would change behavior if you had project specific runtimes defined.
![Screenshot From 2025-05-29 14-18-10](https://github.com/user-attachments/assets/92f57ff0-466f-42de-bfce-20e65690c34b)
Before:
![image](https://github.com/user-attachments/assets/838bc7de-42b3-45e5-8524-5d6bd0d7ecbf)


Here's what it looks like when you have project specific templates too: 
![image](https://github.com/user-attachments/assets/bccd7a71-4bce-4dd0-8d5f-52a55f8ed96f)

<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
