### PR TITLE
Assign node selectors and tolerations to InferenceService when an accelerator/legacy hardware profile is selected

### DIFF
--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -65,9 +65,6 @@ export const mockNimInferenceService = ({
     displayName,
     namespace,
     kserveInternalLabel: true,
-    hardwareProfileNamespace: 'opendatahub',
-    hardwareProfileName: 'migrated-gpu-mglzi-serving',
-    useLegacyHardwareProfile: true,
     resources: {
       limits: { cpu: '16', memory: '64Gi' },
       requests: { cpu: '8', memory: '32Gi' },
@@ -85,6 +82,10 @@ export const mockNimInferenceService = ({
   delete inferenceService.spec.predictor.model?.modelFormat?.version;
   delete inferenceService.spec.predictor.model?.storage;
   delete inferenceService.spec.predictor.imagePullSecrets;
+
+  if (!inferenceService.spec.predictor.tolerations) {
+    inferenceService.spec.predictor.tolerations = [];
+  }
 
   return inferenceService;
 };

--- a/frontend/src/__tests__/cypress/cypress/fixtures/e2e/acceleratorProfiles/testAcceleratorProfileModelServingTolerations.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/e2e/acceleratorProfiles/testAcceleratorProfileModelServingTolerations.yaml
@@ -1,0 +1,6 @@
+# testAcceleratorProfileModelServingTolerations.cy.ts Test Data #
+modelServingTolerationsTestNamespace: 'dsp-model-tolerations-test'
+resourceYamlPath: "resources/acceleratorProfile/acceleratorProfile.yaml"
+acceleratorProfileName: "cypress-accelerator-profile-model"
+modelName: "cypress-accelerator-profile-single-model"
+modelFilePath: "flan-t5-small/flan-t5-small-caikit"

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/acceleratorProfile/acceleratorProfile.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/acceleratorProfile/acceleratorProfile.yaml
@@ -1,0 +1,14 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: AcceleratorProfile
+metadata:
+  name: cypress-accelerator-profile-model
+spec:
+  displayName: cypress-accelerator-profile-model
+  description: Cypress test accelerator profile for model serving
+  enabled: true
+  identifier: nvidia.com/gpu
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Equal
+    value: cypress-test
+    effect: NoSchedule

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/acceleratorProfile/acceleratorProfile.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/acceleratorProfile/acceleratorProfile.yaml
@@ -8,7 +8,6 @@ spec:
   enabled: true
   identifier: nvidia.com/gpu
   tolerations:
-  - key: nvidia.com/gpu
-    operator: Equal
-    value: cypress-test
-    effect: NoSchedule
+    - key: nvidia.com/gpu
+      operator: Equal
+      effect: NoSchedule

--- a/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelServing.ts
@@ -293,6 +293,15 @@ class InferenceServiceModal extends ServingModal {
     cy.findByRole('option', { name }).click();
   }
 
+  findAcceleratorProfileSelect(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('accelerator-profile-select');
+  }
+
+  selectAcceleratorProfileOption(name: string): void {
+    this.findAcceleratorProfileSelect().click();
+    cy.contains(name).click();
+  }
+
   selectPotentiallyDisabledProfile(profileDisplayName: string, profileName?: string): void {
     const dropdown = this.findHardProfileSelection();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testAcceleratorProfileModelServingTolerations.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testAcceleratorProfileModelServingTolerations.cy.ts
@@ -1,0 +1,120 @@
+import type { DataScienceProjectData } from '#~/__tests__/cypress/cypress/types';
+import { deleteOpenShiftProject } from '#~/__tests__/cypress/cypress/utils/oc_commands/project';
+import { loadDSPFixture } from '#~/__tests__/cypress/cypress/utils/dataLoader';
+import { LDAP_CONTRIBUTOR_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import { projectDetails, projectListPage } from '#~/__tests__/cypress/cypress/pages/projects';
+import {
+  modelServingGlobal,
+  inferenceServiceModal,
+  modelServingSection,
+} from '#~/__tests__/cypress/cypress/pages/modelServing';
+import {
+  provisionProjectForModelServing,
+  validateInferenceServiceTolerations,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/modelServing';
+import { retryableBefore } from '#~/__tests__/cypress/cypress/utils/retryableHooks';
+import {
+  cleanupAcceleratorProfiles,
+  createAcceleratorProfile,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/acceleratorProfiles';
+import { generateTestUUID } from '#~/__tests__/cypress/cypress/utils/uuidGenerator';
+
+let projectData: DataScienceProjectData;
+let projectName: string;
+let modelName: string;
+let modelFilePath: string;
+let acceleratorProfileName: string;
+const awsBucket = 'BUCKET_3';
+const uuid = generateTestUUID();
+
+describe('[Bug: RHOAIENG-33131] Verify Model Serving Creation using Accelerator Profiles and applying Tolerations', () => {
+  retryableBefore(() => {
+    return loadDSPFixture('e2e/dataScienceProjects/testSingleModelContributorCreation.yaml').then(
+      (fixtureData: DataScienceProjectData) => {
+        projectData = fixtureData;
+        projectName = `${projectData.projectSingleModelResourceName}-${uuid}`;
+        modelName = projectData.singleModelName;
+        modelFilePath = projectData.modelFilePath;
+        acceleratorProfileName = `cypress-accelerator-profile-model-${uuid}`;
+        if (!projectName) {
+          throw new Error('Project name is undefined or empty in the loaded fixture');
+        }
+        cy.log(`Loaded project name: ${projectName}`);
+        provisionProjectForModelServing(
+          projectName,
+          awsBucket,
+          'resources/yaml/data_connection_model_serving.yaml',
+        );
+      },
+    );
+  });
+
+  after(() => {
+    // Clean up accelerator profile and project
+    cleanupAcceleratorProfiles(acceleratorProfileName);
+    deleteOpenShiftProject(projectName, { wait: true, ignoreNotFound: true });
+  });
+
+  it(
+    'Verify that a Model can be deployed with Accelerator Profile tolerations',
+    {
+      tags: [
+        '@Sanity',
+        '@SanitySet3',
+        '@ModelServing',
+        '@AcceleratorProfiles',
+        '@NonConcurrent',
+        '@Bug',
+      ],
+    },
+    () => {
+      cy.log('Model Name:', modelName);
+      // Create accelerator profile
+      cy.step('Create accelerator profile for testing');
+      cy.log(`Creating Accelerator Profile: ${acceleratorProfileName}`);
+      createAcceleratorProfile('resources/acceleratorProfile/acceleratorProfile.yaml');
+      // Authentication and navigation
+      cy.step(`Log into the application with ${LDAP_CONTRIBUTOR_USER.USERNAME}`);
+      cy.visitWithLogin('/', LDAP_CONTRIBUTOR_USER);
+      // Project navigation - direct navigation to avoid project list sync issues
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+      // Navigate to Model Serving tab and Deploy a Single Model
+      cy.step('Navigate to Model Serving and click to Deploy a Single Model');
+      projectDetails.findSectionTab('model-server').click();
+      modelServingGlobal.findSingleServingModelButton().click();
+      modelServingGlobal.findDeployModelButton().click();
+      inferenceServiceModal.shouldBeOpen();
+      inferenceServiceModal.findModelNameInput().type(modelName);
+      inferenceServiceModal.findServingRuntimeTemplateSearchSelector().click();
+      inferenceServiceModal.findGlobalScopedTemplateOption('OpenVINO Model Server').click();
+      inferenceServiceModal.findModelFrameworkSelect().click();
+      inferenceServiceModal.findOpenVinoIROpSet13().click();
+      inferenceServiceModal.findLocationPathInput().type(modelFilePath);
+      // Select the accelerator profile
+      cy.step('Select the accelerator profile with tolerations');
+      // Select our test accelerator profile
+      inferenceServiceModal.selectAcceleratorProfileOption('cypress-accelerator-profile-model');
+      // Verify the accelerator profile is selected
+      inferenceServiceModal
+        .findAcceleratorProfileSelect()
+        .should('contain', 'cypress-accelerator-profile-model');
+      // Submit the form
+      inferenceServiceModal.findSubmitButton().should('be.enabled').click();
+      inferenceServiceModal.shouldBeOpen(false);
+      modelServingSection.findModelServerDeployedName(modelName);
+      // Validate that the toleration applied from the accelerator profile displays in the inference service
+      cy.step(
+        'Validate the Tolerations for the InferenceService include the accelerator profile toleration',
+      );
+      validateInferenceServiceTolerations(projectName, modelName, {
+        key: 'nvidia.com/gpu',
+        operator: 'Equal',
+        effect: 'NoSchedule',
+      }).then(() => {
+        cy.log('Accelerator profile toleration displays in the InferenceService as expected');
+      });
+    },
+  );
+});

--- a/frontend/src/__tests__/cypress/cypress/types.ts
+++ b/frontend/src/__tests__/cypress/cypress/types.ts
@@ -312,6 +312,14 @@ export type ModelTolerationsTestData = {
   modelFilePath: string;
 };
 
+export type AcceleratorProfilesModelTolerationsTestData = {
+  modelServingTolerationsTestNamespace: string;
+  resourceYamlPath: string;
+  acceleratorProfileName: string;
+  modelName: string;
+  modelFilePath: string;
+};
+
 export type NotebookTolerationsTestData = {
   codeserverImageName: string;
   resourceYamlPath: string;

--- a/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/dataLoader.ts
@@ -12,6 +12,7 @@ import type {
   WBImagesTestData,
   DeployOCIModelData,
   ModelTolerationsTestData,
+  AcceleratorProfilesModelTolerationsTestData,
   ManageRegistryPermissionsTestData,
   ModelRegistryTestData,
 } from '#~/__tests__/cypress/cypress/types';
@@ -106,6 +107,14 @@ export const loadModelTolerationsFixture = (
   cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
     const data = yaml.load(yamlContent) as ModelTolerationsTestData;
 
+    return data;
+  });
+
+export const loadAcceleratorProfileModelTolerationsFixture = (
+  fixturePath: string,
+): Cypress.Chainable<AcceleratorProfilesModelTolerationsTestData> =>
+  cy.fixture(fixturePath, 'utf8').then((yamlContent: string) => {
+    const data = yaml.load(yamlContent) as AcceleratorProfilesModelTolerationsTestData;
     return data;
   });
 

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/acceleratorProfiles.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/acceleratorProfiles.ts
@@ -1,0 +1,51 @@
+import type { CommandLineResult } from '#~/__tests__/cypress/cypress/types';
+import { createCustomResource } from './customResources';
+
+const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE') || 'redhat-ods-applications';
+
+/**
+ * `cleanupAcceleratorProfiles` searches for an AcceleratorProfile in the specified namespace that contains a provided name.
+ *
+ * If an AcceleratorProfile is found, it is deleted using `oc`. If no matching profile is found, a message is logged.
+ *
+ * @param acceleratorProfile - The `displayName` substring to search for in AcceleratorProfiles.
+ * @returns A Cypress.Chainable that resolves to:
+ *   - The `CommandLineResult` of the deletion command, if a profile was found and deleted.
+ *   - The original `CommandLineResult` if no matching profile was found. This allows chaining even if no deletion occurs.
+ */
+export const cleanupAcceleratorProfiles = (
+  acceleratorProfile: string,
+): Cypress.Chainable<CommandLineResult> => {
+  const ocCommand = `oc get acceleratorprofiles -ojson -n ${applicationNamespace} | jq --arg profile "${acceleratorProfile}" '.items[] | select(.spec.displayName | contains($profile)) | .metadata.name' | tr -d '"'`;
+  cy.log(`Executing command: ${ocCommand}`);
+
+  return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
+    const profileName = result.stdout.trim();
+
+    if (profileName) {
+      cy.log(`Accelerator Profile found: ${profileName}. Proceeding to delete.`);
+      const deleteCommand = `oc delete acceleratorprofiles ${profileName} -n ${applicationNamespace}`;
+      return cy.exec(deleteCommand, { failOnNonZeroExit: false });
+    }
+
+    return cy.wrap(result);
+  });
+};
+
+/**
+ * Creates a clean accelerator profile by first cleaning up any existing profile with the same name,
+ * then creating a new one.
+ *
+ * @param acceleratorProfile - The name or path of the accelerator profile to create
+ *
+ * This function performs the following steps:
+ * 1. Cleans up any existing accelerator profile with the given name by calling `cleanupAcceleratorProfiles`.
+ * 2. Creates a new accelerator profile using the provided name or path.
+ */
+export const createAcceleratorProfile = (acceleratorProfile: string): void => {
+  cy.log(`Cleaning up and creating Accelerator Profile: ${acceleratorProfile}`);
+  cleanupAcceleratorProfiles(acceleratorProfile).then(() => {
+    cy.log(`Creating Accelerator Profile: ${acceleratorProfile}`);
+    createCustomResource(applicationNamespace, acceleratorProfile);
+  });
+};

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/acceleratorProfiles.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/acceleratorProfiles.ts
@@ -1,7 +1,7 @@
 import type { CommandLineResult } from '#~/__tests__/cypress/cypress/types';
 import { createCustomResource } from './customResources';
 
-const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE') || 'redhat-ods-applications';
+const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
 
 /**
  * `cleanupAcceleratorProfiles` searches for an AcceleratorProfile in the specified namespace that contains a provided name.
@@ -16,7 +16,7 @@ const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE') || 'redhat-od
 export const cleanupAcceleratorProfiles = (
   acceleratorProfile: string,
 ): Cypress.Chainable<CommandLineResult> => {
-  const ocCommand = `oc get acceleratorprofiles -ojson -n ${applicationNamespace} | jq --arg profile "${acceleratorProfile}" '.items[] | select(.spec.displayName | contains($profile)) | .metadata.name' | tr -d '"'`;
+  const ocCommand = `oc get acceleratorprofiles -ojson -n ${applicationNamespace} | jq '.items[] | select(.spec.displayName | contains("${acceleratorProfile}")) | .metadata.name' | tr -d '"'`;
   cy.log(`Executing command: ${ocCommand}`);
 
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {
@@ -27,7 +27,7 @@ export const cleanupAcceleratorProfiles = (
       const deleteCommand = `oc delete acceleratorprofiles ${profileName} -n ${applicationNamespace}`;
       return cy.exec(deleteCommand, { failOnNonZeroExit: false });
     }
-
+    cy.log('No matching profile found, proceeding with the test.');
     return cy.wrap(result);
   });
 };

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -200,10 +200,14 @@ export const assembleInferenceService = (
     data.isKServeRawDeployment,
   );
 
-  // Only add resources for KServe, but not tolerations and nodeSelector
-  if (!isModelMesh && podSpecOptions) {
-    const { resources } = podSpecOptions;
-
+  if (!isModelMesh && podSpecOptions && !podSpecOptions.selectedHardwareProfile) {
+    const { tolerations, resources, nodeSelector } = podSpecOptions;
+    if (tolerations) {
+      updatedInferenceService.spec.predictor.tolerations = tolerations;
+    }
+    if (nodeSelector) {
+      updatedInferenceService.spec.predictor.nodeSelector = nodeSelector;
+    }
     updatedInferenceService.spec.predictor.model = {
       ...updatedInferenceService.spec.predictor.model,
       resources: {

--- a/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
+++ b/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
@@ -78,12 +78,10 @@ export const useModelServingPodSpecOptionsState = (
   const existingNodeSelector =
     inferenceService?.spec.predictor.nodeSelector || servingRuntime?.spec.nodeSelector;
 
-  const annotationData = {
-    selectedAcceleratorProfile: acceleratorProfile.formData.profile,
-    selectedHardwareProfile: hardwareProfile.formData.selectedProfile,
-  };
-
   if (isHardwareProfilesAvailable && !isModelMesh) {
+    const annotationData = {
+      selectedHardwareProfile: hardwareProfile.formData.selectedProfile,
+    };
     if (hardwareProfile.formData.useExistingSettings) {
       podSpecOptions = {
         resources: existingResources,
@@ -125,7 +123,7 @@ export const useModelServingPodSpecOptionsState = (
       resources: newResources,
       tolerations: newTolerations,
       nodeSelector: existingNodeSelector,
-      ...annotationData,
+      selectedAcceleratorProfile: acceleratorProfile.formData.profile,
     };
   }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-33131

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
With hardware profiles being managed by the operator, we stopped applying node selectors and tolerations to InferenceService because it's injected with a mutating webhook by the operator. However, this broke accelerator profiles, which still requires tolerations to be applied by the dashboard.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Test case 1: Accelerator profile
- Create an accelerator profile with tolerations
- Go to Data science projects > Models tab > Select Single-model serving > Deploy model 
- In the Deploy model modal, select the accelerator profile created earlier
- Check the InferenceService CR created, tolerations should be present in `spec.predictor.tolerations`

### Test case 2: Legacy hardware profile (feature enabled)
- Enable the hardware profiles feature
- Follow the same deployment steps as Test Case 1, but select the legacy hardware profile that was created as an accelerator profile
- The InferenceService CR should have tolerations applied to `spec.predictor.tolerations`

### Test case 3: Original hardware profile (managed by operator)
- Create a new hardware profile with tolerations
- Follow the same deployment steps, but select this new hardware profile
- The InferenceService POST request should not contain tolerations in the spec
- The final InferenceService CR should have tolerations injected by the mutating webhook

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Test added.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Model Serving now applies tolerations and node selectors from accelerator profiles when no hardware profile is selected.
  - GPU accelerator profiles automatically set GPU resource requests and limits.
  - UI now supports selecting an accelerator profile during model deployment.

- Tests
  - Added end-to-end tests validating accelerator profile selection and resulting tolerations.
  - Introduced utilities and fixtures to manage accelerator profiles in test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->