### PR TITLE
Move 'Use existing settings' to top of Hardware Profile select list

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -171,7 +171,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
 
     // allow usage of existing settings if no hardware profile is found
     if (allowExistingSettings) {
-      formattedOptions.push({
+      formattedOptions.unshift({
         key: EXISTING_SETTINGS_KEY,
         label: 'Use existing settings',
         description: 'Use existing resource requests/limits, tolerations, and node selectors.',

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -171,6 +171,7 @@ describe('HardwareProfileSelect - Use existing settings', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
 
     const options = screen.getAllByRole('option');
+    expect(screen.queryByText('Use existing settings')).not.toBeInTheDocument();
     expect(options[0]).toHaveTextContent('Node Profile');
     expect(options[1]).toHaveTextContent('Node Profile 2');
   });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -69,6 +69,7 @@ const renderComponent = (
   hardwareProfiles: HardwareProfileKind[],
   currentProject: ProjectKind,
   isKueueEnabled: boolean,
+  allowExistingSettings = false,
 ) => {
   useIsAreaAvailableMock.mockReturnValue({
     status: isKueueEnabled,
@@ -112,7 +113,7 @@ const renderComponent = (
         hardwareProfilesLoaded
         hardwareProfilesError={undefined}
         projectScopedHardwareProfiles={[[], true, undefined, () => Promise.resolve()]}
-        allowExistingSettings={false}
+        allowExistingSettings={allowExistingSettings}
         hardwareProfileConfig={hardwareProfileConfig}
         isHardwareProfileSupported={() => true}
         onChange={() => null}
@@ -159,5 +160,18 @@ describe('HardwareProfileSelect filtering', () => {
     expect(screen.getByText('Kueue Profile 2')).toBeInTheDocument();
     expect(screen.getByText('Node Profile')).toBeInTheDocument();
     expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
+  });
+
+  it('should show "Use existing settings" as the first option when allowExistingSettings is true', async () => {
+    const project = mockProjectK8sResource({});
+    project.metadata.labels ??= {};
+    project.metadata.labels[KnownLabels.KUEUE_MANAGED] = 'true';
+
+    renderComponent(mockProfiles, project, true, true);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Use existing settings');
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileSelect.spec.tsx
@@ -161,17 +161,32 @@ describe('HardwareProfileSelect filtering', () => {
     expect(screen.getByText('Node Profile')).toBeInTheDocument();
     expect(screen.getByText('Node Profile 2')).toBeInTheDocument();
   });
+});
+
+describe('HardwareProfileSelect - Use existing settings', () => {
+  it('should not show "Use existing settings" as the first option when allowExistingSettings is false', async () => {
+    const project = mockProjectK8sResource({});
+    renderComponent([nodeHardwareProfile, nodeHardwareProfile2], project, false, false);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Node Profile');
+    expect(options[1]).toHaveTextContent('Node Profile 2');
+  });
 
   it('should show "Use existing settings" as the first option when allowExistingSettings is true', async () => {
     const project = mockProjectK8sResource({});
     project.metadata.labels ??= {};
     project.metadata.labels[KnownLabels.KUEUE_MANAGED] = 'true';
 
-    renderComponent(mockProfiles, project, true, true);
+    renderComponent([nodeHardwareProfile, nodeHardwareProfile2], project, false, true);
 
     await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
 
     const options = screen.getAllByRole('option');
     expect(options[0]).toHaveTextContent('Use existing settings');
+    expect(options[1]).toHaveTextContent('Node Profile');
+    expect(options[2]).toHaveTextContent('Node Profile 2');
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://issues.redhat.com/browse/RHOAIENG-22844

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
For Hardware profile selection boxes, the "Use existing settings" option is now displayed at the beginning of the list instead of at the end.

<img width="831" height="321" alt="Screenshot 2025-08-05 at 10 56 30 AM" src="https://github.com/user-attachments/assets/86dcde89-1590-4182-928b-24d89e61f3f1" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
First with accelerator profiles, create a workbench. After creating, enable hardware profiles and go to edit the workbench. You should see under hardware profile selection the "Use existing settings" option at the top.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed since this is just changes the order. Functionality does not rely on the order of options but rather their key.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Moved the "Use existing settings" option to the top of the hardware profile selection dropdown for easier access.  
* **Tests**
  * Added tests to confirm the visibility and order of the "Use existing settings" option depending on user settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->