### PR TITLE
feat: implement dynamic notebook image selection with backend fallback

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -14,6 +14,10 @@ import { createPersistentVolumeClaim } from '#~/__tests__/cypress/cypress/utils/
 import { getOpenshiftDefaultStorageClass } from '#~/__tests__/cypress/cypress/utils/oc_commands/storageClass';
 import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
 import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
+import {
+  selectNotebookImageWithBackendFallback,
+  getImageStreamDisplayName,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/imageStreams';
 
 describe('Workbench and PVSs tests', () => {
   let projectName: string;
@@ -73,6 +77,7 @@ describe('Workbench and PVSs tests', () => {
     { tags: ['@Smoke', '@SmokeSet1', '@ODS-1814', '@Dashboard'] },
     () => {
       const workbenchName = projectName.replace('dsp-', '');
+      let selectedImageStream: string;
 
       // Authentication and navigation
       cy.step('Log into the application');
@@ -87,24 +92,39 @@ describe('Workbench and PVSs tests', () => {
       cy.step(`Create Workbench ${projectName} using storage ${PVCDisplayName}`);
       workbenchPage.findCreateButton().click();
       createSpawnerPage.getNameInput().fill(workbenchName);
-      createSpawnerPage.findNotebookImage('code-server-notebook').click();
-      createSpawnerPage.findAttachExistingStorageButton().click();
-      attachExistingStorageModal.verifyPSDropdownIsDisabled();
-      attachExistingStorageModal.verifyPSDropdownText(PVCDisplayName);
-      attachExistingStorageModal.findStandardPathInput().fill(workbenchName);
-      attachExistingStorageModal.findAttachButton().click();
-      createSpawnerPage.findSubmitButton().click();
 
-      cy.step(`Wait for Workbench ${workbenchName} to display a "Running" status`);
-      const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-      notebookRow.expectStatusLabelToBe('Running', 120000);
-      notebookRow.shouldHaveNotebookImageName('code-server');
-      notebookRow.shouldHaveContainerSize('Small');
+      // Select notebook image with fallback
+      selectNotebookImageWithBackendFallback('code-server-notebook', createSpawnerPage).then(
+        (imageStreamName) => {
+          selectedImageStream = imageStreamName;
+          cy.log(`Selected imagestream: ${selectedImageStream}`);
 
-      cy.step(`Check the cluster storage ${PVCDisplayName} is now connected to ${workbenchName}`);
-      projectDetails.findSectionTab('cluster-storages').click();
-      const csRow = clusterStorage.getClusterStorageRow(PVCDisplayName);
-      csRow.findConnectedResources().should('have.text', workbenchName);
+          // Attach existing storage workflow
+          createSpawnerPage.findAttachExistingStorageButton().click();
+          attachExistingStorageModal.verifyPSDropdownIsDisabled();
+          attachExistingStorageModal.verifyPSDropdownText(PVCDisplayName);
+          attachExistingStorageModal.findStandardPathInput().fill(workbenchName);
+          attachExistingStorageModal.findAttachButton().click();
+          createSpawnerPage.findSubmitButton().click();
+
+          cy.step(`Wait for Workbench ${workbenchName} to display a "Running" status`);
+          const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+          notebookRow.expectStatusLabelToBe('Running', 120000);
+
+          // Use dynamic image name verification based on what was actually selected
+          getImageStreamDisplayName(selectedImageStream).then((displayName) => {
+            notebookRow.shouldHaveNotebookImageName(displayName);
+            notebookRow.shouldHaveContainerSize('Small');
+
+            cy.step(
+              `Check the cluster storage ${PVCDisplayName} is now connected to ${workbenchName}`,
+            );
+            projectDetails.findSectionTab('cluster-storages').click();
+            const csRow = clusterStorage.getClusterStorageRow(PVCDisplayName);
+            csRow.findConnectedResources().should('have.text', workbenchName);
+          });
+        },
+      );
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/imageStreams.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/imageStreams.ts
@@ -1,3 +1,5 @@
+const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE') || 'opendatahub';
+
 export interface NotebookImageInfo {
   image: string;
   name: string | null;
@@ -15,6 +17,9 @@ interface ImageStreamTag {
 interface ImageStream {
   metadata: {
     name: string;
+    annotations?: {
+      [key: string]: string;
+    };
   };
   spec: {
     tags: ImageStreamTag[];
@@ -26,6 +31,195 @@ interface ExecResult {
   stdout: string;
   stderr: string;
 }
+
+/**
+ * Gets the display name of an imagestream based on the opendatahub.io/notebook-image-name annotation
+ * @param imageStreamName - The name of the imagestream (e.g., 'code-server-notebook')
+ * @param namespace - The namespace where the imagestream is located (defaults to APPLICATIONS_NAMESPACE)
+ * @returns The display name from the annotation or the imagestream name as fallback
+ */
+export const getImageStreamDisplayName = (
+  imageStreamName: string,
+  namespace: string = applicationNamespace,
+): Cypress.Chainable<string> => {
+  return cy
+    .exec(`oc get imagestream ${imageStreamName} -n ${namespace} -o json`)
+    .then((result: ExecResult) => {
+      if (result.code !== 0) {
+        throw new Error(`Failed to get image stream: ${result.stderr}`);
+      }
+      const imageStream: ImageStream = JSON.parse(result.stdout);
+
+      // Get display name from opendatahub.io/notebook-image-name annotation
+      const displayName = imageStream.metadata.annotations?.['opendatahub.io/notebook-image-name'];
+
+      // Fallback to imagestream name if annotation is not present
+      return displayName || imageStream.metadata.name;
+    });
+};
+
+/**
+ * Checks if an imagestream exists in the given namespace
+ * @param imageStreamName - The name of the imagestream
+ * @param namespace - The namespace to check (defaults to APPLICATIONS_NAMESPACE)
+ * @returns Promise that resolves to true if imagestream exists, false otherwise
+ */
+export const imageStreamExists = (
+  imageStreamName: string,
+  namespace: string = applicationNamespace,
+): Cypress.Chainable<boolean> => {
+  return cy
+    .exec(`oc get imagestream ${imageStreamName} -n ${namespace} --ignore-not-found -o name`)
+    .then((result: ExecResult) => {
+      return result.stdout.trim() !== '';
+    });
+};
+
+/**
+ * Gets all available notebook imagestreams in a namespace
+ * @param namespace - The namespace to search (defaults to APPLICATIONS_NAMESPACE)
+ * @returns Array of imagestream names that contain 'notebook'
+ */
+export const getAvailableNotebookImageStreams = (
+  namespace: string = applicationNamespace,
+): Cypress.Chainable<string[]> => {
+  return cy
+    .exec(`oc get imagestream -n ${namespace} -o jsonpath='{.items[*].metadata.name}'`)
+    .then((result: ExecResult) => {
+      if (result.code !== 0) {
+        throw new Error(`Failed to get image streams: ${result.stderr}`);
+      }
+      const imageNames = result.stdout.trim().split(' ').filter(Boolean);
+      return imageNames.filter((imageName) => imageName.includes('notebook'));
+    });
+};
+
+/**
+ * Selects an appropriate imagestream for testing. Prefers the specified imagestream,
+ * but falls back to any available notebook imagestream if the preferred one doesn't exist.
+ * @param preferredImageStream - The preferred imagestream name (e.g., 'code-server-notebook')
+ * @param namespace - The namespace to search (defaults to APPLICATIONS_NAMESPACE)
+ * @returns The name of the imagestream to use for testing
+ */
+export const selectTestImageStream = (
+  preferredImageStream: string,
+  namespace: string = applicationNamespace,
+): Cypress.Chainable<string> => {
+  return imageStreamExists(preferredImageStream, namespace).then((exists) => {
+    if (exists) {
+      cy.log(`Using preferred imagestream: ${preferredImageStream}`);
+      return cy.wrap(preferredImageStream);
+    }
+    cy.log(`Preferred imagestream ${preferredImageStream} not found, looking for alternatives`);
+    return getAvailableNotebookImageStreams(namespace).then((availableImageStreams) => {
+      if (availableImageStreams.length === 0) {
+        throw new Error(`No notebook imagestreams found in namespace: ${namespace}`);
+      }
+      const selectedImageStream = availableImageStreams[0];
+      cy.log(`Using alternative imagestream: ${selectedImageStream}`);
+      return selectedImageStream;
+    });
+  });
+};
+
+/**
+ * Helper function to assert that a notebook row displays the correct image name
+ * based on the imagestream's display name annotation
+ * @param imageStreamName - The name of the imagestream (e.g., 'code-server-notebook')
+ * @param notebookRowTestId - The test id of the notebook row element (optional)
+ * @param namespace - The namespace where the imagestream is located (defaults to APPLICATIONS_NAMESPACE)
+ */
+export const verifyNotebookImageDisplayName = (
+  imageStreamName: string,
+  notebookRowTestId?: string,
+  namespace: string = applicationNamespace,
+): void => {
+  getImageStreamDisplayName(imageStreamName, namespace).then((expectedName) => {
+    const selector = notebookRowTestId
+      ? `[data-testid="${notebookRowTestId}"] [data-testid="image-display-name"]`
+      : '[data-testid="image-display-name"]';
+    cy.get(selector).should('contain.text', expectedName);
+  });
+};
+
+/**
+ * Validates that a notebook row shows the correct image display name for a given imagestream
+ * @param imageStreamName - The name of the imagestream
+ * @param rowSelector - Cypress chainable that returns the notebook row element
+ * @param namespace - The namespace where the imagestream is located (defaults to APPLICATIONS_NAMESPACE)
+ */
+export const validateNotebookRowImageName = (
+  imageStreamName: string,
+  rowSelector: () => Cypress.Chainable<JQuery<HTMLElement>>,
+  namespace: string = applicationNamespace,
+): void => {
+  getImageStreamDisplayName(imageStreamName, namespace).then((expectedName) => {
+    rowSelector().findByTestId('image-display-name').should('contain.text', expectedName);
+  });
+};
+
+/**
+ * Utility function to verify notebook image name from imagestream - can be used in page objects
+ * @param imageStreamName - The name of the imagestream
+ * @param namespace - The namespace where the imagestream is located (defaults to APPLICATIONS_NAMESPACE)
+ */
+export const shouldHaveNotebookImageNameFromImageStream = (
+  imageStreamName: string,
+  namespace: string = applicationNamespace,
+): void => {
+  getImageStreamDisplayName(imageStreamName, namespace).then((expectedName) => {
+    cy.findByTestId('image-display-name').should('contain.text', expectedName);
+  });
+};
+
+/**
+ * Attempts to select a notebook image in UI, with backend fallback if not found
+ * @param preferredImageStream - The preferred imagestream name (e.g., 'code-server-notebook')
+ * @param createSpawnerPage - The page object instance for UI interaction
+ * @param namespace - The namespace to search for alternatives if preferred fails (defaults to APPLICATIONS_NAMESPACE)
+ * @returns The name of the imagestream that was actually selected
+ */
+export const selectNotebookImageWithBackendFallback = (
+  preferredImageStream: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  createSpawnerPage: any,
+  namespace: string = applicationNamespace,
+): Cypress.Chainable<string> => {
+  // Try to select the preferred image directly using page object method first
+  cy.log(`Trying to select ${preferredImageStream} directly`);
+
+  // Open the dropdown first so we can check if the element exists
+  return createSpawnerPage
+    .findNotebookImageSelector()
+    .click()
+    .then(() => {
+      // Check if the preferred image exists in the dropdown
+      return cy.get('body').then(($body) => {
+        if ($body.find(`[data-testid="${preferredImageStream}"]`).length > 0) {
+          // Preferred image found - select it
+          cy.log(`Successfully found ${preferredImageStream} in dropdown`);
+          return createSpawnerPage
+            .findNotebookImage(preferredImageStream)
+            .click()
+            .then(() => cy.wrap(preferredImageStream));
+        }
+        // Preferred image not found - use backend fallback
+        cy.log(`${preferredImageStream} not found in UI, using backend fallback`);
+        return getAvailableNotebookImageStreams(namespace).then((availableImageStreams) => {
+          if (availableImageStreams.length === 0) {
+            throw new Error(`No notebook imagestreams found in namespace: ${namespace}`);
+          }
+
+          const [firstAvailableImage] = availableImageStreams;
+          cy.log(`Selected fallback imagestream: ${firstAvailableImage}`);
+          return createSpawnerPage
+            .findNotebookImage(firstAvailableImage)
+            .click()
+            .then(() => cy.wrap(firstAvailableImage));
+        });
+      });
+    });
+};
 
 export const getImageStreamTags = (
   namespace: string,


### PR DESCRIPTION
- Replace hardcoded 'jupyter' image validation with dynamic selection
- Add selectNotebookImageWithBackendFallback utility function:
  - Try UI selection first (createSpawnerPage.findNotebookImage)
  - Fall back to backend query if UI element not found
  - Uses opendatahub.io/notebook-image-name annotation for display name
- Update workbench tests to use scoped validation (notebookRow.shouldHaveNotebookImageName)
- Centralize all OC commands in imageStreams.ts utility per Cypress E2E rules
- Handle environment variables (APPLICATIONS_NAMESPACE) internally in utilities
- Fix async/sync mixing issues in Cypress command chaining

Resolves: RHOAIENG-30224

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
