### PR TITLE
feat: Add authentication button to Swagger UI for Bearer token support

### DIFF
--- a/frontend/packages/llama-stack-modular-ui/bff/internal/api/openapi_handler.go
+++ b/frontend/packages/llama-stack-modular-ui/bff/internal/api/openapi_handler.go
@@ -146,7 +146,22 @@ func (h *OpenAPIHandler) HandleSwaggerUI(w http.ResponseWriter, r *http.Request,
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
                 ],
-                layout: "StandaloneLayout"
+                layout: "StandaloneLayout",
+                // Enable authentication
+                onComplete: function() {
+                    // Add authentication button to the top bar
+                    const authBtn = ui.getSystem().authActions.authorize;
+                    if (authBtn) {
+                        // Trigger the authorize dialog
+                        authBtn();
+                    }
+                },
+                // Configure authentication
+                initOAuth: {
+                    clientId: "swagger-ui",
+                    realm: "swagger-ui",
+                    appName: "Llama Stack Modular UI API"
+                }
             });
         };
     </script>

--- a/frontend/packages/llama-stack-modular-ui/bff/openapi/src/llama-stack-modular-ui.yaml
+++ b/frontend/packages/llama-stack-modular-ui/bff/openapi/src/llama-stack-modular-ui.yaml
@@ -8,6 +8,11 @@ info:
     url: "https://www.apache.org/licenses/LICENSE-2.0"
 servers:
   - url: "http://localhost:8080"
+
+# Global security requirement - all endpoints require Bearer token by default
+security:
+  - Bearer: []
+
 paths:
   /healthcheck:
     summary: BFF service health check
@@ -35,9 +40,13 @@ paths:
     get:
       tags:
         - Models
+      security:
+        - Bearer: []
       responses:
         "200":
           $ref: "#/components/responses/ModelsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: listModels
@@ -52,6 +61,8 @@ paths:
     get:
       tags:
         - VectorStores
+      security:
+        - Bearer: []
       parameters:
         - name: limit
           in: query
@@ -77,6 +88,8 @@ paths:
           $ref: "#/components/responses/VectorStoresResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: listVectorStores
@@ -85,6 +98,8 @@ paths:
     post:
       tags:
         - VectorStores
+      security:
+        - Bearer: []
       requestBody:
         description: Vector store creation request (only name is required, all other parameters are optional)
         content:
@@ -97,6 +112,8 @@ paths:
           $ref: "#/components/responses/VectorStoreResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: createVectorStore
@@ -112,6 +129,8 @@ paths:
     post:
       tags:
         - Files
+      security:
+        - Bearer: []
       requestBody:
         description: Multipart form with file and vector store information
         content:
@@ -124,6 +143,8 @@ paths:
           $ref: "#/components/responses/FileUploadResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: uploadFile
@@ -138,6 +159,8 @@ paths:
     post:
       tags:
         - Responses
+      security:
+        - Bearer: []
       requestBody:
         description: Response creation request with comprehensive parameter support
         content:
@@ -150,6 +173,8 @@ paths:
           $ref: "#/components/responses/CreateResponseResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: createResponse
@@ -165,6 +190,8 @@ paths:
     post:
       tags:
         - CodeExporter
+      security:
+        - Bearer: []
       requestBody:
         description: Code generation request with configuration parameters
         content:
@@ -177,6 +204,8 @@ paths:
           $ref: "#/components/responses/CodeExportResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
       operationId: exportCode
@@ -192,6 +221,8 @@ paths:
     get:
       tags:
         - Kubernetes
+      security:
+        - Bearer: []
       responses:
         "200":
           $ref: "#/components/responses/NamespacesResponse"
@@ -217,6 +248,8 @@ paths:
     get:
       tags:
         - Kubernetes
+      security:
+        - Bearer: []
       parameters:
         - name: namespace
           in: query
@@ -241,6 +274,12 @@ paths:
       description: Gets the status of LlamaStack Distribution in the specified namespace.
 
 components:
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Bearer token authentication using OAuth2 JWT tokens
   schemas:
     HealthCheckModel:
       type: object


### PR DESCRIPTION
- Add Bearer token security scheme to OpenAPI specification
- Add security requirements to all protected endpoints
- Update Swagger UI configuration with authentication support
- Add onComplete function to automatically trigger authorization dialog
- Add OAuth configuration for better user experience
- All /genai/v1/* endpoints now require Bearer token authentication
- Health check endpoint remains unprotected for service monitoring

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
browse to: http://localhost:8080/openapi

you should see the swagger page with a padlock button that allows you to pass the bearer token.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<img width="1177" height="616" alt="image" src="https://github.com/user-attachments/assets/474d41a0-156f-47c1-9d30-54cfa39224b8" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - API docs UI now auto-opens the OAuth/authorize dialog and initializes OAuth settings for interactive auth.

- Security
  - JWT Bearer authentication enforced by default for most API endpoints.
  - Health check endpoint remains publicly accessible.

- Documentation
  - OpenAPI spec updated with global Bearer security and per-endpoint 401 Unauthorized responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->