### PR TITLE
Show PVC Select Instead of Existing URI for Missing PVCs

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -500,7 +500,7 @@ export const ConnectionSection: React.FC<Props> = ({
               )
             }
           />
-          {pvcs && pvcs.length > 0 && (
+          {(pvcs && pvcs.length > 0) || pvcNameFromUri ? (
             <Radio
               label="Existing cluster storage"
               name="pvc-serving-radio"
@@ -536,7 +536,7 @@ export const ConnectionSection: React.FC<Props> = ({
                 )
               }
             />
-          )}
+          ) : null}
         </>
       ) : pvcs && pvcs.length === 0 ? ( // No connections and no pvcs
         <FormGroup

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -521,11 +521,11 @@ export const ConnectionSection: React.FC<Props> = ({
                   <PvcSelect
                     pvcs={pvcs}
                     selectedPVC={selectedPVC}
-                    onSelect={(selection) => {
+                    onSelect={(selection?: PersistentVolumeClaimKind | undefined) => {
                       setData('storage', {
                         ...data.storage,
                         type: InferenceServiceStorageType.PVC_STORAGE,
-                        pvcConnection: selection.metadata.name,
+                        pvcConnection: selection?.metadata.name ?? '',
                       });
                     }}
                     setModelUri={(uri) => setData('storage', { ...data.storage, uri })}

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCFields.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCFields.tsx
@@ -14,7 +14,8 @@ import {
 import { PersistentVolumeClaimKind } from '#~/k8sTypes';
 
 type PVCFieldsProps = {
-  selectedPVC: PersistentVolumeClaimKind;
+  selectedPVC?: PersistentVolumeClaimKind;
+  selectedPVCName: string;
   setModelUri: (uri: string) => void;
   modelPath: string;
   setIsConnectionValid: (isValid: boolean) => void;
@@ -23,6 +24,7 @@ type PVCFieldsProps = {
 
 export const PVCFields: React.FC<PVCFieldsProps> = ({
   selectedPVC,
+  selectedPVCName,
   setModelUri,
   modelPath,
   setModelPath,
@@ -32,7 +34,7 @@ export const PVCFields: React.FC<PVCFieldsProps> = ({
   const generateModelUri = (pvcName: string, path: string): string => `pvc://${pvcName}/${path}`;
 
   const validateModelPath = (newPath: string): boolean => {
-    const uri = generateModelUri(selectedPVC.metadata.name, newPath);
+    const uri = generateModelUri(selectedPVCName, newPath);
     return pathRegex.test(uri);
   };
 
@@ -40,7 +42,7 @@ export const PVCFields: React.FC<PVCFieldsProps> = ({
     const trimmedPath = newPath.trim();
     setModelPath(trimmedPath);
     if (trimmedPath && validateModelPath(trimmedPath)) {
-      setModelUri(generateModelUri(selectedPVC.metadata.name, trimmedPath));
+      setModelUri(generateModelUri(selectedPVCName, trimmedPath));
       setIsConnectionValid(true);
     } else {
       setIsConnectionValid(false);
@@ -59,7 +61,7 @@ export const PVCFields: React.FC<PVCFieldsProps> = ({
       <StackItem>
         <FormGroup label="Model path" isRequired>
           <InputGroup>
-            <InputGroupText>pvc://{selectedPVC.metadata.name}/</InputGroupText>
+            <InputGroupText>pvc://{selectedPVCName}/</InputGroupText>
             <InputGroupItem isFill>
               <TextInput
                 id="folder-path"

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCSelect.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCSelect.tsx
@@ -68,7 +68,6 @@ export const PvcSelect: React.FC<PvcSelectProps> = ({
           content: pvcNameFromUri || '',
           value: pvcNameFromUri || '',
           isSelected: !selectedPVC,
-          description: 'Cluster storage not found',
         },
       ];
     }

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCSelect.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/PVCSelect.tsx
@@ -54,8 +54,9 @@ export const PvcSelect: React.FC<PvcSelectProps> = ({
   const didInitialPrefill = React.useRef(false);
 
   // Whether to show the PVC not founderror
-  const showPVCError = React.useRef(
-    existingUriOption && !pvcExists && pvcNameFromUri && !selectedPVC,
+  const showPVCError = React.useMemo(
+    () => Boolean(existingUriOption && !pvcExists && pvcNameFromUri && !selectedPVC),
+    [existingUriOption, pvcExists, pvcNameFromUri, selectedPVC],
   );
 
   // Create a local copy of pvcs with the missing PVC added if needed
@@ -173,7 +174,7 @@ export const PvcSelect: React.FC<PvcSelectProps> = ({
             </Alert>
           </StackItem>
         )}
-        {showPVCError.current && !selectedPVC && (
+        {showPVCError && !selectedPVC && (
           <StackItem>
             <Alert variant="warning" title="Cannot access cluster storage" isInline>
               The selected <strong>{pvcNameFromUri}</strong> cluster storage has been deleted or


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-31854](https://issues.redhat.com/browse/RHOAIENG-31854)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If a model was deployed with a PVC that was deleted or never existed, the edit modal would show the `existing uri` option:
<img width="261" height="275" alt="Screenshot 2025-08-20 at 3 58 17 PM" src="https://github.com/user-attachments/assets/19ca5f56-40b8-4554-9649-d02779430560" />

But now if the PVC was deleted or never existed the `existing cluster storage` option will prefill the selection with the name and path from the `pvc://` uri used to deploy the model:
<img width="819" height="523" alt="Screenshot 2025-08-20 at 3 58 59 PM" src="https://github.com/user-attachments/assets/e4f64a35-8a7c-4825-b2b9-fcb804dad676" />
and show a warning that the cluster storage doesn't exist anymore
it doesn't stop them from redeploying with the missing pvc, just a warning'

it also shows the missing pvc within the dropdown options in case they switch around pvcs and decide they want to go back to the missing one
<img width="813" height="502" alt="Screenshot 2025-08-20 at 4 08 41 PM" src="https://github.com/user-attachments/assets/acaba6ad-7855-4189-ae88-fe939b5ea73b" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- Deploy a model from a PVC (doesn't need to have a model in it) 
- and one from uri with this as a uri `pvc://fake-pvc/fake-path` to fake a pvc not existing
- and one from regular uri
- Don't need to wait for them to deploy fully, just stop them
- edit the one from a real pvc and see it pre-fills the `existing cluster storage` just as it did before
- mess around, select other connections radio buttons and other pvcs
- edit the one from the fake pvc and see it also now pre-fills the `existing cluster storage` -> and the fake pvc should be listed in the dropdown of pvcs
- mess around, select other connections radio buttons and other pvcs
- with the regular uri it should show up as it did before with the `current uri` option

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects PVC names embedded in provided URIs and prefers PVC-backed storage when available.
  * Prefills storage selection and model path from PVC-derived URIs; exposes URI context to PVC selection and fields.
  * Adds a synthetic PVC option and displays a warning when a URI-referenced PVC is not found.

* **Bug Fixes**
  * Hides plain-URI option when a PVC can be inferred; only prefill when a PVC name is derivable.
  * Improves validation and keeps PVC selection/path consistent as PVCs load or change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->