### PR TITLE
Add storage class access mode e2e tests

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/storage_class.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{SC_NAME}}
   annotations:
     description: description
-    opendatahub.io/sc-config: '{"isDefault":{{SC_IS_DEFAULT}},"isEnabled":{{SC_IS_ENABLED}},"displayName":"{{SC_NAME}}","lastModified":"2024-10-01T15:22:42.480Z"}'
-provisioner: cinder.csi.openstack.org
+    opendatahub.io/sc-config: '{"isDefault":{{SC_IS_DEFAULT}},"isEnabled":{{SC_IS_ENABLED}},"displayName":"{{SC_NAME}}","lastModified":"2024-10-01T15:22:42.480Z","accessModeSettings":{{SC_ACCESS_MODE}}}'
+provisioner: {{SC_PROVISIONER}}
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageAccessModes.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageAccessModes.cy.ts
@@ -1,0 +1,244 @@
+import { StorageProvisioner } from '@odh-dashboard/internal/pages/storageClasses/storageEnums';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  provisionStorageClass,
+  tearDownStorageClassFeature,
+  provisionClusterStorageSCFeature,
+  tearDownClusterStorageSCFeature,
+} from '#~/__tests__/cypress/cypress/utils/storageClass';
+import {
+  clusterStorage,
+  addClusterStorageModal,
+  updateClusterStorageModal,
+} from '#~/__tests__/cypress/cypress/pages/clusterStorage';
+import { projectDetails, projectListPage } from '#~/__tests__/cypress/cypress/pages/projects';
+import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
+import type { SCAccessMode } from '#~/__tests__/cypress/cypress/types';
+
+describe('Cluster Storage Access Modes Tests', () => {
+  const createdStorageClasses: string[] = [];
+
+  const projectName = 'test-cluster-storage-access-modes-preset';
+  const scRWOName = 'sc-rwo-preset';
+  const scRWXName = 'sc-rwx-preset';
+  const scROXName = 'sc-rox-preset';
+  const scRWOPName = 'sc-rwop-preset';
+  const scMultiAccessName = 'sc-multi-access-preset';
+
+  retryableBefore(() => {
+    cy.step('Provisioning storage classes with different access modes');
+
+    const scRWO: SCAccessMode = {
+      ReadWriteOnce: true,
+      ReadWriteMany: false,
+    };
+    provisionStorageClass(scRWOName, StorageProvisioner.VSPHERE_VOLUME, scRWO);
+    createdStorageClasses.push(scRWOName);
+
+    const scRWX: SCAccessMode = {
+      ReadWriteOnce: false,
+      ReadWriteMany: true,
+    };
+    provisionStorageClass(scRWXName, StorageProvisioner.BLOCK_CSI_IBM, scRWX);
+    createdStorageClasses.push(scRWXName);
+
+    const scROX: SCAccessMode = {
+      ReadWriteOnce: false,
+      ReadWriteMany: false,
+      ReadOnlyMany: true,
+    };
+    provisionStorageClass(scROXName, StorageProvisioner.QUOBYTE, scROX);
+    createdStorageClasses.push(scROXName);
+
+    const scRWOP: SCAccessMode = {
+      ReadOnlyMany: false,
+      ReadWriteOncePod: true,
+    };
+    provisionStorageClass(scRWOPName, StorageProvisioner.PD_CSI_GKE, scRWOP);
+    createdStorageClasses.push(scRWOPName);
+
+    const scMultiAccess: SCAccessMode = {
+      ReadWriteOnce: true,
+      ReadWriteMany: true,
+      ReadOnlyMany: true,
+      ReadWriteOncePod: false,
+    };
+    provisionStorageClass(scMultiAccessName, StorageProvisioner.AZURE_FILE, scMultiAccess);
+    createdStorageClasses.push(scMultiAccessName);
+
+    cy.step('Provisioning data science project');
+    provisionClusterStorageSCFeature(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME);
+  });
+
+  after(() => {
+    if (createdStorageClasses.length > 0) {
+      cy.step('Cleaning up storage classes');
+      tearDownStorageClassFeature(createdStorageClasses);
+    }
+    cy.step('Cleaning up data science project');
+    tearDownClusterStorageSCFeature(projectName);
+  });
+
+  beforeEach(() => {
+    cy.step('Log into the application');
+    cy.visitWithLogin('/projects', HTPASSWD_CLUSTER_ADMIN_USER);
+
+    cy.step(`Navigate to the Project list tab and search for ${projectName}`);
+    projectListPage.filterProjectByName(projectName);
+    projectListPage.findProjectLink(projectName).click();
+
+    cy.step('Navigate to the Cluster Storage tab');
+    projectDetails.findSectionTab('cluster-storages').click();
+  });
+
+  it(
+    'Should display storage classes with different access modes in cluster storage dropdown',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@NonConcurrent'] },
+    () => {
+      cy.step('Open the Create cluster storage modal');
+      clusterStorage.findCreateButton().click();
+
+      cy.step('Verify storage class dropdown is enabled and contains our storage classes');
+      const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+      storageClassSelect.find().should('not.be.disabled');
+
+      cy.step('Click on the storage class dropdown to open it');
+      storageClassSelect.find().click();
+
+      cy.step('Verify storage classes with different access modes are available');
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWOName, 'i'));
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWXName, 'i'));
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scROXName, 'i'));
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWOPName, 'i'));
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scMultiAccessName, 'i'));
+      addClusterStorageModal.findCloseButton().click({ force: true });
+    },
+  );
+
+  it(
+    'Should show correct access modes when selecting storage classes with RWO access mode',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@NonConcurrent'] },
+    () => {
+      cy.step('Open the Create cluster storage modal');
+      clusterStorage.findCreateButton().click();
+
+      cy.step(`Select storage class with ReadWriteOnce access mode: ${scRWOName}`);
+      const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWOName, 'i'));
+
+      cy.step('Verify ReadWriteOnce access mode is available and selected');
+      addClusterStorageModal.findRWOAccessMode().should('exist').should('be.checked');
+      cy.step('Verify other access modes are not available for RWO-only storage class');
+      addClusterStorageModal.findRWXAccessMode().should('exist').should('be.disabled');
+      cy.step('Verify other access modes are not available for RWX-only storage class');
+      addClusterStorageModal.findROXAccessMode().should('not.exist');
+      addClusterStorageModal.findRWOPAccessMode().should('not.exist');
+
+      cy.step('Verify that correct access modes are shown and selected for other storage classes');
+      cy.step(`Select storage class with ReadWriteMany access mode: ${scRWOName}`);
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWXName, 'i'));
+
+      cy.step('Verify ReadWriteMany access mode is available');
+      addClusterStorageModal.findRWXAccessMode().should('exist').should('not.be.disabled');
+      addClusterStorageModal.findRWXAccessMode().click();
+      addClusterStorageModal.findRWXAccessMode().should('be.checked');
+      // RWO access mode is never disabled
+      addClusterStorageModal.findRWOAccessMode().should('exist').should('not.be.disabled');
+
+      cy.step('Verify other access modes are not available for RWX-only storage class');
+      addClusterStorageModal.findROXAccessMode().should('not.exist');
+      addClusterStorageModal.findRWOPAccessMode().should('not.exist');
+      addClusterStorageModal.findCloseButton().click({ force: true });
+    },
+  );
+
+  it(
+    'Should show multiple access modes when selecting storage class with multiple access modes',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@NonConcurrent'] },
+    () => {
+      cy.step('Open the Create cluster storage modal');
+      clusterStorage.findCreateButton().click();
+
+      cy.step(`Select storage class with multiple access modes: ${scMultiAccessName}`);
+      const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scMultiAccessName, 'i'));
+
+      cy.step('Verify multiple access modes are available and can be selected');
+      addClusterStorageModal.findRWOAccessMode().should('exist').should('not.be.disabled');
+      addClusterStorageModal.findRWXAccessMode().should('exist').should('not.be.disabled');
+      addClusterStorageModal.findROXAccessMode().should('exist').should('not.be.disabled');
+
+      // RWOP should be disabled since it wasn't included in this storage class
+      addClusterStorageModal.findRWOPAccessMode().should('exist').should('be.disabled');
+
+      cy.step('Test switching between available access modes');
+
+      cy.step('Default should be RWO');
+      addClusterStorageModal.findRWOAccessMode().should('be.checked');
+
+      cy.step('Switch to RWX');
+      addClusterStorageModal.findRWXAccessMode().click();
+      addClusterStorageModal.findRWXAccessMode().should('be.checked');
+      addClusterStorageModal.findRWOAccessMode().should('not.be.checked');
+
+      cy.step('Switch ROX');
+      addClusterStorageModal.findROXAccessMode().click();
+      addClusterStorageModal.findROXAccessMode().should('be.checked');
+      addClusterStorageModal.findRWXAccessMode().should('not.be.checked');
+      addClusterStorageModal.findCloseButton().click({ force: true });
+    },
+  );
+
+  it(
+    'Should successfully create cluster storage with different access modes, and not be allowed to change access modes on edit',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@NonConcurrent'] },
+    () => {
+      cy.step('Fill in the create cluster storage with ReadWriteMany access mode');
+      clusterStorage.findCreateButton().click();
+
+      const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWXName, 'i'));
+      addClusterStorageModal.findRWXAccessMode().click();
+      const storageName = 'test-rwx-storage-preset';
+      addClusterStorageModal.findNameInput().type(storageName);
+      addClusterStorageModal
+        .findDescriptionInput()
+        .type('Test storage with ReadWriteMany access mode');
+
+      cy.step('Submit the form');
+      addClusterStorageModal.findSubmitButton().should('not.be.disabled').click();
+
+      cy.step('Verify cluster storage was created successfully');
+      clusterStorage.getClusterStorageRow(storageName).find().should('exist');
+
+      const storageRow = clusterStorage.getClusterStorageRow(storageName);
+      storageRow.findStorageClassColumn().should('contain.text', scRWXName);
+
+      cy.step('Attempt to edit the cluster storage');
+      clusterStorage.getClusterStorageRow(storageName).findKebabAction('Edit storage').click();
+
+      cy.step('Verify edit modal opens with correct title');
+      updateClusterStorageModal.find().should('be.visible');
+
+      cy.step('Verify access mode is displayed in read-only format like "ReadWriteMany (RWX)"');
+      updateClusterStorageModal.findExistingAccessMode().should('exist');
+      updateClusterStorageModal.findExistingAccessMode().should('contain.text', 'ReadWriteMany');
+      updateClusterStorageModal.findExistingAccessMode().should('contain.text', 'RWX');
+
+      cy.step('Verify that access mode radio buttons are not available for editing');
+      updateClusterStorageModal.findRWOAccessMode().should('not.exist');
+      updateClusterStorageModal.findRWXAccessMode().should('not.exist');
+      updateClusterStorageModal.findROXAccessMode().should('not.exist');
+      updateClusterStorageModal.findRWOPAccessMode().should('not.exist');
+      updateClusterStorageModal.findCloseButton().click({ force: true });
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
@@ -1,0 +1,117 @@
+import { StorageProvisioner } from '@odh-dashboard/internal/pages/storageClasses/storageEnums';
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  provisionStorageClass,
+  tearDownStorageClassFeature,
+  provisionClusterStorageSCFeature,
+  tearDownClusterStorageSCFeature,
+} from '#~/__tests__/cypress/cypress/utils/storageClass';
+import {
+  workbenchPage,
+  createSpawnerPage,
+  attachExistingStorageModal,
+} from '#~/__tests__/cypress/cypress/pages/workbench';
+import {
+  clusterStorage,
+  addClusterStorageModal,
+} from '#~/__tests__/cypress/cypress/pages/clusterStorage';
+import { projectDetails, projectListPage } from '#~/__tests__/cypress/cypress/pages/projects';
+import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
+import type { SCAccessMode } from '#~/__tests__/cypress/cypress/types';
+import { selectNotebookImageWithBackendFallback } from '#~/__tests__/cypress/cypress/utils/oc_commands/imageStreams';
+
+describe('Workbench Storage Classes Tests', () => {
+  const createdStorageClasses: string[] = [];
+  const projectName = 'test-workbench-storage-preset';
+
+  const scRWOName = 'sc-rwo-preset';
+
+  retryableBefore(() => {
+    cy.step('Provisioning storage class');
+    const scRWO: SCAccessMode = {
+      ReadWriteOnce: true,
+      ReadWriteMany: true,
+    };
+    provisionStorageClass(scRWOName, StorageProvisioner.VSPHERE_VOLUME, scRWO);
+    createdStorageClasses.push(scRWOName);
+
+    cy.step('Provisioning data science project');
+    provisionClusterStorageSCFeature(projectName, HTPASSWD_CLUSTER_ADMIN_USER.USERNAME);
+  });
+
+  after(() => {
+    if (createdStorageClasses.length > 0) {
+      cy.step('Cleaning up storage classes');
+      tearDownStorageClassFeature(createdStorageClasses);
+    }
+    cy.step('Cleaning up data science project');
+    tearDownClusterStorageSCFeature(projectName);
+  });
+
+  beforeEach(() => {
+    cy.step('Log into the application');
+    cy.visitWithLogin('/projects', HTPASSWD_CLUSTER_ADMIN_USER);
+
+    cy.step(`Navigate to the Project list tab and search for ${projectName}`);
+    projectListPage.filterProjectByName(projectName);
+    projectListPage.findProjectLink(projectName).click();
+  });
+
+  it(
+    'Create workbench with RWO storage and verify storage attachment',
+    { tags: ['@Storage', '@ODS-1931', '@Dashboard', '@Workbenches'] },
+    () => {
+      const workbenchName = 'wb-rwo-storage';
+      const storageName = 'rwo-storage';
+      const mountPath = 'mnt/different-path';
+      let selectedImageStream: string;
+
+      cy.step('Navigate to cluster storage and create RWO storage');
+      projectDetails.findSectionTab('cluster-storages').click();
+      clusterStorage.findCreateButton().click();
+      addClusterStorageModal.findNameInput().type(storageName);
+
+      const storageClassSelect = addClusterStorageModal.findStorageClassSelect();
+      storageClassSelect.find().click();
+      storageClassSelect.selectStorageClassSelectOption(new RegExp(scRWOName, 'i'));
+
+      cy.step('Submit the form');
+      addClusterStorageModal.findSubmitButton().should('not.be.disabled').click();
+
+      cy.step('Create workbench and attach RWO storage');
+      projectDetails.findSectionTab('workbenches').click();
+      workbenchPage.findCreateButton().click();
+      createSpawnerPage.getNameInput().fill(workbenchName);
+
+      selectNotebookImageWithBackendFallback('code-server-notebook', createSpawnerPage).then(
+        (imageStreamName: string) => {
+          selectedImageStream = imageStreamName;
+          cy.log(`Selected imagestream: ${selectedImageStream}`);
+          cy.step('Attach RWO storage to workbench');
+          createSpawnerPage.findAttachExistingStorageButton().click();
+          attachExistingStorageModal.findStandardPathInput().fill(mountPath);
+          attachExistingStorageModal.findAttachButton().should('be.enabled');
+          attachExistingStorageModal.findAttachButton().click();
+          createSpawnerPage.findSubmitButton().click();
+
+          cy.step('Verify workbench is running with attached RWO storage');
+          const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+
+          cy.step('Verify RWO storage details in workbench edit view');
+          notebookRow.findKebab().click();
+          notebookRow.findKebabAction('Edit workbench').click();
+
+          createSpawnerPage
+            .getStorageTable()
+            .find()
+            .within(() => {
+              cy.contains(storageName).should('exist');
+              cy.contains('ReadWriteOnce').should('exist');
+            });
+
+          createSpawnerPage.findSubmitButton().click();
+        },
+      );
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -1,12 +1,18 @@
+import {
+  AccessMode,
+  StorageProvisioner,
+} from '@odh-dashboard/internal/pages/storageClasses/storageEnums';
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
 import {
   verifyStorageClassConfig,
   provisionStorageClassFeature,
   tearDownStorageClassFeature,
+  provisionStorageClass,
 } from '#~/__tests__/cypress/cypress/utils/storageClass';
 import {
   storageClassesPage,
   storageClassesTable,
+  storageClassEditModal,
 } from '#~/__tests__/cypress/cypress/pages/storageClasses';
 import {
   retryableBefore,
@@ -14,14 +20,29 @@ import {
 } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
 
 const scName = 'qe-settings-sc';
+const scAccessModeName1 = `${scName}-manila-csi`;
+const scAccessModeName2 = `${scName}-vsphere-volume`;
 
 // Using testIsolation will reuse the login (cache)
 // describe('An admin user can manage Storage Classes', { testIsolation: false }, () => {
 describe('An admin user can manage Storage Classes from Settings -> Storage classes view', () => {
   let createdStorageClasses: string[];
+  let accessModeStorageClasses: string[];
   retryableBefore(() => {
     // Provision different SCs
     createdStorageClasses = provisionStorageClassFeature(scName);
+    accessModeStorageClasses = [
+      provisionStorageClass(scAccessModeName1, StorageProvisioner.MANILA_CSI, {
+        ReadWriteOnce: true,
+        ReadWriteMany: false,
+        ReadWriteOncePod: false,
+        ReadOnlyMany: false,
+      }),
+      provisionStorageClass(scAccessModeName2, StorageProvisioner.VSPHERE_VOLUME, {
+        ReadWriteOnce: true,
+        ReadWriteMany: true,
+      }),
+    ];
   });
 
   after(() => {
@@ -32,6 +53,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
 
     // Delete provisioned SCs
     tearDownStorageClassFeature(createdStorageClasses);
+    tearDownStorageClassFeature(accessModeStorageClasses);
   });
 
   it(
@@ -128,6 +150,69 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
       cy.step('Check the Enable switch is disabled');
       scToDefaultRow.findEnableSwitchInput().should('be.disabled');
       verifyStorageClassConfig(scToDefaultName, true, true);
+    },
+  );
+
+  it(
+    'An admin user can edit the access mode of a storage class',
+    { tags: ['@Smoke', '@SmokeSet2', '@Dashboard', '@NonConcurrent'] },
+    () => {
+      cy.step('Navigate to Storage Classes view');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+      storageClassesPage.navigate();
+
+      const scAccessModeRow = storageClassesTable.getRowByConfigName(scAccessModeName1);
+
+      cy.step('Check SC initial access modes');
+      storageClassesTable.findRowByName(scAccessModeName1).should('be.visible');
+      scAccessModeRow.shouldContainAccessModeLabels(['RWO']);
+
+      cy.step('Navigate to edit SC');
+      storageClassesTable.getRowByConfigName(scAccessModeName1).findKebabAction('Edit').click();
+
+      cy.step('Check initial access mode checkboxes state');
+      storageClassEditModal
+        .findAccessModeCheckbox(AccessMode.RWO)
+        .should('be.disabled')
+        .and('be.checked');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.RWX).should('not.be.checked');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.ROX).should('not.be.checked');
+      storageClassEditModal
+        .findAccessModeCheckbox(AccessMode.RWOP)
+        .should('be.disabled')
+        .should('not.be.checked');
+
+      cy.step('Change access modes - enable ReadWriteMany and ReadOnlyMany');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.RWX).click();
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.ROX).click();
+
+      cy.step('Verify the checkboxes are now checked');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.RWX).should('be.checked');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.ROX).should('be.checked');
+
+      cy.step('Save the changes');
+      storageClassEditModal.findSaveButton().click();
+      cy.step('Verify that the correct access mode labels are displayed in the table');
+      scAccessModeRow.shouldContainAccessModeLabels(['RWO', 'RWX', 'ROX']);
+      cy.step('Verify that access modes are updated in the storage class CR');
+      verifyStorageClassConfig(scAccessModeName1, false, true, undefined, undefined, {
+        ReadWriteOnce: true,
+        ReadWriteMany: true,
+        ReadOnlyMany: true,
+      });
+
+      cy.step('Check that an alert shows up when unchecking RWX');
+      storageClassesTable.getRowByConfigName(scAccessModeName1).findKebabAction('Edit').click();
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.RWX).click(); // uncheck
+      storageClassEditModal.findAccessModeAlert().should('be.visible');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.RWX).click(); // re-check
+      storageClassEditModal.findAccessModeAlert().should('not.exist');
+
+      cy.step('Check that an alert does not show up when unchecking access mode other than RWX');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.ROX).click(); // uncheck
+      storageClassEditModal.findAccessModeAlert().should('not.exist');
+      storageClassEditModal.findAccessModeCheckbox(AccessMode.ROX).click(); // re-check
+      storageClassEditModal.findAccessModeAlert().should('not.exist');
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -67,12 +67,15 @@ export type StorageClassConfig = {
   isEnabled: boolean;
   displayName: string;
   description?: string;
+  accessModeSettings?: SCAccessMode;
 };
 
 export type SCReplacements = {
   SC_NAME: string;
   SC_IS_DEFAULT: string;
   SC_IS_ENABLED: string;
+  SC_ACCESS_MODE: string;
+  SC_PROVISIONER: string;
 };
 
 export type PVCReplacements = {
@@ -362,3 +365,10 @@ export enum AccessMode {
   ROX = 'ReadOnlyMany',
   RWOP = 'ReadWriteOncePod',
 }
+
+export type SCAccessMode = {
+  ReadWriteOnce?: boolean;
+  ReadWriteMany?: boolean;
+  ReadOnlyMany?: boolean;
+  ReadWriteOncePod?: boolean;
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/storageClass.ts
@@ -1,3 +1,4 @@
+import { StorageProvisioner } from '@odh-dashboard/internal/pages/storageClasses/storageEnums';
 import type { SCReplacements, CommandLineResult } from '#~/__tests__/cypress/cypress/types';
 import { replacePlaceholdersInYaml } from '#~/__tests__/cypress/cypress/utils/yaml_files';
 import { MetadataAnnotation } from '#~/k8sTypes';
@@ -205,6 +206,8 @@ export const disableNonDefaultStorageClasses = (): Cypress.Chainable<void> => {
             SC_NAME: scName,
             SC_IS_DEFAULT: 'false',
             SC_IS_ENABLED: 'false',
+            SC_ACCESS_MODE: JSON.stringify({ ReadWriteOnce: true }),
+            SC_PROVISIONER: StorageProvisioner.CINDER_CSI,
           };
           return () => updateStorageClass(scReplacements);
         }

--- a/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/StorageClassSelect.tsx
@@ -150,6 +150,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
         popperProps={{ appendTo: menuAppendTo }}
         toggleProps={{ status: validated ? validatedToToggleStatus[validated] : undefined }}
         previewDescription={false}
+        isScrollable
       />
       <FormHelperText>
         {selectedStorageClassConfig && !selectedStorageClassConfig.isEnabled ? (

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -221,6 +221,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
               if (!isSupported) {
                 return (
                   <Tooltip
+                    data-testid="sc-access-mode-unsupported-tooltip"
                     content="This access mode is not supported by the selected storage class."
                     key={`${modeName}-tooltip`}
                     position="top-start"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-28386

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Created E2E tests for storage class access modes. 
   - Provisions storage classes with different access modes 
   - Tests access mode enabling/disabling in settings
   - Adding pvc in a project, selecting storage class and access mode
   - Updating pvc, ensuring the access mode is immutable
   - Attaching existing storage in workbenches

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Storage class dropdown is now scrollable for easier selection in long lists.

- **Tests**
  - Added comprehensive end-to-end tests covering storage class access modes: provisioning, cluster storage creation/editing, and UI access-mode behavior.
  - Added scenarios for attaching storage to workbenches and validating displayed access modes and backend verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->