### PR TITLE
Aggregate get/list/watch permissions to project admins/contributors

### DIFF
--- a/manifests/core-bases/base/aggregate-permissions.rbac.yaml
+++ b/manifests/core-bases/base/aggregate-permissions.rbac.yaml
@@ -1,0 +1,33 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-hardware-profiles-permissions
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+rules:
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - hardwareprofiles
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-accelerator-profiles-permissions
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+rules:
+  - apiGroups:
+      - dashboard.opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - acceleratorprofiles

--- a/manifests/core-bases/base/kustomization.yaml
+++ b/manifests/core-bases/base/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - fetch-accelerators.rbac.yaml
   - fetch-hardwares.rbac.yaml
   - fetch-nim-account.rbac.yaml
+  - aggregate-permissions.rbac.yaml
 images:
   - name: oauth-proxy
     newName: registry.redhat.io/openshift4/ose-oauth-proxy


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: [RHOAIENG-26758](https://issues.redhat.com/browse/RHOAIENG-26758)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We need to create 2 cluster roles for HardwareProfiles and AcceleratorProfiles to aggregate the proper permissions to a project admin/contributor.

Check the RoleBinding of the DS project, it's obvious that the project admin is bound with `admin` role, and project contributor is bound with `edit` role.
<img width="1182" height="141" alt="Screenshot 2025-07-17 at 3 22 06 PM" src="https://github.com/user-attachments/assets/0ef50f67-958b-4c6d-878d-2928e27df055" />

To implement this, we will need to apply the following 2 labels to the cluster role we created
```
rbac.authorization.k8s.io/aggregate-to-admin: 'true'
rbac.authorization.k8s.io/aggregate-to-edit: 'true'
```
and that will apply the rules to view hardware/accelerator profiles to the `admin` and `edit` cluster roles

**NOTE: The hardware profile is broken right now, because the API group is migrating from `dashboard.opendatahub.io` to `infrastructure.opendatahub.io`. This PR will use the new API group, which will be available in RHOAI 2.23**

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The hardware profile is broken temporarily, and we can use accelerator profiles to test. So set `disableHardwareProfiles` to `true` and `disableAcceleratorProfiles` to `false` in you dashboard config.

1. Login as a normal user A to a cluster (not a cluster admin/dashboard admin)
2. Create a project, now you should be the admin of this project
3. Go to the permission tab of the project, add user B as a contributor, user B needs to be a normal user, too
4. Create an accelerator profile in the project you created through the OpenShift console. You can do this step as the cluster admin
5. Login to the dashboard as user A and user B, and create a workbench in the project, and you will see accelerator profile selection shows `None` because they don't have permissions
6. Apply the `aggregate-permissions.rbac.yaml` in the changes to the cluster by importing the YAML
7. Both user A and user B should be able to see the accelerator profile you created in step 4

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new permissions to support viewing hardware and accelerator profiles for users with admin and edit roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->