### PR TITLE
Fix deployment status bug

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -64,6 +64,8 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
   const modelServingStatus = getInferenceServiceStoppedStatus(inferenceService);
   const [isStarting, setIsStarting] = React.useState(false);
 
+  const isNewlyDeployed = !inferenceService.status?.modelStatus?.states?.activeModelState;
+
   const onStart = React.useCallback(() => {
     setIsStarting(true);
     patchInferenceServiceStoppedStatus(inferenceService, 'false')
@@ -153,7 +155,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
         <InferenceServiceStatus
           inferenceService={inferenceService}
           isKserve={!modelMesh}
-          isStarting={isStarting}
+          isStarting={isStarting || isNewlyDeployed}
         />
       </Td>
       <Td>


### PR DESCRIPTION
Closes: [RHOAIENG-28262](https://issues.redhat.com/browse/RHOAIENG-28262)

## Description
Fixes a small bug where when first deploying a model, that status shows 'Inference Service Status' instead of 'Starting'

## How Has This Been Tested?
Tested locally
- Go to your data science project and deploy a new model
- Once deployed, the status should immediately show 'Starting'

## Test Impact
No tests changed

## Screenshots
Before when you first deploy the model:
![Screenshot 2025-07-02 at 1 08 55 PM](https://github.com/user-attachments/assets/244e204a-7188-4f8c-94c7-25c97dac9a72)
After, showing starting straight away:
![Screenshot 2025-07-02 at 1 09 51 PM](https://github.com/user-attachments/assets/48c37c79-7d26-4476-9146-dca747ec1935)


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status display for inference services by treating newly deployed models as "starting" when no active model state is present. This ensures more accurate and intuitive status information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->