### PR TITLE
Model Deployment Notification Update

### DIFF
--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points.d.ts
@@ -3,11 +3,11 @@ import type { ComponentCodeRef } from '@odh-dashboard/plugin-core/extension-poin
 import { ModelVersion } from '~/app/types';
 import { DisplayNameAnnotations, K8sAPIOptions, ProjectKind } from '@odh-dashboard/internal/k8sTypes.js';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types.js';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types.js';
 import { EitherNotBoth, ProjectObjectType } from 'mod-arch-shared';
 import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types.js';
 export type DeploymentStatus = {
-    state: InferenceServiceModelState;
+    state: ModelDeploymentState;
     message?: string;
 };
 export type DeploymentEndpoint = {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -26,7 +26,7 @@ import {
   modelVersionDetails,
   navigationBlockerModal,
 } from '#~/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDetails';
-import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import { modelServingGlobal } from '#~/__tests__/cypress/cypress/pages/modelServing';
 import {
   ModelRegistryMetadataType,
@@ -585,7 +585,7 @@ describe('Model version details', () => {
         mockK8sResourceList([
           mockInferenceServiceK8sResource({
             url: 'test-inference-status.url.com',
-            activeModelState: InferenceServiceModelState.LOADED,
+            activeModelState: ModelDeploymentState.LOADED,
             additionalLabels: {
               [KnownLabels.REGISTERED_MODEL_ID]: '1',
               [KnownLabels.MODEL_VERSION_ID]: '1',
@@ -595,7 +595,7 @@ describe('Model version details', () => {
             url: 'test-inference-status.url.com',
             displayName: 'Test Inference Service-2',
             name: 'Test Inference Service-2',
-            activeModelState: InferenceServiceModelState.LOADED,
+            activeModelState: ModelDeploymentState.LOADED,
             additionalLabels: {
               [KnownLabels.REGISTERED_MODEL_ID]: '1',
               [KnownLabels.MODEL_VERSION_ID]: '1',
@@ -606,7 +606,7 @@ describe('Model version details', () => {
             url: 'test-inference-status.url.com',
             displayName: 'Test Inference Service-3',
             name: 'Test Inference Service-3',
-            activeModelState: InferenceServiceModelState.LOADED,
+            activeModelState: ModelDeploymentState.LOADED,
             additionalLabels: {
               [KnownLabels.REGISTERED_MODEL_ID]: '1',
               [KnownLabels.MODEL_VERSION_ID]: '1',

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -294,7 +294,9 @@ export const getInferenceServicePods = (
         model: PodModel,
         queryOptions: {
           ns: namespace,
-          selector: { 'serving.kserve.io/inferenceservice': name },
+          queryParams: {
+            labelSelector: `serving.kserve.io/inferenceservice=${name}`,
+          },
         },
       },
       opts,

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -8,8 +8,8 @@ import {
   k8sUpdateResource,
   k8sPatchResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
-import { InferenceServiceModel } from '#~/api/models';
-import { InferenceServiceKind, K8sAPIOptions, KnownLabels } from '#~/k8sTypes';
+import { InferenceServiceModel, PodModel } from '#~/api/models';
+import { InferenceServiceKind, K8sAPIOptions, KnownLabels, PodKind } from '#~/k8sTypes';
 import { CreatingInferenceServiceObject } from '#~/pages/modelServing/screens/types';
 import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 import { getInferenceServiceDeploymentMode } from '#~/pages/modelServing/screens/projects/utils';
@@ -282,6 +282,24 @@ export const getInferenceService = (
       opts,
     ),
   );
+
+export const getInferenceServicePods = (
+  name: string,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<PodKind[]> =>
+  k8sListResource<PodKind>(
+    applyK8sAPIOptions(
+      {
+        model: PodModel,
+        queryOptions: {
+          ns: namespace,
+          selector: { 'serving.kserve.io/inferenceservice': name },
+        },
+      },
+      opts,
+    ),
+  ).then((listResource) => listResource.items);
 
 export const createInferenceService = (
   data: CreatingInferenceServiceObject,

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -8,11 +8,11 @@ import {
   PlayIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
-import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import { ToggleState } from '#~/components/StateActionToggle';
 
 type ModelStatusIconProps = {
-  state: InferenceServiceModelState;
+  state: ModelDeploymentState;
   defaultHeaderContent?: string;
   bodyContent?: string;
   isCompact?: boolean;
@@ -56,8 +56,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
     if (
       stoppedStates?.isStarting ||
-      state === InferenceServiceModelState.LOADING ||
-      state === InferenceServiceModelState.PENDING
+      state === ModelDeploymentState.LOADING ||
+      state === ModelDeploymentState.PENDING
     ) {
       return {
         label: 'Starting',
@@ -69,21 +69,21 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
 
     // Only check the state if not stopped
     switch (state) {
-      case InferenceServiceModelState.LOADED:
-      case InferenceServiceModelState.STANDBY:
+      case ModelDeploymentState.LOADED:
+      case ModelDeploymentState.STANDBY:
         return {
           label: 'Started',
           status: 'success',
           icon: <PlayIcon />,
           message: 'Model deployment is active.',
         };
-      case InferenceServiceModelState.FAILED_TO_LOAD:
+      case ModelDeploymentState.FAILED_TO_LOAD:
         return {
           label: 'Failed',
           status: 'danger',
           icon: <ExclamationCircleIcon />,
         };
-      case InferenceServiceModelState.UNKNOWN:
+      case ModelDeploymentState.UNKNOWN:
         return {
           label: defaultHeaderContent || 'Status',
           color: 'grey',

--- a/frontend/src/concepts/modelServingKServe/kserveStatusUtils.ts
+++ b/frontend/src/concepts/modelServingKServe/kserveStatusUtils.ts
@@ -1,5 +1,5 @@
 import { InferenceServiceKind, PodKind } from '#~/k8sTypes';
-import { InferenceServiceModelState, ModelStatus } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState, ModelStatus } from '#~/pages/modelServing/screens/types';
 import { asEnumMember } from '#~/utilities/utils';
 
 /**
@@ -14,14 +14,14 @@ import { asEnumMember } from '#~/utilities/utils';
 export const getInferenceServiceModelState = (
   is: InferenceServiceKind,
   podStatus?: ModelStatus | null,
-): InferenceServiceModelState => {
+): ModelDeploymentState => {
   if (podStatus?.failedToSchedule) {
-    return InferenceServiceModelState.FAILED_TO_LOAD;
+    return ModelDeploymentState.FAILED_TO_LOAD;
   }
   return (
-    asEnumMember(is.status?.modelStatus?.states?.targetModelState, InferenceServiceModelState) ||
-    asEnumMember(is.status?.modelStatus?.states?.activeModelState, InferenceServiceModelState) ||
-    InferenceServiceModelState.UNKNOWN
+    asEnumMember(is.status?.modelStatus?.states?.targetModelState, ModelDeploymentState) ||
+    asEnumMember(is.status?.modelStatus?.states?.activeModelState, ModelDeploymentState) ||
+    ModelDeploymentState.UNKNOWN
   );
 };
 
@@ -59,17 +59,17 @@ export const getInferenceServiceStatusMessage = (
   const stateMessage = (targetModelState || activeModelState) ?? 'Unknown';
 
   if (
-    activeModelState === InferenceServiceModelState.FAILED_TO_LOAD ||
-    targetModelState === InferenceServiceModelState.FAILED_TO_LOAD
+    activeModelState === ModelDeploymentState.FAILED_TO_LOAD ||
+    targetModelState === ModelDeploymentState.FAILED_TO_LOAD
   ) {
     const lastFailureMessage = is.status?.modelStatus?.lastFailureInfo?.message;
     return lastFailureMessage || stateMessage;
   }
 
   if (
-    activeModelState === InferenceServiceModelState.LOADED &&
-    (targetModelState === InferenceServiceModelState.LOADING ||
-      targetModelState === InferenceServiceModelState.PENDING)
+    activeModelState === ModelDeploymentState.LOADED &&
+    (targetModelState === ModelDeploymentState.LOADING ||
+      targetModelState === ModelDeploymentState.PENDING)
   ) {
     return 'Redeploying';
   }

--- a/frontend/src/pages/modelServing/__tests__/useInferenceServiceStatus.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/useInferenceServiceStatus.spec.ts
@@ -3,7 +3,7 @@ import { InferenceServiceKind } from '#~/k8sTypes';
 import { getInferenceServiceModelState } from '#~/concepts/modelServingKServe/kserveStatusUtils';
 import { FAST_POLL_INTERVAL } from '#~/utilities/const';
 import { useInferenceServiceStatus } from '#~/pages/modelServing/useInferenceServiceStatus.ts';
-import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import { getInferenceServiceStoppedStatus } from '#~/pages/modelServing/utils';
 
 // Mock dependencies
@@ -46,8 +46,8 @@ describe('useInferenceServiceStatus', () => {
     status: {
       modelStatus: {
         states: {
-          targetModelState: InferenceServiceModelState.LOADED,
-          activeModelState: InferenceServiceModelState.LOADED,
+          targetModelState: ModelDeploymentState.LOADED,
+          activeModelState: ModelDeploymentState.LOADED,
         },
       },
     },
@@ -87,7 +87,7 @@ describe('useInferenceServiceStatus', () => {
       refresh: jest.fn(),
     });
 
-    mockGetInferenceServiceModelState.mockReturnValue(InferenceServiceModelState.LOADED);
+    mockGetInferenceServiceModelState.mockReturnValue(ModelDeploymentState.LOADED);
     mockGetInferenceServiceStoppedStatus.mockReturnValue({
       inferenceService: mockInferenceService,
       isStopped: false,
@@ -138,7 +138,7 @@ describe('useInferenceServiceStatus', () => {
 
   describe('isStarting state management', () => {
     it('should set isStarting to true when model state is LOADING', () => {
-      mockGetInferenceServiceModelState.mockReturnValue(InferenceServiceModelState.LOADING);
+      mockGetInferenceServiceModelState.mockReturnValue(ModelDeploymentState.LOADING);
 
       const { result } = renderHook(
         ({ inferenceService, refresh }) => useInferenceServiceStatus(inferenceService, refresh),
@@ -155,7 +155,7 @@ describe('useInferenceServiceStatus', () => {
     });
 
     it('should set isStarting to true when model state is PENDING', () => {
-      mockGetInferenceServiceModelState.mockReturnValue(InferenceServiceModelState.PENDING);
+      mockGetInferenceServiceModelState.mockReturnValue(ModelDeploymentState.PENDING);
 
       const { result } = renderHook(
         ({ inferenceService, refresh }) => useInferenceServiceStatus(inferenceService, refresh),
@@ -172,7 +172,7 @@ describe('useInferenceServiceStatus', () => {
     });
 
     it('should set isStarting to false when model state is LOADED', () => {
-      mockGetInferenceServiceModelState.mockReturnValue(InferenceServiceModelState.LOADED);
+      mockGetInferenceServiceModelState.mockReturnValue(ModelDeploymentState.LOADED);
 
       const { result, rerender } = renderHook(
         ({ inferenceService, refresh }) => useInferenceServiceStatus(inferenceService, refresh),
@@ -194,7 +194,7 @@ describe('useInferenceServiceStatus', () => {
     });
 
     it('should set isStarting to false when model state is FAILED_TO_LOAD', () => {
-      mockGetInferenceServiceModelState.mockReturnValue(InferenceServiceModelState.FAILED_TO_LOAD);
+      mockGetInferenceServiceModelState.mockReturnValue(ModelDeploymentState.FAILED_TO_LOAD);
 
       const { result, rerender } = renderHook(
         ({ inferenceService, refresh }) => useInferenceServiceStatus(inferenceService, refresh),

--- a/frontend/src/pages/modelServing/screens/global/useRouteForInferenceService.ts
+++ b/frontend/src/pages/modelServing/screens/global/useRouteForInferenceService.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { InferenceServiceKind } from '#~/k8sTypes';
 import { getRoute } from '#~/api';
 import { getUrlFromKserveInferenceService } from '#~/pages/modelServing/screens/projects/utils';
-import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import { getInferenceServiceModelState } from '#~/concepts/modelServingKServe/kserveStatusUtils';
 
 const useRouteForInferenceService = (
@@ -18,7 +18,7 @@ const useRouteForInferenceService = (
   const routeNamespace = inferenceService.metadata.namespace;
   const kserveRoute = isKServe ? getUrlFromKserveInferenceService(inferenceService) : null;
   const state = getInferenceServiceModelState(inferenceService);
-  const kserveLoaded = state === InferenceServiceModelState.LOADED;
+  const kserveLoaded = state === ModelDeploymentState.LOADED;
 
   React.useEffect(() => {
     if (isKServe) {

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -13,6 +13,7 @@ import {
 } from '#~/concepts/modelServingKServe/kserveStatusUtils';
 import { useModelStatus } from '#~/pages/modelServing/screens/global/useModelStatus';
 import { getInferenceServiceStoppedStatus } from '#~/pages/modelServing/utils';
+import { FAST_POLL_INTERVAL } from '#~/utilities/const';
 
 type ModelDeploymentNotification = {
   watchDeployment: () => void;
@@ -31,6 +32,7 @@ export const useModelDeploymentNotification = (
 
   const watchDeployment = React.useCallback(() => {
     registerNotification({
+      callbackDelay: FAST_POLL_INTERVAL,
       callback: async (signal) => {
         // Early failure detection from pod scheduling
         if (modelStatus?.failedToSchedule) {

--- a/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useModelDeploymentNotification.ts
@@ -6,7 +6,7 @@ import {
   NotificationWatcherContext,
 } from '#~/concepts/notificationWatcher/NotificationWatcherContext';
 import { getInferenceService } from '#~/api';
-import { InferenceServiceModelState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import {
   getInferenceServiceLastFailureReason,
   getInferenceServiceModelState,
@@ -28,7 +28,7 @@ export const useModelDeploymentNotification = (
   const notification = useNotification();
   const { registerNotification } = React.useContext(NotificationWatcherContext);
   const [modelStatus] = useModelStatus(namespace, modelName, isKserve);
-  const lastSeenState = React.useRef<InferenceServiceModelState | null>(null);
+  const lastSeenState = React.useRef<ModelDeploymentState | null>(null);
 
   const watchDeployment = React.useCallback(() => {
     registerNotification({
@@ -59,10 +59,10 @@ export const useModelDeploymentNotification = (
           const isStarting =
             !inferenceService.status?.modelStatus?.states?.activeModelState &&
             inferenceService.status?.modelStatus?.states?.targetModelState !==
-              InferenceServiceModelState.FAILED_TO_LOAD &&
+              ModelDeploymentState.FAILED_TO_LOAD &&
             !baseStatus.isStopped;
 
-          const isRunning = inferenceServiceModelState === InferenceServiceModelState.LOADED;
+          const isRunning = inferenceServiceModelState === ModelDeploymentState.LOADED;
 
           // Track previous state
           const lastState = lastSeenState.current;
@@ -71,8 +71,8 @@ export const useModelDeploymentNotification = (
           // Only consider it failed if it's not stopped, the state is FAILED_TO_LOAD, and the last state was PENDING
           const isFailed =
             !isStopped &&
-            inferenceServiceModelState === InferenceServiceModelState.FAILED_TO_LOAD &&
-            lastState === InferenceServiceModelState.PENDING;
+            inferenceServiceModelState === ModelDeploymentState.FAILED_TO_LOAD &&
+            lastState === ModelDeploymentState.PENDING;
 
           const lastFailureReason = getInferenceServiceLastFailureReason(inferenceService);
 
@@ -91,7 +91,7 @@ export const useModelDeploymentNotification = (
             return { status: NotificationResponseStatus.STOP };
           }
 
-          if (isRunning && lastState === InferenceServiceModelState.LOADED) {
+          if (isRunning && lastState === ModelDeploymentState.LOADED) {
             // Model is running, stop polling
             return { status: NotificationResponseStatus.STOP };
           }
@@ -103,8 +103,8 @@ export const useModelDeploymentNotification = (
 
           if (
             isStarting ||
-            inferenceServiceModelState === InferenceServiceModelState.PENDING ||
-            inferenceServiceModelState === InferenceServiceModelState.LOADING
+            inferenceServiceModelState === ModelDeploymentState.PENDING ||
+            inferenceServiceModelState === ModelDeploymentState.LOADING
           ) {
             // Model is still starting/loading, continue polling
             return { status: NotificationResponseStatus.REPOLL };

--- a/frontend/src/pages/modelServing/screens/types.ts
+++ b/frontend/src/pages/modelServing/screens/types.ts
@@ -28,7 +28,7 @@ export enum ServingRuntimeTableTabs {
   TOKENS = 3,
 }
 
-export enum InferenceServiceModelState {
+export enum ModelDeploymentState {
   PENDING = 'Pending',
   STANDBY = 'Standby',
   FAILED_TO_LOAD = 'FailedToLoad',

--- a/frontend/src/pages/modelServing/useInferenceServiceStatus.ts
+++ b/frontend/src/pages/modelServing/useInferenceServiceStatus.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { getInferenceServiceModelState } from '#~/concepts/modelServingKServe/kserveStatusUtils.ts';
-import { InferenceServiceModelState, ModelServingState } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState, ModelServingState } from '#~/pages/modelServing/screens/types';
 import useModelPodStatus from '#~/pages/modelServing/useModelPodStatus';
 import { FAST_POLL_INTERVAL } from '#~/utilities/const.ts';
 import { InferenceServiceKind } from '#~/k8sTypes.ts';
@@ -61,17 +61,13 @@ export const useInferenceServiceStatus = (
     const currentState = getInferenceServiceModelState(inferenceService);
 
     if (
-      currentState === InferenceServiceModelState.LOADING ||
-      currentState === InferenceServiceModelState.PENDING
+      currentState === ModelDeploymentState.LOADING ||
+      currentState === ModelDeploymentState.PENDING
     ) {
       setIsStarting(true);
     }
 
-    if (
-      [InferenceServiceModelState.LOADED, InferenceServiceModelState.FAILED_TO_LOAD].includes(
-        currentState,
-      )
-    ) {
+    if ([ModelDeploymentState.LOADED, ModelDeploymentState.FAILED_TO_LOAD].includes(currentState)) {
       setIsStarting(false);
     }
   }, [isStarting, inferenceService]);
@@ -84,13 +80,13 @@ export const useInferenceServiceStatus = (
     () =>
       !inferenceService.status?.modelStatus?.states?.activeModelState &&
       inferenceService.status?.modelStatus?.states?.targetModelState !==
-        InferenceServiceModelState.FAILED_TO_LOAD &&
+        ModelDeploymentState.FAILED_TO_LOAD &&
       !isStopped &&
       !isStopping,
     [inferenceService.status?.modelStatus?.states, isStopped, isStopping],
   );
 
-  const inferenceServiceModelState = getInferenceServiceModelState(inferenceService);
+  const modelDeploymentState = getInferenceServiceModelState(inferenceService);
 
   return {
     ...baseStatus,
@@ -98,7 +94,7 @@ export const useInferenceServiceStatus = (
     isStopping,
     isStopped,
     isRunning,
-    isFailed: inferenceServiceModelState === InferenceServiceModelState.FAILED_TO_LOAD,
+    isFailed: modelDeploymentState === ModelDeploymentState.FAILED_TO_LOAD,
     setIsStarting,
     setIsStopping,
   };

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
@@ -19,14 +19,14 @@ import {
   checkModelPodStatus,
   getInferenceServiceModelState,
 } from '#~/concepts/modelServingKServe/kserveStatusUtils';
-import { InferenceServiceModelState, ModelStatus } from '#~/pages/modelServing/screens/types';
+import { ModelDeploymentState, ModelStatus } from '#~/pages/modelServing/screens/types';
 import { InferenceServiceKind, ServingRuntimeKind } from '#~/k8sTypes';
 import DeployedModelCard from './DeployedModelCard';
 
-const SUCCESS_STATUSES = [InferenceServiceModelState.LOADED, InferenceServiceModelState.STANDBY];
-const FAILED_STATUSES = [InferenceServiceModelState.FAILED_TO_LOAD];
+const SUCCESS_STATUSES = [ModelDeploymentState.LOADED, ModelDeploymentState.STANDBY];
+const FAILED_STATUSES = [ModelDeploymentState.FAILED_TO_LOAD];
 
-type InferenceServiceStates = { [key: string]: InferenceServiceModelState };
+type InferenceServiceStates = { [key: string]: ModelDeploymentState };
 
 interface DeployedModelsGalleryProps {
   deployedModels: InferenceServiceKind[];
@@ -54,7 +54,7 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
 
     const updateServiceState = (inferenceService: InferenceServiceKind, status?: ModelStatus) => {
       const state = status?.failedToSchedule
-        ? InferenceServiceModelState.FAILED_TO_LOAD
+        ? ModelDeploymentState.FAILED_TO_LOAD
         : getInferenceServiceModelState(inferenceService);
 
       setInferenceServiceStates((prev) => {

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -132,7 +132,7 @@ const extensions: (
     type: 'model-serving.platform/fetch-deployment-status',
     properties: {
       platform: KSERVE_ID,
-      fetch: () => import('./src/deployments').then((m) => m.useFetchDeploymentStatus),
+      fetch: () => import('./src/deployments').then((m) => m.fetchDeploymentStatus),
     },
   },
 ];

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -12,6 +12,7 @@ import type {
   ModelServingAuthExtension,
   DeployedModelServingDetails,
   ModelServingStartStopAction,
+  ModelServingPlatformFetchDeploymentStatus,
 } from '@odh-dashboard/model-serving/extension-points';
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/index';
@@ -29,6 +30,7 @@ const extensions: (
   | ModelServingMetricsExtension<KServeDeployment>
   | DeployedModelServingDetails<KServeDeployment>
   | ModelServingStartStopAction<KServeDeployment>
+  | ModelServingPlatformFetchDeploymentStatus<KServeDeployment>
 )[] = [
   {
     type: 'model-serving.platform',
@@ -124,6 +126,13 @@ const extensions: (
       platform: KSERVE_ID,
       patchDeploymentStoppedStatus: () =>
         import('./src/deploymentStatus').then((m) => m.patchDeploymentStoppedStatus),
+    },
+  },
+  {
+    type: 'model-serving.platform/fetch-deployment-status',
+    properties: {
+      platform: KSERVE_ID,
+      fetch: () => import('./src/deployments').then((m) => m.useFetchDeploymentStatus),
     },
   },
 ];

--- a/packages/kserve/src/deploymentStatus.ts
+++ b/packages/kserve/src/deploymentStatus.ts
@@ -5,7 +5,7 @@ import {
   getInferenceServiceStatusMessage,
 } from '@odh-dashboard/internal/concepts/modelServingKServe/kserveStatusUtils';
 import { DeploymentStatus } from '@odh-dashboard/model-serving/extension-points';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceModel } from '@odh-dashboard/internal/api/models/kserve';
 import { isModelServingStopped } from './utils';
@@ -48,17 +48,16 @@ export const getKServeDeploymentStatus = (
   const stoppedStates = {
     // ISVC doesn't have annotation and state is LOADED
     isRunning:
-      (state === InferenceServiceModelState.LOADED ||
-        state === InferenceServiceModelState.FAILED_TO_LOAD) &&
+      (state === ModelDeploymentState.LOADED || state === ModelDeploymentState.FAILED_TO_LOAD) &&
       !isStopped,
     // ISVC has annotation and there are no pods
     isStopped: isStopped && !deploymentPod,
     // ISVC doesn't have annotation and state is PENDING, LOADING, STANDBY or UNKNOWN
     isStarting:
-      (state === InferenceServiceModelState.PENDING ||
-        state === InferenceServiceModelState.LOADING ||
-        state === InferenceServiceModelState.STANDBY ||
-        state === InferenceServiceModelState.UNKNOWN) &&
+      (state === ModelDeploymentState.PENDING ||
+        state === ModelDeploymentState.LOADING ||
+        state === ModelDeploymentState.STANDBY ||
+        state === ModelDeploymentState.UNKNOWN) &&
       !isStopped,
     // ISVC has annotation and there are pods
     isStopping: isStopped && !!deploymentPod,

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -75,7 +75,7 @@ export const useWatchDeployments = (
   ];
 };
 
-export const useFetchDeploymentStatus = async (
+export const fetchDeploymentStatus = async (
   name: string,
   namespace: string,
   opts?: K8sAPIOptions,

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -235,3 +235,17 @@ export const isModelServingStartStopAction = <D extends Deployment = Deployment>
   extension: Extension,
 ): extension is ModelServingStartStopAction<D> =>
   extension.type === 'model-serving.deployments-table/start-stop-action';
+
+export type ModelServingPlatformFetchDeploymentStatus<D extends Deployment = Deployment> =
+  Extension<
+    'model-serving.platform/fetch-deployment-status',
+    {
+      platform: D['modelServingPlatformId'];
+      fetch: CodeRef<(name: string, namespace: string) => Promise<D | null>>;
+    }
+  >;
+
+export const isModelServingPlatformFetchDeploymentStatus = <D extends Deployment = Deployment>(
+  extension: Extension,
+): extension is ModelServingPlatformFetchDeploymentStatus<D> =>
+  extension.type === 'model-serving.platform/fetch-deployment-status';

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -10,12 +10,12 @@ import type {
 import type { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
 import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
 import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import type { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 
 export type DeploymentStatus = {
-  state: InferenceServiceModelState;
+  state: ModelDeploymentState;
   message?: string;
   stoppedStates?: ToggleState;
 };

--- a/packages/model-serving/src/components/deployments/DeploymentStatus.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import { DeploymentEndpointsPopupButton } from './DeploymentEndpointsPopupButton';
 import { Deployment } from '../../../extension-points';
@@ -15,7 +15,7 @@ const DeploymentStatus: React.FC<DeploymentStatusProps> = ({ deployment, stopped
   }
 
   if (
-    deployment.status?.state === InferenceServiceModelState.FAILED_TO_LOAD ||
+    deployment.status?.state === ModelDeploymentState.FAILED_TO_LOAD ||
     stoppedStates?.isStopped ||
     stoppedStates?.isStopping
   ) {

--- a/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
@@ -66,15 +66,7 @@ export const DeploymentRow: React.FC<{
   const [dontShowModalValue] = useStopModalPreference();
   const [isOpenConfirm, setOpenConfirm] = React.useState(false);
 
-  // Use a ref to always get the latest deployment status
-  const statusRef = React.useRef(deployment.status);
-  statusRef.current = deployment.status; // Always update with latest status
-
-  // Always call the hook unconditionally
-  const { watchDeployment } = useModelDeploymentNotification(
-    statusRef,
-    deployment.model.metadata.namespace,
-  );
+  const { watchDeployment } = useModelDeploymentNotification(deployment);
 
   const onStart = React.useCallback(() => {
     startStopActionExtension?.properties.patchDeploymentStoppedStatus().then((resolvedFunction) => {

--- a/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
@@ -69,11 +69,14 @@ export const DeploymentRow: React.FC<{
   const { watchDeployment } = useModelDeploymentNotification(deployment);
 
   const onStart = React.useCallback(() => {
-    startStopActionExtension?.properties.patchDeploymentStoppedStatus().then((resolvedFunction) => {
-      resolvedFunction(deployment, false);
-      // Start watching for deployment status changes
-      watchDeployment();
-    });
+    if (!startStopActionExtension) return;
+    startStopActionExtension.properties
+      .patchDeploymentStoppedStatus()
+      .then(async (resolvedFunction) => {
+        await resolvedFunction(deployment, false);
+        // Start watching for deployment status changes
+        watchDeployment();
+      });
   }, [deployment, startStopActionExtension, watchDeployment]);
 
   const onStop = React.useCallback(() => {

--- a/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
@@ -4,7 +4,7 @@ import { Label, Content, ContentVariants } from '@patternfly/react-core';
 import ResourceActionsColumn from '@odh-dashboard/internal/components/ResourceActionsColumn';
 import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
 import StateActionToggle from '@odh-dashboard/internal/components/StateActionToggle';
@@ -148,7 +148,7 @@ export const DeploymentRow: React.FC<{
         </Td>
         <Td dataLabel="Status">
           <ModelStatusIcon
-            state={deployment.status?.state ?? InferenceServiceModelState.UNKNOWN}
+            state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
             bodyContent={deployment.status?.message}
             defaultHeaderContent="Inference Service Status"
             stoppedStates={deployment.status?.stoppedStates}

--- a/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentsTableRow.tsx
@@ -66,10 +66,14 @@ export const DeploymentRow: React.FC<{
   const [dontShowModalValue] = useStopModalPreference();
   const [isOpenConfirm, setOpenConfirm] = React.useState(false);
 
+  // Use a ref to always get the latest deployment status
+  const statusRef = React.useRef(deployment.status);
+  statusRef.current = deployment.status; // Always update with latest status
+
   // Always call the hook unconditionally
   const { watchDeployment } = useModelDeploymentNotification(
+    statusRef,
     deployment.model.metadata.namespace,
-    deployment.model.metadata.name,
   );
 
   const onStart = React.useCallback(() => {

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { Deployment } from '../../../../extension-points';
 import { mockExtensions } from '../../../__tests__/mockUtils';
 import { DeploymentRow } from '../DeploymentsTableRow';
@@ -104,7 +104,7 @@ describe('DeploymentsTableRow', () => {
         <tbody>
           <DeploymentRow
             deployment={mockDeployment({
-              status: { state: InferenceServiceModelState.LOADED },
+              status: { state: ModelDeploymentState.LOADED },
             })}
             platformColumns={[]}
             onDelete={onDelete}

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -1,12 +1,19 @@
-import React, { act } from 'react';
+import * as React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { Deployment } from '../../../../extension-points';
 import { mockExtensions } from '../../../__tests__/mockUtils';
 import { DeploymentRow } from '../DeploymentsTableRow';
 
 jest.mock('@odh-dashboard/plugin-core');
+
+// Mock the useModelDeploymentNotification hook
+jest.mock('../../../concepts/useModelDeploymentNotification', () => ({
+  useModelDeploymentNotification: () => ({
+    watchDeployment: jest.fn(),
+  }),
+}));
 
 const mockDeployment = (partial: Partial<Deployment> = {}) => ({
   modelServingPlatformId: 'test-platform',

--- a/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
+++ b/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
@@ -26,7 +26,7 @@ import CollapsibleSection from '@odh-dashboard/internal/concepts/design/Collapsi
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
 import { useExtensions } from '@odh-dashboard/plugin-core';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
@@ -40,8 +40,8 @@ enum FilterStates {
   failed = 'failed',
 }
 
-const SUCCESS_STATUSES = [InferenceServiceModelState.LOADED, InferenceServiceModelState.STANDBY];
-const FAILED_STATUSES = [InferenceServiceModelState.FAILED_TO_LOAD];
+const SUCCESS_STATUSES = [ModelDeploymentState.LOADED, ModelDeploymentState.STANDBY];
+const FAILED_STATUSES = [ModelDeploymentState.FAILED_TO_LOAD];
 
 const DeployedModelCard: React.FC<{ deployment: Deployment }> = ({ deployment }) => {
   const displayName = getDisplayNameFromK8sResource(deployment.model);
@@ -53,7 +53,7 @@ const DeployedModelCard: React.FC<{ deployment: Deployment }> = ({ deployment })
           <Flex gap={{ default: 'gapSm' }} direction={{ default: 'column' }}>
             <FlexItem>
               <ModelStatusIcon
-                state={deployment.status?.state ?? InferenceServiceModelState.UNKNOWN}
+                state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
                 bodyContent={deployment.status?.message}
                 stoppedStates={deployment.status?.stoppedStates}
               />
@@ -61,7 +61,7 @@ const DeployedModelCard: React.FC<{ deployment: Deployment }> = ({ deployment })
             <FlexItem>
               <ResourceNameTooltip resource={deployment.model}>
                 {deployment.model.metadata.namespace &&
-                deployment.status?.state === InferenceServiceModelState.LOADED ? (
+                deployment.status?.state === ModelDeploymentState.LOADED ? (
                   <Link
                     to={`/projects/${deployment.model.metadata.namespace}/metrics/model/${deployment.model.metadata.name}`}
                   >

--- a/packages/model-serving/src/concepts/deploymentUtils.ts
+++ b/packages/model-serving/src/concepts/deploymentUtils.ts
@@ -1,5 +1,5 @@
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { Deployment } from '../../extension-points';
 
 const isDeploymentInactive = (deployment: Deployment): boolean =>
@@ -11,8 +11,8 @@ export const deploymentNameSort = (a: Deployment, b: Deployment): number =>
 export const deploymentLastDeployedSort = (a: Deployment, b: Deployment): number => {
   const getScore = (deployment: Deployment): number => {
     if (
-      deployment.status?.state === InferenceServiceModelState.LOADING ||
-      deployment.status?.state === InferenceServiceModelState.PENDING
+      deployment.status?.state === ModelDeploymentState.LOADING ||
+      deployment.status?.state === ModelDeploymentState.PENDING
     ) {
       return 2;
     }

--- a/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
+++ b/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
@@ -6,20 +6,16 @@ import {
   NotificationWatcherContext,
 } from '@odh-dashboard/internal/concepts/notificationWatcher/NotificationWatcherContext';
 import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
-import {
-  getInferenceServiceLastFailureReason,
-  getInferenceServiceModelState,
-} from '@odh-dashboard/internal/concepts/modelServingKServe/kserveStatusUtils';
-
-import { getInferenceService } from '@odh-dashboard/internal/api/k8s/inferenceServices';
+import { FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
+import { DeploymentStatus } from '../../extension-points';
 
 type ModelDeploymentNotification = {
   watchDeployment: () => void;
 };
 
 export const useModelDeploymentNotification = (
+  deploymentStatusRef: React.MutableRefObject<DeploymentStatus | undefined>,
   namespace: string,
-  modelName: string,
 ): ModelDeploymentNotification => {
   const navigate = useNavigate();
   const notification = useNotification();
@@ -28,43 +24,34 @@ export const useModelDeploymentNotification = (
 
   const watchDeployment = React.useCallback(() => {
     registerNotification({
-      callback: async (signal) => {
+      callbackDelay: FAST_POLL_INTERVAL,
+      callback: async () => {
         try {
-          const inferenceService = await getInferenceService(modelName, namespace, { signal });
-          const inferenceServiceModelState = getInferenceServiceModelState(inferenceService);
+          const currentStatus = deploymentStatusRef.current;
+          if (!currentStatus) {
+            return { status: NotificationResponseStatus.STOP };
+          }
 
-          // A model is considered "stopped" if it has no active pods and is not in a starting/failed state
-          const isStopped =
-            !inferenceService.status?.modelStatus?.states?.activeModelState &&
-            inferenceServiceModelState !== InferenceServiceModelState.PENDING &&
-            inferenceServiceModelState !== InferenceServiceModelState.LOADING &&
-            inferenceServiceModelState !== InferenceServiceModelState.UNKNOWN &&
-            inferenceServiceModelState !== InferenceServiceModelState.FAILED_TO_LOAD; // Don't consider failed models as stopped
-
-          const isStarting =
-            !inferenceService.status?.modelStatus?.states?.activeModelState &&
-            inferenceService.status?.modelStatus?.states?.targetModelState !==
-              InferenceServiceModelState.FAILED_TO_LOAD &&
-            !isStopped;
-
-          const isRunning = inferenceServiceModelState === InferenceServiceModelState.LOADED;
+          const deploymentState = currentStatus.state;
+          //const isStoppedState = currentStatus.stoppedStates?.isStopped || false;
+          const {
+            isStarting: isStartingState,
+            isRunning: isRunningState,
+            isStopped: isStoppedState,
+          } = currentStatus.stoppedStates || {};
+          const isFailedState = deploymentState === InferenceServiceModelState.FAILED_TO_LOAD;
 
           // Track previous state
           const lastState = lastSeenState.current;
-          lastSeenState.current = inferenceServiceModelState;
+          lastSeenState.current = deploymentState;
 
           // Only consider it failed if it's not stopped, the state is FAILED_TO_LOAD, and the last state was PENDING
-          const isFailed =
-            !isStopped &&
-            inferenceServiceModelState === InferenceServiceModelState.FAILED_TO_LOAD &&
-            lastState === InferenceServiceModelState.PENDING;
-
-          const lastFailureReason = getInferenceServiceLastFailureReason(inferenceService);
+          const isFailed = isFailedState && lastState === InferenceServiceModelState.PENDING;
 
           if (isFailed) {
             notification.error(
               'Model deployment failed',
-              lastFailureReason ||
+              currentStatus.message ||
                 'Failed to load the model. Please check the model configuration and try again.',
               [
                 {
@@ -76,12 +63,12 @@ export const useModelDeploymentNotification = (
             return { status: NotificationResponseStatus.STOP };
           }
 
-          if (isRunning && lastState === InferenceServiceModelState.LOADED) {
+          if (isRunningState && lastState === InferenceServiceModelState.LOADED) {
             // Model is running, stop polling
             return { status: NotificationResponseStatus.STOP };
           }
 
-          if (isStopped) {
+          if (isStoppedState) {
             // Model appears stopped, but let's continue polling for a bit to see if it's just in transition
             // Only stop if we've seen the same stopped state multiple times
             if (lastState === InferenceServiceModelState.UNKNOWN || lastState === null) {
@@ -93,9 +80,9 @@ export const useModelDeploymentNotification = (
           }
 
           if (
-            isStarting ||
-            inferenceServiceModelState === InferenceServiceModelState.PENDING ||
-            inferenceServiceModelState === InferenceServiceModelState.LOADING
+            isStartingState ||
+            lastState === InferenceServiceModelState.PENDING ||
+            lastState === InferenceServiceModelState.LOADING
           ) {
             // Model is still starting/loading, continue polling
             return { status: NotificationResponseStatus.REPOLL };
@@ -117,7 +104,7 @@ export const useModelDeploymentNotification = (
         }
       },
     });
-  }, [registerNotification, navigate, namespace, modelName, notification]);
+  }, [registerNotification, navigate, deploymentStatusRef, namespace, notification]);
 
   return { watchDeployment };
 };

--- a/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
+++ b/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
@@ -7,16 +7,19 @@ import {
 } from '@odh-dashboard/internal/concepts/notificationWatcher/NotificationWatcherContext';
 import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
-import { DeploymentStatus } from '../../extension-points';
+import { Deployment } from '../../extension-points';
 
 type ModelDeploymentNotification = {
   watchDeployment: () => void;
 };
 
 export const useModelDeploymentNotification = (
-  deploymentStatusRef: React.MutableRefObject<DeploymentStatus | undefined>,
-  namespace: string,
+  deployment: Deployment,
 ): ModelDeploymentNotification => {
+  const deploymentStatusRef = React.useRef(deployment.status);
+  deploymentStatusRef.current = deployment.status;
+  const { namespace } = deployment.model.metadata;
+
   const navigate = useNavigate();
   const notification = useNotification();
   const { registerNotification } = React.useContext(NotificationWatcherContext);
@@ -31,9 +34,9 @@ export const useModelDeploymentNotification = (
           if (!currentStatus) {
             return { status: NotificationResponseStatus.STOP };
           }
+          console.log('currentStatus', currentStatus);
 
           const deploymentState = currentStatus.state;
-          //const isStoppedState = currentStatus.stoppedStates?.isStopped || false;
           const {
             isStarting: isStartingState,
             isRunning: isRunningState,

--- a/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
+++ b/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
@@ -68,8 +68,7 @@ export const useModelDeploymentNotification = (
           const isFailedState = deploymentState === ModelDeploymentState.FAILED_TO_LOAD;
 
           // Track previous state of the deployment
-          const lastState = lastSeenState.current;
-          let adjustedLastState = lastState;
+          let lastState = lastSeenState.current;
 
           // Reset lastState if we're transitioning from a failed state to a starting state
           if (
@@ -78,13 +77,13 @@ export const useModelDeploymentNotification = (
               deploymentState === ModelDeploymentState.PENDING)
           ) {
             lastSeenState.current = null;
-            adjustedLastState = null;
+            lastState = null;
           } else {
             lastSeenState.current = deploymentState;
           }
 
           // Only consider it failed if it's not stopped, the state is FAILED_TO_LOAD, and the last state was PENDING
-          const isFailed = isFailedState && adjustedLastState === ModelDeploymentState.PENDING;
+          const isFailed = isFailedState && lastState === ModelDeploymentState.PENDING;
 
           if (isFailed) {
             notification.error(
@@ -101,7 +100,7 @@ export const useModelDeploymentNotification = (
             return { status: NotificationResponseStatus.STOP };
           }
 
-          if (isRunningState && adjustedLastState === ModelDeploymentState.LOADED) {
+          if (isRunningState && lastState === ModelDeploymentState.LOADED) {
             // Model is running, stop polling
             return { status: NotificationResponseStatus.STOP };
           }
@@ -109,7 +108,7 @@ export const useModelDeploymentNotification = (
           if (isStoppedState) {
             // Model appears stopped, but let's continue polling for a bit to see if it's just in transition
             // Only stop if we've seen the same stopped state multiple times
-            if (adjustedLastState === ModelDeploymentState.UNKNOWN || adjustedLastState === null) {
+            if (lastState === ModelDeploymentState.UNKNOWN || lastState === null) {
               // First time seeing this state, continue polling
               return { status: NotificationResponseStatus.REPOLL };
             }
@@ -119,8 +118,8 @@ export const useModelDeploymentNotification = (
 
           if (
             isStartingState ||
-            adjustedLastState === ModelDeploymentState.PENDING ||
-            adjustedLastState === ModelDeploymentState.LOADING
+            lastState === ModelDeploymentState.PENDING ||
+            lastState === ModelDeploymentState.LOADING
           ) {
             // Model is still starting/loading, continue polling
             return { status: NotificationResponseStatus.REPOLL };

--- a/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
+++ b/packages/model-serving/src/concepts/useModelDeploymentNotification.ts
@@ -5,7 +5,7 @@ import {
   NotificationResponseStatus,
   NotificationWatcherContext,
 } from '@odh-dashboard/internal/concepts/notificationWatcher/NotificationWatcherContext';
-import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
 import { DeploymentStatus } from '../../extension-points';
 
@@ -20,7 +20,7 @@ export const useModelDeploymentNotification = (
   const navigate = useNavigate();
   const notification = useNotification();
   const { registerNotification } = React.useContext(NotificationWatcherContext);
-  const lastSeenState = React.useRef<InferenceServiceModelState | null>(null);
+  const lastSeenState = React.useRef<ModelDeploymentState | null>(null);
 
   const watchDeployment = React.useCallback(() => {
     registerNotification({
@@ -39,14 +39,14 @@ export const useModelDeploymentNotification = (
             isRunning: isRunningState,
             isStopped: isStoppedState,
           } = currentStatus.stoppedStates || {};
-          const isFailedState = deploymentState === InferenceServiceModelState.FAILED_TO_LOAD;
+          const isFailedState = deploymentState === ModelDeploymentState.FAILED_TO_LOAD;
 
           // Track previous state
           const lastState = lastSeenState.current;
           lastSeenState.current = deploymentState;
 
           // Only consider it failed if it's not stopped, the state is FAILED_TO_LOAD, and the last state was PENDING
-          const isFailed = isFailedState && lastState === InferenceServiceModelState.PENDING;
+          const isFailed = isFailedState && lastState === ModelDeploymentState.PENDING;
 
           if (isFailed) {
             notification.error(
@@ -63,7 +63,7 @@ export const useModelDeploymentNotification = (
             return { status: NotificationResponseStatus.STOP };
           }
 
-          if (isRunningState && lastState === InferenceServiceModelState.LOADED) {
+          if (isRunningState && lastState === ModelDeploymentState.LOADED) {
             // Model is running, stop polling
             return { status: NotificationResponseStatus.STOP };
           }
@@ -71,7 +71,7 @@ export const useModelDeploymentNotification = (
           if (isStoppedState) {
             // Model appears stopped, but let's continue polling for a bit to see if it's just in transition
             // Only stop if we've seen the same stopped state multiple times
-            if (lastState === InferenceServiceModelState.UNKNOWN || lastState === null) {
+            if (lastState === ModelDeploymentState.UNKNOWN || lastState === null) {
               // First time seeing this state, continue polling
               return { status: NotificationResponseStatus.REPOLL };
             }
@@ -81,8 +81,8 @@ export const useModelDeploymentNotification = (
 
           if (
             isStartingState ||
-            lastState === InferenceServiceModelState.PENDING ||
-            lastState === InferenceServiceModelState.LOADING
+            lastState === ModelDeploymentState.PENDING ||
+            lastState === ModelDeploymentState.LOADING
           ) {
             // Model is still starting/loading, continue polling
             return { status: NotificationResponseStatus.REPOLL };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-29986](https://issues.redhat.com/browse/RHOAIENG-29986)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The bug was that if you have a failed model, then redeploy with info that should deploy successfully, the failure notification would show up which is not ideal.
So I fixed that but I also realized we were only polling for the notification when the submit/redeploy button is hit in the deploy modal and not when we hit `start` on the model. So I added that and had to rework most of the logic in the notification file. Mostly because it got really finicky with it polling before the `InferenceService` had a change to update
ex. this is what caused the bug, when you redeployed it was reading the previously failed state from the previous deployment before the inference service had a chance to update

Also I made a more generic version and added it to the refactor since the original was more kserve specific

Also it was doing this thing where it sends the failure notification if you delete a model so I fixed that too

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
Remember how it takes ages for a model to fail? I figured that out too! Deploy a model and in the `spec.predictor.annotations` add `serving.knative.dev/progress-deadline: 1m` and it gets rid of the weird 10 minute timeout kserve has going on for failed models
(you can start/stop but if you edit the model the annotation gets removed so you might have to add it back)
(also it gets weird with the predictor pods when you add the annotation so do this with a model you don't mind deleting)
In old code:
- Deploy a model with broken info like `uri://https://github.com/fake/fake/fake.zip`
- Go add that annotation^
- Wait for it to fail (still takes 1-2 minutes)
- Once you get the notification edit the model with info that will deploy successfully
- Redeploy and you should not see any notifications
- Delete the model and notice there's also no notification for a failed model
- Repeat but in the refactor

Once the wizard is done we'll need to just chuck in a line to add the notification watcher on submission

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic monitoring starts after launching a deployment and opens live status updates.
  - Platform fetch for deployment status added so deployments show combined pod + service status.
  - Notifications with a “View deployment” action appear on deployment failures.

- Bug Fixes
  - Handles deleted/404 deployments gracefully during status checks.
  - More reliable detection of starting, running, stopped, and failed-to-load states.
  - UI refreshes and polling behavior improved to avoid stale status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->