### PR TITLE
Fix glob pattern linting os discrepancies

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -7,4 +7,3 @@ jest-coverage
 public
 public-cypress
 node_modules
-.eslintrc*

--- a/frontend/.eslintrc.goal.js
+++ b/frontend/.eslintrc.goal.js
@@ -19,7 +19,8 @@ module.exports = {
           {
             target: './src/components/**/*',
             from: ['./src/!(utilities|components|images)/**/*'],
-            message: 'Modules in `src/components` may only import external modules from `src/utilities``.',
+            message:
+              'Modules in `src/components` may only import external modules from `src/utilities``.',
           },
           {
             target: './src/utilities/**/*',

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -427,7 +427,11 @@ module.exports = {
       },
     },
     {
-      files: ["src/plugins/extensions/**", "packages/**/extensions.ts", "packages/**/extension-points/*.{ts,tsx,js,jsx}"],
+      files: [
+        'src/plugins/extensions/**',
+        'packages/**/extensions.ts',
+        'packages/**/extension-points/*.{ts,tsx,js,jsx}',
+      ],
       rules: {
         '@typescript-eslint/consistent-type-imports': 'error',
         'no-restricted-syntax': [
@@ -458,7 +462,7 @@ function srcRulesOverrides() {
         'import/no-extraneous-dependencies': [
           'error',
           {
-            packageDir: ['.', './src'],
+            packageDir: [__dirname, path.join(__dirname, 'src')],
           },
         ],
       },

--- a/frontend/packages/tsconfig/tsconfig.json
+++ b/frontend/packages/tsconfig/tsconfig.json
@@ -22,6 +22,6 @@
         "noEmit": true,
         "allowImportingTsExtensions": true
     },
-    "include": ["${configDir}/**/*.ts", "${configDir}/**/*.tsx", "${configDir}/**/*.jsx", "${configDir}/**/*.js"],
+    "include": ["${configDir}/**/*.ts", "${configDir}/**/*.tsx", "${configDir}/**/*.jsx", "${configDir}/**/**.js"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The js files in `frontend/` got errors because of issues with them not being ignored from the `.eslintignore` in linux and typescript was seeing this discrepancy. They are now being fully linted and the glob file patterns was fixed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
