### PR TITLE
Min max deployment improvements

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -532,6 +532,12 @@ class KServeModal extends InferenceServiceModal {
     return this.find().findByTestId('max-replicas').findByRole('button', { name: 'Minus' });
   }
 
+  findMaxReplicasErrorMessage() {
+    return this.find().contains(
+      'Maximum replicas must be greater than or equal to minimum replicas',
+    );
+  }
+
   findCPURequestedCheckbox() {
     return this.find().findByTestId('cpu-requested-checkbox');
   }

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -538,6 +538,10 @@ class KServeModal extends InferenceServiceModal {
     );
   }
 
+  findMinReplicasErrorMessage() {
+    return this.find().contains('Minimum replicas must be less than or equal to maximum replicas');
+  }
+
   findCPURequestedCheckbox() {
     return this.find().findByTestId('cpu-requested-checkbox');
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1928,6 +1928,13 @@ describe('Serving Runtime List', () => {
       kserveModal.findMaxReplicasInput().type('6');
       kserveModal.findMaxReplicasErrorMessage().should('not.exist');
 
+      // Test min replicas error message
+      kserveModal.findMaxReplicasInput().clear().type('6');
+      kserveModal.findMinReplicasInput().clear().type('8');
+      kserveModal.findMinReplicasErrorMessage().should('exist');
+      kserveModal.findMinReplicasInput().clear().type('4');
+      kserveModal.findMinReplicasErrorMessage().should('not.exist');
+
       // Test max limit of 99
       kserveModal.findMaxReplicasInput().clear().type('100');
       kserveModal.findMaxReplicasInput().should('have.value', '99');
@@ -1993,8 +2000,8 @@ describe('Serving Runtime List', () => {
           },
           spec: {
             predictor: {
-              minReplicas: 2,
-              maxReplicas: 2,
+              minReplicas: 40,
+              maxReplicas: 40,
               model: {
                 modelFormat: { name: 'onnx', version: '1' },
                 runtime: 'test-name',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1923,7 +1923,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findMinReplicasInput().should('have.value', '2');
 
       // Test max replicas error message
-      kserveModal.findMaxReplicasInput().clear();
+      kserveModal.findMaxReplicasInput().clear().type('1');
       kserveModal.findMaxReplicasErrorMessage().should('exist');
       kserveModal.findMaxReplicasInput().type('6');
       kserveModal.findMaxReplicasErrorMessage().should('not.exist');
@@ -1932,8 +1932,10 @@ describe('Serving Runtime List', () => {
       kserveModal.findMaxReplicasInput().clear().type('6');
       kserveModal.findMinReplicasInput().clear().type('8');
       kserveModal.findMinReplicasErrorMessage().should('exist');
+      kserveModal.findSubmitButton().should('be.disabled');
       kserveModal.findMinReplicasInput().clear().type('4');
       kserveModal.findMinReplicasErrorMessage().should('not.exist');
+      kserveModal.findSubmitButton().should('be.enabled');
 
       // Test max limit of 99
       kserveModal.findMaxReplicasInput().clear().type('100');
@@ -2000,8 +2002,8 @@ describe('Serving Runtime List', () => {
           },
           spec: {
             predictor: {
-              minReplicas: 40,
-              maxReplicas: 40,
+              minReplicas: 4,
+              maxReplicas: 4,
               model: {
                 modelFormat: { name: 'onnx', version: '1' },
                 runtime: 'test-name',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1922,6 +1922,12 @@ describe('Serving Runtime List', () => {
       kserveModal.findMinReplicasPlusButton().click();
       kserveModal.findMinReplicasInput().should('have.value', '2');
 
+      // Test max replicas error message
+      kserveModal.findMaxReplicasInput().clear();
+      kserveModal.findMaxReplicasErrorMessage().should('exist');
+      kserveModal.findMaxReplicasInput().type('6');
+      kserveModal.findMaxReplicasErrorMessage().should('not.exist');
+
       // Test max limit of 99
       kserveModal.findMaxReplicasInput().clear().type('100');
       kserveModal.findMaxReplicasInput().should('have.value', '99');

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -45,7 +45,7 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
   const showMinWarning = minGreaterThanMax && editingField === 'min';
   const showMaxWarning = maxLessThanMin && editingField === 'max';
 
-  const hasValidationErrors = showMinWarning || showMaxWarning;
+  const hasValidationErrors = editingField !== null && (showMinWarning || showMaxWarning);
 
   React.useEffect(() => {
     onValidationChange?.(hasValidationErrors);

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { FormGroup, Popover, Icon, Flex, FlexItem } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import {
+  FormGroup,
+  Popover,
+  Icon,
+  Flex,
+  FlexItem,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import NumberInputWrapper from '#~/components/NumberInputWrapper';
 import { normalizeBetween } from '#~/utilities/utils';
 
@@ -27,6 +36,7 @@ const ReplicaFormGroup: React.FC<ReplicaSectionProps> = ({
   onMaxChange,
 }) => {
   const maxLimit = showMinMax ? upperLimit : maxValue;
+  const maxLessThanMin = !showMinMax && maxValue < value;
 
   return (
     <FormGroup
@@ -87,16 +97,32 @@ const ReplicaFormGroup: React.FC<ReplicaSectionProps> = ({
               data-testid="max-replicas"
             >
               <NumberInputWrapper
-                min={value}
+                min={lowerLimit}
                 max={upperLimit}
                 value={maxValue}
+                validated={maxLessThanMin ? 'warning' : 'default'}
+                minusBtnProps={{ isDisabled: maxValue <= value }}
+                onBlur={() => {
+                  if (maxValue < value) {
+                    onMaxChange(value);
+                  }
+                }}
                 onChange={(val) => {
                   const newSize = val === undefined ? 0 : Number(val);
-                  if (!Number.isNaN(newSize) && newSize <= upperLimit && newSize >= value) {
-                    onMaxChange(normalizeBetween(newSize, value, upperLimit));
+                  if (!Number.isNaN(newSize) && newSize <= upperLimit) {
+                    onMaxChange(normalizeBetween(newSize, lowerLimit, upperLimit));
                   }
                 }}
               />
+              {maxLessThanMin && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem icon={<ExclamationTriangleIcon />} variant="warning">
+                      Maximum replicas must be greater than or equal to minimum replicas.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
             </FormGroup>
           </FlexItem>
         )}

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -27,7 +27,7 @@ type ReplicaSectionProps = {
   onValidationChange?: (hasValidationErrors: boolean) => void;
 };
 
-const ReplicaFormGroup: React.FC<ReplicaSectionProps> = ({
+const ReplicaSection: React.FC<ReplicaSectionProps> = ({
   value,
   onChange,
   infoContent,
@@ -177,4 +177,4 @@ const ReplicaFormGroup: React.FC<ReplicaSectionProps> = ({
   );
 };
 
-export default ReplicaFormGroup;
+export default ReplicaSection;

--- a/frontend/src/components/ReplicaSection.tsx
+++ b/frontend/src/components/ReplicaSection.tsx
@@ -38,6 +38,8 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
   onValidationChange,
 }) => {
   const [editingField, setEditingField] = React.useState<'min' | 'max' | null>(null);
+  const [isMinEmpty, setIsMinEmpty] = React.useState(false);
+  const [isMaxEmpty, setIsMaxEmpty] = React.useState(false);
   const maxLessThanMin = !showMinMax && maxValue < value;
   const minGreaterThanMax = !showMinMax && value > maxValue;
   const showMinWarning = minGreaterThanMax && editingField === 'min';
@@ -74,21 +76,27 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
               data-testid="min-replicas"
             >
               <NumberInputWrapper
-                min={lowerLimit}
+                min={isMinEmpty && editingField === 'min' ? undefined : lowerLimit}
                 max={upperLimit}
-                value={value}
+                value={isMinEmpty && editingField === 'min' ? '' : value}
                 validated={showMinWarning ? 'warning' : 'default'}
                 plusBtnProps={{ isDisabled: value >= maxValue }}
                 onFocus={() => setEditingField('min')}
                 onBlur={() => {
                   setEditingField(null);
+                  setIsMinEmpty(false);
                   if (value > maxValue) {
                     onChange(maxValue);
                   }
                 }}
                 onChange={(val) => {
                   setEditingField('min');
-                  const newSize = val === undefined ? 0 : Number(val);
+                  if (val === undefined) {
+                    setIsMinEmpty(true);
+                    return;
+                  }
+                  setIsMinEmpty(false);
+                  const newSize = Number(val);
                   if (!Number.isNaN(newSize) && newSize <= upperLimit) {
                     onChange(normalizeBetween(newSize, lowerLimit, upperLimit));
                   }
@@ -119,21 +127,27 @@ const ReplicaSection: React.FC<ReplicaSectionProps> = ({
               style={{ position: 'relative' }}
             >
               <NumberInputWrapper
-                min={lowerLimit}
+                min={isMaxEmpty && editingField === 'max' ? undefined : lowerLimit}
                 max={upperLimit}
-                value={maxValue}
+                value={isMaxEmpty && editingField === 'max' ? '' : maxValue}
                 validated={showMaxWarning ? 'warning' : 'default'}
                 minusBtnProps={{ isDisabled: maxValue <= value }}
                 onFocus={() => setEditingField('max')}
                 onBlur={() => {
                   setEditingField(null);
+                  setIsMaxEmpty(false);
                   if (maxValue < value) {
                     onMaxChange(value);
                   }
                 }}
                 onChange={(val) => {
                   setEditingField('max');
-                  const newSize = val === undefined ? 0 : Number(val);
+                  if (val === undefined) {
+                    setIsMaxEmpty(true);
+                    return;
+                  }
+                  setIsMaxEmpty(false);
+                  const newSize = Number(val);
                   if (!Number.isNaN(newSize) && newSize <= upperLimit) {
                     onMaxChange(normalizeBetween(newSize, lowerLimit, upperLimit));
                   }

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
@@ -30,9 +30,6 @@ const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionPro
     maxValue={data.maxReplicas}
     onMaxChange={(value) => {
       setData('maxReplicas', value);
-      if (value < data.minReplicas) {
-        setData('minReplicas', value);
-      }
     }}
   />
 );

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeAutoscalerReplicaSection.tsx
@@ -7,12 +7,14 @@ type KServeAutoscalerReplicaSectionProps = {
   data: CreatingInferenceServiceObject;
   setData: UpdateObjectAtPropAndValue<CreatingInferenceServiceObject>;
   infoContent?: string;
+  onValidationChange?: (hasValidationErrors: boolean) => void;
 };
 
 const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionProps> = ({
   data,
   setData,
   infoContent,
+  onValidationChange,
 }) => (
   <ReplicaSection
     infoContent={infoContent}
@@ -20,8 +22,6 @@ const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionPro
     onChange={(value) => {
       setData('minReplicas', value);
       if (data.isKServeRawDeployment) {
-        setData('maxReplicas', value);
-      } else if (value > data.maxReplicas) {
         setData('maxReplicas', value);
       }
     }}
@@ -31,6 +31,7 @@ const KServeAutoscalerReplicaSection: React.FC<KServeAutoscalerReplicaSectionPro
     onMaxChange={(value) => {
       setData('maxReplicas', value);
     }}
+    onValidationChange={onValidationChange}
   />
 );
 

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -131,6 +131,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
 
   const [connection, setConnection] = React.useState<Connection>();
   const [isConnectionValid, setIsConnectionValid] = React.useState(false);
+  const [hasReplicaValidationErrors, setHasReplicaValidationErrors] = React.useState(false);
 
   const isAuthAvailable =
     useIsAreaAvailable(SupportedArea.K_SERVE_AUTH).status ||
@@ -432,6 +433,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   setData={setCreateDataInferenceService}
                   infoContent="Consider network traffic and failover scenarios when specifying the number of model
                 server replicas."
+                  onValidationChange={setHasReplicaValidationErrors}
                 />
                 <ServingRuntimeSizeSection
                   podSpecOptionState={podSpecOptionsState}
@@ -501,7 +503,9 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
           submitLabel={editInfo ? 'Redeploy' : 'Deploy'}
           onSubmit={submit}
           onCancel={() => onBeforeClose(false)}
-          isSubmitDisabled={isDisabledServingRuntime || isDisabledInferenceService}
+          isSubmitDisabled={
+            isDisabledServingRuntime || isDisabledInferenceService || hasReplicaValidationErrors
+          }
           error={error}
           alertTitle="Error creating model server"
         />


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHOAIENG-26252

## Description
Updates how the server replica deployment min/max works. Before, it was difficult to edit the max using your keyboard, limiting you to use the - / + buttons. Now you're able to edit the max using your keyboard much easier. You're able to properly backspace and modify the number. 
There is now a popup that will warn you if you're trying to set a number to max that's lower than min, and when you click away it will snap to the min. Edit: It will now also show the warning if you try to set the min to be higher than the max, and will snap to the max when you click away. It will also now disable the deploy button when the warning is being shown.

## How Has This Been Tested?
Tested locally. 

- Navigate to a project, then go to deploy a modal. Within the deploy modal, scroll to the 'Number of model server replicas to deploy'
- When adjusting the max, you should be able to backspace the number and type whatever you want. It will still max out at 99, and if you try to set it to a number lower than the min, it will show a warning.
- If you try to set a number lower than the min, when you click away, it will snap to the min number. 
- Same with min, if you try to set the min to a number higher than the max and click away, it will snap to the max.
- Anytime you're editing the numbers and the warning pops up, the deploy button will change to be disabled

## Test Impact
Modified cypress test to check for error message

## Screen Record
Before: 

https://github.com/user-attachments/assets/8fc5e643-c1b3-4b50-80d7-eaa921430b0b

After:


https://github.com/user-attachments/assets/635a42ad-3c30-4ab0-8a89-33b044c6ff22




## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Inline warnings when minimum and maximum replicas are inconsistent.
  - Form submission is blocked if replica settings are invalid.
  - Replica controls now surface validation status to the parent so the modal can prevent submit when invalid.
  - Layout adjusted to display warnings beneath replica inputs.

- Bug Fixes
  - Removed unexpected auto-sync between min and max replicas (except for specific raw deployments), reducing accidental value changes.
  - Improved bounds enforcement and clearer control behavior at limits.

- Tests
  - Added end-to-end tests verifying replica validation messages and modal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->