### PR TITLE
set tsconfig allowImportingTsExtensions: true

### DIFF
--- a/frontend/packages/tsconfig/tsconfig.json
+++ b/frontend/packages/tsconfig/tsconfig.json
@@ -19,7 +19,8 @@
         "skipLibCheck": true,
         "noErrorTruncation": true,
         "baseUrl": "${configDir}/src",
-        "noEmit": true
+        "noEmit": true,
+        "allowImportingTsExtensions": true
     },
     "include": ["${configDir}/**/*.ts", "${configDir}/**/*.tsx", "${configDir}/**/*.jsx", "${configDir}/**/*.js"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When using `moduleResolution: bundler` in the tsconfig, vscode auto complete import is adding file extensions. While I work on finding a solution to prevent addition of file extensions, this setting will help auto complete file extensions to .ts or .tsx instead of .js.

While file extensions in the import aren't wrong, we prefer to have no file extensions required for .ts / .tsx files. Without this setting, a .js file extension is added which will cause jest tests to fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using cursor / vscode, auto complete an import. Check that the file extension is omitted entirely or set to .ts or .tsx.

- Delete an existing import
- Find the usage of the removed import in the code file where the error indicates that it cannot be found
- Go use quick fix or auto complete after the usage
- Check that the import includes a .ts, .tsx or no file extension at all

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
