### PR TITLE
RHOAIENG-34068: Implement open configuration for storage class

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/clusterStorage.cy.ts
@@ -226,8 +226,6 @@ describe('ClusterStorage', () => {
     // select access mode
     addClusterStorageModal.findRWOAccessMode().should('be.checked');
     addClusterStorageModal.findRWXAccessMode().click();
-    addClusterStorageModal.findROXAccessMode().should('be.disabled');
-    addClusterStorageModal.findRWOPAccessMode().should('be.disabled');
 
     //connect workbench
     addClusterStorageModal.findAddWorkbenchButton().click();

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/storageClasses/storageClasses.cy.ts
@@ -601,18 +601,18 @@ describe('Storage classes', () => {
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.RWX)
-        .should('be.disabled')
-        .and('not.be.checked');
+        .should('be.enabled')
+        .and('be.checked');
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.ROX)
-        .should('be.disabled')
-        .and('not.be.checked');
+        .should('be.enabled')
+        .and('be.checked');
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.RWOP)
-        .should('be.disabled')
-        .and('not.be.checked');
+        .should('be.enabled')
+        .and('be.checked');
     });
 
     it('should show access mode checkboxes with empty access mode settings', () => {
@@ -634,17 +634,17 @@ describe('Storage classes', () => {
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.RWX)
-        .should('be.disabled')
+        .should('be.enabled')
         .and('not.be.checked');
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.ROX)
-        .should('be.disabled')
+        .should('be.enabled')
         .and('not.be.checked');
 
       storageClassEditModal
         .findAccessModeCheckbox(AccessMode.RWOP)
-        .should('be.disabled')
+        .should('be.enabled')
         .and('not.be.checked');
     });
 

--- a/frontend/src/pages/projects/screens/spawner/storage/AccessModeField.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/AccessModeField.tsx
@@ -11,7 +11,6 @@ type AccessModeFieldProps = {
   canEditAccessMode?: boolean;
   storageClassesLoaded: boolean;
   adminSupportedAccessModes: AccessMode[];
-  openshiftSupportedAccessModes: AccessMode[];
   setAccessMode: (value: AccessMode) => void;
 };
 
