### PR TITLE
Enable MR Modular Architecture deployment

### DIFF
--- a/frontend/config/moduleFederation.js
+++ b/frontend/config/moduleFederation.js
@@ -42,6 +42,11 @@ const readModuleFederationConfigFromPackages = () => {
 };
 
 const getModuleFederationConfig = () => {
+  // Disable module federation for Cypress tests
+  if (process.env.CYPRESS_TESTS === 'true') {
+    return [];
+  }
+
   if (process.env.MODULE_FEDERATION_CONFIG) {
     try {
       return JSON.parse(process.env.MODULE_FEDERATION_CONFIG);

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -3,8 +3,10 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const webpack = require('webpack');
 const { setupWebpackDotenvFilesForEnv } = require('./dotenv');
 const GenerateExtensionsPlugin = require('./generateExtensionsPlugin');
+const { moduleFederationConfig, moduleFederationPlugins } = require('./moduleFederation');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -232,6 +234,10 @@ module.exports = (env) => ({
     new MonacoWebpackPlugin({
       languages: ['yaml'],
     }),
+    new webpack.EnvironmentPlugin({
+      MF_CONFIG: JSON.stringify(moduleFederationConfig),
+    }),
+    ...moduleFederationPlugins,
   ],
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.jsx'],

--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 const { execSync } = require('child_process');
 const path = require('path');
-const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
@@ -12,7 +11,7 @@ const smp = new SpeedMeasurePlugin({ disable: !process.env.MEASURE });
 
 setupDotenvFilesForEnv({ env: 'development' });
 const webpackCommon = require('./webpack.common.js');
-const { moduleFederationConfig, moduleFederationPlugins } = require('./moduleFederation');
+const { moduleFederationConfig } = require('./moduleFederation');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -166,10 +165,6 @@ module.exports = smp.wrap(
       plugins: [
         new ForkTsCheckerWebpackPlugin(),
         new ReactRefreshWebpackPlugin({ overlay: false }),
-        new webpack.EnvironmentPlugin({
-          MF_CONFIG: JSON.stringify(moduleFederationConfig),
-        }),
-        ...moduleFederationPlugins,
       ],
     },
   ),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,10 +54,10 @@
     "cypress:run:mock:coverage": "rimraf src/__tests__/cypress/coverage src/__tests__/cypress/.nyc_output && CY_COVERAGE=true npm run cypress:run:mock -- {@}",
     "cypress:open:record": "CY_RECORD=1 npm run cypress:open",
     "cypress:run:record": "CY_RECORD=1 npm run cypress:run && npm run cypress:format",
-    "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 WS_HOSTNAME=localhost:9002 npm run build",
-    "cypress:server:build:coverage": "COVERAGE=true npm run cypress:server:build",
+    "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 WS_HOSTNAME=localhost:9002 CYPRESS_TESTS=true npm run build",
+    "cypress:server:build:coverage": "COVERAGE=true CYPRESS_TESTS=true npm run cypress:server:build",
     "cypress:server": "serve ./public-cypress -p 9001 -s -L",
-    "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 WS_HOSTNAME=localhost:9002 npm run start:dev",
+    "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 WS_HOSTNAME=localhost:9002 CYPRESS_TESTS=true npm run start:dev",
     "cypress:format": "prettier --write src/__tests__/**/*.snap.json",
     "test:cypress:e2e": "cd src/__tests__/cypress && npx cypress run --env grepTags=\"${CY_TEST_TAGS}\",skipTags=\"${CY_SKIP_TAGS}\" --browser chrome",
     "test:cypress:e2e:open": "cd src/__tests__/cypress && npx cypress open --env grepTags=\"${CY_TEST_TAGS}\",skipTags=\"${CY_SKIP_TAGS}\""

--- a/frontend/packages/model-registry/Dockerfile
+++ b/frontend/packages/model-registry/Dockerfile
@@ -1,0 +1,64 @@
+# Source code for the repos
+ARG UI_SOURCE_CODE=./upstream/frontend
+ARG BFF_SOURCE_CODE=./upstream/bff
+
+# Set the base images for the build stages
+ARG NODE_BASE_IMAGE=node:20
+ARG GOLANG_BASE_IMAGE=golang:1.24.3
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
+
+# UI build stage
+FROM ${NODE_BASE_IMAGE} AS ui-builder
+
+ARG UI_SOURCE_CODE
+ARG DEPLOYMENT_MODE
+ARG PLATFORM_MODE
+
+WORKDIR /usr/src/app
+
+# Copy the source code to the container
+COPY ${UI_SOURCE_CODE} /usr/src/app
+
+# List files for debugging
+RUN ls -la /usr/src/app
+
+# Install the dependencies and build
+RUN npm cache clean --force
+RUN npm ci --omit=optional
+RUN npm run build:prod
+
+# BFF build stage
+FROM ${GOLANG_BASE_IMAGE} AS bff-builder
+
+ARG BFF_SOURCE_CODE
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /usr/src/app
+
+# Copy the Go Modules manifests
+COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the go source files
+COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
+COPY ${BFF_SOURCE_CODE}/internal/ internal/
+
+# Build the Go application
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd
+
+# Final stage
+# Use distroless as minimal base image to package the application binary
+FROM ${DISTROLESS_BASE_IMAGE}
+WORKDIR /
+COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=ui-builder /usr/src/app/dist ./static/
+USER 65532:65532
+
+# Expose port 8080
+EXPOSE 8080
+
+ENTRYPOINT ["/bff"]

--- a/frontend/packages/model-registry/package.json
+++ b/frontend/packages/model-registry/package.json
@@ -28,8 +28,8 @@
       "port": 9000
     },
     "service": {
-      "name": "model-registry-ui-service",
-      "port": 8080
+      "name": "odh-dashboard",
+      "port": 8043
     }
   }
 }

