### PR TITLE
RHOAIENG-15191: Deprecate/Remove the DSPA RBAC setting from Dashboard 

### DIFF
--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -11,7 +11,6 @@ import { Toleration } from '#~/types';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { mock200Status } from '#~/__mocks__/mockK8sStatus';
-import { mockRoleBindingK8sResource } from '#~/__mocks__/mockRoleBindingK8sResource';
 import { mockStartNotebookData } from '#~/__mocks__/mockStartNotebookData';
 
 import {
@@ -35,7 +34,6 @@ import {
 } from '#~/api/k8s/notebooks';
 
 import {
-  createElyraServiceAccountRoleBinding,
   getPipelineVolumePatch,
   getPipelineVolumeMountPatch,
   ELYRA_VOLUME_NAME,
@@ -62,7 +60,6 @@ jest.mock('#~/concepts/pipelines/elyra/utils', () => {
   const originalModule = jest.requireActual('#~/concepts/pipelines/elyra/utils');
   return {
     ...originalModule,
-    createElyraServiceAccountRoleBinding: jest.fn(),
   };
 });
 
@@ -72,7 +69,6 @@ const k8sPatchResourceMock = jest.mocked(k8sPatchResource<NotebookKind>);
 const k8sListResourceMock = jest.mocked(k8sListResource<NotebookKind>);
 const k8sMergePatchResourceMock = jest.mocked(k8sMergePatchResource<NotebookKind>);
 const k8sDeleteResourceMock = jest.mocked(k8sDeleteResource<NotebookKind, K8sStatus>);
-const createElyraServiceAccountRoleBindingMock = jest.mocked(createElyraServiceAccountRoleBinding);
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
 
@@ -307,10 +303,6 @@ describe('assembleNotebook', () => {
     const notebook = assembleNotebook(startNotebookDataMock, username, true);
     k8sCreateResourceMock.mockResolvedValue(mockNotebookK8sResource({ uid: 'test' }));
 
-    createElyraServiceAccountRoleBindingMock.mockResolvedValue(
-      mockRoleBindingK8sResource({ uid: 'test' }),
-    );
-
     const renderResult = await createNotebook(startNotebookDataMock, username, true);
 
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
@@ -321,11 +313,6 @@ describe('assembleNotebook', () => {
         queryParams: {},
       },
     });
-    expect(createElyraServiceAccountRoleBindingMock).toHaveBeenCalledWith(
-      mockNotebookK8sResource({ uid: 'test' }),
-      undefined,
-    );
-    expect(createElyraServiceAccountRoleBindingMock).toHaveBeenCalledTimes(1);
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebookK8sResource({ uid: 'test' }));
   });
@@ -335,10 +322,6 @@ describe('assembleNotebook', () => {
     startNotebookMock.volumeMounts = undefined;
     const notebook = assembleNotebook(startNotebookMock, username, false);
     k8sCreateResourceMock.mockResolvedValue(mockNotebookK8sResource({ uid: 'test' }));
-
-    createElyraServiceAccountRoleBindingMock.mockResolvedValue(
-      mockRoleBindingK8sResource({ uid: 'test' }),
-    );
 
     const renderResult = await createNotebook(startNotebookMock, username, false);
 
@@ -350,7 +333,6 @@ describe('assembleNotebook', () => {
         queryParams: {},
       },
     });
-    expect(createElyraServiceAccountRoleBindingMock).toHaveBeenCalledTimes(0);
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebookK8sResource({ uid: 'test' }));
   });
