### PR TITLE
Update Label url to Internal

### DIFF
--- a/frontend/packages/kserve/src/deploymentEndpoints.ts
+++ b/frontend/packages/kserve/src/deploymentEndpoints.ts
@@ -11,13 +11,13 @@ export const getKServeDeploymentEndpoints = (
   const endpoints: DeploymentEndpoint[] = [];
   if (inferenceService.status?.address?.url) {
     endpoints.push({
-      name: 'url',
+      name: 'Internal (can be accessed from inside or outside the cluster)',
       type: 'internal',
       url: inferenceService.status.address.url,
     });
   } else {
     endpoints.push({
-      name: 'url',
+      name: 'Internal (can be accessed from inside or outside the cluster)',
       type: 'internal',
       url: '',
       error: 'Could not find any internal service enabled',

--- a/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InternalServicePopoverContent.tsx
@@ -31,7 +31,7 @@ const InternalServicePopoverContent: React.FC<InternalServicePopoverContentProps
     return (
       <DescriptionList isCompact>
         <DescriptionListGroup>
-          <DescriptionListTerm>url</DescriptionListTerm>
+          <DescriptionListTerm>Internal (can only be accessed from inside the cluster)</DescriptionListTerm>
           <DescriptionListDescription>
             <ClipboardCopy
               hoverTip="Copy"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-27443

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Update the internal "url" to "Internal (can only be accessed from inside the cluster)"
Currently, the internal inference endpoint Label is "url". Update it to "Internal (can only be accessed from inside the cluster)" for both the refactor and the old model serving code.
old model serving code:
old:
<img width="1217" height="401" alt="Screenshot 2025-07-11 at 9 57 48 AM" src="https://github.com/user-attachments/assets/4109640e-1df4-4f8f-b580-e00e9d1a8e73" />
 new:
<img width="1499" height="602" alt="Screenshot 2025-07-11 at 10 06 23 AM" src="https://github.com/user-attachments/assets/dbb2818f-fedf-40b5-821e-1380fc9aa1b3" />

Refactor code:
<img width="1246" height="694" alt="Screenshot 2025-07-11 at 10 08 58 AM" src="https://github.com/user-attachments/assets/8e20a387-01ff-4bf7-8a88-ae03eb9b4b96" />
old:
<img width="1499" height="602" alt="Screenshot 2025-07-11 at 9 59 27 AM" src="https://github.com/user-attachments/assets/7a0cc3e4-5600-48ea-8287-f02eca2b6a3f" />
new:
<img width="1202" height="531" alt="Screenshot 2025-07-11 at 10 08 29 AM" src="https://github.com/user-attachments/assets/44c6435c-de9f-434b-8b36-d8aef10fadb4" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, used Zaffre Shared Clusters Env.
To test:
1. Deployed single serving model successfully.
2. Point to Internal and External endpoints link for popover.
3. Verfied manually Internal Label updated from "url" to "Internal (can only be accessed from inside the cluster)"
4. Similar steps for new Refactor code.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
**No New Tests are added.**
Run **npm run test**
<img width="735" height="298" alt="Screenshot 2025-07-11 at 10 28 02 AM" src="https://github.com/user-attachments/assets/14beba49-a506-4ff6-ad33-7ccce7d575ef" />

No Unit Tests Failed.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the label for internal deployment endpoints to provide a more descriptive name, improving clarity for users viewing endpoint information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->