### PR TITLE
feat: added info for insufficient resources error when deploying a model

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -118,7 +118,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   };
 
   const bodyContent = modelStatus?.failedToSchedule
-    ? 'Insufficient resources'
+    ? modelStatus.failureMessage || 'Insufficient resources'
     : getInferenceServiceStatusMessage(inferenceService);
 
   return (

--- a/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/global/__tests__/utils.spec.ts
@@ -5,19 +5,17 @@ import {
 import { mockPodK8sResource } from '~/__mocks__/mockPodK8sResource';
 import { mockInferenceServiceK8sResource } from '~/__mocks__';
 
-const mockModelStatus = (status: boolean) => ({
-  failedToSchedule: status,
-});
-
 describe('checkModelStatus', () => {
-  it('Should return true  when pod fails to schedule due to insufficient resources.', async () => {
-    expect(checkModelStatus(mockPodK8sResource({ isPending: true }))).toEqual(
-      mockModelStatus(true),
-    );
+  it('Should return true when pod fails to schedule due to insufficient resources.', () => {
+    const result = checkModelStatus(mockPodK8sResource({ isPending: true }));
+    expect(result.failedToSchedule).toBe(true);
+    expect(result.failureMessage).toMatch(/Insufficient|taint|Preemption/i); // checks if message is informative
   });
 
-  it('Should return false when pod is scheduled.', async () => {
-    expect(checkModelStatus(mockPodK8sResource({}))).toEqual(mockModelStatus(false));
+  it('Should return false when pod is scheduled.', () => {
+    const result = checkModelStatus(mockPodK8sResource({}));
+    expect(result.failedToSchedule).toBe(false);
+    expect(result.failureMessage).toBeNull();
   });
 });
 

--- a/frontend/src/pages/modelServing/screens/global/utils.ts
+++ b/frontend/src/pages/modelServing/screens/global/utils.ts
@@ -44,10 +44,14 @@ export const getInferenceServiceProjectDisplayName = (
 };
 
 export const checkModelStatus = (model: PodKind): ModelStatus => {
-  const modelStatus = !!model.status?.conditions.some(
-    (currentModel) => currentModel.reason === 'Unschedulable',
+  const unschedulableCondition = model.status?.conditions.find(
+    (condition) => condition.reason === 'Unschedulable',
   );
+
+  const failedToSchedule = model.status?.phase === 'Pending' && !!unschedulableCondition;
+
   return {
-    failedToSchedule: model.status?.phase === 'Pending' && modelStatus,
+    failedToSchedule,
+    failureMessage: failedToSchedule ? unschedulableCondition.message || null : null,
   };
 };

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -33,6 +33,7 @@ export enum InferenceServiceModelState {
 
 export type ModelStatus = {
   failedToSchedule: boolean;
+  failureMessage?: string | null;
 };
 
 export type SupportedModelFormatsInfo = {


### PR DESCRIPTION
(cherry picked from commit 9d462ae65efa3c4db9d4f41b47eca822dfa4ded9)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Related to the following:
https://issues.redhat.com/browse/NVPE-293
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Improved scheduling error message for failed model deployments
This update enhances the clarity of the status tooltip shown when a model fails to schedule due to resource constraints. Previously, users only saw a generic "Insufficient resources" message. Now, the UI extracts and displays the actual reason from the Pod condition (e.g., "0/3 nodes are available: 3 Insufficient nvidia.com/gpu"), making it easier to understand and resolve scheduling issues.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Deploy NIM.
2. Try to deploy a NIM model (i used llama-3.1-8b-instruct - 1.8.3)
3. Wait a few moments for the status to get updated and watch the tooltip over it.
Before:
![image](https://github.com/user-attachments/assets/6e135148-b399-4763-86fe-60f1154550bc)
After:
![image](https://github.com/user-attachments/assets/3863364d-e426-4ea0-9569-e22a890c048a)
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
