### PR TITLE
Upgrading react-router and react-router-dom to fix CVE-2025-31137 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,8 +43,8 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
         "react-redux": "^8.0.4",
-        "react-router": "^7.1.5",
-        "react-router-dom": "^7.1.5",
+        "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",
         "showdown": "^2.1.0",
@@ -19825,9 +19825,10 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.5.tgz",
-      "integrity": "sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
         "cookie": "^1.0.1",
@@ -19848,11 +19849,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
-      "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
       "dependencies": {
-        "react-router": "7.1.5"
+        "react-router": "7.6.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,8 +89,8 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-redux": "^8.0.4",
-    "react-router": "^7.1.5",
-    "react-router-dom": "^7.1.5",
+    "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
     "showdown": "^2.1.0",
@@ -222,8 +222,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.1.5",
-      "react-router-dom": "^7.1.5",
+      "react-router": "^7.6.2",
+      "react-router-dom": "^7.6.2",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.0.0",
@@ -238,6 +238,7 @@
     "@patternfly/quickstarts": {
       "@patternfly/react-core": "^6.0.0"
     },
+    "react-router": "^7.6.2",
     "ws": "^8.17.1",
     "dompurify": "^3.2.4"
   }


### PR DESCRIPTION
[RHOAIENG-27287](https://issues.redhat.com/browse/RHOAIENG-27287)


