### PR TITLE
Enable Modular Architecture deployments in RHOAI

### DIFF
--- a/manifests/odh/kustomization.yaml
+++ b/manifests/odh/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
 resources:
   - ../common
   - ../modular-architecture
-# - ../core-bases/base
+# - ../core-bases/base Disabling it to enable modular architecture, re-enable if we switch mod arch deployments
   - ../core-bases/consolelink
 configMapGenerator:
   - name: odh-dashboard-params

--- a/manifests/rhoai/shared/base/kustomization.yaml
+++ b/manifests/rhoai/shared/base/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../core-bases/base
+  - ../../../modular-architecture
+# - ../../../core-bases/base Disabling it to enable modular architecture, re-enable if we switch mod arch deployments
 patchesJson6902:
   - path: service-account.yaml
     target:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Now that we have a rhoai compatible build we can enable modular architecture in RHOAI
Part of 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Generating and deploying the manifest with
`oc apply -k manifests/rhoai/addon/`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
