### PR TITLE
Fixing type error in kserve extension import

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -1,11 +1,11 @@
 import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
-import type { Deployment } from 'extension-points';
 import { isValidModelType, type ModelTypeFieldData } from './fields/ModelTypeSelectField';
 import {
   ConnectionTypeRefs,
   ModelLocationType,
   ModelLocationData,
 } from './fields/modelLocationFields/types';
+import type { Deployment } from '../../../extension-points';
 
 export const getDeploymentWizardRoute = (currentpath: string, deploymentName?: string): string => {
   if (deploymentName) {


### PR DESCRIPTION
## Description
Fixed the type error 

```
/Users/dipgupta/Documents/odh/odh-dashboard/packages/kserve && npm run type-check

> @odh-dashboard/kserve@0.0.0 type-check
> tsc --noEmit

dipgupta@dipgupta-mac kserve % 
```

## How Has This Been Tested?
npm run type-check

## Test Impact
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal type import path within the deployment wizard utilities.
  * No changes to features, functionality, performance, or UI.
  * Existing workflows and configurations continue to operate as before.
  * No impact on data, compatibility, or integrations.
  * This is a maintenance-only update; no action is required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->