### PR TITLE
Update the pipelines E2E test for FIPS

### DIFF
--- a/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
+++ b/frontend/src/__mocks__/mockPipelineVersionsProxy.ts
@@ -720,7 +720,8 @@ export const mockMetricsVisualizationVersion: PipelineVersionKF = {
               'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
               "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef digit_classification(metrics: Output[Metrics]):\n    from sklearn import model_selection\n    from sklearn.linear_model import LogisticRegression\n    from sklearn import datasets\n    from sklearn.metrics import accuracy_score\n\n    # Load digits dataset\n    iris = datasets.load_iris()\n\n    # # Create feature matrix\n    X = iris.data\n\n    # Create target vector\n    y = iris.target\n\n    #test size\n    test_size = 0.33\n\n    seed = 7\n    #cross-validation settings\n    kfold = model_selection.KFold(n_splits=10, random_state=seed, shuffle=True)\n\n    #Model instance\n    model = LogisticRegression()\n    scoring = 'accuracy'\n    results = model_selection.cross_val_score(model, X, y, cv=kfold, scoring=scoring)\n\n    #split data\n    X_train, X_test, y_train, y_test = model_selection.train_test_split(X, y, test_size=test_size, random_state=seed)\n    #fit model\n    model.fit(X_train, y_train)\n\n    #accuracy on test set\n    result = model.score(X_test, y_test)\n    metrics.log_metric('accuracy', (result*100.0))\n\n",
             ],
-            image: 'ubi8/python-39:latest',
+            image:
+              'registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7',
           },
         },
         'exec-html-visualization': {
@@ -750,7 +751,8 @@ export const mockMetricsVisualizationVersion: PipelineVersionKF = {
               'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
               "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef iris_sgdclassifier(test_samples_fraction: float, metrics: Output[ClassificationMetrics]):\n    from sklearn import datasets, model_selection\n    from sklearn.linear_model import SGDClassifier\n    from sklearn.metrics import confusion_matrix\n\n    iris_dataset = datasets.load_iris()\n    train_x, test_x, train_y, test_y = model_selection.train_test_split(\n        iris_dataset['data'], iris_dataset['target'], test_size=test_samples_fraction)\n\n\n    classifier = SGDClassifier()\n    classifier.fit(train_x, train_y)\n    predictions = model_selection.cross_val_predict(classifier, train_x, train_y, cv=3)\n    metrics.log_confusion_matrix(\n        ['Setosa', 'Versicolour', 'Virginica'],\n        confusion_matrix(train_y, predictions).tolist() # .tolist() to convert np array to list.\n    )\n\n",
             ],
-            image: 'ubi8/python-39:latest',
+            image:
+              'registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7',
           },
         },
         'exec-markdown-visualization': {
@@ -780,7 +782,8 @@ export const mockMetricsVisualizationVersion: PipelineVersionKF = {
               'program_path=$(mktemp -d)\n\nprintf "%s" "$0" \u003e "$program_path/ephemeral_component.py"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"\n',
               "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef wine_classification(metrics: Output[ClassificationMetrics]):\n    from sklearn.ensemble import RandomForestClassifier\n    from sklearn.metrics import roc_curve\n    from sklearn.datasets import load_wine\n    from sklearn.model_selection import train_test_split, cross_val_predict\n\n    X, y = load_wine(return_X_y=True)\n    # Binary classification problem for label 1.\n    y = y == 1\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)\n    rfc = RandomForestClassifier(n_estimators=10, random_state=42)\n    rfc.fit(X_train, y_train)\n    y_scores = cross_val_predict(rfc, X_train, y_train, cv=3, method='predict_proba')\n    y_predict = cross_val_predict(rfc, X_train, y_train, cv=3, method='predict')\n    fpr, tpr, thresholds = roc_curve(y_true=y_train, y_score=y_scores[:,1], pos_label=True)\n    thresholds[0] = 2\n    metrics.log_roc_curve(fpr, tpr, thresholds)\n\n",
             ],
-            image: 'ubi8/python-39:latest',
+            image:
+              'registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7',
           },
         },
       },

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/pipelines/iris_pipeline_pip_index_url_compiled.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/pipelines/iris_pipeline_pip_index_url_compiled.yaml
@@ -111,7 +111,7 @@ deploymentSpec:
             , \"Sepal_Width\", \"Petal_Length\", \"Petal_Width\", \"Labels\"]\n    df\
             \ = pd.read_csv(StringIO(data), names=col_names)\n\n    with open(iris_dataset.path,\
             \ \"w\") as f:\n        df.to_csv(f)\n\n"
