### PR TITLE
Fix loading state and stopped state for inference service endpoint

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -39,8 +39,11 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
   const modelMesh = isModelMesh(inferenceService);
   const modelMetricsSupported = modelMetricsEnabled && (modelMesh || kserveMetricsEnabled);
 
-  const { isStarting, isStopping, isStopped } = useModelStatus(inferenceService);
-  const isNewlyDeployed = !inferenceService.status?.modelStatus?.states?.activeModelState;
+  const { isStarting, isStopping, isStopped, isRunning } = useModelStatus(inferenceService);
+  const isNewlyDeployed = React.useMemo(
+    () => !inferenceService.status?.modelStatus?.states?.activeModelState,
+    [inferenceService.status?.modelStatus?.states?.activeModelState],
+  );
 
   const inferenceServiceDisplayName = getDisplayNameFromK8sResource(inferenceService);
 
@@ -105,6 +108,12 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
             inferenceService={inferenceService}
             servingRuntime={servingRuntime}
             isKserve={!isModelMesh(inferenceService)}
+            modelState={{
+              isStarting: isStarting || isNewlyDeployed,
+              isStopping,
+              isStopped,
+              isRunning,
+            }}
           />
         </CardFooter>
       </TypeBorderedCard>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-27147
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes a bug where an external model would stay in loading state when it was stopped.

Also removes the state toggle from model mesh
## How Has This Been Tested?
1. Deploy an external kserve model
2. stop the model
3. Check the endpoint to see service isn't enabled
4. start model
5. check endpoint to see loading state until the model is running and shows the URL's

Also check that model mesh models don't have start stop
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<img width="1021" height="341" alt="Screenshot From 2025-07-11 08-10-09" src="https://github.com/user-attachments/assets/695fe558-5e86-419a-a0f7-87886eedab6c" />
<img width="1021" height="341" alt="Screenshot From 2025-07-11 08-10-24" src="https://github.com/user-attachments/assets/05f7ebef-b159-4980-ab97-44dc82e425a8" />

<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The display of external service endpoints now adapts based on the model's current state, showing relevant messages or loading indicators as appropriate.
  * The external service URL presentation is enhanced with conditional suffixes and improved clipboard functionality.

* **Refactor**
  * Improved state management and rendering logic for model deployment cards and service endpoints, resulting in more accurate and responsive status displays.
  * Optimized component rendering with memoization and conditional toggles to streamline user interface behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->