### PR TITLE
Add model format field to wizard

### DIFF
--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -1,7 +1,7 @@
 import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
 import { DeploymentMode, InferenceServiceKind, KnownLabels } from '#~/k8sTypes';
 import { genUID } from '#~/__mocks__/mockUtils';
-import { ContainerResources, NodeSelector, Toleration } from '#~/types';
+import { ContainerResources, NodeSelector, ServingRuntimeModelType, Toleration } from '#~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -45,7 +45,7 @@ type MockResourceConfigType = {
   isReady?: boolean;
   predictorAnnotations?: Record<string, string>;
   storageUri?: string;
-  modelType?: string;
+  modelType?: ServingRuntimeModelType;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -123,7 +123,7 @@ export const mockInferenceServiceK8sResource = ({
   isReady = false,
   predictorAnnotations = undefined,
   storageUri = undefined,
-  modelType = 'predictive',
+  modelType,
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',

--- a/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockInferenceServiceK8sResource.ts
@@ -45,6 +45,7 @@ type MockResourceConfigType = {
   isReady?: boolean;
   predictorAnnotations?: Record<string, string>;
   storageUri?: string;
+  modelType?: string;
 };
 
 type InferenceServicek8sError = K8sStatus & {
@@ -122,6 +123,7 @@ export const mockInferenceServiceK8sResource = ({
   isReady = false,
   predictorAnnotations = undefined,
   storageUri = undefined,
+  modelType = 'predictive',
 }: MockResourceConfigType): InferenceServiceKind => ({
   apiVersion: 'serving.kserve.io/v1beta1',
   kind: 'InferenceService',
@@ -146,6 +148,7 @@ export const mockInferenceServiceK8sResource = ({
       ...(hardwareProfileNamespace && {
         'opendatahub.io/hardware-profile-namespace': hardwareProfileNamespace,
       }),
+      ...(modelType && { 'opendatahub.io/model-type': modelType }),
     },
     creationTimestamp,
     ...(deleted ? { deletionTimestamp: new Date().toUTCString() } : {}),

--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,5 +1,9 @@
 import { K8sDSGResource, SupportedModelFormats, TemplateKind } from '#~/k8sTypes';
-import { ServingRuntimeAPIProtocol, ServingRuntimePlatform } from '#~/types';
+import {
+  ServingRuntimeAPIProtocol,
+  ServingRuntimePlatform,
+  type ServingRuntimeModelType,
+} from '#~/types';
 
 type MockResourceConfigType = {
   name?: string;
@@ -7,6 +11,7 @@ type MockResourceConfigType = {
   displayName?: string;
   replicas?: number;
   platforms?: ServingRuntimePlatform[];
+  modelTypes?: ServingRuntimeModelType[];
   preInstalled?: boolean;
   apiProtocol?: ServingRuntimeAPIProtocol;
   isModelmesh?: boolean;
@@ -26,6 +31,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   isModelmesh = false,
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
+  modelTypes,
   preInstalled = false,
   containerName = 'ovms',
   containerEnvVars = undefined,
@@ -57,7 +63,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
     annotations: {
       'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
       'opendatahub.io/apiProtocol': apiProtocol,
-      'opendatahub.io/modelServingType': '["predictive","generative"]',
+      'opendatahub.io/model-type': JSON.stringify(modelTypes),
       ...annotations,
     },
   },

--- a/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
+++ b/frontend/src/__mocks__/mockServingRuntimeTemplateK8sResource.ts
@@ -1,8 +1,8 @@
 import { K8sDSGResource, SupportedModelFormats, TemplateKind } from '#~/k8sTypes';
 import {
   ServingRuntimeAPIProtocol,
+  ServingRuntimeModelType,
   ServingRuntimePlatform,
-  type ServingRuntimeModelType,
 } from '#~/types';
 
 type MockResourceConfigType = {
@@ -31,7 +31,7 @@ export const mockServingRuntimeTemplateK8sResource = ({
   isModelmesh = false,
   apiProtocol = ServingRuntimeAPIProtocol.REST,
   platforms,
-  modelTypes,
+  modelTypes = [ServingRuntimeModelType.PREDICTIVE, ServingRuntimeModelType.GENERATIVE],
   preInstalled = false,
   containerName = 'ovms',
   containerEnvVars = undefined,

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -879,6 +879,14 @@ class ModelServingWizard extends Wizard {
   findModelDeploymentNameInput() {
     return cy.findByTestId('model-deployment-name');
   }
+
+  findModelFormatSelect() {
+    return cy.findByTestId('model-framework-select');
+  }
+
+  findModelFormatSelectOption(name: string) {
+    return this.findModelFormatSelect().findSelectOption(name);
+  }
 }
 
 export const modelServingGlobal = new ModelServingGlobal();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -233,6 +233,7 @@ describe('Model Serving Deploy Wizard', () => {
       { model: InferenceServiceModel, ns: 'test-project' },
       mockK8sResourceList([
         mockInferenceServiceK8sResource({
+          modelType: ServingRuntimeModelType.PREDICTIVE,
           hardwareProfileName: 'large-profile',
           hardwareProfileNamespace: 'opendatahub',
           resources: {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -22,7 +22,7 @@ import {
   ServingRuntimeModel,
   TemplateModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
-import { ServingRuntimePlatform } from '#~/types';
+import { ServingRuntimeModelType, ServingRuntimePlatform } from '#~/types';
 import { mockGlobalScopedHardwareProfiles } from '#~/__mocks__/mockHardwareProfile';
 
 const initIntercepts = () => {
@@ -59,16 +59,39 @@ const initIntercepts = () => {
           name: 'template-2',
           displayName: 'OpenVINO',
           platforms: [ServingRuntimePlatform.SINGLE],
+          modelTypes: [ServingRuntimeModelType.PREDICTIVE],
         }),
         mockServingRuntimeTemplateK8sResource({
           name: 'template-3',
           displayName: 'Caikit',
           platforms: [ServingRuntimePlatform.SINGLE],
+          modelTypes: [ServingRuntimeModelType.PREDICTIVE],
           supportedModelFormats: [
             {
-              autoSelect: true,
               name: 'openvino_ir',
               version: 'opset1',
+            },
+          ],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-4',
+          displayName: 'vLLM AMD',
+          platforms: [ServingRuntimePlatform.SINGLE],
+          modelTypes: [ServingRuntimeModelType.GENERATIVE],
+          supportedModelFormats: [
+            {
+              name: 'vLLM',
+            },
+          ],
+        }),
+        mockServingRuntimeTemplateK8sResource({
+          name: 'template-5',
+          displayName: 'vLLM NVIDIA',
+          platforms: [ServingRuntimePlatform.SINGLE],
+          modelTypes: [ServingRuntimeModelType.GENERATIVE],
+          supportedModelFormats: [
+            {
+              name: 'vLLM',
             },
           ],
         }),
@@ -112,7 +135,7 @@ describe('Model Serving Deploy Wizard', () => {
     cy.url().should('include', '/projects/test-project');
   });
 
-  it('Create a new deployment and submit', () => {
+  it('Create a new generative deployment and submit', () => {
     initIntercepts();
     cy.interceptK8sList(
       { model: InferenceServiceModel, ns: 'test-project' },
@@ -154,6 +177,53 @@ describe('Model Serving Deploy Wizard', () => {
       })
       .click();
     hardwareProfileSection.findGlobalScopedLabel().should('exist');
+    modelServingWizard.findModelFormatSelect().should('not.exist');
+    modelServingWizard.findNextButton().should('be.enabled').click();
+  });
+
+  it('Create a new predictive deployment and submit', () => {
+    initIntercepts();
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([mockInferenceServiceK8sResource({})]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([mockServingRuntimeK8sResource({})]),
+    );
+
+    // TODO: visit directly when plugin is enabled
+    cy.visitWithLogin('/modelServing/test-project?devFeatureFlags=Model+Serving+Plugin%3Dtrue');
+    modelServingGlobal.findDeployModelButton().click();
+
+    // Step 1: Model source
+    modelServingWizard.findModelSourceStep().should('be.enabled');
+    modelServingWizard.findModelDeploymentStep().should('be.disabled');
+    modelServingWizard.findNextButton().should('be.disabled');
+    modelServingWizard.findModelTypeSelectOption('Generative AI model (e.g. LLM)').should('exist');
+    modelServingWizard.findModelTypeSelectOption('Predictive model').should('exist').click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 2: Model deployment
+    modelServingWizard.findModelDeploymentStep().should('be.enabled');
+    modelServingWizard.findAdvancedOptionsStep().should('be.disabled');
+    modelServingWizard.findNextButton().should('be.disabled');
+    modelServingWizard.findModelDeploymentNameInput().type('test-model');
+    modelServingWizard.findAdvancedOptionsStep().should('be.disabled');
+    hardwareProfileSection.findHardwareProfileSearchSelector().click();
+    const globalScopedHardwareProfile = hardwareProfileSection.getGlobalScopedHardwareProfile();
+    globalScopedHardwareProfile
+      .find()
+      .findByRole('menuitem', {
+        name: /Medium/,
+        hidden: true,
+      })
+      .click();
+    hardwareProfileSection.findGlobalScopedLabel().should('exist');
+    modelServingWizard.findNextButton().should('be.disabled');
+    modelServingWizard.findModelFormatSelect().should('exist');
+    modelServingWizard.findModelFormatSelectOption('vLLM').should('not.exist');
+    modelServingWizard.findModelFormatSelectOption('openvino_ir - opset1').should('exist').click();
     modelServingWizard.findNextButton().should('be.enabled').click();
   });
 
@@ -189,14 +259,12 @@ describe('Model Serving Deploy Wizard', () => {
 
     // Step 1: Model source
     modelServingWizardEdit.findModelSourceStep().should('be.enabled');
-    modelServingWizardEdit.findNextButton().should('be.disabled');
+    modelServingWizardEdit.findNextButton().should('be.enabled');
 
     // Need to update this when you extract model type from deployment
-    modelServingWizardEdit.findModelTypeSelectOption('Predictive model').should('exist');
     modelServingWizardEdit
-      .findModelTypeSelectOption('Generative AI model (e.g. LLM)')
-      .should('exist')
-      .click();
+      .findModelTypeSelectOption('Predictive model')
+      .should('have.attr', 'aria-selected', 'true');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
     // Step 2: Model deployment

--- a/frontend/src/api/k8s/templates.ts
+++ b/frontend/src/api/k8s/templates.ts
@@ -47,7 +47,7 @@ export const assembleServingRuntimeTemplate = (
       annotations: {
         'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
         ...(modelTypes.length > 0 && {
-          'opendatahub.io/modelServingType': JSON.stringify(modelTypes),
+          'opendatahub.io/model-type': JSON.stringify(modelTypes),
         }),
         ...(apiProtocol && { 'opendatahub.io/apiProtocol': apiProtocol }),
       },

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1228,7 +1228,7 @@ export type TemplateKind = K8sResourceCommon & {
       'opendatahub.io/template-enabled': string;
       'opendatahub.io/modelServingSupport': string;
       'opendatahub.io/apiProtocol': string;
-      'opendatahub.io/modelServingType': string;
+      'opendatahub.io/model-type': string;
     }>;
     name: string;
     namespace: string;

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -194,15 +194,16 @@ export const getAPIProtocolFromTemplate = (
 };
 
 export const getModelTypesFromTemplate = (template: TemplateKind): ServingRuntimeModelType[] => {
-  if (!template.metadata.annotations?.['opendatahub.io/modelServingType']) {
+  if (!template.metadata.annotations?.['opendatahub.io/model-type']) {
     return [];
   }
 
   try {
-    const modelTypes = JSON.parse(template.metadata.annotations['opendatahub.io/modelServingType']);
+    const modelTypes = JSON.parse(template.metadata.annotations['opendatahub.io/model-type']);
     if (!Array.isArray(modelTypes)) {
       return [];
     }
+    console.log('modelTypes', modelTypes);
     const validTypes: ServingRuntimeModelType[] = [];
     for (const type of modelTypes) {
       if (
@@ -212,6 +213,7 @@ export const getModelTypesFromTemplate = (template: TemplateKind): ServingRuntim
         validTypes.push(type);
       }
     }
+    console.log('validTypes', validTypes);
     return validTypes;
   } catch (e) {
     return [];

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -203,7 +203,6 @@ export const getModelTypesFromTemplate = (template: TemplateKind): ServingRuntim
     if (!Array.isArray(modelTypes)) {
       return [];
     }
-    console.log('modelTypes', modelTypes);
     const validTypes: ServingRuntimeModelType[] = [];
     for (const type of modelTypes) {
       if (
@@ -213,7 +212,6 @@ export const getModelTypesFromTemplate = (template: TemplateKind): ServingRuntim
         validTypes.push(type);
       }
     }
-    console.log('validTypes', validTypes);
     return validTypes;
   } catch (e) {
     return [];

--- a/frontend/src/services/templateService.ts
+++ b/frontend/src/services/templateService.ts
@@ -113,17 +113,17 @@ export const updateServingRuntimeTemplateBackend = (
                   'opendatahub.io/modelServingSupport': JSON.stringify(platforms),
                 },
               },
-          ...(existingTemplate.metadata.annotations?.['opendatahub.io/modelServingType']
+          ...(existingTemplate.metadata.annotations?.['opendatahub.io/model-type']
             ? [
                 runtimeModelTypeValue
                   ? {
                       op: 'replace',
-                      path: '/metadata/annotations/opendatahub.io~1modelServingType',
+                      path: '/metadata/annotations/opendatahub.io~1model-type',
                       value: runtimeModelTypeValue,
                     }
                   : {
                       op: 'remove',
-                      path: '/metadata/annotations/opendatahub.io~1modelServingType',
+                      path: '/metadata/annotations/opendatahub.io~1model-type',
                     },
               ]
             : runtimeModelTypeValue

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -13,6 +13,7 @@ import type {
   DeployedModelServingDetails,
   ModelServingStartStopAction,
   ModelServingPlatformFetchDeploymentStatus,
+  ModelServingDeploymentFormDataExtension,
 } from '@odh-dashboard/model-serving/extension-points';
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/index';
@@ -24,6 +25,7 @@ const extensions: (
   | ModelServingPlatformExtension<KServeDeployment>
   | ModelServingPlatformWatchDeploymentsExtension<KServeDeployment>
   | ModelServingDeploymentResourcesExtension<KServeDeployment>
+  | ModelServingDeploymentFormDataExtension<KServeDeployment>
   | ModelServingAuthExtension<KServeDeployment>
   | ModelServingDeploymentsExpandedInfo<KServeDeployment>
   | ModelServingDeleteModal<KServeDeployment>
@@ -76,10 +78,6 @@ const extensions: (
     properties: {
       platform: KSERVE_ID,
       useResources: () => import('./src/useKServeResources').then((m) => m.useKServeResources),
-      extractHardwareProfileConfig: () =>
-        import('./src/useKServeResources').then((m) => m.extractHardwareProfileConfig),
-      applyHardwareProfileToDeployment: () =>
-        import('./src/useKServeResources').then((m) => m.applyHardwareProfileToDeployment),
     },
   },
   {
@@ -137,6 +135,15 @@ const extensions: (
     properties: {
       platform: KSERVE_ID,
       fetch: () => import('./src/deployments').then((m) => m.fetchDeploymentStatus),
+    },
+  },
+  {
+    type: 'model-serving.deployment/form-data',
+    properties: {
+      platform: KSERVE_ID,
+      extractHardwareProfileConfig: () =>
+        import('./src/useKServeResources').then((m) => m.extractHardwareProfileConfig),
+      extractModelFormat: () => import('./src/modelFormat').then((m) => m.extractKServeModelFormat),
     },
   },
 ];

--- a/packages/kserve/src/modelFormat.ts
+++ b/packages/kserve/src/modelFormat.ts
@@ -1,0 +1,27 @@
+import type { SupportedModelFormats } from '@odh-dashboard/internal/k8sTypes.js';
+import type { KServeDeployment } from './deployments';
+
+export const extractKServeModelFormat = (
+  deployment: KServeDeployment,
+): SupportedModelFormats | null => {
+  const modelFormat = deployment.model.spec.predictor.model?.modelFormat;
+  if (modelFormat) {
+    return {
+      name: modelFormat.name,
+      version: modelFormat.version,
+    };
+  }
+  return null;
+};
+
+export const applyKServeModelFormatToDeployment = (
+  deployment: KServeDeployment,
+  modelFormat: SupportedModelFormats,
+): KServeDeployment => {
+  const updatedDeployment = { ...deployment };
+  if (!updatedDeployment.model.spec.predictor.model) {
+    updatedDeployment.model.spec.predictor.model = {};
+  }
+  updatedDeployment.model.spec.predictor.model.modelFormat = modelFormat;
+  return updatedDeployment;
+};

--- a/packages/kserve/src/modelFormat.ts
+++ b/packages/kserve/src/modelFormat.ts
@@ -18,7 +18,7 @@ export const applyKServeModelFormatToDeployment = (
   deployment: KServeDeployment,
   modelFormat: SupportedModelFormats,
 ): KServeDeployment => {
-  const updatedDeployment = { ...deployment };
+  const updatedDeployment = structuredClone(deployment);
   if (!updatedDeployment.model.spec.predictor.model) {
     updatedDeployment.model.spec.predictor.model = {};
   }

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -5,6 +5,7 @@ import type {
   DisplayNameAnnotations,
   K8sAPIOptions,
   ProjectKind,
+  SupportedModelFormats,
 } from '@odh-dashboard/internal/k8sTypes';
 // eslint-disable-next-line no-restricted-syntax, @typescript-eslint/consistent-type-imports
 import type { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
@@ -46,7 +47,10 @@ export type ModelResourceType = K8sResourceCommon & {
   metadata: {
     name: string;
     namespace: string;
-    annotations?: DisplayNameAnnotations;
+    annotations?: DisplayNameAnnotations &
+      Partial<{
+        'opendatahub.io/model-type': string;
+      }>;
   };
 };
 
@@ -134,18 +138,27 @@ export type ModelServingDeploymentResourcesExtension<D extends Deployment = Depl
   {
     platform: D['modelServingPlatformId'];
     useResources: CodeRef<(deployment: D) => ModelServingPodSpecOptionsState | null>;
-    extractHardwareProfileConfig: CodeRef<
-      (deployment: D) => Parameters<typeof useHardwareProfileConfig> | null
-    >;
-    applyHardwareProfileToDeployment: CodeRef<
-      (deployment: D, parameters: ReturnType<typeof useHardwareProfileConfig>) => D
-    >;
   }
 >;
 export const isModelServingDeploymentResourcesExtension = <D extends Deployment = Deployment>(
   extension: Extension,
 ): extension is ModelServingDeploymentResourcesExtension<D> =>
   extension.type === 'model-serving.deployment/resources';
+
+export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deployment> = Extension<
+  'model-serving.deployment/form-data',
+  {
+    platform: D['modelServingPlatformId'];
+    extractHardwareProfileConfig: CodeRef<
+      (deployment: D) => Parameters<typeof useHardwareProfileConfig> | null
+    >;
+    extractModelFormat: CodeRef<(deployment: D) => SupportedModelFormats | null>;
+  }
+>;
+export const isModelServingDeploymentFormDataExtension = <D extends Deployment = Deployment>(
+  extension: Extension,
+): extension is ModelServingDeploymentFormDataExtension<D> =>
+  extension.type === 'model-serving.deployment/form-data';
 
 export type ModelServingAuthExtension<D extends Deployment = Deployment> = Extension<
   'model-serving.auth',

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { z } from 'zod';
+import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import SimpleSelect, {
+  type SimpleSelectOption,
+} from '@odh-dashboard/internal/components/SimpleSelect';
+import type { SupportedModelFormats } from '@odh-dashboard/internal/k8sTypes';
+import {
+  getModelTypesFromTemplate,
+  getServingRuntimeFromTemplate,
+} from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import { modelTypeSelectFieldSchema, type ModelTypeFieldData } from './ModelTypeSelectField';
+import { useServingRuntimeTemplates } from '../../../concepts/servingRuntimeTemplates/useServingRuntimeTemplates';
+
+// Schema
+
+export const modelFormatFieldSchema = z
+  .object({
+    type: modelTypeSelectFieldSchema.optional(),
+    format: z.custom<SupportedModelFormats>().optional(),
+  })
+  .refine((data) => !(data.type === ServingRuntimeModelType.PREDICTIVE && !data.format), {
+    message: 'Model format is requied for predictive models',
+  });
+
+// Hooks
+
+export type ModelFormatState = {
+  modelFormatOptions: SupportedModelFormats[];
+  modelFormat?: SupportedModelFormats;
+  setModelFormat: (modelFormat: SupportedModelFormats) => void;
+  isVisible?: boolean;
+  error?: Error;
+  loaded?: boolean;
+};
+
+export const useModelFormatField = (
+  initialModelFormat?: SupportedModelFormats,
+  modelType?: ModelTypeFieldData,
+): ModelFormatState => {
+  const [servingRuntimeTemplates, servingRuntimeTemplatesLoaded, servingRuntimeTemplatesError] =
+    useServingRuntimeTemplates();
+
+  const templatesFilteredForModelType = React.useMemo(() => {
+    return servingRuntimeTemplates.filter((template) => {
+      // If no model type is specified, show anyways for compatibility
+      if (getModelTypesFromTemplate(template).length === 0) {
+        return true;
+      }
+      if (!modelType) {
+        return true;
+      }
+      const templateModelTypes = getModelTypesFromTemplate(template);
+      if (templateModelTypes.includes(modelType)) {
+        return true;
+      }
+      return false;
+    });
+  }, [servingRuntimeTemplates, modelType]);
+
+  const modelFormatOptions = React.useMemo(() => {
+    const formats: SupportedModelFormats[] = [];
+    for (const template of templatesFilteredForModelType) {
+      const servingRuntime = getServingRuntimeFromTemplate(template);
+      if (servingRuntime?.spec.supportedModelFormats) {
+        for (const format of servingRuntime.spec.supportedModelFormats) {
+          if (!formats.find((f) => f.name === format.name && f.version === format.version)) {
+            formats.push(format);
+          }
+        }
+      }
+    }
+    return formats.toSorted((a, b) => a.name.localeCompare(b.name));
+  }, [templatesFilteredForModelType]);
+
+  const [tmpModelFormat, setModelFormat] = React.useState<SupportedModelFormats | undefined>(
+    initialModelFormat,
+  );
+
+  const modelFormat = React.useMemo(() => {
+    if (modelType === ServingRuntimeModelType.GENERATIVE) {
+      return {
+        name: 'vLLM',
+      };
+    }
+    return tmpModelFormat;
+  }, [modelType, tmpModelFormat]);
+
+  return {
+    modelFormatOptions,
+    modelFormat,
+    setModelFormat,
+    isVisible: modelType === ServingRuntimeModelType.PREDICTIVE,
+    error: servingRuntimeTemplatesError,
+    loaded: servingRuntimeTemplatesLoaded,
+  };
+};
+
+// Component
+
+type ModelFormatFieldProps = {
+  modelFormatState: ModelFormatState;
+};
+
+export const ModelFormatField: React.FC<ModelFormatFieldProps> = ({ modelFormatState }) => {
+  const { modelFormatOptions, modelFormat, setModelFormat, isVisible, error, loaded } =
+    modelFormatState;
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <FormGroup label="Model framework (name - version)" fieldId="model-framework-select" isRequired>
+      <SimpleSelect
+        dataTestId="model-framework-select"
+        toggleProps={{ id: 'model-framework-select' }}
+        options={modelFormatOptions.map((framework): SimpleSelectOption => {
+          const name = framework.version
+            ? `${framework.name} - ${framework.version}`
+            : `${framework.name}`;
+          return {
+            optionKey: name,
+            key: name,
+            label: name,
+          };
+        })}
+        isSkeleton={!loaded}
+        isFullWidth
+        toggleLabel={
+          modelFormat?.version ? `${modelFormat.name} - ${modelFormat.version}` : modelFormat?.name
+        }
+        placeholder="Select a model format"
+        value={modelFormat?.name}
+        onChange={(option) => {
+          const [name, version] = option.split(' - ');
+          setModelFormat({ name, version });
+        }}
+        popperProps={{ appendTo: 'inline' }}
+      />
+      {error && (
+        <HelperText>
+          <HelperTextItem variant="error">{error.message}</HelperTextItem>
+        </HelperText>
+      )}
+    </FormGroup>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
@@ -21,8 +21,8 @@ const getModelFormatLabel = (modelFormat: SupportedModelFormats): string => {
 
 export const modelFormatFieldSchema = z
   .object({
-    type: modelTypeSelectFieldSchema.optional(),
-    format: z.custom<SupportedModelFormats>().optional(),
+    type: modelTypeSelectFieldSchema,
+    format: z.custom<SupportedModelFormats>(),
   })
   .refine((data) => !(data.type === ServingRuntimeModelType.PREDICTIVE && !data.format), {
     message: 'Model format is required for predictive models',

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
@@ -13,6 +13,10 @@ import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { modelTypeSelectFieldSchema, type ModelTypeFieldData } from './ModelTypeSelectField';
 import { useServingRuntimeTemplates } from '../../../concepts/servingRuntimeTemplates/useServingRuntimeTemplates';
 
+const getModelFormatLabel = (modelFormat: SupportedModelFormats): string => {
+  return modelFormat.version ? `${modelFormat.name} - ${modelFormat.version}` : modelFormat.name;
+};
+
 // Schema
 
 export const modelFormatFieldSchema = z
@@ -21,7 +25,7 @@ export const modelFormatFieldSchema = z
     format: z.custom<SupportedModelFormats>().optional(),
   })
   .refine((data) => !(data.type === ServingRuntimeModelType.PREDICTIVE && !data.format), {
-    message: 'Model format is requied for predictive models',
+    message: 'Model format is required for predictive models',
   });
 
 // Hooks
@@ -117,22 +121,18 @@ export const ModelFormatField: React.FC<ModelFormatFieldProps> = ({ modelFormatS
         dataTestId="model-framework-select"
         toggleProps={{ id: 'model-framework-select' }}
         options={modelFormatOptions.map((framework): SimpleSelectOption => {
-          const name = framework.version
-            ? `${framework.name} - ${framework.version}`
-            : `${framework.name}`;
+          const label = getModelFormatLabel(framework);
           return {
-            optionKey: name,
-            key: name,
-            label: name,
+            optionKey: label,
+            key: label,
+            label,
           };
         })}
         isSkeleton={!loaded}
         isFullWidth
-        toggleLabel={
-          modelFormat?.version ? `${modelFormat.name} - ${modelFormat.version}` : modelFormat?.name
-        }
+        toggleLabel={modelFormat ? getModelFormatLabel(modelFormat) : undefined}
         placeholder="Select a model format"
-        value={modelFormat?.name}
+        value={modelFormat ? getModelFormatLabel(modelFormat) : undefined}
         onChange={(option) => {
           const [name, version] = option.split(' - ');
           setModelFormat({ name, version });

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -4,17 +4,21 @@ import { z, type ZodIssue } from 'zod';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
 import { FieldValidationProps } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { ZodErrorHelperText } from '@odh-dashboard/internal/components/ZodErrorFormHelperText';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 
 // Schema
 
-export const modelTypeSelectFieldSchema = z.enum(['predictive-model', 'generative-model'], {
-  // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase
-  required_error: 'Select a model type.',
-});
+export const modelTypeSelectFieldSchema = z.enum(
+  [ServingRuntimeModelType.PREDICTIVE, ServingRuntimeModelType.GENERATIVE],
+  {
+    // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase
+    required_error: 'Select a model type.',
+  },
+);
 
 export type ModelTypeFieldData = z.infer<typeof modelTypeSelectFieldSchema>;
 export const isValidModelType = (value: string): value is ModelTypeFieldData =>
-  value === 'predictive-model' || value === 'generative-model';
+  value === ServingRuntimeModelType.PREDICTIVE || value === ServingRuntimeModelType.GENERATIVE;
 
 // Hooks
 
@@ -49,11 +53,11 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
     <SimpleSelect
       options={[
         {
-          key: 'predictive-model',
+          key: ServingRuntimeModelType.PREDICTIVE,
           label: 'Predictive model',
         },
         {
-          key: 'generative-model',
+          key: ServingRuntimeModelType.GENERATIVE,
           label: 'Generative AI model (e.g. LLM)',
         },
       ]}

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
@@ -1,0 +1,324 @@
+import React, { act } from 'react';
+import { render, screen, fireEvent, renderHook } from '@testing-library/react';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import type { SupportedModelFormats, TemplateKind } from '@odh-dashboard/internal/k8sTypes';
+import { ModelFormatField, modelFormatFieldSchema, useModelFormatField } from '../ModelFormatField';
+import { useServingRuntimeTemplates } from '../../../../concepts/servingRuntimeTemplates/useServingRuntimeTemplates';
+
+// Mock dependencies
+jest.mock('@odh-dashboard/internal/concepts/servingRuntimeTemplates/useServingRuntimeTemplates');
+jest.mock('@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils', () => ({
+  getModelTypesFromTemplate: jest.fn(),
+  getServingRuntimeFromTemplate: jest.fn(),
+}));
+
+const mockUseServingRuntimeTemplates = useServingRuntimeTemplates as jest.MockedFunction<
+  typeof useServingRuntimeTemplates
+>;
+
+const {
+  getModelTypesFromTemplate,
+  getServingRuntimeFromTemplate,
+} = require('@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils');
+
+describe('ModelFormatField', () => {
+  const mockFormats: SupportedModelFormats[] = [
+    { name: 'tensorflow', version: '2.0' },
+    { name: 'pytorch', version: '1.8' },
+    { name: 'onnx' },
+  ];
+
+  const mockTemplate: Partial<TemplateKind> = {
+    metadata: { name: 'test-template', namespace: 'test-namespace' },
+  };
+
+  const mockServingRuntime = {
+    spec: {
+      supportedModelFormats: mockFormats,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseServingRuntimeTemplates.mockReturnValue([[], false, undefined]);
+    getModelTypesFromTemplate.mockReturnValue([]);
+    getServingRuntimeFromTemplate.mockReturnValue(mockServingRuntime);
+  });
+
+  describe('Schema validation', () => {
+    it('should validate when format is provided for predictive models', () => {
+      const data = {
+        type: ServingRuntimeModelType.PREDICTIVE,
+        format: { name: 'tensorflow', version: '2.0' },
+      };
+      const result = modelFormatFieldSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate when no format is provided for generative models', () => {
+      const data = {
+        type: ServingRuntimeModelType.GENERATIVE,
+      };
+      const result = modelFormatFieldSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail validation when format is missing for predictive models', () => {
+      const data = {
+        type: ServingRuntimeModelType.PREDICTIVE,
+      };
+      const result = modelFormatFieldSchema.safeParse(data);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Model format is requied for predictive models',
+        );
+      }
+    });
+  });
+
+  describe('useModelFormatField hook', () => {
+    it('should initialize with default values', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+
+      const { result } = renderHook(() => useModelFormatField());
+
+      expect(result.current.modelFormatOptions).toEqual([]);
+      expect(result.current.modelFormat).toBeUndefined();
+      expect(result.current.isVisible).toBe(false);
+      expect(result.current.loaded).toBe(true);
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it('should initialize with initial model format', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+      const initialFormat = { name: 'tensorflow', version: '2.0' };
+
+      const { result } = renderHook(() => useModelFormatField(initialFormat));
+
+      expect(result.current.modelFormat).toEqual(initialFormat);
+    });
+
+    it('should show field for predictive model type', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      expect(result.current.isVisible).toBe(true);
+    });
+
+    it('should hide field for generative model type', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.GENERATIVE),
+      );
+
+      expect(result.current.isVisible).toBe(false);
+    });
+
+    it('should return vLLM format for generative models', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.GENERATIVE),
+      );
+
+      expect(result.current.modelFormat).toEqual({ name: 'vLLM' });
+    });
+
+    it('should extract and sort model formats from templates', () => {
+      const templates = [mockTemplate] as TemplateKind[];
+      mockUseServingRuntimeTemplates.mockReturnValue([templates, true, undefined]);
+      getModelTypesFromTemplate.mockReturnValue([ServingRuntimeModelType.PREDICTIVE]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      expect(result.current.modelFormatOptions).toEqual([
+        { name: 'onnx' },
+        { name: 'pytorch', version: '1.8' },
+        { name: 'tensorflow', version: '2.0' },
+      ]);
+    });
+
+    it('should filter templates by model type', () => {
+      const templates = [mockTemplate] as TemplateKind[];
+      mockUseServingRuntimeTemplates.mockReturnValue([templates, true, undefined]);
+      getModelTypesFromTemplate.mockReturnValue([ServingRuntimeModelType.GENERATIVE]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      expect(result.current.modelFormatOptions).toEqual([]);
+    });
+
+    it('should include templates with no model types for compatibility', () => {
+      const templates = [mockTemplate] as TemplateKind[];
+      mockUseServingRuntimeTemplates.mockReturnValue([templates, true, undefined]);
+      getModelTypesFromTemplate.mockReturnValue([]);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      expect(result.current.modelFormatOptions).toEqual([
+        { name: 'onnx' },
+        { name: 'pytorch', version: '1.8' },
+        { name: 'tensorflow', version: '2.0' },
+      ]);
+    });
+
+    it('should update model format', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, undefined]);
+      const newFormat = { name: 'pytorch', version: '1.8' };
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      act(() => {
+        result.current.setModelFormat(newFormat);
+      });
+
+      expect(result.current.modelFormat).toEqual(newFormat);
+    });
+
+    it('should handle loading state', () => {
+      mockUseServingRuntimeTemplates.mockReturnValue([[], false, undefined]);
+
+      const { result } = renderHook(() => useModelFormatField());
+
+      expect(result.current.loaded).toBe(false);
+    });
+
+    it('should handle error state', () => {
+      const error = new Error('Failed to load templates');
+      mockUseServingRuntimeTemplates.mockReturnValue([[], true, error]);
+
+      const { result } = renderHook(() => useModelFormatField());
+
+      expect(result.current.error).toBe(error);
+    });
+
+    it('should deduplicate model formats', () => {
+      const duplicateFormats = [
+        { name: 'tensorflow', version: '2.0' },
+        { name: 'tensorflow', version: '2.0' },
+        { name: 'pytorch' },
+      ];
+      const servingRuntimeWithDuplicates = {
+        spec: { supportedModelFormats: duplicateFormats },
+      };
+
+      const templates = [mockTemplate, mockTemplate] as TemplateKind[];
+      mockUseServingRuntimeTemplates.mockReturnValue([templates, true, undefined]);
+      getModelTypesFromTemplate.mockReturnValue([ServingRuntimeModelType.PREDICTIVE]);
+      getServingRuntimeFromTemplate.mockReturnValue(servingRuntimeWithDuplicates);
+
+      const { result } = renderHook(() =>
+        useModelFormatField(undefined, ServingRuntimeModelType.PREDICTIVE),
+      );
+
+      expect(result.current.modelFormatOptions).toEqual([
+        { name: 'pytorch' },
+        { name: 'tensorflow', version: '2.0' },
+      ]);
+    });
+  });
+
+  describe('Component', () => {
+    const mockSetModelFormat = jest.fn();
+    const defaultModelFormatState = {
+      modelFormatOptions: mockFormats,
+      modelFormat: undefined,
+      setModelFormat: mockSetModelFormat,
+      isVisible: true,
+      loaded: true,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should not render when not visible', () => {
+      const { container } = render(
+        <ModelFormatField modelFormatState={{ ...defaultModelFormatState, isVisible: false }} />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render select field when visible', () => {
+      render(<ModelFormatField modelFormatState={defaultModelFormatState} />);
+      expect(screen.getByLabelText(/Model framework/)).toBeInTheDocument();
+      expect(screen.getByText('Select a model format')).toBeInTheDocument();
+    });
+
+    it('should display selected format with version', () => {
+      const stateWithSelection = {
+        ...defaultModelFormatState,
+        modelFormat: { name: 'tensorflow', version: '2.0' },
+      };
+      render(<ModelFormatField modelFormatState={stateWithSelection} />);
+      expect(screen.getByText('tensorflow - 2.0')).toBeInTheDocument();
+    });
+
+    it('should display selected format without version', () => {
+      const stateWithSelection = {
+        ...defaultModelFormatState,
+        modelFormat: { name: 'onnx' },
+      };
+      render(<ModelFormatField modelFormatState={stateWithSelection} />);
+      expect(screen.getByText('onnx')).toBeInTheDocument();
+    });
+
+    it('should show skeleton when loading', () => {
+      const { container } = render(
+        <ModelFormatField modelFormatState={{ ...defaultModelFormatState, loaded: false }} />,
+      );
+      expect(container.querySelector('.pf-v6-c-skeleton')).toBeInTheDocument();
+    });
+
+    it('should display error message', () => {
+      const error = new Error('Test error');
+      render(<ModelFormatField modelFormatState={{ ...defaultModelFormatState, error }} />);
+      expect(screen.getByText('Test error')).toBeInTheDocument();
+    });
+
+    it('should call setModelFormat on selection', async () => {
+      render(<ModelFormatField modelFormatState={defaultModelFormatState} />);
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      const option = screen.getByText('tensorflow - 2.0');
+      await act(async () => {
+        fireEvent.click(option);
+      });
+
+      expect(mockSetModelFormat).toHaveBeenCalledWith({ name: 'tensorflow', version: '2.0' });
+    });
+
+    it('should handle format without version in selection', async () => {
+      render(<ModelFormatField modelFormatState={defaultModelFormatState} />);
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      const option = screen.getByText('onnx');
+      await act(async () => {
+        fireEvent.click(option);
+      });
+
+      expect(mockSetModelFormat).toHaveBeenCalledWith({ name: 'onnx', version: undefined });
+    });
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
@@ -6,7 +6,7 @@ import { ModelFormatField, modelFormatFieldSchema, useModelFormatField } from '.
 import { useServingRuntimeTemplates } from '../../../../concepts/servingRuntimeTemplates/useServingRuntimeTemplates';
 
 // Mock dependencies
-jest.mock('@odh-dashboard/internal/concepts/servingRuntimeTemplates/useServingRuntimeTemplates');
+jest.mock('../../../../concepts/servingRuntimeTemplates/useServingRuntimeTemplates');
 jest.mock('@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils', () => ({
   getModelTypesFromTemplate: jest.fn(),
   getServingRuntimeFromTemplate: jest.fn(),

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelFormatField.test.tsx
@@ -71,7 +71,7 @@ describe('ModelFormatField', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0].message).toBe(
-          'Model format is requied for predictive models',
+          'Model format is required for predictive models',
         );
       }
     });

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -1,7 +1,7 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent, renderHook } from '@testing-library/react';
 import { type ZodIssue } from 'zod';
-import { ServingRuntimeModelType } from '@odh-dashboard/internal/types.js';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import {
   ModelTypeSelectField,
   modelTypeSelectFieldSchema,
@@ -11,16 +11,16 @@ import {
 
 describe('ModelTypeSelectField', () => {
   describe('Schema validation', () => {
-    it('should validate predictive-model', () => {
-      const result = modelTypeSelectFieldSchema.safeParse('predictive-model');
+    it('should validate predictive', () => {
+      const result = modelTypeSelectFieldSchema.safeParse(ServingRuntimeModelType.PREDICTIVE);
       expect(result.success).toBe(true);
-      expect(result.data).toBe('predictive-model');
+      expect(result.data).toBe(ServingRuntimeModelType.PREDICTIVE);
     });
 
     it('should validate generative-model', () => {
-      const result = modelTypeSelectFieldSchema.safeParse('generative-model');
+      const result = modelTypeSelectFieldSchema.safeParse(ServingRuntimeModelType.GENERATIVE);
       expect(result.success).toBe(true);
-      expect(result.data).toBe('generative-model');
+      expect(result.data).toBe(ServingRuntimeModelType.GENERATIVE);
     });
 
     it('should reject invalid values', () => {
@@ -39,8 +39,8 @@ describe('ModelTypeSelectField', () => {
 
   describe('isValidModelType', () => {
     it('should return true for valid model types', () => {
-      expect(isValidModelType('predictive-model')).toBe(true);
-      expect(isValidModelType('generative-model')).toBe(true);
+      expect(isValidModelType(ServingRuntimeModelType.PREDICTIVE)).toBe(true);
+      expect(isValidModelType(ServingRuntimeModelType.GENERATIVE)).toBe(true);
     });
 
     it('should return false for invalid model types', () => {
@@ -99,7 +99,7 @@ describe('ModelTypeSelectField', () => {
         fireEvent.click(option);
       });
 
-      expect(mockSetModelType).toHaveBeenCalledWith('generative-model');
+      expect(mockSetModelType).toHaveBeenCalledWith(ServingRuntimeModelType.GENERATIVE);
     });
 
     it('should display validation errors', () => {

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent, renderHook } from '@testing-library/react';
 import { type ZodIssue } from 'zod';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types.js';
 import {
   ModelTypeSelectField,
   modelTypeSelectFieldSchema,
@@ -55,16 +56,16 @@ describe('ModelTypeSelectField', () => {
     });
 
     it('should initialize with existing data', () => {
-      const { result } = renderHook(() => useModelTypeField('predictive-model'));
-      expect(result.current.data).toBe('predictive-model');
+      const { result } = renderHook(() => useModelTypeField(ServingRuntimeModelType.PREDICTIVE));
+      expect(result.current.data).toBe(ServingRuntimeModelType.PREDICTIVE);
     });
 
     it('should update model type', () => {
       const { result } = renderHook(() => useModelTypeField());
       act(() => {
-        result.current.setData('generative-model');
+        result.current.setData(ServingRuntimeModelType.GENERATIVE);
       });
-      expect(result.current.data).toBe('generative-model');
+      expect(result.current.data).toBe(ServingRuntimeModelType.GENERATIVE);
     });
   });
 
@@ -82,7 +83,7 @@ describe('ModelTypeSelectField', () => {
     });
 
     it('should render with selected value', () => {
-      render(<ModelTypeSelectField modelType="predictive-model" />);
+      render(<ModelTypeSelectField modelType={ServingRuntimeModelType.PREDICTIVE} />);
       expect(screen.getByText('Predictive model')).toBeInTheDocument();
     });
 

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -4,6 +4,7 @@ import K8sNameDescriptionField from '@odh-dashboard/internal/concepts/k8s/K8sNam
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import ProjectSection from '../fields/ProjectSection';
 import { ModelServingHardwareProfileSection } from '../fields/ModelServingHardwareProfileSection';
+import { ModelFormatField } from '../fields/ModelFormatField';
 
 type ModelDeploymentStepProps = {
   projectName: string;
@@ -31,6 +32,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
           hardwareProfileConfig={wizardState.state.hardwareProfileConfig}
           isEditing={false}
         />
+        <ModelFormatField modelFormatState={wizardState.state.modelFormatState} />
       </FormSection>
     </Form>
   );

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import * as _ from 'lodash-es';
 import { mockK8sNameDescriptionFieldData } from '@odh-dashboard/internal/__mocks__/mockK8sNameDescriptionFieldData';
 import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { ModelSourceStepContent } from '../ModelSourceStep';
 import { modelTypeSelectFieldSchema } from '../../fields/ModelTypeSelectField';
 import type { UseModelDeploymentWizardState } from '../../useDeploymentWizard';
@@ -52,6 +53,14 @@ const mockDeploymentWizardState = (
           resetFormData: jest.fn(),
           profilesLoaded: true,
         },
+        modelFormatState: {
+          modelFormatOptions: [],
+          modelFormat: undefined,
+          setModelFormat: jest.fn(),
+          isVisible: false,
+          error: undefined,
+          loaded: true,
+        },
       },
     },
     overrides,
@@ -95,7 +104,7 @@ describe('ModelSourceStep', () => {
   describe('Schema validation', () => {
     it('should validate complete data', () => {
       const validData: ModelSourceStepData = {
-        modelType: 'predictive-model',
+        modelType: ServingRuntimeModelType.PREDICTIVE,
       };
       const result = modelSourceStepSchema.safeParse(validData);
       expect(result.success).toBe(true);
@@ -123,7 +132,7 @@ describe('ModelSourceStep', () => {
       const wizardDataWithSelection = mockDeploymentWizardState({
         state: {
           modelType: {
-            data: 'generative-model',
+            data: ServingRuntimeModelType.GENERATIVE,
           },
         },
       });

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -2,12 +2,15 @@ import { K8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8
 import { useK8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { extractK8sNameDescriptionFieldData } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import type { SupportedModelFormats } from '@odh-dashboard/internal/k8sTypes';
 import { useModelTypeField, type ModelTypeFieldData } from './fields/ModelTypeSelectField';
+import { useModelFormatField } from './fields/ModelFormatField';
 
 export type ModelDeploymentWizardData = {
   modelTypeField?: ModelTypeFieldData;
   k8sNameDesc?: K8sNameDescriptionFieldData;
   hardwareProfile?: Parameters<typeof useHardwareProfileConfig>;
+  modelFormat?: SupportedModelFormats;
 };
 
 export type UseModelDeploymentWizardState = {
@@ -16,6 +19,7 @@ export type UseModelDeploymentWizardState = {
     modelType: ReturnType<typeof useModelTypeField>;
     k8sNameDesc: ReturnType<typeof useK8sNameDescriptionFieldData>;
     hardwareProfileConfig: ReturnType<typeof useHardwareProfileConfig>;
+    modelFormatState: ReturnType<typeof useModelFormatField>;
   };
 };
 
@@ -30,6 +34,7 @@ export const useModelDeploymentWizard = (
     initialData: extractK8sNameDescriptionFieldData(initialData?.k8sNameDesc),
   });
   const hardwareProfileConfig = useHardwareProfileConfig(...(initialData?.hardwareProfile ?? []));
+  const modelFormatState = useModelFormatField(initialData?.modelFormat, modelType.data);
 
   // Step 3: Advanced Options
 
@@ -41,6 +46,7 @@ export const useModelDeploymentWizard = (
       modelType,
       k8sNameDesc,
       hardwareProfileConfig,
+      modelFormatState,
     },
   };
 };

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -5,6 +5,7 @@ import { useValidation } from '@odh-dashboard/internal/utilities/useValidation';
 import { hardwareProfileValidationSchema } from '@odh-dashboard/internal/concepts/hardwareProfiles/validationUtils';
 import type { UseModelDeploymentWizardState } from './useDeploymentWizard';
 import { modelSourceStepSchema, type ModelSourceStepData } from './steps/ModelSourceStep';
+import { modelFormatFieldSchema } from './fields/ModelFormatField';
 
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
@@ -34,13 +35,21 @@ export const useModelDeploymentWizardValidation = (
     state.hardwareProfileConfig.formData,
     hardwareProfileValidationSchema,
   );
+  const modelFormatValidation = useValidation(
+    {
+      type: state.modelType.data,
+      format: state.modelFormatState.modelFormat,
+    },
+    modelFormatFieldSchema,
+  );
 
   // Step validation
   const isModelSourceStepValid =
     modelSourceStepValidation.getFieldValidation(undefined, true).length === 0;
   const isModelDeploymentStepValid =
     isK8sNameDescriptionDataValid(state.k8sNameDesc.data) &&
-    Object.keys(hardwareProfileValidation.getAllValidationIssues()).length === 0;
+    Object.keys(hardwareProfileValidation.getAllValidationIssues()).length === 0 &&
+    Object.keys(modelFormatValidation.getAllValidationIssues()).length === 0;
 
   return {
     modelSource: modelSourceStepValidation,

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -1,3 +1,6 @@
+import type { Deployment } from 'extension-points';
+import { isValidModelType, type ModelTypeFieldData } from './fields/ModelTypeSelectField';
+
 export const getDeploymentWizardRoute = (currentpath: string, deploymentName?: string): string => {
   if (deploymentName) {
     return `${currentpath}/deploy/edit/${deploymentName}`;
@@ -11,4 +14,16 @@ export const getDeploymentWizardExitRoute = (currentPath: string): string => {
     basePath += '?section=model-server';
   }
   return basePath;
+};
+
+export const getModelTypeFromDeployment = (
+  deployment: Deployment,
+): ModelTypeFieldData | undefined => {
+  if (
+    deployment.model.metadata.annotations?.['opendatahub.io/model-type'] &&
+    isValidModelType(deployment.model.metadata.annotations['opendatahub.io/model-type'])
+  ) {
+    return deployment.model.metadata.annotations['opendatahub.io/model-type'];
+  }
+  return undefined;
 };

--- a/packages/model-serving/src/concepts/__tests__/useAvailableClusterPlatforms.spec.ts
+++ b/packages/model-serving/src/concepts/__tests__/useAvailableClusterPlatforms.spec.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderHook } from '@odh-dashboard/jest-config/hooks';
 import { isEnabled } from '@odh-dashboard/internal/concepts/integrations/useIsComponentIntegrationEnabled';
-import { IntegrationAppStatus } from '@odh-dashboard/internal/types.js';
+import { IntegrationAppStatus } from '@odh-dashboard/internal/types';
 import { NamespaceApplicationCase } from '@odh-dashboard/internal/pages/projects/types';
 import { useAvailableClusterPlatforms } from '../useAvailableClusterPlatforms';
 import { ModelServingPlatform } from '../useProjectServingPlatform';

--- a/packages/model-serving/src/concepts/extensionUtils.ts
+++ b/packages/model-serving/src/concepts/extensionUtils.ts
@@ -53,7 +53,7 @@ export const useDeploymentExtension = <T extends PlatformExtension>(
 export const useResolvedDeploymentExtension = <T extends PlatformExtension>(
   extensionPredicate: ExtensionPredicate<T>,
   deployment?: Deployment | null,
-): [ResolvedExtension<T> | null, boolean, unknown[]] => {
+): [ResolvedExtension<T> | null, boolean, Error[]] => {
   const [resolvedExtensions, loaded, errors] = useResolvedExtensions<T>(extensionPredicate);
 
   return React.useMemo(
@@ -62,7 +62,7 @@ export const useResolvedDeploymentExtension = <T extends PlatformExtension>(
         (ext) => ext.properties.platform === deployment?.modelServingPlatformId,
       ) ?? null,
       loaded,
-      errors,
+      errors.map((error) => (error instanceof Error ? error : new Error(String(error)))),
     ],
     [resolvedExtensions, deployment?.modelServingPlatformId, loaded, errors],
   );


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://issues.redhat.com/browse/RHOAIENG-33068

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds the "Model framework (name - version)" select field
- When generative type is selected, the field is hidden
- formats are only shown for the runtimes that support that type
  - selecting generative is hidden but it would show vLLM only
  - selecting predictive will show formats that are only from "predictive" templates

<img width="774" height="857" alt="image" src="https://github.com/user-attachments/assets/dd67f5b7-f757-4001-a969-54dc713f158b" />

<img width="721" height="771" alt="image" src="https://github.com/user-attachments/assets/c52504bb-7e87-4abd-a9e5-c218efdf6a25" />

Editing will also now correctly load the saved value for the model type on step 1
<img width="427" height="404" alt="image" src="https://github.com/user-attachments/assets/b45f604a-bf28-420f-b6fb-2f3554635d8d" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Enable the model serving plug and the wizard
2. Create a model
3. Select "predictive" model type
4. The frameworks dropdown should only list predictive ones (all but vLLM basically)
5. Once selected, the "Next" button becomes enabled
6. Select "generative" model type
7. The frameworks field doesn't exist (when deployed, they should have vLLM)

Edit
1. Edit a deployed model
2. It should load the saved framework

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Cypress tests added and jest tests added

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.
cc @vconzola 
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a model format field to the deployment wizard (required for predictive models; generative auto-selects vLLM).
  - Unified model type selection and pre-fill from deployment metadata; wizard adapts generative vs predictive flows.
  - Templates, mocks, and deployment metadata now support configurable model-type annotations to enable multi-path behavior.
  - New extension to expose model-format extraction for deployments.

- Bug Fixes
  - Improved error reporting when resolving deployment extensions for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->