### PR TITLE
RHOAIENG-30110: The workload priority is not maintained when switching between local queue and not selectors.

### DIFF
--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
@@ -172,9 +172,7 @@ const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
             />
             <ManageResourceAllocationSection
               scheduling={state.scheduling}
-              setScheduling={(updated) => {
-                setState('scheduling', updated);
-              }}
+              setScheduling={(updated) => setState('scheduling', updated)}
               existingType={existingHardwareProfile?.spec.scheduling?.type}
             />
           </Form>

--- a/frontend/src/pages/hardwareProfiles/manage/ManageResourceAllocationSection.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageResourceAllocationSection.tsx
@@ -43,9 +43,7 @@ const ManageResourceAllocationSection: React.FC<ManageResourceAllocationSectionP
         type: SchedulingType.QUEUE,
         kueue: {
           localQueueName: overrides.localQueueName ?? localQueueName,
-          ...(updatedPriorityClass !== DEFAULT_PRIORITY_CLASS && {
-            priorityClass: updatedPriorityClass,
-          }),
+          priorityClass: updatedPriorityClass,
         },
       });
     },
@@ -67,10 +65,28 @@ const ManageResourceAllocationSection: React.FC<ManageResourceAllocationSectionP
 
   const setSchedulingType = React.useCallback(
     (type: SchedulingType) => {
-      setScheduling({
+      // Preserve existing kueue and node data when switching types
+      // Make sure to explicitly preserve the priorityClass if it exists
+      const currentKueue = scheduling?.kueue;
+      const preservedKueue = {
+        localQueueName: currentKueue?.localQueueName || '',
+        priorityClass: currentKueue?.priorityClass || DEFAULT_PRIORITY_CLASS,
+      };
+
+      const currentNode = scheduling?.node;
+      const preservedNode = {
+        nodeSelector: currentNode?.nodeSelector || {},
+        tolerations: currentNode?.tolerations || [],
+      };
+
+      const newScheduling = {
         ...scheduling,
         type,
-      });
+        kueue: preservedKueue,
+        node: preservedNode,
+      };
+
+      setScheduling(newScheduling);
     },
     [setScheduling, scheduling],
   );
@@ -94,6 +110,10 @@ const ManageResourceAllocationSection: React.FC<ManageResourceAllocationSectionP
         kueue: {
           ...scheduling?.kueue,
           localQueueName: defaultLocalQueueName,
+          // PRESERVE the existing priorityClass if it exists
+          ...(scheduling?.kueue?.priorityClass && {
+            priorityClass: scheduling.kueue.priorityClass,
+          }),
         },
       });
       isDefaultLocalQueueNameSet.current = true;

--- a/frontend/src/pages/hardwareProfiles/manage/ManageWorkloadPrioritySection.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageWorkloadPrioritySection.tsx
@@ -33,10 +33,23 @@ const ManageWorkloadPrioritySection: React.FC<ManageWorkloadPrioritySectionProps
     };
 
     if (!loaded || error) {
+      // If we have a current priorityClass that's not "None", include it in the options
+      // This prevents SimpleSelect from auto-calling onChange when the real options haven't loaded yet
+      if (priorityClass && priorityClass !== DEFAULT_PRIORITY_CLASS) {
+        return [
+          noneOption,
+          {
+            key: priorityClass,
+            label: priorityClass,
+            dropdownLabel: priorityClass,
+          },
+        ];
+      }
+
       return [noneOption];
     }
 
