### PR TITLE
Link refactor deploy buttons to existing deploy modal

### DIFF
--- a/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
+++ b/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
@@ -1,5 +1,18 @@
 import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
+import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
+import { ServingRuntimePlatform } from '@odh-dashboard/internal/types';
+import {
+  getSortedTemplates,
+  getTemplateEnabled,
+  getTemplateEnabledForPlatform,
+} from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
+import { getProjectModelServingPlatform } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { isProjectNIMSupported } from '@odh-dashboard/internal/pages/modelServing/screens/projects/nimUtils';
+import ManageServingRuntimeModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal';
+import ManageKServeModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
+import ManageNIMServingModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal';
+import useServingPlatformStatuses from '@odh-dashboard/internal/pages/modelServing/useServingPlatformStatuses';
 import { ModelServingPlatform } from '../../concepts/useProjectServingPlatform';
 
 export const DeployButton: React.FC<{
@@ -7,24 +20,98 @@ export const DeployButton: React.FC<{
   variant?: 'primary' | 'secondary';
   isDisabled?: boolean;
 }> = ({ platform, variant = 'primary', isDisabled }) => {
+  const [modalShown, setModalShown] = React.useState<boolean>(false);
+  const [platformSelected, setPlatformSelected] = React.useState<
+    ServingRuntimePlatform | undefined
+  >(undefined);
+
+  const servingPlatformStatuses = useServingPlatformStatuses();
+
+  const {
+    servingRuntimes: { refresh: refreshServingRuntime },
+    servingRuntimeTemplates: [templates],
+    servingRuntimeTemplateOrder: { data: templateOrder },
+    servingRuntimeTemplateDisablement: { data: templateDisablement },
+    connections: { data: connections },
+    serverSecrets: { refresh: refreshTokens },
+    inferenceServices: { refresh: refreshInferenceServices },
+    currentProject,
+  } = React.useContext(ProjectDetailsContext);
+
+  const templatesSorted = getSortedTemplates(templates, templateOrder);
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, templateDisablement),
+  );
+
+  const { platform: currentProjectServingPlatform } = getProjectModelServingPlatform(
+    currentProject,
+    servingPlatformStatuses,
+  );
+
+  const isKServeNIMEnabled = isProjectNIMSupported(currentProject);
+
+  const onSubmit = (submit: boolean) => {
+    setModalShown(false);
+    setPlatformSelected(undefined);
+    if (submit) {
+      refreshServingRuntime();
+      refreshInferenceServices();
+      setTimeout(refreshTokens, 500);
+    }
+  };
+
+  const handleDeployClick = () => {
+    if (platform) {
+      setPlatformSelected(
+        platform.properties.id === 'modelmesh'
+          ? ServingRuntimePlatform.MULTI
+          : ServingRuntimePlatform.SINGLE,
+      );
+    } else {
+      setPlatformSelected(currentProjectServingPlatform);
+    }
+    setModalShown(true);
+  };
+
   const deployButton = (
     <Button
       variant={variant}
       data-testid="deploy-button"
-      // onClick={() => {
-      //   do something
-      // }}
+      onClick={handleDeployClick}
       isAriaDisabled={isDisabled}
     >
       Deploy model
     </Button>
   );
-  if (!platform || isDisabled) {
-    return (
-      <Tooltip data-testid="deploy-model-tooltip" content="To deploy a model, select a project.">
-        {deployButton}
-      </Tooltip>
-    );
+
+  if (!platform && !currentProjectServingPlatform) {
+    return <Tooltip content="To deploy a model, select a project.">{deployButton}</Tooltip>;
   }
-  return <>{deployButton}</>;
+
+  return (
+    <>
+      {deployButton}
+      {modalShown && platformSelected === ServingRuntimePlatform.MULTI ? (
+        <ManageServingRuntimeModal
+          currentProject={currentProject}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
+          )}
+          onClose={onSubmit}
+        />
+      ) : null}
+      {modalShown && platformSelected === ServingRuntimePlatform.SINGLE && isKServeNIMEnabled ? (
+        <ManageNIMServingModal projectContext={{ currentProject }} onClose={onSubmit} />
+      ) : null}
+      {modalShown && platformSelected === ServingRuntimePlatform.SINGLE && !isKServeNIMEnabled ? (
+        <ManageKServeModal
+          projectContext={{ currentProject, connections }}
+          servingRuntimeTemplates={templatesEnabled.filter((template) =>
+            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
+          )}
+          onClose={onSubmit}
+        />
+      ) : null}
+    </>
+  );
 };

