### PR TITLE
Refactor notebook namespace handling to workbench namespace across backend and frontend components. Removed deprecated notebookNamespace references and updated related logic to ensure consistency in namespace usage. This change prepares the codebase for future enhancements and aligns with the ongoing transition away from the old namespace structure.

### DIFF
--- a/backend/src/routes/api/notebooks/utils.ts
+++ b/backend/src/routes/api/notebooks/utils.ts
@@ -68,13 +68,13 @@ export const enableNotebook = async (
   }>,
 ): Promise<Notebook> => {
   const notebookData = request.body;
-  const { notebookNamespace } = getNamespaces(fastify);
+  const { workbenchNamespace } = getNamespaces(fastify);
   const username = request.body.username || (await getUserInfo(fastify, request)).userName;
   const name = generateNotebookNameFromUsername(username);
   const url = request.headers.origin;
 
   try {
-    const notebook = await getNotebook(fastify, notebookNamespace, name);
+    const notebook = await getNotebook(fastify, workbenchNamespace, name);
     return await updateNotebook(fastify, username, url ?? '', notebookData, notebook);
   } catch (e) {
     if (isHttpError(e) && e.response.statusCode === 404) {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -58,7 +58,8 @@ export type DashboardConfig = K8sResourceCommon & {
     notebookController?: {
       enabled: boolean;
       pvcSize?: string;
-      notebookNamespace?: string;
+      // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
+      // notebookNamespace?: string;
       notebookTolerationSettings?: {
         enabled: boolean;
         key: string;
@@ -1006,6 +1007,9 @@ export type DataScienceClusterKindStatus = {
   components?: {
     modelregistry?: {
       registriesNamespace?: string;
+    };
+    workbenches?: {
+      workbenchNamespace?: string;
     };
   };
   conditions: K8sCondition[];

--- a/backend/src/utils/adminUtils.ts
+++ b/backend/src/utils/adminUtils.ts
@@ -31,7 +31,7 @@ export const getAdminUserList = async (fastify: KubeFastifyInstance): Promise<st
 
 export const getClusterAdminUserList = async (fastify: KubeFastifyInstance): Promise<string[]> => {
   // fetch all the users and groups who have cluster-admin role and put them into the admin user list
-  const { notebookNamespace } = getNamespaces(fastify);
+  const { workbenchNamespace } = getNamespaces(fastify);
   const clusterAdminUsersAndGroups = await fastify.kube.customObjectsApi
     // This is not actually fetching all the groups who have admin access to the notebook resources
     // But only the cluster admins
@@ -41,7 +41,7 @@ export const getClusterAdminUserList = async (fastify: KubeFastifyInstance): Pro
       resourceAPIGroup: 'kubeflow.org',
       resourceAPIVersion: 'v1',
       verb: '*',
-      namespace: notebookNamespace,
+      namespace: workbenchNamespace,
     })
     .then((rar) => rar.body as ResourceAccessReviewResponse)
     .catch((e) => {

--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -67,13 +67,13 @@ const requestSecurityGuard = async (
   needsAdmin: boolean,
   name?: string,
 ): Promise<void> => {
-  const { notebookNamespace, dashboardNamespace } = getNamespaces(fastify);
+  const { workbenchNamespace, dashboardNamespace } = getNamespaces(fastify);
   const userInfo = await getUserInfo(fastify, request);
   const translatedUsername = usernameTranslate(userInfo.userName);
   const isReadRequest = request.method.toLowerCase() === 'get';
 
   // Check to see if a request was made against one of our namespaces
-  if (![notebookNamespace, dashboardNamespace].includes(namespace)) {
+  if (![workbenchNamespace, dashboardNamespace].includes(namespace)) {
     // Not a valid namespace -- cannot make direct calls to just any namespace no matter who you are
     fastify.log.error(
       `User requested a resource that was not in our namespaces. Namespace: ${namespace}`,
@@ -96,23 +96,23 @@ const requestSecurityGuard = async (
   }
 
   // Api with no name object, allow reads
-  if (name == null && namespace === notebookNamespace && isReadRequest) {
+  if (name == null && namespace === workbenchNamespace && isReadRequest) {
     return;
   }
 
   // RoleBinding -- first users to access the dash
-  if (namespace === dashboardNamespace && name === `${notebookNamespace}-image-pullers`) {
+  if (namespace === dashboardNamespace && name === `${workbenchNamespace}-image-pullers`) {
     return;
   }
 
   // Notebook api endpoint
-  if (namespace === notebookNamespace && name === `jupyter-nb-${translatedUsername}`) {
+  if (namespace === workbenchNamespace && name === `jupyter-nb-${translatedUsername}`) {
     return;
   }
 
   // ConfigMap and Secret endpoint (for env variables)
   if (
-    namespace === notebookNamespace &&
+    namespace === workbenchNamespace &&
     name === `jupyterhub-singleuser-profile-${translatedUsername}-envs`
   ) {
     return;

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -68,16 +68,24 @@ const App: React.FC = () => {
       return null;
     }
     const releaseName = dscStatus?.release?.name;
+    const workbenchNamespace = dscStatus?.components?.workbenches?.workbenchNamespace;
 
     return {
       buildStatuses,
       dashboardConfig,
+      workbenchNamespace,
       storageClasses,
       isRHOAI:
         releaseName === OdhPlatformType.SELF_MANAGED_RHOAI ||
         releaseName === OdhPlatformType.MANAGED_RHOAI,
     };
-  }, [buildStatuses, dashboardConfig, storageClasses, dscStatus]);
+  }, [
+    dashboardConfig,
+    dscStatus?.release?.name,
+    dscStatus?.components?.workbenches?.workbenchNamespace,
+    buildStatuses,
+    storageClasses,
+  ]);
 
   const isUnauthorized = fetchConfigError?.request?.status === 403;
 

--- a/frontend/src/app/AppContext.ts
+++ b/frontend/src/app/AppContext.ts
@@ -5,6 +5,7 @@ import { BuildStatus } from '#~/types';
 type AppContextProps = {
   buildStatuses: BuildStatus[];
   dashboardConfig: DashboardConfigKind;
+  workbenchNamespace?: string;
   storageClasses: StorageClassKind[];
   isRHOAI: boolean;
 };

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1248,7 +1248,8 @@ export type DashboardConfigKind = K8sResourceCommon & {
       enabled: boolean;
       pvcSize?: string;
       storageClassName?: string;
-      notebookNamespace?: string;
+      // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
+      // notebookNamespace?: string;
       notebookTolerationSettings?: TolerationSettings;
     };
     templateOrder?: string[];
@@ -1419,6 +1420,9 @@ export type DataScienceClusterKindStatus = {
     /** Status of Model Registry, including its namespace configuration. */
     [DataScienceStackComponent.MODEL_REGISTRY]?: DataScienceClusterComponentStatus & {
       registriesNamespace?: string;
+    };
+    [DataScienceStackComponent.WORKBENCHES]?: DataScienceClusterComponentStatus & {
+      workbenchNamespace?: string;
     };
   };
   conditions: K8sCondition[];

--- a/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
+++ b/frontend/src/pages/notebookController/NotebookLogoutRedirect.tsx
@@ -11,21 +11,21 @@ const NotebookLogoutRedirect: React.FC = () => {
   const { namespace, notebookName } = useParams<{ namespace: string; notebookName: string }>();
   const notification = useNotification();
   const navigate = useNavigate();
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const [routeLink, loaded, error] = useRouteForNotebook(notebookName, namespace, true);
 
   React.useEffect(() => {
     let cancelled = false;
-    if (namespace && notebookName && namespace === notebookNamespace) {
+    if (namespace && notebookName && namespace === workbenchNamespace) {
       getNotebook(namespace, notebookName)
         .then(() => {
           if (cancelled) {
             return;
           }
-          getRoute(notebookNamespace, notebookName)
+          getRoute(workbenchNamespace, notebookName)
             .then((route) => {
               const location = new URL(
-                `https://${route.spec.host}/notebook/${notebookNamespace}/${notebookName}`,
+                `https://${route.spec.host}/notebook/${workbenchNamespace}/${notebookName}`,
               );
               window.location.href = `${location.origin}/oauth/sign_out`;
             })
@@ -45,10 +45,10 @@ const NotebookLogoutRedirect: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [namespace, notebookName, navigate, notification, notebookNamespace]);
+  }, [namespace, notebookName, navigate, notification, workbenchNamespace]);
 
   React.useEffect(() => {
-    if (namespace && notebookName && namespace !== notebookNamespace) {
+    if (namespace && notebookName && namespace !== workbenchNamespace) {
       if (loaded) {
         if (error) {
           notification.error(`Error when logging out ${notebookName}`, error.message);
@@ -67,7 +67,7 @@ const NotebookLogoutRedirect: React.FC = () => {
     namespace,
     notebookName,
     navigate,
-    notebookNamespace,
+    workbenchNamespace,
   ]);
 
   return (

--- a/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
+++ b/frontend/src/pages/notebookController/SetupCurrentNotebook.tsx
@@ -17,10 +17,10 @@ const SetupCurrentNotebook: React.FC<SetupCurrentNotebookProps> = ({
   currentNotebook,
   setNotebookState,
 }) => {
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const { user: username } = useSpecificNotebookUserState(currentNotebook ?? null);
   const { notebooks, loaded, loadError, forceRefresh, setPollInterval } = useWatchNotebooksForUsers(
-    notebookNamespace,
+    workbenchNamespace,
     [username],
   );
   const notebookRunningState: NotebookRunningState | undefined = loaded

--- a/frontend/src/pages/notebookController/ValidateNotebookNamespace.tsx
+++ b/frontend/src/pages/notebookController/ValidateNotebookNamespace.tsx
@@ -8,13 +8,13 @@ type ValidateNotebookNamespaceProps = {
 };
 
 const ValidateNotebookNamespace: React.FC<ValidateNotebookNamespaceProps> = ({ children }) => {
-  const { notebookNamespace, dashboardNamespace } = useNamespaces();
+  const { workbenchNamespace, dashboardNamespace } = useNamespaces();
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | undefined>();
 
   React.useEffect(() => {
-    if (notebookNamespace && dashboardNamespace) {
-      validateNotebookNamespaceRoleBinding(notebookNamespace, dashboardNamespace)
+    if (workbenchNamespace && dashboardNamespace) {
+      validateNotebookNamespaceRoleBinding(workbenchNamespace, dashboardNamespace)
         .then(() => {
           setLoaded(true);
         })
@@ -25,7 +25,7 @@ const ValidateNotebookNamespace: React.FC<ValidateNotebookNamespaceProps> = ({ c
           setLoadError(error);
         });
     }
-  }, [notebookNamespace, dashboardNamespace]);
+  }, [workbenchNamespace, dashboardNamespace]);
 
   return loaded ? (
     <>{children}</>

--- a/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
+++ b/frontend/src/pages/notebookController/screens/admin/useAdminUsers.ts
@@ -11,7 +11,7 @@ const useAdminUsers = (): [AdminViewUserData[], boolean, Error | undefined] => {
   const { requestNotebookRefresh } = React.useContext(NotebookControllerContext);
   const { username: loggedInUser } = useUser();
 
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const [allowedUsers, allowedUsersLoaded, allowedUsersError] = useCheckForAllowedUsers();
 
   const {
@@ -20,7 +20,7 @@ const useAdminUsers = (): [AdminViewUserData[], boolean, Error | undefined] => {
     loadError: notebookError,
     forceRefresh,
   } = useWatchNotebooksForUsers(
-    notebookNamespace,
+    workbenchNamespace,
     allowedUsers.map(({ username }) => username),
   );
 

--- a/frontend/src/pages/notebookController/screens/admin/useCheckForAllowedUsers.ts
+++ b/frontend/src/pages/notebookController/screens/admin/useCheckForAllowedUsers.ts
@@ -8,13 +8,13 @@ const useCheckForAllowedUsers = (): [
   loaded: boolean,
   error: Error | undefined,
 ] => {
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const [allowedUsers, setAllowedUsers] = React.useState<AllowedUser[]>([]);
   const [loaded, setLoaded] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
 
   React.useEffect(() => {
-    getAllowedUsers(notebookNamespace)
+    getAllowedUsers(workbenchNamespace)
       .then((users) => {
         setAllowedUsers(users);
         setLoaded(true);
@@ -23,7 +23,7 @@ const useCheckForAllowedUsers = (): [
         setError(new Error(e.response.data.message));
         setLoaded(false);
       });
-  }, [notebookNamespace]);
+  }, [workbenchNamespace]);
 
   return [allowedUsers, loaded, error];
 };

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -67,7 +67,7 @@ const SpawnerPage: React.FC = () => {
   const { buildStatuses } = useAppContext();
   const { currentUserNotebook, requestNotebookRefresh, impersonatedUsername, setImpersonating } =
     React.useContext(NotebookControllerContext);
-  const { notebookNamespace: projectName } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const currentUserState = useNotebookUserState();
   const username = currentUserState.user;
   const [createInProgress, setCreateInProgress] = React.useState(false);
@@ -134,7 +134,7 @@ const SpawnerPage: React.FC = () => {
       const envVarFileName = generateEnvVarFileNameFromUsername(username);
       const response = await verifyResource<ConfigMap | Secret>(
         envVarFileName,
-        projectName,
+        workbenchNamespace,
         fetchFunc,
       );
       if (response && response.data) {
@@ -160,7 +160,7 @@ const SpawnerPage: React.FC = () => {
       }
       return fetchedVariableRows;
     },
-    [username, projectName],
+    [username, workbenchNamespace],
   );
 
   React.useEffect(() => {

--- a/frontend/src/pages/notebookController/screens/server/useSpawnerNotebookModalState.ts
+++ b/frontend/src/pages/notebookController/screens/server/useSpawnerNotebookModalState.ts
@@ -35,7 +35,7 @@ const useSpawnerNotebookModalState = (
 } => {
   const { currentUserNotebook: notebook, currentUserNotebookIsRunning: isNotebookRunning } =
     React.useContext(NotebookControllerContext);
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const navigate = useNavigate();
   const [startShown, setStartShown] = React.useState(false);
 
@@ -65,7 +65,7 @@ const useSpawnerNotebookModalState = (
         navigate('/notebookController', { replace: true });
       }
     }
-  }, [notebook, navigate, startShown, isNotebookRunning, createInProgress, notebookNamespace]);
+  }, [notebook, navigate, startShown, isNotebookRunning, createInProgress, workbenchNamespace]);
 
   const refreshNotebookForStart = useRefreshNotebookAndCleanup(startShown);
   const hideStartShown = React.useCallback(() => setStartShown(false), []);

--- a/frontend/src/pages/notebookController/useNamespaces.ts
+++ b/frontend/src/pages/notebookController/useNamespaces.ts
@@ -2,17 +2,13 @@ import { useAppContext } from '#~/app/AppContext';
 import { useDashboardNamespace } from '#~/redux/selectors';
 
 const useNamespaces = (): {
-  /** @deprecated - all new functionality should use project creation under DSG */
-  notebookNamespace: string;
+  workbenchNamespace: string;
   dashboardNamespace: string;
 } => {
-  const { dashboardConfig } = useAppContext();
   const { dashboardNamespace } = useDashboardNamespace();
+  const { workbenchNamespace } = useAppContext();
 
-  /** @deprecated */
-  const notebookNamespace = dashboardConfig.spec.notebookController?.notebookNamespace;
-
-  return { notebookNamespace: notebookNamespace || dashboardNamespace, dashboardNamespace };
+  return { workbenchNamespace: workbenchNamespace || dashboardNamespace, dashboardNamespace };
 };
 
 export default useNamespaces;

--- a/frontend/src/utilities/notebookControllerUtils.ts
+++ b/frontend/src/utilities/notebookControllerUtils.ts
@@ -193,7 +193,7 @@ export const validateNotebookNamespaceRoleBinding = async (
 export const useNotebookRedirectLink = (): (() => Promise<string>) => {
   const { currentUserNotebook, currentUserNotebookLink } =
     React.useContext(NotebookControllerContext);
-  const { notebookNamespace } = useNamespaces();
+  const { workbenchNamespace } = useNamespaces();
   const fetchCountRef = React.useRef(5); // how many tries to get the Route
 
   const routeName = currentUserNotebook?.metadata.name;
@@ -212,9 +212,9 @@ export const useNotebookRedirectLink = (): (() => Promise<string>) => {
         if (currentUserNotebookLink) {
           resolve(currentUserNotebookLink);
         } else {
-          getRoute(notebookNamespace, routeName)
+          getRoute(workbenchNamespace, routeName)
             .then((route) => {
-              resolve(`https://${route.spec.host}/notebook/${notebookNamespace}/${routeName}`);
+              resolve(`https://${route.spec.host}/notebook/${workbenchNamespace}/${routeName}`);
             })
             .catch((e) => {
               /* eslint-disable-next-line no-console */
@@ -237,7 +237,7 @@ export const useNotebookRedirectLink = (): (() => Promise<string>) => {
         preject();
       });
     });
-  }, [notebookNamespace, routeName, currentUserNotebookLink]);
+  }, [workbenchNamespace, routeName, currentUserNotebookLink]);
 };
 
 export const getEventTimestamp = (event: EventKind): string =>

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -173,8 +173,12 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    # TODO: Remove before going to v1
                     notebookNamespace:
                       type: string
+                      x-kubernetes-validations:
+                        - rule: self == oldSelf
+                          message: Can no longer modify notebookNamespace here
                     pvcSize:
                       type: string
                     notebookTolerationSettings:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-22098

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- This PR refactors the codebase to transition from the deprecated notebookNamespace to the new workbenchNamespace across both backend and frontend components which is pulled from the DSC
- renaming of notebookNamespace to workbenchNamespace was also done


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
check that the you csn still run the workbench tile and a notebook is created in the proper namespace defined in the DSC

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no test impact. integration manual testing needed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
