### PR TITLE
Update model to show string status

### DIFF
--- a/frontend/packages/modelServing/src/components/deployments/__tests__/deploymentsTableRow.spec.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/__tests__/deploymentsTableRow.spec.tsx
@@ -44,7 +44,7 @@ describe('DeploymentsTableRow', () => {
     // API protocol Column
     expect(screen.getByText('Not defined')).toBeInTheDocument();
     // Status Column
-    expect(screen.getByRole('button', { name: 'warning status' })).toBeInTheDocument();
+    expect(screen.getByText('Inference Service Status')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Kebab toggle' }));
@@ -91,7 +91,7 @@ describe('DeploymentsTableRow', () => {
       </table>,
     );
 
-    expect(screen.getByRole('button', { name: 'success status' })).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
   });
 
   describe('Inference endpoints', () => {

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -612,12 +612,16 @@ class KServeRow extends ModelMeshRow {
   findStateActionToggle() {
     return this.find().findByTestId('state-action-toggle');
   }
+
+  findStatusLabel(label: string) {
+    return this.find().findByTestId('model-status-text').should('include.text', label);
+  }
 }
 
 class InferenceServiceRow extends TableRow {
   findStatusTooltip() {
     return this.find()
-      .findByTestId('status-tooltip')
+      .findByTestId('model-status-text')
       .click()
       .then(() => {
         cy.findByTestId('model-status-tooltip');
@@ -659,6 +663,10 @@ class InferenceServiceRow extends TableRow {
 
   findProject() {
     return this.find().find(`[data-label=Project]`);
+  }
+
+  findStatusLabel(label: string) {
+    return this.find().findByTestId('model-status-text').should('include.text', label);
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1379,7 +1379,6 @@ describe('Serving Runtime List', () => {
       );
 
       kserveRow.findStateActionToggle().should('have.text', 'Stop').click();
-      kserveRow.findStatusLabel('Stopped');
       kserveRow.findConfirmStopModal().should('exist');
       kserveRow.findConfirmStopModalCheckbox().should('exist');
       kserveRow.findConfirmStopModalCheckbox().should('not.be.checked');
@@ -1387,6 +1386,7 @@ describe('Serving Runtime List', () => {
       kserveRow.findConfirmStopModalCheckbox().should('be.checked');
       kserveRow.findConfirmStopModalButton().click();
       cy.wait(['@stopModelPatch', '@getStoppedModel']);
+      kserveRow.findStatusLabel('Stopped');
       kserveRow.findStateActionToggle().should('have.text', 'Start');
       cy.window().then((win) => {
         const preference = win.localStorage.getItem(STOP_MODAL_PREFERENCE_KEY);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -699,11 +699,13 @@ describe('Serving Runtime List', () => {
         .click();
       modelServingSection.findInferenceServiceTable().should('exist');
       let inferenceServiceRow = modelServingSection.getInferenceServiceRow('OVMS ONNX');
+      inferenceServiceRow.findStatusLabel('Failed');
       inferenceServiceRow.findStatusTooltip();
       inferenceServiceRow.findStatusTooltipValue('Failed to pull model from storage due to error');
 
       // Check status of deployed model which loaded successfully after an error
       inferenceServiceRow = modelServingSection.getInferenceServiceRow('Loaded model');
+      inferenceServiceRow.findStatusLabel('Running');
       inferenceServiceRow.findStatusTooltip().should('be.visible');
       inferenceServiceRow.findStatusTooltipValue('Loaded');
 
@@ -1346,6 +1348,7 @@ describe('Serving Runtime List', () => {
       projectDetails.visitSection('test-project', 'model-server');
 
       const kserveRow = modelServingSection.getKServeRow('test-model');
+      kserveRow.findStatusLabel('Running');
 
       const stoppedInferenceService = mockInferenceServiceK8sResource({
         name: 'test-model',
@@ -1376,6 +1379,7 @@ describe('Serving Runtime List', () => {
       );
 
       kserveRow.findStateActionToggle().should('have.text', 'Stop').click();
+      kserveRow.findStatusLabel('Stopped');
       kserveRow.findConfirmStopModal().should('exist');
       kserveRow.findConfirmStopModalCheckbox().should('exist');
       kserveRow.findConfirmStopModalCheckbox().should('not.be.checked');
@@ -1415,6 +1419,7 @@ describe('Serving Runtime List', () => {
 
       kserveRow.findStateActionToggle().should('have.text', 'Start').click();
       cy.wait(['@startModelPatch', '@getStartedModel']);
+      kserveRow.findStatusLabel('Running');
       kserveRow.findStateActionToggle().should('have.text', 'Stop');
     });
 

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -35,6 +35,11 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
     status?: LabelProps['status'];
     icon: React.ReactNode;
   } => {
+    // Highest-priority: service explicitly stopped
+    const isStopped = inferenceService?.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
+    if (isStopped) {
+      return { label: 'Stopped', color: 'grey', icon: <OffIcon /> };
+    }
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
     if (
       isStarting ||
@@ -48,34 +53,28 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       };
     }
 
-    // Check if the service is stopped via annotation
-    const isStopped = inferenceService?.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
-    if (!isStopped) {
-      // Only check the state if not stopped
-      switch (state) {
-        case InferenceServiceModelState.LOADED:
-        case InferenceServiceModelState.STANDBY:
-          return {
-            label: 'Running',
-            status: 'success',
-            icon: <PlayIcon />,
-          };
-        case InferenceServiceModelState.FAILED_TO_LOAD:
-          return {
-            label: 'Failed',
-            status: 'danger',
-            icon: <ExclamationCircleIcon />,
-          };
-        case InferenceServiceModelState.UNKNOWN:
-          return {
-            label: defaultHeaderContent || 'Status',
-            color: 'grey',
-            icon: <OutlinedQuestionCircleIcon />,
-          };
-      }
+    // Only check the state if not stopped
+    switch (state) {
+      case InferenceServiceModelState.LOADED:
+      case InferenceServiceModelState.STANDBY:
+        return {
+          label: 'Running',
+          status: 'success',
+          icon: <PlayIcon />,
+        };
+      case InferenceServiceModelState.FAILED_TO_LOAD:
+        return {
+          label: 'Failed',
+          status: 'danger',
+          icon: <ExclamationCircleIcon />,
+        };
+      case InferenceServiceModelState.UNKNOWN:
+        return {
+          label: defaultHeaderContent || 'Status',
+          color: 'grey',
+          icon: <OutlinedQuestionCircleIcon />,
+        };
     }
-    // If stopped, show stopped state
-    return { label: 'Stopped', color: 'grey', icon: <OffIcon /> };
   }, [state, defaultHeaderContent, inferenceService, isStarting]);
 
   return (

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -1,120 +1,103 @@
 import React from 'react';
-import { Icon, Popover, Button } from '@patternfly/react-core';
+import { Label, LabelProps, Popover } from '@patternfly/react-core';
 import {
-  CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
+  OffIcon,
   OutlinedQuestionCircleIcon,
+  PlayIcon,
 } from '@patternfly/react-icons';
 import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { InferenceServiceKind } from '#~/k8sTypes';
 
 type ModelStatusIconProps = {
   state: InferenceServiceModelState;
   defaultHeaderContent?: string;
   bodyContent?: string;
-  iconSize?: React.ComponentProps<typeof Icon>['iconSize'];
+  isCompact?: boolean;
+  onClick?: LabelProps['onClick'];
+  inferenceService?: InferenceServiceKind;
+  isStarting?: boolean;
 };
 
 export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   state,
   defaultHeaderContent = 'Status',
   bodyContent = '',
-  iconSize,
+  isCompact,
+  onClick,
+  inferenceService,
+  isStarting,
 }) => {
-  const statusIcon = () => {
-    switch (state) {
-      case InferenceServiceModelState.LOADED:
-      case InferenceServiceModelState.STANDBY:
-        return (
-          <Button
-            aria-label="success status"
-            variant="link"
-            isInline
-            data-testid="status-tooltip"
-            icon={
-              <Icon status="success" isInline iconSize={iconSize}>
-                <CheckCircleIcon />
-              </Icon>
-            }
-          />
-        );
-      case InferenceServiceModelState.FAILED_TO_LOAD:
-        return (
-          <Button
-            aria-label="danger status"
-            variant="link"
-            isInline
-            data-testid="status-tooltip"
-            icon={
-              <Icon status="danger" isInline iconSize={iconSize}>
-                <ExclamationCircleIcon />
-              </Icon>
-            }
-          />
-        );
-      case InferenceServiceModelState.PENDING:
-      case InferenceServiceModelState.LOADING:
-        return (
-          <Icon isInline iconSize={iconSize}>
-            <InProgressIcon />
-          </Icon>
-        );
-      case InferenceServiceModelState.UNKNOWN:
-        return (
-          <Button
-            aria-label="warning status"
-            variant="link"
-            isInline
-            data-testid="status-tooltip"
-            icon={
-              <Icon status="warning" isInline iconSize={iconSize}>
-                <OutlinedQuestionCircleIcon />
-              </Icon>
-            }
-          />
-        );
-      default:
-        return (
-          <Button
-            aria-label="warning status"
-            variant="link"
-            isInline
-            data-testid="status-tooltip"
-            icon={
-              <Icon status="warning" isInline iconSize={iconSize}>
-                <OutlinedQuestionCircleIcon />
-              </Icon>
-            }
-          />
-        );
+  const statusSettings = React.useMemo((): {
+    label: string;
+    color?: LabelProps['color'];
+    status?: LabelProps['status'];
+    icon: React.ReactNode;
+  } => {
+    // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
+    if (
+      isStarting ||
+      state === InferenceServiceModelState.LOADING ||
+      state === InferenceServiceModelState.PENDING
+    ) {
+      return {
+        label: 'Starting',
+        color: 'blue',
+        icon: <InProgressIcon className="odh-u-spin" />,
+      };
     }
-  };
-  const headerContent = (): string => {
-    switch (state) {
-      case InferenceServiceModelState.LOADED:
-        return 'Available';
-      case InferenceServiceModelState.FAILED_TO_LOAD:
-        return 'Failed';
-      case InferenceServiceModelState.PENDING:
-      case InferenceServiceModelState.LOADING:
-        return 'In Progress';
-      case InferenceServiceModelState.UNKNOWN:
-        return 'Status Unknown';
-      default:
-        return defaultHeaderContent || 'Status';
+
+    // Check if the service is stopped via annotation
+    const isStopped = inferenceService?.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
+    if (!isStopped) {
+      // Only check the state if not stopped
+      switch (state) {
+        case InferenceServiceModelState.LOADED:
+        case InferenceServiceModelState.STANDBY:
+          return {
+            label: 'Running',
+            status: 'success',
+            icon: <PlayIcon />,
+          };
+        case InferenceServiceModelState.FAILED_TO_LOAD:
+          return {
+            label: 'Failed',
+            status: 'danger',
+            icon: <ExclamationCircleIcon />,
+          };
+        case InferenceServiceModelState.UNKNOWN:
+          return {
+            label: defaultHeaderContent || 'Status',
+            color: 'grey',
+            icon: <OutlinedQuestionCircleIcon />,
+          };
+      }
     }
-  };
+    // If stopped, show stopped state
+    return { label: 'Stopped', color: 'grey', icon: <OffIcon /> };
+  }, [state, defaultHeaderContent, inferenceService, isStarting]);
 
   return (
     <Popover
       data-testid="model-status-tooltip"
       className="odh-u-scrollable"
       position="top"
-      headerContent={headerContent}
+      headerContent={statusSettings.label}
       bodyContent={bodyContent}
       isVisible={bodyContent ? undefined : false}
     >
-      {statusIcon()}
+      <Label
+        isCompact={isCompact}
+        color={statusSettings.color}
+        status={statusSettings.status}
+        icon={statusSettings.icon}
+        data-testid="model-status-text"
+        style={{ width: 'fit-content', cursor: 'pointer' }}
+        onClick={onClick}
+      >
+        {statusSettings.label}
+      </Label>
     </Popover>
   );
 };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Icon } from '@patternfly/react-core';
-import { InferenceServiceKind } from '#~/k8sTypes';
 import { ModelStatusIcon } from '#~/concepts/modelServing/ModelStatusIcon';
+import { InferenceServiceKind } from '#~/k8sTypes';
 import {
   getInferenceServiceModelState,
   getInferenceServiceStatusMessage,
@@ -11,13 +10,13 @@ import { useModelStatus } from './useModelStatus';
 type InferenceServiceStatusProps = {
   inferenceService: InferenceServiceKind;
   isKserve: boolean;
-  iconSize?: React.ComponentProps<typeof Icon>['iconSize'];
+  isStarting?: boolean;
 };
 
 const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   inferenceService,
   isKserve,
-  iconSize,
+  isStarting,
 }) => {
   const [modelPodStatus] = useModelStatus(
     inferenceService.metadata.namespace,
@@ -33,7 +32,8 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
       state={state}
       defaultHeaderContent="Inference Service Status"
       bodyContent={bodyContent}
-      iconSize={iconSize}
+      inferenceService={inferenceService}
+      isStarting={isStarting}
     />
   );
 };

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -17,6 +17,7 @@ import { patchInferenceServiceStoppedStatus } from '#~/api/k8s/inferenceServices
 import { getInferenceServiceModelState } from '#~/concepts/modelServingKServe/kserveStatusUtils.ts';
 import useStopModalPreference from '#~/pages/modelServing/useStopModalPreference.ts';
 import ModelServingStopModal from '#~/pages/modelServing/ModelServingStopModal';
+import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
 import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
@@ -77,7 +78,12 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     const isStopped = inferenceService.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
     const currentState = getInferenceServiceModelState(inferenceService);
 
-    if (!isStopped && ['Running', 'Succeeded', 'Failed', 'Error'].includes(currentState)) {
+    if (
+      !isStopped &&
+      [InferenceServiceModelState.LOADED, InferenceServiceModelState.FAILED_TO_LOAD].includes(
+        currentState,
+      )
+    ) {
       setIsStarting(false);
     }
   }, [isStarting, inferenceService]);

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -65,7 +65,9 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
 
   const onStart = React.useCallback(() => {
     setIsStarting(true);
-    patchInferenceServiceStoppedStatus(inferenceService, 'false').then(refresh);
+    patchInferenceServiceStoppedStatus(inferenceService, 'false')
+      .then(refresh)
+      .catch(() => setIsStarting(false));
   }, [inferenceService, refresh]);
 
   React.useEffect(() => {
@@ -75,7 +77,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
     const isStopped = inferenceService.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
     const currentState = getInferenceServiceModelState(inferenceService);
 
-    if (!isStopped && (currentState === 'Loading' || currentState === 'Pending')) {
+    if (!isStopped && ['Running', 'Succeeded', 'Failed', 'Error'].includes(currentState)) {
       setIsStarting(false);
     }
   }, [isStarting, inferenceService]);

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -49,7 +49,6 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
               <InferenceServiceStatus
                 inferenceService={inferenceService}
                 isKserve={!isModelMesh(inferenceService)}
-                iconSize="lg"
               />
             </FlexItem>
             <FlexItem>


### PR DESCRIPTION
Closes: [RHOAIENG-27143](https://issues.redhat.com/browse/RHOAIENG-27143)

## Description
Updates the icon in deployed models to show string labels for the status.

## How Has This Been Tested?
Tested locally

## Test Impact
Updated Cypress tests to reflect changes

## Screenshots
<img width="378" alt="Screenshot 2025-06-18 at 10 56 57 AM" src="https://github.com/user-attachments/assets/75953d6e-53bd-4c9b-afdc-3230741ab175" />


https://github.com/user-attachments/assets/5aa29b2a-be59-4ee1-94d6-ec75c3a6c8b3



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Status labels for models now clearly indicate "Starting", "Running", "Stopped", or "Failed" with distinct icons and colors.
  - The status display updates in real-time when starting or stopping a model.
  - Added click handling and compact mode options to status labels.

- **Improvements**
  - Status labels are now more consistent and visually unified across the interface using a single label component.
  - Enhanced test coverage to verify status label display during model lifecycle actions.
  - Added "Starting" state detection to better reflect model initiation progress.
  - UI status label presence checks added to multiple test scenarios for inference service and KServe rows.
  - Simplified and unified status tooltip and label handling in model serving rows.
  - Refined status label logic to consolidate rendering and improve clarity.

- **Bug Fixes**
  - Status icons and labels now accurately reflect intermediate states such as "Starting".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->