### PR TITLE
RHOAIENG-27574: Filter Hardware profiles if kueue disabled

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -38,6 +38,7 @@ import {
 } from '#~/pages/hardwareProfiles/utils.ts';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
+import { SchedulingType } from '#~/types.ts';
 
 type HardwareProfileSelectProps = {
   initialHardwareProfile?: HardwareProfileKind;
@@ -92,7 +93,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   const filterKueue = React.useCallback(
     (hp: HardwareProfileKind) => {
       if (shouldFilterKueueProfiles) {
-        return hp.spec.scheduling?.type !== 'Queue';
+        return hp.spec.scheduling?.type !== SchedulingType.QUEUE;
       }
       return true;
     },

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -38,7 +38,7 @@ import {
 } from '#~/pages/hardwareProfiles/utils.ts';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
-import { SchedulingType } from '#~/types.ts';
+import { SchedulingType } from '#~/types';
 
 type HardwareProfileSelectProps = {
   initialHardwareProfile?: HardwareProfileKind;

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -241,7 +241,6 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   const getHardwareProfiles = () => {
     const currentProjectEnabledProfiles = currentProjectHardwareProfiles
       .filter((hp) => isHardwareProfileEnabled(hp))
-      .filter(filterKueue)
       .toSorted((a, b) => {
         const aHasExtra = (a.spec.identifiers ?? []).length > 2;
         const bHasExtra = (b.spec.identifiers ?? []).length > 2;
@@ -253,17 +252,18 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     if (initialHardwareProfile && isHardwareProfileEnabled(initialHardwareProfile)) {
       currentProjectEnabledProfiles.push(initialHardwareProfile);
     }
-    return currentProjectEnabledProfiles.filter((profile) =>
-      getHardwareProfileDisplayName(profile)
-        .toLocaleLowerCase()
-        .includes(searchHardwareProfile.toLocaleLowerCase()),
-    );
+    return currentProjectEnabledProfiles
+      .filter(filterKueue)
+      .filter((profile) =>
+        getHardwareProfileDisplayName(profile)
+          .toLocaleLowerCase()
+          .includes(searchHardwareProfile.toLocaleLowerCase()),
+      );
   };
 
   const getDashboardHardwareProfiles = () => {
     const DashboardEnabledProfiles = hardwareProfiles
       .filter((hp) => isHardwareProfileEnabled(hp))
-      .filter(filterKueue)
       .toSorted((a, b) => {
         const aHasExtra = (a.spec.identifiers ?? []).length > 2;
         const bHasExtra = (b.spec.identifiers ?? []).length > 2;
@@ -275,7 +275,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     if (initialHardwareProfile && isHardwareProfileEnabled(initialHardwareProfile)) {
       DashboardEnabledProfiles.push(initialHardwareProfile);
     }
-    return DashboardEnabledProfiles.filter((profile) =>
+    return DashboardEnabledProfiles.filter(filterKueue).filter((profile) =>
       getHardwareProfileDisplayName(profile)
         .toLocaleLowerCase()
         .includes(searchHardwareProfile.toLocaleLowerCase()),

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -90,7 +90,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
 
   const shouldFilterKueueProfiles = !isKueueEnabled || !isProjectKueueEnabled;
 
-  const filterKueue = React.useCallback(
+  const maybeRemoveKueueProfiles = React.useCallback(
     (hp: HardwareProfileKind) => {
       if (shouldFilterKueueProfiles) {
         return hp.spec.scheduling?.type !== SchedulingType.QUEUE;
@@ -103,7 +103,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
   const options = React.useMemo(() => {
     const enabledProfiles = hardwareProfiles
       .filter((hp) => isHardwareProfileEnabled(hp))
-      .filter(filterKueue)
+      .filter(maybeRemoveKueueProfiles)
       .toSorted((a, b) => {
         // First compare by whether they have extra resources
         const aHasExtra = (a.spec.identifiers ?? []).length > 2;
@@ -184,7 +184,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     initialHardwareProfile,
     allowExistingSettings,
     isHardwareProfileSupported,
-    filterKueue,
+    maybeRemoveKueueProfiles,
   ]);
 
   const renderMenuItem = (
@@ -254,7 +254,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
       currentProjectEnabledProfiles.push(initialHardwareProfile);
     }
     return currentProjectEnabledProfiles
-      .filter(filterKueue)
+      .filter(maybeRemoveKueueProfiles)
       .filter((profile) =>
         getHardwareProfileDisplayName(profile)
           .toLocaleLowerCase()
@@ -276,7 +276,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
     if (initialHardwareProfile && isHardwareProfileEnabled(initialHardwareProfile)) {
       DashboardEnabledProfiles.push(initialHardwareProfile);
     }
-    return DashboardEnabledProfiles.filter(filterKueue).filter((profile) =>
+    return DashboardEnabledProfiles.filter(maybeRemoveKueueProfiles).filter((profile) =>
       getHardwareProfileDisplayName(profile)
         .toLocaleLowerCase()
         .includes(searchHardwareProfile.toLocaleLowerCase()),

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -250,7 +250,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
         }
         return getProfileScore(a) - getProfileScore(b);
       });
-    if (initialHardwareProfile && isHardwareProfileEnabled(initialHardwareProfile)) {
+    if (initialHardwareProfile && !isHardwareProfileEnabled(initialHardwareProfile)) {
       currentProjectEnabledProfiles.push(initialHardwareProfile);
     }
     return currentProjectEnabledProfiles
@@ -273,7 +273,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
         }
         return getProfileScore(a) - getProfileScore(b);
       });
-    if (initialHardwareProfile && isHardwareProfileEnabled(initialHardwareProfile)) {
+    if (initialHardwareProfile && !isHardwareProfileEnabled(initialHardwareProfile)) {
       DashboardEnabledProfiles.push(initialHardwareProfile);
     }
     return DashboardEnabledProfiles.filter(maybeRemoveKueueProfiles).filter((profile) =>

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -129,8 +129,8 @@ describe('HardwareProfileSelect filtering', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
 
-    expect(screen.queryByText('Kueue Profile')).toBeNull();
-    expect(screen.queryByText('Kueue Profile 2')).toBeNull();
+    expect(screen.queryByText('Kueue Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Kueue Profile 2')).not.toBeInTheDocument();
     expect(screen.getByText('Node Profile')).toBeInTheDocument();
     expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
   });
@@ -141,8 +141,8 @@ describe('HardwareProfileSelect filtering', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
 
-    expect(screen.queryByText('Kueue Profile')).toBeNull();
-    expect(screen.queryByText('Kueue Profile 2')).toBeNull();
+    expect(screen.queryByText('Kueue Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Kueue Profile 2')).not.toBeInTheDocument();
     expect(screen.getByText('Node Profile')).toBeInTheDocument();
     expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
   });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import { useIsAreaAvailable } from '#~/concepts/areas';
+import { HardwareProfileKind, KnownLabels, ProjectKind } from '#~/k8sTypes';
+import { SchedulingType } from '#~/types';
+import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
+import HardwareProfileSelect from '../HardwareProfileSelect';
+
+jest.mock('#~/concepts/areas', () => ({
+  ...jest.requireActual('#~/concepts/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+jest.mock('#~/concepts/hardwareProfiles/useHardwareProfileConfig');
+
+const useIsAreaAvailableMock = jest.mocked(useIsAreaAvailable);
+const useHardwareProfileConfigMock = jest.mocked(useHardwareProfileConfig);
+
+const kueueHardwareProfile = mockHardwareProfile({
+  name: 'kueue-profile',
+  displayName: 'Kueue Profile',
+});
+kueueHardwareProfile.spec.scheduling = {
+  type: SchedulingType.QUEUE,
+  kueue: {
+    localQueueName: 'test-queue',
+    priorityClass: 'high-priority',
+  },
+};
+
+const kueueHardwareProfile2 = mockHardwareProfile({
+  name: 'kueue-profile-2',
+  displayName: 'Kueue Profile 2',
+});
+kueueHardwareProfile2.spec.scheduling = {
+  type: SchedulingType.QUEUE,
+  kueue: {
+    localQueueName: 'test-queue-2',
+    priorityClass: 'high-priority',
+  },
+};
+
+const nodeHardwareProfile = mockHardwareProfile({
+  name: 'node-profile',
+  displayName: 'Node Profile',
+});
+
+const nodeHardwareProfile2 = mockHardwareProfile({
+  name: 'node-profile-2',
+  displayName: 'Node Profile 2',
+});
+
+const mockProfiles = [
+  kueueHardwareProfile,
+  kueueHardwareProfile2,
+  nodeHardwareProfile,
+  nodeHardwareProfile2,
+];
+
+const renderComponent = (
+  hardwareProfiles: HardwareProfileKind[],
+  currentProject: ProjectKind,
+  isKueueEnabled: boolean,
+) => {
+  useIsAreaAvailableMock.mockReturnValue({
+    status: isKueueEnabled,
+    devFlags: {},
+    featureFlags: {},
+    reliantAreas: {},
+    requiredComponents: {},
+    requiredCapabilities: {},
+    customCondition: () => false,
+  });
+
+  const hardwareProfileConfig = {
+    formData: {
+      useExistingSettings: false,
+    },
+    useExistingSettings: false,
+    setFormData: () => null,
+    resetFormData: () => null,
+    isFormDataValid: true,
+    profilesLoaded: true,
+    profilesLoadError: undefined,
+    initialHardwareProfile: undefined,
+  };
+
+  useHardwareProfileConfigMock.mockReturnValue(hardwareProfileConfig);
+
+  return render(
+    <ProjectDetailsContext.Provider
+      value={
+        {
+          currentProject,
+          refresh: jest.fn(),
+        } as unknown as ProjectDetailsContextType
+      }
+    >
+      <HardwareProfileSelect
+        initialHardwareProfile={undefined}
+        previewDescription={false}
+        hardwareProfiles={hardwareProfiles}
+        isProjectScoped={false}
+        hardwareProfilesLoaded
+        hardwareProfilesError={undefined}
+        projectScopedHardwareProfiles={[[], true, undefined, () => Promise.resolve()]}
+        allowExistingSettings={false}
+        hardwareProfileConfig={hardwareProfileConfig}
+        isHardwareProfileSupported={() => true}
+        onChange={() => null}
+        project="test-project"
+      />
+    </ProjectDetailsContext.Provider>,
+  );
+};
+
+describe('HardwareProfileSelect filtering', () => {
+  it('should filter out kueue profiles when kueue is disabled cluster-wide', async () => {
+    const project = mockProjectK8sResource({});
+    renderComponent(mockProfiles, project, false);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    expect(screen.queryByText('Kueue Profile')).toBeNull();
+    expect(screen.queryByText('Kueue Profile 2')).toBeNull();
+    expect(screen.getByText('Node Profile')).toBeInTheDocument();
+    expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
+  });
+
+  it('should filter out kueue profiles when project is not kueue-enabled', async () => {
+    const project = mockProjectK8sResource({});
+    renderComponent(mockProfiles, project, true);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    expect(screen.queryByText('Kueue Profile')).toBeNull();
+    expect(screen.queryByText('Kueue Profile 2')).toBeNull();
+    expect(screen.getByText('Node Profile')).toBeInTheDocument();
+    expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
+  });
+
+  it('should show kueue profiles when kueue is enabled for cluster and project', async () => {
+    const project = mockProjectK8sResource({});
+    project.metadata.labels ??= {};
+    project.metadata.labels[KnownLabels.KUEUE_MANAGED] = 'true';
+    renderComponent(mockProfiles, project, true);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    expect(screen.getByText('Kueue Profile')).toBeInTheDocument();
+    expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
+    expect(screen.getByText('Node Profile')).toBeInTheDocument();
+    expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -12,7 +12,7 @@ import { useIsAreaAvailable } from '#~/concepts/areas';
 import { HardwareProfileKind, KnownLabels, ProjectKind } from '#~/k8sTypes';
 import { SchedulingType } from '#~/types';
 import { useHardwareProfileConfig } from '#~/concepts/hardwareProfiles/useHardwareProfileConfig';
-import HardwareProfileSelect from '../HardwareProfileSelect';
+import HardwareProfileSelect from '#~/concepts/hardwareProfiles/HardwareProfileSelect';
 
 jest.mock('#~/concepts/areas', () => ({
   ...jest.requireActual('#~/concepts/areas'),

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -1,2 +1,7 @@
 export const HARDWARE_PROFILES_MISSING_CPU_MEMORY_MESSAGE =
   'Omitting CPU or Memory resources is not recommended.';
+
+export enum SchedulingType {
+  QUEUE = 'Queue',
+  NODE = 'Node',
+}

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -1,7 +1,2 @@
 export const HARDWARE_PROFILES_MISSING_CPU_MEMORY_MESSAGE =
   'Omitting CPU or Memory resources is not recommended.';
-
-export enum SchedulingType {
-  QUEUE = 'Queue',
-  NODE = 'Node',
-}

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -33,6 +33,7 @@ export enum KnownLabels {
   REGISTERED_MODEL_ID = 'modelregistry.opendatahub.io/registered-model-id',
   MODEL_VERSION_ID = 'modelregistry.opendatahub.io/model-version-id',
   MODEL_REGISTRY_NAME = 'modelregistry.opendatahub.io/name',
+  KUEUE_MANAGED = 'kueue.openshift.io/managed',
 }
 
 export type K8sVerb =


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-27574

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
  * Hardware profiles are now filtered based on whether the "Kueue" scheduling type is enabled globally and for the current project, improving the relevance of selectable options.
  * Added a new label for "Kueue managed" resources to enhance internal labeling consistency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Notes:**

1. Tested for Notebook and Model deployment pages where we display Hardware profiles selector.
2. In order to enable Kueue for a project, first set `disableKueue` feature flag to FALSE and create a new project.


https://github.com/user-attachments/assets/6c185a93-29b0-491b-8891-d1cd6f008067



**Test scenario 1: `disableKueue` feature flag set to FALSE and project is Kueue enabled**

1. Create a Hardware profile with local kueue options.
4. Go to a project and create/edit a workbench.
5. In the select dropdown for Hardware profiles, you should see the kueue enabled hardware profiles.

------------------------------------------

**Test scenario 2: `disableKueue` feature flag set to TRUE and project is Kueue enabled**

1. Go to a project and create/edit a workbench.
2. In the select dropdown for Hardware profiles, you should not see the kueue enabled hardware profiles.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware profiles with "Queue" scheduling are now filtered based on global and project-specific Kueue availability.
* **Bug Fixes**
  * Corrected logic to ensure disabled initial hardware profiles are included in selection lists.
* **Tests**
  * Added comprehensive tests to verify hardware profile filtering behavior under different Kueue enablement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->