### PR TITLE
Add Deployments column extension for Model Registry

### DIFF
--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/index.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/index.d.ts
@@ -2,3 +2,4 @@ export * from './deploy';
 export * from './connection';
 export * from './details';
 export * from './detailsCard';
+export * from './table';

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
@@ -1,15 +1,11 @@
-import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
-import type { SortableData } from '@odh-dashboard/internal/components/table/types';
-import type { RegisteredModel } from '~/app/types';
-
-export type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
-  cellRenderer: (registeredModel: RM) => React.ReactNode;
-};
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
+import type { RegisteredModel } from '../../app/types';
 
 export type ModelRegistryTableColumnExtension = Extension<
   'model-registry.registered-models/table-column',
   {
-    column: CodeRef<() => ModelRegistryTableColumn<RegisteredModel>>;
+    column: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
   }
 >;
 

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
@@ -1,0 +1,18 @@
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+import type { SortableData } from '@odh-dashboard/internal/components/table/types';
+import type { RegisteredModel } from '~/app/types';
+
+export type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
+  cellRenderer: (registeredModel: RM) => React.ReactNode;
+};
+
+export type ModelRegistryTableColumnExtension = Extension<
+  'model-registry.registered-models/table-column',
+  {
+    column: CodeRef<() => ModelRegistryTableColumn<RegisteredModel>>;
+  }
+>;
+
+export const isModelRegistryTableColumnExtension: (
+  extension: Extension,
+) => extension is ModelRegistryTableColumnExtension;

--- a/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
+++ b/frontend/@mf-types/@mf/modelRegistry/compiled-types/src/odh/extension-points/table.d.ts
@@ -5,7 +5,7 @@ import type { RegisteredModel } from '../../app/types';
 export type ModelRegistryTableColumnExtension = Extension<
   'model-registry.registered-models/table-column',
   {
-    column: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
+    component: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
   }
 >;
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelRegistry.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/ModelRegistry.tsx
@@ -4,7 +4,7 @@ import { ProjectObjectType, ApplicationsPage, TitleWithIcon } from 'mod-arch-sha
 import useRegisteredModels from '~/app/hooks/useRegisteredModels';
 import useModelVersions from '~/app/hooks/useModelVersions';
 import ModelRegistrySelectorNavigator from './ModelRegistrySelectorNavigator';
-import RegisteredModelListView from './RegisteredModels/RegisteredModelListView';
+import ExtendedRegisteredModelListView from '~/odh/components/ExtendedRegisteredModelListView';
 import { modelRegistryUrl } from './routeUtils';
 
 type ModelRegistryProps = Omit<
