### PR TITLE
RHOAIENG-32537: Create the Project Namespace Dropdown for choosing the LS 

### DIFF
--- a/packages/gen-ai/frontend/.eslintrc.js
+++ b/packages/gen-ai/frontend/.eslintrc.js
@@ -231,6 +231,13 @@ module.exports = {
   },
   overrides: [
     {
+      // Workspace packages: disable import/no-extraneous-dependencies for @odh-dashboard packages
+      files: ['src/**/*.{ts,tsx}'],
+      rules: {
+        'import/no-extraneous-dependencies': 'off',
+      },
+    },
+    {
       // Config files: disable TypeScript parser to avoid project conflicts
       files: ['.eslintrc.js', 'config/**/*.js'],
       parser: 'espree',

--- a/packages/gen-ai/frontend/config/webpack.common.js
+++ b/packages/gen-ai/frontend/config/webpack.common.js
@@ -166,6 +166,7 @@ module.exports = (env) => ({
     extensions: ['.js', '.ts', '.tsx', '.jsx'],
     alias: {
       '~': path.resolve(SRC_DIR),
+      '@odh-dashboard/internal': path.resolve(RELATIVE_DIRNAME, '../../../frontend/src'),
     },
     symlinks: false,
     cacheWithContext: false,

--- a/packages/gen-ai/frontend/config/webpack.dev.js
+++ b/packages/gen-ai/frontend/config/webpack.dev.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { merge } = require('webpack-merge');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
@@ -13,8 +12,6 @@ const PROXY_HOST = process.env._PROXY_HOST;
 const PROXY_PROTOCOL = process.env._PROXY_PROTOCOL;
 const PROXY_PORT = process.env._PROXY_PORT;
 const RELATIVE_DIRNAME = process.env._RELATIVE_DIRNAME;
-const SRC_DIR = process.env._SRC_DIR;
-const COMMON_DIR = process.env._COMMON_DIR;
 const IS_PROJECT_ROOT_DIR = process.env._IS_PROJECT_ROOT_DIR;
 const DIST_DIR = process.env._DIST_DIR;
 const PUBLIC_PATH = process.env._PUBLIC_PATH;
@@ -70,12 +67,6 @@ module.exports = merge(
       rules: [
         {
           test: /\.css$/,
-          include: [
-            SRC_DIR,
-            COMMON_DIR,
-            path.resolve(RELATIVE_DIRNAME, 'node_modules/@patternfly'),
-            path.resolve(RELATIVE_DIRNAME, 'node_modules/mod-arch-shared/node_modules/@patternfly'),
-          ],
           use: ['style-loader', 'css-loader'],
         },
       ],

--- a/packages/gen-ai/frontend/config/webpack.prod.js
+++ b/packages/gen-ai/frontend/config/webpack.prod.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { merge } = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
@@ -11,8 +10,6 @@ const common = require('./webpack.common.js'); // Required after env setup
 
 const RELATIVE_DIRNAME = process.env._RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._IS_PROJECT_ROOT_DIR;
-const SRC_DIR = process.env._SRC_DIR;
-const COMMON_DIR = process.env._COMMON_DIR;
 const DIST_DIR = process.env._DIST_DIR;
 const OUTPUT_ONLY = process.env._OUTPUT_ONLY;
 
@@ -54,12 +51,6 @@ module.exports = merge(
       rules: [
         {
           test: /\.css$/,
-          include: [
-            SRC_DIR,
-            COMMON_DIR,
-            path.resolve(RELATIVE_DIRNAME, 'node_modules/@patternfly'),
-            path.resolve(RELATIVE_DIRNAME, 'node_modules/mod-arch-shared/node_modules/@patternfly'),
-          ],
           use: [MiniCssExtractPlugin.loader, 'css-loader'],
         },
       ],

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -21,7 +21,7 @@
     "test:type-check": "tsc --noEmit",
     "test:type-check:standalone": "tsc --noEmit -p tsconfig-standalone.json",
     "test:unit": "npm run test:jest -- --silent",
-    "lint": "npm run eslint",
+    "lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx ./src",
     "format": "prettier --check --write \"./src/**/*.{tsx,ts}\"",
     "ci-checks": "npm run test:type-check && npm run lint && npm run test:coverage",
     "build:bundle-profile": "webpack --config ./config/webpack.prod.js --profile --json > stats.json",

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeader.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Flex, FlexItem, Title } from '@patternfly/react-core';
+import ProjectIcon from '@odh-dashboard/internal/images/icons/ProjectIcon';
+import ProjectDropdown from './components/ProjectDropdown';
+
+interface ChatbotHeaderProps {
+  selectedProject: string;
+  onProjectChange: (projectName: string) => void;
+  onProjectsLoaded: (projects: string[]) => void;
+  isLoading?: boolean;
+}
+
+const ChatbotHeader: React.FunctionComponent<ChatbotHeaderProps> = ({
+  selectedProject,
+  onProjectChange,
+  onProjectsLoaded,
+  isLoading = false,
+}) => (
+  <Flex component="span" alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapLg' }}>
+    <FlexItem>
+      <Title headingLevel="h1">AI playground</Title>
+    </FlexItem>
+    <FlexItem>
+      <Flex
+        spaceItems={{ default: 'spaceItemsXs' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        style={{ display: 'inline-flex' }}
+      >
+        <FlexItem>
+          <ProjectIcon
+            style={{ width: '20px', height: '20px', marginTop: '10px', marginLeft: '10px' }}
+          />
+        </FlexItem>
+        <FlexItem>
+          <span style={{ fontSize: '16px', marginRight: '10px' }}>Project</span>
+        </FlexItem>
+        <FlexItem>
+          <ProjectDropdown
+            selectedProject={selectedProject}
+            onProjectChange={onProjectChange}
+            onProjectsLoaded={onProjectsLoaded}
+            isDisabled={isLoading}
+          />
+        </FlexItem>
+      </Flex>
+    </FlexItem>
+  </Flex>
+);
+
+export default ChatbotHeader;

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -24,6 +24,7 @@ import useFetchLlamaModels from '~/app/hooks/useFetchLlamaModels';
 import { ChatbotSourceSettingsModal } from './sourceUpload/ChatbotSourceSettingsModal';
 import { ChatbotMessages } from './ChatbotMessagesList';
 import { ChatbotSettingsPanel } from './components/ChatbotSettingsPanel';
+import ChatbotHeader from './ChatbotHeader';
 import useChatbotMessages from './hooks/useChatbotMessages';
 import useSourceManagement from './hooks/useSourceManagement';
 import useAlertManagement from './hooks/useAlertManagement';
@@ -37,11 +38,23 @@ const ChatbotMain: React.FunctionComponent = () => {
   const displayMode = ChatbotDisplayMode.embedded;
   const { models, loading, error } = useFetchLlamaModels();
   const [selectedModel, setSelectedModel] = React.useState<string>('');
+  const [availableProjects, setAvailableProjects] = React.useState<string[]>([]);
+  const [selectedProject, setSelectedProject] = React.useState<string>('');
+
+  React.useEffect(() => {
+    if (!selectedProject && availableProjects.length > 0) {
+      setSelectedProject(availableProjects[0]);
+    }
+  }, [selectedProject, availableProjects]);
 
   const modelId = selectedModel || models[0]?.id;
   const [systemInstruction, setSystemInstruction] = React.useState<string>(
     DEFAULT_SYSTEM_INSTRUCTIONS,
   );
+
+  const handleProjectChange = (projectName: string) => {
+    setSelectedProject(projectName);
+  };
 
   React.useEffect(() => {
     if (!selectedModel) {
@@ -103,7 +116,19 @@ const ChatbotMain: React.FunctionComponent = () => {
   );
 
   const applicationsPage = (
-    <ApplicationsPage title="AI playground" loaded={!loading} empty={false} loadError={error}>
+    <ApplicationsPage
+      title={
+        <ChatbotHeader
+          selectedProject={selectedProject}
+          onProjectChange={handleProjectChange}
+          onProjectsLoaded={setAvailableProjects}
+          isLoading={loading}
+        />
+      }
+      loaded={!loading}
+      empty={false}
+      loadError={error}
+    >
       <ChatbotSourceSettingsModal
         isOpen={sourceManagement.isSourceSettingsOpen}
         onToggle={() =>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ProjectDropdown.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ProjectDropdown.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { MenuItem } from '@patternfly/react-core';
+import SearchSelector from '@odh-dashboard/internal/components/searchSelector/SearchSelector';
+import { useGenaiNamespaces } from '~/app/hooks/useGenaiNamespaces';
+
+interface ProjectDropdownProps {
+  selectedProject?: string;
+  onProjectChange: (projectName: string) => void;
+  onProjectsLoaded: (projects: string[]) => void;
+  isDisabled?: boolean;
+}
+
+const ProjectDropdown: React.FC<ProjectDropdownProps> = ({
+  selectedProject,
+  onProjectChange,
+  onProjectsLoaded,
+  isDisabled = false,
+}) => {
+  const [searchText, setSearchText] = React.useState('');
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useGenaiNamespaces();
+
+  // Extract namespace names and convert to project names
+  const availableProjects = React.useMemo(() => {
+    if (namespaces.length === 0) {
+      return [];
+    }
+    return namespaces
+      .map((namespace) => namespace.name)
+      .filter((name): name is string => !!name)
+      .toSorted();
+  }, [namespaces]);
+
+  // Notify parent component when projects are loaded
+  React.useEffect(() => {
+    if (namespacesLoaded && availableProjects.length > 0) {
+      onProjectsLoaded(availableProjects);
+    }
+  }, [namespacesLoaded, availableProjects, onProjectsLoaded]);
+
+  // Filter projects based on search text
+  const bySearchText = React.useCallback(
+    (projectName: string) =>
+      !searchText || projectName.toLowerCase().includes(searchText.toLowerCase()),
+    [searchText],
+  );
+
+  const filteredProjects = availableProjects.filter(bySearchText);
+
+  let toggleLabel = selectedProject || 'Select a project';
+  if (!namespacesLoaded) {
+    toggleLabel = 'Loading...';
+  }
+  if (namespacesLoadError) {
+    toggleLabel = 'Error fetching projects';
+  }
+
+  if (namespacesLoadError) {
+    return (
+      <span style={{ color: 'red', marginLeft: '10px' }}>
+        {namespacesLoadError.message || 'Error loading namespaces'}
+      </span>
+    );
+  }
+
+  return (
+    <SearchSelector
+      dataTestId="ai-playground-project-selector"
+      minWidth="300px"
+      onSearchChange={(value: string) => setSearchText(value)}
+      onSearchClear={() => setSearchText('')}
+      searchFocusOnOpen
+      searchPlaceholder="Search projects..."
+      searchValue={searchText}
+      isLoading={!namespacesLoaded}
+      isDisabled={isDisabled || !namespacesLoaded}
+      toggleContent={toggleLabel}
+    >
+      <>
+        {!namespacesLoaded && <MenuItem isDisabled>Loading projects...</MenuItem>}
+        {namespacesLoaded && filteredProjects.length === 0 && (
+          <MenuItem isDisabled>No projects available</MenuItem>
+        )}
+        {namespacesLoaded &&
+          filteredProjects.map((projectName) => (
+            <MenuItem
+              key={projectName}
+              isSelected={projectName === selectedProject}
+              onClick={() => {
+                setSearchText('');
+                onProjectChange(projectName);
+              }}
+            >
+              {projectName}
+            </MenuItem>
+          ))}
+      </>
+    </SearchSelector>
+  );
+};
+
+export default ProjectDropdown;

--- a/packages/gen-ai/frontend/src/app/hooks/useGenaiNamespaces.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useGenaiNamespaces.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { getNamespaces } from '~/app/services/llamaStackService';
+import { NamespaceModel } from '~/app/types';
+
+/**
+ * Hook to fetch namespaces from the Llama Stack GenAI endpoint.
+ * @returns Object containing namespaces array, loading state, and error state
+ */
+export const useGenaiNamespaces = (): {
+  namespaces: NamespaceModel[];
+  namespacesLoaded: boolean;
+  namespacesLoadError: Error | null;
+} => {
+  const [namespaces, setNamespaces] = React.useState<NamespaceModel[]>([]);
+  const [namespacesLoaded, setNamespacesLoaded] = React.useState(false);
+  const [namespacesLoadError, setNamespacesLoadError] = React.useState<Error | null>(null);
+
+  React.useEffect(() => {
+    const fetchNamespaces = async () => {
+      setNamespacesLoaded(false);
+      setNamespacesLoadError(null);
+
+      try {
+        const data = await getNamespaces();
+        setNamespaces(data);
+      } catch (error) {
+        setNamespacesLoadError(
+          error instanceof Error ? error : new Error('Unknown error fetching namespaces'),
+        );
+      } finally {
+        setNamespacesLoaded(true);
+      }
+    };
+
+    fetchNamespaces();
+  }, []);
+
+  return { namespaces, namespacesLoaded, namespacesLoadError };
+};
+
+export default useGenaiNamespaces;

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -7,10 +7,28 @@ import {
   CreateResponseRequest,
   SimplifiedResponseData,
   LlamaModel,
+  NamespaceModel,
   FileUploadResult,
 } from '../types';
 import axios from '../utilities/axios';
 import { URL_PREFIX } from '../utilities/const';
+
+/**
+ * Fetches all available namespaces from the Llama Stack API
+ * @returns Promise<NamespaceModel[]> - Array of available namespaces with their metadata
+ * @throws Error - When the API request fails or returns an error response
+ */
+export const getNamespaces = (): Promise<NamespaceModel[]> => {
+  const url = `${URL_PREFIX}/api/v1/namespaces`;
+  return axios
+    .get<{ data: NamespaceModel[] }>(url)
+    .then((response) => response.data.data)
+    .catch((error) => {
+      throw new Error(
+        error.response?.data?.error?.message || error.message || 'Failed to fetch namespaces',
+      );
+    });
+};
 
 /**
  * Fetches all available models from the Llama Stack API

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -7,6 +7,10 @@ export type LlamaModel = {
   owned_by: string;
 };
 
+export type NamespaceModel = {
+  name: string;
+};
+
 export type FileCounts = {
   /** Number of cancelled file operations */
   cancelled: number;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-32537


**Project Dropdown UI:**
<img width="717" height="366" alt="image" src="https://github.com/user-attachments/assets/dc0bfd71-ac6f-4868-b78d-ce7caabd6768" />

This pull request introduces project selection support to the AI playground chatbot UI, allowing users to choose and filter projects (namespaces) from the Llama Stack backend. The changes include new UI components for project selection, hooks and service methods for fetching namespaces, and configuration updates to support shared internal packages.

**Project selection feature:**

* Added a new `ChatbotHeader` component with a project dropdown, displaying the selected project and allowing users to change it. (`frontend/src/app/Chatbot/ChatbotHeader.tsx`)
* Implemented the `ProjectDropdown` component, which fetches available projects (namespaces), supports search/filtering, and handles loading/error states. (`frontend/src/app/Chatbot/components/ProjectDropdown.tsx`)
* Introduced the `useGenaiNamespaces` hook to fetch namespaces from the backend and manage loading/error state. (`frontend/src/app/hooks/useGenaiNamespaces.ts`)
* Added the `getNamespaces` service method and the `NamespaceModel` type for API integration. (`frontend/src/app/services/llamaStackService.ts`, `frontend/src/app/types.ts`) [[1]](diffhunk://#diff-b00e907272b7cdf22db137ba87013099e9330b0911c6c9231e9130e1aa54daeaR10-R32) [[2]](diffhunk://#diff-81396f5e015d6fbb2b5cd89b1e4cce299a99cee34b90629d0dff4034503df226R10-R13)
* Updated `ChatbotMain` to manage project selection state and render the new header and dropdown. (`frontend/src/app/Chatbot/ChatbotMain.tsx`) [[1]](diffhunk://#diff-366edd26170bf66189afaa81d6c8cdf6779efc3c15414f2cf1afe3705b6d57d6R27) [[2]](diffhunk://#diff-366edd26170bf66189afaa81d6c8cdf6779efc3c15414f2cf1afe3705b6d57d6R41-R58) [[3]](diffhunk://#diff-366edd26170bf66189afaa81d6c8cdf6779efc3c15414f2cf1afe3705b6d57d6L106-R131)

**Configuration updates for shared packages:**

* Updated ESLint and Webpack configs to support importing shared internal packages (`@odh-dashboard/internal`) and their assets/styles. (`.eslintrc.js`, `webpack.dev.js`, `webpack.prod.js`) [[1]](diffhunk://#diff-11779bdf85aeac49245c1e9e4d63f553c27dee2bf707921cc618b01e9582b381R233-R239) [[2]](diffhunk://#diff-7b580d837a6ed9fd4ae61d665274e9d2eca3501bf300f612fdc33af2d2314eb4R78-R79) [[3]](diffhunk://#diff-e9df25e37fd98022ab856234a73be7fa1857a90b4231b1de78430990ce2b0aedR62-R63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a project selector in the AI playground header with search, loading, and error states.
  - Automatically selects the first available project when projects load.

- Chores
  - Expanded CSS handling in development and production builds to cover all CSS imports.
  - Introduced a module alias to simplify internal imports.
  - Updated linting configuration and script for stricter checks within the frontend source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->