### PR TITLE
Add skeleton for accelerator profile while loading

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -156,6 +156,7 @@ const ServingRuntimeSizeSection = ({
                 hasAdditionalPopoverInfo
                 currentProject={projectName}
                 initialState={podSpecOptionState.acceleratorProfile.initialState}
+                acceleratorProfilesLoaded={podSpecOptionState.acceleratorProfile.loaded}
                 compatibleIdentifiers={
                   servingRuntimeSelected ? getCompatibleIdentifiers(servingRuntimeSelected) : []
                 }

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -70,9 +70,9 @@ const ServingRuntimeSizeSection = ({
       const desc =
         name !== 'Custom'
           ? `Limits: ${size.resources.limits?.cpu || '??'} CPU, ` +
-            `${formatMemory(size.resources.limits?.memory) || '??'} Memory ` +
-            `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
-            `${formatMemory(size.resources.requests?.memory) || '??'} Memory`
+          `${formatMemory(size.resources.limits?.memory) || '??'} Memory ` +
+          `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
+          `${formatMemory(size.resources.requests?.memory) || '??'} Memory`
           : '';
       return { key: name, label: name, description: desc };
     });

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -70,9 +70,9 @@ const ServingRuntimeSizeSection = ({
       const desc =
         name !== 'Custom'
           ? `Limits: ${size.resources.limits?.cpu || '??'} CPU, ` +
-          `${formatMemory(size.resources.limits?.memory) || '??'} Memory ` +
-          `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
-          `${formatMemory(size.resources.requests?.memory) || '??'} Memory`
+            `${formatMemory(size.resources.limits?.memory) || '??'} Memory ` +
+            `Requests: ${size.resources.requests?.cpu || '??'} CPU, ` +
+            `${formatMemory(size.resources.requests?.memory) || '??'} Memory`
           : '';
       return { key: name, label: name, description: desc };
     });

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -49,6 +49,7 @@ type AcceleratorProfileSelectFieldProps = {
   formData: AcceleratorProfileFormData;
   isRequired?: boolean;
   setFormData: UpdateObjectAtPropAndValue<AcceleratorProfileFormData>;
+  acceleratorProfilesLoaded?: boolean;
 };
 
 const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps> = ({
@@ -61,6 +62,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
   isRequired = false,
   setFormData,
   currentProject,
+  acceleratorProfilesLoaded = false,
 }) => {
   const acceleratorCountWarning = useAcceleratorCountWarning(
     formData.count,
@@ -258,12 +260,6 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     }
   }
 
-  // add none option
-  options.push({
-    key: 'none',
-    label: 'None',
-  });
-
   if (initialState.unknownProfileDetected) {
     options.push({
       key: 'use-existing',
@@ -273,6 +269,15 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
   } else if (formData.profile && !formData.profile.spec.enabled) {
     options.push(formatOption(formData.profile));
   }
+
+  // add none option
+  options.push({
+    key: 'none',
+    label:
+      options.length > 0
+        ? 'None'
+        : 'No enabled or valid hardware profiles are available. Contact your administrator',
+  });
 
   return (
     <Stack hasGutter>
@@ -390,6 +395,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
                 }
               }}
               dataTestId="accelerator-profile-select"
+              isSkeleton={!acceleratorProfilesLoaded || !currentProjectAcceleratorProfilesLoaded}
             />
           )}
         </FormGroup>

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -276,7 +276,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
     label:
       options.length > 0
         ? 'None'
-        : 'No enabled or valid hardware profiles are available. Contact your administrator',
+        : 'No enabled or valid accelerator profiles are available. Contact your administrator',
   });
 
   return (

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -261,9 +261,8 @@ const SpawnerPage: React.FC = () => {
         tolerations: podSpecOptionsState.podSpecOptions.tolerations,
         nodeSelector: podSpecOptionsState.podSpecOptions.nodeSelector,
       }),
-      lastSelectedImage: `${selectedImageTag.image?.name ?? ''}:${
-        selectedImageTag.tag?.name ?? ''
-      }`,
+      lastSelectedImage: `${selectedImageTag.image?.name ?? ''}:${selectedImageTag.tag?.name ?? ''
+        }`,
     });
   };
 
@@ -362,6 +361,7 @@ const SpawnerPage: React.FC = () => {
                 />
                 <AcceleratorProfileSelectField
                   initialState={podSpecOptionsState.acceleratorProfile.initialState}
+                  acceleratorProfilesLoaded={podSpecOptionsState.acceleratorProfile.loaded}
                   formData={podSpecOptionsState.acceleratorProfile.formData}
                   setFormData={podSpecOptionsState.acceleratorProfile.setFormData}
                 />

--- a/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
+++ b/frontend/src/pages/notebookController/screens/server/SpawnerPage.tsx
@@ -261,8 +261,9 @@ const SpawnerPage: React.FC = () => {
         tolerations: podSpecOptionsState.podSpecOptions.tolerations,
         nodeSelector: podSpecOptionsState.podSpecOptions.nodeSelector,
       }),
-      lastSelectedImage: `${selectedImageTag.image?.name ?? ''}:${selectedImageTag.tag?.name ?? ''
-        }`,
+      lastSelectedImage: `${selectedImageTag.image?.name ?? ''}:${
+        selectedImageTag.tag?.name ?? ''
+      }`,
     });
   };
 

--- a/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingAcceleratorFormSection.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/trainingHardwareSection/TrainingAcceleratorFormSection.tsx
@@ -17,6 +17,7 @@ export const TrainingAcceleratorFormSection: React.FC<TrainingAcceleratorSection
       isRequired
       currentProject={projectName}
       initialState={podSpecOptionsState.acceleratorProfile.initialState}
+      acceleratorProfilesLoaded={podSpecOptionsState.acceleratorProfile.loaded}
       formData={podSpecOptionsState.acceleratorProfile.formData}
       setFormData={podSpecOptionsState.acceleratorProfile.setFormData}
     />

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -210,6 +210,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
       initialState: acceleratorProfileInitialState,
       formData: acceleratorProfileFormData,
       setFormData: setAcceleratorProfileFormData,
+      loaded: acceleratorProfilesLoaded,
     },
     hardwareProfile: { formData: hardwareProfileFormData },
   } = podSpecOptionsState;
@@ -307,6 +308,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                     }
                     initialState={acceleratorProfileInitialState}
                     formData={acceleratorProfileFormData}
+                    acceleratorProfilesLoaded={acceleratorProfilesLoaded}
                     setFormData={setAcceleratorProfileFormData}
                   />
                 </>

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -31,15 +31,6 @@ const useAcceleratorProfileFormState = (
   namespace?: string,
   acceleratorProfileNamespace?: string,
 ): UseAcceleratorProfileFormResult => {
-  const { dashboardNamespace } = useDashboardNamespace();
-
-  // Get the actual loading state from useAcceleratorProfiles
-  const [, globalProfilesLoaded, globalProfilesLoadError] =
-    useAcceleratorProfiles(dashboardNamespace);
-  const [, projectProfilesLoaded, projectProfilesLoadError] = useAcceleratorProfiles(
-    namespace ?? dashboardNamespace,
-  );
-
   const [globalScopedInitialState, globalScopedLoaded, globalScopedLoadError, refresh] =
     useReadAcceleratorState(resources, tolerations, existingAcceleratorProfileName);
   const [projectScopedInitialState, projectScopedLoaded, projectScopedLoadError] =
@@ -51,16 +42,11 @@ const useAcceleratorProfileFormState = (
       acceleratorProfileNamespace,
     );
 
-  const loaded = namespace
-    ? projectScopedLoaded && globalScopedLoaded && projectProfilesLoaded && globalProfilesLoaded
-    : globalScopedLoaded && globalProfilesLoaded;
+  const loaded = namespace ? projectScopedLoaded && globalScopedLoaded : globalScopedLoaded;
 
   const loadError = namespace
-    ? projectScopedLoadError ||
-      globalScopedLoadError ||
-      projectProfilesLoadError ||
-      globalProfilesLoadError
-    : globalScopedLoadError || globalProfilesLoadError;
+    ? projectScopedLoadError || globalScopedLoadError
+    : globalScopedLoadError;
 
   const initialState = React.useMemo(() => {
     // Check if project-scoped feature flag is off but workbench has project-scoped profile

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -2,8 +2,6 @@ import React from 'react';
 import { AcceleratorProfileKind } from '#~/k8sTypes';
 import { ContainerResources, Toleration } from '#~/types';
 import { UpdateObjectAtPropAndValue } from '#~/pages/projects/types';
-import useAcceleratorProfiles from '#~/pages/notebookController/screens/server/useAcceleratorProfiles.ts';
-import { useDashboardNamespace } from '#~/redux/selectors';
 import useGenericObjectState from './useGenericObjectState';
 import useReadAcceleratorState, { AcceleratorProfileState } from './useReadAcceleratorState';
 

--- a/frontend/src/utilities/useReadAcceleratorState.ts
+++ b/frontend/src/utilities/useReadAcceleratorState.ts
@@ -169,7 +169,7 @@ const useReadAcceleratorState = (
     dashboardNamespace,
   ]);
 
-  return useFetchState<AcceleratorProfileState>(
+  const [state, stateLoaded, stateError, refresh] = useFetchState<AcceleratorProfileState>(
     fetchAcceleratorState,
     {
       acceleratorProfiles: [],
@@ -179,6 +179,10 @@ const useReadAcceleratorState = (
     },
     { initialPromisePurity: true },
   );
+
+  const allLoaded = loaded && stateLoaded;
+  const actualError = loadError || stateError;
+  return [state, allLoaded, actualError, refresh];
 };
 
 export default useReadAcceleratorState;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-25721 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
For modals/forms that have an accelerator field, there is now a skeleton before all the profiles are loaded and filtered.


https://github.com/user-attachments/assets/98d41976-21e1-4b9d-b3ca-8edb96a4b067

When there are no accelerator profiles, a new message is displayed:

![Screenshot 2025-07-07 at 11 02 45 AM](https://github.com/user-attachments/assets/991e552e-3a47-4a06-945d-bcfb63947c49)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Anywhere there is an AcceleratorProfileSelectField component, this change can be seen. This includes:
- Project -> create workbench
- Application -> enabled -> start basic workbench
- Project -> models -> deploy model

With no available accelerator profiles, the message should show with the selection disabled. When there are profiles, they should be listed.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Tested the changed components with successful accelerator profile fetches, unsuccessful fetches, with multiple profiles, 1 profile, and none available.

No tests were added since this change is just a text change with loading indicator. Existing tests already cover the required functionality of accelerator profile select fields.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved loading indicators and user feedback when selecting accelerator profiles, including a loading skeleton state during data fetching.
  * Enhanced messaging when no valid hardware profiles are available in selection dropdowns.
  * Added UI behavior to disable accelerator profile selection and display informative messages when no profiles are available.

* **Bug Fixes**
  * Resolved duplicated "none" option in accelerator profile selection.

* **Refactor**
  * Unified loading and error handling for accelerator profile selection across multiple sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->