### PR TITLE
RHOAIENG-25719: Deleting Memory or CPU from a Hardware Profile, disables the Update button

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -229,6 +229,7 @@ describe('Manage Hardware Profile', () => {
     createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
     createHardwareProfile.findNodeResourceDeletionDialogDeleteButton().click();
     createHardwareProfile.findNodeResourceDeletionDialog().should('not.exist');
+    createHardwareProfile.findSubmitButton().should('be.enabled');
 
     createHardwareProfile.findNodeResourceTableAlert().should('exist');
     createHardwareProfile.findAddNodeResourceButton().click();
@@ -261,6 +262,7 @@ describe('Manage Hardware Profile', () => {
     // now: test deleting the last Memory trigger the alert shown
     createHardwareProfile.getNodeResourceTableRow('memory').findDeleteAction().click();
     createHardwareProfile.findNodeResourceDeletionDialog().should('exist');
+    createHardwareProfile.findSubmitButton().should('be.enabled');
 
     // first; cancel; should be a no-op (row still there, no alert shown)
     createHardwareProfile.findNodeResourceDeletionDialogCancelButton().click();

--- a/frontend/src/pages/hardwareProfiles/manage/__tests__/validationUtils.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/manage/__tests__/validationUtils.spec.ts
@@ -85,44 +85,6 @@ describe('manageHardwareProfileValidationSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should fail if memory resource is missing', () => {
-    const invalidData = {
-      ...validData,
-      identifiers: [
-        {
-          displayName: 'CPU',
-          identifier: 'cpu',
-          resourceType: IdentifierResourceType.CPU,
-          defaultCount: 2,
-          minCount: 1,
-          maxCount: 4,
-        },
-      ],
-    };
-
-    const result = manageHardwareProfileValidationSchema.safeParse(invalidData);
-    expect(result.success).toBe(false);
-  });
-
-  it('should fail if CPU resource is missing', () => {
-    const invalidData = {
-      ...validData,
-      identifiers: [
-        {
-          displayName: 'Memory',
-          identifier: 'memory',
-          resourceType: IdentifierResourceType.MEMORY,
-          defaultCount: 2,
-          minCount: 1,
-          maxCount: 4,
-        },
-      ],
-    };
-
-    const result = manageHardwareProfileValidationSchema.safeParse(invalidData);
-    expect(result.success).toBe(false);
-  });
-
   describe('nodeSelectorSchema', () => {
     it('should pass for valid nodeSelector', () => {
       const validNodeSelector = { key1: 'value1', key2: 'value2' };

--- a/frontend/src/pages/hardwareProfiles/manage/validationUtils.ts
+++ b/frontend/src/pages/hardwareProfiles/manage/validationUtils.ts
@@ -157,26 +157,13 @@ export const tolerationSchema = z.object({
 
 export const nodeSelectorSchema = z.record(z.string().min(1), z.string().min(1));
 
-export const manageHardwareProfileValidationSchema = z
-  .object({
-    displayName: z.string().trim().min(1, 'Display name is required'),
-    enabled: z.boolean(),
-    identifiers: z.array(identifierSchema),
-    tolerations: z.array(tolerationSchema).optional(),
-    nodeSelector: nodeSelectorSchema.optional(),
-    name: z.string().trim().min(1).max(253).regex(k8sNameRegex),
-    description: z.string().optional(),
-    visibility: z.array(z.string()),
-  })
-  .superRefine((data, ctx) => {
-    if (!hasCPUandMemory(data.identifiers)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: createIdentifierWarningMessage(HARDWARE_PROFILES_MISSING_CPU_MEMORY_MESSAGE),
-        params: {
-          code: HardwareProfileWarningType.HARDWARE_PROFILES_MISSING_CPU_MEMORY,
-        },
-        path: ['identifiers'],
-      });
-    }
-  });
+export const manageHardwareProfileValidationSchema = z.object({
+  displayName: z.string().trim().min(1, 'Display name is required'),
+  enabled: z.boolean(),
+  identifiers: z.array(identifierSchema),
+  tolerations: z.array(tolerationSchema).optional(),
+  nodeSelector: nodeSelectorSchema.optional(),
+  name: z.string().trim().min(1).max(253).regex(k8sNameRegex),
+  description: z.string().optional(),
+  visibility: z.array(z.string()),
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA story:** https://issues.redhat.com/browse/RHOAIENG-25719

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We wan't to enable the Update hardware profile button when
1. there is last cpu or memory resource is present.
2. you have deleted all the resources and no resources are present.

We should continue showing the warning for cpu and memory.

<img width="1494" alt="Screenshot 2025-06-11 at 5 49 06 PM" src="https://github.com/user-attachments/assets/f6c772dc-70cf-49d9-ab37-528c49078bfb" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Go to Hardware profiles page (you might have to enable it using feature flags)
2. Create a new hardware profile with default node resources.
3. Edit it and remove either CPU or Memory resource.
4. The update button should be enabled and not disabled.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Removed the unit tests for failed validation when CPU or Memory node was deleted. Added a check for update button being enabled in the cypress mock test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
