### PR TITLE
Retrieve default local queue name from DSC

### DIFF
--- a/frontend/src/__mocks__/mockDsc.ts
+++ b/frontend/src/__mocks__/mockDsc.ts
@@ -38,6 +38,11 @@ export const mockDsc = ({
           name: 'knative-serving',
         },
       },
+      kueue: {
+        defaultClusterQueueName: 'default',
+        defaultLocalQueueName: 'default',
+        managementState: 'Managed',
+      },
     },
   },
   status: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/manageHardwareProfiles.cy.ts
@@ -9,6 +9,7 @@ import {
   HardwareProfileModel,
   AcceleratorProfileModel,
   WorkloadPriorityClassModel,
+  DataScienceClusterModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { asProductAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
@@ -29,6 +30,7 @@ import {
 import { migrationModal } from '#~/__tests__/cypress/cypress/pages/components/MigrationModal';
 import { mock200Status, mockDashboardConfig } from '#~/__mocks__';
 import { mockWorkloadPriorityClassK8sResource as mockWorkloadPriorityClass } from '#~/__mocks__/mockWorkloadPriorityClassK8Resource';
+import { mockDsc } from '#~/__mocks__/mockDsc';
 
 type HandlersProps = {
   isPresent?: boolean;
@@ -120,6 +122,8 @@ function setupIntercepts({ disableKueue = false, isPresent = true, withLocalQueu
     { model: HardwareProfileModel, ns: 'opendatahub', name: 'test-hardware-profile' },
     isPresent ? makeProfile({ withLocalQueue }) : { statusCode: 404 },
   );
+
+  cy.interceptK8sList({ model: DataScienceClusterModel }, mockK8sResourceList([mockDsc({})]));
 }
 
 describe('Manage Hardware Profile', () => {
@@ -957,7 +961,7 @@ describe('Manage Hardware Profile', () => {
       // The default workload allocation strategy pick should be 'Local queue'
       createHardwareProfile.findLocalQueueRadio().should('be.checked');
 
-      // The default local queue value is ''
+      // The default local queue value is 'default'
       createHardwareProfile.findLocalQueueInput().should('have.value', 'default');
 
       // The default workload priority is None, and is optional
@@ -989,7 +993,7 @@ describe('Manage Hardware Profile', () => {
 
       // Switch back to local queue and set values
       createHardwareProfile.findLocalQueueRadio().click();
-      createHardwareProfile.findLocalQueueInput().clear().type('my-queue');
+      createHardwareProfile.findLocalQueueInput().fill('my-queue');
       createHardwareProfile.selectWorkloadPriority('high');
 
       cy.interceptK8s(
@@ -1030,7 +1034,7 @@ describe('Manage Hardware Profile', () => {
       editHardwareProfile.findWorkloadPrioritySelect().should('contain.text', 'high');
 
       // Update the values
-      editHardwareProfile.findLocalQueueInput().clear().type('updated-queue');
+      editHardwareProfile.findLocalQueueInput().fill('updated-queue');
       editHardwareProfile.selectWorkloadPriority('medium');
 
       cy.interceptK8s(

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1413,6 +1413,10 @@ export type DataScienceClusterKind = K8sResourceCommon & {
       [DataScienceStackComponent.MODEL_REGISTRY]?: DataScienceClusterComponent & {
         registriesNamespace: string;
       };
+      [DataScienceStackComponent.KUEUE]?: DataScienceClusterComponent & {
+        defaultLocalQueueName: string;
+        defaultClusterQueueName: string;
+      };
     };
   };
   status?: DataScienceClusterKindStatus;

--- a/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
@@ -89,9 +89,6 @@ export const DEFAULT_MEMORY_SIZE = {
 export const DEFAULT_CPU_IDENTIFIER = 'cpu';
 export const DEFAULT_MEMORY_IDENTIFIER = 'memory';
 
-// Default local queue name reference:
-// https://github.com/opendatahub-io/opendatahub-operator/pull/2131/files
-export const DEFAULT_LOCAL_QUEUE = 'default';
 export const DEFAULT_PRIORITY_CLASS = 'None';
 
 export const HARDWARE_PROFILE_RESOURCE_ALLOCATION_HELP = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-29134

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The default local queue name is configurable through the DSC. Therefore, in the HWP create/edit page, under the Resource allocation section, the default local queue name displayed in the text input should match the one in the DSC.
Ref: https://github.com/opendatahub-io/opendatahub-operator/pull/2131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The platform team's kueue integration is still ongoing, however they've kindly provided us with an operator image with up-to-date changes required to test this PR.

<img width="394" height="395" alt="image" src="https://github.com/user-attachments/assets/2fb64cc3-4a86-4bdd-95b2-372edee7308d" />
<img width="487" height="87" alt="image" src="https://github.com/user-attachments/assets/9ff74288-5dea-44d9-8584-886d2fa4f085" />


_Instructions to deploy the operator image:_ 

**Note: you can also reach out to me directly for access to a cluster with everything already configured.**

- Uninstall ODH operator (if applicable)
- In the opendatahub-operator repo, checkout the following PR: https://github.com/opendatahub-io/opendatahub-operator/pull/2080
- From the root, run the following command:
```
make deploy IMG=quay.io/csantiago/opendatahub-operator OPERATOR_NAMESPACE=opendatahub-operator-system
```
 Note: You won't see the ODH operator under Installed Operators, but you should see the odh deployments under Workloads > Deployments
- Find DSC and DSCI resources under Home > Search > Resources, and create default instances for both. The default option won't be presented, you would need to refer to another cluster with a recent odh version with existing `default-dsc` and `default-dsci` and copy the yaml. 
- Go to Administration > CustomResourceDefinitions > Search HardwareProfile . Verify that it exists with both `dashboard.opendatahub.io` and `infrastructure.opendatahub.io` groups.

_Testing:_ 

- In the console, go to the DSC yaml, and verify that `spec.components.kueue` contains fields `defaultLocalQueueName` and `defaultClusterQueueName`
- Change those values to whatever you prefer
- Through dashboard, while running the frontend locally, navigate to the HWP create / edit page. Under the Resource allocation section, check that the local queue text input has loaded the corresponding `defaultLocalQueueName` value you changed earlier. 
- Verify that it only loads to the default when creating a new HWP or editing a HWP without local queue configured. When editing a HWP with local queue configured, the text input loads the configured local queue name.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested manually as described above, updated cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The default local queue name for hardware profiles is now dynamically fetched from cluster settings instead of being hardcoded.

* **Bug Fixes**
  * Improved consistency in input handling for local queue names during hardware profile creation and editing.

* **Tests**
  * Updated tests to better reflect dynamic queue name defaults and improved input simulation for hardware profile management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->