### PR TITLE
Update advanced / standard vocab

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployKserveRaw.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployKserveRaw.cy.ts
@@ -55,7 +55,7 @@ describe('[Product Bug: RHOAIENG-31261] Verify a user can deploy KServe Raw Depl
   });
 
   it(
-    'Verify model deployment with Standard deployment mode (KServe Raw)',
+    'Verify model deployment with KServe RawDeployment mode',
     {
       tags: ['@Smoke', '@SmokeSet3', '@Dashboard', '@Modelserving', '@NonConcurrent', '@Bug'],
     },
@@ -79,20 +79,21 @@ describe('[Product Bug: RHOAIENG-31261] Verify a user can deploy KServe Raw Depl
       inferenceServiceModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
       inferenceServiceModal.findModelFrameworkSelect().click();
       inferenceServiceModal.findOpenVinoIROpSet13().click();
-      // Select Standard Deployment mode (KServe Raw)
-      cy.step(
-        'Verify deployment mode dropdown exists and Select Standard Deployment mode (KServe Raw)',
-      );
+      // Select KServe RawDeployment mode
+      cy.step('Verify deployment mode dropdown exists and Select KServe RawDeployment mode');
       inferenceServiceModal.findDeploymentModeSelect().should('exist');
-      inferenceServiceModal.findDeploymentModeSelect().findSelectOption('Standard').click();
       inferenceServiceModal
         .findDeploymentModeSelect()
-        .findSelectOption('Standard')
+        .findSelectOption('KServe RawDeployment')
+        .click();
+      inferenceServiceModal
+        .findDeploymentModeSelect()
+        .findSelectOption('KServe RawDeployment')
         .should('have.attr', 'aria-selected', 'true');
 
       inferenceServiceModal
         .findDeploymentModeSelect()
-        .findSelectOption('Advanced')
+        .findSelectOption('Knative Serverless')
         .should('have.attr', 'aria-selected', 'false');
       inferenceServiceModal.findLocationPathInput().type(modelFilePath);
       cy.step('Deploy the model');

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
@@ -140,17 +140,17 @@ describe('Cluster Settings', () => {
 
     modelServingSettings
       .findSinglePlatformDeploymentModeSelect()
-      .findSelectOption('Standard (No additional dependencies)')
+      .findSelectOption('KServe RawDeployment')
       .should('have.attr', 'aria-selected', 'true');
     modelServingSettings
       .findSinglePlatformDeploymentModeSelect()
-      .findSelectOption('Advanced (Serverless and Service Mesh)')
+      .findSelectOption('Knative Serverless')
       .should('have.attr', 'aria-selected', 'false');
 
     modelServingSettings.findSubmitButton().should('be.disabled');
     modelServingSettings
       .findSinglePlatformDeploymentModeSelect()
-      .findSelectOption('Advanced (Serverless and Service Mesh)')
+      .findSelectOption('Knative Serverless')
       .click();
 
     modelServingSettings.findSubmitButton().should('be.enabled');
@@ -159,11 +159,11 @@ describe('Cluster Settings', () => {
 
     modelServingSettings
       .findSinglePlatformDeploymentModeSelect()
-      .findSelectOption('Standard (No additional dependencies)')
+      .findSelectOption('KServe RawDeployment')
       .should('have.attr', 'aria-selected', 'false');
     modelServingSettings
       .findSinglePlatformDeploymentModeSelect()
-      .findSelectOption('Advanced (Serverless and Service Mesh)')
+      .findSelectOption('Knative Serverless')
       .should('have.attr', 'aria-selected', 'true');
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -1901,9 +1901,9 @@ describe('Serving Runtime List', () => {
       kserveModal.findLocationPathInput().type('test-model/');
       kserveModal.findSubmitButton().should('be.enabled');
       // raw
-      kserveModal.findDeploymentModeSelect().should('contain.text', 'Advanced');
+      kserveModal.findDeploymentModeSelect().should('contain.text', 'Knative Serverless');
 
-      // Test advanced mode replica settings
+      // Test Knative Serverless mode replica settings
       kserveModal.findMinReplicasInput().should('have.value', '1');
       kserveModal.findMinReplicasPlusButton().should('be.disabled');
       kserveModal.findMaxReplicasInput().should('have.value', '1');
@@ -1932,7 +1932,7 @@ describe('Serving Runtime List', () => {
       kserveModal.findMaxReplicasInput().clear().type('100');
       kserveModal.findMaxReplicasInput().should('have.value', '99');
       kserveModal.findMaxReplicasPlusButton().should('be.disabled');
-      kserveModal.findDeploymentModeSelect().findSelectOption('Standard').click();
+      kserveModal.findDeploymentModeSelect().findSelectOption('KServe RawDeployment').click();
 
       // test submitting form, the modal should close to indicate success.
       kserveModal.findSubmitButton().click();

--- a/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
+++ b/frontend/src/pages/clusterSettings/ModelServingPlatformSettings.tsx
@@ -8,9 +8,12 @@ import {
   Flex,
   FlexItem,
   FormGroup,
+  Icon,
+  Popover,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import SettingSection from '#~/components/SettingSection';
 import SimpleSelect, { SimpleSelectOption } from '#~/components/SimpleSelect';
 import { ModelServingPlatformEnabled } from '#~/types';
@@ -77,12 +80,12 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
   const options: SimpleSelectOption[] = [
     {
       key: DeploymentMode.RawDeployment,
-      label: 'Standard (No additional dependencies)',
+      label: 'KServe RawDeployment',
       isDisabled: !allowedToPatchDSC,
     },
     {
       key: DeploymentMode.Serverless,
-      label: 'Advanced (Serverless and Service Mesh)',
+      label: 'Knative Serverless',
       isDisabled: !isServerlessAvailable || !allowedToPatchDSC,
     },
   ];
@@ -147,7 +150,40 @@ const ModelServingPlatformSettings: React.FC<ModelServingPlatformSettingsProps> 
                   fieldId="default-deployment-mode-select"
                   label="Default deployment mode"
                   labelHelp={
-                    <DashboardHelpTooltip content="Deployment modes define which technology stack will be used to deploy a model, offering different levels of management and scalability. The default deployment mode will be automatically selected during deployment." />
+                    <Popover
+                      bodyContent={
+                        <>
+                          <div>
+                            The selected deployment mode determines how the model server runs in
+                            your environment. The default deployment mode will be automatically
+                            selected for users during deployment.
+                          </div>
+                          <ul
+                            style={{
+                              listStyleType: 'disc',
+                              paddingLeft: '1.5rem',
+                              marginTop: '0.5rem',
+                              marginBottom: 0,
+                            }}
+                          >
+                            <li>
+                              <strong>Knative Serverless</strong>: Autoscale to and from zero based
+                              on request volume with minimal customization. Recommended for most
+                              workloads.
+                            </li>
+                            <li>
+                              <strong>KServe RawDeployment</strong>: Always running with no
+                              autoscaling. Use for custom serving setups or if your model needs to
+                              stay active.
+                            </li>
+                          </ul>
+                        </>
+                      }
+                    >
+                      <Icon aria-label="Deployment mode info" role="button">
+                        <OutlinedQuestionCircleIcon />
+                      </Icon>
+                    </Popover>
                   }
                 >
                   <SimpleSelect

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/KServeDeploymentModeDropdown.tsx
@@ -13,11 +13,11 @@ type Props = {
 export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw, isDisabled }) => {
   const options: SimpleSelectOption[] = [
     {
-      label: `Standard`,
+      label: `KServe RawDeployment`,
       key: DeploymentMode.RawDeployment,
     },
     {
-      label: `Advanced`,
+      label: `Knative Serverless`,
       key: DeploymentMode.Serverless,
     },
   ];
@@ -31,7 +31,10 @@ export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw,
         <Popover
           bodyContent={
             <>
-              <div>Deployment modes determine the technology used to deploy your model:</div>
+              <div>
+                The selected deployment mode determines how the model server runs in your
+                environment.
+              </div>
               <ul
                 style={{
                   listStyleType: 'disc',
@@ -41,12 +44,12 @@ export const KServeDeploymentModeDropdown: React.FC<Props> = ({ isRaw, setIsRaw,
                 }}
               >
                 <li>
-                  <strong>Advanced</strong>: Uses Knative Serverless but requires some manual
-                  customization. Supports autoscaling.
+                  <strong>Knative Serverless</strong>: Autoscale to and from zero based on request
+                  volume with minimal customization. Recommended for most workloads.
                 </li>
                 <li>
-                  <strong>Standard</strong>: Uses Kubernetes resources with fewer dependencies and a
-                  simpler setup. Does not support autoscaling.
+                  <strong>KServe RawDeployment</strong>: Always running with no autoscaling. Use for
+                  custom serving setups or if your model needs to stay active.
                 </li>
               </ul>
             </>


### PR DESCRIPTION
Closes: [RHOAIENG-32741](https://issues.redhat.com/browse/RHOAIENG-32741)

## Description
Updates the vocab for advanced and standard deployment, as well as the tooltips associated with those deployment modes.

## How Has This Been Tested?
Tested locally.

- In the cluster settings under model serving platform, the name and tooltip for default deployment mode is updated.
- When deploying a model, at the deployment mode section. Names and tooltip updated.

## Test Impact
Update Cypress tests to reflect changes

## Screenshots
Before:
<img width="362" height="181" alt="Screenshot 2025-08-11 at 4 10 23 PM" src="https://github.com/user-attachments/assets/faf78f89-b2db-4769-be3a-36a9f59368a0" />
After:
<img width="299" height="159" alt="Screenshot 2025-08-26 at 10 50 28 AM" src="https://github.com/user-attachments/assets/6d84b723-c65f-4c80-9e63-4aecff259c11" />

Before:
<img width="420" height="256" alt="Screenshot 2025-08-11 at 4 10 17 PM" src="https://github.com/user-attachments/assets/20a39616-e17a-45e1-9b79-af76f5b52752" />
After:
<img width="436" height="401" alt="Screenshot 2025-08-26 at 10 50 43 AM" src="https://github.com/user-attachments/assets/224aaadd-8840-491e-a1b7-a2df08d46fd0" />

Before:
<img width="318" height="163" alt="Screenshot 2025-08-11 at 4 09 46 PM" src="https://github.com/user-attachments/assets/2404666d-94a6-4246-a72e-2ff752911645" />
After:
<img width="592" height="198" alt="Screenshot 2025-08-26 at 10 51 35 AM" src="https://github.com/user-attachments/assets/d3da3997-5c7d-4725-be63-a0f816cbf916" />

Before:
<img width="390" height="288" alt="Screenshot 2025-08-11 at 4 09 39 PM" src="https://github.com/user-attachments/assets/59d6b0ef-1b1b-4eed-bbbd-56923bfe9b2b" />
After:
<img width="399" height="328" alt="Screenshot 2025-08-26 at 10 52 02 AM" src="https://github.com/user-attachments/assets/a84848b0-21b5-498c-a602-1b07ab927d2a" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Replaced inline tooltip with a question-icon popover explaining deployment modes in Model Serving settings and deployment dialogs.

* Documentation
  * Renamed deployment modes to “KServe RawDeployment” and “Knative Serverless.”
  * Clarified descriptions: Knative Serverless autoscales to/from zero; KServe RawDeployment is always-on. Improved ARIA label for the help popover.

* Tests
  * Updated Cypress and E2E tests to use the new labels and assertions for deployment mode selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->