### PR TITLE
Globals page exports routes with metrics too

### DIFF
--- a/frontend/packages/modelServing/extensions.ts
+++ b/frontend/packages/modelServing/extensions.ts
@@ -56,16 +56,16 @@ const extensions: (
     properties: {
       id: 'modelServing',
       title: 'Model deployments',
-      href: '/model-serving',
+      href: '/modelServing',
       section: 'models',
-      path: '/model-serving/:namespace?/*',
+      path: '/modelServing/:namespace?/*',
     },
   },
   {
     type: 'app.route',
     properties: {
-      path: '/model-serving/:namespace?/*',
-      component: () => import('./src/GlobalModelsPage'),
+      path: '/modelServing/:namespace?/*',
+      component: () => import('./src/GlobalModelsRoutes'),
     },
     flags: {
       required: [PLUGIN_MODEL_SERVING],

--- a/frontend/packages/modelServing/src/GlobalModelsRoutes.tsx
+++ b/frontend/packages/modelServing/src/GlobalModelsRoutes.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate, Route } from 'react-router-dom';
+import useModelMetricsEnabled from '@odh-dashboard/internal/pages/modelServing/useModelMetricsEnabled';
+import ProjectsRoutes from '@odh-dashboard/internal/concepts/projects/ProjectsRoutes';
+import GlobalModelsPage from './components/global/GlobalModelsPage';
+import GlobalMetricsRoutes from './components/metrics/GlobalMetricsRoutes';
+
+const GlobalModelsRoutes: React.FC = () => {
+  const [modelMetricsEnabled] = useModelMetricsEnabled();
+
+  return (
+    <ProjectsRoutes>
+      <Route index element={<GlobalModelsPage />} />
+      {modelMetricsEnabled && <Route path="metrics/*" element={<GlobalMetricsRoutes />} />}
+      <Route path="*" element={<Navigate to="." />} />
+    </ProjectsRoutes>
+  );
+};
+
+export default GlobalModelsRoutes;

--- a/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
+++ b/frontend/packages/modelServing/src/components/deployments/DeploymentsTableRow.tsx
@@ -5,7 +5,6 @@ import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
 import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
-import { Link } from 'react-router-dom';
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
 import { DeploymentRowExpandedSection } from './DeploymentsTableRowExpandedSection';
 import DeploymentLastDeployed from './DeploymentLastDeployed';
@@ -23,6 +22,7 @@ import {
   isModelServingDeploymentsExpandedInfo,
   isModelServingMetricsExtension,
 } from '../../../extension-points';
+import { DeploymentMetricsLink } from '../metrics/DeploymentMetricsLink';
 
 export const DeploymentRow: React.FC<{
   deployment: Deployment;
@@ -71,12 +71,7 @@ export const DeploymentRow: React.FC<{
             {metricsExtension &&
             deployment.model.metadata.namespace &&
             deployment.status?.state === InferenceServiceModelState.LOADED ? (
-              <Link
-                to={`/projects/${deployment.model.metadata.namespace}/metrics/model/${deployment.model.metadata.name}`}
-                data-testid="deployed-model-name"
-              >
-                {getDisplayNameFromK8sResource(deployment.model)}
-              </Link>
+              <DeploymentMetricsLink deployment={deployment} data-testid="deployed-model-name" />
             ) : (
               <span data-testid="deployed-model-name">
                 {getDisplayNameFromK8sResource(deployment.model)}

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
@@ -35,7 +35,7 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ projects 
         <TitleWithIcon title="Model deployments" objectType={ProjectObjectType.deployedModels} />
       }
       headerContent={
-        <ModelServingProjectSelection getRedirectPath={(ns: string) => `/model-serving/${ns}`} />
+        <ModelServingProjectSelection getRedirectPath={(ns: string) => `/modelServing/${ns}`} />
       }
       provideChildrenPadding
     >

--- a/frontend/packages/modelServing/src/components/global/GlobalModelsPage.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalModelsPage.tsx
@@ -3,9 +3,9 @@ import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/Proje
 import { useExtensions } from '@odh-dashboard/plugin-core';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useNavigate, useParams } from 'react-router-dom';
-import GlobalDeploymentsView from './components/global/GlobalDeploymentsView';
-import { ModelDeploymentsProvider } from './concepts/ModelDeploymentsContext';
-import { isModelServingPlatformExtension } from '../extension-points';
+import GlobalDeploymentsView from './GlobalDeploymentsView';
+import { ModelDeploymentsProvider } from '../../concepts/ModelDeploymentsContext';
+import { isModelServingPlatformExtension } from '../../../extension-points';
 
 const GlobalModelsPage: React.FC = () => {
   const availablePlatforms = useExtensions(isModelServingPlatformExtension);
@@ -27,7 +27,7 @@ const GlobalModelsPage: React.FC = () => {
 
   React.useEffect(() => {
     if (!namespace && preferredProject) {
-      navigate(`/model-serving/${preferredProject.metadata.name}`, { replace: true });
+      navigate(`/modelServing/${preferredProject.metadata.name}`, { replace: true });
     }
   }, [namespace, preferredProject, navigate]);
 
@@ -38,7 +38,6 @@ const GlobalModelsPage: React.FC = () => {
       </Bullseye>
     );
   }
-
   return (
     <ModelDeploymentsProvider modelServingPlatforms={availablePlatforms} projects={projectsToShow}>
       <GlobalDeploymentsView projects={projectsToShow} />

--- a/frontend/packages/modelServing/src/components/metrics/DeploymentMetricsLink.tsx
+++ b/frontend/packages/modelServing/src/components/metrics/DeploymentMetricsLink.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import type { Deployment } from '../../../extension-points';
 
 const getMetricsUrl = (currentPath: string, deployment: Deployment) => {
-  const firstPath = currentPath.split('/')[1];
+  const firstPath = currentPath.split('/').filter(Boolean)[0];
   if (firstPath === 'modelServing') {
     return `/modelServing/${deployment.model.metadata.namespace}/metrics/${deployment.model.metadata.name}`;
   }
@@ -14,8 +14,9 @@ const getMetricsUrl = (currentPath: string, deployment: Deployment) => {
 export const DeploymentMetricsLink: React.FC<{
   deployment: Deployment;
 }> = ({ deployment, ...props }) => {
-  const currentPath = window.location.pathname;
+  const currentPath = useLocation().pathname;
   const metricsUrl = getMetricsUrl(currentPath, deployment);
+
   return (
     <Link to={metricsUrl} {...props}>
       {getDisplayNameFromK8sResource(deployment.model)}

--- a/frontend/packages/modelServing/src/components/metrics/DeploymentMetricsLink.tsx
+++ b/frontend/packages/modelServing/src/components/metrics/DeploymentMetricsLink.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import type { Deployment } from '../../../extension-points';
+
+const getMetricsUrl = (currentPath: string, deployment: Deployment) => {
+  const firstPath = currentPath.split('/')[1];
+  if (firstPath === 'modelServing') {
+    return `/modelServing/${deployment.model.metadata.namespace}/metrics/${deployment.model.metadata.name}`;
+  }
+  return `/projects/${deployment.model.metadata.namespace}/metrics/model/${deployment.model.metadata.name}`;
+};
+
+export const DeploymentMetricsLink: React.FC<{
+  deployment: Deployment;
+}> = ({ deployment, ...props }) => {
+  const currentPath = window.location.pathname;
+  const metricsUrl = getMetricsUrl(currentPath, deployment);
+  return (
+    <Link to={metricsUrl} {...props}>
+      {getDisplayNameFromK8sResource(deployment.model)}
+    </Link>
+  );
+};

--- a/frontend/packages/modelServing/src/components/metrics/GlobalMetricsRoutes.tsx
+++ b/frontend/packages/modelServing/src/components/metrics/GlobalMetricsRoutes.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import GlobalModelServingCoreLoader from '@odh-dashboard/internal/pages/modelServing/screens/global/GlobalModelServingCoreLoader';
+import BiasConfigurationBreadcrumbPage from '@odh-dashboard/internal/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationBreadcrumbPage';
+import GlobalModelMetricsPage from '@odh-dashboard/internal/pages/modelServing/screens/metrics/GlobalModelMetricsPage';
+import GlobalModelMetricsWrapper from '@odh-dashboard/internal/pages/modelServing/screens/metrics/GlobalModelMetricsWrapper';
+import ModelServingExplainabilityWrapper from '@odh-dashboard/internal/pages/modelServing/screens/metrics/ModelServingExplainabilityWrapper';
+import useIsAreaAvailable from '@odh-dashboard/internal/concepts/areas/useIsAreaAvailable';
+import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/index';
+
+// TODO: refactor metrics https://issues.redhat.com/browse/RHOAIENG-30172
+const GlobalMetricsRoutes: React.FC = () => {
+  const biasMetricsAreaAvailable = useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;
+  return (
+    <Routes>
+      <Route
+        path=""
+        element={
+          <GlobalModelServingCoreLoader
+            getInvalidRedirectPath={(namespace) => `/modelServing/${namespace}`}
+          />
+        }
+      >
+        <Route path="" element={<ModelServingExplainabilityWrapper />}>
+          <Route index element={<Navigate to=".." />} />
+          <Route path=":inferenceService" element={<GlobalModelMetricsWrapper />}>
+            <Route path=":tab?" element={<GlobalModelMetricsPage />} />
+            {biasMetricsAreaAvailable && (
+              <Route path="configure" element={<BiasConfigurationBreadcrumbPage />} />
+            )}
+          </Route>
+          <Route path="*" element={<Navigate to="." />} />
+        </Route>
+      </Route>
+    </Routes>
+  );
+};
+
+export default GlobalMetricsRoutes;

--- a/frontend/src/plugins/extensions/routes.ts
+++ b/frontend/src/plugins/extensions/routes.ts
@@ -84,6 +84,9 @@ const extensions: RouteExtension[] = [
       path: '/modelServing/*',
       component: () => import('#~/pages/modelServing/ModelServingRoutes'),
     },
+    flags: {
+      disallowed: [SupportedArea.PLUGIN_MODEL_SERVING],
+    },
   },
   {
     type: 'app.route',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-30238

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes the metrics hyperlink in the global model serving page  from the projects one to the globals one
This also updates the refactor link from `model-serving` to `modelServing` 

Before
<img width="477" height="278" alt="image" src="https://github.com/user-attachments/assets/8d05833c-35f5-4226-8acc-86d5ade71e06" />
After
<img width="477" height="278" alt="image" src="https://github.com/user-attachments/assets/cfae1d58-c6ec-406e-a617-4b04e72cb793" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable the model serving plugin devFlag
2. Go to the global model serving page
3. Click on a deployed model's metric link
4. It should go to `/modelServing/...` and not `/projects/...`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests but the fixes should now work better in the existing cypress tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new components for global model serving and metrics routing, enabling conditional and nested navigation based on feature availability.
  * Added a dedicated link component for navigating to deployment metrics pages.

* **Bug Fixes**
  * Updated navigation and URL paths from hyphenated to camelCase format for consistency across the application.

* **Chores**
  * Added route flags to control access to certain plugin areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->