### PR TITLE
Hardware Profile dropdown description text overflow issue

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
 import { FormGroup, Stack, StackItem, ExpandableSection } from '@patternfly/react-core';
-import { hardwareProfileValidationSchema } from './validationUtils';
-import HardwareProfileSelect from './HardwareProfileSelect';
-import HardwareProfileCustomize from './HardwareProfileCustomize';
-import { PodSpecOptionsState, PodSpecOptions } from './types';
-import { getContainerResourcesFromHardwareProfile } from './utils';
 import { HardwareProfileKind, HardwareProfileFeatureVisibility } from '#~/k8sTypes';
 import { useValidation, ValidationContext } from '#~/utilities/useValidation';
 import { ContainerResources } from '#~/types';
@@ -12,6 +7,11 @@ import { useHardwareProfilesByFeatureVisibility } from '#~/pages/hardwareProfile
 import { ZodErrorHelperText } from '#~/components/ZodErrorFormHelperText';
 import ProjectScopedPopover from '#~/components/ProjectScopedPopover';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
+import { hardwareProfileValidationSchema } from './validationUtils';
+import HardwareProfileSelect from './HardwareProfileSelect';
+import HardwareProfileCustomize from './HardwareProfileCustomize';
+import { PodSpecOptionsState, PodSpecOptions } from './types';
+import { getContainerResourcesFromHardwareProfile } from './utils';
 
 type HardwareProfileFormSectionProps<T extends PodSpecOptions> = {
   isEditing: boolean;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-22906

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
For hardware profile selection dropdown, changed the description to be limited to a single line even if the description is written on multiple lines. Furthermore, the description preview below the dropdown after selecting a hardware profile is truncated to 1 line as well.

The hardware profiles below use the following descriptions respectively
```
<very long description without new lines>
```
```
Lorem ipsum dolor sit amet, 
consectetur adipiscing elit, 
...
```
```
This is a very long description. This is a very long description...

This is a very long description. This is a very long description...

This is a very long description. This is a very long description...
```

<img width="797" alt="Screenshot 2025-06-02 at 2 57 34 PM" src="https://github.com/user-attachments/assets/fd8fb8a6-a1d9-4542-9309-ae3432d7e936" />

<img width="748" alt="Screenshot 2025-06-02 at 2 58 11 PM" src="https://github.com/user-attachments/assets/372f2fa5-7b34-47e5-ba82-1589cd8f5ef6" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable hardware profiles by changing the OdhDashboardConfig CRD > dashboardConfig -> disableHardwareProfiles: false
2. Create a hardware profile and add a description that takes up multiple lines (with new lines, not text wrap).
3. Go to any page that has a hardware profile selection (e.g. create workbench).
4. Click the hardware profile dropdown and see the description be on 1 line with ... truncation.
5. Select a profile and view the description below the dropdown box and view the 1 line truncated with ...
You will not see `...` if the new-line-merged description does not overflow.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Existing tests cover flow. Test by using varying hardware profile descriptions (new lines, no new lines, many new lines to cause overflow, etc.) and see that the description remains on one line with `...` appended if overflowing.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
