### PR TITLE
Model Serving Refactor: Add endpoint info to table row

### DIFF
--- a/frontend/packages/kserve/src/deploymentEndpoints.ts
+++ b/frontend/packages/kserve/src/deploymentEndpoints.ts
@@ -1,0 +1,43 @@
+import { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import {
+  getUrlFromKserveInferenceService,
+  isInferenceServiceRouteEnabled,
+} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { DeploymentEndpoint } from '@odh-dashboard/model-serving/extension-points';
+
+export const getKServeDeploymentEndpoints = (
+  inferenceService: InferenceServiceKind,
+): DeploymentEndpoint[] => {
+  const endpoints: DeploymentEndpoint[] = [];
+  if (inferenceService.status?.address?.url) {
+    endpoints.push({
+      name: 'url',
+      type: 'internal',
+      url: inferenceService.status.address.url,
+    });
+  } else {
+    endpoints.push({
+      name: 'url',
+      type: 'internal',
+      url: '',
+      error: 'Could not find any internal service enabled',
+    });
+  }
+
+  if (isInferenceServiceRouteEnabled(inferenceService)) {
+    const routeUrl = getUrlFromKserveInferenceService(inferenceService);
+    if (routeUrl) {
+      endpoints.push({
+        type: 'external',
+        url: routeUrl,
+      });
+    } else {
+      endpoints.push({
+        type: 'external',
+        url: '',
+        error: 'Route not found',
+      });
+    }
+  }
+  return endpoints;
+};

--- a/frontend/packages/kserve/src/deployments.ts
+++ b/frontend/packages/kserve/src/deployments.ts
@@ -7,6 +7,7 @@ import {
 } from '@odh-dashboard/internal/k8sTypes';
 import { Deployment } from '@odh-dashboard/model-serving/extension-points';
 import { deleteInferenceService, deleteServingRuntime } from '@odh-dashboard/internal/api/index';
+import { getKServeDeploymentEndpoints } from './deploymentEndpoints';
 import { useWatchDeploymentPods, useWatchServingRuntimes, useWatchInferenceServices } from './api';
 import { getKServeDeploymentStatus } from './deploymentStatus';
 import { KSERVE_ID } from '../extensions';
@@ -40,6 +41,7 @@ export const useWatchDeployments = (
             servingRuntime.metadata.name === inferenceService.spec.predictor.model?.runtime,
         ),
         status: getKServeDeploymentStatus(inferenceService, deploymentPods),
+        endpoints: getKServeDeploymentEndpoints(inferenceService),
       })),
     [inferenceServices, servingRuntimes, deploymentPods],
   );

--- a/frontend/packages/modelServing/extension-points/index.ts
+++ b/frontend/packages/modelServing/extension-points/index.ts
@@ -11,19 +11,21 @@ export type DeploymentStatus = {
 };
 
 export type DeploymentEndpoint = {
-  name: string;
+  type: 'internal' | 'external';
+  name?: string;
   url: string;
+  error?: string;
 };
 
 //// Model serving platform extension
 
 export type Deployment<
-  M extends K8sDSGResource = K8sDSGResource,
-  S extends K8sDSGResource = K8sDSGResource,
+  ModelResource extends K8sDSGResource = K8sDSGResource,
+  ServerResource extends K8sDSGResource = K8sDSGResource,
 > = {
   modelServingPlatformId: string;
-  model: M;
-  server?: S;
+  model: ModelResource;
+  server?: ServerResource;
   status?: DeploymentStatus;
   endpoints?: DeploymentEndpoint[];
 };

