### PR TITLE
RHOAIENG-32237: Update Resource requests and limits section in hardware profiles creation page

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/hardwareProfile.ts
@@ -218,7 +218,7 @@ class HardwareProfile {
 
 class NodeResourceRow extends TableRow {
   shouldHaveResourceLabel(name: string) {
-    this.find().find(`[data-label="Resource label"]`).should('have.text', name);
+    this.find().find(`[data-label="Resource name"]`).should('have.text', name);
     return this;
   }
 
@@ -529,7 +529,7 @@ class NodeResourceModal extends Modal {
   }
 
   findNodeResourceLabelInput() {
-    return this.find().findByTestId('node-resource-label-input');
+    return this.find().findByTestId('node-resource-name-input');
   }
 
   findNodeResourceIdentifierInput() {

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -54,7 +54,14 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
 
   return (
     <Form>
-      <FormGroup isRequired label="Resource name" fieldId="resource-name">
+      <FormGroup
+        isRequired
+        label="Resource name"
+        fieldId="resource-name"
+        labelHelp={
+          <DashboardHelpTooltip content={HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceName} />
+        }
+      >
         <TextInput
           id="node-resource-name-input"
           value={identifier.displayName || ''}
@@ -63,7 +70,14 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
         />
       </FormGroup>
 
-      <FormGroup isRequired label="Resource identifier" fieldId="resource-identifier">
+      <FormGroup
+        isRequired
+        label="Resource identifier"
+        fieldId="resource-identifier"
+        labelHelp={
+          <DashboardHelpTooltip content={HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceIdentifier} />
+        }
+      >
         <TextInput
           id="node-resource-identifier-input"
           value={identifier.identifier || ''}
@@ -83,7 +97,14 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
         )}
       </FormGroup>
 
-      <FormGroup isRequired label="Resource type" fieldId="resource-type">
+      <FormGroup
+        isRequired
+        label="Resource type"
+        fieldId="resource-type"
+        labelHelp={
+          <DashboardHelpTooltip content={HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceType} />
+        }
+      >
         <SimpleSelect
           dataTestId="node-resource-type-select"
           isFullWidth

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceForm.tsx
@@ -54,12 +54,12 @@ const NodeResourceForm: React.FC<NodeResourceFormProps> = ({
 
   return (
     <Form>
-      <FormGroup isRequired label="Resource label" fieldId="resource-label">
+      <FormGroup isRequired label="Resource name" fieldId="resource-name">
         <TextInput
-          id="node-resource-label-input"
+          id="node-resource-name-input"
           value={identifier.displayName || ''}
           onChange={(_, value) => setIdentifier('displayName', value)}
-          data-testid="node-resource-label-input"
+          data-testid="node-resource-name-input"
         />
       </FormGroup>
 

--- a/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/NodeResourceTableRow.tsx
@@ -28,7 +28,7 @@ const NodeResourceTableRow: React.FC<NodeResourceTableRowProps> = ({
   showActions,
 }) => (
   <Tr>
-    <Td dataLabel="Resource label">
+    <Td dataLabel="Resource name">
       <Flex>
         <FlexItem spacer={{ default: 'spacerSm' }}>
           <Truncate content={identifier.displayName} />

--- a/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
@@ -9,8 +9,8 @@ export const HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP = {
 
 export const nodeResourceColumns: SortableData<Identifier>[] = [
   {
-    field: 'resourceLabel',
-    label: 'Resource label',
+    field: 'resourceName',
+    label: 'Resource name',
     sortable: false,
   },
   {

--- a/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
+++ b/frontend/src/pages/hardwareProfiles/nodeResource/const.ts
@@ -5,6 +5,11 @@ export const HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP = {
   minCount: 'The minimum number of resources that users can define for requests.',
   maxCount: 'The maximum resources that users can request.',
   defaultCount: 'The default request and limit presented to the user.',
+  resourceName: 'The resource name is the display name shown for this resource in the dashboard.',
+  resourceIdentifier:
+    'The resource identifier is the key that matches how this resource is defined on the cluster.',
+  resourceType:
+    'The resource type defines the category of this resource, such as CPU, Memory, Accelerator, and other.',
 };
 
 export const nodeResourceColumns: SortableData<Identifier>[] = [
@@ -12,16 +17,25 @@ export const nodeResourceColumns: SortableData<Identifier>[] = [
     field: 'resourceName',
     label: 'Resource name',
     sortable: false,
+    info: {
+      popover: HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceName,
+    },
   },
   {
     field: 'identifier',
     label: 'Resource identifier',
     sortable: false,
+    info: {
+      popover: HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceIdentifier,
+    },
   },
   {
     field: 'resourceType',
     label: 'Resource type',
     sortable: false,
+    info: {
+      popover: HARDWARE_PROFILE_COLUMN_HELP_TOOLTIP.resourceType,
+    },
   },
   {
     field: 'defaultCount',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-32237

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- Change resource label to resource name, and have a helper tooltip with an explanation
- Add a helper tooltip for resource type and resource identifier 
- Helper text for each:
   - Resource name: "The resource name is the display name shown for this resource in the dashboard."
   - Resource identifier: "The resource identifier is the key that matches how this resource is defined on the cluster." 
   - Resource type: "The resource type defines the category of this resource, such as CPU, Memory, Accelerator, and other." 

https://github.com/user-attachments/assets/916ba7b9-6819-45e3-a23c-354ec135e613

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Go to Hardware profiles settings page
2. Expand a HW profile and verify the `Node resources` section.
3. Edit/Add a HW profile and verify the `Resource requests and limits` section.
4. Add a resource and verify the resource name, identifier and type form fields

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No need to add new tests since just microcopy changes and added popver/tooltip.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual help tooltips for Hardware Profile node resources: Resource name, Resource identifier, and Resource type, offering in-UI guidance.

* **Style**
  * Renamed “Resource label” to “Resource name” across the form and table for clearer terminology.
  * Updated related input and column headers to reflect the new naming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->