### PR TITLE
Easy Developer Access for the Commit Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ We also have some [contributing guidelines] you can follow.
 
 ## Documentation
 
+To get the current commit hash from the UI, to confirm which code is deployed, the commit hash is printed to the console every time the About Dialog is opened.
+
 Read more about the Dashboard in one of our documentation links.
 
 * [Dev setup & Requirements]

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -36,12 +36,11 @@ const COMMIT_HASH_DIRECT = (() => {
     return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
       .toString()
       .trim();
-  }catch (error) {
+  } catch (error) {
     console.warn('Unable to get git commit hash:', error.message);
     return 'unknown';
   }
 })();
-
 
 if (OUTPUT_ONLY !== 'true') {
   console.info(

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -22,7 +22,6 @@ const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const COVERAGE = process.env.COVERAGE;
 const COMMIT_HASH_DIRECT = execSync('git rev-parse --short HEAD').toString().trim();
 
-
 if (OUTPUT_ONLY !== 'true') {
   console.info(
     `\nPrepping files...\n  SRC DIR: ${SRC_DIR}\n  OUTPUT DIR: ${DIST_DIR}\n  PUBLIC PATH: ${PUBLIC_PATH}\n`,
@@ -249,7 +248,7 @@ module.exports = (env) => ({
       MF_CONFIG: JSON.stringify(moduleFederationConfig),
     }),
     new webpack.DefinePlugin({
-	__COMMIT_HASH__: JSON.stringify(COMMIT_HASH_DIRECT),
+      __COMMIT_HASH__: JSON.stringify(COMMIT_HASH_DIRECT),
     }),
     ...moduleFederationPlugins,
   ],

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -1,5 +1,6 @@
 /* eslint-disable prefer-destructuring, @typescript-eslint/restrict-template-expressions */
 const path = require('path');
+const { execSync } = require('child_process');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -19,6 +20,8 @@ const OUTPUT_ONLY = process.env._ODH_OUTPUT_ONLY;
 const ODH_FAVICON = process.env.ODH_FAVICON;
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const COVERAGE = process.env.COVERAGE;
+const COMMIT_HASH_DIRECT = execSync('git rev-parse --short HEAD').toString().trim();
+
 
 if (OUTPUT_ONLY !== 'true') {
   console.info(
@@ -244,6 +247,9 @@ module.exports = (env) => ({
     }),
     new webpack.EnvironmentPlugin({
       MF_CONFIG: JSON.stringify(moduleFederationConfig),
+    }),
+    new webpack.DefinePlugin({
+	__COMMIT_HASH__: JSON.stringify(COMMIT_HASH_DIRECT),
     }),
     ...moduleFederationPlugins,
   ],

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -20,7 +20,13 @@ const OUTPUT_ONLY = process.env._ODH_OUTPUT_ONLY;
 const ODH_FAVICON = process.env.ODH_FAVICON;
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const COVERAGE = process.env.COVERAGE;
-const COMMIT_HASH_DIRECT = execSync('git rev-parse --short HEAD').toString().trim();
+let COMMIT_HASH_DIRECT;
+try {
+  COMMIT_HASH_DIRECT = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (error) {
+  console.warn('Unable to get git commit hash:', error.message);
+  COMMIT_HASH_DIRECT = 'unknown';
+}
 
 if (OUTPUT_ONLY !== 'true') {
   console.info(

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -21,26 +21,14 @@ const ODH_FAVICON = process.env.ODH_FAVICON;
 const ODH_PRODUCT_NAME = process.env.ODH_PRODUCT_NAME;
 const COVERAGE = process.env.COVERAGE;
 
-const COMMIT_HASH_DIRECT = (() => {
-  // Prefer CI-provided SHAs, then fall back to git; never fail the build due to missing git/.git
-  const fromEnv =
-    process.env.ODH_COMMIT_HASH ||
-    process.env.SOURCE_GIT_COMMIT ||
-    process.env.GITHUB_SHA ||
-    process.env.GIT_COMMIT ||
-    process.env.OPENSHIFT_BUILD_COMMIT;
-  if (fromEnv) {
-    return fromEnv.slice(0, 7);
-  }
-  try {
-    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
-      .toString()
-      .trim();
-  } catch (error) {
-    console.warn('Unable to get git commit hash:', error.message);
-    return 'unknown';
-  }
-})();
+let COMMIT_HASH_DIRECT;
+
+try {
+  COMMIT_HASH_DIRECT = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (error) {
+  console.warn('Unable to get git commit hash:', error.message);
+  COMMIT_HASH_DIRECT = 'unknown';
+}
 
 if (OUTPUT_ONLY !== 'true') {
   console.info(

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -111,7 +111,6 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
             <Content component="dd" data-testid="about-version">
               {dsciStatus?.release?.version || 'Unknown'}
             </Content>
-
             <Content component="dt">Channel</Content>
             <Content component="dd" data-testid="about-channel">
               {subStatus?.channel || 'Unknown'}

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -24,6 +24,9 @@ interface AboutDialogProps {
   onClose: () => void;
 }
 
+// The current commit hash of the latest code is printed to the console 
+// every time this dialog is opened.  it is not put on the 
+// dialog itself so as not to confuse users.
 const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
   const { isAdmin } = useUser();
   const { isRHOAI } = useAppContext();

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -105,6 +105,10 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
             <Content component="dd" data-testid="about-version">
               {dsciStatus?.release?.version || 'Unknown'}
             </Content>
+            <Content component="dt">Commit Hash</Content>
+            <Content component="dd" data-testid="about-commit-hash">
+              {__COMMIT_HASH__ || 'Unknown'}
+            </Content>
             <Content component="dt">Channel</Content>
             <Content component="dd" data-testid="about-channel">
               {subStatus?.channel || 'Unknown'}

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -72,6 +72,12 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
     return result;
   }, [dscStatus?.components]);
 
+  // Print commit hash only *once* when dialog opens (though since this is mounted twice; it prints out twice)
+  // (to make it only show once we would need to use a reference; which is overkill)
+  React.useEffect(() => {
+    console.log('commit hash: ', __COMMIT_HASH__ || 'Unknown');
+  }, []);
+
   return (
     <AboutModal
       className="odh-about-dialog"
@@ -105,10 +111,7 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
             <Content component="dd" data-testid="about-version">
               {dsciStatus?.release?.version || 'Unknown'}
             </Content>
-            <Content component="dt">Commit Hash</Content>
-            <Content component="dd" data-testid="about-commit-hash">
-              {__COMMIT_HASH__ || 'Unknown'}
-            </Content>
+
             <Content component="dt">Channel</Content>
             <Content component="dd" data-testid="about-channel">
               {subStatus?.channel || 'Unknown'}

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -24,8 +24,8 @@ interface AboutDialogProps {
   onClose: () => void;
 }
 
-// The current commit hash of the latest code is printed to the console 
-// every time this dialog is opened.  it is not put on the 
+// The current commit hash of the latest code is printed to the console
+// every time this dialog is opened.  it is not put on the
 // dialog itself so as not to confuse users.
 const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
   const { isAdmin } = useUser();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -270,6 +270,10 @@ declare global {
     analytics?: any;
     clusterID?: string;
   }
+
+  // Webpack injected global variables
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __COMMIT_HASH__: string | undefined;
 }
 
 export type ApplicationAction = {

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -9,7 +9,6 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 // @ts-ignore
 global.TextEncoder = TextEncoder;
  
-
 // Mock webpack-injected global variables
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -10,7 +10,7 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 global.TextEncoder = TextEncoder;
 
 // Mock webpack-injected global variables
-(global as any).__COMMIT_HASH__ = 'test-commit-hash';
+(global as typeof globalThis & { __COMMIT_HASH__?: string }).__COMMIT_HASH__ = 'test-commit-hash';
 
 const tryExpect = (expectFn: () => void) => {
   try {

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -8,7 +8,7 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.TextEncoder = TextEncoder;
- 
+
 // Mock webpack-injected global variables
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -10,6 +10,10 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 global.TextEncoder = TextEncoder;
 
 // Mock webpack-injected global variables
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __COMMIT_HASH__: string | undefined;
+}
 global.__COMMIT_HASH__ = 'test-commit-hash';
 
 const tryExpect = (expectFn: () => void) => {

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -8,9 +8,14 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 global.TextEncoder = TextEncoder;
+ 
 
 // Mock webpack-injected global variables
-(global as typeof globalThis & { __COMMIT_HASH__?: string }).__COMMIT_HASH__ = 'test-commit-hash';
+declare global {
+  // eslint-disable-next-line no-var
+  var __COMMIT_HASH__: string;
+}
+globalThis.__COMMIT_HASH__ = 'test-commit-hash';
 
 const tryExpect = (expectFn: () => void) => {
   try {

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -9,6 +9,9 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 // @ts-ignore
 global.TextEncoder = TextEncoder;
 
+// Mock webpack-injected global variables
+global.__COMMIT_HASH__ = 'test-commit-hash';
+
 const tryExpect = (expectFn: () => void) => {
   try {
     expectFn();

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -10,11 +10,7 @@ import type { BooleanValues, RenderHookResultExt } from '../types';
 global.TextEncoder = TextEncoder;
 
 // Mock webpack-injected global variables
-declare global {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const __COMMIT_HASH__: string | undefined;
-}
-global.__COMMIT_HASH__ = 'test-commit-hash';
+(global as any).__COMMIT_HASH__ = 'test-commit-hash';
 
 const tryExpect = (expectFn: () => void) => {
   try {

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -12,7 +12,7 @@ global.TextEncoder = TextEncoder;
 
 // Mock webpack-injected global variables
 declare global {
-  // eslint-disable-next-line no-var
+  // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
   var __COMMIT_HASH__: string;
 }
 globalThis.__COMMIT_HASH__ = 'test-commit-hash';


### PR DESCRIPTION
for: https://issues.redhat.com/browse/RHOAIENG-31837


## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
Every time the user opens up the about dialog, the current commit hash will print to the console.
no other functional changes.

the commit hash is added as part of webpack as an process.env variable.

note: this video has audio narration!
https://github.com/user-attachments/assets/c897ba14-0dd5-451a-97ef-87b6b66fd266

really small change.




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
i opened the about dialog and looked at the printout and matched it to the git command line.
see video for full test.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no other tests needed; this is a developer quality-of-life that has no affect on the code functionality at all

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * About dialog now logs the current build commit hash to the browser console when opened (no UI changes).
* **Documentation**
  * Note added that opening the About dialog prints the current build commit to the console to help verify deployments.
* **Tests**
  * Added a test-time mock for the build commit value to ensure consistent test behavior.
* **Chores**
  * Embed the current build commit into the frontend at build time with a graceful "unknown" fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->