@@ -58,7 +58,7 @@ const ModelRegistry: React.FC<ModelRegistryProps> = ({ ...pageProps }) => {
       provideChildrenPadding
       removeChildrenTopPadding
     >
-      <RegisteredModelListView
+      <ExtendedRegisteredModelListView
         registeredModels={registeredModels.items}
         modelVersions={modelVersions.items}
         refresh={refresh}

--- a/packages/model-registry/upstream/frontend/src/odh/ModelRegistryWrapper.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/ModelRegistryWrapper.tsx
@@ -16,7 +16,7 @@ const modularArchConfig: ModularArchConfig = {
   deploymentMode: DeploymentMode.Federated,
   URL_PREFIX,
   BFF_API_VERSION,
-  mandatoryNamespace: 'kubeflow',
+  mandatoryNamespace: 'odh-model-registries',
 };
 
 const ModelRegistryWrapper: React.FC = () => {

--- a/packages/model-registry/upstream/frontend/src/odh/ModelRegistryWrapper.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/ModelRegistryWrapper.tsx
@@ -16,7 +16,7 @@ const modularArchConfig: ModularArchConfig = {
   deploymentMode: DeploymentMode.Federated,
   URL_PREFIX,
   BFF_API_VERSION,
-  mandatoryNamespace: 'odh-model-registries',
+  mandatoryNamespace: 'kubeflow',
 };
 
 const ModelRegistryWrapper: React.FC = () => {

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelListView.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelListView.tsx
@@ -139,16 +139,21 @@ const ExtendedRegisteredModelListView: React.FC<ExtendedRegisteredModelListViewP
     />
   );
 
-  // Wrap with deployments context provider if available
+  // Wrap with deployments context providers if available
   if (deploymentsContextLoaded && deploymentsContextExtensions.length > 0) {
-    const DeploymentsProvider = deploymentsContextExtensions[0].properties.DeploymentsProvider;
-    return (
-      <DeploymentsProvider
-        labelSelectors={{}}
-        mrName={preferredModelRegistry?.name}
-      >
-        {({ deployments, loaded }) => tableContent}
-      </DeploymentsProvider>
+    return deploymentsContextExtensions.reduce(
+      (content, extension) => {
+        const DeploymentsProvider = extension.properties.DeploymentsProvider;
+        return (
+          <DeploymentsProvider
+            key={extension.properties.DeploymentsProvider.toString()}
+            mrName={preferredModelRegistry?.name}
+          >
+          {() => tableContent}
+          </DeploymentsProvider>
+        );
+      },
+      tableContent
     );
   }
 

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelListView.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelListView.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { ToolbarGroup } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { ProjectObjectType, typedEmptyImage } from '@odh-dashboard/internal/concepts/design/utils';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { ModelVersion, RegisteredModel } from '~/app/types';
+import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
+import { isModelRegistryVersionDeploymentsContextExtension } from '~/odh/extension-points/deploy';
+import {
+  registeredModelArchiveUrl,
+  registerModelUrl,
+} from '~/app/pages/modelRegistry/screens/routeUtils';
+import EmptyModelRegistryState from '~/app/pages/modelRegistry/screens/components/EmptyModelRegistryState';
+import { filterRegisteredModels } from '~/app/pages/modelRegistry/screens/utils';
+import { filterArchiveModels, filterLiveModels } from '~/app/utils';
+import {
+  initialModelRegistryFilterData,
+  ModelRegistryFilterDataType,
+  modelRegistryFilterOptions,
+  ModelRegistryFilterOptions,
+} from '~/app/pages/modelRegistry/screens/const';
+import FilterToolbar from '~/app/shared/components/FilterToolbar';
+import ThemeAwareSearchInput from '~/app/pages/modelRegistry/screens/components/ThemeAwareSearchInput';
+import ExtendedRegisteredModelTable from './ExtendedRegisteredModelTable';
+import RegisteredModelsTableToolbar from '~/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableToolbar';
+
+type ExtendedRegisteredModelListViewProps = {
+  registeredModels: RegisteredModel[];
+  modelVersions: ModelVersion[];
+  refresh: () => void;
+};
+
+const ExtendedRegisteredModelListView: React.FC<ExtendedRegisteredModelListViewProps> = ({
+  registeredModels,
+  modelVersions,
+  refresh,
+}) => {
+  const navigate = useNavigate();
+  const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
+  const [filterData, setFilterData] = React.useState<ModelRegistryFilterDataType>(
+    initialModelRegistryFilterData,
+  );
+  const unfilteredRegisteredModels = filterLiveModels(registeredModels);
+  const archiveRegisteredModels = filterArchiveModels(registeredModels);
+
+  const [deploymentsContextExtensions, deploymentsContextLoaded] = useResolvedExtensions(
+    isModelRegistryVersionDeploymentsContextExtension,
+  );
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value: string | { label: string; value: string } | undefined) =>
+      setFilterData((prevValues) => ({ ...prevValues, [key]: value })),
+    [setFilterData],
+  );
+
+  const onClearFilters = React.useCallback(
+    () => setFilterData(initialModelRegistryFilterData),
+    [setFilterData],
+  );
+
+  if (unfilteredRegisteredModels.length === 0) {
+    return (
+      <EmptyModelRegistryState
+        testid="empty-registered-models"
+        title="No models in selected registry"
+        headerIcon={() => (
+          <img
+            src={typedEmptyImage(ProjectObjectType.registeredModels, 'MissingModel')}
+            alt="missing model"
+          />
+        )}
+        description={`${
+          preferredModelRegistry?.name ?? ''
+        } has no active registered models. Register a model in this registry, or select a different registry.`}
+        primaryActionText="Register model"
+        secondaryActionText={
+          archiveRegisteredModels.length !== 0 ? 'View archived models' : undefined
+        }
+        primaryActionOnClick={() => {
+          navigate(registerModelUrl(preferredModelRegistry?.name));
+        }}
+        secondaryActionOnClick={() => {
+          navigate(registeredModelArchiveUrl(preferredModelRegistry?.name));
+        }}
+      />
+    );
+  }
+
+  const filteredRegisteredModels = filterRegisteredModels(
+    unfilteredRegisteredModels,
+    modelVersions,
+    filterData,
+  );
+
+  const toggleGroupItems = (
+    <ToolbarGroup variant="filter-group">
+      <FilterToolbar
+        filterOptions={modelRegistryFilterOptions}
+        filterOptionRenders={{
+          [ModelRegistryFilterOptions.keyword]: ({ onChange, ...props }) => (
+            <ThemeAwareSearchInput
+              {...props}
+              fieldLabel="Filter by keyword"
+              placeholder="Filter by keyword"
+              className="toolbar-fieldset-wrapper"
+              style={{ minWidth: '270px' }}
+              onChange={(value) => onChange(value)}
+            />
+          ),
+          [ModelRegistryFilterOptions.owner]: ({ onChange, ...props }) => (
+            <ThemeAwareSearchInput
+              {...props}
+              fieldLabel="Filter by owner"
+              placeholder="Filter by owner"
+              className="toolbar-fieldset-wrapper"
+              style={{ minWidth: '270px' }}
+              onChange={(value) => onChange(value)}
+            />
+          ),
+        }}
+        filterData={filterData}
+        onFilterUpdate={onFilterUpdate}
+      />
+    </ToolbarGroup>
+  );
+
+  const tableContent = (
+    <ExtendedRegisteredModelTable
+      refresh={refresh}
+      clearFilters={onClearFilters}
+      registeredModels={filteredRegisteredModels}
+      modelVersions={modelVersions}
+      toolbarContent={
+        <RegisteredModelsTableToolbar
+          toggleGroupItems={toggleGroupItems}
+          onClearAllFilters={onClearFilters}
+        />
+      }
+    />
+  );
+
+  // Wrap with deployments context provider if available
+  if (deploymentsContextLoaded && deploymentsContextExtensions.length > 0) {
+    const DeploymentsProvider = deploymentsContextExtensions[0].properties.DeploymentsProvider;
+    return (
+      <DeploymentsProvider
+        labelSelectors={{}}
+        mrName={preferredModelRegistry?.name}
+      >
+        {({ deployments, loaded }) => tableContent}
+      </DeploymentsProvider>
+    );
+  }
+
+  return tableContent;
+};
+
+export default ExtendedRegisteredModelListView;

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
@@ -29,13 +29,17 @@ const ExtendedRegisteredModelTable: React.FC<ExtendedRegisteredModelTableProps> 
     const columns = [...rmColumns];
 
     if (columnExtensionsLoaded && columnExtensions.length > 0) {
-      // Insert Deployments column between "Latest version" and "Labels"
+      // Insert placeholder columns for extension components
+      // The actual rendering is handled in ExtendedRegisteredModelTableRow
       const labelsIndex = columns.findIndex((col) => col.field === 'labels');
       const insertIndex = labelsIndex >= 0 ? labelsIndex : 2; // Default to index 2 if labels not found
 
-      columnExtensions.forEach((extension) => {
-        const column = extension.properties.column();
-        columns.splice(insertIndex, 0, column);
+      columnExtensions.forEach((extension, index) => {
+        columns.splice(insertIndex + index, 0, {
+          field: `extension-${index}`,
+          label: 'Extension',
+          sortable: false,
+        });
       });
     }
 

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
@@ -37,7 +37,7 @@ const ExtendedRegisteredModelTable: React.FC<ExtendedRegisteredModelTableProps> 
       columnExtensions.forEach((extension, index) => {
         columns.splice(insertIndex + index, 0, {
           field: `extension-${index}`,
-          label: 'Extension',
+          label: 'Deployments',
           sortable: false,
         });
       });

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
@@ -27,18 +27,18 @@ const ExtendedRegisteredModelTable: React.FC<ExtendedRegisteredModelTableProps> 
 
   const extendedColumns = React.useMemo(() => {
     const columns = [...rmColumns];
-    
+
     if (columnExtensionsLoaded && columnExtensions.length > 0) {
-      // Add extension columns before the kebab column
-      const kebabIndex = columns.findIndex(col => col.field === 'kebab');
-      const insertIndex = kebabIndex >= 0 ? kebabIndex : columns.length;
-      
-      columnExtensions.forEach(extension => {
+      // Insert Deployments column between "Latest version" and "Labels"
+      const labelsIndex = columns.findIndex((col) => col.field === 'labels');
+      const insertIndex = labelsIndex >= 0 ? labelsIndex : 2; // Default to index 2 if labels not found
+
+      columnExtensions.forEach((extension) => {
         const column = extension.properties.column();
         columns.splice(insertIndex, 0, column);
       });
     }
-    
+
     return columns;
   }, [columnExtensions, columnExtensionsLoaded]);
 

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTable.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Table, DashboardEmptyTableView } from 'mod-arch-shared';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { ModelVersion, RegisteredModel } from '~/app/types';
+import { getLatestVersionForRegisteredModel } from '~/app/pages/modelRegistry/screens/utils';
+import { rmColumns } from '~/app/pages/modelRegistry/screens/RegisteredModels/RegisteredModelsTableColumns';
+import { isModelRegistryTableColumnExtension } from '~/odh/extension-points/table';
+import ExtendedRegisteredModelTableRow from './ExtendedRegisteredModelTableRow';
+
+type ExtendedRegisteredModelTableProps = {
+  clearFilters: () => void;
+  registeredModels: RegisteredModel[];
+  modelVersions: ModelVersion[];
+  refresh: () => void;
+} & Partial<Pick<React.ComponentProps<typeof Table>, 'toolbarContent'>>;
+
+const ExtendedRegisteredModelTable: React.FC<ExtendedRegisteredModelTableProps> = ({
+  clearFilters,
+  registeredModels,
+  modelVersions,
+  toolbarContent,
+  refresh,
+}) => {
+  const [columnExtensions, columnExtensionsLoaded] = useResolvedExtensions(
+    isModelRegistryTableColumnExtension,
+  );
+
+  const extendedColumns = React.useMemo(() => {
+    const columns = [...rmColumns];
+    
+    if (columnExtensionsLoaded && columnExtensions.length > 0) {
+      // Add extension columns before the kebab column
+      const kebabIndex = columns.findIndex(col => col.field === 'kebab');
+      const insertIndex = kebabIndex >= 0 ? kebabIndex : columns.length;
+      
+      columnExtensions.forEach(extension => {
+        const column = extension.properties.column();
+        columns.splice(insertIndex, 0, column);
+      });
+    }
+    
+    return columns;
+  }, [columnExtensions, columnExtensionsLoaded]);
+
+  return (
+    <Table
+      data-testid="registered-model-table"
+      data={registeredModels}
+      columns={extendedColumns}
+      toolbarContent={toolbarContent}
+      defaultSortColumn={2}
+      onClearFilters={clearFilters}
+      enablePagination
+      emptyTableView={<DashboardEmptyTableView onClearFilters={clearFilters} />}
+      rowRenderer={(rm: RegisteredModel) => (
+        <ExtendedRegisteredModelTableRow
+          key={rm.name}
+          hasDeploys={false}
+          registeredModel={rm}
+          latestModelVersion={getLatestVersionForRegisteredModel(modelVersions, rm.id)}
+          refresh={refresh}
+        />
+      )}
+    />
+  );
+};
+
+export default ExtendedRegisteredModelTable;

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -79,7 +79,11 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
       : [
           {
             title: 'Archive model',
-            onClick: () => setIsArchiveModalOpen(true),
+            onClick: () => {
+                            if (!hasDeploys) {
+                              setIsArchiveModalOpen(true);
+                            }
+                          },
             isAriaDisabled: hasDeploys,
             tooltipProps: hasDeploys
               ? { content: 'Models with deployed versions cannot be archived.' }

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -1,0 +1,204 @@
+import { Button, Content, ContentVariants, FlexItem, Truncate } from '@patternfly/react-core';
+import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
+import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
+import { ArchiveRegisteredModelModal } from '~/app/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
+import ModelLabels from '~/app/pages/modelRegistry/screens/components/ModelLabels';
+import ModelTimestamp from '~/app/pages/modelRegistry/screens/components/ModelTimestamp';
+import { RestoreRegisteredModelModal } from '~/app/pages/modelRegistry/screens/components/RestoreRegisteredModel';
+import {
+  archiveModelVersionDetailsUrl,
+  archiveModelVersionListUrl,
+  modelVersionListUrl,
+  modelVersionUrl,
+  registeredModelArchiveDetailsUrl,
+  registeredModelUrl,
+} from '~/app/pages/modelRegistry/screens/routeUtils';
+import { ModelState, ModelVersion, RegisteredModel } from '~/app/types';
+import { isModelRegistryTableColumnExtension } from '~/odh/extension-points/table';
+
+type ExtendedRegisteredModelTableRowProps = {
+  registeredModel: RegisteredModel;
+  latestModelVersion: ModelVersion | undefined;
+  isArchiveRow?: boolean;
+  hasDeploys?: boolean;
+  refresh: () => void;
+};
+
+const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowProps> = ({
+  registeredModel: rm,
+  latestModelVersion,
+  isArchiveRow,
+  hasDeploys = false,
+  refresh,
+}) => {
+  const { apiState } = React.useContext(ModelRegistryContext);
+  const navigate = useNavigate();
+  const { preferredModelRegistry } = React.useContext(ModelRegistrySelectorContext);
+  const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
+  const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
+  const rmUrl = registeredModelUrl(rm.id, preferredModelRegistry?.name);
+
+  const [columnExtensions, columnExtensionsLoaded] = useResolvedExtensions(
+    isModelRegistryTableColumnExtension,
+  );
+
+  const actions: IAction[] = [
+    {
+      title: 'Overview',
+      onClick: () => {
+        navigate(
+          isArchiveRow
+            ? registeredModelArchiveDetailsUrl(rm.id, preferredModelRegistry?.name)
+            : rmUrl,
+        );
+      },
+    },
+    {
+      title: 'Versions',
+      onClick: () => {
+        navigate(
+          isArchiveRow
+            ? archiveModelVersionListUrl(rm.id, preferredModelRegistry?.name)
+            : modelVersionListUrl(rm.id, preferredModelRegistry?.name),
+        );
+      },
+    },
+
+    { isSeparator: true },
+    ...(isArchiveRow
+      ? [
+          {
+            title: 'Restore model',
+            onClick: () => setIsRestoreModalOpen(true),
+          },
+        ]
+      : [
+          {
+            title: 'Archive model',
+            onClick: () => setIsArchiveModalOpen(true),
+            isAriaDisabled: hasDeploys,
+            tooltipProps: hasDeploys
+              ? { content: 'Models with deployed versions cannot be archived.' }
+              : undefined,
+          },
+        ]),
+  ];
+
+  const handleModelNameNavigation = (rmId: string) =>
+    isArchiveRow
+      ? navigate(registeredModelArchiveDetailsUrl(rmId, preferredModelRegistry?.name))
+      : navigate(rmUrl);
+
+  const handleVersionNameNavigation = (mv: ModelVersion) =>
+    isArchiveRow
+      ? navigate(
+          archiveModelVersionDetailsUrl(mv.id, mv.registeredModelId, preferredModelRegistry?.name),
+        )
+      : navigate(modelVersionUrl(mv.id, mv.registeredModelId, preferredModelRegistry?.name));
+
+  const renderExtensionColumns = () => {
+    if (!columnExtensionsLoaded || columnExtensions.length === 0) {
+      return null;
+    }
+
+    return columnExtensions.map((extension, index) => {
+      const column = extension.properties.column();
+      return (
+        <Td key={`extension-${index}`} dataLabel={column.label}>
+          {column.cellRenderer ? column.cellRenderer(rm) : null}
+        </Td>
+      );
+    });
+  };
+
+  return (
+    <Tr>
+      <Td dataLabel="Model name">
+        <div id="model-name" data-testid="model-name">
+          <FlexItem>
+            <Button variant="link" isInline onClick={() => handleModelNameNavigation(rm.id)}>
+              <Truncate content={rm.name} />
+            </Button>
+          </FlexItem>
+        </div>
+        {rm.description && (
+          <Content data-testid="description" component={ContentVariants.small}>
+            <Truncate content={rm.description} />
+          </Content>
+        )}
+      </Td>
+      <Td dataLabel="Latest version">
+        {latestModelVersion ? (
+          <div id="latest-version" data-testid="latest-version">
+            <FlexItem>
+              <Button
+                variant="link"
+                isInline
+                onClick={() => handleVersionNameNavigation(latestModelVersion)}
+              >
+                <Truncate content={latestModelVersion.name} />
+              </Button>
+            </FlexItem>
+          </div>
+        ) : (
+          '-'
+        )}
+      </Td>
+      <Td dataLabel="Labels">
+        <ModelLabels customProperties={rm.customProperties} name={rm.name} />
+      </Td>
+      <Td dataLabel="Last modified">
+        <ModelTimestamp timeSinceEpoch={rm.lastUpdateTimeSinceEpoch} />
+      </Td>
+      <Td dataLabel="Owner">
+        <Content component="p" data-testid="registered-model-owner">
+          {rm.owner || '-'}
+        </Content>
+      </Td>
+      {renderExtensionColumns()}
+      <Td isActionCell>
+        <ActionsColumn items={actions} />
+        {isArchiveModalOpen ? (
+          <ArchiveRegisteredModelModal
+            onCancel={() => setIsArchiveModalOpen(false)}
+            onSubmit={() =>
+              apiState.api
+                .patchRegisteredModel(
+                  {},
+                  {
+                    state: ModelState.ARCHIVED,
+                  },
+                  rm.id,
+                )
+                .then(refresh)
+            }
+            registeredModelName={rm.name}
+          />
+        ) : null}
+        {isRestoreModalOpen ? (
+          <RestoreRegisteredModelModal
+            onCancel={() => setIsRestoreModalOpen(false)}
+            onSubmit={() =>
+              apiState.api
+                .patchRegisteredModel(
+                  {},
+                  {
+                    state: ModelState.LIVE,
+                  },
+                  rm.id,
+                )
+                .then(() => navigate(registeredModelUrl(rm.id, preferredModelRegistry?.name)))
+            }
+            registeredModelName={rm.name}
+          />
+        ) : null}
+      </Td>
+    </Tr>
+  );
+};
+
+export default ExtendedRegisteredModelTableRow;

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -2,7 +2,7 @@ import { Button, Content, ContentVariants, FlexItem, Truncate } from '@patternfl
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useResolvedExtensions, LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
+import { useExtensions, LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
 import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { ArchiveRegisteredModelModal } from '~/app/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
@@ -42,9 +42,7 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const rmUrl = registeredModelUrl(rm.id, preferredModelRegistry?.name);
 
-  const [columnExtensions, columnExtensionsLoaded] = useResolvedExtensions(
-    isModelRegistryTableColumnExtension,
-  );
+  const columnExtensions = useExtensions(isModelRegistryTableColumnExtension);
 
   const actions: IAction[] = [
     {
@@ -105,14 +103,14 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
       : navigate(modelVersionUrl(mv.id, mv.registeredModelId, preferredModelRegistry?.name));
 
   const renderExtensionColumns = () => {
-    if (!columnExtensionsLoaded || columnExtensions.length === 0) {
+    if (columnExtensions.length === 0) {
       return null;
     }
 
     return columnExtensions.map((extension, index) => (
       <Td key={`extension-${index}`}>
         <LazyCodeRefComponent
-          component={extension.properties.column}
+          component={extension.properties.component}
           props={{ registeredModel: rm }}
         />
       </Td>

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -2,7 +2,7 @@ import { Button, Content, ContentVariants, FlexItem, Truncate } from '@patternfl
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
+import { useResolvedExtensions, LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
 import { ModelRegistryContext } from '~/app/context/ModelRegistryContext';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { ArchiveRegisteredModelModal } from '~/app/pages/modelRegistry/screens/components/ArchiveRegisteredModelModal';
@@ -109,14 +109,14 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
       return null;
     }
 
-    return columnExtensions.map((extension, index) => {
-      const column = extension.properties.column();
-      return (
-        <Td key={`extension-${index}`} dataLabel={column.label}>
-          {column.cellRenderer(rm)}
-        </Td>
-      );
-    });
+    return columnExtensions.map((extension, index) => (
+      <Td key={`extension-${index}`}>
+        <LazyCodeRefComponent
+          component={extension.properties.column}
+          props={{ registeredModel: rm }}
+        />
+      </Td>
+    ));
   };
 
   return (

--- a/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ExtendedRegisteredModelTableRow.tsx
@@ -109,7 +109,7 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
       const column = extension.properties.column();
       return (
         <Td key={`extension-${index}`} dataLabel={column.label}>
-          {column.cellRenderer ? column.cellRenderer(rm) : null}
+          {column.cellRenderer(rm)}
         </Td>
       );
     });
@@ -148,6 +148,7 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
           '-'
         )}
       </Td>
+      {renderExtensionColumns()}
       <Td dataLabel="Labels">
         <ModelLabels customProperties={rm.customProperties} name={rm.name} />
       </Td>
@@ -159,7 +160,6 @@ const ExtendedRegisteredModelTableRow: React.FC<ExtendedRegisteredModelTableRowP
           {rm.owner || '-'}
         </Content>
       </Td>
-      {renderExtensionColumns()}
       <Td isActionCell>
         <ActionsColumn items={actions} />
         {isArchiveModalOpen ? (

--- a/packages/model-registry/upstream/frontend/src/odh/extension-points/index.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extension-points/index.ts
@@ -3,3 +3,4 @@ export * from './connection';
 export * from './model-catalog-deploy';
 export * from './details';
 export * from './detailsCard';
+export * from './table';

--- a/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
@@ -5,7 +5,7 @@ import type { RegisteredModel } from '~/app/types';
 export type ModelRegistryTableColumnExtension = Extension<
   'model-registry.registered-models/table-column',
   {
-    column: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
+    component: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
   }
 >;
 

--- a/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
@@ -1,15 +1,11 @@
-import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
-import type { SortableData } from '@odh-dashboard/internal/components/table/types';
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 import type { RegisteredModel } from '~/app/types';
-
-export type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
-  cellRenderer: (registeredModel: RM) => React.ReactNode;
-};
 
 export type ModelRegistryTableColumnExtension = Extension<
   'model-registry.registered-models/table-column',
   {
-    column: CodeRef<() => ModelRegistryTableColumn<RegisteredModel>>;
+    column: ComponentCodeRef<{ registeredModel: RegisteredModel }>;
   }
 >;
 

--- a/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extension-points/table.ts
@@ -1,0 +1,19 @@
+import type { Extension, CodeRef } from '@openshift/dynamic-plugin-sdk';
+import type { SortableData } from '@odh-dashboard/internal/components/table/types';
+import type { RegisteredModel } from '~/app/types';
+
+export type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
+  cellRenderer: (registeredModel: RM) => React.ReactNode;
+};
+
+export type ModelRegistryTableColumnExtension = Extension<
+  'model-registry.registered-models/table-column',
+  {
+    column: CodeRef<() => ModelRegistryTableColumn<RegisteredModel>>;
+  }
+>;
+
+export const isModelRegistryTableColumnExtension = (
+  extension: Extension,
+): extension is ModelRegistryTableColumnExtension =>
+  extension.type === 'model-registry.registered-models/table-column';

--- a/packages/model-serving/extensions/model-registry.ts
+++ b/packages/model-serving/extensions/model-registry.ts
@@ -22,6 +22,7 @@ const extensions: (
   | ModelRegistryDeployModalExtension
   | ModelRegistryVersionDetailsTabExtension
   | ModelRegistryVersionDeploymentsContextExtension
+  | ModelRegistryTableColumnExtension
 )[] = [
   {
     type: 'model-registry.model-version/deploy-modal',
@@ -53,6 +54,16 @@ const extensions: (
     properties: {
       DeploymentsProvider: () =>
         import('../modelRegistry/DeploymentsContextProvider').then((m) => m.default),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_SERVING],
+    },
+  },
+
+  {
+    type: 'model-registry.registered-models/table-column',
+    properties: {
+      column: () => import('../modelRegistry/DeploymentsColumn'),
     },
     flags: {
       required: [SupportedArea.MODEL_SERVING],

--- a/packages/model-serving/extensions/model-registry.ts
+++ b/packages/model-serving/extensions/model-registry.ts
@@ -22,6 +22,8 @@ const extensions: (
   | ModelRegistryDeployModalExtension
   | ModelRegistryVersionDetailsTabExtension
   | ModelRegistryVersionDeploymentsContextExtension
+  | ModelRegistryDetailsTabExtension
+  | ModelDetailsDeploymentCardExtension
   | ModelRegistryTableColumnExtension
 )[] = [
   {
@@ -59,7 +61,26 @@ const extensions: (
       required: [SupportedArea.MODEL_SERVING],
     },
   },
-
+  {
+    type: 'model-registry.details/tab',
+    properties: {
+      id: 'deployments',
+      title: 'Deployments',
+      component: () => import('../modelRegistry/ModelWideDeploymentsTab').then((m) => m.default),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_SERVING],
+    },
+  },
+  {
+    type: 'model-registry.model-details/details-card',
+    properties: {
+      component: () => import('../modelRegistry/ModelDetailsDeploymentCard').then((m) => m.default),
+    },
+    flags: {
+      required: [SupportedArea.MODEL_SERVING],
+    },
+  },
   {
     type: 'model-registry.registered-models/table-column',
     properties: {

--- a/packages/model-serving/extensions/model-registry.ts
+++ b/packages/model-serving/extensions/model-registry.ts
@@ -84,7 +84,7 @@ const extensions: (
   {
     type: 'model-registry.registered-models/table-column',
     properties: {
-      column: () => import('../modelRegistry/DeploymentsColumn'),
+      component: () => import('../modelRegistry/DeploymentsColumn'),
     },
     flags: {
       required: [SupportedArea.MODEL_SERVING],

--- a/packages/model-serving/extensions/model-registry.ts
+++ b/packages/model-serving/extensions/model-registry.ts
@@ -6,6 +6,7 @@ import type {
   ModelRegistryDeployModalExtension,
   ModelRegistryVersionDeploymentsContextExtension,
   ModelRegistryVersionDetailsTabExtension,
+  ModelRegistryTableColumnExtension,
 } from '@mf/modelRegistry/extension-points';
 
 type ModelRegistryDetailsTabExtension = Extension<
@@ -21,8 +22,6 @@ const extensions: (
   | ModelRegistryDeployModalExtension
   | ModelRegistryVersionDetailsTabExtension
   | ModelRegistryVersionDeploymentsContextExtension
-  | ModelRegistryDetailsTabExtension
-  | ModelDetailsDeploymentCardExtension
 )[] = [
   {
     type: 'model-registry.model-version/deploy-modal',
@@ -54,26 +53,6 @@ const extensions: (
     properties: {
       DeploymentsProvider: () =>
         import('../modelRegistry/DeploymentsContextProvider').then((m) => m.default),
-    },
-    flags: {
-      required: [SupportedArea.MODEL_SERVING],
-    },
-  },
-  {
-    type: 'model-registry.details/tab',
-    properties: {
-      id: 'deployments',
-      title: 'Deployments',
-      component: () => import('../modelRegistry/ModelWideDeploymentsTab').then((m) => m.default),
-    },
-    flags: {
-      required: [SupportedArea.MODEL_SERVING],
-    },
-  },
-  {
-    type: 'model-registry.model-details/details-card',
-    properties: {
-      component: () => import('../modelRegistry/ModelDetailsDeploymentCard').then((m) => m.default),
     },
     flags: {
       required: [SupportedArea.MODEL_SERVING],

--- a/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
+++ b/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
@@ -2,20 +2,8 @@ import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { SortableData } from '@odh-dashboard/internal/components/table/types';
-// Define the RegisteredModel type locally since we can't import from @mf/modelRegistry
-type RegisteredModel = {
-  id: string;
-  name: string;
-  description?: string;
-  customProperties?: Record<string, unknown>;
-  owner?: string;
-  lastUpdateTimeSinceEpoch: string;
-};
+import type { RegisteredModel } from '@mf/modelRegistry/compiled-types/src/app/types';
 
-type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
-  cellRenderer: (registeredModel: RM) => React.ReactNode;
-};
 import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
 import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
 
@@ -41,13 +29,13 @@ const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ reg
     return <span>-</span>;
   }
   const handleDeploymentsClick = () => {
-    navigate(`/model-registry/${registeredModel.id}/deployments`);
+    navigate(`/modelServing?registeredModelId=${registeredModel.id}`);
   };
 
   return (
     <div>
       <Link
-        to={`/model-registry/${registeredModel.id}/deployments`}
+        to={`/modelServing?registeredModelId=${registeredModel.id}`}
         onClick={handleDeploymentsClick}
         style={{ textDecoration: 'none' }}
       >
@@ -65,21 +53,5 @@ const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ reg
     </div>
   );
 };
-
-export const createDeploymentsColumn = (): ModelRegistryTableColumn<RegisteredModel> => ({
-  field: 'deployments',
-  label: 'Deployments',
-  sortable: false,
-  info: {
-    popover:
-      'This is the total number of deployments that you have permission to access across all versions of the model.',
-    popoverProps: {
-      position: 'left',
-    },
-  },
-  cellRenderer: (registeredModel: RegisteredModel) => (
-    <DeploymentsColumn registeredModel={registeredModel} />
-  ),
-});
 
 export default DeploymentsColumn;

--- a/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
+++ b/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { SortableData } from '@odh-dashboard/internal/components/table/types';
@@ -21,6 +21,7 @@ import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext
 
 const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ registeredModel }) => {
   const { deployments, loaded } = React.useContext(ModelDeploymentsContext);
+  const navigate = useNavigate();
 
   if (!loaded) {
     return <span>-</span>;
@@ -39,10 +40,8 @@ const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ reg
   if (deploymentCount === 0) {
     return <span>-</span>;
   }
-
   const handleDeploymentsClick = () => {
-    // Navigate to the model's deployments tab
-    // This will be handled by the parent component
+    navigate(`/model-registry/${registeredModel.id}/deployments`);
   };
 
   return (

--- a/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
+++ b/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
 import type { RegisteredModel } from '@mf/modelRegistry/compiled-types/src/app/types';
 
-import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
 import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
 
 const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ registeredModel }) => {

--- a/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
+++ b/packages/model-serving/modelRegistry/DeploymentsColumn.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { SortableData } from '@odh-dashboard/internal/components/table/types';
+// Define the RegisteredModel type locally since we can't import from @mf/modelRegistry
+type RegisteredModel = {
+  id: string;
+  name: string;
+  description?: string;
+  customProperties?: Record<string, unknown>;
+  owner?: string;
+  lastUpdateTimeSinceEpoch: string;
+};
+
+type ModelRegistryTableColumn<RM extends RegisteredModel = RegisteredModel> = SortableData<RM> & {
+  cellRenderer: (registeredModel: RM) => React.ReactNode;
+};
+import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import { ModelDeploymentsContext } from '../src/concepts/ModelDeploymentsContext';
+
+const DeploymentsColumn: React.FC<{ registeredModel: RegisteredModel }> = ({ registeredModel }) => {
+  const { deployments, loaded } = React.useContext(ModelDeploymentsContext);
+
+  if (!loaded) {
+    return <span>-</span>;
+  }
+
+  // Count deployments for this registered model
+  const modelDeployments =
+    deployments?.filter(
+      (deployment) =>
+        deployment.model.kind === 'InferenceService' &&
+        deployment.model.metadata.labels?.[KnownLabels.REGISTERED_MODEL_ID] === registeredModel.id,
+    ) || [];
+
+  const deploymentCount = modelDeployments.length;
+
+  if (deploymentCount === 0) {
+    return <span>-</span>;
+  }
+
+  const handleDeploymentsClick = () => {
+    // Navigate to the model's deployments tab
+    // This will be handled by the parent component
+  };
+
+  return (
+    <div>
+      <Link
+        to={`/model-registry/${registeredModel.id}/deployments`}
+        onClick={handleDeploymentsClick}
+        style={{ textDecoration: 'none' }}
+      >
+        {deploymentCount} {deploymentCount === 1 ? 'deployment' : 'deployments'}
+      </Link>
+      <Tooltip content="View all deployments for this model">
+        <Button
+          variant="link"
+          icon={<ExternalLinkAltIcon />}
+          aria-label="View deployments"
+          onClick={handleDeploymentsClick}
+          style={{ marginLeft: '8px', padding: '0' }}
+        />
+      </Tooltip>
+    </div>
+  );
+};
+
+export const createDeploymentsColumn = (): ModelRegistryTableColumn<RegisteredModel> => ({
+  field: 'deployments',
+  label: 'Deployments',
+  sortable: false,
+  info: {
+    popover:
+      'This is the total number of deployments that you have permission to access across all versions of the model.',
+    popoverProps: {
+      position: 'left',
+    },
+  },
+  cellRenderer: (registeredModel: RegisteredModel) => (
+    <DeploymentsColumn registeredModel={registeredModel} />
+  ),
+});
+
+export default DeploymentsColumn;


### PR DESCRIPTION
## Description

This PR implements a **Deployments Column extension** for the Model Registry table. The extension allows the model-serving package to dynamically add a "Deployments" column to the Registered Models table, displaying the count of deployments for each registered model.

### Key Changes:

- Shows deployment count for each registered model
- Links to deployment details page
- Only appears when model-serving extension is available
- Respects feature flags (MODEL_SERVING area)
- Integrates with existing ModelDeploymentsContext for data access
<img width="1428" height="524" alt="Screenshot 2025-09-04 at 12 57 54 PM" src="https://github.com/user-attachments/assets/408766d9-039e-4710-9245-99624f322af9" />
<img width="720" height="271" alt="Screenshot 2025-09-04 at 12 57 33 PM" src="https://github.com/user-attachments/assets/56f8558a-b302-42db-b16e-ef2503a7e9f4" />


## How Has This Been Tested?
In /packages/model-registry/upstream/frontend, run make dev-start
Run dashboard frontend and backend seprately using npm run start:dev
Turn on model registry plugin dev flag
Go to registered model overview page - if the model have deployments - it will show the latest 5 deployments in the card otherwise No deployments

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model Registry table now supports plugin-provided columns and adds a Deployments column showing deployment counts with quick links when model serving is enabled.
  * New list and table views with enhanced toolbar: keyword/owner search, clear-all, and pagination.
  * Improved empty state with Register Model and View Archived actions.
  * Row actions: Overview/Versions navigation and archive/restore flows with confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->