### PR TITLE
[Cypress e2e]fix: model deployment tooltip text

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -94,7 +94,7 @@ describe(
         // Note reload is required as status tooltip was not found due to a stale element
         cy.reload();
         modelServingSection.findStatusTooltip().click({ force: true });
-        cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+        cy.contains('Model is deployed', { timeout: 120000 }).should('be.visible');
       },
     );
   },

--- a/frontend/src/__tests__/cypress/cypress/utils/models.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/models.ts
@@ -17,7 +17,7 @@ export function attemptToClickTooltip(): void {
   modelServingSection.findStatusTooltip().then(($tooltip) => {
     if ($tooltip.length > 0 && $tooltip.is(':visible')) {
       modelServingSection.findStatusTooltip().click({ force: true });
-      cy.contains('Loaded', { timeout: 120000 }).should('be.visible');
+      cy.contains('Model is deployed', { timeout: 120000 }).should('be.visible');
     } else {
       attempts++;
       cy.reload();


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-27819

## Description
Due to the changes introduced in https://github.com/opendatahub-io/odh-dashboard/pull/4416 we need to update the model serving e2e tests in order to expect the new tooltip text

## How Has This Been Tested?
Failed in nightly:
dashboard-tests/1966/

Nightly with the fix:
dashboard-tests/1968/

## Test Impact
Fix model serving e2e tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to check for "Model is deployed" instead of "Loaded" when verifying model deployment status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->