### PR TITLE
Fix the pipelines run metrics table

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/__tests__/utils.spec.ts
@@ -9,6 +9,9 @@ describe('getArtifactProperties', () => {
   mockArtifact.setId(1);
   mockArtifact.setName('artifact-1');
   mockArtifact.getCustomPropertiesMap().set('display_name', new Value());
+  mockArtifact
+    .getCustomPropertiesMap()
+    .set('store_session_info', new Value().setStringValue('some string'));
 
   it('returns empty array when no custom props exist other than display_name', () => {
     const result = getArtifactProperties(mockArtifact);

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
@@ -10,7 +10,7 @@ export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
         acc: { name: string; value: string }[],
         [customPropKey, { stringValue, intValue, doubleValue, boolValue }],
       ) => {
-        if (customPropKey !== 'display_name') {
+        if (customPropKey !== 'display_name' && customPropKey !== 'store_session_info') {
           acc.push({
             name: customPropKey,
             value: stringValue || (intValue || doubleValue || boolValue).toString(),

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils.ts
@@ -1,26 +1,40 @@
-import { Artifact } from '#~/third_party/mlmd';
+import { Artifact, Value } from '#~/third_party/mlmd';
 import { ArtifactType } from '#~/concepts/pipelines/kfTypes';
 import { ArtifactProperty, PipelineRunArtifactModelData } from './types';
 
-export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] =>
-  artifact
-    .toObject()
-    .customPropertiesMap.reduce(
-      (
-        acc: { name: string; value: string }[],
-        [customPropKey, { stringValue, intValue, doubleValue, boolValue }],
-      ) => {
-        if (customPropKey !== 'display_name' && customPropKey !== 'store_session_info') {
-          acc.push({
-            name: customPropKey,
-            value: stringValue || (intValue || doubleValue || boolValue).toString(),
-          });
-        }
+export const getArtifactProperties = (artifact: Artifact): ArtifactProperty[] => {
+  const result: ArtifactProperty[] = [];
 
-        return acc;
-      },
-      [],
-    );
+  artifact.getCustomPropertiesMap().forEach((value, key) => {
+    if (key !== 'display_name' && key !== 'store_session_info') {
+      let propertyValue = '';
+
+      switch (value.getValueCase()) {
+        case Value.ValueCase.STRING_VALUE:
+          propertyValue = value.getStringValue();
+          break;
+        case Value.ValueCase.INT_VALUE:
+          propertyValue = value.getIntValue().toString();
+          break;
+        case Value.ValueCase.DOUBLE_VALUE:
+          propertyValue = value.getDoubleValue().toString();
+          break;
+        case Value.ValueCase.BOOL_VALUE:
+          propertyValue = value.getBoolValue().toString();
+          break;
+        default:
+          propertyValue = '';
+      }
+
+      result.push({
+        name: key,
+        value: propertyValue,
+      });
+    }
+  });
+
+  return result;
+};
 
 export const isMetricsArtifactType = (artifactType?: string): boolean =>
   artifactType === ArtifactType.METRICS ||


### PR DESCRIPTION
## Description

Resolves:
https://issues.redhat.com/browse/RHOAIENG-31860

This PR addresses two issues with pipeline run metrics display:

1. **Fix crash when displaying zero-value metrics:** Resolves a UI crash that occurred when pipeline run metrics had a value of `0`. The code was incorrectly calling `toString()` on `boolValue` which was undefined, causing the UI to crash until the pipeline run was archived.
1. **Filter out internal implementation details:** Excludes `store_session_info` from the displayed metrics since it's an implementation detail not directly set by users and doesn't need to be shown in the UI.

## How Has This Been Tested?

Added unit test coverage in the area of the code that was crashing.

To reproduce, run a pipeline that produces a metric with a zero value.

## Test Impact

Added unit test coverage.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of artifact properties to correctly display zero values and exclude certain default properties from the visible list.
  * Ensured that undefined or empty property values are shown as empty strings.

* **Tests**
  * Added and updated tests to cover edge cases for zero, undefined, and default artifact property values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->