### PR TITLE
Remove the @ from alias references

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,6 @@
 approvers:
 - openshift-cherrypick-robot
-- @general-approvers
+- general-approvers
 
 reviewers:
 - @opendatahub-io/odh-dashboard-maintainers

--- a/frontend/src/__tests__/cypress/OWNERS
+++ b/frontend/src/__tests__/cypress/OWNERS
@@ -2,11 +2,11 @@ options:
   no_parent_owners: true
 
 approvers:
-  - @quality-e2e-testing-approvers
-  - @general-approvers
+  - quality-e2e-testing-approvers
+  - general-approvers
 
 reviewers:
-  - @quality-e2e-testing-reviewers
+  - quality-e2e-testing-reviewers
 
 labels:
   - area/quality


### PR DESCRIPTION
Trying without `@` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated approver and reviewer entries in project configuration files by removing the "@" prefix from group names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->