### PR TITLE
Increasing memory allocation to 8GB for linting tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
             ${{ github.workspace }}/frontend/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run linting and formatting checks
-        run: NODE_OPTIONS="--max-old-space-size=4096" npm run lint:frontend:backend
+        run: NODE_OPTIONS="--max-old-space-size=8192" npm run lint:frontend:backend
 
   Unit-Tests:
     needs: [Setup, Lint, Type-Check]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "test": "run-s test:lint test:type-check test:unit test:cypress-ci",
     "test:coverage": "run-s test:lint test:type-check test:jest:coverage test:cypress-ci:coverage coverage:merge",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
-    "test:lint": "eslint --max-warnings 0 --ext .js . && eslint --max-warnings 0 --ext .ts . && eslint --max-warnings 0 --ext .jsx,.tsx .",
+    "test:lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint --max-warnings 0 --ext .js . && eslint --max-warnings 0 --ext .ts . && eslint --max-warnings 0 --ext .jsx,.tsx .",
     "test:type-check": "turbo run type-check",
     "test:jest": "jest",
     "test:jest:coverage": "rimraf jest-coverage && jest --silent --coverage --coverageReporters=json --coverageReporters=lcov",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->


Needs more memory to run lint tests

Error we were getting before
```
<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xb8cf03 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0xf060d0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 3: 0xf063b7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0x1118005  [node]
 5: 0x112fe88 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 6: 0x1105fa1 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 7: 0x1107135 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
 8: 0x10e4786 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
 9: 0x15402c6 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
10: 0x1979ef6  [node]
Aborted (core dumped)
ERROR: "test:lint:frontend" exited with 134.
```
## How Has This Been Tested?
Run `npm run test:lint:frontend` in local
Also check for github action is passing.

## Test Impact
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for linting tasks to improve reliability during code checks in both the workflow and frontend scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->