### PR TITLE
PVC Serving Feature Flag

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -52,6 +52,7 @@ export type DashboardConfig = K8sResourceCommon & {
       disableFineTuning: boolean;
       disableKueue: boolean;
       disableLMEval: boolean;
+      disablePVCServing: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
     // groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -83,6 +83,7 @@ export const blankDashboardCR: DashboardConfig = {
       disableFineTuning: true,
       disableKueue: true,
       disableLMEval: true,
+      disablePVCServing: true,
     },
     notebookController: {
       enabled: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -42,6 +42,7 @@ export type MockDashboardConfigType = {
   modelServerSizes?: ModelServingSize[];
   disableLMEval?: boolean;
   disableKueue?: boolean;
+  disablePVCServing?: boolean;
 };
 
 export const mockDashboardConfig = ({
@@ -79,6 +80,7 @@ export const mockDashboardConfig = ({
   disableLlamaStackChatBot = false,
   disableLMEval = true,
   disableKueue = true,
+  disablePVCServing = true,
   modelServerSizes = [
     {
       name: 'Small',
@@ -237,6 +239,7 @@ export const mockDashboardConfig = ({
       disableLlamaStackChatBot,
       disableLMEval,
       disableKueue,
+      disablePVCServing,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -45,6 +45,7 @@ export const definedFeatureFlags: string[] = Object.keys({
   disableKueue: true,
   disableLMEval: true,
   disableLlamaStackChatBot: true, // internal dev only
+  disablePVCServing: true,
 } satisfies DashboardCommonConfig);
 
 export const SupportedAreasStateMap: SupportedAreasState = {
@@ -112,6 +113,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MODEL_SERVING]: {
     featureFlags: ['disableModelServing'],
+  },
+  [SupportedArea.PVCSERVING]: {
+    featureFlags: ['disablePVCServing'],
   },
   [SupportedArea.USER_MANAGEMENT]: {
     featureFlags: ['disableUserManagement'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -61,6 +61,7 @@ export enum SupportedArea {
   TRUSTY_AI = 'trusty-ai',
   NIM_MODEL = 'nim-model',
   SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
+  PVCSERVING = 'pvc-serving',
 
   /* Distributed Workloads areas */
   DISTRIBUTED_WORKLOADS = 'distributed-workloads',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1255,6 +1255,7 @@ export type DashboardCommonConfig = {
   disableLlamaStackChatBot: boolean;
   disableLMEval: boolean;
   disableKueue: boolean;
+  disablePVCServing: boolean;
 };
 
 // [1] Intentionally disjointed fields from the CRD in this type definition

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -39,6 +39,7 @@ import {
 import { isModelPathValid } from '#~/pages/modelServing/screens/projects/utils';
 import DashboardPopupIconButton from '#~/concepts/dashboard/DashboardPopupIconButton';
 import { AccessTypes } from '#~/pages/projects/dataConnections/const';
+import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas/index.ts';
 import ConnectionS3FolderPathField from './ConnectionS3FolderPathField';
 import ConnectionOciPathField from './ConnectionOciPathField';
 import { ConnectionOciAlert } from './ConnectionOciAlert';
@@ -269,7 +270,7 @@ export const ConnectionSection: React.FC<Props> = ({
   );
 
   const hasImagePullSecret = React.useMemo(() => !!data.imagePullSecrets, [data.imagePullSecrets]);
-
+  const pvcServingEnabled = useIsAreaAvailable(SupportedArea.PVCSERVING).status;
   const selectedConnection = React.useMemo(
     () =>
       connections?.find(
@@ -298,6 +299,9 @@ export const ConnectionSection: React.FC<Props> = ({
 
   return (
     <>
+      {pvcServingEnabled && (
+        <Radio label="PVC Serving" name="pvc-serving-radio" id="pvc-serving-radio" />
+      )}
       {existingUriOption && !hasImagePullSecret && (
         <Radio
           id="existing-uri-radio"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-28014](https://issues.redhat.com/browse/RHOAIENG-28014)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a feature flag for pvc serving as it gets developed ([epic](https://issues.redhat.com/browse/RHOAIENG-28013))
Added a little test radio button to demonstrate the flag works but I can also remove that

Flag:
![Screenshot 2025-06-30 at 11 16 22 AM](https://github.com/user-attachments/assets/6a2712f9-a2c6-46dd-9c18-06680dd2073b)

How it looks without any feature flag changes:
![Screenshot 2025-06-30 at 11 16 36 AM](https://github.com/user-attachments/assets/07f00cc7-812b-4a9a-8dc9-16d0dc29463f)

`disablePVCServing` set to false: (useless radio button to show it works)
![Screenshot 2025-06-30 at 11 16 47 AM](https://github.com/user-attachments/assets/3b5fdb24-0e69-4717-8165-8577de5a0cf6)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- Open the deploy modal, notice it is unchanged
- Go set the feature flag (`disablePVCServing`) to false
- Open the deploy modal again, notice there's a new radio button that shows now

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a feature flag to control the availability of "PVC Serving" in the dashboard.
  * Added a new "PVC Serving" connection type option, which is visible only when enabled.
* **Chores**
  * Updated configuration and type definitions to support the new "PVC Serving" feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->