### PR TITLE
Follow up to add token auth

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -3,6 +3,7 @@ import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
+import { mock404Error } from '#~/__mocks__/mockK8sStatus';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
 import { mockServingRuntimeK8sResource } from '#~/__mocks__/mockServingRuntimeK8sResource';
 import {
@@ -19,6 +20,10 @@ import {
   HardwareProfileModel,
   InferenceServiceModel,
   ProjectModel,
+  RoleBindingModel,
+  RoleModel,
+  SecretModel,
+  ServiceAccountModel,
   ServingRuntimeModel,
   TemplateModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
@@ -134,6 +139,109 @@ const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) 
       body: mockInferenceServiceK8sResource({ name: 'test-model', modelType }),
     },
   ).as('createInferenceService');
+
+  cy.interceptK8s(
+    'POST',
+    {
+      model: ServiceAccountModel,
+      ns: 'test-project',
+    },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'v1',
+        kind: 'ServiceAccount',
+        metadata: { name: 'test-model-sa', namespace: 'test-project' },
+      },
+    },
+  ).as('createServiceAccount');
+
+  cy.interceptK8s(
+    'POST',
+    {
+      model: RoleModel,
+      ns: 'test-project',
+    },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'Role',
+        metadata: { name: 'test-model-view-role', namespace: 'test-project' },
+      },
+    },
+  ).as('createRole');
+
+  cy.interceptK8s(
+    'POST',
+    {
+      model: RoleBindingModel,
+      ns: 'test-project',
+    },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: { name: 'test-model-view', namespace: 'test-project' },
+      },
+    },
+  ).as('createRoleBinding');
+
+  cy.interceptK8s(
+    'POST',
+    {
+      model: SecretModel,
+      ns: 'test-project',
+    },
+    {
+      statusCode: 200,
+      body: {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: 'test-model-token', namespace: 'test-project' },
+      },
+    },
+  ).as('createSecret');
+
+  cy.interceptK8s(
+    'GET',
+    {
+      model: ServiceAccountModel,
+      ns: 'test-project',
+      name: 'test-model-sa',
+    },
+    {
+      statusCode: 404,
+      body: mock404Error({}),
+    },
+  ).as('getServiceAccount');
+
+  cy.interceptK8s(
+    'GET',
+    {
+      model: RoleModel,
+      ns: 'test-project',
+      name: 'test-model-view-role',
+    },
+    {
+      statusCode: 404,
+      body: mock404Error({}),
+    },
+  ).as('getRole');
+
+  cy.interceptK8s(
+    'GET',
+    {
+      model: RoleBindingModel,
+      ns: 'test-project',
+      name: 'test-model-view',
+    },
+    {
+      statusCode: 404,
+      body: mock404Error({}),
+    },
+  ).as('getRoleBinding');
 };
 
 describe('Model Serving Deploy Wizard', () => {
@@ -300,6 +408,35 @@ describe('Model Serving Deploy Wizard', () => {
     cy.get('@createInferenceService.all').then((interceptions) => {
       expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
     });
+
+    //dry run request
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.url).to.include('?dryRun=All');
+      expect(interception.request.body).to.containSubset({
+        metadata: {
+          name: 'test-model-view-role',
+          namespace: 'test-project',
+          ownerReferences: [],
+        },
+        rules: [
+          {
+            verbs: ['get'],
+            apiGroups: ['serving.kserve.io'],
+            resources: ['inferenceservices'],
+            resourceNames: ['test-model'],
+          },
+        ],
+      });
+    });
+
+    //Actual request
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.url).not.to.include('?dryRun=All');
+    });
+
+    cy.get('@createRole.all').then((interceptions) => {
+      expect(interceptions).to.have.length(2); //1 dry run request and 1 actual request
+    });
   });
 
   it('Create a new predictive deployment and submit', () => {
@@ -411,6 +548,35 @@ describe('Model Serving Deploy Wizard', () => {
 
     cy.get('@createInferenceService.all').then((interceptions) => {
       expect(interceptions).to.have.length(2); // 1 dry-run request and 1 actual request
+    });
+
+    //dry run request
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.url).to.include('?dryRun=All');
+      expect(interception.request.body).to.containSubset({
+        metadata: {
+          name: 'test-model-view-role',
+          namespace: 'test-project',
+          ownerReferences: [],
+        },
+        rules: [
+          {
+            verbs: ['get'],
+            apiGroups: ['serving.kserve.io'],
+            resources: ['inferenceservices'],
+            resourceNames: ['test-model'],
+          },
+        ],
+      });
+    });
+
+    //Actual request
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.url).not.to.include('?dryRun=All');
+    });
+
+    cy.get('@createRole.all').then((interceptions) => {
+      expect(interceptions).to.have.length(2); //1 dry run request and 1 actual request
     });
   });
 

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -25,7 +25,6 @@ export type CreatingInferenceServiceObject = {
   externalRoute?: ExternalRouteFieldData;
   tokenAuth?: TokenAuthenticationFieldData;
   numReplicas?: NumReplicasFieldData;
-  tokens?: TokenAuthenticationFieldData;
 };
 
 export const deployKServeDeployment = async (
@@ -52,7 +51,6 @@ export const deployKServeDeployment = async (
     externalRoute: wizardData.externalRoute.data,
     tokenAuth: wizardData.tokenAuthentication.data,
     numReplicas: wizardData.numReplicas.data,
-    tokens: wizardData.tokenAuthentication.data,
   };
 
   const inferenceService = await createInferenceService(
@@ -61,7 +59,7 @@ export const deployKServeDeployment = async (
     dryRun,
   );
 
-  if (inferenceServiceData.tokens) {
+  if (inferenceServiceData.tokenAuth) {
     await setUpTokenAuth(
       inferenceServiceData,
       inferenceServiceData.k8sName,

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -15,7 +15,7 @@ import { ExternalRouteFieldData } from '../../model-serving/src/components/deplo
 import { TokenAuthenticationFieldData } from '../../model-serving/src/components/deploymentWizard/fields/TokenAuthenticationField';
 import { NumReplicasFieldData } from '../../model-serving/src/components/deploymentWizard/fields/NumReplicasField';
 
-type CreatingInferenceServiceObject = {
+export type CreatingInferenceServiceObject = {
   project: string;
   name: string;
   k8sName: string;
@@ -25,6 +25,7 @@ type CreatingInferenceServiceObject = {
   externalRoute?: ExternalRouteFieldData;
   tokenAuth?: TokenAuthenticationFieldData;
   numReplicas?: NumReplicasFieldData;
+  tokens?: TokenAuthenticationFieldData;
 };
 
 export const deployKServeDeployment = async (
@@ -51,6 +52,7 @@ export const deployKServeDeployment = async (
     externalRoute: wizardData.externalRoute.data,
     tokenAuth: wizardData.tokenAuthentication.data,
     numReplicas: wizardData.numReplicas.data,
+    tokens: wizardData.tokenAuthentication.data,
   };
 
   const inferenceService = await createInferenceService(
@@ -59,14 +61,9 @@ export const deployKServeDeployment = async (
     dryRun,
   );
 
-  if (wizardData.tokenAuthentication.data && wizardData.tokenAuthentication.data.length > 0) {
-    const inferenceServiceDataWithTokens = {
-      ...inferenceServiceData,
-      tokens: wizardData.tokenAuthentication.data,
-    };
-
+  if (inferenceServiceData.tokens) {
     await setUpTokenAuth(
-      inferenceServiceDataWithTokens,
+      inferenceServiceData,
       inferenceServiceData.k8sName,
       projectName,
       true,

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -9,6 +9,7 @@ import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { KServeDeployment } from './deployments';
+import { setUpTokenAuth } from './deployUtils';
 import { UseModelDeploymentWizardState } from '../../model-serving/src/components/deploymentWizard/useDeploymentWizard';
 import { ExternalRouteFieldData } from '../../model-serving/src/components/deploymentWizard/fields/ExternalRouteField';
 import { TokenAuthenticationFieldData } from '../../model-serving/src/components/deploymentWizard/fields/TokenAuthenticationField';
@@ -57,6 +58,23 @@ export const deployKServeDeployment = async (
     existingDeployment?.model,
     dryRun,
   );
+
+  if (wizardData.tokenAuthentication.data && wizardData.tokenAuthentication.data.length > 0) {
+    const inferenceServiceDataWithTokens = {
+      ...inferenceServiceData,
+      tokens: wizardData.tokenAuthentication.data,
+    };
+
+    await setUpTokenAuth(
+      inferenceServiceDataWithTokens,
+      inferenceServiceData.k8sName,
+      projectName,
+      true,
+      inferenceService,
+      undefined,
+      { dryRun: dryRun ?? false },
+    );
+  }
 
   return Promise.resolve({
     modelServingPlatformId: 'kserve',

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -96,9 +96,10 @@ export const createSecrets = async (
   const deletedSecrets =
     existingSecrets
       ?.map((secret) => secret.metadata.name)
-      .filter((token: string) => !fillData.tokens?.some((tokenEdit) => tokenEdit.name === token)) ||
-    [];
-  const tokensToProcess = fillData.tokens || [];
+      .filter(
+        (token: string) => !fillData.tokenAuth?.some((tokenEdit) => tokenEdit.name === token),
+      ) || [];
+  const tokensToProcess = fillData.tokenAuth || [];
 
   await Promise.all<K8sStatus | SecretKind>([
     ...tokensToProcess.map((token) => {

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -1,0 +1,235 @@
+import { K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  assembleSecretSA,
+  createSecret,
+  deleteSecret,
+} from '@odh-dashboard/internal/api/k8s/secrets';
+import {
+  assembleServiceAccount,
+  createServiceAccount,
+  getServiceAccount,
+} from '@odh-dashboard/internal/api/k8s/serviceAccounts';
+import {
+  generateRoleInferenceService,
+  getRole,
+  createRole,
+} from '@odh-dashboard/internal/api/k8s/roles';
+import {
+  generateRoleBindingServiceAccount,
+  getRoleBinding,
+  createRoleBinding,
+} from '@odh-dashboard/internal/api/k8s/roleBindings';
+import { addOwnerReference } from '@odh-dashboard/internal/api/k8sUtils';
+import {
+  SecretKind,
+  K8sAPIOptions,
+  RoleBindingKind,
+  InferenceServiceKind,
+  ServiceAccountKind,
+  RoleKind,
+} from '@odh-dashboard/internal/k8sTypes';
+import { translateDisplayNameForK8s } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { type TokenAuthenticationFieldData } from '../../model-serving/src/components/deploymentWizard/fields/TokenAuthenticationField';
+
+type CreatingInferenceServiceObject = {
+  project: string;
+  name: string;
+  k8sName: string;
+  modelType: string;
+  hardwareProfile: Record<string, unknown>;
+  modelFormat: Record<string, unknown>;
+  externalRoute?: boolean;
+  tokenAuth?: TokenAuthenticationFieldData;
+  tokens?: TokenAuthenticationFieldData;
+};
+
+type TokenNames = {
+  serviceAccountName: string;
+  roleName: string;
+  roleBindingName: string;
+};
+
+type TokenData = {
+  uuid: string;
+  name: string;
+  error?: string;
+};
+
+export const getModelServingRuntimeName = (namespace: string): string =>
+  `model-server-${namespace}`;
+
+export const getModelServiceAccountName = (name: string): string => `${name}-sa`;
+
+export const getModelRole = (name: string): string => `${name}-view-role`;
+export const getModelRoleBinding = (name: string): string => `${name}-view`;
+
+export const getTokenNames = (servingRuntimeName: string, namespace: string): TokenNames => {
+  const name =
+    servingRuntimeName !== '' ? servingRuntimeName : getModelServingRuntimeName(namespace);
+
+  const serviceAccountName = getModelServiceAccountName(name);
+  const roleName = getModelRole(name);
+  const roleBindingName = getModelRoleBinding(name);
+
+  return { serviceAccountName, roleName, roleBindingName };
+};
+
+export const createServiceAccountIfMissing = async (
+  serviceAccount: ServiceAccountKind,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<ServiceAccountKind> =>
+  getServiceAccount(serviceAccount.metadata.name, namespace).catch((e: unknown) => {
+    if (
+      e &&
+      typeof e === 'object' &&
+      'statusObject' in e &&
+      e.statusObject &&
+      typeof e.statusObject === 'object' &&
+      'code' in e.statusObject &&
+      e.statusObject.code === 404
+    ) {
+      return createServiceAccount(serviceAccount, opts);
+    }
+    return Promise.reject(e);
+  });
+
+export const createRoleIfMissing = async (
+  role: RoleKind,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<RoleKind> =>
+  getRole(namespace, role.metadata.name).catch((e: unknown) => {
+    if (
+      e &&
+      typeof e === 'object' &&
+      'statusObject' in e &&
+      e.statusObject &&
+      typeof e.statusObject === 'object' &&
+      'code' in e.statusObject &&
+      e.statusObject.code === 404
+    ) {
+      return createRole(role, opts);
+    }
+    return Promise.reject(e);
+  });
+
+export const createRoleBindingIfMissing = async (
+  rolebinding: RoleBindingKind,
+  namespace: string,
+  opts?: K8sAPIOptions,
+): Promise<RoleBindingKind> =>
+  getRoleBinding(namespace, rolebinding.metadata.name).catch((e: unknown) => {
+    if (
+      e &&
+      typeof e === 'object' &&
+      'statusObject' in e &&
+      e.statusObject &&
+      typeof e.statusObject === 'object' &&
+      'code' in e.statusObject &&
+      e.statusObject.code === 404
+    ) {
+      return createRoleBinding(rolebinding, opts).catch((error: unknown) => {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'statusObject' in error &&
+          error.statusObject &&
+          typeof error.statusObject === 'object' &&
+          'code' in error.statusObject &&
+          error.statusObject.code === 404 &&
+          opts?.dryRun
+        ) {
+          // If dryRun is enabled and the user is not Cluster Admin it seems that there's a k8s error
+          // that raises a 404 trying to find the role, which is missing since it's a dryRun.
+          return Promise.resolve(rolebinding);
+        }
+        return Promise.reject(error);
+      });
+    }
+    return Promise.reject(e);
+  });
+
+export const createSecrets = async (
+  fillData: CreatingInferenceServiceObject,
+  deployedModelName: string,
+  namespace: string,
+  existingSecrets?: SecretKind[],
+  opts?: K8sAPIOptions,
+): Promise<void> => {
+  const { serviceAccountName } = getTokenNames(deployedModelName, namespace);
+  const deletedSecrets =
+    existingSecrets
+      ?.map((secret) => secret.metadata.name)
+      .filter(
+        (token: string) =>
+          !fillData.tokens?.some((tokenEdit: TokenData) => tokenEdit.name === token),
+      ) || [];
+
+  return Promise.all<K8sStatus | SecretKind>([
+    ...(fillData.tokens || [])
+      .filter((token: TokenData) => translateDisplayNameForK8s(token.name) !== token.name)
+      .map((token: TokenData) => {
+        const secretToken = assembleSecretSA(token.name, serviceAccountName, namespace);
+        return createSecret(secretToken, opts);
+      }),
+    ...deletedSecrets.map((secret) => deleteSecret(namespace, secret, opts)),
+  ])
+    .then(() => Promise.resolve())
+    .catch((error) => Promise.reject(error));
+};
+
+export const setUpTokenAuth = async (
+  fillData: CreatingInferenceServiceObject,
+  deployedModelName: string,
+  namespace: string,
+  createTokenAuth: boolean,
+  owner: InferenceServiceKind,
+  existingSecrets?: SecretKind[],
+  opts?: K8sAPIOptions,
+): Promise<void> => {
+  const { serviceAccountName, roleName, roleBindingName } = getTokenNames(
+    deployedModelName,
+    namespace,
+  );
+
+  const serviceAccount = addOwnerReference(
+    assembleServiceAccount(serviceAccountName, namespace),
+    owner,
+  );
+
+  // For KServe, we need the inferenceservice view role
+  const role = addOwnerReference(
+    generateRoleInferenceService(roleName, deployedModelName, namespace),
+    owner,
+  );
+
+  const roleBinding = addOwnerReference(
+    generateRoleBindingServiceAccount(
+      roleBindingName,
+      serviceAccountName,
+      {
+        kind: 'Role',
+        name: roleName,
+      },
+      namespace,
+    ),
+    owner,
+  );
+
+  return (
+    createTokenAuth
+      ? Promise.all([
+          createServiceAccountIfMissing(serviceAccount, namespace, opts),
+          createRoleIfMissing(role, namespace, opts),
+        ]).then(() => createRoleBindingIfMissing(roleBinding, namespace, opts))
+      : Promise.resolve()
+  )
+    .then(() => createSecrets(fillData, deployedModelName, namespace, existingSecrets, opts))
+    .catch((error) => Promise.reject(error));
+};
+
+// Helper function to convert TokenAuthenticationFieldData to the format expected by CreatingInferenceServiceObject
+export const convertTokenAuthData = (tokenAuthData: TokenAuthenticationFieldData): string[] => {
+  return tokenAuthData.map((token: TokenData) => token.name).filter(Boolean);
+};

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -83,16 +83,6 @@ const mockDeploymentWizardState = (
           setReplicas: jest.fn(),
         },
       },
-      data: {
-        externalRouteField: undefined,
-        tokenAuthenticationField: undefined,
-      },
-      handlers: {
-        setExternalRoute: jest.fn(),
-        updateExternalRoute: jest.fn(),
-        setTokenAuthentication: jest.fn(),
-        updateTokenAuthentication: jest.fn(),
-      },
     },
     overrides,
   );


### PR DESCRIPTION
Closes: [RHOAIENG-32266](https://issues.redhat.com/browse/RHOAIENG-32266)
Follow up from: https://github.com/opendatahub-io/odh-dashboard/pull/4781

## Description
Follow up to implement the setUpTokenAuth resources (secrets, SA, role, rolebinding), based off of the existing implementation in [modelServing/utils.ts](https://github.com/opendatahub-io/odh-dashboard/blob/main/frontend/src/pages/modelServing/utils.ts#L77)
Also removes an unnecessary test missed in PR-4781

## How Has This Been Tested?
Tested locally, by watching the network calls when deploying a new model under the wizard

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now supports optional token-based authentication: when token data is provided, credentials, service accounts/roles/bindings and per-token secrets are provisioned idempotently after deployment, with obsolete tokens removed and dry-run previews available.

* **Tests**
  * Deployment wizard and end-to-end tests updated with RBAC/dry-run mocks and additional resource models to validate token and RBAC creation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->