### PR TITLE
Fix token issue when ISVC and SR are different names (#4209)

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -557,6 +557,9 @@ export type InferenceServiceKind = K8sResourceCommon & {
   };
 };
 
+export const isInferenceServiceKind = (obj: K8sResourceCommon): obj is InferenceServiceKind =>
+  obj.kind === 'InferenceService';
+
 export type RoleBindingSubject = {
   kind: string;
   apiGroup?: string;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -136,7 +136,9 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
               ),
               secrets: [],
             },
-            secrets: filterTokens ? filterTokens(editInferenceService.metadata.name) : [],
+            secrets: filterTokens
+              ? filterTokens(editInferenceService.spec.predictor.model?.runtime)
+              : [],
           }}
           onClose={(edited) => {
             if (edited) {

--- a/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/KServeSection/KServeInferenceServiceTable.tsx
@@ -88,7 +88,9 @@ const KServeInferenceServiceTable: React.FC = () => {
               secrets: [],
             },
             inferenceServiceEditInfo: editKserveResources.inferenceService,
-            secrets: filterTokens(editKserveResources.inferenceService.metadata.name),
+            secrets: filterTokens(
+              editKserveResources.inferenceService.spec.predictor.model?.runtime,
+            ),
           }}
           onClose={(submit: boolean) => {
             setEditKServeResources(undefined);

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokensTable.tsx
@@ -3,7 +3,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import { Table } from '~/components/table';
 import { ProjectDetailsContext } from '~/pages/projects/ProjectDetailsContext';
 import { tokenColumns } from '~/pages/modelServing/screens/global/data';
-import { InferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
+import { InferenceServiceKind, isInferenceServiceKind, ServingRuntimeKind } from '~/k8sTypes';
 import ServingRuntimeTokenTableRow from '~/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeTokenTableRow';
 
 type ServingRuntimeTokensTableProps = {
@@ -20,7 +20,9 @@ const ServingRuntimeTokensTable: React.FC<ServingRuntimeTokensTableProps> = ({
     filterTokens,
   } = React.useContext(ProjectDetailsContext);
 
-  const tokens = filterTokens(obj.metadata.name);
+  const name = isInferenceServiceKind(obj) ? obj.spec.predictor.model?.runtime : obj.metadata.name;
+
+  const tokens = filterTokens(name);
 
   if (!isTokenEnabled) {
     return (

--- a/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal.tsx
@@ -273,8 +273,8 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     const submitInferenceServiceResource = getSubmitInferenceServiceResourceFn(
       createDataInferenceService,
       editInfo?.inferenceServiceEditInfo,
-      servingRuntimeName,
-      inferenceServiceName,
+      editInfo?.servingRuntimeEditInfo?.servingRuntime?.metadata.name || servingRuntimeName,
+      editInfo?.inferenceServiceEditInfo?.metadata.name || inferenceServiceName,
       false,
       podSpecOptionsState.podSpecOptions,
       allowCreate,

--- a/frontend/src/pages/projects/ProjectDetailsContext.tsx
+++ b/frontend/src/pages/projects/ProjectDetailsContext.tsx
@@ -100,7 +100,6 @@ const ProjectDetailsContextProvider: React.FC = () => {
       if (!namespace || !servingRuntimeName) {
         return [];
       }
-
       const { serviceAccountName } = getTokenNames(servingRuntimeName, namespace);
 
       const secrets = serverSecrets.data.filter(
@@ -108,6 +107,7 @@ const ProjectDetailsContextProvider: React.FC = () => {
           secret.metadata.annotations?.['kubernetes.io/service-account.name'] ===
           serviceAccountName,
       );
+
       return secrets;
     },
     [namespace, serverSecrets],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Fixes https://issues.redhat.com/browse/RHOAIENG-27682

Cherry pick of
https://issues.redhat.com/browse/RHOAIENG-23800
Description

When you have an ISVC and a SR that have different names, the token created in the kserve modal will not display. I had to revert one change from a recent PR that will need testing from the NIM team.
How Has This Been Tested?

    Select single model serving
    Create an ISVC and a SR with different names
    Go to edit the model
    Require token authentication
    Redeploy
    Edit the model again
    The service account input field should be visible
