### PR TITLE
added deployments tab extension

### DIFF
--- a/frontend/@mf-types/@mf/modelRegistry/api.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/api.d.ts
@@ -1,0 +1,2 @@
+export * from './compiled-types/src/odh/api';
+export { default } from './compiled-types/src/odh/api';

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/AppContext.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/AppContext.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { UserSettings, ConfigSettings } from 'mod-arch-shared';
+type AppContextProps = {
+    config: ConfigSettings;
+    user: UserSettings;
+};
+export declare const AppContext: React.Context<AppContextProps>;
+export declare const useAppContext: () => AppContextProps;
+export {};

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/ArchiveVersionButton.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/ArchiveVersionButton.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { ModelVersion } from '@odh-dashboard/internal/concepts/modelRegistry/types';
+import { ModelServingPlatformWatchDeployments } from '~/odh/extension-points';
+interface ArchiveButtonProps {
+    mv: ModelVersion;
+    mrName?: string;
+    watcher?: ModelServingPlatformWatchDeployments;
+    setIsArchiveModalOpen: (value: React.SetStateAction<boolean>) => void;
+}
+declare const ArchiveButton: React.ForwardRefExoticComponent<ArchiveButtonProps & React.RefAttributes<HTMLButtonElement>>;
+export default ArchiveButton;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionRegisteredDeploymentsView.d.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+import ModelVersionDetailsTabs from '~/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsTabs';
+type ModelVersionRegisteredDeploymentsViewProps = Pick<React.ComponentProps<typeof ModelVersionDetailsTabs>, 'inferenceServices' | 'servingRuntimes' | 'refresh'>;
+declare const ModelVersionRegisteredDeploymentsView: React.FC<ModelVersionRegisteredDeploymentsViewProps>;
+export default ModelVersionRegisteredDeploymentsView;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/types.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersionDetails/types.d.ts
@@ -1,0 +1,6 @@
+import { InferenceServiceKind, ServingRuntimeKind, FetchStateObject } from 'mod-arch-shared';
+export type ModelVersionRegisteredDeploymentsViewProps = {
+    inferenceServices: FetchStateObject<InferenceServiceKind[]>;
+    servingRuntimes: FetchStateObject<ServingRuntimeKind[]>;
+    refresh: () => void;
+};

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.d.ts
@@ -4,7 +4,6 @@ type ModelVersionsTableRowProps = {
     modelVersion: ModelVersion;
     isArchiveRow?: boolean;
     isArchiveModel?: boolean;
-    hasDeployment?: boolean;
     refresh: () => void;
 };
 declare const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps>;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/ModelRegistryCreateModal.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/ModelRegistryCreateModal.d.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+type CreateModalProps = {
+    onClose: () => void;
+};
+declare const CreateModal: React.FC<CreateModalProps>;
+export default CreateModal;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/ModelRegistryCreateModalFooter.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/ModelRegistryCreateModalFooter.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { ButtonProps } from '@patternfly/react-core';
+type ModelRegistryCreateModalFooterProps = {
+    submitLabel: string;
+    submitButtonVariant?: ButtonProps['variant'];
+    onSubmit: () => void;
+    onCancel: () => void;
+    isSubmitDisabled?: boolean;
+    isSubmitLoading?: boolean;
+    isCancelDisabled?: boolean;
+    alertTitle?: string;
+    error?: Error;
+    alertLinks?: React.ReactNode;
+};
+declare const ModelRegistryCreateModalFooter: React.FC<ModelRegistryCreateModalFooterProps>;
+export default ModelRegistryCreateModalFooter;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/PasswordInput.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/app/pages/settings/PasswordInput.d.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { TextInput } from '@patternfly/react-core';
+type Props = React.ComponentProps<typeof TextInput> & {
+    ariaLabelShow?: string;
+    ariaLabelHide?: string;
+};
+declare const PasswordInput: React.FC<Props>;
+export default PasswordInput;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/components/MRDeploymentsContextProvider.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/components/MRDeploymentsContextProvider.d.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+interface MRDeploymentsContextProviderProps {
+    children: React.ReactNode;
+    labelSelectors?: {
+        [key: string]: string;
+    };
+}
+/**
+ * Provider component that automatically wraps children with deployments context if available.
+ * Uses extensions to provide the deployments provider and hook.
+ */
+export declare const MRDeploymentsContextProvider: React.FC<MRDeploymentsContextProviderProps>;
+export {};

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points.d.ts
@@ -1,0 +1,82 @@
+import type { CodeRef, Extension, ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { ComponentCodeRef } from '@odh-dashboard/plugin-core/extension-points';
+import { ModelVersion } from '~/app/types';
+import { DisplayNameAnnotations, K8sAPIOptions, ProjectKind } from '@odh-dashboard/internal/k8sTypes.js';
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types.js';
+import { EitherNotBoth, ProjectObjectType } from 'mod-arch-shared';
+import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types.js';
+export type DeploymentStatus = {
+    state: InferenceServiceModelState;
+    message?: string;
+};
+export type DeploymentEndpoint = {
+    type: 'internal' | 'external';
+    name?: string;
+    url: string;
+    error?: string;
+};
+export type ServerResourceType = K8sResourceCommon & {
+    metadata: {
+        name: string;
+        annotations?: DisplayNameAnnotations & Partial<{
+            'opendatahub.io/apiProtocol': string;
+        }>;
+    };
+};
+export type ModelResourceType = K8sResourceCommon & {
+    metadata: {
+        name: string;
+        annotations?: DisplayNameAnnotations;
+    };
+};
+export type Deployment<ModelResource extends ModelResourceType = ModelResourceType, ServerResource extends ServerResourceType = ServerResourceType> = {
+    modelServingPlatformId: string;
+    model: ModelResource;
+    server?: ServerResource;
+    status?: DeploymentStatus;
+    endpoints?: DeploymentEndpoint[];
+};
+export type ModelRegistryDeploymentsTabExtension = Extension<'model-registry.version-details/tab', {
+    id: string;
+    title: string;
+    component: ComponentCodeRef<{
+        mv: ModelVersion;
+        mrName?: string;
+        refresh: () => void;
+    }>;
+}>;
+export declare const isModelRegistryDeploymentsTabExtension: (extension: Extension) => extension is ModelRegistryDeploymentsTabExtension;
+export type ModelServingPlatformExtension<D extends Deployment = Deployment> = Extension<'model-serving.platform', {
+    id: D['modelServingPlatformId'];
+    manage: {
+        namespaceApplicationCase: NamespaceApplicationCase;
+        enabledLabel: string;
+        enabledLabelValue: string;
+    };
+    enableCardText: {
+        title: string;
+        description: string;
+        selectText: string;
+        enabledText: string;
+        objectType: ProjectObjectType;
+    };
+    deployedModelsView: {
+        startHintTitle: string;
+        startHintDescription: string;
+        deployButtonText: string;
+    };
+}>;
+export declare const isModelServingPlatformExtension: <D extends Deployment = Deployment>(extension: Extension) => extension is ModelServingPlatformExtension<D>;
+export type ModelServingPlatformWatchDeployments = ResolvedExtension<ModelServingPlatformWatchDeploymentsExtension>;
+export type ModelServingPlatformWatchDeploymentsExtension<D extends Deployment = Deployment> = Extension<'model-serving.platform/watch-deployments', {
+    platform: D['modelServingPlatformId'];
+    watch: CodeRef<(watchParams: EitherNotBoth<{
+        project: ProjectKind;
+    }, {
+        registeredModelId: string;
+        modelVersionId: string;
+        mrName?: string;
+    }>, opts?: K8sAPIOptions) => [D[] | undefined, boolean, Error | undefined]>;
+}>;
+export declare const isModelServingPlatformWatchDeployments: <D extends Deployment = Deployment>(extension: Extension) => extension is ModelServingPlatformWatchDeploymentsExtension<D>;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/deploy.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/deploy.d.ts
@@ -13,3 +13,18 @@ export type ModelRegistryDeployModalExtension = Extension<'model-registry.model-
     }>>;
 }>;
 export declare const isModelRegistryDeployModalExtension: (extension: Extension) => extension is ModelRegistryDeployModalExtension;
