### PR TITLE
PVC E2E test fix

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
@@ -100,8 +100,6 @@ describe('Verify a model can be deployed from a PVC', () => {
       pvcRow.find().should('exist');
       pvcRow.findStorageTypeColumn().should('contain', 'Model storage');
 
-      pvcRow.findConnectedResources().should('contain', modelName);
-
       const pvcReplacements: PVCLoaderPodReplacements = {
         NAMESPACE: projectName,
         PVC_NAME: pvStorageName,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Forgot to remove this in https://github.com/opendatahub-io/odh-dashboard/pull/4651

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
PVC serving test will pass now

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
E2E test will pass

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed the test that checked if the PVC row's connected resources display the model name in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->