### PR TITLE
Allow unset value for customizing container size when selecting legacy hardware profiles

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/components/HardwareProfileSection.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/HardwareProfileSection.ts
@@ -1,4 +1,5 @@
 import type { ContainerResources } from '#~/types';
+import type { ProfileIdentifierType } from '#~/concepts/hardwareProfiles/types';
 import { Contextual } from './Contextual';
 
 class HardwareProfileGroup extends Contextual<HTMLElement> {}
@@ -50,15 +51,53 @@ export class HardwareProfileSection {
     return cy.findByTestId('hardware-profile-customize-form');
   }
 
+  findCPURequestsCheckbox(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`cpu-requests-checkbox`);
+  }
+
+  findCPULimitsCheckbox(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`cpu-limits-checkbox`);
+  }
+
+  findMemoryRequestsCheckbox(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`memory-requests-checkbox`);
+  }
+
+  findMemoryLimitsCheckbox(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`memory-limits-checkbox`);
+  }
+
+  findRequestsLimitsInfoButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('requests-limits-info-button');
+  }
+
+  findRequestsLimitsPopover(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('dialog', { name: 'Requests and Limits' });
+  }
+
+  findResourceCheckbox(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`${resourceType}-${type}-checkbox`);
+  }
+
+  findResourceUnit(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findResourceCheckbox(resourceType, type)
+      .closest('.pf-v6-l-stack')
+      .findByTestId('value-unit-select');
+  }
+
   selectProfile(name: string): void {
     this.findSelect().click();
     cy.findByRole('option', { name }).click();
   }
 
   selectPotentiallyDisabledProfile(profileDisplayName: string, profileName?: string): void {
-    const dropdown = this.findSelect();
-
-    dropdown.then(($el) => {
+    this.findSelect().then(($el) => {
       if ($el.prop('disabled')) {
         // If disabled, verify it contains the base profile name
         // Use the shorter profileName if provided, otherwise use profileDisplayName
@@ -67,7 +106,7 @@ export class HardwareProfileSection {
         cy.log(`Dropdown is disabled with value: ${nameToCheck}`);
       } else {
         // If enabled, proceed with selection as before using the full display name
-        dropdown.click();
+        this.findSelect().click();
         cy.findByRole('option', { name: profileDisplayName }).click();
       }
     });
@@ -106,6 +145,56 @@ export class HardwareProfileSection {
         cy.findByText(errorMessage).should('exist');
       }
     });
+  }
+
+  verifyResourceValue(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+    value: string,
+  ): void {
+    this.verifyResourceValidation(`${resourceType}-${type}`, value);
+  }
+
+  setResourceValue(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+    value: string,
+  ): void {
+    this.verifyResourceValidation(`${resourceType}-${type}`, value);
+  }
+
+  verifyResourceCheckboxState(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+    checked: boolean,
+    disabled?: boolean,
+  ): void {
+    this.findResourceCheckbox(resourceType, type)
+      .should(checked ? 'be.checked' : 'not.be.checked')
+      .then(($el) => {
+        if (disabled !== undefined) {
+          cy.wrap($el).should(disabled ? 'be.disabled' : 'not.be.disabled');
+        }
+      });
+  }
+
+  selectResourceUnit(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+    unit: 'Gi' | 'Mi' | 'Ki',
+  ): void {
+    this.findResourceUnit(resourceType, type).click();
+
+    // Select the desired unit from the dropdown using the key
+    cy.findByRole('menuitem', { name: `${unit}B` }).click();
+  }
+
+  verifyResourceUnit(
+    resourceType: 'cpu' | 'memory',
+    type: ProfileIdentifierType,
+    expectedUnit: 'Gi' | 'Mi',
+  ): void {
+    this.findResourceUnit(resourceType, type).should('contain.text', expectedUnit);
   }
 }
 

