### PR TITLE
Cypress e2e Test - Verify that admin users can edit a model registry

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testRegisterModel.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/modelRegistry/testRegisterModel.yaml
@@ -4,4 +4,6 @@ objectStorageModelName: "test-object-storage-model"
 uriModelName: "test-uri-model"
 version1Name: "v1.0"
 version2Name: "v2.0"
+newNameSuffix: "-edited"
+newDescription: "Updated description for e2e test"
   

--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistrySettings.ts
@@ -5,6 +5,7 @@ import { SearchSelector } from './components/subComponents/SearchSelector';
 
 export enum FormFieldSelector {
   NAME = '#mr-name',
+  DESCRIPTION = '#mr-description',
   HOST = '#mr-host',
   PORT = '#mr-port',
   USERNAME = '#mr-username',
@@ -96,6 +97,10 @@ class ModelRegistrySettings {
 
   findSubmitButton() {
     return cy.findByTestId('modal-submit-button');
+  }
+
+  findCancelButton() {
+    return cy.findByTestId('modal-cancel-button');
   }
 
   findManagePermissionsTooltip() {

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testAdminEditRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testAdminEditRegistry.cy.ts
@@ -1,0 +1,102 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import { retryableBeforeEach } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
+import {
+  checkModelRegistry,
+  checkModelRegistryAvailable,
+  createModelRegistryViaYAML,
+  deleteModelRegistry,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/modelRegistry';
+import { loadRegisterModelFixture } from '#~/__tests__/cypress/cypress/utils/dataLoader';
+import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
+import type { RegisterModelTestData } from '#~/__tests__/cypress/cypress/types';
+import {
+  modelRegistrySettings,
+  FormFieldSelector as SettingsFormFieldSelector,
+} from '#~/__tests__/cypress/cypress/pages/modelRegistrySettings';
+
+describe('Verify that admin users can edit a model registry', () => {
+  let testData: RegisterModelTestData;
+  let registryName: string;
+  let originalRegistryName: string;
+  const uuid = generateTestUUID();
+
+  before(() => {
+    cy.step('Load test data from fixture');
+    loadRegisterModelFixture('e2e/modelRegistry/testRegisterModel.yaml').then((fixtureData) => {
+      testData = fixtureData;
+      registryName = `${testData.registryNamePrefix}-${uuid}`;
+      originalRegistryName = registryName; // Store original name for cleanup
+
+      // creates a model registry
+      cy.step('Create a model registry using YAML');
+      createModelRegistryViaYAML(registryName);
+
+      cy.step('Verify model registry is created');
+      checkModelRegistry(registryName).should('be.true');
+
+      cy.step('Wait for model registry to be in Available state');
+      checkModelRegistryAvailable(registryName).should('be.true');
+    });
+  });
+
+  retryableBeforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
+
+  it(
+    'Logs in as admin user and edits an existing model registry',
+    { tags: ['@Maintain', '@ModelRegistry', '@NonConcurrent'] },
+    () => {
+      cy.step('Login as an Admin');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Navigate to Model Registry Settings');
+      modelRegistrySettings.navigate();
+
+      cy.step('Find and edit the model registry');
+      modelRegistrySettings
+        .findModelRegistryRow(registryName)
+        .findKebabAction('Edit model registry')
+        .click();
+
+      cy.step('Verify the current values are loaded');
+      modelRegistrySettings
+        .findFormField(SettingsFormFieldSelector.NAME)
+        .should('have.value', registryName);
+
+      cy.step('Modify the name and description fields');
+      const { newNameSuffix, newDescription } = testData;
+      const newRegistryName = `${registryName}${newNameSuffix}`;
+
+      modelRegistrySettings
+        .findFormField(SettingsFormFieldSelector.NAME)
+        .clear()
+        .type(newRegistryName);
+
+      modelRegistrySettings
+        .findFormField(SettingsFormFieldSelector.DESCRIPTION)
+        .clear()
+        .type(newDescription);
+
+      cy.step('Submit the changes');
+      modelRegistrySettings.findSubmitButton().should('be.enabled');
+      modelRegistrySettings.findSubmitButton().click();
+
+      cy.step('Verify the registry name and description were updated');
+      modelRegistrySettings.findModelRegistryRow(newRegistryName).should('exist');
+      modelRegistrySettings.findModelRegistryRow(newRegistryName).should('contain', newDescription);
+    },
+  );
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+
+    cy.step('Delete the model registry');
+    deleteModelRegistry(originalRegistryName);
+
+    cy.step('Verify model registry is removed from the backend');
+    checkModelRegistry(originalRegistryName).should('be.false');
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -310,6 +310,8 @@ export type RegisterModelTestData = {
   uriModelName: string;
   version1Name: string;
   version2Name: string;
+  newNameSuffix: string;
+  newDescription: string;
 };
 
 export enum AccessMode {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-22443

## Description
Creates a new Model Registry test. Test is now added to the test script 'testAdminEditRegistry.cy.ts'
All Model Registry e2e tests will be executed using a preconfigured cluster `ui-green`.

## How Has This Been Tested?

- An oc login should be performed in the cluster before running the test

- test-variables.yml should be configured properly

- Export the path to the test-variables.yml: $ export CY_TEST_CONFIG=<path_to>/test-variables.yml

- Prerequisites: 
  - modelregistry:
      managementState: Managed (via the DSC)
  - mysql MR Database preinstalled on the cluster

- Tested against RHOAI-Nightly & ODH nightly via the `ui-green` cluster

![image](https://github.com/user-attachments/assets/831ca305-90aa-40df-b03b-2201644a7857)
- Tested via Jenkins RHOAI cypress/job/dashboard-tests/1875/Test_20Reports/ 


## How to Run
After exporting the test-variables.yml we have 2 different ways:

Using the UI
Go to odh-dashboard/frontend and run the command npm run cypress:open . This will open the Cypress UI where testAdminEditRegistry.cy.ts can be run.

Headless
Go to odh-dashboard/frontend and run the command npm run cypress:run -- --spec src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testAdminEditRegistry.cy.ts.cy.ts

## Test Impact:

- This is already a test

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced new end-to-end tests to verify archiving and restoring models and model versions in the model registry.
  - Enhanced test data and type definitions to support multiple model version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->