### PR TITLE
Kueue extras

### DIFF
--- a/frontend/packages/kserve/src/useKServeResources.ts
+++ b/frontend/packages/kserve/src/useKServeResources.ts
@@ -8,6 +8,7 @@ export const useKServeResources = (
   const resources = useModelServingPodSpecOptionsState(
     kserveDeployment.server,
     kserveDeployment.model,
+    false,
   );
 
   return resources;

--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -37,6 +37,9 @@ type MockResourceConfigType = {
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;
   isNonDashboardItem?: boolean;
+  hardwareProfileName?: string;
+  hardwareProfileNamespace?: string;
+  useLegacyHardwareProfile?: boolean;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -106,6 +109,9 @@ export const mockInferenceServiceK8sResource = ({
   tolerations,
   nodeSelector,
   isNonDashboardItem = false,
+  hardwareProfileName = '',
+  hardwareProfileNamespace = undefined,
+  useLegacyHardwareProfile = false,
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -123,6 +129,13 @@ export const mockInferenceServiceK8sResource = ({
           'sidecar.istio.io/inject': 'true',
           'sidecar.istio.io/rewriteAppHTTPProbers': 'true',
         }),
+      ...(hardwareProfileName && {
+        [`opendatahub.io/${useLegacyHardwareProfile ? 'legacy-' : ''}hardware-profile-name`]:
+          hardwareProfileName,
+      }),
+      ...(hardwareProfileNamespace && {
+        'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
+      }),
     },
     creationTimestamp: '2023-03-17T16:12:41Z',
     ...(deleted ? { deletionTimestamp: new Date().toUTCString() } : {}),

--- a/frontend/src/__mocks__/mockInferenceServiceModalData.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceModalData.ts
@@ -27,6 +27,7 @@ export const mockInferenceServiceModalData = ({
   tokenAuth = false,
   tokens = [],
   isKServeRawDeployment,
+  dashboardNamespace = 'opendatahub',
 }: MockResourceConfigType): CreatingInferenceServiceObject => ({
   name,
   k8sName,
@@ -41,4 +42,5 @@ export const mockInferenceServiceModalData = ({
   tokenAuth,
   tokens,
   isKServeRawDeployment,
+  dashboardNamespace,
 });

--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -65,6 +65,9 @@ export const mockNimInferenceService = ({
     displayName,
     namespace,
     kserveInternalLabel: true,
+    hardwareProfileNamespace: 'opendatahub',
+    hardwareProfileName: 'migrated-gpu-mglzi-serving',
+    useLegacyHardwareProfile: true,
     resources: {
       limits: { cpu: '16', memory: '64Gi' },
       requests: { cpu: '8', memory: '32Gi' },

--- a/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeK8sResource.ts
@@ -150,8 +150,7 @@ export const mockServingRuntimeK8sResource = ({
     annotations: {
       'opendatahub.io/template-display-name': templateDisplayName,
       'opendatahub.io/accelerator-name': acceleratorName,
-      'opendatahub.io/hardware-profile-name': hardwareProfileName,
-
+      ...(hardwareProfileName && { 'opendatahub.io/hardware-profile-name': hardwareProfileName }),
       'opendatahub.io/template-name': templateName,
       'openshift.io/display-name': displayName,
       'opendatahub.io/apiProtocol': apiProtocol,

--- a/frontend/src/__mocks__/mockStartNotebookData.ts
+++ b/frontend/src/__mocks__/mockStartNotebookData.ts
@@ -73,6 +73,7 @@ export const mockStartNotebookData = ({
       name: volumeName,
     },
   ],
+  dashboardNamespace: 'opendatahub',
 });
 
 export const mockStorageData: StorageData[] = [

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -783,21 +783,36 @@ describe('Model Serving Global', () => {
     hardwareProfileSection.findGlobalScopedLabel().should('exist');
   });
 
-  it('Display project scoped label on serving runtime selection on Edit', () => {
+  it('Display project scoped hardware profile on serving runtime selection on Edit', () => {
     initIntercepts({
       projectEnableModelMesh: false,
       disableServingRuntimeParamsConfig: false,
       disableProjectScoped: false,
       disableHardwareProfiles: false,
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          namespace: 'test-project',
           hardwareProfileName: 'large-profile-1',
           hardwareProfileNamespace: 'test-project',
+          resources: {
+            requests: {
+              cpu: '4',
+              memory: '8Gi',
+            },
+            limits: {
+              cpu: '8',
+              memory: '16Gi',
+            },
+          },
         }),
       ],
+      servingRuntimes: [mockServingRuntimeK8sResource({})],
     });
+
     modelServingGlobal.visit('test-project');
     modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
+
+    hardwareProfileSection.findHardwareProfileSearchSelector().should('be.visible');
     hardwareProfileSection
       .findHardwareProfileSearchSelector()
       .should('contain.text', 'Large Profile-1');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -485,7 +485,6 @@ describe('Model Serving Global', () => {
       }); // KServe should send resources in ServingRuntime after migration
       servingRuntimeMockNoResources.metadata.annotations = {
         ...servingRuntimeMockNoResources.metadata.annotations,
-        'opendatahub.io/legacy-hardware-profile-name': '',
       };
       delete servingRuntimeMock.metadata.annotations?.['enable-auth'];
       delete servingRuntimeMock.metadata.annotations?.['enable-route'];
@@ -717,15 +716,21 @@ describe('Model Serving Global', () => {
   });
 
   it('Display project scoped label on serving runtime selection on Edit', () => {
+    const projectScopedServingRuntime = mockServingRuntimeK8sResource({
+      name: 'test-project-scoped-sr',
+      isProjectScoped: true,
+      scope: 'project',
+      templateDisplayName: 'test-project-scoped-sr',
+    });
+
     initIntercepts({
       projectEnableModelMesh: false,
       disableServingRuntimeParamsConfig: false,
       disableProjectScoped: false,
-      servingRuntimes: [
-        mockServingRuntimeK8sResource({
-          isProjectScoped: true,
-          scope: 'project',
-          templateDisplayName: 'test-project-scoped-sr',
+      servingRuntimes: [projectScopedServingRuntime],
+      inferenceServices: [
+        mockInferenceServiceK8sResource({
+          modelName: 'test-project-scoped-sr', // Set runtime to match serving runtime name
         }),
       ],
     });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -2615,7 +2615,7 @@ describe('Serving Runtime List', () => {
         .should('have.text', 'AcceleratorSmall Profile Project-scoped');
     });
 
-    it('Check project-scoped hardware when enabled and selected', () => {
+    it('should not display hardware profile section when project is model mesh enabled and hardware profile flag is enabled', () => {
       initIntercepts({
         projectEnableModelMesh: true,
         disableKServeConfig: false,
@@ -2633,12 +2633,10 @@ describe('Serving Runtime List', () => {
 
       projectDetails.visitSection('test-project', 'model-server');
       modelServingSection.findModelServer().click();
-      modelServingSection
-        .findHardwareSection()
-        .should('have.text', 'Large Profile-1Project-scoped');
+      modelServingSection.findHardwareSection().should('not.exist');
     });
 
-    it('should display hardware profile selection when both hardware profile and project-scoped feature flag is enabled for Model mesh, while adding model server', () => {
+    it('should not display hardware profile selection when both hardware profile and project-scoped feature flag is enabled for Model mesh, while adding model server', () => {
       initIntercepts({
         projectEnableModelMesh: true,
         disableKServeConfig: false,
@@ -2666,32 +2664,10 @@ describe('Serving Runtime List', () => {
 
       createServingRuntimeModal.shouldBeOpen();
 
-      // Verify hardware profile section exists
-      hardwareProfileSection.findHardwareProfileSearchSelector().should('exist');
-      hardwareProfileSection.findHardwareProfileSearchSelector().click();
-
-      // verify available project-scoped hardware profile
-      const projectScopedHardwareProfile = hardwareProfileSection.getProjectScopedHardwareProfile();
-      projectScopedHardwareProfile
-        .find()
-        .findByRole('menuitem', {
-          name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
-          hidden: true,
-        })
-        .click();
-      hardwareProfileSection.findProjectScopedLabel().should('exist');
-
-      // verify available global-scoped hardware profile
-      hardwareProfileSection.findHardwareProfileSearchSelector().click();
-      const globalScopedHardwareProfile = hardwareProfileSection.getGlobalScopedHardwareProfile();
-      globalScopedHardwareProfile
-        .find()
-        .findByRole('menuitem', {
-          name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
-          hidden: true,
-        })
-        .click();
-      hardwareProfileSection.findGlobalScopedLabel().should('exist');
+      // Verify hardware profile section is missing
+      hardwareProfileSection.findHardwareProfileSearchSelector().should('not.exist');
+      // replaced by the Model server size section
+      createServingRuntimeModal.findModelServerSizeSelect().should('exist');
     });
 
     it('should display hardware profile selection when both hardware profile and project-scoped feature flag is enabled for Model mesh, while editing model server', () => {
@@ -2728,10 +2704,7 @@ describe('Serving Runtime List', () => {
 
       editServingRuntimeModal.shouldBeOpen();
 
-      hardwareProfileSection
-        .findHardwareProfileSearchSelector()
-        .should('contain.text', 'Large Profile-1');
-      hardwareProfileSection.findProjectScopedLabel().should('exist');
+      hardwareProfileSection.findHardwareProfileSearchSelector().should('not.exist');
     });
 
     it('Edit ModelMesh model server', () => {

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -6,7 +6,6 @@ import {
   K8sStatus,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { mockAcceleratorProfile } from '#~/__mocks__/mockAcceleratorProfile';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import { mockInferenceServiceModalData } from '#~/__mocks__/mockInferenceServiceModalData';
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
@@ -29,6 +28,7 @@ import { ModelServingPodSpecOptions } from '#~/concepts/hardwareProfiles/useMode
 import { DeploymentMode, InferenceServiceKind, ProjectKind } from '#~/k8sTypes';
 import { ModelServingSize } from '#~/pages/modelServing/screens/types';
 import { TolerationEffect, TolerationOperator } from '#~/types';
+import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile.ts';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sListResource: jest.fn(),
@@ -167,7 +167,7 @@ describe('assembleInferenceService', () => {
     expect(inferenceService.metadata.annotations?.['openshift.io/display-name']).toBe(name);
   });
 
-  it('should add resources and tolerations if kserve and podSpecOptions found', async () => {
+  it('should add resources but not tolerations even if kserve and podSpecOptions found', async () => {
     const podSpecOption: ModelServingPodSpecOptions = mockModelServingPodSpecOptions({
       resources: {
         requests: {
@@ -195,10 +195,8 @@ describe('assembleInferenceService', () => {
       podSpecOption,
     );
 
-    expect(inferenceService.spec.predictor.tolerations).toBeDefined();
-    expect(inferenceService.spec.predictor.tolerations?.[0].key).toBe(
-      mockAcceleratorProfile({}).spec.tolerations?.[0].key,
-    );
+    expect(inferenceService.spec.predictor.tolerations).toBeUndefined();
+    expect(inferenceService.spec.predictor.model?.resources).toBeDefined();
     expect(inferenceService.spec.predictor.model?.resources?.limits?.['nvidia.com/gpu']).toBe(1);
     expect(inferenceService.spec.predictor.model?.resources?.requests?.['nvidia.com/gpu']).toBe(1);
   });
@@ -349,7 +347,7 @@ describe('assembleInferenceService', () => {
     );
   });
 
-  it('should omit requests on modelmesh', async () => {
+  it('should add requests on kserve but omit on modelmesh', async () => {
     const podSpecOption: ModelServingPodSpecOptions = mockModelServingPodSpecOptions({
       resources: {
         requests: {
@@ -363,7 +361,8 @@ describe('assembleInferenceService', () => {
       },
     });
 
-    const inferenceService = assembleInferenceService(
+    // Test with modelmesh
+    const inferenceServiceModelMesh = assembleInferenceService(
       mockInferenceServiceModalData({}),
       undefined,
       undefined,
@@ -373,7 +372,24 @@ describe('assembleInferenceService', () => {
       podSpecOption,
     );
 
-    expect(inferenceService.spec.predictor.model?.resources).toBeUndefined();
+    expect(inferenceServiceModelMesh.spec.predictor.model?.resources).toBeUndefined();
+
+    // Test with KServe
+    const inferenceServiceKServe = assembleInferenceService(
+      mockInferenceServiceModalData({}),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOption,
+    );
+
+    expect(inferenceServiceKServe.spec.predictor.model?.resources).toBeDefined();
+    expect(inferenceServiceKServe.spec.predictor.model?.resources?.requests?.cpu).toBe('1');
+    expect(inferenceServiceKServe.spec.predictor.model?.resources?.requests?.memory).toBe('1Gi');
+    expect(inferenceServiceKServe.spec.predictor.model?.resources?.limits?.cpu).toBe('2');
+    expect(inferenceServiceKServe.spec.predictor.model?.resources?.limits?.memory).toBe('2Gi');
   });
 
   it('should have base annotations for kserve raw', async () => {
@@ -428,6 +444,146 @@ describe('assembleInferenceService', () => {
     expect(both.metadata.labels?.['networking.kserve.io/visibility']).toBe('exposed');
     expect(both.metadata.labels?.['networking.knative.dev/visibility']).toBe(undefined);
   });
+
+  it('should set hardware profile annotation for real profiles', () => {
+    const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
+    hardwareProfile.metadata.uid = 'test-uid';
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
+      'real-profile',
+    );
+  });
+
+  it('should set hardware profile namespace annotation for real profiles if not model mesh', () => {
+    const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
+    hardwareProfile.metadata.uid = 'test-uid';
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
+      'real-profile',
+    );
+  });
+
+  it('should set hardware profile namespace annotation to dashboard namespace when global scoped and not model mesh', () => {
+    const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-namespace']).toBe(
+      'opendatahub',
+    );
+  });
+
+  it('should not set hardware profile name and namespace annotation for real profiles if model mesh', () => {
+    const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
+    hardwareProfile.metadata.uid = 'test-uid';
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBeUndefined();
+    expect(
+      result.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'],
+    ).toBeUndefined();
+  });
+
+  it('should not set pod specs like tolerations and nodeSelector for hardware profiles', () => {
+    const hardwareProfile = mockHardwareProfile({});
+    hardwareProfile.metadata.uid = 'test-uid'; // not a legacy hardware profile
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+
+    // Test with modelmesh
+    const resultModelMesh = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+
+    expect(resultModelMesh.spec.tolerations).toBeUndefined();
+    expect(resultModelMesh.spec.nodeSelector).toBeUndefined();
+
+    // Test with KServe
+    const resultKServe = assembleInferenceService(
+      mockInferenceServiceModalData({
+        isKServeRawDeployment: true,
+        externalRoute: true,
+        tokenAuth: true,
+      }),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+
+    expect(resultKServe.spec.predictor.tolerations).toBeUndefined();
+    expect(resultKServe.spec.predictor.nodeSelector).toBeUndefined();
+  });
 });
 
 describe('listInferenceService', () => {
@@ -455,6 +611,7 @@ describe('listInferenceService', () => {
     });
   });
 });
+
 describe('listScopedInferenceService', () => {
   it('should return list of scoped inference service with no label selector', async () => {
     const inferenceServiceMock = mockInferenceServiceK8sResource({});

--- a/frontend/src/api/k8s/__tests__/notebooks.spec.ts
+++ b/frontend/src/api/k8s/__tests__/notebooks.spec.ts
@@ -336,6 +336,17 @@ describe('assembleNotebook', () => {
     expect(result.spec.template.spec.nodeSelector).toBeUndefined();
   });
 
+  it('should set hardware profile namespace annotation to dashboard namespace when global scoped', () => {
+    const notebookData = mockStartNotebookData({});
+    const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
+    hardwareProfile.metadata.uid = 'test-uid';
+    notebookData.podSpecOptions.selectedHardwareProfile = hardwareProfile;
+    const result = assembleNotebook(notebookData, 'test-user');
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-namespace']).toBe(
+      'opendatahub',
+    );
+  });
+
   it('should create a notebook with pipelines without volumes and volumes mount', async () => {
     const startNotebookDataMock = mockStartNotebookData({});
     startNotebookDataMock.volumeMounts = undefined;

--- a/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
+++ b/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
@@ -282,8 +282,8 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.spec.tolerations).toBeUndefined();
-    expect(result.spec.nodeSelector).toBeUndefined();
+    expect(result.spec.tolerations).toEqual([]);
+    expect(result.spec.nodeSelector).toEqual({});
 
     const hardwareProfile = mockHardwareProfile({});
     hardwareProfile.metadata.uid = 'uid';
@@ -299,8 +299,8 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.spec.tolerations).toBeUndefined();
-    expect(result.spec.nodeSelector).toBeUndefined();
+    expect(result.spec.tolerations).toEqual([]);
+    expect(result.spec.nodeSelector).toEqual({});
   });
 
   it('should not set pod specs like tolerations and nodeSelector for real hardware profiles on modelmesh', () => {
@@ -318,8 +318,8 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.spec.tolerations).toBeUndefined();
-    expect(result.spec.nodeSelector).toBeUndefined();
+    expect(result.spec.tolerations).toEqual([]);
+    expect(result.spec.nodeSelector).toEqual({});
   });
 
   it('should not set annotations for hardware profiles, resources, nodeSelectors, and tolerations when isModelMesh is false', () => {

--- a/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
+++ b/frontend/src/api/k8s/__tests__/servingRuntimes.spec.ts
@@ -246,10 +246,10 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBe('');
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBeUndefined();
   });
 
-  it('should set hardware profile annotation for real profiles', () => {
+  it('should not set hardware profile annotation for real profiles', () => {
     const hardwareProfile = mockHardwareProfile({ name: 'real-profile' });
     hardwareProfile.metadata.uid = 'test-uid';
     const podSpecOptions = mockModelServingPodSpecOptions({
@@ -264,18 +264,16 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
-      'real-profile',
-    );
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBeUndefined();
   });
 
-  it('should set pod specs like tolerations and nodeSelector for legacy hardware profiles on modelmesh', () => {
-    const hardwareProfile = mockHardwareProfile({});
-    hardwareProfile.metadata.uid = undefined;
-    const podSpecOptions = mockModelServingPodSpecOptions({
-      selectedHardwareProfile: hardwareProfile,
+  it('should not set pod specs like tolerations and nodeSelector for legacy and non-legacy hardware profiles', () => {
+    const legacyHardwareProfile = mockHardwareProfile({});
+    legacyHardwareProfile.metadata.uid = undefined;
+    let podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: legacyHardwareProfile,
     });
-    const result = assembleServingRuntime(
+    let result = assembleServingRuntime(
       mockServingRuntimeModalData({}),
       'test-ns',
       mockServingRuntimeK8sResource({}),
@@ -284,8 +282,25 @@ describe('assembleServingRuntime', () => {
       false,
       true,
     );
-    expect(result.spec.tolerations).toBeDefined();
-    expect(result.spec.nodeSelector).toBeDefined();
+    expect(result.spec.tolerations).toBeUndefined();
+    expect(result.spec.nodeSelector).toBeUndefined();
+
+    const hardwareProfile = mockHardwareProfile({});
+    hardwareProfile.metadata.uid = 'uid';
+    podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+    });
+    result = assembleServingRuntime(
+      mockServingRuntimeModalData({}),
+      'test-ns',
+      mockServingRuntimeK8sResource({}),
+      true,
+      podSpecOptions,
+      false,
+      true,
+    );
+    expect(result.spec.tolerations).toBeUndefined();
+    expect(result.spec.nodeSelector).toBeUndefined();
   });
 
   it('should not set pod specs like tolerations and nodeSelector for real hardware profiles on modelmesh', () => {
@@ -305,6 +320,57 @@ describe('assembleServingRuntime', () => {
     );
     expect(result.spec.tolerations).toBeUndefined();
     expect(result.spec.nodeSelector).toBeUndefined();
+  });
+
+  it('should not set annotations for hardware profiles, resources, nodeSelectors, and tolerations when isModelMesh is false', () => {
+    const hardwareProfile = mockHardwareProfile({ name: 'test-profile' });
+    hardwareProfile.metadata.uid = 'test-uid';
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: hardwareProfile,
+      resources: {
+        requests: {
+          'nvidia.com/gpu': 1,
+        },
+        limits: {
+          'nvidia.com/gpu': 1,
+        },
+      },
+      nodeSelector: {
+        'test-key': 'test-value',
+      },
+      tolerations: [
+        {
+          key: 'nvidia.com/gpu',
+          operator: TolerationOperator.EXISTS,
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ],
+    });
+    const result = assembleServingRuntime(
+      mockServingRuntimeModalData({}),
+      'test-ns',
+      mockServingRuntimeK8sResource({}),
+      true,
+      podSpecOptions,
+      false,
+      false, // isModelMesh is false
+    );
+
+    // Verify annotations for hardware profiles are set
+    expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBeUndefined();
+    expect(
+      result.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'],
+    ).toBeUndefined();
+
+    // Verify resources are not set
+    expect(result.spec.containers[0].resources?.limits?.['nvidia.com/gpu']).toBeUndefined();
+    expect(result.spec.containers[0].resources?.requests?.['nvidia.com/gpu']).toBeUndefined();
+
+    // Verify nodeSelector is not set
+    expect(result.spec.nodeSelector).toBeUndefined();
+
+    // Verify tolerations are not set
+    expect(result.spec.tolerations).toBeUndefined();
   });
 });
 

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -120,16 +120,16 @@ export const assembleInferenceService = (
     if (!isLegacyHardwareProfile) {
       annotations['opendatahub.io/hardware-profile-name'] =
         podSpecOptions.selectedHardwareProfile.metadata.name;
-      if (podSpecOptions.selectedHardwareProfile.metadata.namespace === project) {
-        annotations['opendatahub.io/hardware-profile-namespace'] = project;
-      } else {
-        annotations['opendatahub.io/hardware-profile-namespace'] = dashboardNamespace;
-      }
     } else {
       const legacyName = podSpecOptions.selectedHardwareProfile.metadata.name;
       if (legacyName) {
         annotations['opendatahub.io/legacy-hardware-profile-name'] = legacyName;
       }
+    }
+    if (podSpecOptions.selectedHardwareProfile.metadata.namespace === project) {
+      annotations['opendatahub.io/hardware-profile-namespace'] = project;
+    } else {
+      annotations['opendatahub.io/hardware-profile-namespace'] = dashboardNamespace;
     }
   }
 
@@ -138,7 +138,10 @@ export const assembleInferenceService = (
         ...inferenceService,
         metadata: {
           ...inferenceService.metadata,
-          annotations,
+          annotations: {
+            ...inferenceService.metadata.annotations,
+            ...annotations,
+          },
           labels: {
             ...inferenceService.metadata.labels,
           },

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -55,6 +55,7 @@ export const assembleNotebook = (
       selectedHardwareProfile,
     },
   } = data;
+  const dashboardNamespace = data.dashboardNamespace ?? '';
   const {
     name: notebookName,
     description,
@@ -98,11 +99,11 @@ export const assembleNotebook = (
     !!selectedAcceleratorProfile || !selectedHardwareProfile?.metadata.uid;
 
   const hardwareProfileNamespace: Record<string, string | null> =
-    selectedHardwareProfile?.metadata.namespace === projectName
-      ? { 'opendatahub.io/hardware-profile-namespace': projectName }
-      : {
-          'opendatahub.io/hardware-profile-namespace': null,
-        };
+    selectedHardwareProfile && !isLegacyHardwareProfile
+      ? selectedHardwareProfile.metadata.namespace === projectName
+        ? { 'opendatahub.io/hardware-profile-namespace': projectName }
+        : { 'opendatahub.io/hardware-profile-namespace': dashboardNamespace }
+      : { 'opendatahub.io/hardware-profile-namespace': null };
 
   let acceleratorProfileNamespace: Record<string, string | null> = {
     'opendatahub.io/accelerator-profile-namespace': null,

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -48,10 +48,6 @@ export const assembleServingRuntime = (
     : getModelServingRuntimeName(namespace);
   const updatedServingRuntime = { ...servingRuntime };
 
-  const isLegacyHardwareProfile =
-    !!podSpecOptions.selectedAcceleratorProfile ||
-    !podSpecOptions.selectedHardwareProfile?.metadata.uid;
-
   const annotations: ServingRuntimeAnnotations = {
     ...updatedServingRuntime.metadata.annotations,
   };
@@ -97,13 +93,6 @@ export const assembleServingRuntime = (
           'opendatahub.io/template-display-name': getDisplayNameFromK8sResource(servingRuntime),
           'opendatahub.io/accelerator-name':
             podSpecOptions.selectedAcceleratorProfile?.metadata.name || '',
-          'opendatahub.io/hardware-profile-name': isLegacyHardwareProfile
-            ? ''
-            : podSpecOptions.selectedHardwareProfile?.metadata.name || '',
-          'opendatahub.io/legacy-hardware-profile-name':
-            isLegacyHardwareProfile && podSpecOptions.selectedHardwareProfile
-              ? podSpecOptions.selectedHardwareProfile.metadata.name || ''
-              : '',
         }),
       },
     };
@@ -114,13 +103,6 @@ export const assembleServingRuntime = (
         ...annotations,
         'opendatahub.io/accelerator-name':
           podSpecOptions.selectedAcceleratorProfile?.metadata.name || '',
-        'opendatahub.io/hardware-profile-name': isLegacyHardwareProfile
-          ? ''
-          : podSpecOptions.selectedHardwareProfile?.metadata.name || '',
-        'opendatahub.io/legacy-hardware-profile-name':
-          isLegacyHardwareProfile && podSpecOptions.selectedHardwareProfile
-            ? podSpecOptions.selectedHardwareProfile.metadata.name || ''
-            : '',
         ...(isCustomServingRuntimesEnabled && { 'openshift.io/display-name': displayName.trim() }),
       },
     };
@@ -167,10 +149,10 @@ export const assembleServingRuntime = (
   }
 
   if (isModelMesh) {
-    if (tolerations && isLegacyHardwareProfile) {
+    if (tolerations && tolerations.length > 0) {
       updatedServingRuntime.spec.tolerations = tolerations;
     }
-    if (nodeSelector && isLegacyHardwareProfile) {
+    if (nodeSelector && Object.keys(nodeSelector).length > 0) {
       updatedServingRuntime.spec.nodeSelector = nodeSelector;
     }
   }

--- a/frontend/src/api/k8s/servingRuntimes.ts
+++ b/frontend/src/api/k8s/servingRuntimes.ts
@@ -149,10 +149,10 @@ export const assembleServingRuntime = (
   }
 
   if (isModelMesh) {
-    if (tolerations && tolerations.length > 0) {
+    if (tolerations) {
       updatedServingRuntime.spec.tolerations = tolerations;
     }
-    if (nodeSelector && Object.keys(nodeSelector).length > 0) {
+    if (nodeSelector) {
       updatedServingRuntime.spec.nodeSelector = nodeSelector;
     }
   }

--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -7,6 +7,7 @@ import { isCpuLimitLarger, isMemoryLimitLarger } from '#~/utilities/valueUnits';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { useHardwareProfilesByFeatureVisibility } from '#~/pages/hardwareProfiles/migration/useHardwareProfilesByFeatureVisibility';
 import { isHardwareProfileEnabled } from '#~/pages/hardwareProfiles/utils.ts';
+import { useDashboardNamespace } from '#~/redux/selectors';
 import { isHardwareProfileConfigValid } from './validationUtils';
 import { getContainerResourcesFromHardwareProfile } from './utils';
 
@@ -133,6 +134,8 @@ export const useHardwareProfileConfig = (
     [formData, hardwareProfilesAvailable],
   );
 
+  const { dashboardNamespace } = useDashboardNamespace();
+
   React.useEffect(() => {
     if (!profilesLoaded || formData.selectedProfile) {
       return;
@@ -145,7 +148,7 @@ export const useHardwareProfileConfig = (
       if (resources) {
         // try to match to existing profile
         if (existingHardwareProfileName) {
-          if (hardwareProfileNamespace) {
+          if (hardwareProfileNamespace && hardwareProfileNamespace !== dashboardNamespace) {
             selectedProfile = projectScopedProfiles.find(
               (profile) =>
                 profile.metadata.name === existingHardwareProfileName &&
@@ -188,6 +191,7 @@ export const useHardwareProfileConfig = (
     hardwareProfileNamespace,
     projectScopedProfiles,
     dashboardProfiles,
+    dashboardNamespace,
   ]);
 
   return {

--- a/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
+++ b/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
@@ -30,6 +30,7 @@ export type ModelServingPodSpecOptionsState = PodSpecOptionsState<ModelServingPo
 export const useModelServingPodSpecOptionsState = (
   servingRuntime?: ServingRuntimeKind,
   inferenceService?: InferenceServiceKind,
+  isModelMesh?: boolean,
 ): ModelServingPodSpecOptionsState => {
   const { dashboardConfig } = useAppContext();
   const sizes = useDeepCompareMemoize(getModelServingSizes(dashboardConfig));
@@ -49,7 +50,7 @@ export const useModelServingPodSpecOptionsState = (
     servingRuntime,
     inferenceService,
   );
-  const hardwareProfile = useServingHardwareProfileConfig(servingRuntime, inferenceService);
+  const hardwareProfile = useServingHardwareProfileConfig(inferenceService);
 
   // Handle GPU disabled state
   const controlledAcceleratorProfile = {
@@ -82,7 +83,7 @@ export const useModelServingPodSpecOptionsState = (
     selectedHardwareProfile: hardwareProfile.formData.selectedProfile,
   };
 
-  if (isHardwareProfilesAvailable) {
+  if (isHardwareProfilesAvailable && !isModelMesh) {
     if (hardwareProfile.formData.useExistingSettings) {
       podSpecOptions = {
         resources: existingResources,

--- a/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
@@ -1,8 +1,4 @@
-import {
-  HardwareProfileFeatureVisibility,
-  InferenceServiceKind,
-  ServingRuntimeKind,
-} from '#~/k8sTypes';
+import { HardwareProfileFeatureVisibility, InferenceServiceKind } from '#~/k8sTypes';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import {
   useHardwareProfileConfig,
@@ -10,24 +6,19 @@ import {
 } from './useHardwareProfileConfig';
 
 const useServingHardwareProfileConfig = (
-  servingRuntime?: ServingRuntimeKind | null,
   inferenceService?: InferenceServiceKind | null,
 ): UseHardwareProfileConfigResult => {
   const legacyName =
-    servingRuntime?.metadata.annotations?.['opendatahub.io/legacy-hardware-profile-name'];
+    inferenceService?.metadata.annotations?.['opendatahub.io/legacy-hardware-profile-name'];
   const name =
-    legacyName || servingRuntime?.metadata.annotations?.['opendatahub.io/hardware-profile-name'];
-  const resources =
-    inferenceService?.spec.predictor.model?.resources ||
-    servingRuntime?.spec.containers[0].resources;
-  const tolerations =
-    inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;
-  const nodeSelector =
-    inferenceService?.spec.predictor.nodeSelector || servingRuntime?.spec.nodeSelector;
-  const namespace = servingRuntime?.metadata.namespace;
+    legacyName || inferenceService?.metadata.annotations?.['opendatahub.io/hardware-profile-name'];
+  const resources = inferenceService?.spec.predictor.model?.resources;
+  const tolerations = inferenceService?.spec.predictor.tolerations;
+  const nodeSelector = inferenceService?.spec.predictor.nodeSelector;
+  const namespace = inferenceService?.metadata.namespace;
   const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const hardwareProfileNamespace =
-    servingRuntime?.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'];
+    inferenceService?.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'];
 
   return useHardwareProfileConfig(
     name,

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -158,7 +158,6 @@ export type ServingRuntimeAnnotations = Partial<{
   'opendatahub.io/accelerator-name': string;
   'opendatahub.io/apiProtocol': string;
   'opendatahub.io/serving-runtime-scope': string;
-  'opendatahub.io/hardware-profile-namespace': string | undefined;
   'opendatahub.io/accelerator-profile-namespace': string | undefined;
   'enable-route': string;
   'enable-auth': string;
@@ -495,9 +494,17 @@ export enum DeploymentMode {
   Serverless = 'Serverless',
 }
 
-export type InferenceServiceAnnotations = Partial<{
-  'security.opendatahub.io/enable-auth': string;
-}>;
+export type InferenceServiceAnnotations = DisplayNameAnnotations &
+  Partial<{
+    'security.opendatahub.io/enable-auth': string;
+    'serving.kserve.io/deploymentMode': DeploymentMode;
+    'serving.knative.openshift.io/enablePassthrough': 'true';
+    'sidecar.istio.io/inject': 'true';
+    'sidecar.istio.io/rewriteAppHTTPProbers': 'true';
+    'opendatahub.io/hardware-profile-name': string;
+    'opendatahub.io/hardware-profile-namespace': string;
+    'opendatahub.io/legacy-hardware-profile-name': string;
+  }>;
 
 export type InferenceServiceLabels = Partial<{
   'networking.knative.dev/visibility': string;
@@ -512,14 +519,7 @@ export type InferenceServiceKind = K8sResourceCommon & {
   metadata: {
     name: string;
     namespace: string;
-    annotations?: InferenceServiceAnnotations &
-      DisplayNameAnnotations &
-      Partial<{
-        'serving.kserve.io/deploymentMode': DeploymentMode;
-        'serving.knative.openshift.io/enablePassthrough': 'true';
-        'sidecar.istio.io/inject': 'true';
-        'sidecar.istio.io/rewriteAppHTTPProbers': 'true';
-      }>;
+    annotations?: InferenceServiceAnnotations;
     labels?: InferenceServiceLabels;
   };
   spec: {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/__tests__/ManageInferenceServiceModal.spec.tsx
@@ -24,6 +24,10 @@ jest.mock('#~/pages/modelServing/screens/projects/useModelDeploymentNotification
   }),
 }));
 
+jest.mock('#~/redux/selectors', () => ({
+  useDashboardNamespace: jest.fn(() => ({ dashboardNamespace: 'opendatahub' })),
+}));
+
 const useServingRuntimesMock = jest.mocked(useServingRuntimes);
 const useAppContextMock = jest.mocked(useAppContext);
 

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -22,6 +22,10 @@ import {
   getHardwareProfileDisplayName,
   isHardwareProfileEnabled,
 } from '#~/pages/hardwareProfiles/utils.ts';
+import { getProjectModelServingPlatform } from '#~/pages/modelServing/screens/projects/utils.ts';
+import { ServingRuntimePlatform } from '#~/types.ts';
+import useServingPlatformStatuses from '#~/pages/modelServing/useServingPlatformStatuses.ts';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext.tsx';
 
 type ServingRuntimeDetailsProps = {
   project?: string;
@@ -33,10 +37,18 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
   const { dashboardConfig } = React.useContext(AppContext);
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const isHardwareProfileAvailable = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const servingPlatformStatuses = useServingPlatformStatuses();
+  const { platform: currentProjectServingPlatform } = getProjectModelServingPlatform(
+    currentProject,
+    servingPlatformStatuses,
+  );
+  const isModelMesh = currentProjectServingPlatform === ServingRuntimePlatform.MULTI;
+
   const {
     acceleratorProfile: { initialState: initialAcceleratorProfileState },
     hardwareProfile,
-  } = useModelServingPodSpecOptionsState(obj, isvc);
+  } = useModelServingPodSpecOptionsState(obj, isvc, isModelMesh);
   const enabledAcceleratorProfiles = initialAcceleratorProfileState.acceleratorProfiles.filter(
     (ac) => ac.spec.enabled,
   );
@@ -74,7 +86,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
           </DescriptionListDescription>
         </DescriptionListGroup>
       )}
-      {isHardwareProfileAvailable ? (
+      {isHardwareProfileAvailable && !isModelMesh && (
         <DescriptionListGroup>
           <DescriptionListTerm>Hardware profile</DescriptionListTerm>
           <DescriptionListDescription data-testid="hardware-section">
@@ -104,7 +116,8 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
             )}
           </DescriptionListDescription>
         </DescriptionListGroup>
-      ) : (
+      )}
+      {!isHardwareProfileAvailable && (
         <>
           <DescriptionListGroup data-testid="accelerator-section">
             <DescriptionListTerm>Accelerator</DescriptionListTerm>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal.tsx
@@ -64,7 +64,11 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
   editInfo,
 }) => {
   const [createData, setCreateData] = useCreateServingRuntimeObject(editInfo);
-  const podSpecOptionsState = useModelServingPodSpecOptionsState(editInfo?.servingRuntime);
+  const podSpecOptionsState = useModelServingPodSpecOptionsState(
+    editInfo?.servingRuntime,
+    undefined,
+    true,
+  );
 
   const profileIdentifiers = useProfileIdentifiers(
     podSpecOptionsState.acceleratorProfile.formData.profile,
@@ -221,6 +225,7 @@ const ManageServingRuntimeModal: React.FC<ManageServingRuntimeModalProps> = ({
               infoContent="Select a server size that will accommodate your largest model. See the product documentation for more information."
               isEditing={!!editInfo}
               projectName={currentProject.metadata.name}
+              isProjectModelMesh
             />
             <AuthServingRuntimeSection
               data={createData}

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/ServingRuntimeSizeSection.tsx
@@ -24,6 +24,7 @@ type ServingRuntimeSizeSectionProps = {
   infoContent?: string;
   isEditing?: boolean;
   customDefaults?: ModelServingSize;
+  isProjectModelMesh?: boolean;
 };
 
 const ServingRuntimeSizeSection = ({
@@ -33,6 +34,7 @@ const ServingRuntimeSizeSection = ({
   infoContent,
   isEditing = false,
   customDefaults,
+  isProjectModelMesh = false,
 }: ServingRuntimeSizeSectionProps): React.ReactNode => {
   const isHardwareProfileEnabled = useIsAreaAvailable(SupportedArea.HARDWARE_PROFILES).status;
 
@@ -97,7 +99,7 @@ const ServingRuntimeSizeSection = ({
 
   return (
     <>
-      {isHardwareProfileEnabled ? (
+      {isHardwareProfileEnabled && !isProjectModelMesh ? (
         <HardwareProfileFormSection
           project={projectName}
           podSpecOptionsState={podSpecOptionState}
@@ -151,7 +153,7 @@ const ServingRuntimeSizeSection = ({
                 />
               </StackItem>
             )}
-            {!gpuDisabled && (
+            {!gpuDisabled && !isHardwareProfileEnabled && (
               <AcceleratorProfileSelectField
                 hasAdditionalPopoverInfo
                 currentProject={projectName}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -120,6 +120,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
   const podSpecOptionsState = useModelServingPodSpecOptionsState(
     editInfo?.servingRuntimeEditInfo?.servingRuntime,
     editInfo?.inferenceServiceEditInfo,
+    false,
   );
   const { data: kServeNameDesc, onDataChange: setKserveNameDesc } = useK8sNameDescriptionFieldData({
     initialData: editInfo?.inferenceServiceEditInfo,

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -45,6 +45,7 @@ import {
   isModelServingCompatible,
   ModelServingCompatibleTypes,
 } from '#~/concepts/connectionTypes/utils';
+import { useDashboardNamespace } from '#~/redux/selectors';
 import { ModelDeployPrefillInfo } from './usePrefillModelDeployModal';
 
 export const isServingRuntimeTokenEnabled = (servingRuntime: ServingRuntimeKind): boolean =>
@@ -190,10 +191,12 @@ export const useCreateInferenceServiceObject = (
   resetDefaults: () => void,
 ] => {
   const { defaultMode } = useKServeDeploymentMode();
+  const { dashboardNamespace } = useDashboardNamespace();
 
   const createInferenceServiceState = useGenericObjectState<CreatingInferenceServiceObject>({
     ...defaultInferenceService,
     isKServeRawDeployment: defaultMode === DeploymentMode.RawDeployment,
+    dashboardNamespace,
   });
 
   const [, setCreateData] = createInferenceServiceState;

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -85,6 +85,7 @@ export type CreatingInferenceServiceObject = CreatingModelServingObjectCommon & 
   servingRuntimeEnvVars?: ServingContainer['env'];
   isKServeRawDeployment?: boolean;
   imagePullSecrets?: ImagePullSecret[];
+  dashboardNamespace?: string;
 };
 
 export type CreatingModelServingObjectCommon = {

--- a/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
+++ b/frontend/src/pages/projects/screens/spawner/SpawnerPage.tsx
@@ -47,6 +47,7 @@ import {
 } from '#~/concepts/hardwareProfiles/utils';
 import { useNotebookKindPodSpecOptionsState } from '#~/concepts/hardwareProfiles/useNotebookPodSpecOptionsState';
 import { getPvcAccessMode } from '#~/pages/projects/utils.ts';
+import { useDashboardNamespace } from '#~/redux/selectors';
 import { SpawnerPageSectionID } from './types';
 import {
   K8_NOTEBOOK_RESOURCE_NAME_VALIDATOR,
@@ -229,6 +230,8 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
     },
     [selectedImage.imageStream],
   );
+
+  const { dashboardNamespace } = useDashboardNamespace();
 
   return (
     <ApplicationsPage
@@ -415,6 +418,7 @@ const SpawnerPage: React.FC<SpawnerPageProps> = ({ existingNotebook }) => {
                     volumes: [],
                     volumeMounts: [],
                     podSpecOptions: podSpecOptionsState.podSpecOptions,
+                    dashboardNamespace,
                   }}
                   storageData={storageData}
                   envVariables={envVariables}

--- a/frontend/src/pages/projects/types.ts
+++ b/frontend/src/pages/projects/types.ts
@@ -79,6 +79,7 @@ export type StartNotebookData = {
   volumes?: Volume[];
   volumeMounts?: VolumeMount[];
   envFrom?: EnvironmentFromVariable[];
+  dashboardNamespace?: string;
 };
 
 export type SecretRef = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-29450

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- In notebooks and inference service, set `opendatahub.io/hardware-profile-namespace` annotation to `opendatahub` when global scoped
- Remove hardware profiles from model mesh (multi model serving), only show legacy hardware profiles
- For Kserve (single model serving), hardware profile annotations have been moved from serving runtime to inference service

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Go to a project > Models  > Select single model serving
- Deploy model > in the modal, check that all hardware profiles show up in the hardware profile select dropdown. 
- Click deploy, check on the console that the associated inference service contains annotations `opendatahub.io/hardware-profile-name` and `opendatahub.io/hardware-profile-namespace` and the correct corresponding values. The annotation `opendatahub.io/hardware-profile-namespace` should not be set to an empty string.
- Check on the console that the serving runtime doesn't contain those values.
- Go back to project > Models and select multi model serving
- Deploy model > in the modal, check that only legacy hardware profiles show up, and no original hardware profiles.
- Create a workbench
- In the hardware profiles section, select a global scoped hardware profile and create the workbench.
- In the console, check that the notebook has the annotation `opendatahub.io/hardware-profile-namespace` set to `opendatahub`. It should not be an empty string.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added/updated tests, tested manually.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a dashboard namespace in notebook and inference service creation, enabling refined hardware profile annotations.
  * UI now conditionally displays hardware profile options based on project settings and serving platforms, including Model Mesh detection.
  * Enhanced pod specification handling to simplify resource assignment and exclude hardware profile settings when using Model Mesh.

* **Bug Fixes**
  * Hardware profile details are hidden for Model Mesh projects where not applicable.
  * Legacy hardware profiles are excluded from selection menus when project-scoped features are enabled.
  * Fixed annotation inconsistencies by removing legacy hardware profile keys from serving runtime metadata.

* **Tests**
  * Expanded and updated test coverage to verify correct hardware profile annotation and UI behavior across different project and platform configurations.
  * Updated tests to confirm hardware profile sections are not shown for Model Mesh-enabled projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->