### PR TITLE
Stop/Start Model e2e Test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testModelStopStart.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/dataScienceProjects/testModelStopStart.yaml
@@ -1,0 +1,5 @@
+# testModelStopStart.cy.ts Test Data #
+projectResourceName: 'test-model-stop-start'
+projectDisplayName: 'Test Model Stop Start Project'
+singleModelName: 'test-model'
+modelOpenVinoExamplePath: 'kserve-openvino-test/openvino-example-model'

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -625,8 +625,11 @@ class KServeRow extends ModelMeshRow {
     return this.find().findByTestId('state-action-toggle');
   }
 
-  findStatusLabel(label: string) {
-    return this.find().findByTestId('model-status-text').should('include.text', label);
+  findStatusLabel(label?: string) {
+    if (label) {
+      return this.find().findByTestId('model-status-text').should('include.text', label);
+    }
+    return this.find().findByTestId('model-status-text');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
@@ -1,0 +1,140 @@
+import {
+  modelServingGlobal,
+  modelServingSection,
+  inferenceServiceModal,
+} from '#~/__tests__/cypress/cypress/pages/modelServing.ts';
+import { projectDetails, projectListPage } from '#~/__tests__/cypress/cypress/pages/projects';
+import type { DataScienceProjectData } from '#~/__tests__/cypress/cypress/types';
+import { loadDSPFixture } from '#~/__tests__/cypress/cypress/utils/dataLoader';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  checkInferenceServiceState,
+  provisionProjectForModelServing,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
+import { deleteOpenShiftProject } from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
+import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
+import { STOP_MODAL_PREFERENCE_KEY } from '#~/pages/modelServing/useStopModalPreference';
+
+let testData: DataScienceProjectData;
+let projectName: string;
+let modelName: string;
+let modelFilePath: string;
+const awsBucket = 'BUCKET_1' as const;
+const uuid = generateTestUUID();
+
+describe('A model can be stopped and started', () => {
+  retryableBefore(() => {
+    cy.log('Loading test data');
+    return loadDSPFixture('e2e/dataScienceProjects/testModelStopStart.yaml').then(
+      (fixtureData: DataScienceProjectData) => {
+        testData = fixtureData;
+        projectName = `${testData.projectResourceName}-${uuid}`;
+        modelName = testData.singleModelName;
+        modelFilePath = testData.modelOpenVinoExamplePath;
+
+        if (!projectName) {
+          throw new Error('Project name is undefined or empty in the loaded fixture');
+        }
+        cy.log(`Loaded project name: ${projectName}`);
+        // Create a Project
+        provisionProjectForModelServing(
+          projectName,
+          awsBucket,
+          'resources/yaml/data_connection_model_serving.yaml',
+        );
+      },
+    );
+  });
+
+  after(() => {
+    // Delete the Project
+    deleteOpenShiftProject(projectName, { wait: false, ignoreNotFound: true });
+  });
+
+  it(
+    'Verify that a model can be stopped and started',
+    {
+      tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@Modelserving', '@NonConcurrent'],
+    },
+    () => {
+      cy.log('Model Name:', modelName);
+      cy.step(`Log into the application with ${HTPASSWD_CLUSTER_ADMIN_USER.USERNAME}`);
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      // Project navigation
+      cy.step(`Navigate to the Project list tab and search for ${projectName}`);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+
+      // Navigate to Model Serving section and Deploy a Model
+      cy.step('Navigate to Model Serving and deploy a Model');
+      projectDetails.findSectionTab('model-server').click();
+      modelServingGlobal.findSingleServingModelButton().click();
+      modelServingGlobal.findDeployModelButton().click();
+
+      // Deploy a Model
+      cy.step('Deploy a Model');
+      inferenceServiceModal.findModelNameInput().type(testData.singleModelName);
+      inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+      inferenceServiceModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
+      inferenceServiceModal.findModelFrameworkSelect().click();
+      inferenceServiceModal.findOpenVinoIROpSet13().click();
+      inferenceServiceModal.findLocationPathInput().type(modelFilePath);
+      inferenceServiceModal.findSubmitButton().click();
+      inferenceServiceModal.shouldBeOpen(false);
+      modelServingSection.findModelServerName(testData.singleModelName);
+      const kServeRow = modelServingSection.getKServeRow(testData.singleModelName);
+
+      //Verify the model created and is running
+      cy.step('Verify that the Model is running');
+      checkInferenceServiceState(testData.singleModelName, projectName, {
+        checkReady: true,
+        checkLatestDeploymentReady: true,
+      });
+
+      //Stop the model with the modal
+      cy.step('Stop the model');
+      //Ensure the modal is shown
+      cy.window().then((win) => win.localStorage.setItem(STOP_MODAL_PREFERENCE_KEY, 'false'));
+
+      kServeRow.findStateActionToggle().should('have.text', 'Stop').click();
+      kServeRow.findConfirmStopModal().should('exist');
+      kServeRow.findConfirmStopModalCheckbox().should('exist');
+      kServeRow.findConfirmStopModalCheckbox().should('not.be.checked');
+      kServeRow.findConfirmStopModalCheckbox().click();
+      kServeRow.findConfirmStopModalCheckbox().should('be.checked');
+      kServeRow.findConfirmStopModalButton().click();
+
+      kServeRow
+        .findStatusLabel()
+        .invoke('text')
+        .should('match', /Stopping|Stopped/);
+
+      //Verify the model is stopped
+      checkInferenceServiceState(testData.singleModelName, projectName, {
+        checkReady: false,
+        checkLatestDeploymentReady: false,
+        checkStopped: true,
+        requireLoadedState: false,
+      });
+      kServeRow.findStatusLabel('Stopped').should('exist');
+
+      //Restart the model
+      cy.step('Restart the model');
+      kServeRow.findStateActionToggle().should('have.text', 'Start').click();
+      kServeRow.findStatusLabel('Starting').should('exist');
+
+      //Verify the model is running again
+      checkInferenceServiceState(testData.singleModelName, projectName, {
+        checkReady: true,
+        checkLatestDeploymentReady: true,
+      });
+      kServeRow
+        .findStatusLabel()
+        .invoke('text')
+        .should('match', /Starting|Started/);
+    },
+  );
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-27156](https://issues.redhat.com/browse/RHOAIENG-27156)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added an e2e test to verify the user can stop and start a model via the UI.
Steps:
- Log in
- Go to the project / make it
- Deploy a model
- Make sure it's running
- Stop the model -> the modal should pop up as well
- Wait for the model to stop
- Restart the model
- Make sure the model restarts

I also made some changes to `checkInferenceServiceState` because it was only checking if it was `loaded` or not so I added a `checkStopped` and `requireLoadedState` so if you don't need the `loaded` state (like in this case where I need to check that the model has a `stopped` status) then you don't have to check for that, just the conditions you're looking for. 
(Should not affect other tests that use `checkInferenceServiceState` I didn't want to copy and paste this util and make it work just to check stopped status)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and passed all jenkins testing

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Adding cypress e2e test

To test it you can run it locally or run it on Jenkins
**Test e2e tests [locally](https://github.com/opendatahub-io/odh-dashboard/blob/73b8127e3304046c183bcc59ef80fd7e853aa507/frontend/src/__tests__/cypress/cypress/tests/e2e/README.md#running-tests):** 
1. Oc login 
2. Open one terminal 
   a. `cd frontend`
   b. `npm run start:dev:ext`
3. Open another terminal 
   a. `cd frontend`
   b. `export CY_TEST_CONFIG=/Path/to/your/test/variables/here.yml`
   c. `npm run cypress:open`
   d. Opens UI and can run tests from there


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Added a new end-to-end test to verify that machine learning models can be stopped and started within a data science project.
  - Introduced new test data and updated utility functions to support model stop/start state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->