### PR TITLE
Remove provider specification from Jupyter app manifest

### DIFF
--- a/manifests/common/apps/jupyter/jupyter-app.yaml
+++ b/manifests/common/apps/jupyter/jupyter-app.yaml
@@ -21,7 +21,7 @@ spec:
     - odh-notebook-controller
     - notebook-images
   support: red hat
-  provider: Jupyter
+  provider: ''
   docsLink: 'https://jupyter.org'
   quickStart: create-jupyter-notebook
   getStartedMarkDown: >-


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25601

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Sets the provider of the 'Start basic workbench' tile to an empty string. It cannot be fully removed as the CRD requires that value. Our code does a check for a defined value there so it will act as undefined when rendered.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
go to explore section and make sure 'by Jupyter' is gone

## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
none - microcopy

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
