### PR TITLE
Fix bug when stopping model with confirmation modal

### DIFF
--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -195,6 +195,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
           onClose={(confirmStatus) => {
             setOpenConfirm(false);
             if (confirmStatus) {
+              setIsStarting(false);
               setIsStopping(true);
               patchInferenceServiceStoppedStatus(inferenceService, 'true').then(refresh);
             }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-29985
## Description
Stopping a model through the confirmation modal leaves isStarting = true so the button doesn't switch to Start like it should. Easy fix to set isStarting to false when you confirm in the modal.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Deploy a model
2. Stop the model
3. Start the model
4. While it's starting click stop
5. Click confirm in the stop modal
6. Model should switch to Stopping -> Stopped and the link button should say Start.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of inference service status to ensure the starting state is correctly reset when stopping a service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->