### PR TITLE
Global Models Page No Models Component Refactor

### DIFF
--- a/frontend/packages/modelServing/extensions.ts
+++ b/frontend/packages/modelServing/extensions.ts
@@ -58,14 +58,14 @@ const extensions: (
       title: 'Model deployments',
       href: '/modelServing',
       section: 'models',
-      path: '/modelServing/*',
+      path: '/modelServing/:namespace?/*',
     },
   },
   {
     type: 'app.route',
     properties: {
-      path: '/modelServing/*',
-      component: () => import('./src/ModelServingGlobalPlugin'),
+      path: '/modelServing/:namespace?/*',
+      component: () => import('./src/GlobalModelsPage'),
     },
     flags: {
       required: [PLUGIN_MODEL_SERVING],

--- a/frontend/packages/modelServing/src/GlobalModelsPage.tsx
+++ b/frontend/packages/modelServing/src/GlobalModelsPage.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { useNavigate, useParams } from 'react-router-dom';
+import GlobalDeploymentsView from './components/global/GlobalDeploymentsView';
+import { ModelDeploymentsProvider } from './concepts/ModelDeploymentsContext';
+import { ModelServingPlatformProvider } from './concepts/ModelServingPlatformContext';
+import {
+  isModelServingPlatformExtension,
+  isModelServingPlatformWatchDeployments,
+} from '../extension-points';
+
+const GlobalModelsPage: React.FC = () => (
+  <ModelServingPlatformProvider>
+    <GlobalModelsPageCoreLoader />
+  </ModelServingPlatformProvider>
+);
+
+const GlobalModelsPageCoreLoader: React.FC = () => {
+  const availablePlatforms = useExtensions(isModelServingPlatformExtension);
+  const [deploymentWatchers] = useResolvedExtensions(isModelServingPlatformWatchDeployments);
+  const {
+    projects,
+    loaded: projectsLoaded,
+    preferredProject: currentProject,
+  } = React.useContext(ProjectsContext);
+  const selectedProject = currentProject
+    ? projects.find((project) => project.metadata.name === currentProject.metadata.name)
+    : null;
+  const projectsToShow = selectedProject ? [selectedProject] : projects;
+  const { namespace } = useParams();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (!namespace && currentProject) {
+      navigate(`/modelServing/${currentProject.metadata.name}`, { replace: true });
+    }
+  }, [namespace, currentProject, navigate]);
+
+  if (!projectsLoaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+  if (projects.length === 0) {
+    return <div>No projects found component</div>;
+  }
+  return (
+    <ModelDeploymentsProvider
+      modelServingPlatforms={availablePlatforms}
+      projects={projectsToShow}
+      deploymentWatchers={deploymentWatchers}
+    >
+      <GlobalDeploymentsView currentProject={selectedProject} />
+    </ModelDeploymentsProvider>
+  );
+};
+
+export default GlobalModelsPage;

--- a/frontend/packages/modelServing/src/ModelServingGlobalPlugin.tsx
+++ b/frontend/packages/modelServing/src/ModelServingGlobalPlugin.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const GlobalModelsPage: React.FC = () => <>Global Model Deployments Page</>;
-
-export default GlobalModelsPage;

--- a/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
+++ b/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { ModelServingPlatform } from '../../concepts/useProjectServingPlatform';
 
 export const DeployButton: React.FC<{
-  platform: ModelServingPlatform;
+  platform?: ModelServingPlatform;
   variant?: 'primary' | 'secondary';
-}> = ({ platform, variant = 'primary' }) => (
-  <Button variant={variant}>{platform.properties.deployedModelsView.deployButtonText}</Button>
-);
+  isDisabled?: boolean;
+}> = ({ platform, variant = 'primary', isDisabled }) => {
+  const deployButton = (
+    <Button
+      variant={variant}
+      data-testid="deploy-button"
+      // onClick={() => {
+      //   do something
+      // }}
+      isAriaDisabled={isDisabled}
+    >
+      Deploy Model
+    </Button>
+  );
+  if (!platform) {
+    return <Tooltip content="To deploy a model, select a project.">{deployButton}</Tooltip>;
+  }
+  return <>{deployButton}</>;
+};

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const GlobalDeploymentsTable: React.FC = () => <>Global Model Deployments Table</>;
+
+export default GlobalDeploymentsTable;

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
+import TitleWithIcon from '@odh-dashboard/internal/concepts/design/TitleWithIcon';
+import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import { GlobalNoModelsView } from './GlobalNoModelsView';
+import GlobalDeploymentsTable from './GlobalDeploymentsTable';
+import ModelServingProjectSelection from './ModelServingProjectSelection';
+import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
+
+type GlobalDeploymentsViewProps = {
+  currentProject?: ProjectKind | null;
+};
+
+const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ currentProject }) => {
+  const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
+  const hasDeployments = deployments && deployments.length > 0;
+  const isLoading = !deploymentsLoaded;
+
+  return (
+    <ApplicationsPage
+      loaded={!isLoading}
+      empty={!hasDeployments}
+      emptyStatePage={<GlobalNoModelsView project={currentProject ?? undefined} />}
+      description="Manage and view the health and performance of your deployed models."
+      title={
+        <TitleWithIcon title="Model deployments" objectType={ProjectObjectType.deployedModels} />
+      }
+      headerContent={
+        <ModelServingProjectSelection getRedirectPath={(ns: string) => `/modelServing/${ns}`} />
+      }
+    >
+      <GlobalDeploymentsTable />
+    </ApplicationsPage>
+  );
+};
+
+export default GlobalDeploymentsView;

