### PR TITLE
Adapt base images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-# Use ubi8/nodejs-18 as default base image
-ARG BASE_IMAGE="registry.access.redhat.com/ubi8/nodejs-20:latest"
+# Use ubi9/nodejs-20 as default base image
+ARG BASE_IMAGE="registry.access.redhat.com/ubi9/nodejs-20:latest"
 
 FROM ${BASE_IMAGE} as builder
 
@@ -52,6 +52,6 @@ CMD ["npm", "run", "start"]
 
 LABEL io.opendatahub.component="odh-dashboard" \
       io.k8s.display-name="odh-dashboard" \
-      name="open-data-hub/odh-dashboard-ubi8" \
+      name="open-data-hub/odh-dashboard-ubi9" \
       summary="odh-dashboard" \
       description="Open Data Hub Dashboard"

--- a/frontend/packages/llama-stack-modular-ui/Dockerfile
+++ b/frontend/packages/llama-stack-modular-ui/Dockerfile
@@ -3,9 +3,9 @@ ARG UI_SOURCE_CODE=./frontend
 ARG BFF_SOURCE_CODE=./bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=node:20
-ARG GOLANG_BASE_IMAGE=golang:1.24.3
-ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
+ARG DISTROLESS_BASE_IMAGE=registry.redhat.io/ubi9-minimal:latest
 
 # UI build stage
 FROM ${NODE_BASE_IMAGE} AS ui-builder

--- a/frontend/packages/model-registry/Dockerfile
+++ b/frontend/packages/model-registry/Dockerfile
@@ -3,9 +3,9 @@ ARG UI_SOURCE_CODE=./upstream/frontend
 ARG BFF_SOURCE_CODE=./upstream/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=node:20
-ARG GOLANG_BASE_IMAGE=golang:1.24.3
-ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
+ARG DISTROLESS_BASE_IMAGE=registry.redhat.io/ubi9-minimal:latest
 
 # UI build stage
 FROM ${NODE_BASE_IMAGE} AS ui-builder


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Closes https://issues.redhat.com/browse/RHOAIENG-30895
We are starting to onboard modular architecture images to konflux, and we've had some feedback from the dev ops team to adapt our base images to ubi9 flavored ones.

This pull request updates the base images in several `Dockerfile` files to align with Red Hat Universal Base Image (UBI) 9 and ensure consistency across the project. The changes primarily involve replacing UBI 8 and other third-party base images with UBI 9 equivalents.

### Updates to base images:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R5): Updated the base image from `ubi8/nodejs-20` to `ubi9/nodejs-20` and modified the `name` label to reflect the change from UBI 8 to UBI 9. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R5) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L55-R55)
* [`frontend/packages/llama-stack-modular-ui/Dockerfile`](diffhunk://#diff-8adb50d72e160c968b3a8df24845ad02c5e53295f7360f2b2e7eeda247939904L6-R8): Replaced third-party base images (`node:20`, `golang:1.24.3`, and `gcr.io/distroless/static:nonroot`) with UBI 9 equivalents (`ubi9/nodejs-20`, `ubi9/go-toolset:1.24`, and `ubi9-minimal`).
* [`frontend/packages/model-registry/Dockerfile`](diffhunk://#diff-fc783351762e2566b874ef175061c69e3efc6733fe24f225db096d578caf6289L6-R8): Similar to the llama-stack modular UI, replaced third-party base images with UBI 9 equivalents.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We've deployed the Dashboard image and the Model Registry Modular Architecture one in the [monarch cluster](https://console-openshift-console.apps.ui-monarch.dev.datahub.redhat.com) where you can verify the installation.
We've built the following images:

* `quay.io/lferrnan/odh-dashboard:red-hat-images` or `quay.io/opendatahub/odh-dashboard:pr-4565`
* `quay.io/lferrnan/model-registry-ui-federated:red-hat-images`
* `quay.io/lferrnan/llama-stack-federated:latest`

<img width="1708" height="765" alt="Screenshot 2025-07-29 at 17 05 02" src="https://github.com/user-attachments/assets/185caece-7af5-4921-8f39-6687b6f97344" />


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No testing needed here

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker images to use Red Hat UBI 9-based images for improved consistency and security across all components. No changes to application functionality or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->