### PR TITLE
fix: update title and label text in Enable NIM dialog

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/NIMCard.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/NIMCard.ts
@@ -14,7 +14,7 @@ export class NIMCard extends Card {
   }
 
   getNGCAPIKey(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.get('[data-id="NVIDIA AI Enterprise license key"]');
+    return cy.get('[data-id="NVIDIA personal API key"]');
   }
 
   getNIMSubmit(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
+++ b/manifests/rhoai/shared/apps/nvidia-nim/nvidia-nim-app.yaml
@@ -20,7 +20,7 @@ spec:
   getStartedLink: 'https://developer.nvidia.com/nim'
   internalRoute: '/api/integrations/nim'
   enable:
-    title: Enter NVIDIA AI Enterprise license key
+    title: Enter NVIDIA personal API key
     actionLabel: Submit
     description: ''
     inProgressText: |
@@ -29,7 +29,7 @@ spec:
     variables:
       api_key: password
     variableDisplayText:
-      api_key: NVIDIA AI Enterprise license key
+      api_key: NVIDIA personal API key
     variableHelpText:
       api_key: This key is given to you by NVIDIA
   getStartedMarkDown: |-


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-114

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated title and label text in Enable NIM dialog to reference personal key.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested by disabling NIM (removing the secret) and then attempting to re-enable it to verify that the updated dialog text appears as expected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
<img width="596" height="293" alt="image" src="https://github.com/user-attachments/assets/19fedeb0-9228-4e59-a46e-9a217d2fa1b5" />


After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated user-facing text to refer to "NVIDIA personal API key" instead of "NVIDIA AI Enterprise license key" in the NVIDIA NIM application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->