### PR TITLE
Storage class edit modal, access mode configuration

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -3,8 +3,8 @@ import { TableRow } from '#~/__tests__/cypress/cypress/pages/components/table';
 import { mockStorageClassList } from '#~/__mocks__';
 import type { StorageClassKind } from '#~/k8sTypes';
 import { StorageClassModel } from '#~/__tests__/cypress/cypress/utils/models';
-import { Modal } from './components/Modal';
 import { TableToolbar } from './components/TableToolbar';
+import { Modal } from './components/Modal';
 
 class StorageClassesPage {
   visit() {
@@ -193,6 +193,15 @@ class StorageClassEditModal extends Modal {
 
   findInfoAlert() {
     return this.find().findByTestId('edit-sc-modal-info-alert');
+  }
+
+  findAccessModeCheckbox(mode: string) {
+    //mode: rwo, rwx, rox, rwop
+    return this.find().findByTestId(`edit-sc-access-mode-checkbox-${mode.toLowerCase()}`);
+  }
+
+  findAccessModeAlert() {
+    return this.find().findByTestId('edit-sc-access-mode-alert');
   }
 
   mockGetStorageClass(storageClass: StorageClassKind, times = 1) {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -492,12 +492,7 @@ describe('Storage classes', () => {
       storageClassesPage.visit();
       storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
 
-      storageClassEditModal
-        .findAccessModeCheckbox('rwo')
-        .should('be.enabled')
-        .and('be.checked')
-        .click()
-        .should('be.checked');
+      storageClassEditModal.findAccessModeCheckbox('rwo').should('be.disabled').and('be.checked');
 
       storageClassEditModal
         .findAccessModeCheckbox('rwx')

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -1,3 +1,4 @@
+import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import {
   buildMockStorageClass,
   buildMockStorageClassConfig,
@@ -475,6 +476,112 @@ describe('Storage classes', () => {
       storageClassesPage.visit();
 
       storageClassesPage.findNoDefaultAlert().should('exist');
+    });
+
+    it('should show access mode checkboxes with correct enable/disable and checked/unchecked states', () => {
+      const config = {
+        accessModeSettings: {
+          [AccessMode.RWO]: true,
+          [AccessMode.RWX]: false,
+          //ROX missing
+          [AccessMode.RWOP]: true,
+        },
+      };
+      const storageClass = buildMockStorageClass(otherStorageClass, config);
+      storageClassesPage.mockGetStorageClasses([storageClass]);
+      storageClassesPage.visit();
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
+
+      storageClassEditModal
+        .findAccessModeCheckbox('rwo')
+        .should('be.enabled')
+        .and('be.checked')
+        .click()
+        .should('be.checked');
+
+      storageClassEditModal
+        .findAccessModeCheckbox('rwx')
+        .should('be.enabled')
+        .and('not.be.checked')
+        .click()
+        .should('be.checked');
+
+      storageClassEditModal
+        .findAccessModeCheckbox('rox')
+        .should('be.disabled')
+        .and('not.be.checked');
+
+      storageClassEditModal
+        .findAccessModeCheckbox('rwop')
+        .should('be.enabled')
+        .and('be.checked')
+        .click()
+        .and('not.be.checked');
+    });
+
+    it('should update accessModeSettings and persist changes on save', () => {
+      const oldConfig = {
+        accessModeSettings: {
+          [AccessMode.RWO]: true,
+          [AccessMode.RWX]: true,
+          [AccessMode.RWOP]: false,
+        },
+      };
+
+      const newConfig = {
+        accessModeSettings: {
+          [AccessMode.RWO]: true,
+          [AccessMode.RWX]: false,
+          [AccessMode.RWOP]: true,
+        },
+      };
+
+      const storageClass = buildMockStorageClass(otherStorageClass, oldConfig);
+
+      storageClassesPage.mockGetStorageClasses([storageClass]);
+      storageClassesPage.visit();
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
+
+      storageClassEditModal.findAccessModeCheckbox('rwx').click().should('not.be.checked');
+      storageClassEditModal.findAccessModeCheckbox('rwop').click().should('be.checked');
+
+      const newStorageClass = buildMockStorageClass(otherStorageClass, newConfig);
+
+      storageClassEditModal.mockGetStorageClass(newStorageClass);
+      storageClassEditModal.mockPatchStorageClass(newStorageClass).as('patchStorageClass');
+      storageClassesPage.mockGetStorageClasses([newStorageClass]).as('refreshStorageClass');
+
+      storageClassEditModal.findSaveButton().click();
+      cy.wait('@patchStorageClass');
+      cy.wait('@refreshStorageClass');
+
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
+      storageClassEditModal.findAccessModeCheckbox('rwo').should('be.checked');
+      storageClassEditModal.findAccessModeCheckbox('rwx').should('not.be.checked');
+      storageClassEditModal
+        .findAccessModeCheckbox('rox')
+        .should('be.disabled')
+        .and('not.be.checked');
+      storageClassEditModal.findAccessModeCheckbox('rwop').should('be.checked');
+    });
+
+    it('should show the alert when RWX is disabled', () => {
+      const config = {
+        accessModeSettings: {
+          ReadWriteOnce: true,
+          ReadWriteMany: true,
+        },
+      };
+      const storageClass = buildMockStorageClass(otherStorageClass, config);
+      storageClassesPage.mockGetStorageClasses([storageClass]);
+      storageClassesPage.visit();
+      storageClassesTable.getRowByConfigName('Test SC 1').findKebabAction('Edit').click();
+
+      storageClassEditModal.findAccessModeCheckbox('rwx').click().should('not.be.checked');
+      storageClassEditModal.findAccessModeAlert().should('be.visible');
+      storageClassEditModal
+        .findAccessModeAlert()
+        .should('contain.text', 'Disabling the RWX access mode will prevent new storage');
     });
   });
 });

--- a/frontend/src/pages/storageClasses/constants.ts
+++ b/frontend/src/pages/storageClasses/constants.ts
@@ -1,5 +1,6 @@
 import { SortableData, kebabTableColumn } from '#~/components/table';
 import { StorageClassKind } from '#~/k8sTypes';
+import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import { getStorageClassConfig } from './utils';
 
 export enum ColumnLabel {
@@ -85,4 +86,12 @@ export type StorageClassFilterData = Record<StorageClassFilterOption, string>;
 export const initialScFilterData: StorageClassFilterData = {
   [StorageClassFilterOption.DisplayName]: '',
   [StorageClassFilterOption.OpenshiftScName]: '',
+};
+
+export const accessModeDescriptions: Record<AccessMode, string> = {
+  [AccessMode.RWO]:
+    'Supported by default. The storage can be attached to a single workbench at a given time.',
+  [AccessMode.RWX]: 'The storage can be attached to many workbenches simultaneously.',
+  [AccessMode.ROX]: 'Storage with ROX mode can be mounted as read-only by many workbenches.',
+  [AccessMode.RWOP]: 'The storage can be attached to a single pod on a single node as read-write.',
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25533

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added a new section in the storage class edit modal to allow admin to enable/disable one or more access modes. 
* Added a popover to show the explanation of the feature
* Displayed all access modes in checkbox form
* RWO is supported by default and cannot be disabled
* If the class doesn't support the mode, the mode checkbox is disabled
* When hovering over a disabled mode, a tooltip is shown with an explanation
* When RWX mode is initially enabled at modal opening, and then checked off, an alert is displayed explaining the consequences.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create a new storage class in the OpenShift console, with `kubernetes.io/quobyte` as provisioner. 
2. Go to the dashboard and navigate to the storage classes page
3. Click on the kebab button, and edit
4. Test functionality:
   * Tooltip visibility on mouse over RWOP 
   * Warning alert display: 
       * Enable RWX, then save, then go back to edit, and disable
       * Should show warning alert
   * Question mark icon popover
   * Check correct enable/disable and checked/unchecked states
   * Check that changes persist on save

https://github.com/user-attachments/assets/7e91f0d2-7ebb-4dc8-b4c2-27b5b32a5225

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tests added.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