+export type ModelRegistryVersionDeploymentsContextExtension = Extension<'model-registry.model-version/deployments-context', {
+    useDeploymentsContext: CodeRef<() => {
+        deployments?: any[];
+        loaded: boolean;
+        errors?: Error[];
+        projects?: any[];
+    }>;
+    DeploymentsProvider: CodeRef<React.ComponentType<{
+        children: React.ReactNode;
+        labelSelectors?: {
+            [key: string]: string;
+        };
+    }>>;
+}>;
+export declare const isModelRegistryVersionDeploymentsContextExtension: (extension: Extension) => extension is ModelRegistryVersionDeploymentsContextExtension;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/details.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/details.d.ts
@@ -1,0 +1,7 @@
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+export type ModelRegistryVersionDetailsTabExtension = Extension<'model-registry.version-details/tab', {
+    id: string;
+    title: string;
+    component: CodeRef<React.ComponentType>;
+}>;
+export declare const isModelRegistryVersionDetailsTabExtension: (extension: Extension) => extension is ModelRegistryVersionDetailsTabExtension;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/index.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/index.d.ts
@@ -1,2 +1,3 @@
 export * from './deploy';
 export * from './connection';
+export * from './details';

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/version-details.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/version-details.d.ts
@@ -1,0 +1,11 @@
+import { Extension } from "@openshift/dynamic-plugin-sdk";
+import { ModelVersion } from "~/app/types";
+import type { ComponentCodeRef } from '@odh-dashboard/plugin-core/extension-points';
+export type ModelRegistryDeploymentsTabExtension = Extension<'model-registry.version-details/tab', {
+    id: string;
+    title: string;
+    component: ComponentCodeRef<{
+        mv: ModelVersion;
+    }>;
+}>;
+export declare const isModelRegistryDeploymentsTabExtension: (extension: Extension) => extension is ModelRegistryDeploymentsTabExtension;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/hooks/useDeploymentsContext.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/hooks/useDeploymentsContext.d.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+export declare const useDeploymentsContext: () => {
+    deploymentsState: {
+        deployments?: any[];
+        loaded: boolean;
+        errors?: Error[];
+        projects?: any[];
+    };
+    DeploymentsProviderComponent: false | React.ComponentType<{
+        children: React.ReactNode;
+        labelSelectors?: {
+            [key: string]: string;
+        };
+    }>;
+    hookNotifyComponent: React.JSX.Element | null;
+    isExtensionLoaded: boolean;
+};

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/hooks/useDeploymentsState.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/hooks/useDeploymentsState.d.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+type DeploymentsStateContextType = {
+    deployments?: any[];
+    loaded: boolean;
+    errors?: Error[];
+    projects?: any[];
+    isExtensionLoaded: boolean;
+};
+export declare const DeploymentsStateContext: React.Context<DeploymentsStateContextType>;
+/**
+ * Hook to access deployments state from shared context.
+ * Must be used within MRDeploymentsContextProvider.
+ */
+export declare const useDeploymentsState: () => DeploymentsStateContextType;
+export {};

