### PR TITLE
Add hw profiles to deployment wizard

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -16,12 +16,14 @@ import {
   modelServingWizardEdit,
 } from '#~/__tests__/cypress/cypress/pages/modelServing';
 import {
+  HardwareProfileModel,
   InferenceServiceModel,
   ProjectModel,
   ServingRuntimeModel,
   TemplateModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { ServingRuntimePlatform } from '#~/types';
+import { mockGlobalScopedHardwareProfiles } from '#~/__mocks__/mockHardwareProfile';
 
 const initIntercepts = () => {
   cy.interceptOdh(
@@ -43,6 +45,11 @@ const initIntercepts = () => {
     }),
   );
   cy.interceptOdh('GET /api/components', null, []);
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'opendatahub' },
+    mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+  );
 
   cy.interceptK8sList(
     TemplateModel,
@@ -156,8 +163,8 @@ describe('Model Serving Deploy Wizard', () => {
       { model: InferenceServiceModel, ns: 'test-project' },
       mockK8sResourceList([
         mockInferenceServiceK8sResource({
-          hardwareProfileName: 'large-profile-1',
-          hardwareProfileNamespace: 'test-project',
+          hardwareProfileName: 'large-profile',
+          hardwareProfileNamespace: 'opendatahub',
           resources: {
             requests: {
               cpu: '4',
@@ -204,8 +211,8 @@ describe('Model Serving Deploy Wizard', () => {
     hardwareProfileSection.findHardwareProfileSearchSelector().should('be.visible');
     hardwareProfileSection
       .findHardwareProfileSearchSelector()
-      .should('contain.text', 'Large Profile-1');
-    hardwareProfileSection.findProjectScopedLabel().should('exist');
+      .should('contain.text', 'Large Profile');
+    hardwareProfileSection.findGlobalScopedLabel().should('exist');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
@@ -52,7 +52,7 @@ const useServingHardwareProfileConfig = (
     tolerations,
     nodeSelector,
     visibility,
-    isProjectScoped ? namespace : undefined,
+    namespace,
     hardwareProfileNamespace,
   );
 };

--- a/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useServingHardwareProfileConfig.ts
@@ -7,7 +7,6 @@ import {
 
 export const extractHardwareProfileConfigFromInferenceService = (
   inferenceService?: InferenceServiceKind | null,
-  isProjectScoped?: boolean,
 ): Parameters<typeof useHardwareProfileConfig> => {
   const legacyName =
     inferenceService?.metadata.annotations?.['opendatahub.io/legacy-hardware-profile-name'];
@@ -26,7 +25,7 @@ export const extractHardwareProfileConfigFromInferenceService = (
     tolerations,
     nodeSelector,
     [HardwareProfileFeatureVisibility.MODEL_SERVING],
-    isProjectScoped ? namespace : undefined,
+    namespace,
     hardwareProfileNamespace,
   ];
 };
@@ -44,7 +43,7 @@ const useServingHardwareProfileConfig = (
     visibility,
     namespace,
     hardwareProfileNamespace,
-  ] = extractHardwareProfileConfigFromInferenceService(inferenceService, isProjectScoped);
+  ] = extractHardwareProfileConfigFromInferenceService(inferenceService);
 
   return useHardwareProfileConfig(
     name,
@@ -52,7 +51,7 @@ const useServingHardwareProfileConfig = (
     tolerations,
     nodeSelector,
     visibility,
-    namespace,
+    isProjectScoped ? namespace : undefined,
     hardwareProfileNamespace,
   );
 };

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -76,6 +76,10 @@ const extensions: (
     properties: {
       platform: KSERVE_ID,
       useResources: () => import('./src/useKServeResources').then((m) => m.useKServeResources),
+      extractHardwareProfileConfig: () =>
+        import('./src/useKServeResources').then((m) => m.extractHardwareProfileConfig),
+      applyHardwareProfileToDeployment: () =>
+        import('./src/useKServeResources').then((m) => m.applyHardwareProfileToDeployment),
     },
   },
   {

--- a/packages/kserve/src/useKServeResources.ts
+++ b/packages/kserve/src/useKServeResources.ts
@@ -1,5 +1,7 @@
 import { useModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
 import type { ModelServingPodSpecOptionsState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
+import { extractHardwareProfileConfigFromInferenceService } from '@odh-dashboard/internal/concepts/hardwareProfiles/useServingHardwareProfileConfig';
+import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import type { KServeDeployment } from './deployments';
 
 export const useKServeResources = (
@@ -12,4 +14,19 @@ export const useKServeResources = (
   );
 
   return resources;
+};
+
+export const extractHardwareProfileConfig = (
+  kserveDeployment: KServeDeployment,
+): Parameters<typeof useHardwareProfileConfig> => {
+  return extractHardwareProfileConfigFromInferenceService(kserveDeployment.model);
+};
+
+export const applyHardwareProfileToDeployment = (
+  kserveDeployment: KServeDeployment,
+  // TODO: use parameters to assemble hardware profile config
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  parameters: ReturnType<typeof useHardwareProfileConfig>,
+): KServeDeployment => {
+  return kserveDeployment;
 };

--- a/packages/kserve/src/useKServeResources.ts
+++ b/packages/kserve/src/useKServeResources.ts
@@ -24,7 +24,7 @@ export const extractHardwareProfileConfig = (
 
 export const applyHardwareProfileToDeployment = (
   kserveDeployment: KServeDeployment,
-  // TODO: use parameters to assemble hardware profile config
+  // TODO: use parameters to assemble hardware profile config for the deployment action
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   parameters: ReturnType<typeof useHardwareProfileConfig>,
 ): KServeDeployment => {

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -13,6 +13,7 @@ import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
+import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 
 export type DeploymentStatus = {
   state: ModelDeploymentState;
@@ -133,6 +134,12 @@ export type ModelServingDeploymentResourcesExtension<D extends Deployment = Depl
   {
     platform: D['modelServingPlatformId'];
     useResources: CodeRef<(deployment: D) => ModelServingPodSpecOptionsState | null>;
+    extractHardwareProfileConfig: CodeRef<
+      (deployment: D) => Parameters<typeof useHardwareProfileConfig> | null
+    >;
+    applyHardwareProfileToDeployment: CodeRef<
+      (deployment: D, parameters: ReturnType<typeof useHardwareProfileConfig>) => D
+    >;
   }
 >;
 export const isModelServingDeploymentResourcesExtension = <D extends Deployment = Deployment>(

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -74,7 +74,7 @@ const EditModelDeploymentPage: React.FC = () => {
               ? `Project ${namespace ?? ''} not found.`
               : !activePlatform
               ? 'No model serving platform is configured for this project.'
-              : 'Unknown error',
+              : 'Unable to edit model deployment.',
           )
         }
       />

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -15,17 +15,39 @@ import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { setupDefaults } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
 import { ModelDeploymentWizardData } from './useDeploymentWizard';
-import { Deployment } from '../../../extension-points';
+import { Deployment, isModelServingDeploymentResourcesExtension } from '../../../extension-points';
 import {
   ModelDeploymentsContext,
   ModelDeploymentsProvider,
 } from '../../concepts/ModelDeploymentsContext';
 import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
 import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
+import { useResolvedDeploymentExtension } from '../../concepts/extensionUtils';
+
+const ErrorContent: React.FC<{ error: Error }> = ({ error }) => {
+  const navigate = useNavigate();
+  return (
+    <Bullseye>
+      <EmptyState
+        headingLevel="h4"
+        icon={ExclamationCircleIcon}
+        titleText="Unable to edit model deployment"
+      >
+        <EmptyStateBody>{error.message}</EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button variant="primary" onClick={() => navigate(`/modelServing/`)}>
+              Return to model serving
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </Bullseye>
+  );
+};
 
 const EditModelDeploymentPage: React.FC = () => {
   const { namespace } = useParams();
-  const navigate = useNavigate();
 
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const currentProject = projects.find(byName(namespace));
@@ -44,30 +66,18 @@ const EditModelDeploymentPage: React.FC = () => {
 
   if (!currentProject || !activePlatform || clusterPlatformsError) {
     return (
-      <Bullseye>
-        <EmptyState
-          headingLevel="h4"
-          icon={ExclamationCircleIcon}
-          titleText="Unable to edit model deployment"
-        >
-          <EmptyStateBody>
-            {!currentProject
+      <ErrorContent
+        error={
+          clusterPlatformsError ??
+          new Error(
+            !currentProject
               ? `Project ${namespace ?? ''} not found.`
               : !activePlatform
               ? 'No model serving platform is configured for this project.'
-              : clusterPlatformsError
-              ? `Error loading cluster platforms: ${clusterPlatformsError.message}`
-              : 'Unable to edit model deployment.'}
-          </EmptyStateBody>
-          <EmptyStateFooter>
-            <EmptyStateActions>
-              <Button variant="primary" onClick={() => navigate(`/modelServing/`)}>
-                Return to model serving
-              </Button>
-            </EmptyStateActions>
-          </EmptyStateFooter>
-        </EmptyState>
-      </Bullseye>
+              : 'Unknown error',
+          )
+        }
+      />
     );
   }
 
@@ -82,16 +92,27 @@ export default EditModelDeploymentPage;
 
 const EditModelDeploymentContent: React.FC<{ project: ProjectKind }> = ({ project }) => {
   const { name: deploymentName } = useParams();
-  const { deployments, loaded } = React.useContext(ModelDeploymentsContext);
+  const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
 
   const existingDeployment = React.useMemo(() => {
     return deployments?.find((d: Deployment) => d.model.metadata.name === deploymentName);
   }, [deployments, deploymentName]);
 
+  const [
+    extractHWProfileExtension,
+    extractHWProfileExtensionLoaded,
+    extractHWProfileExtensionErrors,
+  ] = useResolvedDeploymentExtension(
+    isModelServingDeploymentResourcesExtension,
+    existingDeployment,
+  );
+
   const extractFormDataFromDeployment: (deployment: Deployment) => ModelDeploymentWizardData = (
     deployment: Deployment,
   ) => ({
     k8sNameDesc: setupDefaults({ initialData: deployment.model }),
+    hardwareProfile:
+      extractHWProfileExtension?.properties.extractHardwareProfileConfig(deployment) ?? undefined,
   });
 
   const formData = React.useMemo(() => {
@@ -101,7 +122,11 @@ const EditModelDeploymentContent: React.FC<{ project: ProjectKind }> = ({ projec
     return undefined;
   }, [existingDeployment, extractFormDataFromDeployment]);
 
-  if (!loaded) {
+  if (extractHWProfileExtensionErrors.length > 0) {
+    return <ErrorContent error={new Error('Unable to extract hardware profile config')} />;
+  }
+
+  if (!deploymentsLoaded || !extractHWProfileExtensionLoaded) {
     return (
       <Bullseye>
         <Spinner />

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -50,7 +50,10 @@ const EditModelDeploymentPage: React.FC = () => {
   const { namespace } = useParams();
 
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
-  const currentProject = projects.find(byName(namespace));
+  const currentProject = React.useMemo(
+    () => projects.find(byName(namespace)),
+    [projects, namespace],
+  );
 
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -8,8 +8,8 @@ import { getDeploymentWizardExitRoute } from './utils';
 import { useModelDeploymentWizard, type ModelDeploymentWizardData } from './useDeploymentWizard';
 import { useModelDeploymentWizardValidation } from './useDeploymentWizardValidation';
 import { ModelSourceStepContent } from './steps/ModelSourceStep';
-import { ModelDeploymentStepContent } from './steps/ModelDeploymentStep';
 import { WizardFooterWithDisablingNext } from './WizardFooterWithDisablingNext';
+import { ModelDeploymentStepContent } from './steps/ModelDeploymentStep';
 
 type ModelDeploymentWizardProps = {
   title: string;
@@ -33,61 +33,42 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
     navigate(getDeploymentWizardExitRoute(location.pathname));
   }, [navigate, location.pathname]);
 
-  return (
-    <ApplicationsPage title={title} description={description} loaded empty={false}>
-      <ModelDeploymentWizardContent
-        primaryButtonText={primaryButtonText}
-        existingData={existingData}
-        project={project}
-        exitWizard={exitWizard}
-      />
-    </ApplicationsPage>
-  );
-};
-
-type ModelDeploymentWizardContentProps = {
-  primaryButtonText: string;
-  existingData?: ModelDeploymentWizardData;
-  project: ProjectKind;
-  exitWizard: () => void;
-};
-const ModelDeploymentWizardContent: React.FC<ModelDeploymentWizardContentProps> = ({
-  primaryButtonText,
-  existingData,
-  project,
-  exitWizard,
-}) => {
   const wizardState = useModelDeploymentWizard(existingData);
   const validation = useModelDeploymentWizardValidation(wizardState.state);
 
   return (
-    <Wizard onClose={exitWizard} onSave={exitWizard} footer={<WizardFooterWithDisablingNext />}>
-      <WizardStep name="Source model" id="source-model-step">
-        <ModelSourceStepContent wizardState={wizardState} validation={validation.modelSource} />
-      </WizardStep>
-      <WizardStep
-        name="Model deployment"
-        id="model-deployment-step"
-        isDisabled={!validation.isModelSourceStepValid}
-      >
-        <ModelDeploymentStepContent projectName={project.metadata.name} wizardState={wizardState} />
-      </WizardStep>
-      <WizardStep
-        name="Advanced options"
-        id="advanced-options-step"
-        isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
-      >
-        Step 3 content
-      </WizardStep>
-      <WizardStep
-        name="Summary"
-        id="summary-step"
-        footer={{ nextButtonText: primaryButtonText }}
-        isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
-      >
-        Review step content
-      </WizardStep>
-    </Wizard>
+    <ApplicationsPage title={title} description={description} loaded empty={false}>
+      <Wizard onClose={exitWizard} onSave={exitWizard} footer={<WizardFooterWithDisablingNext />}>
+        <WizardStep name="Source model" id="source-model-step">
+          <ModelSourceStepContent wizardState={wizardState} validation={validation.modelSource} />
+        </WizardStep>
+        <WizardStep
+          name="Model deployment"
+          id="model-deployment-step"
+          isDisabled={!validation.isModelSourceStepValid}
+        >
+          <ModelDeploymentStepContent
+            projectName={project.metadata.name}
+            wizardState={wizardState}
+          />
+        </WizardStep>
+        <WizardStep
+          name="Advanced options"
+          id="advanced-options-step"
+          isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
+        >
+          Step 3 content
+        </WizardStep>
+        <WizardStep
+          name="Summary"
+          id="summary-step"
+          footer={{ nextButtonText: primaryButtonText }}
+          isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
+        >
+          Review step content
+        </WizardStep>
+      </Wizard>
+    </ApplicationsPage>
   );
 };
 

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -8,8 +8,8 @@ import { getDeploymentWizardExitRoute } from './utils';
 import { useModelDeploymentWizard, type ModelDeploymentWizardData } from './useDeploymentWizard';
 import { useModelDeploymentWizardValidation } from './useDeploymentWizardValidation';
 import { ModelSourceStepContent } from './steps/ModelSourceStep';
-import { WizardFooterWithDisablingNext } from './WizardFooterWithDisablingNext';
 import { ModelDeploymentStepContent } from './steps/ModelDeploymentStep';
+import { WizardFooterWithDisablingNext } from './WizardFooterWithDisablingNext';
 
 type ModelDeploymentWizardProps = {
   title: string;
@@ -33,42 +33,61 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
     navigate(getDeploymentWizardExitRoute(location.pathname));
   }, [navigate, location.pathname]);
 
-  const wizardState = useModelDeploymentWizard(existingData);
-  const validation = useModelDeploymentWizardValidation(wizardState.data);
-
   return (
     <ApplicationsPage title={title} description={description} loaded empty={false}>
-      <Wizard onClose={exitWizard} onSave={exitWizard} footer={<WizardFooterWithDisablingNext />}>
-        <WizardStep name="Source model" id="source-model-step">
-          <ModelSourceStepContent wizardState={wizardState} validation={validation.modelSource} />
-        </WizardStep>
-        <WizardStep
-          name="Model deployment"
-          id="model-deployment-step"
-          isDisabled={!validation.isModelSourceStepValid}
-        >
-          <ModelDeploymentStepContent
-            projectName={project.metadata.name}
-            wizardState={wizardState}
-          />
-        </WizardStep>
-        <WizardStep
-          name="Advanced options"
-          id="advanced-options-step"
-          isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
-        >
-          Step 3 content
-        </WizardStep>
-        <WizardStep
-          name="Summary"
-          id="summary-step"
-          footer={{ nextButtonText: primaryButtonText }}
-          isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
-        >
-          Review step content
-        </WizardStep>
-      </Wizard>
+      <ModelDeploymentWizardContent
+        primaryButtonText={primaryButtonText}
+        existingData={existingData}
+        project={project}
+        exitWizard={exitWizard}
+      />
     </ApplicationsPage>
+  );
+};
+
+type ModelDeploymentWizardContentProps = {
+  primaryButtonText: string;
+  existingData?: ModelDeploymentWizardData;
+  project: ProjectKind;
+  exitWizard: () => void;
+};
+const ModelDeploymentWizardContent: React.FC<ModelDeploymentWizardContentProps> = ({
+  primaryButtonText,
+  existingData,
+  project,
+  exitWizard,
+}) => {
+  const wizardState = useModelDeploymentWizard(existingData);
+  const validation = useModelDeploymentWizardValidation(wizardState.state);
+
+  return (
+    <Wizard onClose={exitWizard} onSave={exitWizard} footer={<WizardFooterWithDisablingNext />}>
+      <WizardStep name="Source model" id="source-model-step">
+        <ModelSourceStepContent wizardState={wizardState} validation={validation.modelSource} />
+      </WizardStep>
+      <WizardStep
+        name="Model deployment"
+        id="model-deployment-step"
+        isDisabled={!validation.isModelSourceStepValid}
+      >
+        <ModelDeploymentStepContent projectName={project.metadata.name} wizardState={wizardState} />
+      </WizardStep>
+      <WizardStep
+        name="Advanced options"
+        id="advanced-options-step"
+        isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
+      >
+        Step 3 content
+      </WizardStep>
+      <WizardStep
+        name="Summary"
+        id="summary-step"
+        footer={{ nextButtonText: primaryButtonText }}
+        isDisabled={!validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid}
+      >
+        Review step content
+      </WizardStep>
+    </Wizard>
   );
 };
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import HardwareProfileFormSection from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfileFormSection';
+import {
+  useHardwareProfileConfig,
+  type UseHardwareProfileConfigResult,
+} from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas/index';
+import { HardwareProfileFeatureVisibility } from '@odh-dashboard/internal/k8sTypes';
+import { ContainerResources, NodeSelector, Toleration } from '@odh-dashboard/internal/types';
+import type {
+  PodSpecOptions,
+  PodSpecOptionsState,
+} from '@odh-dashboard/internal/concepts/hardwareProfiles/types';
+import type { UseAcceleratorProfileFormResult } from '@odh-dashboard/internal/utilities/useAcceleratorProfileFormState.js';
+
+export const useModelServingHardwareProfileSection = (
+  name?: string,
+  resources?: ContainerResources,
+  tolerations?: Toleration[],
+  nodeSelector?: NodeSelector,
+  namespace?: string,
+  hardwareProfileNamespace?: string,
+): UseHardwareProfileConfigResult => {
+  const isProjectScoped = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
+
+  return useHardwareProfileConfig(
+    name,
+    resources,
+    tolerations,
+    nodeSelector,
+    [HardwareProfileFeatureVisibility.MODEL_SERVING],
+    isProjectScoped ? namespace : undefined,
+    hardwareProfileNamespace,
+  );
+};
+
+export const createAcceleratorProfileStub = (): UseAcceleratorProfileFormResult => ({
+  initialState: {
+    acceleratorProfiles: [],
+    acceleratorProfile: undefined,
+    count: 0,
+    unknownProfileDetected: false,
+  },
+  formData: {
+    profile: undefined,
+    count: 0,
+    useExistingSettings: false,
+  },
+  setFormData: () => {
+    // No-op: accelerator profiles are deprecated
+  },
+  resetFormData: () => {
+    // No-op: accelerator profiles are deprecated
+  },
+  loaded: true,
+  loadError: undefined,
+  refresh: () => Promise.resolve(undefined),
+});
+
+type ModelServingHardwareProfileSectionComponentProps = {
+  hardwareProfileConfig: UseHardwareProfileConfigResult;
+  project: string;
+  isEditing?: boolean;
+};
+
+export const ModelServingHardwareProfileSection: React.FC<
+  ModelServingHardwareProfileSectionComponentProps
+> = ({ hardwareProfileConfig, project, isEditing = false }) => {
+  const podSpecOptionsState: PodSpecOptionsState<PodSpecOptions> = React.useMemo(
+    () => ({
+      acceleratorProfile: {
+        initialState: {
+          acceleratorProfiles: [],
+          acceleratorProfile: undefined,
+          count: 0,
+          unknownProfileDetected: false,
+        },
+        formData: {
+          profile: undefined,
+          count: 0,
+          useExistingSettings: false,
+        },
+        setFormData: () => {
+          // No-op: accelerator profiles are deprecated
+        },
+        resetFormData: () => {
+          // No-op: accelerator profiles are deprecated
+        },
+        loaded: true,
+        loadError: undefined,
+        refresh: () => Promise.resolve(undefined),
+      },
+      hardwareProfile: hardwareProfileConfig,
+      podSpecOptions: {
+        resources: hardwareProfileConfig.formData.resources,
+        tolerations: undefined,
+        nodeSelector: undefined,
+      },
+    }),
+    [hardwareProfileConfig],
+  );
+
+  return (
+    <HardwareProfileFormSection
+      project={project}
+      podSpecOptionsState={podSpecOptionsState}
+      isEditing={isEditing}
+      isHardwareProfileSupported={() => true}
+      visibleIn={[HardwareProfileFeatureVisibility.MODEL_SERVING]}
+    />
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelServingHardwareProfileSection.tsx
@@ -68,28 +68,7 @@ export const ModelServingHardwareProfileSection: React.FC<
 > = ({ hardwareProfileConfig, project, isEditing = false }) => {
   const podSpecOptionsState: PodSpecOptionsState<PodSpecOptions> = React.useMemo(
     () => ({
-      acceleratorProfile: {
-        initialState: {
-          acceleratorProfiles: [],
-          acceleratorProfile: undefined,
-          count: 0,
-          unknownProfileDetected: false,
-        },
-        formData: {
-          profile: undefined,
-          count: 0,
-          useExistingSettings: false,
-        },
-        setFormData: () => {
-          // No-op: accelerator profiles are deprecated
-        },
-        resetFormData: () => {
-          // No-op: accelerator profiles are deprecated
-        },
-        loaded: true,
-        loadError: undefined,
-        refresh: () => Promise.resolve(undefined),
-      },
+      acceleratorProfile: createAcceleratorProfileStub(),
       hardwareProfile: hardwareProfileConfig,
       podSpecOptions: {
         resources: hardwareProfileConfig.formData.resources,

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -18,14 +18,17 @@ export const isValidModelType = (value: string): value is ModelTypeFieldData =>
 
 // Hooks
 
-export type ModelTypeField = [
-  data: ModelTypeFieldData | undefined,
-  setData: (data: ModelTypeFieldData) => void,
-];
+export type ModelTypeField = {
+  data: ModelTypeFieldData | undefined;
+  setData: (data: ModelTypeFieldData) => void;
+};
 export const useModelTypeField = (existingData?: ModelTypeFieldData): ModelTypeField => {
   const [modelType, setModelType] = React.useState<ModelTypeFieldData | undefined>(existingData);
 
-  return [modelType, setModelType];
+  return {
+    data: modelType,
+    setData: setModelType,
+  };
 };
 
 // Component

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -51,20 +51,20 @@ describe('ModelTypeSelectField', () => {
   describe('useModelTypeField hook', () => {
     it('should initialize with undefined by default', () => {
       const { result } = renderHook(() => useModelTypeField());
-      expect(result.current[0]).toBeUndefined();
+      expect(result.current.data).toBeUndefined();
     });
 
     it('should initialize with existing data', () => {
       const { result } = renderHook(() => useModelTypeField('predictive-model'));
-      expect(result.current[0]).toBe('predictive-model');
+      expect(result.current.data).toBe('predictive-model');
     });
 
     it('should update model type', () => {
       const { result } = renderHook(() => useModelTypeField());
       act(() => {
-        result.current[1]('generative-model');
+        result.current.setData('generative-model');
       });
-      expect(result.current[0]).toBe('generative-model');
+      expect(result.current.data).toBe('generative-model');
     });
   });
 

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -3,6 +3,7 @@ import { Form, FormSection } from '@patternfly/react-core';
 import K8sNameDescriptionField from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import ProjectSection from '../fields/ProjectSection';
+import { ModelServingHardwareProfileSection } from '../fields/ModelServingHardwareProfileSection';
 
 type ModelDeploymentStepProps = {
   projectName: string;
@@ -17,16 +18,19 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
     <Form>
       <FormSection title="Model deployment">
         {projectName && <ProjectSection projectName={projectName} />}
-        {wizardState.data.k8sNameDesc && (
-          <K8sNameDescriptionField
-            data={wizardState.data.k8sNameDesc}
-            onDataChange={wizardState.handlers.setDeploymentName}
-            dataTestId="model-deployment"
-            nameLabel="Model deployment name"
-            nameHelperText="This is the name of the inference service created when the model is deployed." // TODO: make this non-Kserve specific
-            hideDescription
-          />
-        )}
+        <K8sNameDescriptionField
+          data={wizardState.state.k8sNameDesc.data}
+          onDataChange={wizardState.state.k8sNameDesc.onDataChange}
+          dataTestId="model-deployment"
+          nameLabel="Model deployment name"
+          nameHelperText="This is the name of the inference service created when the model is deployed." // TODO: make this non-Kserve specific
+          hideDescription
+        />
+        <ModelServingHardwareProfileSection
+          project={projectName}
+          hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
+          isEditing={false}
+        />
       </FormSection>
     </Form>
   );

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -23,8 +23,8 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
   return (
     <Form>
       <ModelTypeSelectField
-        modelType={wizardState.data.modelTypeField}
-        setModelType={wizardState.handlers.setModelType}
+        modelType={wizardState.state.modelType.data}
+        setModelType={wizardState.state.modelType.setData}
         validationProps={validation.getFieldValidationProps(['modelType'])}
         validationIssues={validation.getFieldValidation(['modelType'])}
       />

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -1,42 +1,46 @@
-import {
-  K8sNameDescriptionFieldData,
-  K8sNameDescriptionFieldUpdateFunction,
-} from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/types';
+import { K8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/types';
 import { useK8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { extractK8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
+import { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { useModelTypeField, type ModelTypeFieldData } from './fields/ModelTypeSelectField';
 
 export type ModelDeploymentWizardData = {
   modelTypeField?: ModelTypeFieldData;
   k8sNameDesc?: K8sNameDescriptionFieldData;
-};
-
-export type ModelDeploymentWizardDataHandlers = {
-  setModelType: (data: ModelTypeFieldData) => void;
-  setDeploymentName?: K8sNameDescriptionFieldUpdateFunction;
+  hardwareProfile?: Parameters<typeof useHardwareProfileConfig>;
 };
 
 export type UseModelDeploymentWizardState = {
-  data: ModelDeploymentWizardData;
-  handlers: ModelDeploymentWizardDataHandlers;
+  initialData?: ModelDeploymentWizardData;
+  state: {
+    modelType: ReturnType<typeof useModelTypeField>;
+    k8sNameDesc: ReturnType<typeof useK8sNameDescriptionFieldData>;
+    hardwareProfileConfig: ReturnType<typeof useHardwareProfileConfig>;
+  };
 };
 
 export const useModelDeploymentWizard = (
-  existingData?: ModelDeploymentWizardData,
+  initialData?: ModelDeploymentWizardData,
 ): UseModelDeploymentWizardState => {
-  const [modelType, setModelType] = useModelTypeField(existingData?.modelTypeField);
-  const { data: k8sNameDesc, onDataChange: setDeploymentName } = useK8sNameDescriptionFieldData({
-    initialData: extractK8sNameDescriptionFieldData(existingData?.k8sNameDesc),
+  // Step 1: Model Source
+  const modelType = useModelTypeField(initialData?.modelTypeField);
+
+  // Step 2: Model Deployment
+  const k8sNameDesc = useK8sNameDescriptionFieldData({
+    initialData: extractK8sNameDescriptionFieldData(initialData?.k8sNameDesc),
   });
+  const hardwareProfileConfig = useHardwareProfileConfig(...(initialData?.hardwareProfile ?? []));
+
+  // Step 3: Advanced Options
+
+  // Step 4: Summary
 
   return {
-    data: {
-      modelTypeField: modelType,
+    initialData,
+    state: {
+      modelType,
       k8sNameDesc,
-    },
-    handlers: {
-      setModelType,
-      setDeploymentName,
+      hardwareProfileConfig,
     },
   };
 };

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { isK8sNameDescriptionDataValid } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
-import type { ModelDeploymentWizardData } from './useDeploymentWizard';
+import { useValidation } from '@odh-dashboard/internal/utilities/useValidation';
+import { hardwareProfileValidationSchema } from '@odh-dashboard/internal/concepts/hardwareProfiles/validationUtils';
+import type { UseModelDeploymentWizardState } from './useDeploymentWizard';
 import { modelSourceStepSchema, type ModelSourceStepData } from './steps/ModelSourceStep';
 
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
+  hardwareProfile: ReturnType<typeof useValidation>;
   isModelSourceStepValid: boolean;
   isModelDeploymentStepValid: boolean;
 };
 
 export const useModelDeploymentWizardValidation = (
-  data: ModelDeploymentWizardData,
+  state: UseModelDeploymentWizardState['state'],
 ): ModelDeploymentWizardValidation => {
+  // Step 1: Model Source
   const modelSourceStepValidationData: Partial<ModelSourceStepData> = React.useMemo(
     () => ({
-      modelType: data.modelTypeField,
+      modelType: state.modelType.data,
     }),
-    [data.modelTypeField],
+    [state.modelType],
   );
 
   const modelSourceStepValidation = useZodFormValidation(
@@ -25,12 +29,23 @@ export const useModelDeploymentWizardValidation = (
     modelSourceStepSchema,
   );
 
+  // Step 2: Model Deployment
+  const hardwareProfileValidation = useValidation(
+    state.hardwareProfileConfig.formData,
+    hardwareProfileValidationSchema,
+  );
+
+  // Step validation
+  const isModelSourceStepValid =
+    modelSourceStepValidation.getFieldValidation(undefined, true).length === 0;
+  const isModelDeploymentStepValid =
+    isK8sNameDescriptionDataValid(state.k8sNameDesc.data) &&
+    Object.keys(hardwareProfileValidation.getAllValidationIssues()).length === 0;
+
   return {
     modelSource: modelSourceStepValidation,
-    isModelSourceStepValid:
-      modelSourceStepValidation.getFieldValidation(undefined, true).length === 0,
-    isModelDeploymentStepValid: !!(
-      data.k8sNameDesc && isK8sNameDescriptionDataValid(data.k8sNameDesc)
-    ),
+    hardwareProfile: hardwareProfileValidation,
+    isModelSourceStepValid,
+    isModelDeploymentStepValid,
   };
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-31640

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds the "Hardware profile" field to the wizard, all the functionality should be there except for deploying

Creating a new deployment, it will preselect the default profile
<img width="1044" height="734" alt="image" src="https://github.com/user-attachments/assets/023b5a76-2c6d-48e3-89b6-ab5931f642ac" />
You can modify the values and bad validation will disable the next button
<img width="1044" height="734" alt="image" src="https://github.com/user-attachments/assets/df8fb345-b9c4-4c92-beb9-2cc2100ba132" />

Editing the deployment will fetch the existing profile
<img width="1044" height="734" alt="image" src="https://github.com/user-attachments/assets/11d3ebde-9b23-4604-8bce-31c6cfbc07f7" />

Note that the field itself has a loader that is independent of the form wizard so when going to the step it will be loading
<img width="796" height="220" alt="image" src="https://github.com/user-attachments/assets/0a0bfed9-b142-4b0e-b599-d333db78a2b6" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Make sure the model serving refactor plugin is enabled, also enable the wizard dev flag
2. Create a new deployment, go to step 2, see the hardware profiles show up, and the component works as expected
3. Edit an existing deployment that has a hardware profile (you'll have to use the modal and enable the HW dev flag)
4. Make sure the existing profile shows up in the field


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I only added cypress tests, since a lot of the existing functionality is embedded into the hook and field itself, which we are reusing. So we just need to really test the end to end of how it integrates

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@vconzola 
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added hardware profile selection and configuration throughout the Model Serving deployment wizard (create/edit), with scope labels (global/project) and preloading when editing.
  - Exposed hooks/extensions to extract/apply hardware profile configs for deployments.

- Bug Fixes
  - Validation now covers hardware profile settings to prevent incomplete submissions.
  - Unified error screen with “Return to model serving” and improved loading/error handling in edit flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->