### PR TITLE
Fix Serving Runtime Version label not showing on edit

### DIFF
--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -22,6 +22,7 @@ type MockResourceConfigType = {
   scope?: string;
   hardwareProfileNamespace?: string;
   isNonDashboardItem?: boolean;
+  version?: string;
 };
 
 export const mockServingRuntimeK8sResourceLegacy = ({
@@ -132,6 +133,7 @@ export const mockServingRuntimeK8sResource = ({
   scope,
   hardwareProfileNamespace = undefined,
   isNonDashboardItem = false,
+  version,
 }: MockResourceConfigType): ServingRuntimeKind => ({
   apiVersion: 'serving.kserve.io/v1alpha1',
   kind: 'ServingRuntime',
@@ -149,6 +151,9 @@ export const mockServingRuntimeK8sResource = ({
       'opendatahub.io/template-name': 'ovms',
       'openshift.io/display-name': displayName,
       'opendatahub.io/apiProtocol': apiProtocol,
+      ...(version && {
+        'opendatahub.io/runtime-version': version,
+      }),
       ...(!disableModelMeshAnnotations && {
         'enable-auth': auth ? 'true' : 'false',
         'enable-route': route ? 'true' : 'false',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -343,7 +343,7 @@ describe('Model Serving Global', () => {
     modelServingSection
       .getInferenceServiceRow('NIM Model')
       .findServingRuntime()
-      .should('have.text', 'NVIDIA NIM');
+      .should('contain.text', 'NVIDIA NIM');
 
     // Open each modal and make sure it is the correct one
     modelServingGlobal.getModelRow('KServe Model').findKebabAction('Edit').click();
@@ -724,7 +724,7 @@ describe('Model Serving Global', () => {
     kserveModalEdit.findServingRuntimeTemplateSearchSelector().should('be.disabled');
     kserveModalEdit
       .findServingRuntimeTemplateSearchSelector()
-      .should('have.text', 'test-project-scoped-srProject-scoped');
+      .should('contain.text', 'test-project-scoped-sr');
     kserveModalEdit.findProjectScopedLabel().should('exist');
     kserveModalEdit.findModelFrameworkSelect().should('have.text', 'onnx - 1');
   });
@@ -865,7 +865,7 @@ describe('Model Serving Global', () => {
     kserveModalEdit.findServingRuntimeTemplateSearchSelector().should('be.disabled');
     kserveModalEdit
       .findServingRuntimeTemplateSearchSelector()
-      .should('have.text', 'OpenVINO Serving Runtime (Supports GPUs)Global-scoped');
+      .should('contain.text', 'OpenVINO Serving Runtime (Supports GPUs)');
     kserveModalEdit.findGlobalScopedLabel().should('exist');
     kserveModalEdit.findModelFrameworkSelect().should('have.text', 'onnx - 1');
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -118,6 +118,7 @@ const initIntercepts = ({
       route: true,
       tolerations: [],
       nodeSelector: {},
+      version: 'v1.0.0',
     }),
   ],
   inferenceServices = [
@@ -3344,6 +3345,17 @@ describe('Serving Runtime List', () => {
       createServingRuntimeModal.findServingRuntimeTemplateSearchSelector().within(() => {
         createServingRuntimeModal.findServingRuntimeVersionLabel().should('exist');
       });
+      createServingRuntimeModal.findCloseButton().click();
+
+      // Check that the label is displayed when editing
+      modelServingSection
+        .getModelMeshRow('OVMS Model Serving')
+        .find()
+        .findKebabAction('Edit model server')
+        .click();
+      editServingRuntimeModal.findServingRuntimeTemplateSearchSelector().within(() => {
+        editServingRuntimeModal.findServingRuntimeVersionLabel().should('exist');
+      });
     });
 
     it('displays label in search selector when single-model serving is selected', () => {
@@ -3363,6 +3375,13 @@ describe('Serving Runtime List', () => {
       kserveModal.findGlobalScopedTemplateOption('Multi Platform').click();
       kserveModal.findServingRuntimeTemplateSearchSelector().within(() => {
         kserveModal.findServingRuntimeVersionLabel().should('exist');
+      });
+      kserveModal.findCloseButton().click();
+
+      // Check that the label is displayed when editing
+      modelServingSection.getKServeRow('Llama Caikit').find().findKebabAction('Edit').click();
+      kserveModalEdit.findServingRuntimeTemplateSearchSelector().within(() => {
+        kserveModalEdit.findServingRuntimeVersionLabel().should('exist');
       });
     });
   });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
@@ -121,7 +121,7 @@ describe('NIM Model Serving', () => {
       projectDetails
         .getKserveTableRow('Test Name')
         .findServiceRuntime()
-        .should('have.text', 'NVIDIA NIM');
+        .should('contain.text', 'NVIDIA NIM');
       projectDetails.getKserveTableRow('Test Name').findAPIProtocol().should('have.text', 'REST');
 
       // Open toggle to validate Model details
@@ -163,7 +163,7 @@ describe('NIM Model Serving', () => {
       // Card is visible
       projectDetailsOverviewTab
         .findDeployedModelServingRuntime('Test Name')
-        .should('have.text', 'NVIDIA NIM');
+        .should('contain.text', 'NVIDIA NIM');
     });
 
     it('should be blocked if failed to fetch NIM model list', () => {

--- a/frontend/src/pages/modelServing/screens/ServingRuntimeVersionLabel.tsx
+++ b/frontend/src/pages/modelServing/screens/ServingRuntimeVersionLabel.tsx
@@ -4,13 +4,19 @@ import * as React from 'react';
 type ServingRuntimeVersionLabelProps = {
   version: string | undefined;
   isCompact?: boolean;
+  isEditing?: boolean;
 };
 
 const ServingRuntimeVersionLabel: React.FC<ServingRuntimeVersionLabelProps> = ({
   version,
   isCompact,
+  isEditing,
 }) => (
-  <Label data-testid="serving-runtime-version-label" color="blue" isCompact={isCompact}>
+  <Label
+    data-testid="serving-runtime-version-label"
+    color={isEditing ? 'grey' : 'blue'}
+    isCompact={isCompact}
+  >
     {version}
   </Label>
 );

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -209,6 +209,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
                 setData={setCreateData}
                 templates={servingRuntimeTemplates || []}
                 isEditing={!!editInfo}
+                servingRuntimeSelected={servingRuntimeSelected}
                 compatibleIdentifiers={profileIdentifiers}
               />
             </StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeTemplateSection.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { UpdateObjectAtPropAndValue } from '#~/pages/projects/types';
 import { CreatingServingRuntimeObject } from '#~/pages/modelServing/screens/types';
-import { TemplateKind } from '#~/k8sTypes';
+import { ServingRuntimeKind, TemplateKind } from '#~/k8sTypes';
 import {
   getServingRuntimeDisplayNameFromTemplate,
   getServingRuntimeNameFromTemplate,
@@ -43,6 +43,7 @@ type ServingRuntimeTemplateSectionProps = {
   projectSpecificTemplates?: CustomWatchK8sResult<TemplateKind[]>;
   isEditing?: boolean;
   compatibleIdentifiers?: string[];
+  servingRuntimeSelected?: ServingRuntimeKind;
   resetModelFormat?: () => void;
 };
 
@@ -54,6 +55,7 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
   projectSpecificTemplates,
   isEditing,
   compatibleIdentifiers,
+  servingRuntimeSelected,
   resetModelFormat,
 }) => {
   const isHardwareProfilesAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
@@ -203,10 +205,11 @@ const ServingRuntimeTemplateSection: React.FC<ServingRuntimeTemplateSectionProps
             color={isEditing ? 'grey' : 'blue'}
             fallback="Select one"
             additionalContent={
-              getServingRuntimeVersion(selectedTemplate) && (
+              getServingRuntimeVersion(servingRuntimeSelected || selectedTemplate) && (
                 <ServingRuntimeVersionLabel
-                  version={getServingRuntimeVersion(selectedTemplate)}
+                  version={getServingRuntimeVersion(servingRuntimeSelected || selectedTemplate)}
                   isCompact
+                  isEditing={isEditing}
                 />
               )
             }

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -398,6 +398,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   }
                   setData={setCreateDataServingRuntime}
                   templates={servingRuntimeTemplates || []}
+                  servingRuntimeSelected={servingRuntimeSelected}
                   projectSpecificTemplates={projectTemplates}
                   isEditing={!!editInfo}
                   compatibleIdentifiers={profileIdentifiers}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-26961
## Description
Fixed the Serving Runtime Version label not showing up in the disabled selector when editing a model. Fixed in Kserve and model mesh
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Deploy a model with a version for the serving runtime
2. Edit the model and see the version label in the selector (should be grayed out)
3. Repeat for multi or single depending on which platform you tested first
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![Screenshot From 2025-06-09 13-09-47](https://github.com/user-attachments/assets/24023274-8f90-46ea-a92a-b00cbaa331bc)

## Test Impact
Updated previous tests to check for label on edit
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version labels are now displayed for serving runtimes during both creation and editing, with the label color indicating editing mode.
  
- **Bug Fixes**
  - Improved reliability of UI tests by making text assertions less strict, allowing for partial matches.

- **Tests**
  - Enhanced test coverage to verify correct display of version labels in serving runtime modals.
  - Updated test data and assertions to reflect new version label functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->