### PR TITLE
PATCH: Access mode patch

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/storageClasses.ts
@@ -96,6 +96,12 @@ class StorageClassesTableRow extends TableRow {
   findCorruptedMetadataAlert() {
     return cy.findByTestId('corrupted-metadata-alert');
   }
+
+  shouldContainAccessModeLabels(labels: string[]) {
+    return this.find()
+      .findByTestId('access-mode-label-group')
+      .within(() => labels.map((label) => cy.contains(label)));
+  }
 }
 
 class StorageClassesTable {
@@ -143,13 +149,6 @@ class StorageClassesTable {
 
   mockPatchStorageClass(storageClass: StorageClassKind, times = 1) {
     return cy.interceptK8s('PATCH', { model: StorageClassModel, times }, storageClass);
-  }
-
-  shouldContainAccessModeLabels(labels: string[]) {
-    cy.findByTestId('access-mode-label-group').within(() =>
-      labels.map((label) => cy.contains(label)),
-    );
-    return this;
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/workbench.ts
@@ -275,7 +275,7 @@ class NotebookRow extends TableRow {
 
 class AttachExistingStorageModal extends Modal {
   constructor() {
-    super('Attach Existing Storage');
+    super('Attach existing storage');
   }
 
   selectExistingPersistentStorage(name: string) {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -193,8 +193,12 @@ describe('ClusterStorage', () => {
     // default selected
     addClusterStorageModal.find().findByText('openshift-default-sc').should('exist');
 
-    // select storage class
     const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+
+    // confirm radio not enabled when only one storage access mode
+    addClusterStorageModal.findRWOAccessMode().should('be.checked').should('be.disabled');
+
+    // select storage class
     storageClassSelect.find().click();
     storageClassSelect.findSelectStorageClassLabel(/Test SC 1/, AccessMode.RWX).should('exist');
     storageClassSelect.selectStorageClassSelectOption(/Test SC 1/);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -46,10 +46,14 @@ describe('Storage classes', () => {
       storageClassesPage.visit();
 
       storageClassesTable.findRowByName('Test SC 1').should('be.visible');
-      storageClassesTable.shouldContainAccessModeLabels(['RWX']); // display labels other than ROX label
+      storageClassesTable
+        .getRowByConfigName('Test SC 1')
+        .shouldContainAccessModeLabels(['RWO', 'RWX']);
 
       storageClassesTable.findRowByName('openshift-default-sc').should('be.visible');
-      storageClassesTable.shouldContainAccessModeLabels([]); // empty because we do not display ROX label
+      storageClassesTable
+        .getRowByConfigName('openshift-default-sc')
+        .shouldContainAccessModeLabels(['RWO']);
     });
 
     it('table rows allow for toggling of Enable and Default values', () => {
@@ -200,7 +204,7 @@ describe('Storage classes', () => {
       cy.wait('@patchStorageClass');
       cy.wait('@updateStorageClass');
 
-      storageClassTableRow.findDisplayNameValue().should('have.text', 'Readable config');
+      storageClassTableRow.findDisplayNameValue().should('contain.text', 'Readable config');
       storageClassTableRow.findEnableSwitchInput().should('have.attr', 'aria-checked', 'false');
       storageClassTableRow.findDefaultRadioInput().should('not.have.attr', 'checked');
       storageClassTableRow.findLastModifiedValue().should('not.have.text', '-');

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageModal.tsx
@@ -174,7 +174,7 @@ const ClusterStorageModal: React.FC<ClusterStorageModalProps> = ({ existingPvc, 
                   onClick={addEmptyRow}
                   isInline
                 >
-                  Add Workbench
+                  Add workbench
                 </Button>
               </StackItem>
 

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -149,7 +149,11 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
       storageDataEntry.mountPath ? acc.concat(storageDataEntry.mountPath) : acc,
     [],
   );
-  const existingStorageNames = storageData.map((storageDataEntry) => storageDataEntry.name);
+
+  const existingStorageNames = React.useMemo(
+    () => storageData.map((storageDataEntry) => storageDataEntry.name),
+    [storageData],
+  );
 
   const [notebookConnections, setNotebookConnections] = React.useState<Connection[]>(
     existingNotebook ? getConnectionsFromNotebook(existingNotebook, projectConnections) : [],

--- a/frontend/src/pages/projects/screens/spawner/storage/AccessModeField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AccessModeField.tsx
@@ -27,6 +27,16 @@ const AccessModeField: React.FC<AccessModeFieldProps> = ({
     return <Spinner />;
   }
 
+  const availableAccessModes = Object.values(AccessMode).filter(
+    (accessMode: AccessMode) =>
+      openshiftSupportedAccessModes.includes(accessMode) || accessMode === AccessMode.RWO,
+  );
+
+  const allowedAccessModes = availableAccessModes.filter(
+    (accessMode: AccessMode) =>
+      adminSupportedAccessModes.includes(accessMode) || accessMode === AccessMode.RWO,
+  );
+
   return (
     <FormGroup
       label="Access mode"
@@ -46,33 +56,37 @@ const AccessModeField: React.FC<AccessModeFieldProps> = ({
       {canEditAccessMode ? (
         <>
           <Flex>
-            {Object.values(AccessMode).map((accessMode) => {
-              const showAccessMode = openshiftSupportedAccessModes.includes(accessMode);
+            {availableAccessModes.map((accessMode) => {
               const hasAccessMode = adminSupportedAccessModes.includes(accessMode);
               return (
-                (showAccessMode || accessMode === AccessMode.RWO) && (
-                  <FlexItem key={accessMode}>
-                    <AccessModeRadio
-                      id={`${accessMode}-radio`}
-                      name={`${accessMode}-radio`}
-                      isDisabled={!hasAccessMode}
-                      isChecked={currentAccessMode === accessMode}
-                      onChange={() => setAccessMode(accessMode)}
-                      accessMode={accessMode}
-                    />
-                  </FlexItem>
-                )
+                <FlexItem key={accessMode}>
+                  <AccessModeRadio
+                    id={`${accessMode}-radio`}
+                    name={`${accessMode}-radio`}
+                    isDisabled={!hasAccessMode || availableAccessModes.length === 1}
+                    tooltipContent={
+                      !hasAccessMode
+                        ? 'Access mode not supported by the selected storage class.'
+                        : undefined
+                    }
+                    isChecked={currentAccessMode === accessMode}
+                    onChange={() => setAccessMode(accessMode)}
+                    accessMode={accessMode}
+                  />
+                </FlexItem>
               );
             })}
           </Flex>
-          <FormHelperText>
-            <Alert
-              variant="info"
-              title="Access mode cannot be changed after creation. The default access mode is determined by the selected storage class."
-              isInline
-              isPlain
-            />
-          </FormHelperText>
+          {allowedAccessModes.length > 1 && (
+            <FormHelperText>
+              <Alert
+                variant="info"
+                title="Access mode cannot be changed after creation. The default access mode is determined by the selected storage class."
+                isInline
+                isPlain
+              />
+            </FormHelperText>
+          )}
         </>
       ) : (
         <div data-testid="existing-access-mode">

--- a/frontend/src/pages/projects/screens/spawner/storage/AccessModeRadio.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AccessModeRadio.tsx
@@ -9,6 +9,7 @@ type AccessModeRadioProps = {
   accessMode: AccessMode;
   isDisabled: boolean;
   isChecked: boolean;
+  tooltipContent?: string;
   onChange: () => void;
 };
 
@@ -18,6 +19,7 @@ const AccessModeRadio: React.FC<AccessModeRadioProps> = ({
   accessMode,
   isDisabled,
   isChecked,
+  tooltipContent,
   onChange,
 }) => {
   const radioField = (
@@ -31,12 +33,8 @@ const AccessModeRadio: React.FC<AccessModeRadioProps> = ({
       label={toAccessModeFullName(accessMode)}
     />
   );
-  if (isDisabled) {
-    return (
-      <Tooltip content="This access mode is not enabled in the selected storage class.">
-        {radioField}
-      </Tooltip>
-    );
+  if (tooltipContent) {
+    return <Tooltip content={tooltipContent}>{radioField}</Tooltip>;
   }
   return radioField;
 };

--- a/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AttachExistingStorageModal.tsx
@@ -44,7 +44,7 @@ const AttachExistingStorageModal: React.FC<AttachExistingStorageModalProps> = ({
 
   return (
     <Modal variant="medium" onClose={() => onBeforeClose(false)} isOpen>
-      <ModalHeader title="Attach Existing Storage" />
+      <ModalHeader title="Attach existing storage" />
       <ModalBody>
         <Form
           onSubmit={(e) => {

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -18,7 +18,6 @@ import {
   getPossibleStorageClassAccessModes,
   getStorageClassConfig,
 } from '#~/pages/storageClasses/utils';
-import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import { StorageClassConfig, StorageClassKind } from '#~/k8sTypes';
 import useAdminDefaultStorageClass from './useAdminDefaultStorageClass';
 import AccessModeLabel from './AccessModeLabel';
@@ -91,11 +90,11 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
             {/* If multiple storage classes have `isDefault` set to true,
             prioritize the one returned by useAdminDefaultStorageClass() as the default class */}
             <LabelGroup>
-              {getPossibleStorageClassAccessModes(sc)
-                .adminSupportedAccessModes.filter((accessMode) => accessMode !== AccessMode.RWO)
-                .map((accessMode, index) => (
+              {getPossibleStorageClassAccessModes(sc).adminSupportedAccessModes.map(
+                (accessMode, index) => (
                   <AccessModeLabel key={index} accessMode={accessMode} />
-                ))}
+                ),
+              )}
               {sc.metadata.name === defaultSc?.metadata.name && (
                 <Label isCompact color="green" data-testid="is-default-label">
                   Default class

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -221,7 +221,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
               if (!isSupported) {
                 return (
                   <Tooltip
-                    content="This mode is not available in this class."
+                    content="This access mode is not supported by the selected storage class."
                     key={`${modeName}-tooltip`}
                     position="top-start"
                   >

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -37,7 +37,6 @@ import { StorageClassEditModal } from './StorageClassEditModal';
 import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
 import { useStorageClassContext } from './StorageClassesContext';
 import { StorageClassConfigValue } from './StorageClassConfigValue';
-import { AccessMode } from './storageEnums';
 import {
   getSupportedAccessModesForProvisioner,
   isOpenshiftDefaultStorageClass,
@@ -178,8 +177,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({ 
                           {getSupportedAccessModesForProvisioner(storageClass.provisioner)
                             .filter(
                               (modeValue) =>
-                                storageClassConfig.accessModeSettings[modeValue] === true &&
-                                modeValue !== AccessMode.RWO,
+                                storageClassConfig.accessModeSettings[modeValue] === true,
                             )
                             .map((modeValue) => (
                               <AccessModeLabel key={modeValue} accessMode={modeValue} />

--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -25,6 +25,7 @@ export enum StorageProvisioner {
   CEPHFS_CSI = 'cephfs.csi.ceph.com',
   RBD_CSI = 'rbd.csi.ceph.com',
   FILE_CSI_AZURE = 'file.csi.azure.com',
+  NFS_CSI = 'nfs.csi.k8s.io',
 }
 
 // list of access modes
@@ -81,4 +82,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.ROX,
     AccessMode.RWOP,
   ],
+  [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-27582
https://github.com/opendatahub-io/odh-dashboard/pull/4364
https://github.com/opendatahub-io/odh-dashboard/pull/4348

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
