### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '00 03 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          # for now, we will only label PRs as stale, not issues
+          days-before-issue-stale: -1
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          stale-pr-message: 'This PR is stale because it has been open 21 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been stale for 21+7 days with no activity.'
+          stale-pr-label: 'Stale'


### PR DESCRIPTION
Our PRs are hovering in the 40s and we we are not getting a lot of action on our issues either.

Adding a stale workflow to help clean up things that have been open for months if not years to help keep focus on things that need focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated management for inactive pull requests. Pull requests with no activity for 21 days will be marked as stale, and if inactivity continues for 7 more days, they will be automatically closed. Issues are not affected by this automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->