### PR TITLE
Storage class option (#3950) backporting

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -401,6 +401,7 @@ describe('createNIMPVC', () => {
   const pvcName = 'test-pvc';
   const pvcSize = '10Gi';
   const dryRun = true;
+  const storageClassName = 'testStorageClass';
 
   const pvcMock: PersistentVolumeClaimKind = {
     apiVersion: 'v1',
@@ -426,13 +427,14 @@ describe('createNIMPVC', () => {
 
   it('should call createPvc with correct arguments and return the result', async () => {
     (createPvc as jest.Mock).mockResolvedValueOnce(pvcMock);
-    const result = await createNIMPVC(projectName, pvcName, pvcSize, dryRun);
+    const result = await createNIMPVC(projectName, pvcName, pvcSize, dryRun, storageClassName);
 
     expect(createPvc).toHaveBeenCalledWith(
       {
         name: pvcName,
         description: '',
         size: pvcSize,
+        storageClassName,
       },
       projectName,
       { dryRun },
@@ -443,13 +445,14 @@ describe('createNIMPVC', () => {
 
   it('should handle the dryRun flag correctly', async () => {
     const dryRunFlag = false;
-    await createNIMPVC(projectName, pvcName, pvcSize, dryRunFlag);
+    await createNIMPVC(projectName, pvcName, pvcSize, dryRunFlag, storageClassName);
 
     expect(createPvc).toHaveBeenCalledWith(
       {
         name: pvcName,
         description: '',
         size: pvcSize,
+        storageClassName,
       },
       projectName,
       { dryRun: dryRunFlag },

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -666,12 +666,14 @@ export const createNIMPVC = (
   pvcName: string,
   pvcSize: string,
   dryRun: boolean,
+  storageClassName: string,
 ): Promise<PersistentVolumeClaimKind> =>
   createPvc(
     {
       name: pvcName,
       description: '',
       size: pvcSize,
+      storageClassName,
     },
     projectName,
     {


### PR DESCRIPTION
(cherry picked from commit 236211fd2cf6f93b27e75df2611a6b92d747650c)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Jira: https://issues.redhat.com/browse/NVPE-301
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
All info in [this PR.
](https://github.com/opendatahub-io/odh-dashboard/pull/3950)Added an option to select a Storage Class from the NIM deployment UI, with a default option preselected for user convenience.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
