### PR TITLE
Serving refactor: show model in project details from yaml only

### DIFF
--- a/packages/model-serving/src/ServeModelsSection.tsx
+++ b/packages/model-serving/src/ServeModelsSection.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { ProjectDetailsContext } from '@odh-dashboard/internal/pages/projects/ProjectDetailsContext';
-import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
+import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
 import { Bullseye, Card, CardBody, Spinner } from '@patternfly/react-core';
 import CollapsibleSection from '@odh-dashboard/internal/concepts/design/CollapsibleSection';
 import {
   ModelDeploymentsProvider,
   ModelDeploymentsContext,
 } from './concepts/ModelDeploymentsContext';
-import { useProjectServingPlatform } from './concepts/useProjectServingPlatform';
+import {
+  useProjectServingPlatform,
+  type ModelServingPlatform,
+} from './concepts/useProjectServingPlatform';
 import ModelPlatformSection from './components/overview/ModelPlatformSection';
 import DeployedModelsSection from './components/overview/DeployedModelsSection';
 import { useAvailableClusterPlatforms } from './concepts/useAvailableClusterPlatforms';
-import { isModelServingPlatformExtension } from '../extension-points';
 
 const EmptyLoadingSection: React.FC = () => (
   <CollapsibleSection title="Serve models" data-testid="section-model-server">
@@ -25,25 +27,31 @@ const EmptyLoadingSection: React.FC = () => (
   </CollapsibleSection>
 );
 
-const ServeModelsSectionContent: React.FC = () => {
+const ServeModelsSectionContent: React.FC<{ platforms: ModelServingPlatform[] }> = ({
+  platforms,
+}) => {
   const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
-  const { clusterPlatforms, clusterPlatformsLoaded } = useAvailableClusterPlatforms();
 
-  if (!clusterPlatformsLoaded || !deploymentsLoaded) {
+  if (!deploymentsLoaded) {
     return <EmptyLoadingSection />;
   }
 
   const hasModels = !!deployments && deployments.length > 0;
   if (hasModels) {
-    return <DeployedModelsSection />;
+    return <DeployedModelsSection platforms={platforms} />;
   }
-  return <ModelPlatformSection platforms={clusterPlatforms} />;
+  return <ModelPlatformSection platforms={platforms} />;
 };
 
 const ServeModelsSection: React.FC = () => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
-  const platformExtensions = useExtensions(isModelServingPlatformExtension);
-  const { activePlatform } = useProjectServingPlatform(currentProject, platformExtensions);
+
+  const { clusterPlatforms, clusterPlatformsLoaded } = useAvailableClusterPlatforms();
+  const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);
+
+  if (!clusterPlatformsLoaded || !currentProject.metadata.name) {
+    return <EmptyLoadingSection />;
+  }
 
   // TODO: remove this once modelmesh and nim are fully supported plugins
   if (activePlatform?.properties.backport?.ServeModelsSection) {
@@ -60,7 +68,7 @@ const ServeModelsSection: React.FC = () => {
       modelServingPlatforms={activePlatform ? [activePlatform] : []}
       projects={[currentProject]}
     >
-      <ServeModelsSectionContent />
+      <ServeModelsSectionContent platforms={clusterPlatforms} />
     </ModelDeploymentsProvider>
   );
 };

--- a/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
+++ b/packages/model-serving/src/components/overview/DeployedModelsSection.tsx
@@ -28,11 +28,13 @@ import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/
 import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
 import { InferenceServiceModelState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import ResourceNameTooltip from '@odh-dashboard/internal/components/ResourceNameTooltip';
-import { useExtensions } from '@odh-dashboard/plugin-core';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
-import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
+import {
+  useProjectServingPlatform,
+  type ModelServingPlatform,
+} from '../../concepts/useProjectServingPlatform';
 import DeployedModelsDetails from '../deployments/DeployedModelsVersion';
-import { Deployment, isModelServingPlatformExtension } from '../../../extension-points';
+import { Deployment } from '../../../extension-points';
 import DeploymentStatus from '../deployments/DeploymentStatus';
 
 enum FilterStates {
@@ -182,10 +184,9 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
   );
 };
 
-const DeployedModelsSection: React.FC = () => {
-  const availablePlatforms = useExtensions(isModelServingPlatformExtension);
+const DeployedModelsSection: React.FC<{ platforms: ModelServingPlatform[] }> = ({ platforms }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
-  const { activePlatform } = useProjectServingPlatform(currentProject, availablePlatforms);
+  const { activePlatform } = useProjectServingPlatform(currentProject, platforms);
   const [filteredState, setFilteredState] = React.useState<FilterStates | undefined>();
 
   const platformLabel = activePlatform?.properties.enableCardText.enabledText;

--- a/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
+++ b/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
@@ -9,8 +9,10 @@ import type { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { SelectPlatformView } from './SelectPlatformView';
 import { NoModelsView } from './NoModelsView';
 import { ProjectDeploymentsTable } from './ProjectDeploymentsTable';
-import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
-import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
+import {
+  useProjectServingPlatform,
+  type ModelServingPlatform,
+} from '../../concepts/useProjectServingPlatform';
 import { ModelDeploymentsContext } from '../../concepts/ModelDeploymentsContext';
 import { DeployButton } from '../deploy/DeployButton';
 import { ResetPlatformButton } from '../platforms/ResetPlatformButton';
@@ -18,12 +20,8 @@ import { getDeploymentWizardRoute } from '../deploymentWizard/utils';
 
 const ModelsProjectDetailsView: React.FC<{
   project: ProjectKind;
-}> = ({ project }) => {
-  const {
-    clusterPlatforms: platforms,
-    clusterPlatformsLoaded,
-    clusterPlatformsError,
-  } = useAvailableClusterPlatforms();
+  platforms: ModelServingPlatform[];
+}> = ({ project, platforms }) => {
   const {
     deployments,
     loaded: deploymentsLoaded,
@@ -40,8 +38,7 @@ const ModelsProjectDetailsView: React.FC<{
     clearProjectPlatformError,
   } = useProjectServingPlatform(project, platforms);
 
-  const isLoading =
-    !project.metadata.name || !clusterPlatformsLoaded || (!!projectPlatform && !deploymentsLoaded);
+  const isLoading = !project.metadata.name || !deploymentsLoaded;
   const hasModels = !!deployments && deployments.length > 0;
 
   return (
@@ -63,7 +60,7 @@ const ModelsProjectDetailsView: React.FC<{
         ) : undefined
       }
       isLoading={isLoading}
-      loadError={deploymentsErrors?.[0] || clusterPlatformsError}
+      loadError={deploymentsErrors?.[0]}
       actions={
         hasModels && activePlatform
           ? [

--- a/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
+++ b/packages/model-serving/src/components/projectDetails/ModelsProjectDetailsView.tsx
@@ -46,7 +46,7 @@ const ModelsProjectDetailsView: React.FC<{
 
   return (
     <DetailsSection
-      objectType={ProjectObjectType.model}
+      objectType={hasModels ? ProjectObjectType.model : undefined}
       id={ProjectSectionID.MODEL_SERVER}
       title={hasModels ? 'Models and model servers' : undefined}
       popover={

--- a/packages/model-serving/src/concepts/ModelDeploymentsContext.tsx
+++ b/packages/model-serving/src/concepts/ModelDeploymentsContext.tsx
@@ -150,6 +150,10 @@ export const ModelDeploymentsProvider: React.FC<ModelDeploymentsProviderProps> =
             (w) => w.properties.platform === platform?.properties.id,
           );
 
+          if (!deploymentWatchersLoaded) {
+            return null;
+          }
+
           if (!platform || !watcher) {
             // If the project doesn't have model serving, this will set the loaded state to true for it
             return (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-32827

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Shows kserve deployments on a project without needing to select a platform
  - this works by autoselecting the platform `activePlatform` if there is only 1 available. Before, NIM was not being crossed off the list even when not enabled. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run
`oc new-project verify-yaml-deploy`
oc apply (or in the console make)
```
---
kind: InferenceService
apiVersion: serving.kserve.io/v1beta1
metadata:
  name: test-inference
  namespace: verify-yaml-deploy
spec:
  predictor:
    model:
      runtime: test-runtime
---
kind: ServingRuntime
apiVersion: serving.kserve.io/v1alpha1
metadata:
  name: test-runtime
  namespace: verify-yaml-deploy 
spec:
  containers:
    - name: kserve-container
``` 
You should see the `test-inference` deployment
<img width="975" height="350" alt="image" src="https://github.com/user-attachments/assets/f0548489-b60a-4f1e-a7f0-a1cec83e4621" />


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
The old code doesn't behave like this so it's hard to write a test for this while it's not enabled

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified loading and error display across model serving views, providing a consistent fallback while data loads.
- Bug Fixes
  - Prevents premature rendering when project or platform data isn’t ready, reducing flicker and transient errors.
  - More reliable deployments view by deferring watchers until extensions are fully loaded.
- Refactor
  - Streamlined platform detection to use cluster platform data passed through components.
  - Simplified component props and loading logic for clearer data flow and improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->