--- a/frontend/src/components/CPUField.tsx
+++ b/frontend/src/components/CPUField.tsx
@@ -65,6 +65,12 @@ export const CPUFieldWithCheckbox: React.FC<CPUFieldWithCheckboxProps> = ({
   // Store the value when the checkbox is unchecked to restore it when the checkbox is checked again
   const storedValue = React.useRef(value);
 
+  React.useEffect(() => {
+    if (value !== undefined) {
+      storedValue.current = value;
+    }
+  }, [value]);
+
   return (
     <Stack hasGutter>
       <Checkbox

--- a/frontend/src/components/MemoryField.tsx
+++ b/frontend/src/components/MemoryField.tsx
@@ -65,6 +65,12 @@ export const MemoryFieldWithCheckbox: React.FC<MemoryFieldWithCheckboxProps> = (
   // Store the value when the checkbox is unchecked to restore it when the checkbox is checked again
   const storedValue = React.useRef(value);
 
+  React.useEffect(() => {
+    if (value !== undefined) {
+      storedValue.current = value;
+    }
+  }, [value]);
+
   return (
     <Stack hasGutter>
       <Checkbox

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
@@ -62,6 +62,13 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
     setFormData('resources', newResources);
   };
 
+  const [isLegacyHardwareProfile, setIsLegacyHardwareProfile] = React.useState(false);
+  React.useEffect(() => {
+    setIsLegacyHardwareProfile(
+      formData.selectedProfile ? formData.selectedProfile.metadata.uid === undefined : false,
+    );
+  }, [formData.selectedProfile]);
+
   return (
     <ValidationContext.Provider value={validation}>
       <Stack hasGutter data-testid="hardware-profile-section">
@@ -111,6 +118,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
                   identifiers={formData.selectedProfile.spec.identifiers}
                   data={formData.resources}
                   setData={(newData: ContainerResources) => setFormData('resources', newData)}
+                  isLegacyHardwareProfile={isLegacyHardwareProfile}
                 />
               </ExpandableSection>
             </StackItem>

--- a/frontend/src/concepts/hardwareProfiles/__tests__/validationUtils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/validationUtils.spec.ts
@@ -1,0 +1,279 @@
+import { IdentifierResourceType } from '#~/types';
+import { HardwareProfileKind } from '#~/k8sTypes';
+import {
+  createCpuSchema,
+  createMemorySchema,
+  createNumericSchema,
+  hardwareProfileValidationSchema,
+  isHardwareProfileConfigValid,
+} from '#~/concepts/hardwareProfiles/validationUtils';
+
+describe('validationUtils', () => {
+  describe('createCpuSchema', () => {
+    it('should validate CPU values within range', () => {
+      const schema = createCpuSchema('1', '4');
+
+      // Valid values
+      expect(schema.safeParse('2').success).toBe(true);
+      expect(schema.safeParse('3').success).toBe(true);
+      expect(schema.safeParse(2).success).toBe(true);
+      expect(schema.safeParse(undefined).success).toBe(true);
+
+      // Invalid values - below minimum
+      const belowMin = schema.safeParse('0.5');
+      expect(belowMin.success).toBe(false);
+      if (!belowMin.success) {
+        expect(belowMin.error.errors[0].message).toBe('Must be at least 1 Cores');
+      }
+
+      // Invalid values - above maximum
+      const aboveMax = schema.safeParse('5');
+      expect(aboveMax.success).toBe(false);
+      if (!aboveMax.success) {
+        expect(aboveMax.error.errors[0].message).toBe('Must not exceed 4 Cores');
+      }
+    });
+
+    it('should handle CPU values with units', () => {
+      const schema = createCpuSchema('1', '4');
+      expect(schema.safeParse('2').success).toBe(true);
+      expect(schema.safeParse('2000').success).toBe(false);
+    });
+  });
+
+  describe('createMemorySchema', () => {
+    it('should validate memory values within range', () => {
+      const schema = createMemorySchema('1Gi', '4Gi');
+
+      // Valid values
+      expect(schema.safeParse('2Gi').success).toBe(true);
+      expect(schema.safeParse('3Gi').success).toBe(true);
+      expect(schema.safeParse(undefined).success).toBe(true);
+
+      // Invalid values - below minimum
+      const belowMin = schema.safeParse('500Mi');
+      expect(belowMin.success).toBe(false);
+      if (!belowMin.success) {
+        expect(belowMin.error.errors[0].message).toBe('Must be at least 1 GiB');
+      }
+
+      // Invalid values - above maximum
+      const aboveMax = schema.safeParse('5Gi');
+      expect(aboveMax.success).toBe(false);
+      if (!aboveMax.success) {
+        expect(aboveMax.error.errors[0].message).toBe('Must not exceed 4 GiB');
+      }
+    });
+
+    it('should handle memory values with different units', () => {
+      const schema = createMemorySchema('1Gi', '4Gi');
+      expect(schema.safeParse('2048Mi').success).toBe(true);
+      expect(schema.safeParse('2G').success).toBe(true);
+    });
+  });
+
+  describe('createNumericSchema', () => {
+    it('should validate numeric values within range', () => {
+      const schema = createNumericSchema(1, 4);
+
+      // Valid values
+      expect(schema.safeParse(2).success).toBe(true);
+      expect(schema.safeParse('3').success).toBe(true);
+      expect(schema.safeParse(undefined).success).toBe(true);
+
+      // Invalid values - below minimum
+      const belowMin = schema.safeParse(0);
+      expect(belowMin.success).toBe(false);
+      if (!belowMin.success) {
+        expect(belowMin.error.errors[0].message).toBe('Must be at least 1');
+      }
+
+      // Invalid values - above maximum
+      const aboveMax = schema.safeParse(5);
+      expect(aboveMax.success).toBe(false);
+      if (!aboveMax.success) {
+        expect(aboveMax.error.errors[0].message).toBe('Must not exceed 4');
+      }
+
+      // Invalid values - not a number
+      const notNumber = schema.safeParse('abc');
+      expect(notNumber.success).toBe(false);
+      if (!notNumber.success) {
+        expect(notNumber.error.errors[0].message).toBe('Value must be a number');
+      }
+    });
+  });
+
+  describe('hardwareProfileValidationSchema', () => {
+    const mockProfile: HardwareProfileKind = {
+      apiVersion: 'infrastructure.opendatahub.io/v1alpha1',
+      kind: 'HardwareProfile',
+      metadata: {
+        name: 'test',
+        namespace: 'test-namespace',
+        annotations: {
+          'opendatahub.io/display-name': 'Test Profile',
+        },
+      },
+      spec: {
+        identifiers: [
+          {
+            identifier: 'cpu',
+            displayName: 'CPU',
+            resourceType: IdentifierResourceType.CPU,
+            minCount: '1',
+            maxCount: '4',
+            defaultCount: '2',
+          },
+          {
+            identifier: 'memory',
+            displayName: 'Memory',
+            resourceType: IdentifierResourceType.MEMORY,
+            minCount: '1Gi',
+            maxCount: '4Gi',
+            defaultCount: '2Gi',
+          },
+          {
+            identifier: 'gpu',
+            displayName: 'GPU',
+            resourceType: IdentifierResourceType.ACCELERATOR,
+            minCount: 0,
+            maxCount: 2,
+            defaultCount: 0,
+          },
+        ],
+      },
+    };
+
+    it('should validate a valid configuration', () => {
+      const validConfig = {
+        selectedProfile: mockProfile,
+        resources: {
+          requests: {
+            cpu: '2',
+            memory: '2Gi',
+            gpu: '1',
+          },
+          limits: {
+            cpu: '3',
+            memory: '3Gi',
+            gpu: '1',
+          },
+        },
+        useExistingSettings: false,
+      };
+
+      const result = hardwareProfileValidationSchema.safeParse(validConfig);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate that limits are greater than or equal to requests', () => {
+      const invalidConfig = {
+        selectedProfile: mockProfile,
+        resources: {
+          requests: {
+            cpu: '3',
+            memory: '3Gi',
+          },
+          limits: {
+            cpu: '2',
+            memory: '2Gi',
+          },
+        },
+        useExistingSettings: false,
+      };
+
+      const result = hardwareProfileValidationSchema.safeParse(invalidConfig);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const limitError = result.error.issues.find(
+          (issue: { message: string }) =>
+            issue.message === 'Limit must be greater than or equal to request',
+        );
+        expect(limitError?.message).toBe('Limit must be greater than or equal to request');
+      }
+    });
+
+    it('should allow undefined values', () => {
+      const configWithUndefined = {
+        selectedProfile: mockProfile,
+        resources: {
+          requests: {},
+          limits: {},
+        },
+        useExistingSettings: false,
+      };
+
+      const result = hardwareProfileValidationSchema.safeParse(configWithUndefined);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate each resource type independently', () => {
+      const mixedConfig = {
+        selectedProfile: mockProfile,
+        resources: {
+          requests: {
+            cpu: '0.5', // Below min
+            memory: '5Gi', // Above max
+            gpu: 'not-a-number', // Invalid type
+          },
+          limits: {
+            cpu: '4',
+            memory: '4Gi',
+            gpu: '2',
+          },
+        },
+        useExistingSettings: false,
+      };
+
+      const result = hardwareProfileValidationSchema.safeParse(mixedConfig);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(3); // One error for each invalid request
+      }
+    });
+  });
+
+  describe('isHardwareProfileConfigValid', () => {
+    it('should return false when no resources and not using existing settings', () => {
+      const config = {
+        useExistingSettings: false,
+      };
+      expect(isHardwareProfileConfigValid(config)).toBe(false);
+    });
+
+    it('should validate resources when provided', () => {
+      const config = {
+        useExistingSettings: false,
+        resources: {
+          requests: { cpu: '1' },
+          limits: { cpu: '2' },
+        },
+        selectedProfile: {
+          apiVersion: 'infrastructure.opendatahub.io/v1alpha1',
+          kind: 'HardwareProfile',
+          metadata: {
+            name: 'test',
+            namespace: 'test-namespace',
+            annotations: {
+              'opendatahub.io/display-name': 'Test Profile',
+            },
+          },
+          spec: {
+            identifiers: [
+              {
+                identifier: 'cpu',
+                displayName: 'CPU',
+                resourceType: IdentifierResourceType.CPU,
+                minCount: '1',
+                maxCount: '4',
+                defaultCount: '2',
+              },
+            ],
+          },
+        },
+      };
+      expect(isHardwareProfileConfigValid(config)).toBe(true);
+    });
+  });
+});

--- a/frontend/src/concepts/hardwareProfiles/const.ts
+++ b/frontend/src/concepts/hardwareProfiles/const.ts
@@ -1,2 +1,5 @@
 export const HARDWARE_PROFILES_MISSING_CPU_MEMORY_MESSAGE =
   'Omitting CPU or Memory resources is not recommended.';
+
+export const HARDWARE_PROFILES_MISSING_REQUEST_MESSAGE =
+  'Requests must be set in order to set a limit';

--- a/frontend/src/concepts/hardwareProfiles/types.ts
+++ b/frontend/src/concepts/hardwareProfiles/types.ts
@@ -32,3 +32,13 @@ export type PodSpecOptionsState<T extends PodSpecOptions> = {
   hardwareProfile: ReturnType<typeof useHardwareProfileConfig>;
   podSpecOptions: T;
 };
+
+export enum ProfileIdentifier {
+  CPU = 'cpu',
+  MEMORY = 'memory',
+}
+
+export enum ProfileIdentifierType {
+  REQUEST = 'requests',
+  LIMIT = 'limits',
+}

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -10,6 +10,7 @@ import {
 } from '#~/types';
 import { useIsAreaAvailable, SupportedArea } from '#~/concepts/areas';
 import { splitValueUnit, CPU_UNITS, MEMORY_UNITS_FOR_PARSING } from '#~/utilities/valueUnits';
+import { ProfileIdentifierType } from '#~/concepts/hardwareProfiles/types.ts';
 
 export const formatToleration = (toleration: Toleration): string => {
   const parts = [`Key = ${toleration.key}`];
@@ -174,3 +175,11 @@ export const getProfileScore = (profile: HardwareProfileKind): number => {
 
   return score;
 };
+
+export const hardwareProfileIdentifierHelpMessage = (
+  identifier: string,
+  type: ProfileIdentifierType,
+): string =>
+  type === ProfileIdentifierType.REQUEST
+    ? `The minimum amount of ${identifier} that will be reserved for this workload. The scheduler will only place the workload on nodes that can provide this amount.`
+    : `The maximum amount of ${identifier} that this workload is allowed to use. If exceeded, the workload may be terminated or throttled.`;

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/validationUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeModal/validationUtils.ts
@@ -42,10 +42,14 @@ export const containerResourcesSchema = z
     limits: resourceSchema.optional(),
   })
   .superRefine((data, ctx) => {
+    const isUndefinedOkay =
+      (data.requests !== undefined && data.limits === undefined) ||
+      (data.requests === undefined && data.limits === undefined);
+
     if (
       data.requests?.cpu &&
       data.limits?.cpu &&
-      !isCpuLimitLarger(data.requests.cpu, data.limits.cpu, true)
+      !isCpuLimitLarger(data.requests.cpu, data.limits.cpu, true, isUndefinedOkay)
     ) {
       ctx.addIssue({
         path: ['requests', 'cpu'],
@@ -61,7 +65,7 @@ export const containerResourcesSchema = z
     if (
       data.requests?.memory &&
       data.limits?.memory &&
-      !isMemoryLimitLarger(data.requests.memory, data.limits.memory, true)
+      !isMemoryLimitLarger(data.requests.memory, data.limits.memory, true, isUndefinedOkay)
     ) {
       ctx.addIssue({
         path: ['requests', 'memory'],

--- a/frontend/src/utilities/podSpec.ts
+++ b/frontend/src/utilities/podSpec.ts
@@ -18,8 +18,14 @@ export const assemblePodSpecOptions = (
 } => {
   const affinity: PodAffinity = structuredClone(affinitySettings || {});
   let resources: ContainerResources = {
-    limits: { ...existingResources?.limits, ...resourceSettings.limits },
-    requests: { ...existingResources?.requests, ...resourceSettings.requests },
+    limits:
+      Object.keys(resourceSettings.limits ?? {}).length === 0
+        ? {}
+        : { ...existingResources?.limits, ...resourceSettings.limits },
+    requests:
+      Object.keys(resourceSettings.requests ?? {}).length === 0
+        ? {}
+        : { ...existingResources?.requests, ...resourceSettings.requests },
   };
 
   // if not using existing settings, just use the new settings

--- a/frontend/src/utilities/valueUnits.ts
+++ b/frontend/src/utilities/valueUnits.ts
@@ -161,12 +161,13 @@ export const isCpuLimitLarger = (
   requestCpu?: ValueUnitCPU,
   limitCpu?: ValueUnitCPU,
   isEqualOkay = false,
+  isUndefinedOkay = false,
 ): boolean => {
   const requestCpuString = typeof requestCpu === 'number' ? `${requestCpu}` : requestCpu;
   const limitCpuString = typeof limitCpu === 'number' ? `${limitCpu}` : limitCpu;
 
   if (!limitCpuString || !requestCpuString) {
-    return false;
+    return isUndefinedOkay;
   }
 
   return isLarger(limitCpuString, requestCpuString, CPU_UNITS, isEqualOkay);
@@ -182,9 +183,10 @@ export const isMemoryLimitLarger = (
   requestMemory?: ValueUnitString,
   limitMemory?: ValueUnitString,
   isEqualOkay = false,
+  isUndefinedOkay = false,
 ): boolean => {
   if (!limitMemory || !requestMemory) {
-    return false;
+    return isUndefinedOkay;
   }
 
   return isLarger(limitMemory, requestMemory, MEMORY_UNITS_FOR_PARSING, isEqualOkay);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-28035

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updated the behavior of resource customization fields in the hardware profiles customization section to allow users to unset request/limit values for **legacy hardware profiles only**. 

- Added a checkbox next to each identifier request/limit field label to allow users to control whether a value is explicitly set
- When a checkbox is unchecked, the corresponding value is treated as undefined (not set)
- If the request value for a resource is not set, the limit checkbox is disabled and displays a tooltip explaining that a request must be set before a limit can be configured.
- Updated Zod validation to support optional request/limit fields without blocking submission, while still catching invalid inputs when values are provided.
- Ensured correct identifier values are reflected in notebook and model server specs


https://github.com/user-attachments/assets/401ae140-f23e-4592-95bb-6112f925d577


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and tested manually. 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Ensure that the hardware profiles feature flag is enabled
- Go to the create/edit workbench page (SpawnerPage), and in the hardware profile section, select notebook container size profile/accelerator profile. 
- Click on Customize resource requests and limits dropdown
- Make sure that the checkboxes show up next to the resource requests/limits
- Verify that unchecking resource request also unchecks and disables resource limit checkbox. 
- Verify that when the resource limit checkbox is disabled, the tooltip over the checkbox label  shows "Requests must be set in order to set a limit"
- Verify that when both checkboxes are unchecked, the helper messages appear in the tooltip
- Verify that input value validation works as before
- Create the workbench with some or all resources unchecked, and check that the CR resources field is changed as expected. 
- Reproduce the above with single model deployment modal 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for legacy hardware profile customization, including checkbox-enabled CPU and memory fields with enhanced validation and tooltips.
  * Introduced new UI components for number input fields with optional checkboxes and validation error display.
  * Expanded hardware profile customization tests, covering legacy profile behaviors, validation logic, and UI interactions.

* **Bug Fixes**
  * Improved synchronization of stored values for CPU and memory fields to ensure consistent behavior when values change externally.
  * Adjusted resource merging logic to prevent unintended retention of old resource settings.

* **Enhancements**
  * Validation logic now gracefully handles undefined resource values and improves error messaging.
  * Added helper functions and constants to standardize hardware profile identifiers and tooltips.

* **Tests**
  * Added comprehensive unit and integration tests for hardware profile validation utilities and legacy profile UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->