@@ -368,7 +350,6 @@ describe('createNotebook', () => {
 
     const renderResult = await createNotebook(mockStartNotebookData({}), username, false);
 
-    expect(createElyraServiceAccountRoleBinding).not.toHaveBeenCalled();
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
       fetchOptions: { requestInit: {} },
       model: NotebookModel,
@@ -384,8 +365,6 @@ describe('createNotebook', () => {
     const notebook = assembleNotebook(mockStartNotebookData({}), username, true);
     k8sCreateResourceMock.mockResolvedValue(mockNotebookK8sResource({ uid }));
 
-    createElyraServiceAccountRoleBindingMock.mockResolvedValue(mockRoleBindingK8sResource({ uid }));
-
     const renderResult = await createNotebook(mockStartNotebookData({}), username, true);
 
     expect(k8sCreateResourceMock).toHaveBeenCalledWith({
@@ -396,7 +375,6 @@ describe('createNotebook', () => {
         queryParams: {},
       },
     });
-    expect(createElyraServiceAccountRoleBindingMock).toHaveBeenCalledTimes(1);
     expect(k8sCreateResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebookK8sResource({ uid }));
   });
@@ -496,7 +474,6 @@ describe('startNotebook', () => {
         getPipelineVolumeMountPatch(),
       ],
     });
-    expect(createElyraServiceAccountRoleBinding).toHaveBeenCalledWith(mockNotebook);
     expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebook);
   });
@@ -522,7 +499,6 @@ describe('startNotebook', () => {
         getPipelineVolumeMountPatch(),
       ],
     });
-    expect(createElyraServiceAccountRoleBinding).toHaveBeenCalledWith(mockNotebook);
     expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebook);
   });
@@ -548,7 +524,6 @@ describe('startNotebook', () => {
         getPipelineVolumeMountPatch(),
       ],
     });
-    expect(createElyraServiceAccountRoleBinding).toHaveBeenCalledWith(mockNotebook);
     expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
     expect(renderResult).toStrictEqual(mockNotebook);
   });
@@ -571,7 +546,6 @@ describe('startNotebook', () => {
     });
 
     expect(k8sPatchResourceMock).toHaveBeenCalledTimes(1);
