### PR TITLE
Serving refactor: Show deployments of all projects in global page

### DIFF
--- a/frontend/packages/modelServing/extension-points/index.ts
+++ b/frontend/packages/modelServing/extension-points/index.ts
@@ -130,7 +130,7 @@ export const isModelServingAuthExtension = <D extends Deployment = Deployment>(
 // Model serving deployments table extension
 
 export type DeploymentsTableColumn<D extends Deployment = Deployment> = SortableData<D> & {
-  cellRenderer: (deployment: D, column: string) => string;
+  cellRenderer: (deployment: D, column: string) => React.ReactNode;
 };
 
 export type ModelServingDeploymentsTableExtension<D extends Deployment = Deployment> = Extension<

--- a/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
@@ -20,7 +20,7 @@ import {
   isModelServingAuthExtension,
   isModelServingDeploymentResourcesExtension,
   isModelServingDeploymentsExpandedInfo,
-  ModelServingMetricsExtension,
+  isModelServingMetricsExtension,
 } from '../../../extension-points';
 
 export const DeploymentRow: React.FC<{
@@ -28,8 +28,9 @@ export const DeploymentRow: React.FC<{
   platformColumns: DeploymentsTableColumn[];
   onDelete: (deployment: Deployment) => void;
   rowIndex: number;
-  metricsExtension?: ModelServingMetricsExtension;
-}> = ({ deployment, platformColumns, onDelete, rowIndex, metricsExtension }) => {
+  showExpandedInfo?: boolean;
+}> = ({ deployment, platformColumns, onDelete, rowIndex, showExpandedInfo }) => {
+  const metricsExtension = useDeploymentExtension(isModelServingMetricsExtension, deployment);
   // Loads instantly so we know if the row is expandable
   const detailsExtension = useDeploymentExtension(
     isModelServingDeploymentsExpandedInfo,
@@ -54,7 +55,7 @@ export const DeploymentRow: React.FC<{
   return (
     <Tbody isExpanded={isExpanded}>
       <ResourceTr resource={deployment.model}>
-        {detailsExtension && (
+        {detailsExtension && showExpandedInfo && (
           <Td
             expand={{
               rowIndex,
@@ -119,6 +120,7 @@ export const DeploymentRow: React.FC<{
         </Td>
       </ResourceTr>
       {isExpanded &&
+        showExpandedInfo &&
         resolvedResourcesExtension &&
         resolvedExpandedInfoExtension &&
         resolvedAuthExtension && (

--- a/frontend/packages/modelServing/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -39,7 +39,6 @@ describe('DeploymentsTableRow', () => {
           platformColumns={[]}
           onDelete={onDelete}
           rowIndex={0}
-          metricsExtension={undefined}
         />
       </table>,
     );
@@ -77,7 +76,6 @@ describe('DeploymentsTableRow', () => {
           ]}
           onDelete={onDelete}
           rowIndex={0}
-          metricsExtension={undefined}
         />
       </table>,
     );
@@ -95,7 +93,6 @@ describe('DeploymentsTableRow', () => {
           platformColumns={[]}
           onDelete={onDelete}
           rowIndex={0}
-          metricsExtension={undefined}
         />
       </table>,
     );
@@ -120,7 +117,6 @@ describe('DeploymentsTableRow', () => {
             platformColumns={[]}
             onDelete={onDelete}
             rowIndex={0}
-            metricsExtension={undefined}
           />
         </table>,
       );
@@ -149,7 +145,6 @@ describe('DeploymentsTableRow', () => {
             platformColumns={[]}
             onDelete={onDelete}
             rowIndex={0}
-            metricsExtension={undefined}
           />
         </table>,
       );
@@ -183,7 +178,6 @@ describe('DeploymentsTableRow', () => {
             platformColumns={[]}
             onDelete={onDelete}
             rowIndex={0}
-            metricsExtension={undefined}
           />
         </table>,
       );
@@ -218,7 +212,6 @@ describe('DeploymentsTableRow', () => {
           platformColumns={[]}
           onDelete={onDelete}
           rowIndex={0}
-          metricsExtension={undefined}
         />
       </table>,
     );

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
@@ -1,5 +1,126 @@
 import React from 'react';
+import ModelServingToolbar from '@odh-dashboard/internal/pages/modelServing/screens/global/ModelServingToolbar';
+import {
+  initialModelServingFilterData,
+  type ModelServingFilterDataType,
+} from '@odh-dashboard/internal/pages/modelServing/screens/global/const';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
+import { namespaceToProjectDisplayName } from '@odh-dashboard/internal/concepts/projects/utils';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import { Label } from '@patternfly/react-core';
+import DeploymentsTable from '../deployments/DeploymentsTable';
+import {
+  isModelServingDeploymentsTableExtension,
+  isModelServingPlatformExtension,
+  type Deployment,
+  type DeploymentsTableColumn,
+} from '../../../extension-points';
 
-const GlobalDeploymentsTable: React.FC = () => <>Global Model Deployments Table</>;
+const ProjectCell: React.FC<{ deployment: Deployment; projects: ProjectKind[] }> = ({
+  deployment,
+  projects,
+}) => {
+  const platformLabel = useExtensions(isModelServingPlatformExtension);
+  const platform = platformLabel.find((p) => p.properties.id === deployment.modelServingPlatformId);
+  return (
+    <>
+      {namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)}
+      {platform && (
+        <Label data-testid="serving-platform-label" isCompact>
+          {platform.properties.enableCardText.enabledText}
+        </Label>
+      )}
+    </>
+  );
+};
+
+const projectColumn = (projects: ProjectKind[]): DeploymentsTableColumn => ({
+  field: 'project',
+  label: 'Project',
+  sortable: (deploymentA: Deployment, deploymentB: Deployment) =>
+    namespaceToProjectDisplayName(deploymentA.model.metadata.namespace, projects).localeCompare(
+      namespaceToProjectDisplayName(deploymentB.model.metadata.namespace, projects),
+    ),
+  cellRenderer: (deployment: Deployment) => (
+    <ProjectCell deployment={deployment} projects={projects} />
+  ),
+});
+
+const GlobalDeploymentsTable: React.FC<{ deployments: Deployment[]; loaded: boolean }> = ({
+  deployments,
+  loaded,
+}) => {
+  const { projects } = React.useContext(ProjectsContext);
+  const [filterData, setFilterData] = React.useState<ModelServingFilterDataType>(
+    initialModelServingFilterData,
+  );
+
+  const filteredDeployments = React.useMemo(
+    () =>
+      deployments.filter((deployment) => {
+        const nameFilter = filterData.Name?.toLowerCase();
+        const projectFilter = filterData.Project?.toLowerCase();
+
+        if (
+          nameFilter &&
+          !getDisplayNameFromK8sResource(deployment.model).toLowerCase().includes(nameFilter)
+        ) {
+          return false;
+        }
+
+        return (
+          !projectFilter ||
+          namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)
+            .toLowerCase()
+            .includes(projectFilter)
+        );
+      }),
+    [filterData, deployments, projects],
+  );
+
+  const [tableExtensions, tableExtensionsLoaded] = useResolvedExtensions(
+    isModelServingDeploymentsTableExtension,
+  );
+
+  const platformColumns = React.useMemo(() => {
+    const result: DeploymentsTableColumn<Deployment>[] = [];
+    // Add a generic 'project name' column
+    result.push(projectColumn(projects));
+    // Only add platform columns if all platforms have the same columns
+    if (tableExtensions.length > 0) {
+      const [firstExtension, ...restExtensions] = tableExtensions;
+      const firstExtensionColumns = firstExtension.properties.columns();
+      const commonColumns = firstExtensionColumns.filter((column) =>
+        restExtensions.every((a) => a.properties.columns().find((c) => c.field === column.field)),
+      );
+      result.push(...commonColumns);
+    }
+    return result;
+  }, [tableExtensions, projects]);
+
+  return (
+    <DeploymentsTable
+      deployments={filteredDeployments}
+      loaded={loaded && tableExtensionsLoaded}
+      platformColumns={platformColumns}
+      toolbarContent={
+        <ModelServingToolbar
+          filterData={filterData}
+          onFilterUpdate={(key, value) => setFilterData((prev) => ({ ...prev, [key]: value }))}
+        />
+      }
+      onClearFilters={() => setFilterData(initialModelServingFilterData)}
+      enablePagination
+      emptyTableView={
+        <DashboardEmptyTableView
+          onClearFilters={() => setFilterData(initialModelServingFilterData)}
+        />
+      }
+    />
+  );
+};
 
 export default GlobalDeploymentsTable;

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
@@ -27,7 +27,7 @@ const ProjectCell: React.FC<{ deployment: Deployment; projects: ProjectKind[] }>
   const platform = platformLabel.find((p) => p.properties.id === deployment.modelServingPlatformId);
   return (
     <>
-      {namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)}
+      {namespaceToProjectDisplayName(deployment.model.metadata.namespace, projects)}{' '}
       {platform && (
         <Label data-testid="serving-platform-label" isCompact>
           {platform.properties.enableCardText.enabledText}

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
@@ -37,6 +37,7 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ projects 
       headerContent={
         <ModelServingProjectSelection getRedirectPath={(ns: string) => `/model-serving/${ns}`} />
       }
+      provideChildrenPadding
     >
       <GlobalDeploymentsTable deployments={deployments ?? []} loaded />
     </ApplicationsPage>

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
@@ -10,28 +10,24 @@ import NoProjectsPage from './NoProjectsPage';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
 
 type GlobalDeploymentsViewProps = {
-  currentProject?: ProjectKind | null;
+  projects: ProjectKind[];
 };
 
-const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ currentProject }) => {
-  const {
-    deployments,
-    loaded: deploymentsLoaded,
-    projects,
-  } = React.useContext(ModelDeploymentsContext);
+const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ projects }) => {
+  const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
   const hasDeployments = deployments && deployments.length > 0;
   const isLoading = !deploymentsLoaded;
-  const isEmpty = projects?.length === 0 || (!isLoading && !hasDeployments);
+  const isEmpty = projects.length === 0 || (!isLoading && !hasDeployments);
 
   return (
     <ApplicationsPage
       loaded={!isLoading}
       empty={isEmpty}
       emptyStatePage={
-        projects?.length === 0 ? (
+        projects.length === 0 ? (
           <NoProjectsPage />
         ) : (
-          <GlobalNoModelsView project={currentProject ?? undefined} />
+          <GlobalNoModelsView project={projects.length === 1 ? projects[0] : undefined} />
         )
       }
       description="Manage and view the health and performance of your deployed models."
@@ -42,7 +38,7 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ currentPr
         <ModelServingProjectSelection getRedirectPath={(ns: string) => `/model-serving/${ns}`} />
       }
     >
-      <GlobalDeploymentsTable />
+      <GlobalDeploymentsTable deployments={deployments ?? []} loaded />
     </ApplicationsPage>
   );
 };

--- a/frontend/packages/modelServing/src/components/projectDetails/ModelsProjectDetailsView.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/ModelsProjectDetailsView.tsx
@@ -9,8 +9,8 @@ import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { useExtensions } from '@odh-dashboard/plugin-core';
 import { SelectPlatformView } from './SelectPlatformView';
 import { NoModelsView } from './NoModelsView';
+import { ProjectDeploymentsTable } from './ProjectDeploymentsTable';
 import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
-import DeploymentsTable from '../deployments/DeploymentsTable';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
 import { DeployButton } from '../deploy/DeployButton';
 import { isModelServingPlatformExtension } from '../../../extension-points';
@@ -95,7 +95,11 @@ const ModelsProjectDetailsView: React.FC<{
         (!hasModels ? (
           <NoModelsView platform={activePlatform} />
         ) : (
-          <DeploymentsTable modelServingPlatform={activePlatform} deployments={deployments} />
+          <ProjectDeploymentsTable
+            modelServingPlatform={activePlatform}
+            deployments={deployments}
+            loaded={deploymentsLoaded}
+          />
         ))}
     </DetailsSection>
   );

--- a/frontend/packages/modelServing/src/components/projectDetails/ProjectDeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/projectDetails/ProjectDeploymentsTable.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { usePlatformExtension, useResolvedPlatformExtension } from '../../concepts/extensionUtils';
+import DeploymentsTable from '../deployments/DeploymentsTable';
+import {
+  isModelServingDeploymentsExpandedInfo,
+  isModelServingDeploymentsTableExtension,
+  type Deployment,
+} from '../../../extension-points';
+import type { ModelServingPlatform } from '../../concepts/useProjectServingPlatform';
+
+export const ProjectDeploymentsTable: React.FC<{
+  modelServingPlatform: ModelServingPlatform;
+  deployments: Deployment[];
+  loaded: boolean;
+}> = ({ modelServingPlatform, deployments, loaded }) => {
+  const [tableExtension, tableExtensionLoaded] = useResolvedPlatformExtension(
+    isModelServingDeploymentsTableExtension,
+    modelServingPlatform,
+  );
+  const expandedInfoExtension = usePlatformExtension(
+    isModelServingDeploymentsExpandedInfo,
+    modelServingPlatform,
+  );
+
+  return (
+    <DeploymentsTable
+      deployments={deployments}
+      loaded={loaded && tableExtensionLoaded}
+      showExpandedInfo={!!expandedInfoExtension}
+      platformColumns={tableExtension?.properties.columns()}
+    />
+  );
+};

--- a/frontend/packages/modelServing/src/concepts/extensionUtils.ts
+++ b/frontend/packages/modelServing/src/concepts/extensionUtils.ts
@@ -38,13 +38,13 @@ export const useResolvedPlatformExtension = <T extends PlatformExtension>(
 
 export const useDeploymentExtension = <T extends PlatformExtension>(
   extensionPredicate: ExtensionPredicate<T>,
-  deployment: Deployment,
+  deployment?: Deployment,
 ): T | null => {
   const extensions = useExtensions<T>(extensionPredicate);
 
   return React.useMemo(
     () =>
-      extensions.find((ext) => ext.properties.platform === deployment.modelServingPlatformId) ??
+      extensions.find((ext) => ext.properties.platform === deployment?.modelServingPlatformId) ??
       null,
     [extensions, deployment],
   );
@@ -52,18 +52,18 @@ export const useDeploymentExtension = <T extends PlatformExtension>(
 
 export const useResolvedDeploymentExtension = <T extends PlatformExtension>(
   extensionPredicate: ExtensionPredicate<T>,
-  deployment: Deployment,
+  deployment?: Deployment | null,
 ): [ResolvedExtension<T> | null, boolean, unknown[]] => {
   const [resolvedExtensions, loaded, errors] = useResolvedExtensions<T>(extensionPredicate);
 
   return React.useMemo(
     () => [
       resolvedExtensions.find(
-        (ext) => ext.properties.platform === deployment.modelServingPlatformId,
+        (ext) => ext.properties.platform === deployment?.modelServingPlatformId,
       ) ?? null,
       loaded,
       errors,
     ],
-    [resolvedExtensions, deployment.modelServingPlatformId, loaded, errors],
+    [resolvedExtensions, deployment?.modelServingPlatformId, loaded, errors],
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-26257
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds the global model deployments page. On the top left you can change the selected project. The filtering also works. It will show the project name in the table.
Also i fixed a small bug where navigating to `.../mode-serving/ds2` wouldn't select the ds2 project automatically

![image](https://github.com/user-attachments/assets/f9b0feee-0f9d-4486-bb8a-20457a014a4b)
![image](https://github.com/user-attachments/assets/dc977bca-62e0-4b42-866c-97ae5cac6c54)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Toggle the `Model Serving Plugin` to `true`. And go to the left panel > Models > Model Deployments
By default it should show "All projects". If in your session you were last inside of a specific project, it will default to that (this is the "preferred project" mechanism in the dashboard). You can also change the project in the dropdown on the top left. You should be able to go through the different projects and it will show the corresponding deployments in that project. (Note there is no more loader screen when you go from "All projects" to a specific one, because there is no more loading, only when you go from a specifc to all.
Overall it should look and feel identical to the one before

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added 🙈 waiting on cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a fully functional, filterable global deployments table with project and platform columns, sorting, and pagination.
  * Added a dedicated deployments table component for project details, supporting platform-specific columns and expandable info.

* **Refactor**
  * Unified and simplified project selection and navigation logic across global model pages.
  * Generalized the deployments table to accept platform columns and loading state as props, removing internal extension resolution.
  * Updated components to handle multiple projects and clearer empty state logic.
  * Improved internal handling of deployment extensions for safer optional access.

* **Bug Fixes**
  * Improved type safety and rendering flexibility for table cell content.

* **Chores**
  * Updated test files to reflect the new component prop structure and removed obsolete props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->