@@ -21,21 +20,10 @@ const AccessModeField: React.FC<AccessModeFieldProps> = ({
   setAccessMode,
   storageClassesLoaded,
   adminSupportedAccessModes,
-  openshiftSupportedAccessModes,
 }) => {
   if (!storageClassesLoaded) {
     return <Spinner />;
   }
-
-  const availableAccessModes = Object.values(AccessMode).filter(
-    (accessMode: AccessMode) =>
-      openshiftSupportedAccessModes.includes(accessMode) || accessMode === AccessMode.RWO,
-  );
-
-  const allowedAccessModes = availableAccessModes.filter(
-    (accessMode: AccessMode) =>
-      adminSupportedAccessModes.includes(accessMode) || accessMode === AccessMode.RWO,
-  );
 
   return (
     <FormGroup
@@ -44,7 +32,6 @@ const AccessModeField: React.FC<AccessModeFieldProps> = ({
       labelHelp={
         <FieldGroupHelpLabelIcon
           content={getAccessModePopover({
-            openshiftSupportedAccessModes,
             adminSupportedAccessModes,
             canEditAccessMode,
             currentAccessMode,
@@ -56,28 +43,20 @@ const AccessModeField: React.FC<AccessModeFieldProps> = ({
       {canEditAccessMode ? (
         <>
           <Flex>
-            {availableAccessModes.map((accessMode) => {
-              const hasAccessMode = adminSupportedAccessModes.includes(accessMode);
-              return (
-                <FlexItem key={accessMode}>
-                  <AccessModeRadio
-                    id={`${accessMode}-radio`}
-                    name={`${accessMode}-radio`}
-                    isDisabled={!hasAccessMode || availableAccessModes.length === 1}
-                    tooltipContent={
-                      !hasAccessMode
-                        ? 'Access mode not supported by the selected storage class.'
-                        : undefined
-                    }
-                    isChecked={currentAccessMode === accessMode}
-                    onChange={() => setAccessMode(accessMode)}
-                    accessMode={accessMode}
-                  />
-                </FlexItem>
-              );
-            })}
+            {adminSupportedAccessModes.map((accessMode) => (
+              <FlexItem key={accessMode}>
+                <AccessModeRadio
+                  id={`${accessMode}-radio`}
+                  name={`${accessMode}-radio`}
+                  isDisabled={adminSupportedAccessModes.length === 1}
+                  isChecked={currentAccessMode === accessMode}
+                  onChange={() => setAccessMode(accessMode)}
+                  accessMode={accessMode}
+                />
+              </FlexItem>
+            ))}
           </Flex>
-          {allowedAccessModes.length > 1 && (
+          {adminSupportedAccessModes.length > 1 && (
             <FormHelperText>
               <Alert
                 variant="info"

--- a/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/CreateNewStorageSection.tsx
@@ -59,7 +59,6 @@ const CreateNewStorageSection = <D extends StorageData>({
     storageClassesLoaded,
     selectedStorageClassConfig,
     adminSupportedAccessModes,
-    openshiftSupportedAccessModes,
   } = useGetStorageClassConfig(data.storageClassName);
 
   const [isValidModelPath, setIsValidModelPath] = React.useState(true);
@@ -115,7 +114,6 @@ const CreateNewStorageSection = <D extends StorageData>({
           <AccessModeField
             storageClassesLoaded={storageClassesLoaded}
             adminSupportedAccessModes={adminSupportedAccessModes}
-            openshiftSupportedAccessModes={openshiftSupportedAccessModes}
             currentAccessMode={data.accessMode}
             canEditAccessMode={editableK8sName}
             setAccessMode={(accessMode) => setData('accessMode', accessMode)}

--- a/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/__tests__/utils.spec.ts
@@ -162,7 +162,6 @@ describe('useMountPathFormat', () => {
 describe('getPossibleStorageClassAccessModes', () => {
   it('returns RWO as the only supported access mode if no storageClass is provided', () => {
     const result = getPossibleStorageClassAccessModes();
-    expect(result.openshiftSupportedAccessModes).toEqual([]);
     expect(result.adminSupportedAccessModes).toEqual([AccessMode.RWO]);
     expect(result.selectedStorageClassConfig).toBeUndefined();
   });
@@ -170,12 +169,6 @@ describe('getPossibleStorageClassAccessModes', () => {
   it('returns correct adminSupportedAccessModes from config', () => {
     const storageClass = mockStorageClasses[1];
     const result = getPossibleStorageClassAccessModes(storageClass);
-    expect(result.openshiftSupportedAccessModes).toEqual([
-      AccessMode.RWO,
-      AccessMode.RWX,
-      AccessMode.ROX,
-      AccessMode.RWOP,
-    ]);
     expect(result.adminSupportedAccessModes).toEqual([AccessMode.RWO, AccessMode.RWX]);
   });
 

--- a/frontend/src/pages/projects/screens/spawner/storage/getAccessModePopover.tsx
+++ b/frontend/src/pages/projects/screens/spawner/storage/getAccessModePopover.tsx
@@ -10,7 +10,6 @@ type AccessModePopoverProps = {
   canEditAccessMode?: boolean;
   currentAccessMode?: AccessMode;
   showAllAccessModes?: boolean;
-  openshiftSupportedAccessModes?: AccessMode[];
   adminSupportedAccessModes?: AccessMode[];
 };
 
@@ -18,16 +17,16 @@ export const getAccessModePopover = ({
   canEditAccessMode = true,
   currentAccessMode,
   showAllAccessModes = true,
-  openshiftSupportedAccessModes,
   adminSupportedAccessModes,
 }: AccessModePopoverProps): React.ReactNode => {
   const listItems: React.ReactNode[] = [];
+
   Object.values(AccessMode).forEach((accessMode) => {
-    const showAccessMode = openshiftSupportedAccessModes?.includes(accessMode);
     const hasAccessMode = adminSupportedAccessModes?.includes(accessMode);
+
     if (
       showAllAccessModes ||
-      ((accessMode === AccessMode.RWO || (showAccessMode && hasAccessMode)) && canEditAccessMode) ||
+      ((accessMode === AccessMode.RWO || hasAccessMode) && canEditAccessMode) ||
       currentAccessMode === accessMode
     ) {
       listItems.push(
@@ -37,6 +36,7 @@ export const getAccessModePopover = ({
       );
     }
   });
+
   return (
     <PopoverListContent
       leadText="Access mode is a Kubernetes concept that determines how nodes can interact with the volume."

--- a/frontend/src/pages/projects/screens/spawner/storage/useGetStorageClassConfig.ts
+++ b/frontend/src/pages/projects/screens/spawner/storage/useGetStorageClassConfig.ts
@@ -9,20 +9,18 @@ export const useGetStorageClassConfig = (
   storageClasses: StorageClassKind[];
   storageClassesLoaded: boolean;
   selectedStorageClassConfig?: StorageClassConfig;
-  openshiftSupportedAccessModes: AccessMode[];
   adminSupportedAccessModes: AccessMode[];
 } => {
   const [storageClasses, storageClassesLoaded] = useStorageClasses();
   const selectedStorageClass = storageClasses.find((sc) => sc.metadata.name === storageClassName);
 
-  const { selectedStorageClassConfig, openshiftSupportedAccessModes, adminSupportedAccessModes } =
+  const { selectedStorageClassConfig, adminSupportedAccessModes } =
     getPossibleStorageClassAccessModes(selectedStorageClass);
 
   return {
     storageClasses,
     storageClassesLoaded,
     selectedStorageClassConfig,
-    openshiftSupportedAccessModes,
     adminSupportedAccessModes,
   };
 };

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -85,6 +85,11 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
   React.useEffect(() => {
     const recommended = getSupportedAccessModesForProvisioner(storageClass.provisioner);
 
+    if (recommended === null) {
+      setAccessModeMismatch(null);
+      return;
+    }
+
     const selectedModes = Object.values(AccessMode).filter(
       (mode) => accessModeSettings[mode] === true || mode === AccessMode.RWO,
     );

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -191,13 +191,10 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
                 <Checkbox
                   label={modeLabel}
                   description={accessModeDescriptions[modeName]}
-                  // RWO is not allowed to be disabled, and if it's not supported, it should be disabled
-                  isDisabled={modeName === AccessMode.RWO || !isSupported}
-                  // RWO is always enabled, and if it's supported, it should be checked
-                  isChecked={
-                    (isSupported && accessModeSettings?.[modeName] === true) ||
-                    modeName === AccessMode.RWO
-                  }
+                  // RWO is not allowed to be disabled
+                  isDisabled={modeName === AccessMode.RWO}
+                  // RWO is always enabled
+                  isChecked={accessModeSettings?.[modeName] === true || modeName === AccessMode.RWO}
                   aria-label={modeLabel}
                   key={modeName}
                   id={`edit-sc-access-mode-${modeName.toLowerCase()}`}

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -63,7 +63,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
       : '',
   );
 
-  const defaultAccessModeSettings = getStorageClassDefaultAccessModeSettings(storageClass);
+  const defaultAccessModeSettings = getStorageClassDefaultAccessModeSettings();
 
   const [accessModeSettings, setAccessModeSettings] = React.useState(
     isValidConfigValue('accessModeSettings', storageClassConfig?.accessModeSettings)
@@ -84,7 +84,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
         description,
         ...(storageClassConfig?.isDefault === undefined && { isDefault: false }),
         ...(storageClassConfig?.isEnabled === undefined && { isEnabled: false }),
-        accessModeSettings,
+        accessModeSettings: { ...accessModeSettings, [AccessMode.RWO]: true },
       });
       await onSuccess();
       onClose();

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -18,7 +18,6 @@ import {
   Stack,
   StackItem,
   TextArea,
-  Tooltip,
 } from '@patternfly/react-core';
 
 import React from 'react';
@@ -30,7 +29,7 @@ import DashboardModalFooter from '#~/concepts/dashboard/DashboardModalFooter';
 import { updateStorageClassConfig } from '#~/api';
 import { toAccessModeFullName } from '#~/pages/projects/screens/detail/storage/AccessModeFullName.tsx';
 import {
-  getSupportedAccessModesForProvisioner,
+  //getSupportedAccessModesForProvisioner,
   getStorageClassConfig,
   getStorageClassDefaultAccessModeSettings,
   isOpenshiftDefaultStorageClass,
@@ -182,10 +181,10 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
             {Object.values(AccessMode).map((modeName) => {
               const modeLabel = toAccessModeFullName(modeName);
 
-              const supportedAccessModes = getSupportedAccessModesForProvisioner(
-                storageClass.provisioner,
-              );
-              const isSupported = supportedAccessModes.includes(modeName);
+              // const supportedAccessModes = getSupportedAccessModesForProvisioner(
+              //   storageClass.provisioner,
+              // );
+              // const isSupported = supportedAccessModes.includes(modeName);
 
               const checkbox = (
                 <Checkbox
@@ -214,19 +213,6 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
                   }}
                 />
               );
-
-              if (!isSupported) {
-                return (
-                  <Tooltip
-                    data-testid="sc-access-mode-unsupported-tooltip"
-                    content="This access mode is not supported by the selected storage class."
-                    key={`${modeName}-tooltip`}
-                    position="top-start"
-                  >
-                    {checkbox}
-                  </Tooltip>
-                );
-              }
 
               return checkbox;
             })}

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -195,9 +195,8 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
                       with the volume.
                     </StackItem>
                     <StackItem>
-                      Users can create storage using enabled access modes. The OpenShift storage
-                      class determines which access modes (RWO, RWX, ROX and RWOP) are supported by
-                      default.
+                      Enabled access modes are available to users when they create new storage.
+                      ReadWriteOnce (RWO) is always enabled and cannot be disabled.
                     </StackItem>
                   </Stack>
                 }

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -201,6 +201,35 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
             fieldId="edit-sc-access-mode"
             isStack
           >
+            {showAccessModeAlert && (
+              <Alert
+                variant="warning"
+                title="Disabling the RWX access mode will prevent new storage of this class from using
+                 this access mode. Existing storage will be unaffected."
+                isInline
+                data-testid="edit-sc-access-mode-alert"
+                className="pf-v6-u-mb-md"
+              />
+            )}
+            {accessModeMismatch && (
+              <Alert
+                className="pf-v6-u-mb-md"
+                variant="warning"
+                isInline
+                title="Unsupported access modes selected"
+                data-testid="edit-sc-access-mode-mismatch-alert"
+              >
+                <p>
+                  For the provisioner <strong>{storageClass.provisioner}</strong>, the recommended
+                  access modes are:{' '}
+                  {accessModeMismatch.recommended.map((m) => AccessModeLabelMap[m]).join(', ')}.
+                </p>
+                <p>
+                  You have selected unsupported modes:{' '}
+                  {accessModeMismatch.unsupported.map((m) => AccessModeLabelMap[m]).join(', ')}.
+                </p>
+              </Alert>
+            )}
             {Object.values(AccessMode).map((modeName) => {
               const modeLabel = toAccessModeFullName(modeName);
               const checkbox = (
@@ -234,34 +263,6 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
               return checkbox;
             })}
           </FormGroup>
-          {showAccessModeAlert && (
-            <Alert
-              variant="warning"
-              title="Disabling the RWX access mode will prevent new storage of this class from using
-               this access mode. Existing storage will be unaffected."
-              isInline
-              data-testid="edit-sc-access-mode-alert"
-            />
-          )}
-          {accessModeMismatch && (
-            <Alert
-              className="pf-v6-u-mt-md"
-              variant="warning"
-              isInline
-              title="Unsupported access modes selected"
-              data-testid="edit-sc-access-mode-mismatch-alert"
-            >
-              <p>
-                For the provisioner <strong>{storageClass.provisioner}</strong>, the recommended
-                access modes are:
-                {accessModeMismatch.recommended.map((m) => AccessModeLabelMap[m]).join(', ')}.
-              </p>
-              <p>
-                You have selected unsupported modes:
-                {accessModeMismatch.unsupported.map((m) => AccessModeLabelMap[m]).join(', ')}.
-              </p>
-            </Alert>
-          )}
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -195,8 +195,8 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
                       with the volume.
                     </StackItem>
                     <StackItem>
-                      Enabled access modes are available to users when they create new storage.
-                      ReadWriteOnce (RWO) is always enabled and cannot be disabled.
+                      Enabled access modes are available for new storage. ReadWriteOnce (RWO) is
+                      always enabled and cannot be disabled.
                     </StackItem>
                   </Stack>
                 }

--- a/frontend/src/pages/storageClasses/StorageClassesContext.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesContext.tsx
@@ -90,9 +90,7 @@ export const StorageClassContextProvider: React.FC<StorageClassContextProviderPr
         const isFirstConfig = index === 0;
         const isOpenshiftDefault = openshiftDefaultScName === name;
 
-        const accessModeSettings = getStorageClassDefaultAccessModeSettings(storageClass);
-
-        console.log('accessModeSettings', accessModeSettings);
+        const accessModeSettings = getStorageClassDefaultAccessModeSettings();
 
         // Add a default config annotation when one doesn't exist
         if (!config) {

--- a/frontend/src/pages/storageClasses/StorageClassesContext.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesContext.tsx
@@ -92,6 +92,8 @@ export const StorageClassContextProvider: React.FC<StorageClassContextProviderPr
 
         const accessModeSettings = getStorageClassDefaultAccessModeSettings(storageClass);
 
+        console.log('accessModeSettings', accessModeSettings);
+
         // Add a default config annotation when one doesn't exist
         if (!config) {
           let isDefault = isOpenshiftDefault;

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -38,7 +38,7 @@ import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
 import { useStorageClassContext } from './StorageClassesContext';
 import { StorageClassConfigValue } from './StorageClassConfigValue';
 import {
-  getSupportedAccessModesForProvisioner,
+  //getSupportedAccessModesForProvisioner,
   isOpenshiftDefaultStorageClass,
   isValidAccessModeSettings,
   isValidConfigValue,
@@ -170,24 +170,21 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({ 
                   title={
                     <Flex spaceItems={{ default: 'spaceItemsXs' }}>
                       <Truncate content={storageClassConfig.displayName} />
-                      {isValidAccessModeSettings(
-                        storageClass,
-                        storageClassConfig.accessModeSettings,
-                      ) ? (
+                      {isValidAccessModeSettings(storageClassConfig.accessModeSettings) ? (
                         <LabelGroup data-testid="access-mode-label-group">
-                          {getSupportedAccessModesForProvisioner(storageClass.provisioner)
+                          {Object.values(AccessMode)
                             .filter(
-                              (modeValue) =>
-                                storageClassConfig.accessModeSettings[modeValue] === true ||
-                                modeValue === AccessMode.RWO,
+                              (accessMode) =>
+                                storageClassConfig.accessModeSettings[accessMode] === true ||
+                                accessMode === AccessMode.RWO,
                             )
-                            .map((modeValue) => (
-                              <AccessModeLabel key={modeValue} accessMode={modeValue} />
+                            .map((accessMode) => (
+                              <AccessModeLabel key={accessMode} accessMode={accessMode} />
                             ))}
                         </LabelGroup>
                       ) : (
                         // only show tooltip if the access mode settings are not valid
-                        // which means that the supported access modes are not set to a boolean
+                        // which means that the access modes are not set to a boolean
                         <Tooltip content="Edit the access mode settings and save your changes to correct the corrupted metadata.">
                           <Icon status="warning">
                             <ExclamationTriangleIcon />

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -38,7 +38,6 @@ import { StorageClassEnableSwitch } from './StorageClassEnableSwitch';
 import { useStorageClassContext } from './StorageClassesContext';
 import { StorageClassConfigValue } from './StorageClassConfigValue';
 import {
-  //getSupportedAccessModesForProvisioner,
   isOpenshiftDefaultStorageClass,
   isValidAccessModeSettings,
   isValidConfigValue,

--- a/frontend/src/pages/storageClasses/__tests__/StorageClassEditModal.spec.tsx
+++ b/frontend/src/pages/storageClasses/__tests__/StorageClassEditModal.spec.tsx
@@ -71,7 +71,7 @@ describe('StorageClassEditModal', () => {
       unsupportedModes.forEach((mode) => {
         const checkbox = screen.getByTestId(`edit-sc-access-mode-checkbox-${mode.toLowerCase()}`);
         expect(checkbox).not.toBeChecked();
-        expect(checkbox).toBeDisabled();
+        expect(checkbox).toBeEnabled();
       });
     });
   });

--- a/frontend/src/pages/storageClasses/__tests__/utils.spec.ts
+++ b/frontend/src/pages/storageClasses/__tests__/utils.spec.ts
@@ -6,19 +6,8 @@ import {
 } from '#~/pages/storageClasses/storageEnums';
 import {
   getSupportedAccessModesForProvisioner,
-  getAdminDefaultAccessModeSettings,
   isValidAccessModeSettings,
 } from '#~/pages/storageClasses/utils';
-
-const mockStorageClass = (provisioner: StorageProvisioner | string) => ({
-  apiVersion: 'storage.k8s.io/v1',
-  kind: 'StorageClass',
-  metadata: { name: 'test', annotations: {} },
-  provisioner,
-  reclaimPolicy: 'Delete',
-  volumeBindingMode: 'Immediate',
-  allowVolumeExpansion: true,
-});
 
 describe('getSupportedAccessModesForProvisioner', () => {
   it('should return correct access modes for a known provisioner', () => {
@@ -28,77 +17,48 @@ describe('getSupportedAccessModesForProvisioner', () => {
   });
 });
 
-describe('getAdminDefaultAccessModeSettings', () => {
-  it('should set RWO to true and other supported modes to false', () => {
-    const supportedModes = [AccessMode.RWO, AccessMode.RWX, AccessMode.ROX, AccessMode.RWOP];
-    const expectedSettings = {
-      [AccessMode.RWO]: true,
-      [AccessMode.RWX]: false,
-      [AccessMode.ROX]: false,
-      [AccessMode.RWOP]: false,
-    };
-    expect(getAdminDefaultAccessModeSettings(supportedModes)).toEqual(expectedSettings);
-  });
-
-  it('should handle a mix of modes correctly', () => {
-    const supportedModes = [AccessMode.RWO, AccessMode.ROX];
-    const expectedSettings = {
-      [AccessMode.RWO]: true,
-      [AccessMode.ROX]: false,
-    };
-    expect(getAdminDefaultAccessModeSettings(supportedModes)).toEqual(expectedSettings);
-  });
-});
-
 describe('isValidAccessModeSettings', () => {
-  it('returns true for valid settings (all supported, correct types, RWO true)', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
+  it('returns true for valid settings', () => {
     const value: AccessModeSettings = {
       [AccessMode.RWO]: true,
       [AccessMode.RWOP]: false,
     };
-    expect(isValidAccessModeSettings(sc, value)).toBe(true);
+    expect(isValidAccessModeSettings(value)).toBe(true);
   });
   it('returns true if a supported mode is missing', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
     const value: AccessModeSettings = {
       [AccessMode.RWO]: true,
-      // RWOP missing
     };
-    expect(isValidAccessModeSettings(sc, value)).toBe(true);
+    expect(isValidAccessModeSettings(value)).toBe(true);
   });
 
   it('returns false if a mode is not boolean', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
     const value = {
       [AccessMode.RWO]: true,
       [AccessMode.RWOP]: 'notBoolean',
     };
-    expect(isValidAccessModeSettings(sc, value as unknown as AccessModeSettings)).toBe(false);
+    expect(isValidAccessModeSettings(value as unknown as AccessModeSettings)).toBe(false);
   });
 
-  it('returns true if extra unsupported mode is present', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
+  it('returns true if extra unsupported mode is present but is a boolean', () => {
     const value = {
       [AccessMode.RWO]: true,
       [AccessMode.RWOP]: false,
       [AccessMode.RWX]: true,
       randomString: true,
     };
-    expect(isValidAccessModeSettings(sc, value)).toBe(true);
+    expect(isValidAccessModeSettings(value)).toBe(true);
   });
 
   it('returns false if value is not an object', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
-    expect(isValidAccessModeSettings(sc, undefined)).toBe(false);
-    expect(isValidAccessModeSettings(sc, true)).toBe(false);
-    expect(isValidAccessModeSettings(sc, '')).toBe(false);
-    expect(isValidAccessModeSettings(sc, 'random string')).toBe(false);
+    expect(isValidAccessModeSettings(undefined)).toBe(false);
+    expect(isValidAccessModeSettings(true)).toBe(false);
+    expect(isValidAccessModeSettings('')).toBe(false);
+    expect(isValidAccessModeSettings('random string')).toBe(false);
   });
 
   it('returns true if value is an empty object', () => {
-    const sc = mockStorageClass(StorageProvisioner.AWS_EBS);
     const value = {};
-    expect(isValidAccessModeSettings(sc, value)).toBe(true);
+    expect(isValidAccessModeSettings(value)).toBe(true);
   });
 });

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -71,24 +71,13 @@ export const isValidConfigValue = (
 };
 
 export const isValidAccessModeSettings = (
-  storageClass: StorageClassKind,
-  value: string | boolean | undefined | AccessModeSettings,
+  value: string | boolean | undefined | AccessModeSettings | null,
 ): boolean => {
-  if (typeof value !== 'object') {
+  if (typeof value !== 'object' || value === null) {
     return false;
   }
 
-  const supportedAccessModes = getSupportedAccessModesForProvisioner(storageClass.provisioner);
-
-  if (
-    !supportedAccessModes.every(
-      (mode) => value[mode] === undefined || typeof value[mode] === 'boolean',
-    )
-  ) {
-    return false;
-  }
-
-  return true;
+  return Object.values(value).every((v) => typeof v === 'boolean');
 };
 
 // Create a Set of StorageProvisioner values for efficient lookup in the type guard
@@ -143,11 +132,8 @@ export const getAdminDefaultAccessModeSettings = (
   }, initialSettings);
 };
 
-export const getStorageClassDefaultAccessModeSettings = (
-  storageClass: StorageClassKind,
-): AccessModeSettings => {
-  const supportedAccessModesForProvisioner = getSupportedAccessModesForProvisioner(
-    storageClass.provisioner,
-  );
-  return getAdminDefaultAccessModeSettings(supportedAccessModesForProvisioner);
+export const getStorageClassDefaultAccessModeSettings = (): AccessModeSettings => {
+  return {
+    [AccessMode.RWO]: true,
+  };
 };

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -24,25 +24,16 @@ export const getPossibleStorageClassAccessModes = (
   storageClass?: StorageClassKind | null,
 ): {
   selectedStorageClassConfig?: StorageClassConfig;
-  openshiftSupportedAccessModes: AccessMode[];
   adminSupportedAccessModes: AccessMode[];
 } => {
-  const openshiftSupportedAccessModes = getSupportedAccessModesForProvisioner(
-    storageClass?.provisioner,
-  );
   const selectedStorageClassConfig = storageClass ? getStorageClassConfig(storageClass) : undefined;
 
   // RWO is always supported
-  const adminSupportedAccessModes: AccessMode[] = [
-    AccessMode.RWO,
-    ...openshiftSupportedAccessModes.filter(
-      (accessMode) =>
-        accessMode !== AccessMode.RWO &&
-        selectedStorageClassConfig?.accessModeSettings &&
-        selectedStorageClassConfig.accessModeSettings[accessMode] === true,
-    ),
-  ];
-  return { selectedStorageClassConfig, openshiftSupportedAccessModes, adminSupportedAccessModes };
+  const adminSupportedAccessModes = Object.values(AccessMode).filter(
+    (mode) =>
+      selectedStorageClassConfig?.accessModeSettings[mode] === true || mode === AccessMode.RWO,
+  );
+  return { selectedStorageClassConfig, adminSupportedAccessModes };
 };
 
 export const isOpenshiftDefaultStorageClass = (

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -80,7 +80,7 @@ const isStorageProvisioner = (value: string): value is StorageProvisioner =>
 
 export const getSupportedAccessModesForProvisioner = (
   provisionerParameter?: StorageProvisioner | string,
-): AccessMode[] => {
+): AccessMode[] | null => {
   if (!provisionerParameter) {
     return [];
   }
@@ -92,8 +92,8 @@ export const getSupportedAccessModesForProvisioner = (
     return provisionerAccessModes[provisionerString];
   }
 
-  // If it's a provisioner not in the StorageProvisioner enum then return RWO
-  return [AccessMode.RWO];
+  // If it's a provisioner not in the StorageProvisioner enum then we cannot recommend
+  return null;
 };
 
 export const getStorageClassDefaultAccessModeSettings = (): AccessModeSettings => {

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -96,33 +96,6 @@ export const getSupportedAccessModesForProvisioner = (
   return [AccessMode.RWO];
 };
 
-export const getAccessModeSettings = (
-  supportedAccessModes: AccessMode[],
-  accessModeSettings?: AccessModeSettings,
-): AccessMode[] => {
-  const accessModeSettingsArr = [];
-  for (const accessMode of supportedAccessModes) {
-    if (accessModeSettings?.[accessMode] === true) {
-      accessModeSettingsArr.push(accessMode);
-    }
-  }
-  return accessModeSettingsArr;
-};
-
-export const getAdminDefaultAccessModeSettings = (
-  supportedAccessModes: AccessMode[],
-): AccessModeSettings => {
-  const initialSettings: AccessModeSettings = {};
-  return supportedAccessModes.reduce((currentSettings, mode) => {
-    // AccessMode.RWO should be set to true, and all other supported access modes should be set to false
-    const newSetting = mode === AccessMode.RWO;
-    return {
-      ...currentSettings,
-      [mode]: newSetting,
-    };
-  }, initialSettings);
-};
-
 export const getStorageClassDefaultAccessModeSettings = (): AccessModeSettings => {
   return {
     [AccessMode.RWO]: true,

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -52,7 +52,7 @@ export const isOpenshiftDefaultStorageClass = (
 
 export const isValidConfigValue = (
   configKey: keyof StorageClassConfig,
-  value: string | boolean | undefined | AccessModeSettings,
+  value: string | boolean | undefined | AccessModeSettings | null,
 ): boolean => {
   switch (configKey) {
     case 'displayName':
@@ -64,7 +64,7 @@ export const isValidConfigValue = (
     case 'lastModified':
       return typeof value === 'string' && isValidDate(new Date(value));
     case 'accessModeSettings':
-      return typeof value === 'object';
+      return typeof value === 'object' && value !== null;
     default:
       return false;
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-34068

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

1. Enable all UI controls in storage class admin interface (no more grayed-out checkboxes)
2. Convert hard-coded mappings of access mode from enforcement to guidance (show warnings, don't block)

https://github.com/user-attachments/assets/03a741a6-4e9d-4f16-8f9d-596439f028e0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**_Scenario 1: Storage class with a provisioner present in the mapping_**

1. Create a storage class on openshift console with provisioner for example `kubernetes.io/aws-ebs`
2. Load storage class setting page and you should see the newly created storage class.
4. If you check the yaml file on the console then you should see `"accessModeSettings":{"ReadWriteOnce":true}` in the `opendatahub.io/sc-config` annotation as RWO is the **_only_** default access mode added now.
5. Open the Edit storage class modal and now all the access modes except RWO will be enabled and available to be selected.
6. RWO will continue to be checked and disabled by default.
7. Now if you select an access mode that is unsupported according to the mapping then there should be a warning displayed. In this case, the supported access modes are `RWO and RWOP` so if you select `ROX or RWX` then you will see a warning which will not block the users to save.
8. Selecting the right supported access modes will make the warning go away.
9. Go to cluster storage in a project and add a storage. You will now only see the access modes enabled by the admin.
10. Verify the cluster storage section for creating a workbench and NIM serving modal.


**_Scenario 2: Storage class with a provisioner not present in the mapping_**

1. You would have to make some changes locally to test this scenario. For example, comment out `kubernetes.io/quobyte` from the mapping.
2. You will continue seeing RWO as default. All other access modes will be available to be selected.
3. Since this provisioner is not present in the recommended list/mapping, we won't show any warning.
4. Everything else should work as scenario 1.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
I have added a test for the new alert/warning.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline alerts show recommended vs. unsupported access modes; human-readable access-mode labels; RWX-disable warning; saves always preserve RWO.

* **UX Improvements**
  * Access-mode selection simplified: all modes shown and more options enabled by default; helper text/popovers streamlined; non-editable displays preserved.

* **Tests**
  * UI and unit tests updated to match new access-mode behavior and warning messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->