### PR TITLE
RHOAIENG-29339: rework testWorkbenchImages

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchImages.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchImages.cy.ts
@@ -66,16 +66,22 @@ describe('Workbenches - image/version tests', () => {
           cy.log(`Checking image: ${info.image}`);
           createSpawnerPage.findNotebookImage(info.image).click();
 
-          // Log all elements with data-testid attributes in the version selection area
-          cy.get('[data-testid*="-version-"]').then(($elements) => {
-            cy.log(`Found ${$elements.length} version elements for ${info.image}`);
-            $elements.each((_, el) => {
-              const dataTestId = el.getAttribute('data-testid');
-              if (dataTestId) {
-                cy.log(`Version element data-testid: ${dataTestId}`);
-              }
+          // Only validate if there are 2 or more non-outdated versions
+          if (info.versions.length >= 2) {
+            cy.get('[data-testid*="-version-"]').then(($elements) => {
+              cy.log(`Found ${$elements.length} version elements for ${info.image}`);
+              $elements.each((_, el) => {
+                const dataTestId = el.getAttribute('data-testid');
+                if (dataTestId) {
+                  cy.log(`Version element data-testid: ${dataTestId}`);
+                }
+              });
             });
-          });
+          } else {
+            cy.log(
+              `Skipping UI version validation for ${info.image} (only 1 non-outdated version)`,
+            );
+          }
         });
       });
     },


### PR DESCRIPTION
…date UI version dropdown for images with 2+ non-outdated versions\n\nThis change updates the Cypress workbench image/version test to:\n- Filter out outdated notebook image tags (using the opendatahub.io/image-tag-outdated annotation)\n- Only validate the UI version dropdown when there are 2 or more non-outdated versions for an image\n- Skip UI validation for images with only 1 non-outdated version, matching current UI behavior\n\nThis ensures the test is robust and cluster-agnostic, and resolves failures due to outdated or single-version images.\n\nJira: https://issues.redhat.com/browse/RHOAIENG-29339

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
