### PR TITLE
Feature store metrics tab(overview page)

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureMetrics.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureMetrics.ts
@@ -177,34 +177,28 @@ class FeatureMetricsOverview extends Contextual<HTMLElement> {
     return this;
   }
 
-  clickGoToEntities() {
-    this.findEntitiesCard().find('a').contains('Go to Entities').click();
-    return this;
+  findGoToEntitiesLink() {
+    return this.findEntitiesCard().find('a').contains('Go to Entities');
   }
 
-  clickGoToDataSources() {
-    this.findDataSourcesCard().find('a').contains('Go to Data Sources').click();
-    return this;
+  findGoToDataSourcesLink() {
+    return this.findDataSourcesCard().find('a').contains('Go to Data Sources');
   }
 
-  clickGoToSavedDatasets() {
-    this.findSavedDatasetsCard().find('a').contains('Go to Saved Datasets').click();
-    return this;
+  findGoToSavedDatasetsLink() {
+    return this.findSavedDatasetsCard().find('a').contains('Go to Saved Datasets');
   }
 
-  clickGoToFeatures() {
-    this.findFeaturesCard().find('a').contains('Go to Features').click();
-    return this;
+  findGoToFeaturesLink() {
+    return this.findFeaturesCard().find('a').contains('Go to Features');
   }
 
-  clickGoToFeatureViews() {
-    this.findFeatureViewsCard().find('a').contains('Go to Feature Views').click();
-    return this;
+  findGoToFeatureViewsLink() {
+    return this.findFeatureViewsCard().find('a').contains('Go to Feature Views');
   }
 
-  clickGoToFeatureServices() {
-    this.findFeatureServicesCard().find('a').contains('Go to Feature Services').click();
-    return this;
+  findGoToFeatureServicesLink() {
+    return this.findFeatureServicesCard().find('a').contains('Go to Feature Services');
   }
 
   shouldDisplayResourceCounts() {
@@ -274,14 +268,6 @@ class FeatureMetricsPopularTagRow extends Contextual<HTMLElement> {
     this.findViewAllLink().should('contain.text', count.toString());
     return this;
   }
-
-  clickFeatureViewLink(featureViewName: string) {
-    this.findFeatureViewLink(featureViewName).click();
-  }
-
-  clickViewAllLink() {
-    this.findViewAllLink().click();
-  }
 }
 
 class FeatureMetricsRecentlyVisitedRow extends Contextual<HTMLElement> {
@@ -309,10 +295,6 @@ class FeatureMetricsRecentlyVisitedRow extends Contextual<HTMLElement> {
   shouldHaveResourceType(type: string) {
     this.findResourceType().should('contain.text', type);
     return this;
-  }
-
-  clickResourceLink() {
-    this.findResourceLink().click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureMetrics.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureMetrics.ts
@@ -1,0 +1,321 @@
+import { Contextual } from '#~/__tests__/cypress/cypress/pages/components/Contextual';
+
+class FeatureMetricsOverview extends Contextual<HTMLElement> {
+  findMetricsOverview() {
+    return cy.findByTestId('feature-store-metrics-overview');
+  }
+
+  findResourceCountsCard(title: string) {
+    const testId = `feature-store-metrics-card-${title.toLowerCase()}`;
+    return cy.findByTestId(testId, { timeout: 10000 }).scrollIntoView();
+  }
+
+  findEntitiesCard() {
+    return this.findResourceCountsCard('Entities');
+  }
+
+  findDataSourcesCard() {
+    return this.findResourceCountsCard('Data sources');
+  }
+
+  findSavedDatasetsCard() {
+    return this.findResourceCountsCard('Datasets');
+  }
+
+  findFeaturesCard() {
+    return this.findResourceCountsCard('Features');
+  }
+
+  findFeatureViewsCard() {
+    return this.findResourceCountsCard('Feature Views');
+  }
+
+  findFeatureServicesCard() {
+    return this.findResourceCountsCard('Feature Services');
+  }
+
+  findPopularTagsTitle() {
+    return cy.findByTestId('popular-tags-title', { timeout: 10000 }).scrollIntoView();
+  }
+
+  findPopularTagCard(tagKey: string, tagValue: string) {
+    const testId = `feature-store-popular-tag-card-${tagKey}-${tagValue}`;
+    return cy.findByTestId(testId, { timeout: 10000 }).scrollIntoView();
+  }
+
+  findEmptyStateTitle() {
+    return cy.findByTestId('empty-state-title');
+  }
+
+  findPopularTagsEmptyStateTitle() {
+    return cy.findByTestId('popular-tags-empty-state-title');
+  }
+
+  findRecentlyVisitedEmptyStateTitle() {
+    return cy.findByTestId('recently-visited-resources-empty-state-title');
+  }
+
+  findEmptyStateBody() {
+    return cy.findByTestId('empty-state-body');
+  }
+
+  findErrorLoadingPopularTags() {
+    return cy.findByTestId('error-loading-popular-tags', { timeout: 10000 }).scrollIntoView();
+  }
+
+  findRecentlyVisitedTitle() {
+    return cy.findByTestId('recently-visited-resources-title', { timeout: 10000 }).scrollIntoView();
+  }
+
+  findRecentlyVisitedTable() {
+    return cy.findByTestId('recently-visited-resources-table', { timeout: 10000 }).scrollIntoView();
+  }
+
+  shouldHaveEntitiesCount(count: number) {
+    this.findEntitiesCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHaveDataSourcesCount(count: number) {
+    this.findDataSourcesCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHaveSavedDatasetsCount(count: number) {
+    this.findSavedDatasetsCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHaveFeaturesCount(count: number) {
+    this.findFeaturesCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHaveFeatureViewsCount(count: number) {
+    this.findFeatureViewsCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHaveFeatureServicesCount(count: number) {
+    this.findFeatureServicesCard().should('contain.text', count);
+    return this;
+  }
+
+  shouldHavePopularTagsTitle() {
+    this.findPopularTagsTitle().should('be.visible');
+    return this;
+  }
+
+  shouldHavePopularTagCard(tagKey: string, tagValue: string) {
+    this.findPopularTagCard(tagKey, tagValue).should('be.visible');
+    return this;
+  }
+
+  shouldHaveFeatureViewInPopularTag(tagKey: string, tagValue: string, featureViewName: string) {
+    this.findPopularTagCard(tagKey, tagValue)
+      .find('a')
+      .contains(featureViewName)
+      .should('be.visible');
+    return this;
+  }
+
+  shouldHaveFeatureViewsCountInPopularTag(tagKey: string, tagValue: string, count: number) {
+    this.findPopularTagCard(tagKey, tagValue)
+      .find('a')
+      .contains(`View all (${count})`)
+      .should('be.visible');
+    return this;
+  }
+
+  shouldShowEmptyState() {
+    this.findEmptyStateTitle().should('be.visible');
+    this.findEmptyStateBody().should('be.visible');
+    return this;
+  }
+
+  shouldShowEmptyStateWithTitle(expectedTitle: string) {
+    this.findEmptyStateTitle().should('be.visible').contains(expectedTitle);
+    return this;
+  }
+
+  shouldShowRecentlyVisitedEmptyState() {
+    this.findRecentlyVisitedEmptyStateTitle()
+      .should('be.visible')
+      .contains('No recently visited resources.');
+    return this;
+  }
+
+  shouldShowPopularTagsEmptyState() {
+    this.findPopularTagsEmptyStateTitle().should('be.visible').contains('No feature views yet');
+    return this;
+  }
+
+  shouldHaveRecentlyVisitedTitle() {
+    this.findRecentlyVisitedTitle().should('be.visible');
+    return this;
+  }
+
+  shouldHaveRecentlyVisitedTable() {
+    this.findRecentlyVisitedTable().should('be.visible');
+    return this;
+  }
+
+  shouldHaveRecentlyVisitedRow(resourceName: string) {
+    this.findRecentlyVisitedTable()
+      .find('tr')
+      .filter(`:contains("${resourceName}")`)
+      .should('be.visible');
+    return this;
+  }
+
+  shouldHaveRecentlyVisitedRowWithDetails(resourceName: string, resourceType: string) {
+    const row = this.findRecentlyVisitedTable().find('tr').filter(`:contains("${resourceName}")`);
+
+    row.should('be.visible');
+    row.find('[data-label="Resource name"]').should('contain.text', resourceName);
+    row.find('[data-label="Resource type"]').should('contain.text', resourceType);
+    return this;
+  }
+
+  clickGoToEntities() {
+    this.findEntitiesCard().find('a').contains('Go to Entities').click();
+    return this;
+  }
+
+  clickGoToDataSources() {
+    this.findDataSourcesCard().find('a').contains('Go to Data Sources').click();
+    return this;
+  }
+
+  clickGoToSavedDatasets() {
+    this.findSavedDatasetsCard().find('a').contains('Go to Saved Datasets').click();
+    return this;
+  }
+
+  clickGoToFeatures() {
+    this.findFeaturesCard().find('a').contains('Go to Features').click();
+    return this;
+  }
+
+  clickGoToFeatureViews() {
+    this.findFeatureViewsCard().find('a').contains('Go to Feature Views').click();
+    return this;
+  }
+
+  clickGoToFeatureServices() {
+    this.findFeatureServicesCard().find('a').contains('Go to Feature Services').click();
+    return this;
+  }
+
+  shouldDisplayResourceCounts() {
+    this.findEntitiesCard().should('be.visible');
+    this.findDataSourcesCard().should('be.visible');
+    this.findSavedDatasetsCard().should('be.visible');
+    this.findFeaturesCard().should('be.visible');
+    this.findFeatureViewsCard().should('be.visible');
+    this.findFeatureServicesCard().should('be.visible');
+    return this;
+  }
+
+  shouldDisplayPopularTags() {
+    this.findPopularTagsTitle().should('be.visible');
+    return this;
+  }
+
+  shouldDisplayRecentlyVisited() {
+    this.findRecentlyVisitedTitle().should('be.visible');
+    return this;
+  }
+
+  shouldHaveErrorLoadingPopularTags() {
+    this.findErrorLoadingPopularTags().should('be.visible');
+    return this;
+  }
+
+  findPopularTagRow(tagKey: string, tagValue: string) {
+    return new FeatureMetricsPopularTagRow(() => this.findPopularTagCard(tagKey, tagValue));
+  }
+
+  findRecentlyVisitedRow(resourceName: string) {
+    return new FeatureMetricsRecentlyVisitedRow(() =>
+      this.findRecentlyVisitedTable().find('tr').filter(`:contains("${resourceName}")`),
+    );
+  }
+}
+
+class FeatureMetricsPopularTagRow extends Contextual<HTMLElement> {
+  findTagTitle() {
+    return this.find().find('.pf-c-card__title');
+  }
+
+  findFeatureViewsList() {
+    return this.find().find('ul');
+  }
+
+  findFeatureViewLink(featureViewName: string) {
+    return this.find().find('a').contains(featureViewName);
+  }
+
+  findViewAllLink() {
+    return this.find().find('a').contains('View all');
+  }
+
+  shouldHaveTagKey(tagKey: string) {
+    this.findTagTitle().should('contain.text', tagKey);
+    return this;
+  }
+
+  shouldHaveTagValue(tagValue: string) {
+    this.findTagTitle().should('contain.text', tagValue);
+    return this;
+  }
+
+  shouldHaveFeatureViewsCount(count: number) {
+    this.findViewAllLink().should('contain.text', count.toString());
+    return this;
+  }
+
+  clickFeatureViewLink(featureViewName: string) {
+    this.findFeatureViewLink(featureViewName).click();
+  }
+
+  clickViewAllLink() {
+    this.findViewAllLink().click();
+  }
+}
+
+class FeatureMetricsRecentlyVisitedRow extends Contextual<HTMLElement> {
+  findResourceName() {
+    return this.find().find('[data-label="Resource name"]');
+  }
+
+  findResourceType() {
+    return this.find().find('[data-label="Resource type"]');
+  }
+
+  findLastViewed() {
+    return this.find().find('[data-label="Last viewed"]');
+  }
+
+  findResourceLink() {
+    return this.findResourceName().find('a');
+  }
+
+  shouldHaveResourceName(name: string) {
+    this.findResourceName().should('contain.text', name);
+    return this;
+  }
+
+  shouldHaveResourceType(type: string) {
+    this.findResourceType().should('contain.text', type);
+    return this;
+  }
+
+  clickResourceLink() {
+    this.findResourceLink().click();
+  }
+}
+
+export const featureMetricsOverview = new FeatureMetricsOverview(() =>
+  cy.findByTestId('feature-store-metrics-overview'),
+);

--- a/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureStoreGlobal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/featureStore/featureStoreGlobal.ts
@@ -44,6 +44,15 @@ class FeatureStoreGlobal {
     this.waitForFeatureServices();
   }
 
+  visitOverview(project?: string) {
+    cy.visitWithLogin(
+      `/featureStore/overview${
+        project ? `/${project}` : ''
+      }?devFeatureFlags=Feature+store+plugin%3Dtrue`,
+    );
+    this.waitForOverview();
+  }
+
   visitFeatureServiceDetails(project: string, featureService: string) {
     const projectName = project;
     cy.visitWithLogin(
@@ -98,6 +107,11 @@ class FeatureStoreGlobal {
 
   private waitForFeatureServices() {
     cy.findByTestId('app-page-title').should('have.text', 'Feature services');
+    cy.testA11y();
+  }
+
+  private waitForOverview() {
+    cy.findByTestId('app-page-title').should('have.text', 'Overview');
     cy.testA11y();
   }
 

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -4,6 +4,10 @@ import type {
   FeatureService,
   FeatureServicesList,
 } from '@odh-dashboard/feature-store/types/featureServices';
+import type {
+  GetPopularTags,
+  GetRecentlyVisitedResources,
+} from '@odh-dashboard/feature-store/types/metrics';
 import type { FeatureViewsList } from '@odh-dashboard/feature-store/types/featureView';
 import type { EntityList } from '@odh-dashboard/feature-store/types/entities';
 import type { ProjectList } from '@odh-dashboard/feature-store/types/featureStoreProjects';
@@ -848,6 +852,21 @@ declare global {
             };
           },
           response: OdhResponse<FeatureService>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/recently_visited',
+          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
+          response: OdhResponse<GetRecentlyVisitedResources>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/popular_tags',
+          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
+          response: OdhResponse<GetPopularTags>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/resource_counts',
+          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
+          response: OdhResponse<GetPopularTags>,
         ) => Cypress.Chainable<null>);
     }
   }

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -5,8 +5,9 @@ import type {
   FeatureServicesList,
 } from '@odh-dashboard/feature-store/types/featureServices';
 import type {
-  GetPopularTags,
-  GetRecentlyVisitedResources,
+  MetricsCountResponse,
+  PopularTagsResponse,
+  RecentlyVisitedResponse,
 } from '@odh-dashboard/feature-store/types/metrics';
 import type { FeatureViewsList } from '@odh-dashboard/feature-store/types/featureView';
 import type { EntityList } from '@odh-dashboard/feature-store/types/entities';
@@ -855,18 +856,27 @@ declare global {
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/recently_visited',
-          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
-          response: OdhResponse<GetRecentlyVisitedResources>,
+          options: {
+            path: { namespace: string; serviceName: string; apiVersion: string };
+            query?: { project?: string; limit?: string };
+          },
+          response: OdhResponse<RecentlyVisitedResponse>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/popular_tags',
-          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
-          response: OdhResponse<GetPopularTags>,
+          options: {
+            path: { namespace: string; serviceName: string; apiVersion: string };
+            query?: { project?: string; limit?: string };
+          },
+          response: OdhResponse<PopularTagsResponse>,
         ) => Cypress.Chainable<null>) &
         ((
           type: 'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/metrics/resource_counts',
-          options: { path: { namespace: string; serviceName: string; apiVersion: string } },
-          response: OdhResponse<GetPopularTags>,
+          options: {
+            path: { namespace: string; serviceName: string; apiVersion: string };
+            query?: { project?: string };
+          },
+          response: OdhResponse<MetricsCountResponse>,
         ) => Cypress.Chainable<null>);
     }
   }

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
@@ -1,0 +1,422 @@
+/* eslint-disable camelcase */
+
+import { mockFeatureStoreService } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreService';
+import { mockFeatureStore } from '@odh-dashboard/feature-store/mocks/mockFeatureStore';
+import { mockFeatureStoreProject } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreProject';
+import { mockFeatureView } from '@odh-dashboard/feature-store/mocks/mockFeatureViews';
+import {
+  mockPopularTags,
+  mockRecentlyVisited,
+  mockResourceCounts,
+} from '@odh-dashboard/feature-store/mocks/mockMetrics';
+import { featureStoreGlobal } from '#~/__tests__/cypress/cypress/pages/featureStore/featureStoreGlobal';
+import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
+import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
+import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
+import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
+import { featureMetricsOverview } from '#~/__tests__/cypress/cypress/pages/featureStore/featureMetrics';
+
+const k8sNamespace = 'default';
+const fsName = 'demo';
+const fsProjectName = 'rbac';
+
+const initCommonIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      installedComponents: {
+        feastoperator: true,
+      },
+    }),
+  );
+
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableFeatureStore: false }));
+
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: k8sNamespace })]),
+  );
+
+  cy.intercept(
+    'GET',
+    '/api/k8s/apis/feast.dev/v1alpha1/featurestores?labelSelector=feature-store-ui%3Denabled',
+    {
+      items: [mockFeatureStore({ name: fsName, namespace: k8sNamespace })],
+    },
+  );
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([
+      mockFeatureStoreService({
+        name: 'feast-demo-registry-rest',
+        namespace: 'default',
+        featureStoreName: fsName,
+      }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/projects',
+    {
+      path: { namespace: k8sNamespace, serviceName: fsName, apiVersion: 'v1' },
+    },
+    {
+      projects: [
+        mockFeatureStoreProject({ spec: { name: fsProjectName } }),
+        mockFeatureStoreProject({ spec: { name: 'new-project' } }),
+      ],
+      pagination: {
+        total_count: 2,
+        total_pages: 1,
+        has_next: false,
+        has_previous: false,
+        page: 1,
+        limit: 10,
+      },
+    },
+  );
+};
+
+const mockPopularTagsIntercept = () => {
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/popular_tags?project=${fsProjectName}&limit=4*`,
+    mockPopularTags(),
+  ).as('getPopularTags');
+};
+
+const mockRecentlyVisitedIntercept = () => {
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/recently_visited?project=${fsProjectName}*`,
+    mockRecentlyVisited(),
+  ).as('getRecentlyVisited');
+};
+
+const mockResourceCountsIntercept = () => {
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/resource_counts?project=${fsProjectName}*`,
+    mockResourceCounts(),
+  ).as('getResourceCounts');
+};
+
+const mockFeatureViewsIntercept = () => {
+  cy.interceptOdh(
+    'GET /api/service/featurestore/:namespace/:serviceName/api/:apiVersion/feature_views',
+    {
+      path: { namespace: k8sNamespace, serviceName: fsName, apiVersion: 'v1' },
+    },
+    {
+      featureViews: [
+        mockFeatureView({
+          spec: {
+            ...mockFeatureView().spec,
+            name: 'driver_hourly_stats',
+            entities: ['driver'],
+          },
+        }),
+        mockFeatureView({
+          spec: {
+            ...mockFeatureView().spec,
+            name: 'driver_hourly_stats_fresh',
+            entities: ['driver'],
+          },
+        }),
+        mockFeatureView({
+          spec: {
+            ...mockFeatureView().spec,
+            name: 'transformed_conv_rate',
+            entities: ['user_id'],
+          },
+        }),
+      ],
+      relationships: {},
+      pagination: {
+        totalCount: 3,
+        totalPages: 1,
+      },
+    },
+  ).as('getFeatureViews');
+};
+
+const mockFeatureViewDetailsIntercept = () => {
+  cy.intercept(
+    'GET',
+    `**/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/feature_views/driver_hourly_stats?project=${fsProjectName}&include_relationships=true*`,
+    mockFeatureView({
+      spec: {
+        ...mockFeatureView().spec,
+        name: 'driver_hourly_stats',
+        entities: ['driver'],
+      },
+    }),
+  ).as('getFeatureViewDetails_driver_hourly_stats');
+
+  cy.intercept(
+    'GET',
+    `**/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/feature_views/driver_hourly_stats_fresh?project=${fsProjectName}&include_relationships=true*`,
+    mockFeatureView({
+      spec: {
+        ...mockFeatureView().spec,
+        name: 'driver_hourly_stats_fresh',
+        entities: ['driver'],
+      },
+    }),
+  ).as('getFeatureViewDetails_driver_hourly_stats_fresh');
+
+  cy.intercept(
+    'GET',
+    `**/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/feature_views/transformed_conv_rate?project=${fsProjectName}&include_relationships=true*`,
+    mockFeatureView({
+      spec: {
+        ...mockFeatureView().spec,
+        name: 'transformed_conv_rate',
+        entities: ['user_id'],
+      },
+    }),
+  ).as('getFeatureViewDetails_transformed_conv_rate');
+};
+
+const mockAllMetricsIntercepts = () => {
+  mockPopularTagsIntercept();
+  mockRecentlyVisitedIntercept();
+  mockResourceCountsIntercept();
+  mockFeatureViewsIntercept();
+  mockFeatureViewDetailsIntercept();
+};
+
+const mockEmptyStatesIntercept = (project = fsProjectName) => {
+  // Mock empty resource counts
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/resource_counts?project=${project}*`,
+    {
+      project,
+      counts: {
+        entities: 0,
+        dataSources: 0,
+        savedDatasets: 0,
+        features: 0,
+        featureViews: 0,
+        featureServices: 0,
+      },
+    },
+  ).as('getEmptyResourceCounts');
+
+  // Mock empty popular tags
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/popular_tags?project=${project}&limit=4*`,
+    {
+      popular_tags: [],
+      metadata: {
+        totalFeatureViews: 0,
+        totalTags: 0,
+        limit: 4,
+      },
+    },
+  ).as('getEmptyPopularTags');
+
+  // Mock empty recently visited
+  cy.intercept(
+    'GET',
+    `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/recently_visited?project=${project}*`,
+    {
+      visits: [],
+      pagination: {
+        totalCount: 0,
+      },
+    },
+  ).as('getEmptyRecentlyVisited');
+};
+
+describe('Feature Store Metrics Overview', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+    mockAllMetricsIntercepts();
+  });
+
+  it('should display metrics overview page with correct title and content', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    featureStoreGlobal.findHeading().should('have.text', 'Overview');
+    featureStoreGlobal.findProjectSelector().should('exist');
+    featureStoreGlobal.findProjectSelector().click();
+    featureStoreGlobal.findProjectSelectorDropdown().should('contain.text', fsProjectName);
+  });
+
+  it('should display resource counts section with correct data', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getResourceCounts');
+
+    featureMetricsOverview.shouldHaveEntitiesCount(2);
+    featureMetricsOverview.shouldHaveDataSourcesCount(3);
+    featureMetricsOverview.shouldHaveSavedDatasetsCount(0);
+    featureMetricsOverview.shouldHaveFeaturesCount(10);
+    featureMetricsOverview.shouldHaveFeatureViewsCount(2);
+    featureMetricsOverview.shouldHaveFeatureServicesCount(3);
+  });
+
+  it('should display popular tags section with correct data', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getPopularTags');
+
+    featureMetricsOverview.shouldHavePopularTagCard('team', 'driver_performance');
+
+    featureMetricsOverview.shouldHaveFeatureViewInPopularTag(
+      'team',
+      'driver_performance',
+      'driver_hourly_stats',
+    );
+    featureMetricsOverview.shouldHaveFeatureViewInPopularTag(
+      'team',
+      'driver_performance',
+      'driver_hourly_stats_fresh',
+    );
+
+    featureMetricsOverview.shouldHaveFeatureViewsCountInPopularTag('team', 'driver_performance', 2);
+  });
+
+  it('should display recently visited section with correct data', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getRecentlyVisited');
+
+    featureMetricsOverview.shouldHaveRecentlyVisitedTitle();
+    featureMetricsOverview.shouldHaveRecentlyVisitedTable();
+
+    featureMetricsOverview.shouldHaveRecentlyVisitedRow('driver_hourly_stats');
+    featureMetricsOverview.shouldHaveRecentlyVisitedRow('driver');
+    featureMetricsOverview.shouldHaveRecentlyVisitedRow('__dummy');
+  });
+
+  it('should handle empty popular tags state', () => {
+    mockEmptyStatesIntercept();
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getEmptyPopularTags');
+
+    featureMetricsOverview.shouldHavePopularTagsTitle();
+    featureMetricsOverview.shouldShowPopularTagsEmptyState();
+  });
+
+  it('should handle empty recently visited resources state', () => {
+    cy.intercept(
+      'GET',
+      `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/recently_visited?project=${fsProjectName}*`,
+      {
+        visits: [],
+        pagination: {
+          totalCount: 0,
+        },
+      },
+    ).as('getEmptyRecentlyVisited');
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getEmptyRecentlyVisited');
+
+    featureMetricsOverview.shouldHaveRecentlyVisitedTitle();
+    featureMetricsOverview.shouldShowRecentlyVisitedEmptyState();
+  });
+
+  it('should handle empty resource counts state', () => {
+    mockEmptyStatesIntercept();
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getEmptyResourceCounts');
+
+    featureMetricsOverview.shouldHaveEntitiesCount(0);
+    featureMetricsOverview.shouldHaveDataSourcesCount(0);
+    featureMetricsOverview.shouldHaveSavedDatasetsCount(0);
+    featureMetricsOverview.shouldHaveFeaturesCount(0);
+    featureMetricsOverview.shouldHaveFeatureViewsCount(0);
+    featureMetricsOverview.shouldHaveFeatureServicesCount(0);
+  });
+
+  it('should navigate to feature view details when clicking on feature view in recently visited', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getRecentlyVisited');
+    featureMetricsOverview.findRecentlyVisitedRow('driver_hourly_stats').clickResourceLink();
+    cy.url().should('include', `/featureStore/featureViews/${fsProjectName}/driver_hourly_stats`);
+  });
+
+  it('should display correct metadata in popular tags section', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getPopularTags');
+
+    cy.findByText('View all (2)').should('be.visible');
+  });
+
+  it('should handle API errors gracefully', () => {
+    cy.intercept(
+      'GET',
+      `/api/service/featurestore/${k8sNamespace}/${fsName}/api/v1/metrics/popular_tags?project=${fsProjectName}&limit=4*`,
+      {
+        statusCode: 500,
+        body: { detail: 'Internal server error' },
+      },
+    ).as('getPopularTagsError');
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getPopularTagsError');
+    featureMetricsOverview.shouldHaveErrorLoadingPopularTags();
+  });
+});
+
+describe('Feature Store Metrics Overview - Project Switching', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+    mockAllMetricsIntercepts();
+  });
+
+  it('should refresh metrics data when project changes', () => {
+    const newProject = 'new-project';
+
+    mockEmptyStatesIntercept(newProject);
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    cy.wait('@getPopularTags');
+
+    featureStoreGlobal.findProjectSelector().click();
+    cy.findByText(newProject).click();
+
+    cy.wait('@getEmptyResourceCounts');
+    cy.wait('@getEmptyPopularTags');
+    cy.wait('@getEmptyRecentlyVisited');
+
+    featureStoreGlobal.findProjectSelector().should('contain.text', newProject);
+
+    featureMetricsOverview.shouldShowPopularTagsEmptyState();
+    featureMetricsOverview.shouldShowRecentlyVisitedEmptyState();
+  });
+});
+
+describe('Feature Store Metrics Overview Empty States', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+    mockEmptyStatesIntercept();
+  });
+
+  it('should handle all empty states simultaneously', () => {
+    featureStoreGlobal.visitOverview(fsProjectName);
+
+    featureMetricsOverview.shouldDisplayResourceCounts();
+    featureMetricsOverview.shouldHavePopularTagsTitle();
+    featureMetricsOverview.shouldHaveRecentlyVisitedTitle();
+
+    featureMetricsOverview.shouldShowPopularTagsEmptyState();
+    featureMetricsOverview.shouldShowRecentlyVisitedEmptyState();
+
+    featureMetricsOverview.shouldHaveEntitiesCount(0);
+    featureMetricsOverview.shouldHaveDataSourcesCount(0);
+    featureMetricsOverview.shouldHaveSavedDatasetsCount(0);
+    featureMetricsOverview.shouldHaveFeaturesCount(0);
+    featureMetricsOverview.shouldHaveFeatureViewsCount(0);
+    featureMetricsOverview.shouldHaveFeatureServicesCount(0);
+  });
+});

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
@@ -339,7 +339,7 @@ describe('Feature Store Metrics Overview', () => {
   it('should navigate to feature view details when clicking on feature view in recently visited', () => {
     featureStoreGlobal.visitOverview(fsProjectName);
     cy.wait('@getRecentlyVisited');
-    featureMetricsOverview.findRecentlyVisitedRow('driver_hourly_stats').clickResourceLink();
+    featureMetricsOverview.findRecentlyVisitedRow('driver_hourly_stats').findResourceLink().click();
     cy.url().should('include', `/featureStore/featureViews/${fsProjectName}/driver_hourly_stats`);
   });
 

--- a/packages/feature-store/src/FeatureStore.tsx
+++ b/packages/feature-store/src/FeatureStore.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import FeatureStoreProjectSelectorNavigator from './screens/components/FeatureStoreProjectSelectorNavigator';
 import { featureStoreRoute } from './routes';
+import { FeatureStoreTabs } from './const';
+import Metrics from './screens/metrics/Metrics';
 
 type FeatureStoreProps = Omit<
   React.ComponentProps<typeof ApplicationsPage>,
@@ -13,21 +16,61 @@ type FeatureStoreProps = Omit<
   | 'removeChildrenTopPadding'
   | 'headerContent'
 >;
-const FeatureStore: React.FC<FeatureStoreProps> = ({ ...pageProps }) => (
-  <ApplicationsPage
-    {...pageProps}
-    title="Feature Store"
-    description="A catalog of features, entities, feature views and datasets created by your own team"
-    headerContent={
-      <FeatureStoreProjectSelectorNavigator
-        getRedirectPath={(featureStoreObject, featureStoreProject) =>
-          `${featureStoreRoute(featureStoreObject, featureStoreProject)}`
-        }
-      />
-    }
-    loaded
-    provideChildrenPadding
-  />
-);
+const FeatureStore: React.FC<FeatureStoreProps> = ({ ...pageProps }) => {
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(FeatureStoreTabs.METRICS);
+
+  return (
+    <ApplicationsPage
+      {...pageProps}
+      title="Overview"
+      description="Description of feature store"
+      headerContent={
+        <FeatureStoreProjectSelectorNavigator
+          getRedirectPath={(featureStoreObject, featureStoreProject) =>
+            `${featureStoreRoute(featureStoreObject, featureStoreProject)}`
+          }
+        />
+      }
+      loaded
+      provideChildrenPadding
+    >
+      <Tabs
+        activeKey={activeTabKey}
+        aria-label="Feature store page"
+        role="region"
+        data-testid="feature-store-page"
+        onSelect={(e, tabIndex) => {
+          setActiveTabKey(tabIndex);
+        }}
+      >
+        <Tab
+          eventKey={FeatureStoreTabs.METRICS}
+          title={<TabTitleText>{FeatureStoreTabs.METRICS}</TabTitleText>}
+          aria-label="Metrics tab"
+          data-testid="metrics-tab"
+        >
+          <PageSection hasBodyWrapper={false} isFilled data-testid="metrics-tab-content">
+            <Metrics />
+          </PageSection>
+        </Tab>
+        <Tab
+          eventKey={FeatureStoreTabs.LINEAGE}
+          title={<TabTitleText>{FeatureStoreTabs.LINEAGE}</TabTitleText>}
+          aria-label="Lineage tab"
+          data-testid="lineage-tab"
+        >
+          <PageSection
+            hasBodyWrapper={false}
+            isFilled
+            data-testid="lineage-tab-content"
+            className="pf-v6-u-mt-xl"
+          >
+            lineage
+          </PageSection>
+        </Tab>
+      </Tabs>
+    </ApplicationsPage>
+  );
+};
 
 export default FeatureStore;

--- a/packages/feature-store/src/FeatureStoreRoutes.tsx
+++ b/packages/feature-store/src/FeatureStoreRoutes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import { FeatureStoreObject } from './const';
 import FeatureStore from './FeatureStore';
 import FeatureStoreCoreLoader from './FeatureStoreCoreLoader';
@@ -37,6 +37,7 @@ const FeatureStoreRoutes: React.FC = () => (
         />
       }
     >
+      <Route index element={<Navigate to="overview" replace />} />
       <Route path="overview/:fsProjectName?/*" element={<FeatureStore empty={false} />} />
       <Route path="entities/:fsProjectName?/*" element={<FeatureStoreEntities />} />
       <Route path="featureViews/:fsProjectName?/*" element={<FeatureViews />} />

--- a/packages/feature-store/src/FeatureStoreRoutes.tsx
+++ b/packages/feature-store/src/FeatureStoreRoutes.tsx
@@ -37,7 +37,7 @@ const FeatureStoreRoutes: React.FC = () => (
         />
       }
     >
-      <Route index element={<FeatureStore empty={false} />} />
+      <Route path="overview/:fsProjectName?/*" element={<FeatureStore empty={false} />} />
       <Route path="entities/:fsProjectName?/*" element={<FeatureStoreEntities />} />
       <Route path="featureViews/:fsProjectName?/*" element={<FeatureViews />} />
       <Route path="featureViews/:fsProjectName/:featureViewName" element={<FeatureViewDetails />} />

--- a/packages/feature-store/src/__mocks__/mockMetrics.ts
+++ b/packages/feature-store/src/__mocks__/mockMetrics.ts
@@ -1,0 +1,202 @@
+/* eslint-disable camelcase */
+import {
+  PopularTagsResponse,
+  RecentlyVisitedResponse,
+  MetricsCountResponse,
+} from '../types/metrics';
+
+export const mockPopularTags = (partial?: Partial<PopularTagsResponse>): PopularTagsResponse => ({
+  popular_tags: [
+    {
+      tag_key: 'team',
+      tag_value: 'driver_performance',
+      feature_views: [
+        {
+          name: 'driver_hourly_stats',
+          project: 'rbac',
+        },
+        {
+          name: 'driver_hourly_stats_fresh',
+          project: 'rbac',
+        },
+      ],
+      total_feature_views: 2,
+    },
+  ],
+  metadata: {
+    totalFeatureViews: 4,
+    totalTags: 1,
+    limit: 4,
+  },
+  ...partial,
+});
+
+export const mockRecentlyVisited = (
+  partial?: Partial<RecentlyVisitedResponse>,
+): RecentlyVisitedResponse => ({
+  visits: [
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-14T08:59:24.066166+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/feature_views/transformed_conv_rate',
+      timestamp: '2025-08-14T08:59:32.015450+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'feature_views',
+      object_name: 'transformed_conv_rate',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/driver',
+      timestamp: '2025-08-14T10:43:40.457031+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: 'driver',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/driver',
+      timestamp: '2025-08-14T10:43:42.220702+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: 'driver',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-16T14:29:37.800303+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-17T09:01:40.405650+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-17T09:10:06.037243+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-17T17:50:14.578393+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-17T17:50:15.620771+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-18T16:35:07.562273+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-18T17:06:43.475963+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-18T17:44:41.272965+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-19T10:26:43.346491+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/feature_views/driver_hourly_stats',
+      timestamp: '2025-08-19T10:56:50.210598+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'feature_views',
+      object_name: 'driver_hourly_stats',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-21T18:17:04.767932+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+    {
+      path: '/api/v1/entities/__dummy',
+      timestamp: '2025-08-25T14:05:27.209125+00:00',
+      project: 'rbac',
+      user: 'anonymous',
+      object: 'entities',
+      object_name: '__dummy',
+      method: 'GET',
+    },
+  ],
+  pagination: {
+    totalCount: 16,
+  },
+  ...partial,
+});
+
+export const mockResourceCounts = (
+  partial?: Partial<MetricsCountResponse>,
+): MetricsCountResponse => ({
+  project: 'rbac',
+  counts: {
+    entities: 2,
+    dataSources: 3,
+    savedDatasets: 0,
+    features: 10,
+    featureViews: 2,
+    featureServices: 3,
+  },
+  ...partial,
+});

--- a/packages/feature-store/src/api/custom.ts
+++ b/packages/feature-store/src/api/custom.ts
@@ -7,6 +7,11 @@ import { Features, FeaturesList } from '../types/features';
 import { ProjectList } from '../types/featureStoreProjects';
 import { FeatureService, FeatureServicesList } from '../types/featureServices';
 import { FeatureView, FeatureViewsList } from '../types/featureView';
+import {
+  MetricsCountResponse,
+  PopularTagsResponse,
+  RecentlyVisitedResponse,
+} from '../types/metrics';
 
 export const listFeatureStoreProject =
   (hostPath: string) =>
@@ -148,4 +153,58 @@ export const getFeatureViewByName =
     )}?project=${encodeURIComponent(project)}&include_relationships=true`;
 
     return handleFeatureStoreFailures<FeatureView>(proxyGET(hostPath, endpoint, opts));
