### PR TITLE
Access mode support for existing PVC attachment modal in workbench

### DIFF
--- a/frontend/src/__mocks__/mockPVCK8sResource.ts
+++ b/frontend/src/__mocks__/mockPVCK8sResource.ts
@@ -10,6 +10,7 @@ type MockResourceConfigType = {
   displayName?: string;
   uid?: string;
   status?: PersistentVolumeClaimKind['status'];
+  accessModes?: AccessMode[];
 };
 
 export const mockPVCK8sResource = ({
@@ -26,6 +27,7 @@ export const mockPVCK8sResource = ({
       storage,
     },
   },
+  accessModes = [AccessMode.RWO],
 }: MockResourceConfigType): PersistentVolumeClaimKind => ({
   kind: 'PersistentVolumeClaim',
   apiVersion: 'v1',
@@ -42,7 +44,7 @@ export const mockPVCK8sResource = ({
     uid,
   },
   spec: {
-    accessModes: [AccessMode.RWO],
+    accessModes,
     resources: {
       requests: {
         storage,

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -305,6 +305,18 @@ class AttachExistingStorageModal extends Modal {
   findAttachButton() {
     return cy.findByTestId('modal-submit-button');
   }
+
+  findExistingStorageField() {
+    return this.find().findByTestId('persistent-storage-group');
+  }
+
+  findTypeaheadGroup(label: string) {
+    return this.find().get(`[data-testid="typeahead-group-${label}"]`);
+  }
+
+  findTypeaheadOptionUnderGroup(groupLabel: string, optionText: string) {
+    return this.findTypeaheadGroup(groupLabel).contains(optionText);
+  }
 }
 
 class AttachConnectionModal extends Modal {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -21,6 +21,7 @@ import {
   notebookConfirmModal,
   notebookImageUpdateModal,
   workbenchPage,
+  attachExistingStorageModal,
 } from '#~/__tests__/cypress/cypress/pages/workbench';
 import { verifyRelativeURL } from '#~/__tests__/cypress/cypress/utils/url';
 import { be } from '#~/__tests__/cypress/cypress/utils/should';
@@ -49,6 +50,7 @@ import type { NotebookKind, PodKind } from '#~/k8sTypes';
 import type { EnvironmentFromVariable } from '#~/pages/projects/types';
 import { SpawnerPageSectionID } from '#~/pages/projects/screens/spawner/types';
 import { acceleratorProfileSection } from '#~/__tests__/cypress/cypress/pages/components/subComponents/AcceleratorProfileSection';
+import { AccessMode } from '#~/pages/storageClasses/storageEnums.ts';
 
 const configYamlPath = '../../__mocks__/mock-upload-configmap.yaml';
 
@@ -1736,5 +1738,112 @@ describe('Workbench page', () => {
     // Verify custom resources were not deleted
     cy.get('@deleteCustomSecret').should('not.have.been.called');
     cy.get('@deleteCustomConfigMap').should('not.have.been.called');
+  });
+
+  describe('Attach existing storage', () => {
+    it('should correctly display grouped PVCs by access mode and update on selection', () => {
+      initIntercepts({
+        isEmpty: true,
+      });
+
+      cy.interceptK8sList(
+        PVCModel,
+        mockK8sResourceList([
+          mockPVCK8sResource({
+            name: 'pvc-rwo',
+            displayName: 'pvc-rwo',
+            accessModes: [AccessMode.RWO],
+            storage: '10Gi',
+          }),
+          mockPVCK8sResource({
+            name: 'pvc-rwx',
+            displayName: 'pvc-rwx',
+            accessModes: [AccessMode.RWX],
+            storage: '5Gi',
+          }),
+          mockPVCK8sResource({
+            name: 'pvc-rox',
+            displayName: 'pvc-rox',
+            accessModes: [AccessMode.ROX],
+            storage: '1Gi',
+          }),
+          mockPVCK8sResource({
+            name: 'pvc-rwop',
+            displayName: 'pvc-rwop',
+            accessModes: [AccessMode.RWOP],
+            storage: '2Gi',
+          }),
+        ]),
+      );
+
+      workbenchPage.visit('test-project');
+      workbenchPage.findCreateButton().click();
+
+      createSpawnerPage.findAttachExistingStorageButton().click();
+      attachExistingStorageModal.findExistingStorageField().findByRole('button').click();
+
+      attachExistingStorageModal.findTypeaheadGroup('rwo').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('rwx').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('rox').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('rwop').should('exist');
+
+      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwo', 'pvc-rwo').should('exist');
+      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwx', 'pvc-rwx').should('exist');
+      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rox', 'pvc-rox').should('exist');
+      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwop', 'pvc-rwop').should('exist');
+
+      attachExistingStorageModal.selectExistingPersistentStorage('pvc-rwx');
+      attachExistingStorageModal.verifyPSDropdownText('pvc-rwx');
+    });
+
+    it('should not include PVCs that are already attached', () => {
+      initIntercepts({
+        isEmpty: true,
+      });
+
+      const attachedPvcName = 'already-attached-pvc';
+      cy.interceptK8sList(
+        PVCModel,
+        mockK8sResourceList([
+          mockPVCK8sResource({
+            name: attachedPvcName,
+            displayName: attachedPvcName,
+            accessModes: [AccessMode.RWO],
+            storage: '5Gi',
+          }),
+          mockPVCK8sResource({
+            name: 'new-pvc',
+            displayName: 'new-pvc',
+            accessModes: [AccessMode.RWO],
+            storage: '5Gi',
+          }),
+          mockPVCK8sResource({
+            name: 'new-pvc-1',
+            displayName: 'new-pvc-1',
+            accessModes: [AccessMode.RWO],
+            storage: '5Gi',
+          }),
+        ]),
+      );
+
+      workbenchPage.visit('test-project');
+      workbenchPage.findCreateButton().click();
+      createSpawnerPage.findAttachExistingStorageButton().click();
+
+      attachExistingStorageModal.selectExistingPersistentStorage('already-attached-pvc');
+      attachExistingStorageModal.findStandardPathInput().clear().type('mnt/different-path');
+      attachExistingStorageModal.findAttachButton().click();
+
+      createSpawnerPage.findAttachExistingStorageButton().click();
+      attachExistingStorageModal
+        .findExistingStorageField()
+        .findByRole('button')
+        .should('not.be.disabled')
+        .click();
+
+      cy.findAllByRole('option').should('not.contain.text', attachedPvcName);
+      cy.findAllByRole('option').should('contain.text', 'new-pvc');
+      cy.findAllByRole('option').should('contain.text', 'new-pvc-1');
+    });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -1782,15 +1782,25 @@ describe('Workbench page', () => {
       createSpawnerPage.findAttachExistingStorageButton().click();
       attachExistingStorageModal.findExistingStorageField().findByRole('button').click();
 
-      attachExistingStorageModal.findTypeaheadGroup('rwo').should('exist');
-      attachExistingStorageModal.findTypeaheadGroup('rwx').should('exist');
-      attachExistingStorageModal.findTypeaheadGroup('rox').should('exist');
-      attachExistingStorageModal.findTypeaheadGroup('rwop').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('readwriteonce-rwo-storage').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('readwritemany-rwx-storage').should('exist');
+      attachExistingStorageModal.findTypeaheadGroup('readonlymany-rox-storage').should('exist');
+      attachExistingStorageModal
+        .findTypeaheadGroup('readwriteoncepod-rwop-storage')
+        .should('exist');
 
-      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwo', 'pvc-rwo').should('exist');
-      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwx', 'pvc-rwx').should('exist');
-      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rox', 'pvc-rox').should('exist');
-      attachExistingStorageModal.findTypeaheadOptionUnderGroup('rwop', 'pvc-rwop').should('exist');
+      attachExistingStorageModal
+        .findTypeaheadOptionUnderGroup('readwriteonce-rwo-storage', 'pvc-rwo')
+        .should('exist');
+      attachExistingStorageModal
+        .findTypeaheadOptionUnderGroup('readwritemany-rwx-storage', 'pvc-rwx')
+        .should('exist');
+      attachExistingStorageModal
+        .findTypeaheadOptionUnderGroup('readonlymany-rox-storage', 'pvc-rox')
+        .should('exist');
+      attachExistingStorageModal
+        .findTypeaheadOptionUnderGroup('readwriteoncepod-rwop-storage', 'pvc-rwop')
+        .should('exist');
 
       attachExistingStorageModal.selectExistingPersistentStorage('pvc-rwx');
       attachExistingStorageModal.verifyPSDropdownText('pvc-rwx');

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -22,6 +22,7 @@ import {
   FlexItem,
   Flex,
   SelectGroup,
+  Divider,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import TruncatedText from '#~/components/TruncatedText';
@@ -490,18 +491,22 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   const tGroupOption = (
     groupName: string,
     group: { groupLabel: React.ReactNode; options: TypeaheadSelectOption[] },
-    startingIndex: number,
+    optionIdx: number,
+    addDivider: boolean,
   ): { node: React.ReactNode; nextIndex: number } => {
-    let index = startingIndex;
+    let index = optionIdx;
     return {
       node: (
-        <SelectGroup
-          key={groupName}
-          label={group.groupLabel}
-          data-testid={`typeahead-group-${groupName.toLowerCase()}`}
-        >
-          {group.options.map((opt) => tSelectOption(opt, index++))}
-        </SelectGroup>
+        <>
+          <SelectGroup
+            key={groupName}
+            label={group.groupLabel}
+            data-testid={`typeahead-group-${groupName.toLowerCase()}`}
+          >
+            {group.options.map((opt) => tSelectOption(opt, index++))}
+          </SelectGroup>
+          {addDivider && <Divider />}
+        </>
       ),
       nextIndex: index,
     };
@@ -509,8 +514,14 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
 
   const renderOptions = (): React.ReactNode => {
     let idx = 0;
-    const groupOpts = Object.entries(groupedSelections.group).map(([groupName, group]) => {
-      const { node, nextIndex } = tGroupOption(groupName, group, idx);
+    const groupEntries = Object.entries(groupedSelections.group);
+    const groupOpts = groupEntries.map(([groupName, group], groupIndex) => {
+      const { node, nextIndex } = tGroupOption(
+        groupName,
+        group,
+        idx,
+        groupIndex !== groupEntries.length - 1,
+      );
       idx = nextIndex;
       return node;
     });
@@ -518,6 +529,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     return (
       <>
         {groupOpts}
+        {selectOpts.length > 0 && <Divider />}
         {selectOpts}
       </>
     );

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -507,6 +507,22 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
     };
   };
 
+  const renderOptions = (): React.ReactNode => {
+    let idx = 0;
+    const groupOpts = Object.entries(groupedSelections.group).map(([groupName, group]) => {
+      const { node, nextIndex } = tGroupOption(groupName, group, idx);
+      idx = nextIndex;
+      return node;
+    });
+    const selectOpts = groupedSelections.noGroup.map((opt) => tSelectOption(opt, idx++));
+    return (
+      <>
+        {groupOpts}
+        {selectOpts}
+      </>
+    );
+  };
+
   return (
     <>
       <Select
@@ -519,23 +535,7 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
         ref={innerRef}
         {...props}
       >
-        <SelectList>
-          {(() => {
-            let idx = 0;
-            const groupOpts = Object.entries(groupedSelections.group).map(([groupName, group]) => {
-              const { node, nextIndex } = tGroupOption(groupName, group, idx);
-              idx = nextIndex;
-              return node;
-            });
-            const selectOpts = groupedSelections.noGroup.map((opt) => tSelectOption(opt, idx++));
-            return (
-              <>
-                {groupOpts}
-                {selectOpts}
-              </>
-            );
-          })()}
-        </SelectList>
+        <SelectList>{renderOptions()}</SelectList>
       </Select>
       {previewDescription && isSingleOption && selected?.description ? (
         <FormHelperText>

--- a/frontend/src/components/TypeaheadSelect.tsx
+++ b/frontend/src/components/TypeaheadSelect.tsx
@@ -36,10 +36,7 @@ export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content'
   isSelected?: boolean;
   dropdownLabel?: React.ReactNode;
   selectedLabel?: React.ReactNode;
-  group?: {
-    groupName: string;
-    groupLabel: React.ReactNode;
-  };
+  group?: string;
 }
 
 export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSelect'> {
@@ -442,22 +439,15 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   );
 
   const groupedSelections = React.useMemo(() => {
-    const group: Record<string, { groupLabel: React.ReactNode; options: TypeaheadSelectOption[] }> =
-      {};
+    const group: Record<string, TypeaheadSelectOption[]> = {};
     const noGroup: TypeaheadSelectOption[] = [];
 
     filteredSelections.forEach((option) => {
       if (option.group) {
-        const { groupName } = option.group;
-        const { groupLabel } = option.group;
-
-        if (groupName in group) {
-          group[groupName].options.push(option);
+        if (option.group in group) {
+          group[option.group].push(option);
         } else {
-          group[groupName] = {
-            groupLabel,
-            options: [option],
-          };
+          group[option.group] = [option];
         }
       } else {
         noGroup.push(option);
@@ -489,21 +479,21 @@ const TypeaheadSelect: React.FunctionComponent<TypeaheadSelectProps> = ({
   };
 
   const tGroupOption = (
-    groupName: string,
-    group: { groupLabel: React.ReactNode; options: TypeaheadSelectOption[] },
+    group: string,
+    groupOptions: TypeaheadSelectOption[],
     optionIdx: number,
     addDivider: boolean,
   ): { node: React.ReactNode; nextIndex: number } => {
     let index = optionIdx;
+    const testId = `typeahead-group-${group
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[()]/g, '')}`;
     return {
       node: (
         <>
-          <SelectGroup
-            key={groupName}
-            label={group.groupLabel}
-            data-testid={`typeahead-group-${groupName.toLowerCase()}`}
-          >
-            {group.options.map((opt) => tSelectOption(opt, index++))}
+          <SelectGroup key={group} label={group} data-testid={testId}>
+            {groupOptions.map((opt) => tSelectOption(opt, index++))}
           </SelectGroup>
           {addDivider && <Divider />}
         </>

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -21,6 +21,7 @@ import {
 } from '#~/concepts/k8s/utils';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { getStorageClassConfig } from '#~/pages/storageClasses/utils';
+import { getPvcAccessMode } from '#~/pages/projects/utils.ts';
 import AccessModeFullName from '#~/pages/projects/screens/detail/storage/AccessModeFullName';
 import useIsRootVolume from './useIsRootVolume';
 import StorageWarningStatus from './StorageWarningStatus';
@@ -144,7 +145,7 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
       )}
       <Td dataLabel="Access Mode">
         <Content component="p">
-          <AccessModeFullName accessModeString={obj.pvc.spec.accessModes[0]} />
+          <AccessModeFullName accessModeString={getPvcAccessMode(obj.pvc)} />
         </Content>
       </Td>
       <Td dataLabel="Type">

--- a/frontend/src/pages/projects/screens/detail/storage/data.ts
+++ b/frontend/src/pages/projects/screens/detail/storage/data.ts
@@ -1,6 +1,7 @@
 import { SortableData } from '#~/components/table';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
 import { getStorageClassConfig } from '#~/pages/storageClasses/utils';
+import { getPvcAccessMode } from '#~/pages/projects/utils.ts';
 import { getAccessModePopover } from '#~/pages/projects/screens/spawner/storage/getAccessModePopover';
 import { StorageTableData } from './types';
 
@@ -30,8 +31,7 @@ export const columns: SortableData<StorageTableData>[] = [
     field: 'accessMode',
     label: 'Access mode',
     width: 25,
-    sortable: (a, b) =>
-      (a.pvc.spec.accessModes[0] ?? '').localeCompare(b.pvc.spec.accessModes[0] ?? ''),
+    sortable: (a, b) => getPvcAccessMode(a.pvc).localeCompare(getPvcAccessMode(b.pvc)),
     info: {
       popover: getAccessModePopover({}),
       popoverProps: {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -46,6 +46,7 @@ import {
   doesImageStreamSupportHardwareProfile,
 } from '#~/concepts/hardwareProfiles/utils';
 import { useNotebookKindPodSpecOptionsState } from '#~/concepts/hardwareProfiles/useNotebookPodSpecOptionsState';
+import { getPvcAccessMode } from '#~/pages/projects/utils.ts';
 import { SpawnerPageSectionID } from './types';
 import {
   K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
@@ -128,7 +129,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
           size: existingPvc.spec.resources.requests.storage,
           storageClassName: existingPvc.spec.storageClassName,
           mountPath: getNotebookPVCMountPathMap(existingNotebook)[existingPvc.metadata.name],
-          accessMode: existingPvc.spec.accessModes[0],
+          accessMode: getPvcAccessMode(existingPvc),
         }))
       : [
           {
@@ -441,6 +442,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                     description: attachData.pvc?.metadata.annotations?.['openshift.io/description'],
                     size: attachData.pvc?.spec.resources.requests.storage,
                     storageClassName: attachData.pvc?.spec.storageClassName,
+                    accessMode: attachData.pvc ? getPvcAccessMode(attachData.pvc) : undefined,
                   },
                 ]),
               );

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { Alert, FormGroup, FormHelperText, Label, SelectOption } from '@patternfly/react-core';
+import { TypeaheadSelectOption } from '@patternfly/react-templates';
 import { ExistingStorageObject } from '#~/pages/projects/types';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
-import TypeaheadSelect, { TypeaheadSelectGroupOption } from '#~/components/TypeaheadSelect';
+import TypeaheadSelect from '#~/components/TypeaheadSelect';
 import useProjectPvcs from '#~/pages/projects/screens/detail/storage/useProjectPvcs';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import { PersistentVolumeClaimKind } from '#~/k8sTypes';
@@ -40,7 +41,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
     }
     const isPvcAvailable = (pvc: PersistentVolumeClaimKind) =>
       !existingStorageNames?.includes(getDisplayNameFromK8sResource(pvc));
-    const groups: TypeaheadSelectGroupOption[] = [];
+    const groups: TypeaheadSelectOption[] = [];
     Object.entries(AccessMode).forEach(([label, mode]) => {
       const groupModePvc = storages.filter(
         (pvc) => getPvcAccessMode(pvc) === mode && isPvcAvailable(pvc),
@@ -58,12 +59,12 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
               {`${mode} (${label})`}
             </Label>
           ),
+          group: {
+            groupName: label,
+            groupLabel: <SelectOption isDisabled>{`${mode} (${label}) storage`}</SelectOption>,
+          },
         }));
-        groups.push({
-          groupOptions,
-          label: <SelectOption isDisabled>{`${mode} (${label}) storage`}</SelectOption>,
-          groupLabel: label,
-        });
+        groups.push(...groupOptions);
       }
     });
     return groups;

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -111,6 +111,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
         popperProps={{ direction: selectDirection, appendTo: menuAppendTo }}
         isDisabled={!loaded}
         data-testid="persistent-storage-typeahead"
+        isScrollable
       />
       <FormHelperText>
         <Alert

--- a/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AddExistingStorageField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, FormGroup, FormHelperText, Label, SelectOption } from '@patternfly/react-core';
+import { Alert, FormGroup, FormHelperText, Label } from '@patternfly/react-core';
 import { TypeaheadSelectOption } from '@patternfly/react-templates';
 import { ExistingStorageObject } from '#~/pages/projects/types';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
@@ -59,10 +59,7 @@ const AddExistingStorageField: React.FC<AddExistingStorageFieldProps> = ({
               {`${mode} (${label})`}
             </Label>
           ),
-          group: {
-            groupName: label,
-            groupLabel: <SelectOption isDisabled>{`${mode} (${label}) storage`}</SelectOption>,
-          },
+          group: `${mode} (${label}) storage`,
         }));
         groups.push(...groupOptions);
       }

--- a/frontend/src/pages/projects/utils.ts
+++ b/frontend/src/pages/projects/utils.ts
@@ -1,6 +1,7 @@
 import { NotebookKind, PersistentVolumeClaimKind } from '#~/k8sTypes';
 import { NotebookSize } from '#~/types';
 import { formatMemory } from '#~/utilities/valueUnits';
+import { AccessMode } from '#~/pages/storageClasses/storageEnums.ts';
 import { NotebookState } from './notebook/types';
 
 export const getNotebookStatusPriority = (notebookState: NotebookState): number =>
@@ -21,3 +22,6 @@ export const getCustomNotebookSize = (
     requests: {},
   },
 });
+
+export const getPvcAccessMode = (pvc: PersistentVolumeClaimKind): AccessMode =>
+  pvc.spec.accessModes[0];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25578

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
* Added inline plain alert below the storage selection
* In the dropdown menu, grouped the PVCs by the access modes (RWO, RWX, ROX, RWOP)
* Will not show the group if there are no storages in that access mode type
* Added a label next to the storage name to indicate the access mode in the selection toggle

https://github.com/user-attachments/assets/18673304-36e2-422c-99a3-ee9b8b3ddf1b

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Create a PVC in the console with quobyte provisioner storage class in project
   * Create various other PVCs with different storage classes 
* Add the following to the yaml file under metadata:
```yaml
  labels:
    opendatahub.io/dashboard: 'true'
```
* Edit a workbench, and click on Add existing storage
* Click on the Select

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