--- a/frontend/packages/modelServing/src/components/deployments/DeploymentEndpointsPopupButton.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/DeploymentEndpointsPopupButton.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Popover,
+  Button,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Divider,
+  HelperText,
+  HelperTextItem,
+  Skeleton,
+} from '@patternfly/react-core';
+import { DeploymentEndpoint } from '../../../extension-points';
+
+const EndpointListItem: React.FC<{ endpoint: DeploymentEndpoint }> = ({ endpoint }) => (
+  <DescriptionListGroup key={endpoint.name}>
+    {endpoint.name && <DescriptionListTerm>{endpoint.name}</DescriptionListTerm>}
+    <DescriptionListDescription style={{ paddingLeft: 'var(--pf-t--global--spacer--md)' }}>
+      {endpoint.error ? (
+        <HelperText>
+          <HelperTextItem variant="warning">{endpoint.error}</HelperTextItem>
+        </HelperText>
+      ) : (
+        <ClipboardCopy
+          hoverTip="Copy"
+          clickTip="Copied"
+          variant={ClipboardCopyVariant.inlineCompact}
+        >
+          {endpoint.url}
+        </ClipboardCopy>
+      )}
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+);
+
+type DeploymentEndpointsPopupButtonProps = {
+  endpoints?: DeploymentEndpoint[];
+  loading: boolean;
+};
+
+export const DeploymentEndpointsPopupButton: React.FC<DeploymentEndpointsPopupButtonProps> = ({
+  endpoints,
+  loading,
+}) => {
+  if (loading) {
+    return <Skeleton />;
+  }
+
+  if (!endpoints || endpoints.length === 0) {
+    return (
+      <HelperText>
+        <HelperTextItem variant="warning">
+          Failed to get endpoint for this deployed model.
+        </HelperTextItem>
+      </HelperText>
+    );
+  }
+
+  const internalEndpoints = endpoints.filter((endpoint) => endpoint.type === 'internal');
+  const externalEndpoints = endpoints.filter((endpoint) => endpoint.type === 'external');
+
+  const hasExternalEndpoints = externalEndpoints.length > 0;
+
+  return (
+    <Popover
+      data-testid={hasExternalEndpoints ? 'external-service-popover' : 'internal-service-popover'}
+      headerContent="Inference endpoints"
+      aria-label={hasExternalEndpoints ? 'External Service Info' : 'Internal Service Info'}
+      hasAutoWidth
+      bodyContent={
+        <DescriptionList isCompact>
+          {internalEndpoints.length === 0 ? (
+            <DescriptionListTerm>No internal endpoints found</DescriptionListTerm>
+          ) : (
+            internalEndpoints.map((endpoint) => (
+              <EndpointListItem key={endpoint.name} endpoint={endpoint} />
+            ))
+          )}
+
+          {externalEndpoints.length > 0 && (
+            <>
+              <Divider />
+              <DescriptionListTerm>
+                External (can be accessed from inside or outside the cluster)
+              </DescriptionListTerm>
+
+              {externalEndpoints.map((endpoint) => (
+                <EndpointListItem key={endpoint.name} endpoint={endpoint} />
+              ))}
+            </>
+          )}
+        </DescriptionList>
+      }
+    >
+      <Button
+        data-testid={
+          hasExternalEndpoints ? 'internal-external-service-button' : 'internal-service-button'
+        }
+        isInline
+        variant="link"
+      >
+        {hasExternalEndpoints
+          ? 'Internal and external endpoint details'
+          : 'Internal endpoint details'}
+      </Button>
+    </Popover>
+  );
+};

--- a/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
@@ -5,6 +5,7 @@ import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/M
 import { TableRowTitleDescription } from '@odh-dashboard/internal/components/table/index';
 import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { DeploymentEndpointsPopupButton } from './DeploymentEndpointsPopupButton';
 import { Deployment, DeploymentsTableColumn } from '../../../extension-points';
 
 export const DeploymentRow: React.FC<{
@@ -24,7 +25,12 @@ export const DeploymentRow: React.FC<{
         {column.cellRenderer(deployment, column.field)}
       </Td>
     ))}
-    <Td dataLabel="Inference endpoint">-</Td>
+    <Td dataLabel="Inference endpoint">
+      <DeploymentEndpointsPopupButton
+        endpoints={deployment.endpoints}
+        loading={deployment.status?.state !== InferenceServiceModelState.LOADED}
+      />
+    </Td>
     <Td dataLabel="Status">
       <ModelStatusIcon
         state={deployment.status?.state ?? InferenceServiceModelState.UNKNOWN}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
![image](https://github.com/user-attachments/assets/7b4fec43-00e9-48c8-b95b-35b5f9dc182b)
![image](https://github.com/user-attachments/assets/63d42e0d-4f8d-4fa7-be55-58be35f0f00c)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
