### PR TITLE
Fix proxy port issue for llama-stack

### DIFF
--- a/frontend/packages/llama-stack-modular-ui/frontend/config/dotenv.js
+++ b/frontend/packages/llama-stack-modular-ui/frontend/config/dotenv.js
@@ -145,18 +145,18 @@ const setupDotenvFilesForEnv = ({ env }) => {
   setupDotenvFile(path.resolve(RELATIVE_DIRNAME, '.env.local'));
   setupDotenvFile(path.resolve(RELATIVE_DIRNAME, '.env'));
 
-  const DEPLOYMENT_MODE = process.env.DEPLOYMENT_MODE || 'kubeflow';
+  const DEPLOYMENT_MODE = process.env.DEPLOYMENT_MODE || 'federated';
   const AUTH_METHOD = process.env.AUTH_METHOD || 'internal';
   const IMAGES_DIRNAME = process.env.IMAGES_DIRNAME || 'images';
   const PUBLIC_PATH = process.env.PUBLIC_PATH || '/';
   const SRC_DIR = path.resolve(RELATIVE_DIRNAME, process.env.SRC_DIR || TS_BASE_URL || 'src');
   const COMMON_DIR = path.resolve(RELATIVE_DIRNAME, process.env.COMMON_DIR || '../common');
   const DIST_DIR = path.resolve(RELATIVE_DIRNAME, process.env.DIST_DIR || TS_OUT_DIR || 'public');
-  const HOST = process.env.HOST || DEPLOYMENT_MODE === 'kubeflow' ? '0.0.0.0' : 'localhost';
+  const HOST = process.env.HOST ? '0.0.0.0' : 'localhost';
   const PORT = process.env.PORT || '9002';
   const PROXY_PROTOCOL = process.env.PROXY_PROTOCOL || 'http';
   const PROXY_HOST = process.env.PROXY_HOST || 'localhost';
-  const PROXY_PORT = process.env.PROXY_PORT || process.env.PORT || 4000;
+  const PROXY_PORT = process.env.PROXY_PORT || 8080;
   const DEV_MODE = process.env.DEV_MODE || undefined;
   const OUTPUT_ONLY = process.env._OUTPUT_ONLY === 'true';
 

--- a/frontend/packages/llama-stack-modular-ui/frontend/config/webpack.dev.js
+++ b/frontend/packages/llama-stack-modular-ui/frontend/config/webpack.dev.js
@@ -7,11 +7,11 @@ const { setupWebpackDotenvFilesForEnv, setupDotenvFilesForEnv } = require('./dot
 setupDotenvFilesForEnv({ env: 'development' });
 const common = require('./webpack.common.js');
 
-const HOST = process.env.HOST;
-const PORT = process.env.PORT;
-const PROXY_HOST = process.env.PROXY_HOST;
-const PROXY_PROTOCOL = process.env.PROXY_PROTOCOL;
-const PROXY_PORT = process.env.PROXY_PORT;
+const HOST = process.env._HOST;
+const PORT = process.env._PORT;
+const PROXY_HOST = process.env._PROXY_HOST;
+const PROXY_PROTOCOL = process.env._PROXY_PROTOCOL;
+const PROXY_PORT = process.env._PROXY_PORT;
 const RELATIVE_DIRNAME = process.env._RELATIVE_DIRNAME;
 const SRC_DIR = process.env._SRC_DIR;
 const COMMON_DIR = process.env._COMMON_DIR;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Follow-up of https://github.com/opendatahub-io/odh-dashboard/pull/4721

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There are some misconfiguration before which is causing the dev-server for the chatbot to use the wrong proxy port. This PR is to fix that part.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to /frontend/packages/llama-stack-modular-ui folder and run make dev-install-dependencies then make dev-start
2. Start the dev server at the frontend folder
3. Start the dev server at the backend folder
4. Go to the dashboard at localhost:4010 and enable the dev flag to check the integrated mode
5. Go to the standalone mode at localhost: 9002

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variables to configure the static directory and public path in the dev server.

* **Chores**
  * Switched dev server configuration to underscore-prefixed environment variables (_HOST, _PORT, _PROXY_HOST, _PROXY_PROTOCOL, _PROXY_PORT).
  * Updated defaults: deployment mode now defaults to “federated”; proxy port falls back to 8080; host binding logic simplified (binds to 0.0.0.0 when HOST is provided, otherwise localhost).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->