+  };
+
+export const getMetricsResourceCount =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, project?: string): Promise<MetricsCountResponse> => {
+    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/metrics/resource_counts`;
+
+    if (project) {
+      endpoint = `/api/${FEATURE_STORE_API_VERSION}/metrics/resource_counts?project=${encodeURIComponent(
+        project,
+      )}`;
+    }
+
+    return handleFeatureStoreFailures<MetricsCountResponse>(proxyGET(hostPath, endpoint, opts));
+  };
+
+export const getPopularTags =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, project?: string, limit?: number): Promise<PopularTagsResponse> => {
+    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/metrics/popular_tags`;
+
+    const queryParams: string[] = [];
+    if (project) {
+      queryParams.push(`project=${encodeURIComponent(project)}`);
+    }
+    if (limit) {
+      queryParams.push(`limit=${limit}`);
+    }
+
+    if (queryParams.length > 0) {
+      endpoint += `?${queryParams.join('&')}`;
+    }
+
+    return handleFeatureStoreFailures<PopularTagsResponse>(proxyGET(hostPath, endpoint, opts));
+  };
+
+export const getRecentlyVisitedResources =
+  (hostPath: string) =>
+  (opts: K8sAPIOptions, project?: string, limit?: number): Promise<RecentlyVisitedResponse> => {
+    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/metrics/recently_visited`;
+
+    const queryParams: string[] = [];
+    if (project) {
+      queryParams.push(`project=${encodeURIComponent(project)}`);
+    }
+    if (limit) {
+      queryParams.push(`limit=${limit}`);
+    }
+
+    if (queryParams.length > 0) {
+      endpoint += `?${queryParams.join('&')}`;
+    }
+
+    return handleFeatureStoreFailures<RecentlyVisitedResponse>(proxyGET(hostPath, endpoint, opts));
   };

--- a/packages/feature-store/src/apiHooks/__tests__/useMetricsResourceCount.spec.ts
+++ b/packages/feature-store/src/apiHooks/__tests__/useMetricsResourceCount.spec.ts
@@ -1,0 +1,342 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFeatureStoreAPI } from '../../FeatureStoreContext';
+import useMetricsResourceCount from '../useMetricsResourceCount';
+import { MetricsCountResponse } from '../../types/metrics';
+
+jest.mock('../../FeatureStoreContext');
+const mockUseFeatureStoreAPI = useFeatureStoreAPI as jest.MockedFunction<typeof useFeatureStoreAPI>;
+
+jest.mock('@odh-dashboard/internal/utilities/useFetch');
+const mockUseFetch = jest.fn();
+
+describe('useMetricsResourceCount', () => {
+  const mockApi = {
+    getMetricsResourceCount: jest.fn(),
+  };
+
+  const mockMetricsResponse: MetricsCountResponse = {
+    total: {
+      entities: 6,
+      dataSources: 8,
+      savedDatasets: 9,
+      features: 41,
+      featureViews: 6,
+      featureServices: 12,
+    },
+    perProject: {
+      rbac: {
+        entities: 2,
+        dataSources: 3,
+        savedDatasets: 0,
+        features: 10,
+        featureViews: 2,
+        featureServices: 3,
+      },
+      // eslint-disable-next-line camelcase
+      credit_scoring_local: {
+        entities: 4,
+        dataSources: 5,
+        savedDatasets: 9,
+        features: 31,
+        featureViews: 4,
+        featureServices: 9,
+      },
+    },
+  };
+
+  const mockProjectMetricsResponse: MetricsCountResponse = {
+    project: 'rbac',
+    counts: {
+      entities: 2,
+      dataSources: 3,
+      savedDatasets: 0,
+      features: 10,
+      featureViews: 2,
+      featureServices: 3,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseFeatureStoreAPI.mockReturnValue({
+      api: mockApi,
+      apiAvailable: true,
+    } as unknown as ReturnType<typeof useFeatureStoreAPI>);
+  });
+
+  describe('when API is available', () => {
+    describe('without project parameter', () => {
+      it('should call getMetricsResourceCount without project parameter', async () => {
+        mockApi.getMetricsResourceCount.mockResolvedValue(mockMetricsResponse);
+        mockUseFetch.mockReturnValue({
+          data: mockMetricsResponse,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        });
+
+        renderHook(() => useMetricsResourceCount({}));
+
+        await waitFor(() => {
+          expect(mockApi.getMetricsResourceCount).toHaveBeenCalledWith(expect.any(Object));
+          expect(mockApi.getMetricsResourceCount).not.toHaveBeenCalledWith(
+            expect.any(Object),
+            'rbac',
+          );
+        });
+      });
+
+      it('should return metrics data for all projects', async () => {
+        mockApi.getMetricsResourceCount.mockResolvedValue(mockMetricsResponse);
+        mockUseFetch.mockReturnValue({
+          data: mockMetricsResponse,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        });
+
+        const { result } = renderHook(() => useMetricsResourceCount({}));
+
+        expect(result.current.data).toEqual(mockMetricsResponse);
+        expect(result.current.loaded).toBe(true);
+        expect(result.current.error).toBeUndefined();
+      });
+    });
+
+    describe('with project parameter', () => {
+      it('should call getMetricsResourceCount with project parameter', async () => {
+        mockApi.getMetricsResourceCount.mockResolvedValue(mockProjectMetricsResponse);
+        mockUseFetch.mockReturnValue({
+          data: mockProjectMetricsResponse,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        });
+
+        renderHook(() => useMetricsResourceCount({ project: 'rbac' }));
+
+        await waitFor(() => {
+          expect(mockApi.getMetricsResourceCount).toHaveBeenCalledWith(expect.any(Object), 'rbac');
+        });
+      });
+
+      it('should return metrics data for specific project', async () => {
+        mockApi.getMetricsResourceCount.mockResolvedValue(mockProjectMetricsResponse);
+        mockUseFetch.mockReturnValue({
+          data: mockProjectMetricsResponse,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        });
+
+        const { result } = renderHook(() => useMetricsResourceCount({ project: 'rbac' }));
+
+        expect(result.current.data).toEqual(mockProjectMetricsResponse);
+        expect(result.current.loaded).toBe(true);
+        expect(result.current.error).toBeUndefined();
+      });
+    });
+
+    describe('API call behavior', () => {
+      it('should handle successful API response', async () => {
+        mockApi.getMetricsResourceCount.mockResolvedValue(mockMetricsResponse);
+        mockUseFetch.mockReturnValue({
+          data: mockMetricsResponse,
+          loaded: true,
+          error: undefined,
+          refresh: jest.fn(),
+        });
+
+        const { result } = renderHook(() => useMetricsResourceCount({}));
+
+        expect(result.current.data).toEqual(mockMetricsResponse);
+        expect(result.current.loaded).toBe(true);
+      });
+
+      it('should handle API error', async () => {
+        const mockError = new Error('API Error');
+        mockApi.getMetricsResourceCount.mockRejectedValue(mockError);
+        mockUseFetch.mockReturnValue({
+          data: undefined,
+          loaded: false,
+          error: mockError,
+          refresh: jest.fn(),
+        });
+
+        const { result } = renderHook(() => useMetricsResourceCount({}));
+
+        expect(result.current.error).toEqual(mockError);
+        expect(result.current.loaded).toBe(false);
+      });
+    });
+  });
+
+  describe('when API is not available', () => {
+    it('should reject with error when API is not available', async () => {
+      mockUseFeatureStoreAPI.mockReturnValue({
+        api: mockApi,
+        apiAvailable: false,
+      } as unknown as ReturnType<typeof useFeatureStoreAPI>);
+
+      const { result } = renderHook(() => useMetricsResourceCount({}));
+
+      // The hook should still return the initial state even when API is not available
+      expect(result.current.data).toEqual({
+        total: undefined,
+        perProject: undefined,
+        project: undefined,
+        counts: undefined,
+      });
+    });
+  });
+
+  describe('initial state', () => {
+    it('should return initial state with undefined values', () => {
+      mockUseFetch.mockReturnValue({
+        data: {
+          total: undefined,
+          perProject: undefined,
+          project: undefined,
+          counts: undefined,
+        },
+        loaded: false,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useMetricsResourceCount({}));
+
+      expect(result.current.data).toEqual({
+        total: undefined,
+        perProject: undefined,
+        project: undefined,
+        counts: undefined,
+      });
+      expect(result.current.loaded).toBe(false);
+    });
+  });
+
+  describe('hook dependencies', () => {
+    it('should recreate callback when project changes', () => {
+      const { rerender } = renderHook(({ project }) => useMetricsResourceCount({ project }), {
+        initialProps: { project: 'rbac' },
+      });
+
+      rerender({ project: 'credit_scoring_local' });
+
+      // The callback should be recreated due to project dependency change
+      expect(mockApi.getMetricsResourceCount).not.toHaveBeenCalled();
+    });
+
+    it('should recreate callback when API changes', () => {
+      const { rerender } = renderHook(() => useMetricsResourceCount({}));
+
+      // Change the API reference
+      const newMockApi = { getMetricsResourceCount: jest.fn() };
+      mockUseFeatureStoreAPI.mockReturnValue({
+        api: newMockApi,
+        apiAvailable: true,
+      } as unknown as ReturnType<typeof useFeatureStoreAPI>);
+
+      rerender();
+
+      // The callback should be recreated due to API dependency change
+      expect(newMockApi.getMetricsResourceCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty project string', () => {
+      mockUseFetch.mockReturnValue({
+        data: mockMetricsResponse,
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useMetricsResourceCount({ project: '' }));
+
+      expect(result.current.data).toEqual(mockMetricsResponse);
+    });
+
+    it('should handle undefined project', () => {
+      mockUseFetch.mockReturnValue({
+        data: mockMetricsResponse,
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useMetricsResourceCount({ project: undefined }));
+
+      expect(result.current.data).toEqual(mockMetricsResponse);
+    });
+
+    it('should handle null project', () => {
+      mockUseFetch.mockReturnValue({
+        data: mockMetricsResponse,
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useMetricsResourceCount({ project: null as unknown as string }),
+      );
+
+      expect(result.current.data).toEqual(mockMetricsResponse);
+    });
+  });
+
+  describe('useFetch integration', () => {
+    it('should pass correct initial data to useFetch', () => {
+      const mockUseFetchImplementation = jest.fn().mockReturnValue({
+        data: mockMetricsResponse,
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      // Mock the actual useFetch module
+      jest.doMock('@odh-dashboard/internal/utilities/useFetch', () => ({
+        __esModule: true,
+        default: mockUseFetchImplementation,
+      }));
+
+      renderHook(() => useMetricsResourceCount({}));
+
+      expect(mockUseFetchImplementation).toHaveBeenCalledWith(
+        expect.any(Function),
+        {
+          total: undefined,
+          perProject: undefined,
+          project: undefined,
+          counts: undefined,
+        },
+        { initialPromisePurity: true },
+      );
+    });
+
+    it('should pass correct options to useFetch', () => {
+      const mockUseFetchImplementation = jest.fn().mockReturnValue({
+        data: mockMetricsResponse,
+        loaded: true,
+        error: undefined,
+        refresh: jest.fn(),
+      });
+
+      jest.doMock('@odh-dashboard/internal/utilities/useFetch', () => ({
+        __esModule: true,
+        default: mockUseFetchImplementation,
+      }));
+
+      renderHook(() => useMetricsResourceCount({}));
+
+      expect(mockUseFetchImplementation).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Object),
+        { initialPromisePurity: true },
+      );
+    });
+  });
+});

--- a/packages/feature-store/src/apiHooks/useFeatureStoreAPIState.tsx
+++ b/packages/feature-store/src/apiHooks/useFeatureStoreAPIState.tsx
@@ -11,6 +11,9 @@ import {
   getFeatureServices,
   getFeatureServiceByName,
   getFeatureViewByName,
+  getMetricsResourceCount,
+  getPopularTags,
+  getRecentlyVisitedResources,
 } from '../api/custom';
 import { FeatureStoreAPIs } from '../types/global';
 
@@ -30,6 +33,9 @@ const useFeatureStoreAPIState = (
       getFeatureServices: getFeatureServices(path),
       getFeatureServiceByName: getFeatureServiceByName(path),
       getFeatureViewByName: getFeatureViewByName(path),
+      getMetricsResourceCount: getMetricsResourceCount(path),
+      getPopularTags: getPopularTags(path),
+      getRecentlyVisitedResources: getRecentlyVisitedResources(path),
     }),
     [],
   );

--- a/packages/feature-store/src/apiHooks/useMetricsPopularTags.ts
+++ b/packages/feature-store/src/apiHooks/useMetricsPopularTags.ts
@@ -1,0 +1,46 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import useFetch, {
+  FetchStateCallbackPromise,
+  FetchStateObject,
+} from '@odh-dashboard/internal/utilities/useFetch';
+import { useFeatureStoreAPI } from '../FeatureStoreContext';
+import { PopularTagsResponse } from '../types/metrics';
+
+type UseMetricsPopularTagsProps = {
+  project?: string;
+  limit: number;
+};
+
+const useMetricsPopularTags = ({
+  project,
+  limit,
+}: UseMetricsPopularTagsProps): FetchStateObject<PopularTagsResponse> => {
+  const { api, apiAvailable } = useFeatureStoreAPI();
+
+  const call = React.useCallback<FetchStateCallbackPromise<PopularTagsResponse>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+
+      return api.getPopularTags(opts, project, limit);
+    },
+    [api, apiAvailable, project, limit],
+  );
+
+  return useFetch(
+    call,
+    {
+      popular_tags: [],
+      metadata: {
+        totalFeatureViews: 0,
+        totalTags: 0,
+        limit,
+      },
+    },
+    { initialPromisePurity: true },
+  );
+};
+
+export default useMetricsPopularTags;

--- a/packages/feature-store/src/apiHooks/useMetricsResourceCount.ts
+++ b/packages/feature-store/src/apiHooks/useMetricsResourceCount.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import useFetch, {
+  FetchStateCallbackPromise,
+  FetchStateObject,
+} from '@odh-dashboard/internal/utilities/useFetch';
+import { useFeatureStoreAPI } from '../FeatureStoreContext';
+import { MetricsCountResponse } from '../types/metrics';
+
+type UseMetricsResourceCountProps = {
+  project?: string;
+};
+
+const useMetricsResourceCount = ({
+  project,
+}: UseMetricsResourceCountProps): FetchStateObject<MetricsCountResponse> => {
+  const { api, apiAvailable } = useFeatureStoreAPI();
+
+  const call = React.useCallback<FetchStateCallbackPromise<MetricsCountResponse>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      if (project) {
+        return api.getMetricsResourceCount(opts, project);
+      }
+
+      return api.getMetricsResourceCount(opts);
+    },
+    [api, apiAvailable, project],
+  );
+
+  return useFetch(
+    call,
+    {
+      total: undefined,
+      perProject: undefined,
+      project: undefined,
+      counts: undefined,
+    },
+    { initialPromisePurity: true },
+  );
+};
+
+export default useMetricsResourceCount;

--- a/packages/feature-store/src/apiHooks/useRecentlyVisitedResources.ts
+++ b/packages/feature-store/src/apiHooks/useRecentlyVisitedResources.ts
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import useFetch, {
+  FetchStateCallbackPromise,
+  FetchStateObject,
+} from '@odh-dashboard/internal/utilities/useFetch';
+import { useFeatureStoreAPI } from '../FeatureStoreContext';
+import { RecentlyVisitedResponse } from '../types/metrics';
+
+type UseRecentlyVisitedResourcesProps = {
+  project?: string;
+  limit: number;
+};
+
+const useRecentlyVisitedResources = ({
+  project,
+  limit,
+}: UseRecentlyVisitedResourcesProps): FetchStateObject<RecentlyVisitedResponse> => {
+  const { api, apiAvailable } = useFeatureStoreAPI();
+
+  const call = React.useCallback<FetchStateCallbackPromise<RecentlyVisitedResponse>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+
+      return api.getRecentlyVisitedResources(opts, project, limit);
+    },
+    [api, apiAvailable, project, limit],
+  );
+
+  return useFetch(
+    call,
+    {
+      visits: [],
+      pagination: {
+        totalCount: 0,
+      },
+    },
+    { initialPromisePurity: true },
+  );
+};
+
+export default useRecentlyVisitedResources;

--- a/packages/feature-store/src/const.ts
+++ b/packages/feature-store/src/const.ts
@@ -20,3 +20,8 @@ export enum FeatureStoreSections {
 }
 
 export const hasContent = (value: string): boolean => !!value.trim().length;
+
+export enum FeatureStoreTabs {
+  METRICS = 'Metrics',
+  LINEAGE = 'Lineage',
+}

--- a/packages/feature-store/src/screens/metrics/MetricCards.tsx
+++ b/packages/feature-store/src/screens/metrics/MetricCards.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Content,
+  ContentVariants,
+  Flex,
+  Gallery,
+  GalleryItem,
+  Skeleton,
+  Stack,
+  StackItem,
+  Truncate,
+} from '@patternfly/react-core';
+import TruncatedText from '@odh-dashboard/internal/components/TruncatedText';
+import HeaderIcon from '@odh-dashboard/internal/concepts/design/HeaderIcon';
+import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
+import { MetricCardItem, processMetricsData } from './utils';
+import { MetricsCountResponse } from '../../types/metrics';
+
+type MetricCardsProps = {
+  metricsData?: MetricsCountResponse;
+  loaded: boolean;
+};
+
+const MetricCard = ({ item, loaded }: { item: MetricCardItem; loaded: boolean }) => {
+  const totalCount = item.count;
+  return (
+    <Card isFullHeight data-testid={`feature-store-metrics-card-${item.title.toLowerCase()}`}>
+      <CardHeader>
+        <CardTitle>
+          <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <HeaderIcon type={ProjectObjectType.project} />
+            <Truncate content={item.title} />
+          </Flex>
+        </CardTitle>
+        <Content component={ContentVariants.small}>
+          <TruncatedText maxLines={3} content={item.description} />
+        </Content>
+      </CardHeader>
+      <CardBody style={{ paddingBottom: '16px' }}>
+        <Stack hasGutter={false}>
+          <StackItem isFilled />
+          <StackItem>
+            {loaded ? (
+              <Content style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>{totalCount}</Content>
+            ) : (
+              <Skeleton width="15%" height="1.5rem" />
+            )}
+          </StackItem>
+        </Stack>
+      </CardBody>
+      <CardFooter>
+        {loaded ? (
+          totalCount > 0 ? (
+            <Link to={item.route} aria-label={`Go to ${item.title} page`}>
+              Go to <b>{item.title}</b>
+            </Link>
+          ) : (
+            <Content component={ContentVariants.p}>No available {item.title.toLowerCase()}</Content>
+          )
+        ) : (
+          <Skeleton width="75%" height="1.5rem" />
+        )}
+      </CardFooter>
+    </Card>
+  );
+};
+
+const MetricCards: React.FC<MetricCardsProps> = ({ metricsData, loaded }) => {
+  const metricItems = React.useMemo(
+    () => (metricsData ? processMetricsData(metricsData) : []),
+    [metricsData],
+  );
+
+  return (
+    <Gallery hasGutter>
+      {metricItems.map((item: MetricCardItem) => (
+        <GalleryItem key={item.title}>
+          <MetricCard item={item} loaded={loaded} />
+        </GalleryItem>
+      ))}
+    </Gallery>
+  );
+};
+
+export default MetricCards;

--- a/packages/feature-store/src/screens/metrics/Metrics.tsx
+++ b/packages/feature-store/src/screens/metrics/Metrics.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { PageSection } from '@patternfly/react-core';
+import MetricCards from './MetricCards';
+import PopularTags from './PopularTags';
+import RecentlyVisitedResources from './RecentlyVisitedResources';
+import { useFeatureStoreProject } from '../../FeatureStoreContext';
+import useMetricsResourceCount from '../../apiHooks/useMetricsResourceCount';
+
+const Metrics: React.FC = () => {
+  const { currentProject } = useFeatureStoreProject();
+  const { data: metricsResourceCount, loaded: metricsResourceCountLoaded } =
+    useMetricsResourceCount(currentProject ? { project: currentProject } : {});
+
+  return (
+    <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }}>
+      <MetricCards metricsData={metricsResourceCount} loaded={metricsResourceCountLoaded} />
+      <PopularTags project={currentProject} limit={4} />
+      <RecentlyVisitedResources project={currentProject} />
+    </PageSection>
+  );
+};
+
+export default Metrics;

--- a/packages/feature-store/src/screens/metrics/PopularTags.tsx
+++ b/packages/feature-store/src/screens/metrics/PopularTags.tsx
@@ -1,0 +1,182 @@
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+  Gallery,
+  GalleryItem,
+  List,
+  ListItem,
+  Skeleton,
+  Title,
+} from '@patternfly/react-core';
+import { PlusIcon, TagIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { EMPTY_STATE_MESSAGES } from './const';
+import useMetricsPopularTags from '../../apiHooks/useMetricsPopularTags';
+import { featureViewRoute } from '../../routes';
+import { PopularTag } from '../../types/metrics';
+
+type PopularTagsProps = {
+  project?: string;
+  limit: number;
+};
+
+const PopularTagCard = ({ tag }: { tag: PopularTag }) => {
+  return (
+    <Card
+      isFullHeight
+      data-testid={`feature-store-popular-tag-card-${tag.tag_key}-${tag.tag_value}`}
+    >
+      <CardHeader>
+        <Flex gap={{ default: 'gapSm' }}>
+          <FlexItem>
+            <TagIcon />
+          </FlexItem>
+          <FlexItem>
+            <CardTitle>{`${tag.tag_key}=${tag.tag_value}`}</CardTitle>
+          </FlexItem>
+        </Flex>
+      </CardHeader>
+      <CardBody style={{ paddingBottom: '16px' }}>
+        <Content component={ContentVariants.p} style={{ margin: '0' }}>
+          Feature Views:
+        </Content>
+        <List
+          className="pf-u-ps-sm"
+          style={{
+            margin: 0,
+            gap: 'var(--pf-t--global--spacer--xs)',
+          }}
+        >
+          {tag.feature_views.slice(0, 5).map((featureView, index) => (
+            <ListItem key={`${featureView.name}-${featureView.project}-${index}`}>
+              <Link
+                to={featureViewRoute(featureView.name, featureView.project)}
+                aria-label={`Go to ${featureView.name} feature view in ${featureView.project} project`}
+              >
+                {featureView.name}
+              </Link>
+            </ListItem>
+          ))}
+        </List>
+      </CardBody>
+      <CardFooter>
+        <Link
+          to="/featureStore/featureViews"
+          aria-label={`View all ${tag.total_feature_views} feature views for ${tag.tag_key}: ${tag.tag_value}`}
+        >
+          View all ({tag.total_feature_views})
+        </Link>
+      </CardFooter>
+    </Card>
+  );
+};
+
+const PopularTagsSkeleton = () => {
+  const fontSize = 'var(--pf-t--global--font--size--body--sm)';
+  return (
+    <Gallery hasGutter>
+      <GalleryItem>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Skeleton width="100%" height="1.5rem" />
+            </CardTitle>
+          </CardHeader>
+          <CardBody>
+            <List>
+              <ListItem>
+                <Skeleton width="50%" style={{ fontSize }} />
+              </ListItem>
+              <ListItem>
+                <Skeleton width="70%" style={{ fontSize }} />
+              </ListItem>
+              <ListItem>
+                <Skeleton width="70%" style={{ fontSize }} />
+              </ListItem>
+            </List>
+          </CardBody>
+          <CardFooter>
+            <Skeleton width="50%" style={{ fontSize }} />
+          </CardFooter>
+        </Card>
+      </GalleryItem>
+    </Gallery>
+  );
+};
+
+const PopularTags: React.FC<PopularTagsProps> = ({ project, limit = 4 }) => {
+  const { data, loaded, error } = useMetricsPopularTags({ project, limit });
+
+  const emptyState = (
+    <EmptyState
+      headingLevel="h6"
+      icon={PlusIcon}
+      titleText={EMPTY_STATE_MESSAGES.POPULAR_TAGS}
+      variant={EmptyStateVariant.lg}
+      data-testid="popular-tags-empty-state-title"
+    >
+      <EmptyStateBody data-testid="empty-state-body">
+        Create feature views in workbench.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+
+  const renderContent = () => {
+    if (error) {
+      return (
+        <Content component={ContentVariants.p} data-testid="error-loading-popular-tags">
+          Error loading popular tags
+        </Content>
+      );
+    }
+
+    if (!loaded) {
+      return (
+        <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>
+            <PopularTagsSkeleton />
+          </FlexItem>
+          <FlexItem>
+            <PopularTagsSkeleton />
+          </FlexItem>
+        </Flex>
+      );
+    }
+
+    if (data.popular_tags.length === 0) {
+      return emptyState;
+    }
+
+    return (
+      <Gallery hasGutter>
+        {data.popular_tags.map((tag: PopularTag, index: number) => (
+          <GalleryItem key={`${tag.tag_key}-${tag.tag_value}-${index}`}>
+            <PopularTagCard tag={tag} />
+          </GalleryItem>
+        ))}
+      </Gallery>
+    );
+  };
+
+  return (
+    <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+      <Title headingLevel="h3" data-testid="popular-tags-title">
+        Discover feature views by popular tags
+      </Title>
+      {renderContent()}
+    </Flex>
+  );
+};
+
+export default PopularTags;

--- a/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
+++ b/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
@@ -1,0 +1,115 @@
+import Table from '@odh-dashboard/internal/components/table/Table';
+import { relativeTime } from '@odh-dashboard/internal/utilities/time';
+import {
+  Bullseye,
+  capitalize,
+  Content,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { Td, Tr } from '@patternfly/react-table';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { recentlyVisitedResourcesColumns, EMPTY_STATE_MESSAGES } from './const';
+import { formatResourceType, getResourceRoute } from './utils';
+import useRecentlyVisitedResources from '../../apiHooks/useRecentlyVisitedResources';
+import { RecentlyVisitedResource } from '../../types/metrics';
+
+type RecentlyVisitedResourcesProps = {
+  project?: string;
+  limit?: number;
+};
+
+const RecentlyVisitedResourcesTableRow: React.FC<{
+  item: RecentlyVisitedResource;
+}> = ({ item }) => {
+  const resourceType = formatResourceType(item.object);
+  const resourceLink = getResourceRoute(resourceType, item.object_name, item.project);
+  return (
+    <Tr>
+      <Td dataLabel="Resource name">
+        <Link
+          to={resourceLink}
+          aria-label={`Go to ${item.object_name} ${resourceType} in ${item.project} project`}
+        >
+          {item.object_name}
+        </Link>
+      </Td>
+      <Td dataLabel="Resource type">{capitalize(resourceType)}</Td>
+      <Td dataLabel="Last viewed">
+        {relativeTime(Date.now(), new Date(item.timestamp).getTime())}
+      </Td>
+    </Tr>
+  );
+};
+
+const RecentlyVisitedResources: React.FC<RecentlyVisitedResourcesProps> = ({
+  project,
+  limit = 0,
+}) => {
+  const { data, loaded, error } = useRecentlyVisitedResources({ project, limit });
+
+  const emptyTableView = (
+    <EmptyState
+      headingLevel="h6"
+      icon={PlusIcon}
+      titleText={EMPTY_STATE_MESSAGES.RECENTLY_VISITED_RESOURCES}
+      variant={EmptyStateVariant.lg}
+      data-testid="recently-visited-resources-empty-state-title"
+    >
+      <EmptyStateBody data-testid="empty-state-body">
+        {EMPTY_STATE_MESSAGES.RECENTLY_VISITED_RESOURCES}
+      </EmptyStateBody>
+    </EmptyState>
+  );
+
+  const renderContent = () => {
+    if (!loaded) {
+      return (
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      );
+    }
+
+    if (error) {
+      return <Content>Error loading recently visited resources</Content>;
+    }
+
+    if (data.visits.length === 0) {
+      return emptyTableView;
+    }
+
+    return (
+      <Table
+        defaultSortColumn={2}
+        loading={!loaded}
+        data-testid="recently-visited-resources-table"
+        id="recently-visited-resources-table"
+        enablePagination
+        data={data.visits}
+        columns={recentlyVisitedResourcesColumns}
+        rowRenderer={(item, index) => (
+          <RecentlyVisitedResourcesTableRow key={`${item.object_name}-${index}`} item={item} />
+        )}
+        variant="compact"
+      />
+    );
+  };
+
+  return (
+    <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+      <Title headingLevel="h3" data-testid="recently-visited-resources-title">
+        Recently viewed resources
+      </Title>
+      {renderContent()}
+    </Flex>
+  );
+};
+
+export default RecentlyVisitedResources;

--- a/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
+++ b/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
@@ -149,7 +149,7 @@ describe('utils', () => {
 
       const result = processMetricsData(mockData);
 
-      expect(result[0].count).toBe(5); // Should use project counts, not total
+      expect(result[0].count).toBe(5);
       expect(result[1].count).toBe(3);
       expect(result[2].count).toBe(2);
       expect(result[3].count).toBe(10);
@@ -175,7 +175,7 @@ describe('utils', () => {
 
     it('should handle edge cases', () => {
       expect(formatResourceType('entities')).toBe('entity');
-      expect(formatResourceType('data_sources')).toBe('data_sources');
+      expect(formatResourceType('data_sources')).toBe('data sources');
     });
   });
 
@@ -204,7 +204,7 @@ describe('utils', () => {
     });
 
     it('should return correct route for data sources', () => {
-      const result = getResourceRoute('data_sources', mockResourceName, mockProject);
+      const result = getResourceRoute('data sources', mockResourceName, mockProject);
       expect(result).toBe(`/featureStore/dataSources/${mockResourceName}?project=${mockProject}`);
     });
 
@@ -219,39 +219,38 @@ describe('utils', () => {
     });
 
     it('should handle empty resource name', () => {
-      const result = getResourceRoute('entities', '', mockProject);
+      const result = getResourceRoute('entity', '', mockProject);
       expect(result).toBe(`/featureStore/entities/${mockProject}/`);
-    });
-
-    it('should handle empty project', () => {
-      const result = getResourceRoute('entities', mockResourceName, '');
-      expect(result).toBe(`/featureStore/entities//${mockResourceName}`);
     });
 
     it('should handle special characters in resource name and project', () => {
       const specialResourceName = 'test-resource-with-special-chars_123';
       const specialProject = 'test-project-with-special-chars_456';
 
-      const result = getResourceRoute('entities', specialResourceName, specialProject);
+      const result = getResourceRoute('entity', specialResourceName, specialProject);
       expect(result).toBe(`/featureStore/entities/${specialProject}/${specialResourceName}`);
     });
 
     it('should handle all resource type mappings', () => {
       const testCases = [
         {
-          resourceType: 'entities',
+          resourceType: 'entity',
           expectedRoute: `/featureStore/entities/${mockProject}/${mockResourceName}`,
         },
         {
-          resourceType: 'feature_views',
+          resourceType: 'feature views',
           expectedRoute: `/featureStore/featureViews/${mockProject}/${mockResourceName}`,
         },
         {
-          resourceType: 'saved_datasets',
+          resourceType: 'saved datasets',
           expectedRoute: `/featureStore/savedDatasets/${mockResourceName}?project=${mockProject}`,
         },
         {
-          resourceType: 'feature_services',
+          resourceType: 'data sources',
+          expectedRoute: `/featureStore/dataSources/${mockResourceName}?project=${mockProject}`,
+        },
+        {
+          resourceType: 'feature services',
           expectedRoute: `/featureStore/featureServices/${mockProject}/${mockResourceName}`,
         },
         {

--- a/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
+++ b/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
@@ -1,0 +1,270 @@
+import { processMetricsData, formatResourceType, getResourceRoute } from '../utils';
+import { MetricsCountResponse } from '../../../types/metrics';
+
+jest.mock('../../../routes', () => ({
+  featureEntityRoute: jest.fn((name, project) => `/featureStore/entities/${project}/${name}`),
+  featureRoute: jest.fn((name, project) => `/featureStore/features/${project}/${name}`),
+  featureServiceRoute: jest.fn(
+    (name, project) => `/featureStore/featureServices/${project}/${name}`,
+  ),
+  featureViewRoute: jest.fn((name, project) => `/featureStore/featureViews/${project}/${name}`),
+}));
+
+describe('utils', () => {
+  describe('processMetricsData', () => {
+    it('should process data with project and counts', () => {
+      const mockData: MetricsCountResponse = {
+        project: 'test-project',
+        counts: {
+          entities: 5,
+          dataSources: 3,
+          savedDatasets: 2,
+          features: 10,
+          featureViews: 4,
+          featureServices: 1,
+        },
+      };
+
+      const result = processMetricsData(mockData);
+
+      expect(result).toHaveLength(6);
+      expect(result[0]).toEqual({
+        title: 'Entities',
+        count: 5,
+        description:
+          'Entities are collections of related features and can be mapped to the domain of your use case.',
+        route: '/featureStore/entities',
+      });
+      expect(result[1]).toEqual({
+        title: 'Data sources',
+        count: 3,
+        description:
+          'Data sources such as tables or data warehouses contain the raw data from which features are extracted.',
+        route: '/featureStore/dataSources',
+      });
+      expect(result[2]).toEqual({
+        title: 'Datasets',
+        count: 2,
+        description:
+          'Datasets are point-in-time-correct snapshots of feature data used for training or validation.',
+        route: '/featureStore/savedDatasets',
+      });
+      expect(result[3]).toEqual({
+        title: 'Features',
+        count: 10,
+        description: 'A feature is a single data value used in model training or inference.',
+        route: '/featureStore/features',
+      });
+      expect(result[4]).toEqual({
+        title: 'Feature views',
+        count: 4,
+        description:
+          'A feature view is a logical group of time-series feature data as it is found in a data source.',
+        route: '/featureStore/featureViews',
+      });
+      expect(result[5]).toEqual({
+        title: 'Feature services',
+        count: 1,
+        description:
+          'A feature service is a logical group of features from one or more feature views.',
+        route: '/featureStore/featureServices',
+      });
+    });
+
+    it('should process data with total counts', () => {
+      const mockData: MetricsCountResponse = {
+        total: {
+          entities: 10,
+          dataSources: 6,
+          savedDatasets: 4,
+          features: 20,
+          featureViews: 8,
+          featureServices: 2,
+        },
+      };
+
+      const result = processMetricsData(mockData);
+
+      expect(result).toHaveLength(6);
+      expect(result[0].count).toBe(10);
+      expect(result[1].count).toBe(6);
+      expect(result[2].count).toBe(4);
+      expect(result[3].count).toBe(20);
+      expect(result[4].count).toBe(8);
+      expect(result[5].count).toBe(2);
+    });
+
+    it('should return zero counts when no data is provided', () => {
+      const mockData: MetricsCountResponse = {};
+
+      const result = processMetricsData(mockData);
+
+      expect(result).toHaveLength(6);
+      result.forEach((item) => {
+        expect(item.count).toBe(0);
+      });
+    });
+
+    it('should return zero counts when data has empty counts', () => {
+      const mockData: MetricsCountResponse = {
+        project: 'test-project',
+        counts: {
+          entities: 0,
+          dataSources: 0,
+          savedDatasets: 0,
+          features: 0,
+          featureViews: 0,
+          featureServices: 0,
+        },
+      };
+
+      const result = processMetricsData(mockData);
+
+      expect(result).toHaveLength(6);
+      result.forEach((item) => {
+        expect(item.count).toBe(0);
+      });
+    });
+
+    it('should prioritize project counts over total counts', () => {
+      const mockData: MetricsCountResponse = {
+        project: 'test-project',
+        counts: {
+          entities: 5,
+          dataSources: 3,
+          savedDatasets: 2,
+          features: 10,
+          featureViews: 4,
+          featureServices: 1,
+        },
+        total: {
+          entities: 100,
+          dataSources: 50,
+          savedDatasets: 25,
+          features: 200,
+          featureViews: 75,
+          featureServices: 10,
+        },
+      };
+
+      const result = processMetricsData(mockData);
+
+      expect(result[0].count).toBe(5); // Should use project counts, not total
+      expect(result[1].count).toBe(3);
+      expect(result[2].count).toBe(2);
+      expect(result[3].count).toBe(10);
+      expect(result[4].count).toBe(4);
+      expect(result[5].count).toBe(1);
+    });
+  });
+
+  describe('formatResourceType', () => {
+    it('should format known resource types', () => {
+      expect(formatResourceType('entities')).toBe('entity');
+      expect(formatResourceType('feature_views')).toBe('feature views');
+      expect(formatResourceType('saved_datasets')).toBe('saved datasets');
+      expect(formatResourceType('feature_services')).toBe('feature services');
+      expect(formatResourceType('features')).toBe('features');
+    });
+
+    it('should return original string for unknown resource types', () => {
+      expect(formatResourceType('unknown_type')).toBe('unknown_type');
+      expect(formatResourceType('custom_resource')).toBe('custom_resource');
+      expect(formatResourceType('')).toBe('');
+    });
+
+    it('should handle edge cases', () => {
+      expect(formatResourceType('entities')).toBe('entity');
+      expect(formatResourceType('data_sources')).toBe('data_sources'); // Not in resourceTypeMap
+    });
+  });
+
+  describe('getResourceRoute', () => {
+    const mockProject = 'test-project';
+    const mockResourceName = 'test-resource';
+
+    it('should return correct route for feature views', () => {
+      const result = getResourceRoute('feature views', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/featureViews/${mockProject}/${mockResourceName}`);
+    });
+
+    it('should return correct route for entities', () => {
+      const result = getResourceRoute('entity', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/entities/${mockProject}/${mockResourceName}`);
+    });
+
+    it('should return correct route for feature services', () => {
+      const result = getResourceRoute('feature services', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/featureServices/${mockProject}/${mockResourceName}`);
+    });
+
+    it('should return correct route for saved datasets', () => {
+      const result = getResourceRoute('saved datasets', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/savedDatasets/${mockResourceName}?project=${mockProject}`);
+    });
+
+    it('should return correct route for data sources', () => {
+      const result = getResourceRoute('data_sources', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/dataSources/${mockResourceName}?project=${mockProject}`);
+    });
+
+    it('should return correct route for features', () => {
+      const result = getResourceRoute('features', mockResourceName, mockProject);
+      expect(result).toBe(`/featureStore/features/${mockProject}/${mockResourceName}`);
+    });
+
+    it('should return default route for unknown resource types', () => {
+      const result = getResourceRoute('unknown_type', mockResourceName, mockProject);
+      expect(result).toBe('#');
+    });
+
+    it('should handle empty resource name', () => {
+      const result = getResourceRoute('entities', '', mockProject);
+      expect(result).toBe(`/featureStore/entities/${mockProject}/`);
+    });
+
+    it('should handle empty project', () => {
+      const result = getResourceRoute('entities', mockResourceName, '');
+      expect(result).toBe(`/featureStore/entities//${mockResourceName}`);
+    });
+
+    it('should handle special characters in resource name and project', () => {
+      const specialResourceName = 'test-resource-with-special-chars_123';
+      const specialProject = 'test-project-with-special-chars_456';
+
+      const result = getResourceRoute('entities', specialResourceName, specialProject);
+      expect(result).toBe(`/featureStore/entities/${specialProject}/${specialResourceName}`);
+    });
+
+    it('should handle all resource type mappings', () => {
+      // Test all the resource types that are mapped in resourceTypeMap
+      const testCases = [
+        {
+          resourceType: 'entities',
+          expectedRoute: `/featureStore/entities/${mockProject}/${mockResourceName}`,
+        },
+        {
+          resourceType: 'feature_views',
+          expectedRoute: `/featureStore/featureViews/${mockProject}/${mockResourceName}`,
+        },
+        {
+          resourceType: 'saved_datasets',
+          expectedRoute: `/featureStore/savedDatasets/${mockResourceName}?project=${mockProject}`,
+        },
+        {
+          resourceType: 'feature_services',
+          expectedRoute: `/featureStore/featureServices/${mockProject}/${mockResourceName}`,
+        },
+        {
+          resourceType: 'features',
+          expectedRoute: `/featureStore/features/${mockProject}/${mockResourceName}`,
+        },
+      ];
+
+      testCases.forEach(({ resourceType, expectedRoute }) => {
+        const result = getResourceRoute(resourceType, mockResourceName, mockProject);
+        expect(result).toBe(expectedRoute);
+      });
+    });
+  });
+});

--- a/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
+++ b/packages/feature-store/src/screens/metrics/__tests__/utils.spec.ts
@@ -175,7 +175,7 @@ describe('utils', () => {
 
     it('should handle edge cases', () => {
       expect(formatResourceType('entities')).toBe('entity');
-      expect(formatResourceType('data_sources')).toBe('data_sources'); // Not in resourceTypeMap
+      expect(formatResourceType('data_sources')).toBe('data_sources');
     });
   });
 
@@ -237,7 +237,6 @@ describe('utils', () => {
     });
 
     it('should handle all resource type mappings', () => {
-      // Test all the resource types that are mapped in resourceTypeMap
       const testCases = [
         {
           resourceType: 'entities',

--- a/packages/feature-store/src/screens/metrics/const.ts
+++ b/packages/feature-store/src/screens/metrics/const.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { SortableData } from '@odh-dashboard/internal/components/table/types';
-import { RecentlyVisitedResource } from 'src/types/metrics';
+import { RecentlyVisitedResource } from '../../types/metrics';
 
 export const recentlyVisitedResourcesColumns: SortableData<RecentlyVisitedResource>[] = [
   {

--- a/packages/feature-store/src/screens/metrics/const.ts
+++ b/packages/feature-store/src/screens/metrics/const.ts
@@ -31,6 +31,7 @@ export const resourceTypeMap: Record<string, string> = {
   entities: 'entity',
   feature_views: 'feature views',
   saved_datasets: 'saved datasets',
+  data_sources: 'data sources',
   feature_services: 'feature services',
   features: 'features',
 };

--- a/packages/feature-store/src/screens/metrics/const.ts
+++ b/packages/feature-store/src/screens/metrics/const.ts
@@ -1,0 +1,42 @@
+/* eslint-disable camelcase */
+import { SortableData } from '@odh-dashboard/internal/components/table/types';
+import { RecentlyVisitedResource } from 'src/types/metrics';
+
+export const recentlyVisitedResourcesColumns: SortableData<RecentlyVisitedResource>[] = [
+  {
+    field: 'object_name',
+    label: 'Resource name',
+    width: 25,
+    sortable: false,
+  },
+  {
+    field: 'object_type',
+    label: 'Resource type',
+    width: 25,
+    sortable: false,
+  },
+  {
+    field: 'timestamp',
+    label: 'Last viewed',
+    width: 25,
+    sortable: (a: RecentlyVisitedResource, b: RecentlyVisitedResource): number => {
+      const aTime = new Date(a.timestamp).getTime();
+      const bTime = new Date(b.timestamp).getTime();
+      return bTime - aTime;
+    },
+  },
+];
+
+export const resourceTypeMap: Record<string, string> = {
+  entities: 'entity',
+  feature_views: 'feature views',
+  saved_datasets: 'saved datasets',
+  feature_services: 'feature services',
+  features: 'features',
+};
+
+export const EMPTY_STATE_MESSAGES = {
+  RECENTLY_VISITED_RESOURCES: 'No recently visited resources.',
+  POPULAR_TAGS: 'No feature views yet',
+  METRICS: 'No metrics available',
+} as const;

--- a/packages/feature-store/src/screens/metrics/utils.ts
+++ b/packages/feature-store/src/screens/metrics/utils.ts
@@ -1,0 +1,115 @@
+import { resourceTypeMap } from './const';
+import {
+  featureEntityRoute,
+  featureRoute,
+  featureServiceRoute,
+  featureViewRoute,
+} from '../../routes';
+import { MetricsCountResponse } from '../../types/metrics';
+
+export type MetricCardData = {
+  entities: number;
+  dataSources: number;
+  savedDatasets: number;
+  features: number;
+  featureViews: number;
+  featureServices: number;
+};
+
+export type MetricCardItem = {
+  title: string;
+  count: number;
+  description: string;
+  route: string;
+  routeParams?: Record<string, string>;
+};
+
+export const processMetricsData = (data: MetricsCountResponse): MetricCardItem[] => {
+  let counts: MetricCardData;
+
+  if (data.project && data.counts) {
+    counts = data.counts;
+  } else if (data.total) {
+    counts = data.total;
+  } else {
+    counts = {
+      entities: 0,
+      dataSources: 0,
+      savedDatasets: 0,
+      features: 0,
+      featureViews: 0,
+      featureServices: 0,
+    };
+  }
+
+  return [
+    {
+      title: 'Entities',
+      count: counts.entities,
+      description:
+        'Entities are collections of related features and can be mapped to the domain of your use case.',
+      route: '/featureStore/entities',
+    },
+    {
+      title: 'Data sources',
+      count: counts.dataSources,
+      description:
+        'Data sources such as tables or data warehouses contain the raw data from which features are extracted.',
+      route: '/featureStore/dataSources',
+    },
+    {
+      title: 'Datasets',
+      count: counts.savedDatasets,
+      description:
+        'Datasets are point-in-time-correct snapshots of feature data used for training or validation.',
+      route: '/featureStore/savedDatasets',
+    },
+    {
+      title: 'Features',
+      count: counts.features,
+      description: 'A feature is a single data value used in model training or inference.',
+      route: '/featureStore/features',
+    },
+    {
+      title: 'Feature views',
+      count: counts.featureViews,
+      description:
+        'A feature view is a logical group of time-series feature data as it is found in a data source.',
+      route: '/featureStore/featureViews',
+    },
+    {
+      title: 'Feature services',
+      count: counts.featureServices,
+      description:
+        'A feature service is a logical group of features from one or more feature views.',
+      route: '/featureStore/featureServices',
+    },
+  ];
+};
+
+export const formatResourceType = (resourceType: string): string => {
+  return resourceTypeMap[resourceType] || resourceType;
+};
+
+export const getResourceRoute = (
+  resourceType: string,
+  resourceName: string,
+  project: string,
+): string => {
+  switch (resourceType) {
+    case resourceTypeMap.feature_views:
+      return featureViewRoute(resourceName, project);
+    case resourceTypeMap.entities:
+      return featureEntityRoute(resourceName, project);
+    case resourceTypeMap.feature_services:
+      return featureServiceRoute(resourceName, project);
+    case resourceTypeMap.saved_datasets:
+      return `/featureStore/savedDatasets/${resourceName}?project=${project}`;
+    case resourceTypeMap.data_sources:
+      return `/featureStore/dataSources/${resourceName}?project=${project}`;
+    case resourceTypeMap.features:
+      return featureRoute(resourceName, project);
+    default:
+      return '#';
+  }
+};

--- a/packages/feature-store/src/types/global.ts
+++ b/packages/feature-store/src/types/global.ts
@@ -3,6 +3,7 @@ import { GetFeatureByName, GetFeatures } from './features';
 import { GetProjects } from './featureStoreProjects';
 import { GetFeatureViews, GetFeatureViewsByName } from './featureView';
 import { GetFeatureServiceByName, GetFeatureServices } from './featureServices';
+import { GetMetricsResourceCount, GetPopularTags, GetRecentlyVisitedResources } from './metrics';
 
 export type FeatureStorePagination = {
   page: number;
@@ -76,4 +77,7 @@ export type FeatureStoreAPIs = {
   getFeatureServices: GetFeatureServices;
   getFeatureServiceByName: GetFeatureServiceByName;
   getFeatureViewByName: GetFeatureViewsByName;
+  getMetricsResourceCount: GetMetricsResourceCount;
+  getPopularTags: GetPopularTags;
+  getRecentlyVisitedResources: GetRecentlyVisitedResources;
 };

--- a/packages/feature-store/src/types/metrics.ts
+++ b/packages/feature-store/src/types/metrics.ts
@@ -1,0 +1,76 @@
+import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+
+export type ResourceCounts = {
+  entities: number;
+  dataSources: number;
+  savedDatasets: number;
+  features: number;
+  featureViews: number;
+  featureServices: number;
+};
+
+export type MetricsCountResponse = {
+  total?: ResourceCounts;
+  perProject?: Record<string, ResourceCounts>;
+  project?: string;
+  counts?: ResourceCounts;
+};
+
+export type PopularTagFeatureView = {
+  name: string;
+  project: string;
+};
+
+export type PopularTag = {
+  tag_key: string;
+  tag_value: string;
+  feature_views: PopularTagFeatureView[];
+  total_feature_views: number;
+};
+
+export type PopularTagsMetadata = {
+  totalFeatureViews: number;
+  totalTags: number;
+  limit: number;
+};
+
+export type PopularTagsResponse = {
+  popular_tags: PopularTag[];
+  metadata: PopularTagsMetadata;
+};
+
+export type RecentlyVisitedResource = {
+  path: string;
+  timestamp: string;
+  project: string;
+  user: string;
+  object: string;
+  object_name: string;
+  method: string;
+};
+
+export type RecentlyVisitedPagination = {
+  totalCount: number;
+};
+
+export type RecentlyVisitedResponse = {
+  visits: RecentlyVisitedResource[];
+  pagination: RecentlyVisitedPagination;
+};
+
+export type GetMetricsResourceCount = (
+  opts: K8sAPIOptions,
+  project?: string,
+) => Promise<MetricsCountResponse>;
+
+export type GetPopularTags = (
+  opts: K8sAPIOptions,
+  project?: string,
+  limit?: number,
+) => Promise<PopularTagsResponse>;
+
+export type GetRecentlyVisitedResources = (
+  opts: K8sAPIOptions,
+  project?: string,
+  limit?: number,
+) => Promise<RecentlyVisitedResponse>;


### PR DESCRIPTION
Closes 

1. [RHOAIENG-28424](https://issues.redhat.com/browse/RHOAIENG-28424)
2. [RHOAIENG-29693](https://issues.redhat.com/browse/RHOAIENG-29693)
3. [RHOAIENG-29694](https://issues.redhat.com/browse/RHOAIENG-29694)
4. [RHOAIENG-29695](https://issues.redhat.com/browse/RHOAIENG-29695)

[Figma Link for the overview page](https://www.figma.com/design/LmI633EHMv48MWUr5MXnsi/Feature-Store---GA?node-id=5787-110578&t=ezz3zCEeNyDDtCy1-4)

[Figma Link with the icons part currently under review](https://www.figma.com/design/LmI633EHMv48MWUr5MXnsi/Feature-Store---GA?node-id=6609-79709&t=ezz3zCEeNyDDtCy1-4)
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Contains the metrics tab on the overview page for feature store wiith loading state for the cards and the recently visited table 

https://github.com/user-attachments/assets/723265f9-298f-499b-871e-c24484122583

2. Empty state when there is no data

https://github.com/user-attachments/assets/19bddde1-113a-49dc-919c-d23fd10b54b1

3. Also contains the required redirection to the feature store objects.

**Note**:
1. The icons are still being worked on and will update them in a separate PR once we receive them from the branding team.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Go to the overview menu under the Feature store submenu in the side navbar

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Added required cypress and utility test cases

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature Store page replaced by an "Overview" with Metrics and Lineage tabs; default route now redirects to Overview.
  * Metrics dashboard: resource count cards, Popular Tags (linked feature views) and Recently Viewed table with project-aware fetching, loading/empty/error states, and navigable links.
  * New public APIs and React hooks to fetch metrics, popular tags, and recently viewed data.

* **Tests**
  * Comprehensive Cypress e2e suite and page helpers covering metrics rendering, project switching, empty/error states and navigation.
  * Unit tests and mocks for metrics utilities and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->