### PR TITLE
Pipeline failure feedback 2

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -108,6 +108,7 @@ Cypress.Keyboard.defaults({
 Cypress.on('uncaught:exception', (err) => {
   // Returning false here prevents Cypress from failing the test
   if (err.name === 'ChunkLoadError') {
+    // eslint-disable-next-line no-console
     console.warn('ChunkLoadError caught and ignored:', err.message);
     return false;
   }

--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -104,6 +104,17 @@ Cypress.Keyboard.defaults({
   keystrokeDelay: 0,
 });
 
+// Handle ChunkLoadError - ignore these errors as they are usually due to code splitting issues during development
+Cypress.on('uncaught:exception', (err) => {
+  // Returning false here prevents Cypress from failing the test
+  if (err.name === 'ChunkLoadError') {
+    console.warn('ChunkLoadError caught and ignored:', err.message);
+    return false;
+  }
+  // Let other errors fail the test as expected
+  return true;
+});
+
 // Configure grep filtering
 const grepTags = Cypress.env('grepTags') ? Cypress.env('grepTags').split(' ') : [];
 const skipTags = Cypress.env('skipTags') ? Cypress.env('skipTags').split(' ') : [];

--- a/frontend/src/concepts/dashboard/ModalStyles.scss
+++ b/frontend/src/concepts/dashboard/ModalStyles.scss
@@ -1,9 +1,16 @@
 // Common modal styles that can be shared across different modal components
 
 .odh-modal {
+  &__scrollable-panel {
+    overflow-y: auto;
+    height: 100%;
+    padding: 0.5rem;
+  }
+  &__full-height {
+    height: 100%;
+  } 
   
   &__content-height {
-     height: 470px;
     overflow-y: hidden;
   }
 

--- a/frontend/src/concepts/dashboard/ModalStyles.scss
+++ b/frontend/src/concepts/dashboard/ModalStyles.scss
@@ -1,14 +1,6 @@
 // Common modal styles that can be shared across different modal components
 
 .odh-modal {
-  &__scrollable-panel {
-    overflow-y: auto;
-    height: 100%;
-    padding: 0.5rem;
-  }
-  &__full-height {
-    height: 100%;
-  } 
   
   &__content-height {
     overflow-y: hidden;

--- a/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
+++ b/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
@@ -55,20 +55,24 @@ const EnsureAPIAvailability: React.FC<EnsureAPIAvailabilityProps> = ({ children 
     const { isStarting, compatible, timedOut } = pipelinesServer;
 
     if (timedOut && compatible) {
+      console.log('hi, showing pipeline serving timing out....66a', pipelinesServer);
       return <PipelineServerTimedOut />;
     }
-
     if (isStarting) {
+      console.log("it's starting.......66a", pipelinesServer);
       return makePipelineSpinner(!!isStarting);
     }
 
     if (!apiAvailable && compatible) {
+      console.log('66a: showing default spinner', pipelinesServer);
       return (
         <Bullseye style={{ minHeight: '150px' }} data-testid="pipelines-api-not-available">
           <Spinner />
         </Bullseye>
       );
     }
+
+    console.log('66a:  not showing any main components here now', pipelinesServer);
     return children;
   };
   return (

--- a/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
+++ b/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
@@ -55,16 +55,13 @@ const EnsureAPIAvailability: React.FC<EnsureAPIAvailabilityProps> = ({ children 
     const { isStarting, compatible, timedOut } = pipelinesServer;
 
     if (timedOut && compatible) {
-      console.log('hi, showing pipeline serving timing out....66a', pipelinesServer);
       return <PipelineServerTimedOut />;
     }
     if (isStarting) {
-      console.log("it's starting.......66a", pipelinesServer);
       return makePipelineSpinner(!!isStarting);
     }
 
     if (!apiAvailable && compatible) {
-      console.log('66a: showing default spinner', pipelinesServer);
       return (
         <Bullseye style={{ minHeight: '150px' }} data-testid="pipelines-api-not-available">
           <Spinner />
@@ -72,7 +69,6 @@ const EnsureAPIAvailability: React.FC<EnsureAPIAvailabilityProps> = ({ children 
       );
     }
 
-    console.log('66a:  not showing any main components here now', pipelinesServer);
     return children;
   };
   return (

--- a/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
+++ b/frontend/src/concepts/pipelines/EnsureAPIAvailability.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Bullseye, Spinner, Button, Flex, FlexItem } from '@patternfly/react-core';
-import { usePipelinesAPI } from '#~/concepts/pipelines/context';
+import { usePipelinesAPI, PipelineServerTimedOut } from '#~/concepts/pipelines/context';
 import StartingStatusModal from '#~/concepts/pipelines/content/StartingStatusModal.tsx';
 
 type EnsureAPIAvailabilityProps = {
@@ -52,7 +52,11 @@ const EnsureAPIAvailability: React.FC<EnsureAPIAvailabilityProps> = ({ children 
   };
 
   const getMainComponent = () => {
-    const { isStarting, compatible } = pipelinesServer;
+    const { isStarting, compatible, timedOut } = pipelinesServer;
+
+    if (timedOut && compatible) {
+      return <PipelineServerTimedOut />;
+    }
 
     if (isStarting) {
       return makePipelineSpinner(!!isStarting);

--- a/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
+++ b/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
@@ -71,7 +71,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
   const renderProgress = () => (
     <Panel isScrollable>
       <PanelMain className="odh-modal__full-height">
-        {/* Render an Alert for each error condition */}
+        {/* Render an Alert for each error condition  that has a message*/}
         {errorConditions
           .filter((c) => c.message)
           .map((condition, idx) => (

--- a/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
+++ b/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
@@ -70,7 +70,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
 
   const renderProgress = () => (
     <Panel isScrollable>
-      <PanelMain>
+      <PanelMain className="odh-modal__full-height">
         {/* Render an Alert for each error condition */}
         {errorConditions
           .filter((c) => c.message)
@@ -117,7 +117,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
   );
 
   const renderLogs = () => (
-    <Panel className="odh-modal__scrollable-panel">
+    <Panel isScrollable className="odh-modal__scrollable-panel">
       <PanelMain>
         <EventLog
           events={allEvents}

--- a/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
+++ b/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
@@ -66,20 +66,25 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
       ?.filter((contents1) => contents1[0] === StatusType.ERROR)
       .map((contents) => contents[1]) || [];
 
+  const serverErroredOut = errorConditions.some((c) => c.type === 'Ready');
+
   const renderProgress = () => (
     <Panel isScrollable>
       <PanelMain>
         {/* Render an Alert for each error condition */}
-        {errorConditions.map((condition, idx) => (
-          <Alert
-            key={condition.type + idx}
-            variant="danger"
-            title={`${condition.type} - ${condition.reason || 'Unknown'}` || 'Error'}
-            style={{ marginBottom: 16 }}
-          >
-            {condition.message || 'An error occurred.'}
-          </Alert>
-        ))}
+        {errorConditions
+          .filter((c) => c.message)
+          .map((condition, idx) => (
+            <Alert
+              data-testid={`error-${idx}`}
+              key={condition.type + idx}
+              variant="danger"
+              title={`${condition.type} - ${condition.reason || 'Unknown'}` || 'Error'}
+              style={{ marginBottom: 16 }}
+            >
+              {condition.message}
+            </Alert>
+          ))}
         <Stack hasGutter>
           <StackItem>
             <Stack hasGutter>
@@ -134,6 +139,26 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
       Closing this dialog will not affect the pipeline server creation.
     </Content>
   );
+
+  const errorDesc = (
+    <Content data-testid="errorDescription">
+      We encountered an error creating your pipeline server. Close this modal to see further
+      instructions.
+    </Content>
+  );
+
+  const modalTitle = serverErroredOut
+    ? 'Pipeline Initialization Failed'
+    : isServerReadyAndCompletelyDone
+    ? 'Pipeline Server Initialized'
+    : spinner;
+
+  const modalDesc = serverErroredOut
+    ? errorDesc
+    : isServerReadyAndCompletelyDone
+    ? successDesc
+    : inProgressDesc;
+
   return (
     <Modal
       data-testid="pipeline-server-starting-modal"
@@ -143,10 +168,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
       title="Pipeline Server Status"
       disableFocusTrap
     >
-      <ModalHeader
-        title={isServerReadyAndCompletelyDone ? 'Pipeline Server Initialized' : spinner}
-        description={isServerReadyAndCompletelyDone ? successDesc : inProgressDesc}
-      />
+      <ModalHeader title={modalTitle} description={modalDesc} />
       <ModalBody className="odh-modal__content-height">
         <Stack hasGutter>
           <StackItem>

--- a/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
+++ b/frontend/src/concepts/pipelines/content/StartingStatusModal.tsx
@@ -70,7 +70,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
 
   const renderProgress = () => (
     <Panel isScrollable>
-      <PanelMain className="odh-modal__full-height">
+      <PanelMain>
         {/* Render an Alert for each error condition  that has a message*/}
         {errorConditions
           .filter((c) => c.message)
@@ -117,7 +117,7 @@ const StartingStatusModal: React.FC<StartingStatusModalProps> = ({ onClose }) =>
   );
 
   const renderLogs = () => (
-    <Panel isScrollable className="odh-modal__scrollable-panel">
+    <Panel isScrollable>
       <PanelMain>
         <EventLog
           events={allEvents}

--- a/frontend/src/concepts/pipelines/content/__tests__/StartingStatusModal.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/StartingStatusModal.spec.tsx
@@ -124,10 +124,21 @@ describe('StartingStatusModal', () => {
   });
 
   it('should show spinner when no conditions are ready', () => {
+    const recentTime = new Date(Date.now() - 1000 * 60 * 2).toISOString(); // 2 minutes ago
     mockUsePipelinesAPI.mockReturnValue(
       createMockConditions([
-        { type: 'APIServerReady', status: 'False', message: 'API server not ready' },
-        { type: 'Ready', status: 'False', message: 'Server not ready' },
+        {
+          type: 'APIServerReady',
+          status: 'False',
+          message: 'API server not ready',
+          lastTransitionTime: recentTime,
+        },
+        {
+          type: 'Ready',
+          status: 'False',
+          message: 'Server not ready',
+          lastTransitionTime: recentTime,
+        },
       ]),
     );
 
@@ -138,13 +149,15 @@ describe('StartingStatusModal', () => {
   });
 
   it('should show in progress when APIServerReady is True and ready is Not true', () => {
+    const recentTime = new Date(Date.now() - 1000 * 60 * 2).toISOString(); // 2 minutes ago
     mockUsePipelinesAPI.mockReturnValue(
       createMockConditions([
         { type: 'APIServerReady', status: 'True', message: 'API server ready' },
         {
-          reason: 'still spinning up.....',
+          reason: K8sDspaConditionReason.Deploying, // Use Deploying reason to trigger IN_PROGRESS status
           status: 'False',
           type: 'Ready',
+          lastTransitionTime: recentTime,
         },
       ]),
     );

--- a/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
+++ b/frontend/src/concepts/pipelines/context/PipelinesContext.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Alert,
-  AlertActionCloseButton,
   AlertActionLink,
   Bullseye,
   Button,

--- a/frontend/src/pages/pipelines/global/PipelineCoreApplicationPage.tsx
+++ b/frontend/src/pages/pipelines/global/PipelineCoreApplicationPage.tsx
@@ -9,6 +9,7 @@ export type PipelineCoreApplicationPageProps = {
   children: React.ReactNode;
   getRedirectPath: (namespace: string) => string;
   overrideChildPadding?: boolean;
+  overrideTimeout?: boolean;
 } & Omit<
   React.ComponentProps<typeof ApplicationsPage>,
   'loaded' | 'empty' | 'emptyStatePage' | 'headerContent' | 'provideChildrenPadding'
@@ -18,6 +19,7 @@ const PipelineCoreApplicationPage: React.FC<PipelineCoreApplicationPageProps> = 
   children,
   getRedirectPath,
   overrideChildPadding,
+  overrideTimeout = false,
   ...pageProps
 }) => {
   const { pipelinesServer } = usePipelinesAPI();
@@ -31,7 +33,7 @@ const PipelineCoreApplicationPage: React.FC<PipelineCoreApplicationPageProps> = 
       headerContent={<PipelineCoreProjectSelector getRedirectPath={getRedirectPath} />}
       provideChildrenPadding={!overrideChildPadding}
     >
-      {pipelinesServer.timedOut && pipelinesServer.compatible ? (
+      {!overrideTimeout && pipelinesServer.timedOut && pipelinesServer.compatible ? (
         <PipelineServerTimedOut />
       ) : (
         children

--- a/frontend/src/pages/pipelines/global/experiments/GlobalExperiments.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/GlobalExperiments.tsx
@@ -30,6 +30,7 @@ const GlobalExperiments: React.FC<GlobalExperimentsParams> = ({ tab }) => {
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={experimentsBaseRoute}
       overrideChildPadding
+      overrideTimeout
     >
       <EnsureAPIAvailability>
         <EnsureCompatiblePipelineServer>

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/GlobalArtifactsPage.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/GlobalArtifactsPage.tsx
@@ -19,6 +19,7 @@ export const GlobalArtifactsPage: React.FC = () => {
       description="View your artifacts and their metadata."
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={artifactsBaseRoute}
+      overrideTimeout
     >
       <EnsureAPIAvailability>
         <EnsureCompatiblePipelineServer>

--- a/frontend/src/pages/pipelines/global/experiments/executions/GlobalExecutions.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/GlobalExecutions.tsx
@@ -29,6 +29,7 @@ const GlobalExecutions: React.FC = () => {
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={executionsBaseRoute}
       overrideChildPadding
+      overrideTimeout
     >
       <EnsureAPIAvailability>
         <EnsureCompatiblePipelineServer>

--- a/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
@@ -22,20 +22,26 @@ const GlobalPipelines: React.FC = () => {
   // is removed from the DOM)
   // will address this in a future ticket: https://issues.redhat.com/browse/RHOAIENG-27999
   return (
-    <PipelineCoreApplicationPage
-      title={<TitleWithIcon title={pipelinesPageTitle} objectType={ProjectObjectType.pipeline} />}
-      description={pipelinesPageDescription}
-      headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
-      getRedirectPath={pipelinesBaseRoute}
-    >
-      <EnsureAPIAvailability>
-        <EnsureCompatiblePipelineServer>
-          <PipelineAndVersionContextProvider>
-            <PipelinesView />
-          </PipelineAndVersionContextProvider>
-        </EnsureCompatiblePipelineServer>
-      </EnsureAPIAvailability>
-    </PipelineCoreApplicationPage>
+    <div>
+      hi missing piece-4
+      <PipelineCoreApplicationPage
+        title={<TitleWithIcon title={pipelinesPageTitle} objectType={ProjectObjectType.pipeline} />}
+        description={pipelinesPageDescription}
+        headerAction={
+          <PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />
+        }
+        getRedirectPath={pipelinesBaseRoute}
+        overrideTimeout
+      >
+        <EnsureAPIAvailability>
+          <EnsureCompatiblePipelineServer>
+            <PipelineAndVersionContextProvider>
+              <PipelinesView />
+            </PipelineAndVersionContextProvider>
+          </EnsureCompatiblePipelineServer>
+        </EnsureAPIAvailability>
+      </PipelineCoreApplicationPage>
+    </div>
   );
 };
 

--- a/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
+++ b/frontend/src/pages/pipelines/global/pipelines/GlobalPipelines.tsx
@@ -23,7 +23,6 @@ const GlobalPipelines: React.FC = () => {
   // will address this in a future ticket: https://issues.redhat.com/browse/RHOAIENG-27999
   return (
     <div>
-      hi missing piece-4
       <PipelineCoreApplicationPage
         title={<TitleWithIcon title={pipelinesPageTitle} objectType={ProjectObjectType.pipeline} />}
         description={pipelinesPageDescription}

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineRuns.tsx
@@ -32,6 +32,7 @@ const GlobalPipelineRuns: React.FC<GlobalPipelineRunsProps> = ({ tab }) => {
       description={experimentRunsPageDescription}
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={pipelineRunsBaseRoute}
+      overrideTimeout
     >
       <EnsureAPIAvailability>
         <EnsureCompatiblePipelineServer>

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -61,7 +61,9 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({
           ))}
         </Tabs>
       </PageSection>
-      {activeSection.component}
+      <div id={activeSection.id} role="tabpanel" aria-labelledby={`${activeSection.id}-tab`}>
+        {activeSection.component}
+      </div>
     </>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/PipelinesCard.tsx
@@ -12,11 +12,7 @@ import {
   Content,
 } from '@patternfly/react-core';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import {
-  CreatePipelineServerButton,
-  PipelineServerTimedOut,
-  usePipelinesAPI,
-} from '#~/concepts/pipelines/context';
+import { CreatePipelineServerButton, usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { useSafePipelines } from '#~/concepts/pipelines/apiHooks/usePipelines';
 import EnsureAPIAvailability from '#~/concepts/pipelines/EnsureAPIAvailability';
 import EnsureCompatiblePipelineServer from '#~/concepts/pipelines/EnsureCompatiblePipelineServer';
@@ -74,14 +70,6 @@ const PipelinesCard: React.FC = () => {
             />
           </CardFooter>
         </>
-      );
-    }
-
-    if (pipelinesServer.timedOut && pipelinesServer.compatible) {
-      return (
-        <CardBody>
-          <PipelineServerTimedOut />
-        </CardBody>
       );
     }
 

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
@@ -3,7 +3,7 @@ import { ButtonVariant, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '#~/pages/projects/screens/detail/const';
-import { PipelineServerTimedOut, usePipelinesAPI } from '#~/concepts/pipelines/context';
+import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import ImportPipelineSplitButton from '#~/concepts/pipelines/content/import/ImportPipelineSplitButton';
 import PipelinesList from '#~/pages/projects/screens/detail/pipelines/PipelinesList';
 import PipelineServerActions from '#~/concepts/pipelines/content/PipelineServerActions';
@@ -13,6 +13,7 @@ import { ProjectObjectType } from '#~/concepts/design/utils';
 import NoPipelineServer from '#~/concepts/pipelines/NoPipelineServer';
 import PipelineAndVersionContextProvider from '#~/concepts/pipelines/content/PipelineAndVersionContext';
 import EnsureCompatiblePipelineServer from '#~/concepts/pipelines/EnsureCompatiblePipelineServer';
+import EnsureAPIAvailability from '#~/concepts/pipelines/EnsureAPIAvailability.tsx';
 
 const PipelinesSection: React.FC = () => {
   const {
@@ -44,38 +45,36 @@ const PipelinesSection: React.FC = () => {
 
   return (
     <PipelineAndVersionContextProvider>
-      <DetailsSection
-        id={ProjectSectionID.PIPELINES}
-        objectType={ProjectObjectType.pipeline}
-        title={ProjectSectionTitles[ProjectSectionID.PIPELINES]}
-        data-testid={ProjectSectionID.PIPELINES}
-        popover={
-          installed ? (
-            <Popover
-              headerContent="About pipelines"
-              bodyContent="Pipelines are platforms for building and deploying portable and scalable machine-learning (ML) workflows. You can import a pipeline or create one in a workbench."
-            >
-              <DashboardPopupIconButton
-                icon={<OutlinedQuestionCircleIcon />}
-                aria-label="More info"
-              />
-            </Popover>
-          ) : null
-        }
-        actions={actions}
-        isLoading={(!timedOut && compatible && !apiAvailable && installed) || initializing}
-        isEmpty={!installed}
-        emptyState={<NoPipelineServer variant={ButtonVariant.primary} />}
-        showDivider={isPipelinesEmpty}
-      >
-        <EnsureCompatiblePipelineServer>
-          {timedOut ? (
-            <PipelineServerTimedOut />
-          ) : installed ? (
+      <EnsureAPIAvailability>
+        <DetailsSection
+          id={ProjectSectionID.PIPELINES}
+          objectType={ProjectObjectType.pipeline}
+          title={ProjectSectionTitles[ProjectSectionID.PIPELINES]}
+          data-testid={ProjectSectionID.PIPELINES}
+          popover={
+            installed ? (
+              <Popover
+                headerContent="About pipelines"
+                bodyContent="Pipelines are platforms for building and deploying portable and scalable machine-learning (ML) workflows. You can import a pipeline or create one in a workbench."
+              >
+                <DashboardPopupIconButton
+                  icon={<OutlinedQuestionCircleIcon />}
+                  aria-label="More info"
+                />
+              </Popover>
+            ) : null
+          }
+          actions={actions}
+          isLoading={(!timedOut && compatible && !apiAvailable && installed) || initializing}
+          isEmpty={!installed}
+          emptyState={<NoPipelineServer variant={ButtonVariant.primary} />}
+          showDivider={isPipelinesEmpty}
+        >
+          <EnsureCompatiblePipelineServer>
             <PipelinesList setIsPipelinesEmpty={setIsPipelinesEmpty} />
-          ) : null}
-        </EnsureCompatiblePipelineServer>
-      </DetailsSection>
+          </EnsureCompatiblePipelineServer>
+        </DetailsSection>
+      </EnsureAPIAvailability>
     </PipelineAndVersionContextProvider>
   );
 };

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ButtonVariant, FlexItem, Popover } from '@patternfly/react-core';
+import { ButtonVariant, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '#~/pages/projects/screens/detail/const';
@@ -45,7 +45,6 @@ const PipelinesSection: React.FC = () => {
 
   return (
     <PipelineAndVersionContextProvider>
-      <div> missing piece-44axx</div>
       <EnsureAPIAvailability>
         <DetailsSection
           id={ProjectSectionID.PIPELINES}

--- a/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
+++ b/frontend/src/pages/projects/screens/detail/pipelines/PipelinesSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ButtonVariant, Popover } from '@patternfly/react-core';
+import { ButtonVariant, FlexItem, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
 import { ProjectSectionTitles } from '#~/pages/projects/screens/detail/const';
@@ -45,6 +45,7 @@ const PipelinesSection: React.FC = () => {
 
   return (
     <PipelineAndVersionContextProvider>
+      <div> missing piece-44axx</div>
       <EnsureAPIAvailability>
         <DetailsSection
           id={ProjectSectionID.PIPELINES}

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -8,7 +8,7 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
   ? parseInt(process.env.FAST_POLL_INTERVAL)
   : 3000;
-const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 100000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
+const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
 const { DOC_LINK } = process.env;
 const { COMMUNITY_LINK } = process.env;
 const { SUPPORT_LINK } = process.env;

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -8,7 +8,8 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
   ? parseInt(process.env.FAST_POLL_INTERVAL)
   : 3000;
-const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
+// danger will robinson do not check this change in!!!!! (permanently)
+const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 100000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
 const { DOC_LINK } = process.env;
 const { COMMUNITY_LINK } = process.env;
 const { SUPPORT_LINK } = process.env;

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -8,7 +8,7 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
   ? parseInt(process.env.FAST_POLL_INTERVAL)
   : 3000;
-const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
+const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 100000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
 const { DOC_LINK } = process.env;
 const { COMMUNITY_LINK } = process.env;
 const { SUPPORT_LINK } = process.env;

--- a/frontend/src/utilities/const.ts
+++ b/frontend/src/utilities/const.ts
@@ -8,8 +8,7 @@ const POLL_INTERVAL = process.env.POLL_INTERVAL ? parseInt(process.env.POLL_INTE
 const FAST_POLL_INTERVAL = process.env.FAST_POLL_INTERVAL
   ? parseInt(process.env.FAST_POLL_INTERVAL)
   : 3000;
-// danger will robinson do not check this change in!!!!! (permanently)
-const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 100000; // (testing: 100 seconds; original is 300 seconds === 5 minutes)
+const SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
 const { DOC_LINK } = process.env;
 const { COMMUNITY_LINK } = process.env;
 const { SUPPORT_LINK } = process.env;

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -216,17 +216,13 @@ export const convertSecondsToPeriodicTime = (seconds: number): string => {
   return '';
 };
 
-// keep this part:
-
 // server timeout is 5 minutes; in src/utilities/const.ts
+// so we are using that same timeout here
 // SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
 
-// end of keep this part
-
-// so we are using 60 seconds for now; change back! DANGER WILL ROBINSON!
-// temp change for development; change back! DANGER WILL ROBINSON!
-const shortTimeRangeSecondLimit = 60;
-const mediumTimeRangeSecondLimit = 90;
+const shortTimeRangeMinuteLimit = 3; // 3 minutes (3 minutes ago)
+// todo:  use the server_timeout here and convert to minutes
+const mediumTimeRangeMinuteLimit = 5; // 5 minutes (5 minutes ago)  152411
 
 export const getTimeRangeCategory = (
   timestamp: string | undefined | null,
@@ -241,20 +237,16 @@ export const getTimeRangeCategory = (
     return 'longRange';
   }
 
-  const diffSecs = (now - timestampMs) / 1000; // 60 000
-  // const diffMinutes = (now - timestampMs) / 60000; // 60 000
+  const diffMinutes = (now - timestampMs) / 60000; // 60 000
 
-  if (diffSecs < 0) {
-    // if (diffMinutes < 0) {
+  if (diffMinutes < 0) {
     // Future timestamp – treat as shortest range
     return 'shortRange';
   }
-  if (diffSecs > mediumTimeRangeSecondLimit) {
-    // if (diffMinutes > mediumTimeRangeMinuteLimit) {
+  if (diffMinutes > mediumTimeRangeMinuteLimit) {
     return 'longRange';
   }
-  if (diffSecs > shortTimeRangeSecondLimit) {
-    // if (diffMinutes > shortTimeRangeMinuteLimit) {
+  if (diffMinutes > shortTimeRangeMinuteLimit) {
     return 'mediumRange';
   }
   return 'shortRange';

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -216,8 +216,17 @@ export const convertSecondsToPeriodicTime = (seconds: number): string => {
   return '';
 };
 
-const shortTimeRangeMinuteLimit = 3;
-const mediumTimeRangeMinuteLimit = 5;
+// keep this part:
+
+// server timeout is 5 minutes; in src/utilities/const.ts
+// SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
+
+// end of keep this part
+
+// so we are using 60 seconds for now; change back! DANGER WILL ROBINSON!
+// temp change for development; change back! DANGER WILL ROBINSON!
+const shortTimeRangeSecondLimit = 60;
+const mediumTimeRangeSecondLimit = 90;
 
 export const getTimeRangeCategory = (
   timestamp: string | undefined | null,
@@ -232,16 +241,20 @@ export const getTimeRangeCategory = (
     return 'longRange';
   }
 
-  const diffMinutes = (now - timestampMs) / 60000; // 60 000
+  const diffSecs = (now - timestampMs) / 1000; // 60 000
+  // const diffMinutes = (now - timestampMs) / 60000; // 60 000
 
-  if (diffMinutes < 0) {
+  if (diffSecs < 0) {
+    // if (diffMinutes < 0) {
     // Future timestamp – treat as shortest range
     return 'shortRange';
   }
-  if (diffMinutes > mediumTimeRangeMinuteLimit) {
+  if (diffSecs > mediumTimeRangeSecondLimit) {
+    // if (diffMinutes > mediumTimeRangeMinuteLimit) {
     return 'longRange';
   }
-  if (diffMinutes > shortTimeRangeMinuteLimit) {
+  if (diffSecs > shortTimeRangeSecondLimit) {
+    // if (diffMinutes > shortTimeRangeMinuteLimit) {
     return 'mediumRange';
   }
   return 'shortRange';

--- a/frontend/src/utilities/time.ts
+++ b/frontend/src/utilities/time.ts
@@ -3,6 +3,7 @@ import {
   RunDateTime,
   periodicOptionAsSeconds,
 } from '#~/concepts/pipelines/content/createRun/types';
+import { SERVER_TIMEOUT } from '#~/utilities/const.ts';
 
 const printAgo = (time: number, unit: string) => `${time} ${unit}${time > 1 ? 's' : ''} ago`;
 const printIn = (time: number, unit: string) => `in ${time} ${unit}${time > 1 ? 's' : ''}`;
@@ -218,11 +219,8 @@ export const convertSecondsToPeriodicTime = (seconds: number): string => {
 
 // server timeout is 5 minutes; in src/utilities/const.ts
 // so we are using that same timeout here
-// SERVER_TIMEOUT = process.env.SERVER_TIMEOUT ? parseInt(process.env.SERVER_TIMEOUT) : 300000; // 5 minutes
-
-const shortTimeRangeMinuteLimit = 3; // 3 minutes (3 minutes ago)
-// todo:  use the server_timeout here and convert to minutes
-const mediumTimeRangeMinuteLimit = 5; // 5 minutes (5 minutes ago)  152411
+const shortTimeRangeMinuteLimit = 3; // 3 minutes
+const mediumTimeRangeMinuteLimit = SERVER_TIMEOUT / 60000; // 5 minutes is the default server timeout
 
 export const getTimeRangeCategory = (
   timestamp: string | undefined | null,


### PR DESCRIPTION
for: https://issues.redhat.com/browse/RHOAIENG-27999

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
should still show the dialog after the pipeline has failed.
also: removing the 'close' ability of the alert upon the pipeline initialization timing out.
as a bonus: also adding the modal to the one screen that didn't have it (found it when searching for timeouts)

here is a video of the transitions; the waits for each transition time have been edited out (this would normally take 5 minutes; which is the server timeout).  
an error is induced by putting in the wrong password

https://github.com/user-attachments/assets/f6c1cbd4-80d7-4ab7-9d95-888ff890644b


here are individual screenshots:

the modal showing with the error messages on the top in blocks.  only showing blocks when there is an actual message to be shown (some of the errors/components do not have an associated message).  note that the timeout alert shows behind the modal:
<img width="1336" alt="Screenshot 2025-06-30 at 9 23 17 AM" src="https://github.com/user-attachments/assets/f7d5bc6e-c77f-4ba6-9fe9-327985f5ba59" />

here is the timeout alert.  it is unchanged from before; *except* that the close functionality has now been removed (with guidance from UX) now that there is a status modal.  
<img width="1328" alt="Screenshot 2025-06-30 at 9 23 35 AM" src="https://github.com/user-attachments/assets/8e504481-0a80-4446-b663-9b34f7da728d" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually tested this *a lot*; added to the unit test a test for the error block on top of the modal.
Tested inducing an error by putting in an incorrect password; also tested that when the password is *correct* that the positive /working pages still work as they should.

tested this and went over every instance of EnsureApiAvailability and the timeout alert; and thus found one instance that needed an ensureApiAvailability:  the pipelines tab in the data science projects page.
<img width="1393" alt="Screenshot 2025-06-30 at 11 25 39 AM" src="https://github.com/user-attachments/assets/9c4ae104-2b9c-486e-b5d1-be057d8e9a9b" />

here is a spreadsheet with the files that use EnsureApiAvailability, and i went through and tested them and fixed the places that needed to stop showing the TimeOut warning.  

here is the spreadsheet:
https://docs.google.com/spreadsheets/d/1525K-MQQORxeC39_mUznw5tIz9oa09IXqssw5xoM8jo/edit?usp=sharing
referenced screenshots in this folder: https://drive.google.com/drive/folders/1dule6ez-Lf6FyJRH396UPnGwRrsF1myN?usp=sharing

@acrago please take a look.


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I added a test to check the rendering of the error; but since this is about user interactivity didn't add tests for that.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error and timeout handling in pipeline-related pages, including improved modal titles and descriptions for initialization failures.
  * Added the ability to override pipeline server timeout messages on key pages for more flexible user experience.

* **Bug Fixes**
  * Error alerts in pipeline initialization now display only when relevant messages are present and include improved details.

* **Style**
  * Updated modal styles to support scrollable panels and full-height layouts.
  * Improved accessibility by adding ARIA roles and attributes to tab panel content.

* **Chores**
  * Refactored and simplified timeout logic across pipeline components for consistency.
  * Adjusted time range calculations to dynamically align with server timeout settings.
  * Added global error handling in Cypress tests to ignore specific loading errors and prevent test failures.

* **Tests**
  * Added new test coverage for error alert rendering in pipeline initialization modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->