### PR TITLE
RHOAIENG-28909: Add Storage Class Provisioner "disk.csi.azure.com" to Storage Enums

### DIFF
--- a/frontend/src/pages/storageClasses/__tests__/StorageClassEditModal.spec.tsx
+++ b/frontend/src/pages/storageClasses/__tests__/StorageClassEditModal.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StorageClassEditModal } from '#~/pages/storageClasses/StorageClassEditModal';
+import { StorageClassKind } from '#~/k8sTypes';
+import { AccessMode, provisionerAccessModes } from '#~/pages/storageClasses/storageEnums';
+
+const mockStorageClass = (provisioner: string): StorageClassKind => ({
+  apiVersion: 'storage.k8s.io/v1',
+  kind: 'StorageClass',
+  allowVolumeExpansion: true,
+  metadata: {
+    name: `test-sc-${provisioner}`,
+    uid: '123',
+    resourceVersion: '1',
+    creationTimestamp: '2022-01-01T00:00:00Z',
+    labels: {},
+    annotations: {},
+  },
+  provisioner,
+  reclaimPolicy: 'Delete',
+  volumeBindingMode: 'Immediate',
+});
+
+describe('StorageClassEditModal', () => {
+  const onSuccess = jest.fn();
+  const onClose = jest.fn();
+
+  const allAccessModes = Object.values(AccessMode);
+  const testCases: [string, AccessMode[], AccessMode[]][] = Object.entries(
+    provisionerAccessModes,
+  ).map(([provisioner, supportedModes]) => {
+    const unsupportedModes = allAccessModes.filter((mode) => !supportedModes.includes(mode));
+    return [provisioner, supportedModes, unsupportedModes];
+  });
+
+  // Add the unknown provisioner case, which should default to only supporting RWO
+  testCases.push([
+    'unknown-provisioner',
+    [AccessMode.RWO],
+    [AccessMode.RWX, AccessMode.ROX, AccessMode.RWOP],
+  ]);
+
+  testCases.forEach(([provisioner, supportedModes, unsupportedModes]) => {
+    it(`should display correct access modes for ${provisioner}`, () => {
+      const storageClass = mockStorageClass(provisioner);
+      // StorageClassEditModal can be rendered standalone - no context needed
+      render(
+        <StorageClassEditModal
+          storageClass={storageClass}
+          onSuccess={onSuccess}
+          onClose={onClose}
+        />,
+      );
+
+      // RWO is always checked and disabled
+      const rwoCheckbox = screen.getByTestId('edit-sc-access-mode-checkbox-readwriteonce');
+      expect(rwoCheckbox).toBeChecked();
+      expect(rwoCheckbox).toBeDisabled();
+
+      supportedModes.forEach((mode) => {
+        if (mode === AccessMode.RWO) {
+          return; // already tested
+        }
+        const checkbox = screen.getByTestId(`edit-sc-access-mode-checkbox-${mode.toLowerCase()}`);
+        // Supported modes should be unchecked by default but enabled
+        expect(checkbox).not.toBeChecked();
+        expect(checkbox).toBeEnabled();
+      });
+
+      unsupportedModes.forEach((mode) => {
+        const checkbox = screen.getByTestId(`edit-sc-access-mode-checkbox-${mode.toLowerCase()}`);
+        expect(checkbox).not.toBeChecked();
+        expect(checkbox).toBeDisabled();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -84,5 +84,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.RWOP,
   ],
   [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
-  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.ROX],
+  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.RWOP],
 };

--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -26,6 +26,7 @@ export enum StorageProvisioner {
   RBD_CSI = 'rbd.csi.ceph.com',
   FILE_CSI_AZURE = 'file.csi.azure.com',
   NFS_CSI = 'nfs.csi.k8s.io',
+  DISK_CSI_AZURE = 'disk.csi.azure.com',
 }
 
 // list of access modes
@@ -83,4 +84,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.RWOP,
   ],
   [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
+  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.ROX],
 };

--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -84,5 +84,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.RWOP,
   ],
   [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
-  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.RWOP],
+  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.RWX, AccessMode.RWOP],
 };

--- a/frontend/src/pages/storageClasses/storageEnums.ts
+++ b/frontend/src/pages/storageClasses/storageEnums.ts
@@ -84,5 +84,5 @@ export const provisionerAccessModes: Record<StorageProvisioner, AccessMode[]> = 
     AccessMode.RWOP,
   ],
   [StorageProvisioner.NFS_CSI]: [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX],
-  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO, AccessMode.RWX, AccessMode.RWOP],
+  [StorageProvisioner.DISK_CSI_AZURE]: [AccessMode.RWO],
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-28909

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We want to provide the right access modes for Storage Class Provisioner `disk.csi.azure.com`. As per https://github.com/openshift/azure-disk-csi-driver?tab=readme-ov-file#about, the supported access mode is `RWO`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
An azure cloud was used to test with openshift deployed to it. Reach out to me to get the details about the test environment and setting it up locally.

<img width="580" height="791" alt="Screenshot 2025-07-29 at 10 52 27 AM" src="https://github.com/user-attachments/assets/e7323e9a-273d-41c4-9c22-32489a5d1e03" />
<img width="866" height="146" alt="Screenshot 2025-07-29 at 10 52 54 AM" src="https://github.com/user-attachments/assets/15d0f77d-9b21-49a5-ba22-6a0fe37218cc" />
<img width="884" height="202" alt="Screenshot 2025-07-29 at 10 53 00 AM" src="https://github.com/user-attachments/assets/f3c6034d-827e-439f-bcc0-95ac72658ab0" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I have added unit tests for the storage class edit modal to check if the correct access modes are shown for each provisioner.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for the Azure Disk CSI provisioner, including its associated access modes, in storage class management.

* **Tests**
  * Introduced a new test suite to verify correct display of access mode options in the storage class edit modal for various provisioners, including the newly supported Azure Disk CSI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->