### PR TITLE
Add operator parameter to modular architecture image 

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -10,7 +10,7 @@
   path: /spec/template/spec/containers/-
   value: 
     name: model-registry-ui
-    image: model-registry-ui
+    image: $(model-registry-ui-image)
     imagePullPolicy: Always
     livenessProbe:
       httpGet:

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -3,6 +3,21 @@ kind: Kustomization
 resources:
   - ../core-bases/base
   - federation-configmap.yaml
+configMapGenerator:
+  - name: modular-architecture-params
+    env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+  - name: model-registry-ui-image
+    objref:
+      kind: ConfigMap
+      name: modular-architecture-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.model-registry-ui-image
+configurations:
+  - params.yaml
 patchesJson6902:
   - path: deployment.yaml
     target:
@@ -15,8 +30,3 @@ patchesJson6902:
       version: v1
       kind: Service
       name: odh-dashboard
-
-images:
-  - name: model-registry-ui
-    newName: quay.io/lferrnan/model-registry-ui-federated # TODO: Update to the correct image once we set up the module in konflux and onboard it in quay and parametrize this value
-    newTag: latest

--- a/manifests/modular-architecture/params.env
+++ b/manifests/modular-architecture/params.env
@@ -1,0 +1,2 @@
+# Injected variables from the Operator
+model-registry-ui-image=quay.io/opendatahub/odh-mod-arch-modular-architecture:latest

--- a/manifests/modular-architecture/params.yaml
+++ b/manifests/modular-architecture/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Continuation of https://issues.redhat.com/browse/RHOAIENG-30716
Step needed for the operator to inject the required image for modular architecture.
This will enable https://github.com/opendatahub-io/opendatahub-operator/pull/2233

This pull request introduces changes to parameterize the `model-registry-ui` image in the modular architecture manifests, improving configurability and enabling easier updates. The most important changes include replacing hardcoded image references with a parameterized approach, adding configuration files to manage these parameters, and removing outdated image definitions.

### Parameterization of `model-registry-ui` image:

* [`manifests/modular-architecture/deployment.yaml`](diffhunk://#diff-52da88caf3ee51f86d0afc986bf1a37991db9ea62ef94d78330f3d9ae1fc051dL13-R13): Updated the `image` field for the `model-registry-ui` container to use the `$(model-registry-ui-image)` variable instead of a hardcoded value.

* [`manifests/modular-architecture/kustomization.yaml`](diffhunk://#diff-a716212cbafa854fd1ef98a75902dc29acc05c4ace1c72fc2a4627e15f61b697R6-R20): Added a `configMapGenerator` to define the `model-registry-ui-image` variable, linked it to the `params.env` file, and disabled the name suffix hash for the generated ConfigMap. Removed the outdated `images` section that hardcoded the image details. [[1]](diffhunk://#diff-a716212cbafa854fd1ef98a75902dc29acc05c4ace1c72fc2a4627e15f61b697R6-R20) [[2]](diffhunk://#diff-a716212cbafa854fd1ef98a75902dc29acc05c4ace1c72fc2a4627e15f61b697L18-L22)

### Configuration file additions:

* [`manifests/modular-architecture/params.env`](diffhunk://#diff-1081b90fda2b2d52b98cc97660f22a773427b36a469e770abaa504b156c55f04R1-R2): Introduced a new file to define environment variables, including the `model-registry-ui-image` with its default value.

* [`manifests/modular-architecture/params.yaml`](diffhunk://#diff-0132c64db9c2876acfb56352b8a773a867b9393be81fddd755672185aca469cfR1-R3): Added a new configuration file to specify variable references for the `image` field in the `Deployment` resource.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed in the [monarch cluster](https://console-openshift-console.apps.ui-monarch.dev.datahub.redhat.com/)

```yaml
    dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/lucferbux/odh-dashboard/tarball/get-params-env-mod-arch'
      managementState: Managed
```

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to allow dynamic specification of the model-registry-ui container image using environment parameters.
  * Introduced parameter files and ConfigMap generation for improved flexibility in image management.
  * Removed hardcoded image references, enabling easier updates and customization during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->