### PR TITLE
Add fix to only show images that have the correct annotation in notebooks

### DIFF
--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageSelectorField.tsx
@@ -30,7 +30,7 @@ const ImageSelectorField: React.FC<ImageSelectorFieldProps> = ({
 }) => {
   const { dashboardNamespace } = useDashboardNamespace();
   const buildStatuses = useBuildStatuses(dashboardNamespace);
-  const [imageStreams, loaded, error] = useImageStreams(dashboardNamespace);
+  const [imageStreams, loaded, error] = useImageStreams(dashboardNamespace, { enabled: true });
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const [
     currentProjectImageStreams,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-30321

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When creating a workbench, the image dropdown should only show image streams that have the label `opendatahub.io/notebook-image` set to true.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- On the console, set a few image streams to have the label `opendatahub.io/notebook-image` set to false or remove the label completely, and remember their display name (in annotation `opendatahub.io/notebook-image-name`)
- Go to the Spawner page to create a workbench inside a project
- Under the image selection dropdown, make sure that those image streams don't show up. 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested manually.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of image selection by ensuring image data is always fetched as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->