### PR TITLE
Add reviewers in llama-stack-modular-ui (rag-playground)

### DIFF
--- a/frontend/packages/llama-stack-modular-ui/OWNERS
+++ b/frontend/packages/llama-stack-modular-ui/OWNERS
@@ -1,28 +1,29 @@
 approvers:
-- alexcreasy
 - agagancarczyk
-- pnaik1
 - akram
-- varshaprasad96
-- Schimuneck
-- ederign
-- christianvogt
+- alexcreasy
 - andrewballantyne
-- lucferbux
 - antowaddle
+- christianvogt
+- ederign
+- lucferbux
+- pnaik1
+- Schimuneck
+- varshaprasad96
 
 reviewers:
-- alexcreasy
 - agagancarczyk
-- pnaik1
 - akram
-- varshaprasad96
-- Schimuneck
-- ederign
-- christianvogt
+- alexcreasy
 - andrewballantyne
-- lucferbux
 - antowaddle
+- christianvogt
+- ChristianZaccaria
+- ederign
+- lucferbux
+- pnaik1
+- Schimuneck
+- varshaprasad96
 
 labels:
   - area/llama-stack-modular-ui

--- a/frontend/packages/llama-stack-modular-ui/OWNERS
+++ b/frontend/packages/llama-stack-modular-ui/OWNERS
@@ -17,6 +17,7 @@ reviewers:
 - alexcreasy
 - andrewballantyne
 - antowaddle
+- Bobbins228
 - christianvogt
 - ChristianZaccaria
 - ederign
@@ -24,6 +25,7 @@ reviewers:
 - pnaik1
 - Schimuneck
 - varshaprasad96
+- Ygnas
 
 labels:
   - area/llama-stack-modular-ui


### PR DESCRIPTION
I think this could provide me enough permissions to add the `area/llama-stack-modular-ui`label to PRs.

## Changes
- Added ChristianZaccaria as a reviewer in OWNERS file under the llama-stack-modular-ui (rag-playground) project.]
- Re-ordered the members in alphabetical order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the list and order of approvers and reviewers for the package.
  * Added new reviewers: Bobbins228, ChristianZaccaria, and Ygnas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->