### PR TITLE
Add the link to the Stop workbench modal when navigating from the admin tab.

### DIFF
--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -15,6 +15,7 @@ import ApplicationsPage from '#~/pages/ApplicationsPage';
 import StopServerModal from '#~/pages/notebookController/screens/server/StopServerModal';
 import { Notebook } from '#~/types';
 import { ODH_PRODUCT_NAME } from '#~/utilities/const';
+import useRouteForNotebook from '#~/pages/projects/notebook/useRouteForNotebook.ts';
 import { columns } from './data';
 import StopAllServersButton from './StopAllServersButton';
 import UserTableCellTransform from './UserTableCellTransform';
@@ -24,6 +25,9 @@ import { NotebookAdminContext } from './NotebookAdminContext';
 const NotebookAdminControl: React.FC = () => {
   const [users, loaded, loadError] = useAdminUsers();
   const { serverStatuses, setServerStatuses } = React.useContext(NotebookAdminContext);
+  const [selectedNotebook, setSelectedNotebook] = React.useState<Notebook | undefined>(undefined);
+  const [currentNotebookLink, currentNotebookLinkLoaded, currentNotebookLinkError] =
+    useRouteForNotebook(selectedNotebook?.metadata.name, selectedNotebook?.metadata.namespace);
 
   const onNotebooksStop = React.useCallback(
     (didStop: boolean) => {
@@ -44,6 +48,14 @@ const NotebookAdminControl: React.FC = () => {
         .filter((notebook): notebook is Notebook => !!notebook),
     [serverStatuses],
   );
+
+  React.useEffect(() => {
+    if (notebooksToStop.length === 1) {
+      setSelectedNotebook(notebooksToStop[0]);
+    } else {
+      setSelectedNotebook(undefined);
+    }
+  }, [notebooksToStop]);
 
   return (
     <ApplicationsPage
@@ -107,11 +119,11 @@ const NotebookAdminControl: React.FC = () => {
           />
         </StackItem>
       </Stack>
-      {notebooksToStop.length ? (
+      {(currentNotebookLinkLoaded && notebooksToStop.length === 1) || notebooksToStop.length > 1 ? (
         <StopServerModal
           notebooksToStop={notebooksToStop}
           onNotebooksStop={onNotebooksStop}
-          link="https://google.com"
+          link={currentNotebookLinkError || !currentNotebookLink ? '#' : currentNotebookLink}
         />
       ) : null}
     </ApplicationsPage>

--- a/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
+++ b/frontend/src/pages/notebookController/screens/admin/NotebookAdminControl.tsx
@@ -111,7 +111,7 @@ const NotebookAdminControl: React.FC = () => {
         <StopServerModal
           notebooksToStop={notebooksToStop}
           onNotebooksStop={onNotebooksStop}
-          link="#"
+          link="https://google.com"
         />
       ) : null}
     </ApplicationsPage>

--- a/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
+++ b/frontend/src/pages/notebookController/screens/server/StopServerModal.tsx
@@ -117,7 +117,7 @@ const StopServerModal: React.FC<StopServerModalProps> = ({
       isOpen
       onClose={onClose}
     >
-      <ModalHeader title={`Stop ${textToShow}`} />
+      <ModalHeader title={`Stop ${textToShow}?`} />
       <ModalBody>
         <Stack hasGutter>
           <StackItem>Any unsaved changes to the {getWorkbenchName()} will be lost.</StackItem>

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -190,6 +190,19 @@ export const validateNotebookNamespaceRoleBinding = async (
   );
 };
 
+export const getNotebookRedirectLink = async (
+  notebookNamespace: string,
+  routeName: string,
+): Promise<string | undefined> => {
+  try {
+    const route = await getRoute(notebookNamespace, routeName);
+    return `https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}`;
+  } catch (e) {
+    // console.warn('Unable to get the route for notebook redirect link', e);
+    return undefined;
+  }
+};
+
 export const useNotebookRedirectLink = (): (() => Promise<string>) => {
   const { currentUserNotebook, currentUserNotebookLink } =
     React.useContext(NotebookControllerContext);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-25556 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Within the /notebookController route -> administration tab, made it so that when you click on stop workbench, the modal that comes up has been changed slightly to reflect UX requirements by changing some text and adding a link to open the notebook within the stop workbench modal.

If stopping one or stopping all workbenches but there is only one workbench to stop:
<img width="949" alt="Screenshot 2025-06-03 at 3 36 21 PM" src="https://github.com/user-attachments/assets/0055d888-53c3-4656-9dba-505093b5c74a" />

If stopping all workbenches and there are multiple:
<img width="963" alt="Screenshot 2025-06-03 at 3 39 48 PM" src="https://github.com/user-attachments/assets/0941162e-d10b-42a2-8831-336c9e5e8569" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Head to Applications -> Enabled -> Launch application (start basic workbench).
    a. You should have a workbench created by any user first.
3. Go to administration panel and click on the 3 dots on the rightmost column, click stop workbench
4. View the new modal and click on the link to go to the notebook IDE.
5. Click on "Stop all workbenches" and if there are more than 1 to stop, there will be no link and the text reflects it.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added since primarily a text change. No new reusable functions added either. You can test this by creating multiple accounts with different permissions (developer and admin), creating workbenches through the Applications -> Enabled tab, through a data science project tab, or other, and view the page as an admin. You should be able to stop all the workbenches for any user and also open the notebook from within the close workbench modal.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
