### PR TITLE
Cypress e2e: add namespace to oc modelserving calls

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -89,7 +89,7 @@ describe(
         inferenceServiceModal.findOpenVinoOnnx().click();
         inferenceServiceModal.findOCIModelURI().type(modelDeploymentURI);
         inferenceServiceModal.findSubmitButton().focus().click();
-        checkInferenceServiceState(modelDeploymentName);
+        checkInferenceServiceState(modelDeploymentName, projectName);
         modelServingSection.findModelServerName(modelDeploymentName);
         // Note reload is required as status tooltip was not found due to a stale element
         cy.reload();

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testMultiModelAdminCreation.cy.ts
@@ -127,9 +127,9 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
 
       //Verify the Model was created successfully
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(testData.multiModelAdminName);
+      checkInferenceServiceState(testData.multiModelAdminName, projectName);
       // Check only LatestDeploymentReady
-      checkInferenceServiceState(testData.multiModelAdminName, {
+      checkInferenceServiceState(testData.multiModelAdminName, projectName, {
         checkReady: true,
         checkLatestDeploymentReady: false,
       });
@@ -141,7 +141,7 @@ describe('Verify Admin Multi Model Creation and Validation using the UI', () => 
 
       //Verify the Model is accessible externally
       cy.step('Verify the model is accessible externally');
-      modelExternalTester(modelName).then(({ url, response }) => {
+      modelExternalTester(modelName, projectName).then(({ url, response }) => {
         expect(response.status).to.equal(200);
 
         //verify the External URL Matches the Backend

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -102,7 +102,7 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(testData.singleModelAdminName, {
+      checkInferenceServiceState(testData.singleModelAdminName, projectName, {
         checkReady: true,
         checkLatestDeploymentReady: true,
       });
@@ -113,7 +113,7 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
 
       //Verify the Model is accessible externally
       cy.step('Verify the model is accessible externally');
-      modelExternalTester(modelName).then(({ url, response }) => {
+      modelExternalTester(modelName, projectName).then(({ url, response }) => {
         expect(response.status).to.equal(200);
 
         //verify the External URL Matches the Backend

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -99,7 +99,7 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(testData.singleModelName, {
+      checkInferenceServiceState(testData.singleModelName, projectName, {
         checkReady: true,
         checkLatestDeploymentReady: true,
       });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/settings/hardwareProfiles/testModelServingTolerations.cy.ts
@@ -134,7 +134,7 @@ describe('Notebooks - tolerations tests', () => {
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      checkInferenceServiceState(modelName);
+      checkInferenceServiceState(modelName, projectName);
       modelServingSection.findModelServerName(modelName);
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelServing.ts
@@ -89,14 +89,16 @@ const safeString = (value: string | undefined | null): string => value ?? '';
  * Check InferenceService active model state and additional conditions
  *
  * @param serviceName InferenceService name
+ * @param namespace The namespace where the InferenceService is deployed
  * @param options Optional configuration for condition checks
  * @returns Result Object of the operation
  */
 export const checkInferenceServiceState = (
   serviceName: string,
+  namespace: string,
   options: ConditionCheckOptions = {},
 ): Cypress.Chainable<Cypress.Exec> => {
-  const ocCommand = `oc get inferenceService ${serviceName} -o json`;
+  const ocCommand = `oc get inferenceService ${serviceName} -n ${namespace} -o json`;
   const maxAttempts = 96; // 8 minutes / 5 seconds = 96 attempts
   let attempts = 0;
 
@@ -257,11 +259,13 @@ export const checkInferenceServiceState = (
  * Retries the request every 5 seconds for up to 30 seconds if the initial request fails.
  *
  * @param modelName - The name of the InferenceService/model to test.
+ * @param namespace - The namespace where the InferenceService is deployed.
  */
 export const modelExternalTester = (
   modelName: string,
+  namespace: string,
 ): Cypress.Chainable<{ url: string; response: Cypress.Response<unknown> }> => {
-  return cy.exec(`oc get inferenceService ${modelName} -o json`).then((result) => {
+  return cy.exec(`oc get inferenceService ${modelName} -n ${namespace} -o json`).then((result) => {
     const inferenceService = JSON.parse(result.stdout);
     const { url } = inferenceService.status;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-26465

## Description
Add namespace to modelseving backend calls. 

## How Has This Been Tested?
2.21: dashboard-tests/1690
![image](https://github.com/user-attachments/assets/58d88310-7cee-4bc8-a834-b39a50a58487)

2.22: dashboard-tests/1691 
![image](https://github.com/user-attachments/assets/b23bf291-a428-4b8b-9f55-8ae3636b1a63)


## Test Impact
Affect to model serving e2e tests

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)


