### PR TITLE
[RHOAIENG-32294] Quarantine Authorino-related test changes

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
@@ -25,7 +25,7 @@ let modelFilePath: string;
 const awsBucket = 'BUCKET_1' as const;
 const uuid = generateTestUUID();
 
-describe('A model can be deployed with token auth', () => {
+describe('[Automation Bug: RHOAIENG-32294] A model can be deployed with token auth', () => {
   retryableBefore(() => {
     cy.log('Loading test data');
     return loadDSPFixture('e2e/dataScienceProjects/testModelTokenAuth.yaml').then(
@@ -56,7 +56,7 @@ describe('A model can be deployed with token auth', () => {
 
   it(
     'Verify that a model can be deployed with token auth',
-    { tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@ModelServing'] },
+    { tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@ModelServing', '@Maintain'] },
     () => {
       cy.log('Model Name:', modelName);
       cy.step(`Log into the application with ${HTPASSWD_CLUSTER_ADMIN_USER.USERNAME}`);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -24,7 +24,7 @@ let modelFilePath: string;
 const awsBucket = 'BUCKET_1' as const;
 const uuid = generateTestUUID();
 
-describe('Verify Admin Single Model Creation and Validation using the UI', () => {
+describe('[Automation Bug: RHOAIENG-32294] Verify Admin Single Model Creation and Validation using the UI', () => {
   retryableBefore(() =>
     // Setup: Load test data and ensure clean state
     loadDSPFixture('e2e/dataScienceProjects/testSingleModelAdminCreation.yaml').then(
@@ -56,7 +56,15 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
   it(
     'Verify that an Admin can Serve, Query a Single Model using both the UI and External links',
     {
-      tags: ['@Smoke', '@SmokeSet3', '@ODS-2626', '@Dashboard', '@Modelserving', '@NonConcurrent'],
+      tags: [
+        '@Smoke',
+        '@SmokeSet3',
+        '@ODS-2626',
+        '@Dashboard',
+        '@Modelserving',
+        '@NonConcurrent',
+        '@Maintain',
+      ],
     },
     () => {
       cy.log('Model Name:', modelName);


### PR DESCRIPTION
## Description
- Quaranited testModelTokenAuth.cy.ts and testSingleModelAdminCreation.cy.ts
- Related to PR #2594 in ods-ci that made Authorino installation optional
- Task https://issues.redhat.com/browse/RHOAIENG-32294 created to align with the new authorino installation step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test metadata by adding an automation-bug identifier to relevant suites and introducing an @Maintain tag to selected tests for improved categorization and triage.
  * Clarifies test grouping and stability tracking without altering test steps or assertions.
  * No impact on product behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->