--- a/frontend/packages/modelServing/src/components/global/GlobalNoModelsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalNoModelsView.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import EmptyDetailsView from '@odh-dashboard/internal/components/EmptyDetailsView';
+import { ProjectObjectType, typedEmptyImage } from '@odh-dashboard/internal/concepts/design/utils';
+import { useNavigate } from 'react-router-dom';
+import { ProjectSectionID } from '@odh-dashboard/internal/pages/projects/screens/detail/types';
+import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import { Button, Truncate } from '@patternfly/react-core';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { DeployButton } from '../../components/deploy/DeployButton';
+
+type GlobalNoModelsViewProps = {
+  project?: ProjectKind | undefined;
+};
+
+export const GlobalNoModelsView: React.FC<GlobalNoModelsViewProps> = ({ project }) => {
+  const navigate = useNavigate();
+  if (project) {
+    return (
+      <EmptyDetailsView
+        allowCreate
+        iconImage={typedEmptyImage(ProjectObjectType.modelServer)}
+        imageAlt="deploy a model"
+        title="No Deployed Models"
+        description="To get started, deploy a model from the Models section of a project."
+        createButton={
+          <Button
+            data-testid="empty-state-action-button"
+            variant="link"
+            onClick={() =>
+              navigate(
+                `/projects/${project.metadata.name}?section=${ProjectSectionID.MODEL_SERVER}`,
+              )
+            }
+          >
+            <Truncate content={`Go to ${getDisplayNameFromK8sResource(project)}`} />
+          </Button>
+        }
+      />
+    );
+  }
+  return (
+    <EmptyDetailsView
+      title="No Deployed Models"
+      description="To get started, deploy a model from the Models section of a project."
+      iconImage={typedEmptyImage(ProjectObjectType.modelServer)}
+      imageAlt="deploy a model"
+      createButton={<DeployButton isDisabled platform={undefined} />}
+    />
+  );
+};
+export default GlobalNoModelsView;

--- a/frontend/packages/modelServing/src/components/global/ModelServingProjectSelection.tsx
+++ b/frontend/packages/modelServing/src/components/global/ModelServingProjectSelection.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import ProjectSelectorNavigator from '@odh-dashboard/internal/concepts/projects/ProjectSelectorNavigator';
+
+type ModelServingProjectSelectionProps = {
+  getRedirectPath: (namespace: string) => string;
+};
+
+const ModelServingProjectSelection: React.FC<ModelServingProjectSelectionProps> = ({
+  getRedirectPath,
+}) => (
+  <ProjectSelectorNavigator
+    getRedirectPath={getRedirectPath}
+    invalidDropdownPlaceholder="All projects"
+    selectAllProjects
+    showTitle
+  />
+);
+
+export default ModelServingProjectSelection;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-26254](https://issues.redhat.com/browse/RHOAIENG-26254)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
-Added the no models view to the global model serving page
-Edited context to work with global view
-Renamed ModelServingPlatformContext to ProjectPlatformContext
-Added placeholder component for the deployment table

![Screenshot 2025-06-09 at 4 00 47 PM](https://github.com/user-attachments/assets/9d88f91d-8eac-4da5-8523-175718b9b5fc)

![Screenshot 2025-06-17 at 3 23 07 PM](https://github.com/user-attachments/assets/f1a67d60-bd70-4a06-94e5-69c9f428cc4c)
![Screenshot 2025-06-17 at 3 22 55 PM](https://github.com/user-attachments/assets/36a8f9aa-3cb9-48ce-b71e-0ed47eb0e048)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- Have no models deployed
- Use feature flag to enable the model serving plugin
- Go to the global model deployments page
- See the no models component
- Use the project selector to view different projects
- Go deploy a model (either disable the plugin or use your your cluster dashboard)
- Go back to the plugin global page
- See the placeholder component for the deployment table
- Switch around through projects that do and don't have models


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a namespace-aware model serving page, allowing users to filter and view model deployments by project or across all projects.
  - Added a project selection interface for easier navigation between projects in the model serving section.
  - Implemented a new deployments view with improved loading state, empty state messaging, and a dedicated deployments table.
  - Provided a contextual empty state view with guidance and actions when no models are deployed.

- **Improvements**
  - Updated the "Deploy Model" button for better accessibility and feedback, including disabled states and tooltips when no project is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->