### PR TITLE
Prevent number of accelerators count reset in standalone workbench creation

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/notebookServer.ts
@@ -136,6 +136,10 @@ class NotebookServer {
   findNotebookVersion(version: string) {
     return cy.get(`[data-id="${version}"]`);
   }
+
+  findNumberOfAcceleratorsInput() {
+    return cy.findByTestId('number-of-accelerators').find('input');
+  }
 }
 
 export const notebookServer = new NotebookServer();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -245,14 +245,17 @@ describe('NotebookServer', () => {
     });
   });
 
-  it('should start a workbench with accelerator profile', () => {
+  it('should start a workbench with accelerator profile and preserve GPU count', () => {
     notebookServer.visit();
+    notebookServer.findNotebookImage('code-server-notebook').click();
     notebookServer.findAcceleratorProfileSelect().click();
     notebookServer.findAcceleratorProfileSelect().findSelectOption('Test GPU').click();
     notebookServer.findAcceleratorProfileSelect().should('contain', 'Test GPU');
-    notebookServer.findStartServerButton().should('be.visible');
+    notebookServer.findNumberOfAcceleratorsInput().should('have.value', '1');
+    notebookServer.findAcceleratorProfileSelect().should('contain', 'Test GPU');
+    notebookServer.findStartServerButton().should('not.be.disabled');
     notebookServer.findStartServerButton().click();
-
+    notebookServer.findNumberOfAcceleratorsInput().should('have.value', '1');
     cy.wait('@startNotebookServer').then((interception) => {
       expect(interception.request.body).to.eql({
         podSpecOptions: {

--- a/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
+++ b/frontend/src/pages/notebookController/screens/server/AcceleratorProfileSelectField.tsx
@@ -415,6 +415,7 @@ const AcceleratorProfileSelectField: React.FC<AcceleratorProfileSelectFieldProps
           <FormGroup label="Number of accelerators" fieldId="number-of-accelerators">
             <InputGroup>
               <NumberInputWrapper
+                data-testid="number-of-accelerators"
                 inputAriaLabel="Number of accelerators"
                 id="number-of-accelerators"
                 name="number-of-accelerators"

--- a/frontend/src/utilities/useAcceleratorProfileFormState.ts
+++ b/frontend/src/utilities/useAcceleratorProfileFormState.ts
@@ -153,11 +153,13 @@ const useAcceleratorProfileFormState = (
     useExistingSettings: false,
   });
 
+  const initializedRef = React.useRef(false);
   React.useEffect(() => {
-    if (loaded) {
+    if (loaded && !initializedRef.current) {
       setFormData('profile', initialState.acceleratorProfile);
       setFormData('count', initialState.count);
       setFormData('useExistingSettings', initialState.unknownProfileDetected);
+      initializedRef.current = true;
     }
   }, [loaded, initialState, setFormData]);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-33476

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The number of accelerators count resets to 0 when creating standalone workbenches, preventing GPU resources from being properly assigned to workbench pods. The `useAcceleratorProfileFormState` hook was overriding user selections with initial state values whenever the `initialState` changed, which happens during form processing. Added an `isInitialized` state to ensure the form initialization only happens once when the component first loads, preventing additional resets of user-selected values.
The following is also needed for this to work:  [PR #4763](https://github.com/opendatahub-io/odh-dashboard/pull/4763)

https://github.com/user-attachments/assets/95ba534c-0b5b-4c6a-bb72-c176747d6692

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, see above.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents the Accelerator Profile form from re-initializing after first load, avoiding unintended overwrites and visual flicker.
  - Ensures the form populates only once when data is available, improving stability across reloads and edits.
- Tests
  - Adds end-to-end coverage verifying accelerator profile selection, GPU count preservation, and GPU-related fields are included when starting a server.
- Notes
  - No changes to user-facing APIs; includes a testability attribute for the GPU count input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->