-        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
     exec-normalize-dataset:
       container:
         args:
@@ -150,7 +150,7 @@ deploymentSpec:
             \    normalized_iris_dataset.metadata[\"state\"] = \"Normalized\"\n    with\
             \ open(normalized_iris_dataset.path, \"w\") as f:\n        df.to_csv(f)\n\
             \n"
-        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
     exec-train-model:
       container:
         args:
@@ -195,7 +195,7 @@ deploymentSpec:
             \ predictions).tolist(),  # .tolist() to convert np array to list.\n   \
             \ )\n\n    model.metadata[\"framework\"] = \"scikit-learn\"\n    with open(model.path,\
             \ \"wb\") as f:\n        pickle.dump(clf, f)\n\n"
-        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
 pipelineInfo:
   name: iris-training-pipeline
 root:

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/v1-pipeline.yaml
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/v1-pipeline.yaml
@@ -81,7 +81,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         results:
         - name: Output
           type: string
@@ -151,7 +151,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         results:
         - name: Output
           type: string
@@ -196,7 +196,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         params:
         - name: random-num-Output
         metadata:
@@ -238,7 +238,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         params:
         - name: random-num-Output
         metadata:
@@ -311,7 +311,7 @@ spec:
                     pass
                 with open(output_file, 'w') as f:
                     f.write(_output_serializers[idx](_outputs[idx]))
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         results:
         - name: Output
           type: string
@@ -356,7 +356,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         params:
         - name: random-num-2-Output
         metadata:
@@ -398,7 +398,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = print_msg(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
         params:
         - name: random-num-2-Output
         metadata:
@@ -452,7 +452,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
     - name: condition-2
       params:
       - name: operand1
@@ -493,7 +493,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
       when:
       - input: $(tasks.condition-1.results.outcome)
         operator: in
@@ -539,7 +539,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
       when:
       - input: $(tasks.condition-1.results.outcome)
         operator: in
@@ -585,7 +585,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
     - name: condition-5
       params:
       - name: operand1
@@ -626,7 +626,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
       when:
       - input: $(tasks.condition-4.results.outcome)
         operator: in
@@ -672,7 +672,7 @@ spec:
             f.close()
           - $(inputs.params.operand1)
           - $(inputs.params.operand2)
-          image: registry.access.redhat.com/ubi8/python-39
+          image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
       when:
       - input: $(tasks.condition-4.results.outcome)
         operator: in

--- a/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline.py
+++ b/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline.py
@@ -1,6 +1,6 @@
 from kfp import compiler, dsl
 
-common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+common_base_image = "registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7"
 
 
 @dsl.component(base_image=common_base_image)

--- a/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml
+++ b/frontend/src/__tests__/resources/pipelines_samples/dummy_pipeline_compiled.yaml
@@ -22,7 +22,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.2'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -38,7 +38,7 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef dummy(message: str):\n    \"\"\"Print a message\"\"\"\n    print(message)\n\
           \n"
-        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        image: registry.redhat.io/ubi9/python-311@sha256:82a16d7c4da926081c0a4cc72a84d5ce37859b50a371d2f9364313f66b89adf7
 pipelineInfo:
   description: Dummy Pipeline
   name: dummy-pipeline
@@ -58,4 +58,4 @@ root:
         taskInfo:
           name: dummy
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.14.2


### PR DESCRIPTION
## Description

In FIPS mode, the UBI/RHEL version must match the versions RHOAI DSP was built with, otherwise, the dynamically linked C libraries do not match for the injected argoexec binary and KFP launcher binaries.

## How Has This Been Tested?

I ran the pipeline successfully on a RHOAI 2.23 installation on a FIPS enabled cluster.

## Test Impact

N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated sample pipeline assets and executors to use a Python 3.11 base image and KFP runtime 2.14.2 for improved compatibility.
  - Aligned test fixtures and mocked pipelines with the newer runtime to ensure consistent test behavior.

- Chores
  - Refreshed container image references to supported (digest-pinned) images.
  - Updated test resources to match latest tooling versions for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->