--- a/frontend/src/__tests__/cypress/cypress/support/e2e.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/e2e.ts
@@ -20,6 +20,7 @@ import '@cypress/code-coverage/support';
 import 'cypress-mochawesome-reporter/register';
 import 'cypress-plugin-steps';
 import './commands';
+import '#~/__tests__/cypress/cypress/utils/moduleFederationMock';
 import { asProjectAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { addCommands as webSocketsAddCommands } from './websockets';
@@ -325,6 +326,10 @@ beforeEach(function beforeEachHook(this: Mocha.Context) {
   if (Cypress.env('MOCK')) {
     // Fallback: return 404 for all API requests.
     cy.intercept({ pathname: '/api/**' }, { statusCode: 404 });
+
+    // Return 404 for all module federation requests.
+    cy.intercept({ pathname: '/_mf/**' }, { statusCode: 404 });
+
     // Default intercepts.
     cy.interceptOdh('GET /api/dsc/status', mockDscStatus({}));
     asProjectAdminUser();

--- a/frontend/src/__tests__/cypress/cypress/utils/moduleFederationMock.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/moduleFederationMock.ts
@@ -1,0 +1,87 @@
+/**
+ * Module Federation Mock Utilities for Cypress Tests
+ *
+ * This file provides utilities to mock module federation behavior
+ * during Cypress tests to prevent runtime errors.
+ */
+
+/**
+ * Mock remote entry content that provides a basic module federation interface
+ */
+export const createMockRemoteEntry = (moduleName: string): string => `
+  // Mock module federation remote entry for ${moduleName}
+  (function() {
+    if (!window.__FEDERATION__) {
+      window.__FEDERATION__ = {};
+    }
+    
+    if (!window.__FEDERATION__.moduleMap) {
+      window.__FEDERATION__.moduleMap = {};
+    }
+    
+    // Mock the module exports
+    window.__FEDERATION__.moduleMap['${moduleName}'] = {
+      get: function(scope) {
+        if (scope === 'extensions') {
+          return Promise.resolve({
+            default: []
+          });
+        }
+        return Promise.resolve({});
+      },
+      init: function() {
+        return Promise.resolve();
+      }
+    };
+    
+    // Export for ES modules compatibility
+    if (typeof module !== 'undefined' && module.exports) {
+      module.exports = window.__FEDERATION__.moduleMap['${moduleName}'];
+    }
+  })();
+`;
+
+/**
+ * Cypress command to set up module federation mocks
+ */
+export const setupModuleFederationMocks = (modules: string[] = ['modelRegistry']): void => {
+  modules.forEach((moduleName) => {
+    // Mock the remote entry file
+    cy.intercept(
+      { pathname: `/_mf/${moduleName}/remoteEntry.js` },
+      {
+        statusCode: 200,
+        headers: { 'content-type': 'application/javascript' },
+        body: createMockRemoteEntry(moduleName),
+      },
+    );
+
+    // Mock the extensions endpoint
+    cy.intercept(
+      { url: `**/_mf/${moduleName}/**/extensions` },
+      {
+        statusCode: 200,
+        headers: { 'content-type': 'application/javascript' },
+        body: 'export default [];',
+      },
+    );
+  });
+
+  // Mock any other module federation paths with 404
+  cy.intercept({ pathname: '/_mf/**' }, { statusCode: 404 });
+};
+
+/**
+ * Add the command to Cypress
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      setupModuleFederationMocks: (modules?: string[]) => Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('setupModuleFederationMocks', setupModuleFederationMocks);

--- a/manifests/core-bases/base/service.yaml
+++ b/manifests/core-bases/base/service.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     deployment: odh-dashboard
   ports:
-  - protocol: TCP
-    targetPort: 8443
-    port: 8443
+    - name: dashboard-ui
+      protocol: TCP
+      port: 8443
+      targetPort: 8443

--- a/manifests/modular-architecture/README.md
+++ b/manifests/modular-architecture/README.md
@@ -1,0 +1,22 @@
+We are disabling this until we can ensure compatibility with ODH Nithlies.
+
+To test the modular architecture, you can use the following steps:
+
+1. Modify the `manifests/odh/kustomization.yaml` file to include the `../modular-architecture` path.
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+  - ../common
+  - ../modular-architecture
+  - ../core-bases/consolelink
+configMapGenerator:
+  - name: odh-dashboard-params
+    env: params.env
+```
+
+2. Deploy to the cluster with the command `kubectl apply -k manifests/odh`.

--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -1,0 +1,61 @@
+- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    name: MODULE_FEDERATION_CONFIG
+    valueFrom:
+      configMapKeyRef:
+        name: federation-config
+        key: module-federation-config.json
+- op: add
+  path: /spec/template/spec/containers/-
+  value: 
+    name: model-registry-ui
+    image: model-registry-ui
+    imagePullPolicy: Always
+    livenessProbe:
+      httpGet:
+        path: /healthcheck
+        port: 8043
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /healthcheck
+        port: 8043
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 1Gi
+    ports:
+      - containerPort: 8043
+        name: https
+    volumeMounts:
+      - name: proxy-tls
+        mountPath: /etc/tls/private
+        readOnly: true
+    args:
+      - "--deployment-mode=federated"
+      - "--auth-method=user_token"
+      - "--auth-token-header=x-forwarded-access-token"
+      - "--auth-token-prefix="
+      - "--port=8043"
+      - "--cert-file=/etc/tls/private/tls.crt"
+      - "--key-file=/etc/tls/private/tls.key"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: federation-config
+data:
+  module-federation-config.json: |
+    [
+      {
+        "name": "modelRegistry",
+        "remoteEntry": "/remoteEntry.js",
+        "authorize": true,
+        "tls": true,
+        "proxy": [
+          {
+            "path": "/model-registry/api",
+            "pathRewrite": "/api"
+          }
+        ],
+        "local": {
+          "host": "localhost",
+          "port": 8080
+        },
+        "service": {
+          "name": "odh-dashboard",
+          "namespace": "opendatahub",
+          "port": 8043
+        }
+      }
+    ]

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+  - ../core-bases/base
+  - federation-configmap.yaml
+patchesJson6902:
+  - path: deployment.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: odh-dashboard
+  - path: service.yaml
+    target:
+      version: v1
+      kind: Service
+      name: odh-dashboard
+
+images:
+  - name: model-registry-ui
+    newName: quay.io/lferrnan/model-registry-ui-federated # TODO: Update to the correct image once we set up the module in konflux and onboard it in quay and parametrize this value
+    newTag: latest

--- a/manifests/modular-architecture/service.yaml
+++ b/manifests/modular-architecture/service.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/ports/-
+  value:
+    name: model-registry-ui
+    protocol: TCP
+    port: 8043
+    targetPort: 8043


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes https://issues.redhat.com/browse/RHOAIENG-25523

This pull request introduces significant updates to the frontend build system, module federation integration, and deployment configurations for the `model-registry` package. The changes include adding module federation support in the Webpack configuration, creating Dockerfile and Kubernetes manifests for the `model-registry` UI, and integrating a federation configuration for seamless service communication.

### Webpack Configuration Updates:
* Added module federation support by including `webpack.EnvironmentPlugin` and `moduleFederationPlugins` in `webpack.common.js` and removing unused references in `webpack.dev.js`. [[1]](diffhunk://#diff-dee600fced96e74e4aa60501779365784026a6be5bcc92b2b141b548aaa1e279R6-R9) [[2]](diffhunk://#diff-dee600fced96e74e4aa60501779365784026a6be5bcc92b2b141b548aaa1e279R237-R240) [[3]](diffhunk://#diff-750d30d2a7c8430eefeeb814949873eef27dd68057c78b4c31db33112f0ef37eL4) [[4]](diffhunk://#diff-750d30d2a7c8430eefeeb814949873eef27dd68057c78b4c31db33112f0ef37eL15-R14) [[5]](diffhunk://#diff-750d30d2a7c8430eefeeb814949873eef27dd68057c78b4c31db33112f0ef37eL169-L172)

### Dockerfile and Build Pipeline:
* Introduced a multi-stage Dockerfile for the `model-registry` package, defining separate stages for building the UI (`Node.js`) and backend (`Go`) components, and packaging them in a minimal distroless image.

### Kubernetes Manifests for Model Registry:
* Added Kubernetes manifests for deploying the `model-registry` UI, including deployment, service, service account, and role configurations. These enable secure and scalable deployment of the UI component. [[1]](diffhunk://#diff-a5d519d5842b9cc081e777d158e806b00b3e6071f2076de2583eac335516ad26R1-R13) [[2]](diffhunk://#diff-888529d6f8d50f3808ca9228320a2a05606c95224ea14f3e8bb72b78785a3255R1-R65) [[3]](diffhunk://#diff-783bac2e4b027fca42d44f643a083144eb927191fcc591baa53ef7db1ba5e7d2R1-R5) [[4]](diffhunk://#diff-3206ccff0f7aa130f112d3275a43876c2320f820395934d7df0d826cc40fd46dR1-R16) [[5]](diffhunk://#diff-61baeb77336ba3cfbb10f7e04b3ac1f1e91c769734867aff33fc78b2ec91b5e8R1-R77)

### Federation Configuration:
* Added a `federation-config` ConfigMap and updated deployment configurations to include module federation settings, enabling integration with other services in the Open Data Hub ecosystem. [[1]](diffhunk://#diff-769dfd70686efaba25c17f5a15f4605c47be32892ea205de277e3fe39116c7daR34-R39) [[2]](diffhunk://#diff-769dfd70686efaba25c17f5a15f4605c47be32892ea205de277e3fe39116c7daR144-R146) [[3]](diffhunk://#diff-9dae934d847b830667f12016afb542da8bbe61d0c3b4f06dc9849ca22ab8ea74R1-R29)

### Environment-Specific Customizations:
* Included a `kustomization.yaml` file for the `rhoai` environment to apply deployment-specific patches, such as enabling standalone mode and platform-specific arguments. [[1]](diffhunk://#diff-4dccebf0b61613342feaf7a91d58206ed3b11705692e73bd4259df9a426eed42R1-R13) [[2]](diffhunk://#diff-0f8d81d923fa418786d9800d93fa839c7ac194a2e4fc5a5464fc045e9d0f6e89R1-R6)

## Module Federation Testing

The ODH Dashboard application has been updated to use Module Federation, which allows dynamic loading of remote modules at runtime. However, this caused Cypress tests to fail because:

1. **Static Serving**: Tests serve a static build from `public-cypress` without a backend
2. **Missing Remote Endpoints**: Module federation requires `/_mf/` endpoints to serve remote entries
3. **Runtime Errors**: The app tries to load remote modules that return 404 in test environment

### Solution

We've implemented a multi-layered approach to handle module federation in tests:

#### 1. Build-time Module Federation Disabling

The webpack module federation configuration now checks for test environment variables:

```javascript
// In moduleFederation.js
const getModuleFederationConfig = () => {
  // Disable module federation for Cypress tests
  if (process.env.CYPRESS_TESTS === 'true' || process.env.DISABLE_MODULE_FEDERATION === 'true') {
    return [];
  }
  // ... rest of the config
};
```

#### 2. Updated Build Scripts

The Cypress build scripts now set the `CYPRESS_TESTS=true` environment variable:

```json
{
  "cypress:server:build": "ODH_DIST_DIR=./public-cypress POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 WS_HOSTNAME=localhost:9002 CYPRESS_TESTS=true npm run build",
  "cypress:server:build:coverage": "COVERAGE=true CYPRESS_TESTS=true npm run cypress:server:build",
  "cypress:server:dev": "POLL_INTERVAL=9999999 FAST_POLL_INTERVAL=9999999 ODH_PORT=9001 WS_HOSTNAME=localhost:9002 CYPRESS_TESTS=true npm run start:dev"
}
```

#### 3. Runtime Error Handling

Enhanced the `useAppExtensions.ts` hook to handle module federation failures gracefully:

- Added try-catch blocks around module federation initialization
- Added error handling for remote module loading
- Ensured the app continues to function even if remote modules fail to load

#### 4. Cypress Mocking Layer

Created comprehensive mocking for module federation in tests:

- **Mock Remote Entries**: Intercepts `/_mf/**/remoteEntry.js` requests
- **Mock Extensions**: Provides empty extension arrays for remote modules
- **Fallback Handling**: Returns 404 for other module federation requests

The mocking is implemented in:

- `cypress/utils/moduleFederationMock.ts` - Reusable mock utilities
- `cypress/support/e2e.ts` - Automatic setup for all tests

#### 5. Custom Cypress Command

Added a new Cypress command for easy module federation mocking:

```typescript
cy.setupModuleFederationMocks(['modelRegistry']);
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploying the whole application in modular architecture, there's a current deployment in:

https://oauth-openshift.apps.ui-monarch.dev.datahub.redhat.com/

Images used:

`quay.io/lferrnan/odh-dashboard:mod-arch-integration`

`quay.io/lferrnan/model-registry-ui-federated:latest`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced modular architecture manifests and configuration for model registry UI integration, including deployment, service, and ConfigMap resources.
  * Added a multi-stage Dockerfile to build and package the model registry frontend and backend components.

* **Improvements**
  * Enhanced error handling and logging for module federation initialization and extension loading.
  * Updated service and module federation configurations for improved integration and deployment flexibility.

* **Testing**
  * Added utilities and configuration to mock module federation during Cypress tests, improving test reliability and coverage.

* **Documentation**
  * Added a README with instructions for testing the modular architecture setup.

* **Chores**
  * Updated Kubernetes manifests and package configurations to support new architecture and deployment patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->