-    expect(createElyraServiceAccountRoleBinding).not.toHaveBeenCalled();
     expect(renderResult).toStrictEqual(mockNotebook);
   });
   it('should handle errors and rethrow', async () => {

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -23,7 +23,6 @@ import { ROOT_MOUNT_PATH } from '#~/pages/projects/pvc/const';
 import { getTolerationPatch, TolerationChanges } from '#~/utilities/tolerations';
 import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 import {
-  createElyraServiceAccountRoleBinding,
   ELYRA_VOLUME_NAME,
   getElyraVolume,
   getElyraVolumeMount,
@@ -255,7 +254,6 @@ export const startNotebook = async (
   if (enablePipelines) {
     patches.push(getPipelineVolumePatch());
     patches.push(getPipelineVolumeMountPatch());
-    await createElyraServiceAccountRoleBinding(notebook);
   }
 
   return k8sPatchResource<NotebookKind>({
@@ -284,13 +282,7 @@ export const createNotebook = (
       ),
     )
       .then((fetchedNotebook) => {
-        if (canEnablePipelines) {
-          createElyraServiceAccountRoleBinding(fetchedNotebook, opts)
-            .then(() => resolve(fetchedNotebook))
-            .catch(reject);
-        } else {
-          resolve(fetchedNotebook);
-        }
+        resolve(fetchedNotebook);
       })
       .catch(reject);
   });

--- a/frontend/src/concepts/pipelines/elyra/utils.ts
+++ b/frontend/src/concepts/pipelines/elyra/utils.ts
@@ -2,7 +2,6 @@ import { Patch } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   DSPipelineExternalStorageKind,
   ImageStreamSpecTagType,
-  K8sAPIOptions,
   KnownLabels,
   NotebookKind,
   RoleBindingKind,
@@ -17,7 +16,6 @@ import {
 } from '#~/concepts/pipelines/elyra/const';
 import { Volume, VolumeMount } from '#~/types';
 import { RUNTIME_MOUNT_PATH } from '#~/pages/projects/pvc/const';
-import { createRoleBinding, getRoleBinding, patchRoleBindingOwnerRef } from '#~/api';
 import { experimentsBaseRoute } from '#~/routes/pipelines/experiments';
 import { getImageVersionDependencies } from '#~/pages/projects/screens/spawner/spawnerUtils';
 

--- a/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
+++ b/frontend/src/pages/projects/screens/spawner/__tests__/SpawnerFooter.spec.tsx
@@ -1,7 +1,7 @@
 import React, { act } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { k8sCreateResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { useUser } from '#~/redux/selectors';
 import SpawnerFooter from '#~/pages/projects/screens/spawner/SpawnerFooter';
 import {
@@ -11,14 +11,8 @@ import {
 } from '#~/__mocks__/mockStartNotebookData';
 import { useAppContext } from '#~/app/AppContext';
 import { mockDashboardConfig, mockNotebookK8sResource } from '#~/__mocks__';
-import {
-  ConfigMapKind,
-  NotebookKind,
-  PersistentVolumeClaimKind,
-  RoleBindingKind,
-  SecretKind,
-} from '#~/k8sTypes';
-import { ConfigMapModel, NotebookModel, PVCModel, RoleBindingModel, SecretModel } from '#~/api';
+import { ConfigMapKind, NotebookKind, PersistentVolumeClaimKind, SecretKind } from '#~/k8sTypes';
+import { ConfigMapModel, NotebookModel, PVCModel, SecretModel } from '#~/api';
 import { mockPVCK8sResource } from '#~/__mocks__/mockPVCK8sResource';
 import { mockConnection } from '#~/__mocks__/mockConnection';
 
@@ -47,12 +41,9 @@ const k8sCreateSecretMock = jest.mocked(k8sCreateResource<SecretKind>);
 const k8sCreatePVCMock = jest.mocked(k8sCreateResource<PersistentVolumeClaimKind>);
 const k8sCreateConfigMapMock = jest.mocked(k8sCreateResource<ConfigMapKind>);
 const k8sCreateNotebookMock = jest.mocked(k8sCreateResource<NotebookKind>);
-const k8sCreateRoleBindingMock = jest.mocked(k8sCreateResource<RoleBindingKind>);
-const k8sGetRoleBindingMock = jest.mocked(k8sGetResource<RoleBindingKind>);
 
 k8sCreatePVCMock.mockResolvedValue(mockPVCK8sResource({}));
 k8sCreateNotebookMock.mockResolvedValue(mockNotebookK8sResource({}));
-k8sGetRoleBindingMock.mockRejectedValue(new Error());
 
 const useAppContextMock = jest.mocked(useAppContext);
 useAppContextMock.mockReturnValue({
@@ -124,12 +115,6 @@ describe('EmptyProjects', () => {
     expect(k8sCreateNotebookMock).toHaveBeenCalledWith(
       expect.objectContaining({
         model: NotebookModel,
-        ...dryRunOptions,
-      }),
-    );
-    expect(k8sCreateRoleBindingMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: RoleBindingModel,
         ...dryRunOptions,
       }),
     );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA story:** https://issues.redhat.com/browse/RHOAIENG-15191

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. The Dashboard code responsible for creating or managing RoleBindings for notebook Service Accounts (related to DSPA/Elyra) is removed.
2. Specifically, calls to createElyraServiceAccountRoleBinding (or similar functions that manage these RoleBindings) within createNotebook and startNotebook in frontend/src/api/k8s/notebooks.ts are removed.
3. When a new workbench is created or an existing one is started with pipeline capabilities enabled, the Dashboard no longer attempts to create any RoleBinding for the notebook's service account.
4. The createElyraServiceAccountRoleBinding function, if no longer used elsewhere after these changes, is removed from ~/concepts/pipelines/elyra/utils.ts and its import is removed from frontend/src/api/k8s/notebooks.ts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

@srtanish1992 will add shortly

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NO tests impact as just deleting the code.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