--- a/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
+++ b/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
@@ -19,7 +19,6 @@ import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/i
 import useTemplateOrder from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateOrder';
 import useTemplateDisablement from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateDisablement';
 import useConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useConnections';
-import useServingRuntimeSecrets from '@odh-dashboard/internal/pages/modelServing/screens/projects/useServingRuntimeSecrets';
 import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { isProjectNIMSupported } from '@odh-dashboard/internal/pages/modelServing/screens/projects/nimUtils';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
@@ -37,12 +36,8 @@ const DeployButtonModal: React.FC<{
   const { namespace } = useParams();
   const { dashboardNamespace } = useDashboardNamespace();
   const [servingRuntimeTemplates] = useTemplates(dashboardNamespace);
-  const servingRuntimeTemplateOrder = useTemplateOrder(dashboardNamespace, undefined, {
-    refreshRate: POLL_INTERVAL,
-  });
-  const servingRuntimeTemplateDisablement = useTemplateDisablement(dashboardNamespace, undefined, {
-    refreshRate: POLL_INTERVAL,
-  });
+  const servingRuntimeTemplateOrder = useTemplateOrder(dashboardNamespace, undefined);
+  const servingRuntimeTemplateDisablement = useTemplateDisablement(dashboardNamespace, undefined);
   const connections = useConnections(namespace);
   const templatesSorted = getSortedTemplates(
     servingRuntimeTemplates,
@@ -88,7 +83,7 @@ export const DeployButton: React.FC<{
   const [platformSelected, setPlatformSelected] = React.useState<ServingRuntimePlatform>();
   const { namespace } = useParams();
   const { projects } = React.useContext(ProjectsContext);
-  const match = namespace ? projects.find(byName(namespace)) ?? null : null;
+  const match = namespace ? projects.find(byName(namespace)) : undefined;
   const { clusterPlatforms } = useAvailableClusterPlatforms();
   const { activePlatform, projectPlatform } = useProjectServingPlatform(match, clusterPlatforms);
   const inferenceServices = useInferenceServices(namespace, undefined, undefined, undefined, {
@@ -97,7 +92,6 @@ export const DeployButton: React.FC<{
   const inferenceServiceRefresh = inferenceServices.refresh;
   const servingRuntimes = useServingRuntimes(namespace, undefined, { refreshRate: POLL_INTERVAL });
   const servingRuntimeRefresh = servingRuntimes.refresh;
-  const serverSecrets = useServingRuntimeSecrets(namespace, { refreshRate: POLL_INTERVAL });
   const { projects: modelProjects } = React.useContext(ModelDeploymentsContext);
   const { namespace: modelNamespace } = useParams<{ namespace: string }>();
   const currentProject = modelProjects?.find(byName(modelNamespace));
@@ -108,7 +102,6 @@ export const DeployButton: React.FC<{
     if (submit) {
       servingRuntimeRefresh();
       inferenceServiceRefresh();
-      setTimeout(serverSecrets.refresh, 500);
     }
   };
 

--- a/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
+++ b/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
@@ -1,20 +1,83 @@
 import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
-import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { ServingRuntimePlatform } from '@odh-dashboard/internal/types';
 import {
   getSortedTemplates,
   getTemplateEnabled,
   getTemplateEnabledForPlatform,
 } from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
-import { isProjectNIMSupported } from '@odh-dashboard/internal/pages/modelServing/screens/projects/nimUtils';
 import ManageServingRuntimeModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/ServingRuntimeModal/ManageServingRuntimeModal';
 import ManageKServeModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
 import ManageNIMServingModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal';
+import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { useParams } from 'react-router-dom';
+import { POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
+import useInferenceServices from '@odh-dashboard/internal/pages/modelServing/useInferenceServices';
+import useServingRuntimes from '@odh-dashboard/internal/pages/modelServing/useServingRuntimes';
+import { useTemplates } from '@odh-dashboard/internal/api/k8s/templates';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/index';
+import useTemplateOrder from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateOrder';
+import useTemplateDisablement from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateDisablement';
+import useConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useConnections';
+import useServingRuntimeSecrets from '@odh-dashboard/internal/pages/modelServing/screens/projects/useServingRuntimeSecrets';
+import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import { isProjectNIMSupported } from '@odh-dashboard/internal/pages/modelServing/screens/projects/nimUtils';
+import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
 import {
   useProjectServingPlatform,
   ModelServingPlatform,
 } from '../../concepts/useProjectServingPlatform';
+import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
+
+const DeployButtonModal: React.FC<{
+  platform: ServingRuntimePlatform;
+  currentProject: ProjectKind;
+  onClose: (submit: boolean) => void;
+}> = ({ platform, currentProject, onClose }) => {
+  const { namespace } = useParams();
+  const { dashboardNamespace } = useDashboardNamespace();
+  const [servingRuntimeTemplates] = useTemplates(dashboardNamespace);
+  const servingRuntimeTemplateOrder = useTemplateOrder(dashboardNamespace, undefined, {
+    refreshRate: POLL_INTERVAL,
+  });
+  const servingRuntimeTemplateDisablement = useTemplateDisablement(dashboardNamespace, undefined, {
+    refreshRate: POLL_INTERVAL,
+  });
+  const connections = useConnections(namespace);
+  const templatesSorted = getSortedTemplates(
+    servingRuntimeTemplates,
+    servingRuntimeTemplateOrder.data,
+  );
+  const templatesEnabled = templatesSorted.filter((template) =>
+    getTemplateEnabled(template, servingRuntimeTemplateDisablement.data),
+  );
+
+  if (platform === ServingRuntimePlatform.MULTI) {
+    return (
+      <ManageServingRuntimeModal
+        currentProject={currentProject}
+        servingRuntimeTemplates={templatesEnabled.filter((t) =>
+          getTemplateEnabledForPlatform(t, ServingRuntimePlatform.MULTI),
+        )}
+        onClose={onClose}
+      />
+    );
+  }
+
+  const isNIMSupported = isProjectNIMSupported(currentProject);
+  if (isNIMSupported) {
+    return <ManageNIMServingModal projectContext={{ currentProject }} onClose={onClose} />;
+  }
+  return (
+    <ManageKServeModal
+      projectContext={{ currentProject, connections: connections.data }}
+      servingRuntimeTemplates={templatesEnabled.filter((t) =>
+        getTemplateEnabledForPlatform(t, ServingRuntimePlatform.SINGLE),
+      )}
+      onClose={onClose}
+    />
+  );
+};
 
 export const DeployButton: React.FC<{
   platform?: ModelServingPlatform;
@@ -23,34 +86,29 @@ export const DeployButton: React.FC<{
 }> = ({ platform, variant = 'primary', isDisabled }) => {
   const [modalShown, setModalShown] = React.useState<boolean>(false);
   const [platformSelected, setPlatformSelected] = React.useState<ServingRuntimePlatform>();
-
-  const {
-    servingRuntimes: { refresh: refreshServingRuntime },
-    servingRuntimeTemplates: [templates],
-    servingRuntimeTemplateOrder: { data: templateOrder },
-    servingRuntimeTemplateDisablement: { data: templateDisablement },
-    connections: { data: connections },
-    serverSecrets: { refresh: refreshTokens },
-    inferenceServices: { refresh: refreshInferenceServices },
-    currentProject,
-  } = React.useContext(ProjectDetailsContext);
-
-  const { activePlatform, projectPlatform } = useProjectServingPlatform(currentProject);
-
-  const templatesSorted = getSortedTemplates(templates, templateOrder);
-  const templatesEnabled = templatesSorted.filter((template) =>
-    getTemplateEnabled(template, templateDisablement),
-  );
-
-  const isKServeNIMEnabled = isProjectNIMSupported(currentProject);
+  const { namespace } = useParams();
+  const { projects } = React.useContext(ProjectsContext);
+  const match = namespace ? projects.find(byName(namespace)) ?? null : null;
+  const { clusterPlatforms } = useAvailableClusterPlatforms();
+  const { activePlatform, projectPlatform } = useProjectServingPlatform(match, clusterPlatforms);
+  const inferenceServices = useInferenceServices(namespace, undefined, undefined, undefined, {
+    refreshRate: POLL_INTERVAL,
+  });
+  const inferenceServiceRefresh = inferenceServices.refresh;
+  const servingRuntimes = useServingRuntimes(namespace, undefined, { refreshRate: POLL_INTERVAL });
+  const servingRuntimeRefresh = servingRuntimes.refresh;
+  const serverSecrets = useServingRuntimeSecrets(namespace, { refreshRate: POLL_INTERVAL });
+  const { projects: modelProjects } = React.useContext(ModelDeploymentsContext);
+  const { namespace: modelNamespace } = useParams<{ namespace: string }>();
+  const currentProject = modelProjects?.find(byName(modelNamespace));
 
   const onSubmit = (submit: boolean) => {
     setModalShown(false);
     setPlatformSelected(undefined);
     if (submit) {
-      refreshServingRuntime();
-      refreshInferenceServices();
-      setTimeout(refreshTokens, 500);
+      servingRuntimeRefresh();
+      inferenceServiceRefresh();
+      setTimeout(serverSecrets.refresh, 500);
     }
   };
 
@@ -63,7 +121,7 @@ export const DeployButton: React.FC<{
       );
     } else {
       const currentPlatform = activePlatform || projectPlatform;
-      if (currentPlatform) {
+      if (currentProject && currentPlatform) {
         setPlatformSelected(
           currentPlatform.properties.id === 'modelmesh'
             ? ServingRuntimePlatform.MULTI
@@ -79,39 +137,27 @@ export const DeployButton: React.FC<{
       variant={variant}
       data-testid="deploy-button"
       onClick={handleDeployClick}
-      isAriaDisabled={isDisabled}
+      isAriaDisabled={!currentProject}
     >
       Deploy model
     </Button>
   );
 
-  const hasPlatform = platform || activePlatform || projectPlatform;
-
-  if (!hasPlatform) {
-    return <Tooltip content="To deploy a model, select a project.">{deployButton}</Tooltip>;
+  if (!currentProject || isDisabled) {
+    return (
+      <Tooltip data-testid="deploy-model-tooltip" content="To deploy a model, select a project.">
+        {deployButton}
+      </Tooltip>
+    );
   }
 
   return (
     <>
       {deployButton}
-      {modalShown && platformSelected === ServingRuntimePlatform.MULTI ? (
-        <ManageServingRuntimeModal
+      {modalShown && platformSelected ? (
+        <DeployButtonModal
+          platform={platformSelected}
           currentProject={currentProject}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.MULTI),
-          )}
-          onClose={onSubmit}
-        />
-      ) : null}
-      {modalShown && platformSelected === ServingRuntimePlatform.SINGLE && isKServeNIMEnabled ? (
-        <ManageNIMServingModal projectContext={{ currentProject }} onClose={onSubmit} />
-      ) : null}
-      {modalShown && platformSelected === ServingRuntimePlatform.SINGLE && !isKServeNIMEnabled ? (
-        <ManageKServeModal
-          projectContext={{ currentProject, connections }}
-          servingRuntimeTemplates={templatesEnabled.filter((template) =>
-            getTemplateEnabledForPlatform(template, ServingRuntimePlatform.SINGLE),
-          )}
           onClose={onSubmit}
         />
       ) : null}

--- a/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
+++ b/frontend/packages/modelServing/src/components/deploy/DeployButton.tsx
@@ -11,9 +11,6 @@ import ManageKServeModal from '@odh-dashboard/internal/pages/modelServing/screen
 import ManageNIMServingModal from '@odh-dashboard/internal/pages/modelServing/screens/projects/NIMServiceModal/ManageNIMServingModal';
 import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
 import { useParams } from 'react-router-dom';
-import { POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
-import useInferenceServices from '@odh-dashboard/internal/pages/modelServing/useInferenceServices';
-import useServingRuntimes from '@odh-dashboard/internal/pages/modelServing/useServingRuntimes';
 import { useTemplates } from '@odh-dashboard/internal/api/k8s/templates';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/index';
 import useTemplateOrder from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/useTemplateOrder';
@@ -86,23 +83,13 @@ export const DeployButton: React.FC<{
   const match = namespace ? projects.find(byName(namespace)) : undefined;
   const { clusterPlatforms } = useAvailableClusterPlatforms();
   const { activePlatform, projectPlatform } = useProjectServingPlatform(match, clusterPlatforms);
-  const inferenceServices = useInferenceServices(namespace, undefined, undefined, undefined, {
-    refreshRate: POLL_INTERVAL,
-  });
-  const inferenceServiceRefresh = inferenceServices.refresh;
-  const servingRuntimes = useServingRuntimes(namespace, undefined, { refreshRate: POLL_INTERVAL });
-  const servingRuntimeRefresh = servingRuntimes.refresh;
   const { projects: modelProjects } = React.useContext(ModelDeploymentsContext);
   const { namespace: modelNamespace } = useParams<{ namespace: string }>();
   const currentProject = modelProjects?.find(byName(modelNamespace));
 
-  const onSubmit = (submit: boolean) => {
+  const onSubmit = () => {
     setModalShown(false);
     setPlatformSelected(undefined);
-    if (submit) {
-      servingRuntimeRefresh();
-      inferenceServiceRefresh();
-    }
   };
 
   const handleDeployClick = () => {

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ModelServingToolbar from '@odh-dashboard/internal/pages/modelServing/screens/global/ModelServingToolbar';
 import {
   initialModelServingFilterData,
   type ModelServingFilterDataType,
@@ -11,6 +10,7 @@ import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/Proje
 import { useExtensions, useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { Label } from '@patternfly/react-core';
+import GlobalModelsToolbar from './GlobalModelsToolbar';
 import DeploymentsTable from '../deployments/DeploymentsTable';
 import {
   isModelServingDeploymentsTableExtension,
@@ -107,7 +107,7 @@ const GlobalDeploymentsTable: React.FC<{ deployments: Deployment[]; loaded: bool
       loaded={loaded && tableExtensionsLoaded}
       platformColumns={platformColumns}
       toolbarContent={
-        <ModelServingToolbar
+        <GlobalModelsToolbar
           filterData={filterData}
           onFilterUpdate={(key, value) => setFilterData((prev) => ({ ...prev, [key]: value }))}
         />

--- a/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalDeploymentsView.tsx
@@ -4,8 +4,8 @@ import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils
 import TitleWithIcon from '@odh-dashboard/internal/concepts/design/TitleWithIcon';
 import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import ModelServingLoading from '@odh-dashboard/internal/pages/modelServing/screens/global/ModelServingLoading';
-import { useNavigate } from 'react-router-dom';
-import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { useNavigate, useParams } from 'react-router-dom';
+import { byName, ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
 import { GlobalNoModelsView } from './GlobalNoModelsView';
 import GlobalDeploymentsTable from './GlobalDeploymentsTable';
 import ModelServingProjectSelection from './ModelServingProjectSelection';
@@ -24,6 +24,9 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ projects 
   const hasDeployments = deployments && deployments.length > 0;
   const isLoading = !deploymentsLoaded;
   const isEmpty = projects.length === 0 || (!isLoading && !hasDeployments);
+  const { projects: modelProjects } = React.useContext(ModelDeploymentsContext);
+  const { namespace: modelNamespace } = useParams<{ namespace: string }>();
+  const currentProject = modelProjects?.find(byName(modelNamespace));
 
   return (
     <ApplicationsPage
@@ -46,7 +49,7 @@ const GlobalDeploymentsView: React.FC<GlobalDeploymentsViewProps> = ({ projects 
         projects.length === 0 ? (
           <NoProjectsPage />
         ) : (
-          <GlobalNoModelsView project={preferredProject ?? undefined} />
+          <GlobalNoModelsView project={currentProject ?? undefined} />
         )
       }
       description="Manage and view the health and performance of your deployed models."

--- a/frontend/packages/modelServing/src/components/global/GlobalModelsToolbar.tsx
+++ b/frontend/packages/modelServing/src/components/global/GlobalModelsToolbar.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
+import {
+  ModelServingFilterDataType,
+  modelServingFilterOptions,
+  ModelServingToolbarFilterOptions,
+} from '@odh-dashboard/internal/pages/modelServing/screens/global/const';
+import { DeployButton } from '../deploy/DeployButton';
+
+type GlobalModelsToolbarProps = {
+  filterData: ModelServingFilterDataType;
+  onFilterUpdate: (key: string, value?: string | { label: string; value: string }) => void;
+};
+
+const GlobalModelsToolbar: React.FC<GlobalModelsToolbarProps> = ({
+  filterData,
+  onFilterUpdate,
+}) => (
+  <FilterToolbar<keyof typeof modelServingFilterOptions>
+    data-testid="model-serving-table-toolbar"
+    filterOptions={modelServingFilterOptions}
+    filterOptionRenders={{
+      [ModelServingToolbarFilterOptions.name]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          aria-label="Filter by name"
+          placeholder="Filter by name"
+          onChange={(_event, value) => onChange(value)}
+        />
+      ),
+      [ModelServingToolbarFilterOptions.project]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          aria-label="Filter by project"
+          placeholder="Filter by project"
+          onChange={(_event, value) => onChange(value)}
+        />
+      ),
+    }}
+    filterData={filterData}
+    onFilterUpdate={onFilterUpdate}
+  >
+    <ToolbarGroup>
+      <ToolbarItem>
+        <DeployButton />
+      </ToolbarItem>
+    </ToolbarGroup>
+  </FilterToolbar>
+);
+
+export default GlobalModelsToolbar;

--- a/frontend/packages/modelServing/src/concepts/useProjectServingPlatform.ts
+++ b/frontend/packages/modelServing/src/concepts/useProjectServingPlatform.ts
@@ -57,7 +57,7 @@ export const getMultiProjectServingPlatforms = (
 };
 
 export const useProjectServingPlatform = (
-  project: ProjectKind,
+  project: ProjectKind | null,
   platforms?: ModelServingPlatform[],
 ): {
   activePlatform?: ModelServingPlatform | null; // This includes preselecting a platform if there is only one
@@ -69,14 +69,14 @@ export const useProjectServingPlatform = (
 } => {
   const [tmpProjectPlatform, setTmpProjectPlatform] = React.useState<
     ModelServingPlatform | null | undefined
-  >(project.metadata.name && platforms ? getProjectServingPlatform(project, platforms) : undefined);
+  >(project && platforms ? getProjectServingPlatform(project, platforms) : undefined);
   const [projectPlatformError, setProjectPlatformError] = React.useState<string | null>(null);
   const [newProjectPlatformLoading, setNewProjectPlatformLoading] = React.useState<
     ModelServingPlatform | null | undefined
   >();
 
   React.useEffect(() => {
-    if (!project.metadata.name || !platforms) {
+    if (!project || !platforms) {
       return;
     }
     const p = getProjectServingPlatform(project, platforms);
@@ -88,6 +88,9 @@ export const useProjectServingPlatform = (
 
   const setProjectPlatform = React.useCallback(
     (platformToEnable: ModelServingPlatform) => {
+      if (!project) {
+        return;
+      }
       setNewProjectPlatformLoading(platformToEnable);
       setProjectPlatformError(null);
 
@@ -103,6 +106,9 @@ export const useProjectServingPlatform = (
   );
 
   const resetProjectPlatform = React.useCallback(() => {
+    if (!project) {
+      return;
+    }
     setNewProjectPlatformLoading(null);
     setProjectPlatformError(null);
 

--- a/frontend/packages/modelServing/src/concepts/useProjectServingPlatform.ts
+++ b/frontend/packages/modelServing/src/concepts/useProjectServingPlatform.ts
@@ -57,7 +57,7 @@ export const getMultiProjectServingPlatforms = (
 };
 
 export const useProjectServingPlatform = (
-  project: ProjectKind | null,
+  project?: ProjectKind,
   platforms?: ModelServingPlatform[],
 ): {
   activePlatform?: ModelServingPlatform | null; // This includes preselecting a platform if there is only one


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-28902

## Description
Routes the deploy model buttons in our refactor to our existing modal code (how it’s being done in [ServeModelButton.tsx](https://github.com/opendatahub-io/odh-dashboard/blob/main/frontend/src/pages/modelServing/screens/global/ServeModelButton.tsx)).

## How Has This Been Tested?
Tested locally. With our Model Serving Plugin feature flag enabled, deploy buttons should now let you deploy a model.

- Projects > Projects overview > when 0 models there will be a hyperlink to deploy
- Projects > project details > models tab > when 0 models there will be a empty state page and the button in the center
- Projects > project details > models tab > when there are models, it's on the top right
- Global models page > When you select a project > the button is on the top and becomes enabled 

## Test Impact
No tests changed

## Screenshot
Example in global page when deploy model button is clicked
<img width="1782" height="1101" alt="Screenshot 2025-07-31 at 10 42 31 AM" src="https://github.com/user-attachments/assets/4c3bc6d7-e018-4f67-9edb-b6eae33d8234" />

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new toolbar for global model deployments, featuring improved filter options and integrated deploy button.
  * Added a modal that adapts to the selected serving platform, providing tailored deployment options for different environments.

* **Bug Fixes**
  * Improved handling of cases where no project is selected, preventing errors and guiding users to select a project.

* **Refactor**
  * Enhanced the deploy button with context-driven logic, conditional modal rendering, and automated refresh workflows.
  * Updated internal logic to safely handle scenarios where project information may be unavailable.
  * Updated global deployments view to dynamically select projects based on URL parameters for more accurate context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->