### PR TITLE
Add NFS CSI provisioner to the access mode mapping

### DIFF
--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -25,6 +25,7 @@ export enum StorageProvisioner {
   CEPHFS_CSI = 'cephfs.csi.ceph.com',
   RBD_CSI = 'rbd.csi.ceph.com',
   FILE_CSI_AZURE = 'file.csi.azure.com',
+  NFS_CSI = 'nfs.csi.k8s.io',
 }
 
 // list of access modes
@@ -81,4 +82,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.ROX,
     AccessMode.RWOP,
   ],
+  [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-27449

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added NFS CSI supports (Reference: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Follow https://github.com/opendatahub-io/ilab-on-ocp/blob/main/manifests/nfs_storage/nfs_storage.md and create an nfs-csi storage class on the cluster
2. Go to the storage class settings page, and make sure you can enable the RWX and ROX access mode for the newly created storage class
3. (Optional) You can try to create a workbench using the storage class with the RWX access mode to see if it works

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
