### PR TITLE
Apply kueue.openshift.io/managed=true label to new Projects if kueue …

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -991,6 +991,7 @@ export enum KnownLabels {
   DATA_CONNECTION_AWS = 'opendatahub.io/managed',
   CONNECTION_TYPE = 'opendatahub.io/connection-type',
   LABEL_SELECTOR_MODEL_REGISTRY = 'component=model-registry',
+  KUEUE_MANAGED = 'kueue.openshift.io/managed',
 }
 
 type ComponentNames =


### PR DESCRIPTION
…feature is enabled

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-25337

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When a user creates a new project, the corresponding namespace object in Kubernetes must automatically have the label `kueue.openshift.io/managed=true` applied only if the feature `disableKueue` is false (kueue is enabled).
This label signals to Kueue that workloads within this namespace should be managed by its scheduling system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Go to the dev feature flags modal, and set `disableKueue` to `false`. 
*Create a project: Data science projects > Create project
* In the console, navigate to Home > Projects > Search created project by name > YAML
* Under `metadata.labels`, we should see `kueue.openshift.io/managed: 'true'`:
<img width="642" alt="image" src="https://github.com/user-attachments/assets/f0731f20-ec61-47ee-857e-3a1084cdb475" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