-    return [
+    const options = [
       noneOption,
       ...workloadPriorityClasses.map((priority: WorkloadPriorityClassKind) => ({
         key: priority.metadata.name,
@@ -54,7 +67,9 @@ const ManageWorkloadPrioritySection: React.FC<ManageWorkloadPrioritySectionProps
         dropdownLabel: priority.metadata.name,
       })),
     ];
-  }, [workloadPriorityClasses, loaded, error]);
+
+    return options;
+  }, [workloadPriorityClasses, loaded, error, priorityClass]);
   return (
     <FormGroup
       label={ManageHardwareProfileSectionTitles[ManageHardwareProfileSectionID.WORKLOAD_PRIORITY]}

--- a/frontend/src/pages/hardwareProfiles/manage/ManageWorkloadStrategySection.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageWorkloadStrategySection.tsx
@@ -26,7 +26,7 @@ const ManageWorkloadStrategySection: React.FC<ManageWorkloadStrategySectionProps
       labelHelp={
         <DashboardHelpTooltip
           content={
-            <Stack>
+            <Stack hasGutter={hideQueueOption}>
               <StackItem>
                 The selected workload allocation strategy defines how workloads are assigned to
                 nodes.

--- a/frontend/src/pages/hardwareProfiles/manage/__tests__/ManageResourceAllocationSection.spec.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/__tests__/ManageResourceAllocationSection.spec.tsx
@@ -1,0 +1,452 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useIsAreaAvailable } from '#~/concepts/areas';
+import useDefaultDsc from '#~/pages/clusterSettings/useDefaultDsc';
+import useWorkloadPriorityClasses from '#~/concepts/distributedWorkloads/useWorkloadPriorityClasses';
+import { SchedulingType, TolerationOperator } from '#~/types';
+import { DEFAULT_PRIORITY_CLASS } from '#~/pages/hardwareProfiles/nodeResource/const';
+import ManageResourceAllocationSection from '#~/pages/hardwareProfiles/manage/ManageResourceAllocationSection';
+
+// Mock only external dependencies/hooks
+jest.mock('#~/concepts/areas');
+jest.mock('#~/pages/clusterSettings/useDefaultDsc');
+jest.mock('#~/concepts/distributedWorkloads/useWorkloadPriorityClasses');
+
+const mockUseIsAreaAvailable = useIsAreaAvailable as jest.MockedFunction<typeof useIsAreaAvailable>;
+const mockUseDefaultDsc = useDefaultDsc as jest.MockedFunction<typeof useDefaultDsc>;
+const mockUseWorkloadPriorityClasses = useWorkloadPriorityClasses as jest.MockedFunction<
+  typeof useWorkloadPriorityClasses
+>;
+
+describe('ManageResourceAllocationSection', () => {
+  const mockSetScheduling = jest.fn();
+
+  const defaultProps = {
+    scheduling: undefined,
+    setScheduling: mockSetScheduling,
+    existingType: undefined,
+  };
+
+  // Mock workload priority classes data
+  const mockWorkloadPriorityClasses = [
+    {
+      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      kind: 'WorkloadPriorityClass',
+      metadata: { name: 'high-priority', namespace: 'default' },
+      description: 'High priority workloads',
+      value: 100,
+    },
+    {
+      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      kind: 'WorkloadPriorityClass',
+      metadata: { name: 'medium-priority', namespace: 'default' },
+      description: 'Medium priority workloads',
+      value: 50,
+    },
+    {
+      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      kind: 'WorkloadPriorityClass',
+      metadata: { name: 'low-priority', namespace: 'default' },
+      description: 'Low priority workloads',
+      value: 10,
+    },
+  ] as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mocks
+    mockUseIsAreaAvailable.mockReturnValue({ status: true } as any);
+    mockUseDefaultDsc.mockReturnValue([
+      { spec: { components: { kueue: { defaultLocalQueueName: 'default-queue' } } } },
+      true,
+      undefined,
+    ] as any);
+    mockUseWorkloadPriorityClasses.mockReturnValue([mockWorkloadPriorityClasses, true, undefined]);
+  });
+
+  describe('Priority Preservation', () => {
+    it('should preserve priority class when switching from QUEUE to NODE and back to QUEUE', async () => {
+      const initialScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      const { rerender } = render(
+        <ManageResourceAllocationSection {...defaultProps} scheduling={initialScheduling} />,
+      );
+
+      // Wait for components to load
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('test-queue')).toBeInTheDocument();
+      });
+
+      // Find and click the Node strategy radio button
+      const nodeRadio = screen.getByRole('radio', { name: /node selectors and tolerations/i });
+      fireEvent.click(nodeRadio);
+
+      // Verify setScheduling was called with preserved data
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.NODE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+        node: {
+          nodeSelector: {},
+          tolerations: [],
+        },
+      });
+
+      // Simulate the state change by re-rendering with NODE type
+      const nodeScheduling = {
+        type: SchedulingType.NODE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+        node: {
+          nodeSelector: {},
+          tolerations: [],
+        },
+      };
+
+      rerender(<ManageResourceAllocationSection {...defaultProps} scheduling={nodeScheduling} />);
+
+      // Clear previous calls
+      mockSetScheduling.mockClear();
+
+      // Switch back to QUEUE type
+      const queueRadio = screen.getByRole('radio', { name: /local queue/i });
+      fireEvent.click(queueRadio);
+
+      // Verify setScheduling preserves the priority
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+        node: {
+          nodeSelector: {},
+          tolerations: [],
+        },
+      });
+    });
+
+    it('should preserve node selector and tolerations when switching from NODE to QUEUE', () => {
+      const initialScheduling = {
+        type: SchedulingType.NODE,
+        node: {
+          nodeSelector: { 'node-type': 'gpu' },
+          tolerations: [{ key: 'gpu-node', operator: TolerationOperator.EQUAL, value: 'true' }],
+        },
+      };
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={initialScheduling} />);
+
+      // Switch to QUEUE type
+      const queueRadio = screen.getByRole('radio', { name: /local queue/i });
+      fireEvent.click(queueRadio);
+
+      // Verify setScheduling preserves node data
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: '',
+          priorityClass: DEFAULT_PRIORITY_CLASS,
+        },
+        node: {
+          nodeSelector: { 'node-type': 'gpu' },
+          tolerations: [{ key: 'gpu-node', operator: TolerationOperator.EQUAL, value: 'true' }],
+        },
+      });
+    });
+
+    it('should handle empty scheduling state gracefully', () => {
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={undefined} />);
+
+      // Should show queue sections by default when kueue is available
+      expect(screen.getByRole('radio', { name: /local queue/i })).toBeChecked();
+
+      // Switch to NODE type
+      const nodeRadio = screen.getByRole('radio', { name: /node selectors and tolerations/i });
+      fireEvent.click(nodeRadio);
+
+      // Verify setScheduling handles undefined scheduling
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.NODE,
+        kueue: {
+          localQueueName: '',
+          priorityClass: DEFAULT_PRIORITY_CLASS,
+        },
+        node: {
+          nodeSelector: {},
+          tolerations: [],
+        },
+      });
+    });
+  });
+
+  describe('Priority Updates', () => {
+    it('should update priority class correctly', async () => {
+      const initialScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: DEFAULT_PRIORITY_CLASS,
+        },
+      };
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={initialScheduling} />);
+
+      // Wait for priority dropdown to load
+      await waitFor(() => {
+        expect(screen.getByTestId('workload-priority-select')).toBeInTheDocument();
+      });
+
+      // Click the priority dropdown
+      const priorityDropdown = screen.getByTestId('workload-priority-select');
+      fireEvent.click(priorityDropdown);
+
+      // Select high priority
+      await waitFor(() => {
+        const highPriorityOption = screen.getByText('high-priority');
+        fireEvent.click(highPriorityOption);
+      });
+
+      // Verify setScheduling was called with updated priority
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+      });
+    });
+
+    it('should preserve existing priority when updating local queue name', async () => {
+      const initialScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'old-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={initialScheduling} />);
+
+      // Update local queue name
+      const localQueueInput = screen.getByDisplayValue('old-queue');
+      fireEvent.change(localQueueInput, { target: { value: 'new-queue' } });
+
+      // Verify setScheduling preserves priority
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'new-queue',
+          priorityClass: 'high-priority',
+        },
+      });
+    });
+  });
+
+  describe('Default Local Queue Effect', () => {
+    it('should preserve priority when setting default local queue', () => {
+      const initialScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: '',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      // Mock DSC with default local queue
+      mockUseDefaultDsc.mockReturnValue([
+        { spec: { components: { kueue: { defaultLocalQueueName: 'default-queue' } } } },
+        true,
+        undefined,
+      ] as any);
+
+      render(
+        <ManageResourceAllocationSection
+          {...defaultProps}
+          scheduling={initialScheduling}
+          existingType={SchedulingType.NODE} // Trigger the effect
+        />,
+      );
+
+      // Verify effect preserves existing priority
+      expect(mockSetScheduling).toHaveBeenCalledWith({
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'default-queue',
+          priorityClass: 'high-priority',
+        },
+      });
+    });
+
+    it('should not trigger effect when local queue already exists', () => {
+      const initialScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'existing-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      render(
+        <ManageResourceAllocationSection
+          {...defaultProps}
+          scheduling={initialScheduling}
+          existingType={SchedulingType.NODE}
+        />,
+      );
+
+      // Verify effect doesn't trigger when local queue already exists
+      expect(mockSetScheduling).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('UI Conditional Rendering', () => {
+    it('should show queue sections when scheduling type is QUEUE', async () => {
+      const queueScheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={queueScheduling} />);
+
+      // Should show local queue and priority sections
+      expect(screen.getByDisplayValue('test-queue')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('workload-priority-select')).toBeInTheDocument();
+      });
+
+      // Should not show node sections
+      expect(screen.queryByText(/add node selector/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/add toleration/i)).not.toBeInTheDocument();
+    });
+
+    it('should show node sections when scheduling type is NODE', () => {
+      const nodeScheduling = {
+        type: SchedulingType.NODE,
+        node: {
+          nodeSelector: {},
+          tolerations: [],
+        },
+      };
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={nodeScheduling} />);
+
+      // Should show node selector and toleration sections
+      expect(screen.getByText(/add node selector/i)).toBeInTheDocument();
+      expect(screen.getByText(/add toleration/i)).toBeInTheDocument();
+
+      // Should not show queue sections
+      expect(screen.queryByTestId('workload-priority-select')).not.toBeInTheDocument();
+    });
+
+    it('should show queue sections when kueue is available and no scheduling type', async () => {
+      mockUseIsAreaAvailable.mockReturnValue({ status: true } as any);
+
+      render(<ManageResourceAllocationSection {...defaultProps} scheduling={undefined} />);
+
+      // Should default to queue sections
+      expect(screen.getByRole('radio', { name: /local queue/i })).toBeChecked();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('workload-priority-select')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Kueue Availability', () => {
+    it('should handle disabled kueue correctly', () => {
+      mockUseIsAreaAvailable.mockReturnValue({ status: false } as any);
+
+      const scheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      render(
+        <ManageResourceAllocationSection
+          {...defaultProps}
+          scheduling={scheduling}
+          existingType={SchedulingType.QUEUE}
+        />,
+      );
+
+      // Should show disabled alert
+      expect(screen.getByText(/kueue feature flag is disabled/i)).toBeInTheDocument();
+    });
+
+    it('should show only node strategy when kueue is disabled and no existing queue type', () => {
+      mockUseIsAreaAvailable.mockReturnValue({ status: false } as any);
+
+      render(
+        <ManageResourceAllocationSection
+          {...defaultProps}
+          scheduling={undefined}
+          existingType={undefined}
+        />,
+      );
+
+      // Should only show node strategy
+      expect(screen.queryByRole('radio', { name: /local queue/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/node selectors and tolerations/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('WorkloadPriority Race Condition Fix', () => {
+    it('should handle workload priority options loading delay', async () => {
+      // Start with loading state
+      mockUseWorkloadPriorityClasses.mockReturnValue([[], false, undefined]);
+
+      const scheduling = {
+        type: SchedulingType.QUEUE,
+        kueue: {
+          localQueueName: 'test-queue',
+          priorityClass: 'high-priority',
+        },
+      };
+
+      const { rerender } = render(
+        <ManageResourceAllocationSection {...defaultProps} scheduling={scheduling} />,
+      );
+
+      // Priority dropdown should still show the current value even when options haven't loaded
+      await waitFor(() => {
+        const prioritySelect = screen.getByTestId('workload-priority-select');
+        expect(prioritySelect).toHaveTextContent('high-priority');
+      });
+
+      // Now simulate options loading
+      mockUseWorkloadPriorityClasses.mockReturnValue([
+        mockWorkloadPriorityClasses,
+        true,
+        undefined,
+      ]);
+
+      rerender(<ManageResourceAllocationSection {...defaultProps} scheduling={scheduling} />);
+
+      // Should still show the correct priority
+      await waitFor(() => {
+        const prioritySelect = screen.getByTestId('workload-priority-select');
+        expect(prioritySelect).toHaveTextContent('high-priority');
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-30110

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The workload priority option is not maintained and set to None when switching between local queue and node selectors.

https://github.com/user-attachments/assets/e6af3020-ec0e-48ed-8dae-34f1c7cd309c

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Testing instructions:**

1. Create a hardware profile with kueue enabled.
2. Select a high priority class.
3. Switch to node selectors.
4. Switch back to local queue.
5. You should see high priority class instead of None.

https://github.com/user-attachments/assets/ed6d2363-f9ae-4259-b75d-6165b511e488

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and preservation of the current priority class selection in workload priority options, preventing unintended selection changes during loading or error states.
  * Ensured consistent preservation and explicit setting of scheduling configuration details, including priority class, when updating or switching scheduling types.

* **Refactor**
  * Simplified and clarified internal logic for setting scheduling configurations and generating priority options, enhancing maintainability without altering user-facing behavior.

* **New Features**
  * Enhanced tooltip spacing behavior in workload strategy settings for better visual clarity based on user options.

* **Tests**
  * Added comprehensive tests for resource allocation scheduling, covering UI behavior, state preservation, feature availability, and race condition handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->