--- a/frontend/packages/kserve/src/api.ts
+++ b/frontend/packages/kserve/src/api.ts
@@ -16,6 +16,7 @@ import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
 
 export const useWatchInferenceServices = (
   project: ProjectKind,
+  labelSelectors?: { [key: string]: string },
   opts?: K8sAPIOptions,
 ): CustomWatchK8sResult<InferenceServiceKind[]> =>
   useK8sWatchResourceList<InferenceServiceKind[]>(
@@ -23,6 +24,7 @@ export const useWatchInferenceServices = (
       isList: true,
       groupVersionKind: groupVersionKind(InferenceServiceModel),
       namespace: project.metadata.name,
+      ...(labelSelectors && { selector: labelSelectors }),
     },
     InferenceServiceModel,
     opts,

--- a/frontend/packages/kserve/src/deployments.ts
+++ b/frontend/packages/kserve/src/deployments.ts
@@ -19,10 +19,11 @@ export const isKServeDeployment = (deployment: Deployment): deployment is KServe
 
 export const useWatchDeployments = (
   project: ProjectKind,
+  labelSelectors?: { [key: string]: string },
   opts?: K8sAPIOptions,
 ): [KServeDeployment[] | undefined, boolean, Error | undefined] => {
   const [inferenceServices, inferenceServiceLoaded, inferenceServiceError] =
-    useWatchInferenceServices(project, opts);
+    useWatchInferenceServices(project, labelSelectors, opts);
   const [servingRuntimes, servingRuntimeLoaded, servingRuntimeError] = useWatchServingRuntimes(
     project,
     opts,

--- a/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersionDetails/ModelVersionDetailsHeaderActions.tsx
@@ -15,6 +15,7 @@ import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { ArchiveModelVersionModal } from '~/app/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { modelVersionListUrl } from '~/app/pages/modelRegistry/screens/routeUtils';
+import { useDeploymentsState } from '~/odh/hooks/useDeploymentsState';
 
 interface ModelVersionsDetailsHeaderActionsProps {
   mv: ModelVersion;
@@ -26,6 +27,8 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   refresh,
 }) => {
+  const { deployments } = useDeploymentsState();
+  const hasDeployment = deployments && deployments.length > 0;
   const { apiState } = React.useContext(ModelRegistryContext);
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const navigate = useNavigate();
@@ -61,10 +64,16 @@ const ModelVersionsDetailsHeaderActions: React.FC<ModelVersionsDetailsHeaderActi
           >
             <DropdownList>
               <DropdownItem
+                isAriaDisabled={hasDeployment}
                 id="archive-version-button"
                 aria-label="Archive model version"
                 key="archive-version-button"
                 onClick={() => setIsArchiveModalOpen(true)}
+                tooltipProps={
+                  hasDeployment
+                    ? { content: 'Deployed model versions cannot be archived' }
+                    : undefined
+                }
                 ref={tooltipRef}
               >
                 Archive model version

--- a/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTable.tsx
@@ -3,6 +3,7 @@ import { DashboardEmptyTableView, Table } from 'mod-arch-shared';
 import { ModelVersion } from '~/app/types';
 import { mvColumns } from '~/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableColumns';
 import ModelVersionsTableRow from '~/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow';
+import { MRDeploymentsContextProvider } from '~/odh/components/MRDeploymentsContextProvider';
 
 type ModelVersionsTableProps = {
   clearFilters: () => void;
@@ -28,13 +29,14 @@ const ModelVersionsTable: React.FC<ModelVersionsTableProps> = ({
     onClearFilters={clearFilters}
     emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
     rowRenderer={(mv: ModelVersion) => (
-      <ModelVersionsTableRow
-        hasDeployment={false}
-        key={mv.name}
-        modelVersion={mv}
-        isArchiveModel={isArchiveModel}
-        refresh={refresh}
-      />
+      <MRDeploymentsContextProvider>
+        <ModelVersionsTableRow
+          key={mv.name}
+          modelVersion={mv}
+          isArchiveModel={isArchiveModel}
+          refresh={refresh}
+        />
+      </MRDeploymentsContextProvider>
     )}
   />
 );

--- a/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelVersions/ModelVersionsTableRow.tsx
@@ -15,12 +15,12 @@ import ModelLabels from '~/app/pages/modelRegistry/screens/components/ModelLabel
 import { ArchiveModelVersionModal } from '~/app/pages/modelRegistry/screens/components/ArchiveModelVersionModal';
 import { RestoreModelVersionModal } from '~/app/pages/modelRegistry/screens/components/RestoreModelVersionModal';
 import MRVersionRowActionColumns from '~/odh/components/MRVersionRowActionColumns';
+import { useDeploymentsState } from '~/odh/hooks/useDeploymentsState';
 
 type ModelVersionsTableRowProps = {
   modelVersion: ModelVersion;
   isArchiveRow?: boolean;
   isArchiveModel?: boolean;
-  hasDeployment?: boolean;
   refresh: () => void;
 };
 
@@ -28,9 +28,10 @@ const ModelVersionsTableRow: React.FC<ModelVersionsTableRowProps> = ({
   modelVersion: mv,
   isArchiveRow,
   isArchiveModel,
-  hasDeployment = false,
   refresh,
 }) => {
+  const { deployments } = useDeploymentsState();
+  const hasDeployment = deployments && deployments.length > 0;
   const navigate = useNavigate();
   const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
   const { apiState } = React.useContext(ModelRegistryContext);

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/components/MRDeploymentsContextProvider.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/components/MRDeploymentsContextProvider.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useDeploymentsContext } from '~/odh/hooks/useDeploymentsContext';
+import { DeploymentsStateContext } from '~/odh/hooks/useDeploymentsState';
+
+interface MRDeploymentsContextProviderProps {
+  children: React.ReactNode;
+  labelSelectors?: { [key: string]: string };
+}
+
+/**
+ * Provider component that automatically wraps children with deployments context if available.
+ * Uses extensions to provide the deployments provider and hook.
+ */
+export const MRDeploymentsContextProvider: React.FC<MRDeploymentsContextProviderProps> = ({
+  children,
+  labelSelectors,
+}) => {
+  const { DeploymentsProviderComponent, hookNotifyComponent, deploymentsState, isExtensionLoaded } =
+    useDeploymentsContext();
+
+  // Create context value for deployments state
+  const deploymentsContextValue = React.useMemo(
+    () => ({
+      deployments: deploymentsState.deployments,
+      loaded: deploymentsState.loaded,
+      errors: deploymentsState.errors,
+      projects: deploymentsState.projects,
+      isExtensionLoaded,
+    }),
+    [deploymentsState, isExtensionLoaded],
+  );
+
+  const content = (
+    <DeploymentsStateContext.Provider value={deploymentsContextValue}>
+      {hookNotifyComponent}
+      {children}
+    </DeploymentsStateContext.Provider>
+  );
+
+  // Wrap with provider if available
+  if (DeploymentsProviderComponent) {
+    return (
+      <DeploymentsProviderComponent labelSelectors={labelSelectors}>
+        {content}
+      </DeploymentsProviderComponent>
+    );
+  }
+
+  return content;
+};

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/deploy.ts
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/deploy.ts
@@ -23,3 +23,28 @@ export const isModelRegistryDeployModalExtension = (
   extension: Extension,
 ): extension is ModelRegistryDeployModalExtension =>
   extension.type === 'model-registry.model-version/deploy-modal';
+
+export type ModelRegistryVersionDeploymentsContextExtension = Extension<
+  'model-registry.model-version/deployments-context',
+  {
+    useDeploymentsContext: CodeRef<
+      () => {
+        deployments?: any[];
+        loaded: boolean;
+        errors?: Error[];
+        projects?: any[];
+      }
+    >;
+    DeploymentsProvider: CodeRef<
+      React.ComponentType<{
+        children: React.ReactNode;
+        labelSelectors?: { [key: string]: string };
+      }>
+    >;
+  }
+>;
+
+export const isModelRegistryVersionDeploymentsContextExtension = (
+  extension: Extension,
+): extension is ModelRegistryVersionDeploymentsContextExtension =>
+  extension.type === 'model-registry.model-version/deployments-context';

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/details.ts
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/details.ts
@@ -1,0 +1,17 @@
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+
+export type ModelRegistryVersionDetailsTabExtension = Extension<
+  'model-registry.version-details/tab',
+  {
+    id: string;
+    title: string;
+    component: CodeRef<
+      React.ComponentType
+    >;
+  }
+>;
+
+export const isModelRegistryVersionDetailsTabExtension = (
+  extension: Extension,
+): extension is ModelRegistryVersionDetailsTabExtension =>
+  extension.type === 'model-registry.version-details/tab';

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/index.ts
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/extension-points/index.ts
@@ -1,2 +1,3 @@
 export * from './deploy';
 export * from './connection';
+export * from './details';

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/hooks/useDeploymentsContext.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/hooks/useDeploymentsContext.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useResolvedExtensions, HookNotify } from '@odh-dashboard/plugin-core';
+import { isModelRegistryVersionDeploymentsContextExtension } from '~/odh/extension-points/deploy';
+
+export const useDeploymentsContext = () => {
+  // Get deployments context extension
+  const [deploymentsContextExtensions, deploymentsContextLoaded] = useResolvedExtensions(
+    isModelRegistryVersionDeploymentsContextExtension,
+  );
+
+  const useDeploymentsHook = React.useMemo(
+    () =>
+      deploymentsContextLoaded &&
+      deploymentsContextExtensions?.[0]?.properties.useDeploymentsContext,
+    [deploymentsContextLoaded, deploymentsContextExtensions],
+  );
+
+  const DeploymentsProviderComponent = React.useMemo(
+    () =>
+      deploymentsContextLoaded && deploymentsContextExtensions?.[0]?.properties.DeploymentsProvider,
+    [deploymentsContextLoaded, deploymentsContextExtensions],
+  );
+
+  const [deploymentsState, setDeploymentsState] = React.useState<{
+    deployments?: any[];
+    loaded: boolean;
+    errors?: Error[];
+    projects?: any[];
+  }>({
+    deployments: undefined,
+    loaded: false,
+    errors: undefined,
+    projects: undefined,
+  });
+
+  const hookNotifyComponent = React.useMemo(
+    () =>
+      useDeploymentsHook && DeploymentsProviderComponent ? (
+        <HookNotify
+          useHook={useDeploymentsHook}
+          onNotify={(value) => {
+            if (value) {
+              setDeploymentsState(value);
+            }
+          }}
+        />
+      ) : null,
+    [useDeploymentsHook, DeploymentsProviderComponent],
+  );
+
+  return {
+    deploymentsState,
+    DeploymentsProviderComponent,
+    hookNotifyComponent,
+    isExtensionLoaded: deploymentsContextLoaded,
+  };
+};

--- a/frontend/packages/model-registry/upstream/frontend/src/odh/hooks/useDeploymentsState.tsx
+++ b/frontend/packages/model-registry/upstream/frontend/src/odh/hooks/useDeploymentsState.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+// Context for sharing deployments state
+type DeploymentsStateContextType = {
+  deployments?: any[];
+  loaded: boolean;
+  errors?: Error[];
+  projects?: any[];
+  isExtensionLoaded: boolean;
+};
+
+export const DeploymentsStateContext = React.createContext<DeploymentsStateContextType>({
+  deployments: undefined,
+  loaded: false,
+  errors: undefined,
+  projects: undefined,
+  isExtensionLoaded: false,
+});
+
+/**
+ * Hook to access deployments state from shared context.
+ * Must be used within MRDeploymentsContextProvider.
+ */
+export const useDeploymentsState = () => {
+  const context = React.useContext(DeploymentsStateContext);
+
+  return context;
+};

--- a/frontend/packages/modelServing/extension-points/index.ts
+++ b/frontend/packages/modelServing/extension-points/index.ts
@@ -115,6 +115,7 @@ export type ModelServingPlatformWatchDeploymentsExtension<D extends Deployment =
       watch: CodeRef<
         (
           project: ProjectKind,
+          labelSelectors?: { [key: string]: string },
           opts?: K8sAPIOptions,
         ) => [D[] | undefined, boolean, Error | undefined]
       >;

--- a/frontend/packages/modelServing/extensions/model-registry.ts
+++ b/frontend/packages/modelServing/extensions/model-registry.ts
@@ -1,8 +1,16 @@
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
-import type { ModelRegistryDeployModalExtension } from '@mf/modelRegistry/extension-points';
+import type {
+  ModelRegistryDeployModalExtension,
+  ModelRegistryVersionDeploymentsContextExtension,
+  ModelRegistryVersionDetailsTabExtension,
+} from '@mf/modelRegistry/extension-points';
 
-const extensions: ModelRegistryDeployModalExtension[] = [
+const extensions: (
+  | ModelRegistryDeployModalExtension
+  | ModelRegistryVersionDetailsTabExtension
+  | ModelRegistryVersionDeploymentsContextExtension
+)[] = [
   {
     type: 'model-registry.model-version/deploy-modal',
     properties: {
@@ -12,6 +20,28 @@ const extensions: ModelRegistryDeployModalExtension[] = [
         import('../modelRegistry/DeployRegisteredVersionModal').then(
           (m) => m.DeployRegisteredVersionModal,
         ),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_SERVING],
+    },
+  },
+  {
+    type: 'model-registry.version-details/tab',
+    properties: {
+      id: 'deployments',
+      title: 'Deployments',
+      component: () => import('../modelRegistry/DeploymentsTab').then((m) => m.default),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_SERVING],
+    },
+  },
+  {
+    type: 'model-registry.model-version/deployments-context',
+    properties: {
+      useDeploymentsContext: () => import('../modelRegistry/useDeployments').then((m) => m.default),
+      DeploymentsProvider: () =>
+        import('../modelRegistry/DeploymentsContextProvider').then((m) => m.default),
     },
     flags: {
       required: [SupportedArea.MODEL_SERVING],

--- a/frontend/packages/modelServing/modelRegistry/DeploymentsContextProvider.tsx
+++ b/frontend/packages/modelServing/modelRegistry/DeploymentsContextProvider.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { useExtensions } from '@odh-dashboard/plugin-core';
+import { ModelDeploymentsProvider } from '../src/concepts/ModelDeploymentsContext';
+import { isModelServingPlatformExtension } from '../extension-points';
+
+interface DeploymentsContextProviderProps {
+  children: React.ReactNode;
+  labelSelectors?: { [key: string]: string };
+}
+
+/**
+ * Wrapper component for ModelDeploymentsProvider to be used as an extension
+ * Gets projects and modelServingPlatforms internally to be self-contained
+ */
+const DeploymentsContextProvider: React.FC<DeploymentsContextProviderProps> = ({
+  children,
+  labelSelectors,
+}) => {
+  const { projects } = React.useContext(ProjectsContext);
+  const modelServingPlatforms = useExtensions(isModelServingPlatformExtension);
+
+  return (
+    <ModelDeploymentsProvider
+      projects={projects}
+      modelServingPlatforms={modelServingPlatforms}
+      labelSelectors={labelSelectors}
+    >
+      {children}
+    </ModelDeploymentsProvider>
+  );
+};
+
+export default DeploymentsContextProvider;

--- a/frontend/packages/modelServing/modelRegistry/DeploymentsTab.tsx
+++ b/frontend/packages/modelServing/modelRegistry/DeploymentsTab.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ProjectObjectType, typedEmptyImage } from '@odh-dashboard/internal/concepts/design/utils';
+import EmptyModelRegistryState from './EmptyModelRegistryState';
+import GlobalDeploymentsTable from '../src/components/global/GlobalDeploymentsTable';
+import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
+
+const DeploymentsTab: React.FC = () => {
+  // Note: We don't use the props currently, but they're required by the extension interface
+  const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
+  if (deploymentsLoaded && deployments?.length === 0) {
+    return (
+      <EmptyModelRegistryState
+        title="No deployments from model registry"
+        headerIcon={() => (
+          <img
+            src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingDeployment')}
+            alt="missing deployment"
+          />
+        )}
+        description="No deployments initiated from model registry for this model version."
+        testid="model-version-deployments-empty-state"
+      />
+    );
+  }
+  return <GlobalDeploymentsTable deployments={deployments ?? []} loaded={deploymentsLoaded} />;
+};
+
+export default DeploymentsTab;

--- a/frontend/packages/modelServing/modelRegistry/EmptyModelRegistryState.tsx
+++ b/frontend/packages/modelServing/modelRegistry/EmptyModelRegistryState.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+type EmptyModelRegistryStateType = {
+  testid?: string;
+  title: string;
+  description: React.ReactNode;
+  primaryActionText?: string;
+  primaryActionOnClick?: () => void;
+  secondaryActionText?: string;
+  secondaryActionOnClick?: () => void;
+  headerIcon?: React.ComponentType;
+  customAction?: React.ReactNode;
+};
+
+const EmptyModelRegistryState: React.FC<EmptyModelRegistryStateType> = ({
+  testid,
+  title,
+  description,
+  primaryActionText,
+  secondaryActionText,
+  primaryActionOnClick,
+  secondaryActionOnClick,
+  headerIcon,
+  customAction,
+}) => (
+  <EmptyState
+    icon={headerIcon ?? PlusCircleIcon}
+    titleText={title}
+    variant={EmptyStateVariant.sm}
+    data-testid={testid}
+  >
+    <EmptyStateBody>{description}</EmptyStateBody>
+    <EmptyStateFooter>
+      {primaryActionText && (
+        <EmptyStateActions>
+          <Button
+            data-testid="empty-model-registry-primary-action"
+            variant={ButtonVariant.primary}
+            onClick={primaryActionOnClick}
+          >
+            {primaryActionText}
+          </Button>
+        </EmptyStateActions>
+      )}
+
+      {secondaryActionText && (
+        <EmptyStateActions>
+          <Button
+            data-testid="empty-model-registry-secondary-action"
+            variant="link"
+            onClick={secondaryActionOnClick}
+          >
+            {secondaryActionText}
+          </Button>
+        </EmptyStateActions>
+      )}
+
+      {customAction && <EmptyStateActions>{customAction}</EmptyStateActions>}
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+export default EmptyModelRegistryState;

--- a/frontend/packages/modelServing/modelRegistry/useDeployments.tsx
+++ b/frontend/packages/modelServing/modelRegistry/useDeployments.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
+import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
+import type { Deployment } from '../extension-points';
+
+const useDeployments = (): {
+  deployments?: Deployment[];
+  loaded: boolean;
+  errors?: Error[];
+  projects?: ProjectKind[];
+} => {
+  const { deployments, loaded, errors, projects } = React.useContext(ModelDeploymentsContext);
+
+  return {
+    deployments,
+    loaded,
+    errors,
+    projects,
+  };
+};
+
+export default useDeployments;

--- a/frontend/packages/modelServing/src/concepts/ModelDeploymentsContext.tsx
+++ b/frontend/packages/modelServing/src/concepts/ModelDeploymentsContext.tsx
@@ -30,16 +30,19 @@ type ProjectDeploymentWatcherProps = {
     state: { deployments?: Deployment[]; loaded: boolean; error?: Error },
   ) => void;
   unloadProjectDeployments: (projectName: string) => void;
+  labelSelectors?: { [key: string]: string };
 };
 
 const ProjectDeploymentWatcher: React.FC<ProjectDeploymentWatcherProps> = ({
   project,
   watcher,
+  labelSelectors,
   onStateChange,
   unloadProjectDeployments,
 }) => {
   const useWatchDeployments = watcher.properties.watch;
-  const [deployments, loaded, error] = useWatchDeployments(project);
+
+  const [deployments, loaded, error] = useWatchDeployments(project, labelSelectors);
   const projectName = project.metadata.name;
 
   React.useEffect(() => {
@@ -55,12 +58,14 @@ const ProjectDeploymentWatcher: React.FC<ProjectDeploymentWatcherProps> = ({
 type ModelDeploymentsProviderProps = {
   projects: ProjectKind[];
   modelServingPlatforms: ModelServingPlatform[];
+  labelSelectors?: { [key: string]: string };
   children: React.ReactNode;
 };
 
 export const ModelDeploymentsProvider: React.FC<ModelDeploymentsProviderProps> = ({
   projects,
   modelServingPlatforms,
+  labelSelectors,
   children,
 }) => {
   const [deploymentWatchers, deploymentWatchersLoaded] = useResolvedExtensions(
@@ -118,7 +123,7 @@ export const ModelDeploymentsProvider: React.FC<ModelDeploymentsProviderProps> =
       {
         // the only way to dynamically call hooks (useWatchDeployments) is to render them in dynamic components
         projects.map((project) => {
-          const platform = getProjectServingPlatform(project, modelServingPlatforms, true);
+          const platform = getProjectServingPlatform(project, modelServingPlatforms);
           const watcher = deploymentWatchers.find(
             (w) => w.properties.platform === platform?.properties.id,
           );
@@ -132,6 +137,7 @@ export const ModelDeploymentsProvider: React.FC<ModelDeploymentsProviderProps> =
               key={project.metadata.name}
               project={project}
               watcher={watcher}
+              labelSelectors={labelSelectors}
               onStateChange={updateProjectDeployments}
               unloadProjectDeployments={unloadProjectDeployments}
             />


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-20457

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Added a tab to the Deployed Models section in midstream through an extension. I also made an extension for the Model serving context so that the archive button can access deployment information through the context.

Thanks to @DaoDaoNoCode, @christianvogt, @emilys314, @Griffin-Sullivan, and @lucferbux for the help

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. In ODH, deploy a model.
2. Go to the OpenShift console and search for the `InferenceService` resource. Then find the one you created.
3. In the `yaml`, create these labels:
```
    modelregistry.opendatahub.io/model-version-id: '1'
    modelregistry.opendatahub.io/name: model-registry-bella
    modelregistry.opendatahub.io/registered-model-id: '1'
```
4. Spin up midstream and enable the `Model Registry Plugin` and `Model Serving Plugin` dev flags
5. In the sidebar, click on `Models` -> `Model registry (KF)`
6. Click on `Model One` -> `Version One`
7. Click on `Actions`, and you should see that the `Archive model version` option should be greyed out
8. Click on Deployments. You should see the deployment populated

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced extension points for dynamically adding deployment-related tabs and actions to model version details.
  * Added support for dynamic detection and display of model deployments using extension-driven watchers.
  * Added new React components and hooks for managing model registry, registered models, model versions, and deployments.
  * Added module federation support to enable sharing modules across applications.

* **Refactor**
  * Updated deployment and serving runtime watchers to support flexible filtering by project, registered model, or model version.
  * Refactored context and provider components to support mutually exclusive deployment watching modes.

* **Bug Fixes**
  * Improved filtering and state management for deployments and serving runtimes.

* **Chores**
  * Added comprehensive TypeScript type declarations for model registry UI components, hooks, and utilities.
  * Enhanced test support for React hooks and improved Cypress test setup for module federation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->