### PR TITLE
Add tests, edit, and deploy functionality for wizard model location

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -66,6 +66,48 @@ const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) 
         },
       ],
     }),
+    mockConnectionTypeConfigMap({
+      displayName: 'S3',
+      name: 's3',
+      category: ['existing-category'],
+      fields: [
+        {
+          type: 'short-text',
+          name: 'AWS_ACCESS_KEY_ID',
+          envVar: 'AWS_ACCESS_KEY_ID',
+          required: true,
+          properties: {},
+        },
+        {
+          type: 'short-text',
+          name: 'AWS_SECRET_ACCESS_KEY',
+          envVar: 'AWS_SECRET_ACCESS_KEY',
+          required: true,
+          properties: {},
+        },
+        {
+          type: 'short-text',
+          name: 'AWS_S3_ENDPOINT',
+          envVar: 'AWS_S3_ENDPOINT',
+          required: true,
+          properties: {},
+        },
+        {
+          type: 'short-text',
+          name: 'AWS_S3_BUCKET',
+          envVar: 'AWS_S3_BUCKET',
+          required: true,
+          properties: {},
+        },
+        {
+          type: 'short-text',
+          name: 'AWS_DEFAULT_REGION',
+          envVar: 'AWS_DEFAULT_REGION',
+          required: false,
+          properties: {},
+        },
+      ],
+    }),
   ]).as('getConnectionTypes');
 
   cy.interceptK8sList(
@@ -774,6 +816,8 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingGlobal.getModelRow('Test Inference Service').findKebabAction('Edit').click();
 
     // Step 1: Model source
+    modelServingWizardEdit.findModelLocationSelect().should('exist');
+    modelServingWizardEdit.findUrilocationInput().should('have.value', 'https://test');
     modelServingWizardEdit.findModelSourceStep().should('be.enabled');
     modelServingWizardEdit.findNextButton().should('be.enabled');
 
@@ -781,9 +825,6 @@ describe('Model Serving Deploy Wizard', () => {
       .findModelTypeSelect()
       .should('have.text', 'Predictive model')
       .should('be.disabled');
-
-    modelServingWizardEdit.findModelLocationSelect().should('exist');
-    modelServingWizardEdit.findUrilocationInput().should('have.value', 'https://test');
 
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -760,8 +760,8 @@ describe('Model Serving Deploy Wizard', () => {
               memory: '16Gi',
             },
           },
+          storageUri: 'https://test',
         }),
-        mockInferenceServiceK8sResource({ storageUri: 'https://test' }),
       ]),
     );
     cy.interceptK8sList(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -29,7 +29,10 @@ import {
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { ServingRuntimeModelType, ServingRuntimePlatform } from '#~/types';
 import { mockGlobalScopedHardwareProfiles } from '#~/__mocks__/mockHardwareProfile';
-import { mockConnectionTypeConfigMap } from '../../../../../../__mocks__/mockConnectionType';
+import {
+  mockConnectionTypeConfigMap,
+  mockModelServingFields,
+} from '../../../../../../__mocks__/mockConnectionType';
 
 const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) => {
   cy.interceptOdh(
@@ -70,43 +73,7 @@ const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) 
       displayName: 'S3',
       name: 's3',
       category: ['existing-category'],
-      fields: [
-        {
-          type: 'short-text',
-          name: 'AWS_ACCESS_KEY_ID',
-          envVar: 'AWS_ACCESS_KEY_ID',
-          required: true,
-          properties: {},
-        },
-        {
-          type: 'short-text',
-          name: 'AWS_SECRET_ACCESS_KEY',
-          envVar: 'AWS_SECRET_ACCESS_KEY',
-          required: true,
-          properties: {},
-        },
-        {
-          type: 'short-text',
-          name: 'AWS_S3_ENDPOINT',
-          envVar: 'AWS_S3_ENDPOINT',
-          required: true,
-          properties: {},
-        },
-        {
-          type: 'short-text',
-          name: 'AWS_S3_BUCKET',
-          envVar: 'AWS_S3_BUCKET',
-          required: true,
-          properties: {},
-        },
-        {
-          type: 'short-text',
-          name: 'AWS_DEFAULT_REGION',
-          envVar: 'AWS_DEFAULT_REGION',
-          required: false,
-          properties: {},
-        },
-      ],
+      fields: mockModelServingFields,
     }),
   ]).as('getConnectionTypes');
 

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -78,6 +78,7 @@ export enum MetadataAnnotation {
   K8sDescription = 'kubernetes.io/description',
   OdhStorageClassConfig = 'opendatahub.io/sc-config',
   Description = 'description',
+  ConnectionName = 'opendatahub.io/connections',
 }
 
 type StorageClassAnnotations = Partial<{

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -131,6 +131,8 @@ const extensions: (
       extractEnvironmentVariables: () =>
         import('./src/hardware').then((m) => m.extractEnvironmentVariables),
       extractAiAssetData: () => import('./src/aiAssets').then((m) => m.extractAiAssetData),
+      extractModelLocationData: () =>
+        import('./src/modelLocationData').then((m) => m.extractKServeModelLocationData),
     },
   },
   {

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -19,12 +19,14 @@ import { NumReplicasFieldData } from '../../model-serving/src/components/deploym
 import { RuntimeArgsFieldData } from '../../model-serving/src/components/deploymentWizard/fields/RuntimeArgsField';
 import { EnvironmentVariablesFieldData } from '../../model-serving/src/components/deploymentWizard/fields/EnvironmentVariablesField';
 import { AvailableAiAssetsFieldsData } from '../../model-serving/src/components/deploymentWizard/fields/AvailableAiAssetsFields';
+import { ModelLocationData } from '../../model-serving/src/components/deploymentWizard/fields/modelLocationFields/types';
 
 export type CreatingInferenceServiceObject = {
   project: string;
   name: string;
   k8sName: string;
   description: string;
+  modelLocationData?: ModelLocationData;
   modelType: ServingRuntimeModelType;
   hardwareProfile: HardwareProfileConfig;
   modelFormat: SupportedModelFormats;
@@ -57,6 +59,7 @@ export const deployKServeDeployment = async (
     name: wizardData.k8sNameDesc.data.name,
     k8sName: wizardData.k8sNameDesc.data.k8sName.value,
     description: wizardData.k8sNameDesc.data.description,
+    modelLocationData: wizardData.modelLocationData.data,
     modelType: wizardData.modelType.data,
     hardwareProfile: wizardData.hardwareProfileConfig.formData,
     modelFormat: wizardData.modelFormatState.modelFormat,

--- a/packages/kserve/src/modelLocationData.ts
+++ b/packages/kserve/src/modelLocationData.ts
@@ -5,55 +5,11 @@ import {
 import { MetadataAnnotation, InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
 import { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import { ModelServingCompatibleTypes } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
-import { getSecret } from '@odh-dashboard/internal/api/k8s/secrets';
 import {
   ModelLocationData,
   ModelLocationType,
   ConnectionTypeRefs,
 } from '../../model-serving/src/components/deploymentWizard/fields/modelLocationFields/types';
-
-type SecretData = {
-  hasOwnerRef: boolean;
-  connectionTypeRef: string;
-  data: Record<string, string>;
-};
-
-const getSecretData = async (
-  secretName: string,
-  namespace: string,
-): Promise<SecretData | undefined> => {
-  try {
-    const secret = await getSecret(namespace, secretName);
-    return {
-      hasOwnerRef: !!secret.metadata.ownerReferences?.length,
-      connectionTypeRef:
-        secret.metadata.annotations?.['opendatahub.io/connection-type-ref'] ||
-        secret.metadata.annotations?.['opendatahub.io/connection-type'] ||
-        '',
-      data: Object.entries(secret.data || {}).reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: (() => {
-            const decoded = window.atob(value);
-            // Only parse if it looks like a JSON array (ex. OCI access types)
-            if (decoded.startsWith('[') && decoded.endsWith(']')) {
-              try {
-                return JSON.parse(decoded);
-              } catch {
-                return decoded;
-              }
-            }
-            return decoded;
-          })(),
-        }),
-        {},
-      ),
-    };
-  } catch (e) {
-    console.error('Failed to fetch secret:', e);
-    return undefined;
-  }
-};
 
 export const getModelLocationUri = (deployment: InferenceServiceKind): string | undefined => {
   return deployment.spec.predictor.model?.storageUri;
@@ -63,17 +19,11 @@ const getConnectionTypeObject = (
   connectionTypeRef: string,
   connectionTypes: ConnectionTypeConfigMapObj[],
 ): ConnectionTypeConfigMapObj | undefined => {
-  // Try to find the full connection type object first
   const foundType = connectionTypes.find((ct) => ct.metadata.name === connectionTypeRef);
   if (foundType) {
     return foundType;
   }
   return undefined;
-};
-
-const hasConnectionAnnotation = (deployment: InferenceServiceKind): string | undefined => {
-  const { annotations } = deployment.metadata;
-  return annotations?.[MetadataAnnotation.ConnectionName];
 };
 
 const extractAdditionalFields = (deployment: InferenceServiceKind): Record<string, string> => {
@@ -98,13 +48,10 @@ const extractAdditionalFields = (deployment: InferenceServiceKind): Record<strin
   return additionalFields;
 };
 
-export const extractKServeModelLocationData = async (
+export const extractKServeModelLocationData = (
   deployment: { model: InferenceServiceKind },
   connectionTypes: ConnectionTypeConfigMapObj[],
-): Promise<ModelLocationData> => {
-  // Check for connection annotation first
-  const connectionAnnotation = hasConnectionAnnotation(deployment.model);
-  // Handle PVC/URI cases first (no connection needed)
+): ModelLocationData => {
   const uri = getModelLocationUri(deployment.model);
   if (uri && isPVCUri(uri)) {
     return {
@@ -116,54 +63,26 @@ export const extractKServeModelLocationData = async (
     };
   }
 
-  // If we have a connection annotation, use that
-  if (connectionAnnotation) {
-    const additionalFields = extractAdditionalFields(deployment.model);
-    const secretData = await getSecretData(
-      connectionAnnotation,
-      deployment.model.metadata.namespace,
-    );
-    if (secretData?.hasOwnerRef) {
-      // Secret has owner ref - show as new connection with prefilled data
-      return {
-        type: ModelLocationType.NEW,
-        fieldValues: secretData.data,
-        connectionTypeObject: getConnectionTypeObject(
-          secretData.connectionTypeRef,
-          connectionTypes,
-        ),
-        additionalFields,
-      };
-    }
-    // No owner ref - existing connection
+  const connectionName =
+    deployment.model.metadata.annotations?.[MetadataAnnotation.ConnectionName] ||
+    deployment.model.spec.predictor.model?.storage?.key ||
+    deployment.model.spec.predictor.imagePullSecrets?.[0]?.name;
+
+  const additionalFields = extractAdditionalFields(deployment.model);
+
+  if (connectionName) {
     return {
       type: ModelLocationType.EXISTING,
-      connection: connectionAnnotation,
+      connection: connectionName,
       fieldValues: {},
       additionalFields,
     };
   }
 
-  // Check for legacy connection methods in predictor
-  const { predictor } = deployment.model.spec;
-  const secretName = predictor.model?.storage?.key || predictor.imagePullSecrets?.[0]?.name;
-
-  if (secretName) {
-    const additionalFields = extractAdditionalFields(deployment.model);
-    return {
-      type: ModelLocationType.EXISTING,
-      connection: secretName,
-      fieldValues: {},
-      additionalFields,
-    };
-  }
-
-  // No connection - default to URI
   return {
     type: ModelLocationType.NEW,
     fieldValues: { URI: uri },
-    // Add connection type object for URI to preselect on edit
     connectionTypeObject: getConnectionTypeObject(ConnectionTypeRefs.URI, connectionTypes),
-    additionalFields: {},
+    additionalFields,
   };
 };

--- a/packages/kserve/src/modelLocationData.ts
+++ b/packages/kserve/src/modelLocationData.ts
@@ -3,7 +3,10 @@ import {
   ModelResourceType,
   ServerResourceType,
 } from '@odh-dashboard/model-serving/extension-points';
-import { isPVCUri } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import {
+  getPVCNameFromURI,
+  isPVCUri,
+} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import { KnownLabels, MetadataAnnotation } from '@odh-dashboard/internal/k8sTypes';
 import { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import { ModelServingCompatibleTypes } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
@@ -166,7 +169,9 @@ export const extractKServeModelLocationData = async (
     return {
       type: ModelLocationType.PVC,
       fieldValues: { URI: uri },
-      additionalFields: {},
+      additionalFields: {
+        pvcConnection: getPVCNameFromURI(uri),
+      },
     };
   }
 

--- a/packages/kserve/src/modelLocationData.ts
+++ b/packages/kserve/src/modelLocationData.ts
@@ -3,27 +3,14 @@ import {
   isPVCUri,
 } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 import { MetadataAnnotation, InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
-import { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import { ModelServingCompatibleTypes } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
 import {
   ModelLocationData,
   ModelLocationType,
-  ConnectionTypeRefs,
 } from '../../model-serving/src/components/deploymentWizard/fields/modelLocationFields/types';
 
 export const getModelLocationUri = (deployment: InferenceServiceKind): string | undefined => {
   return deployment.spec.predictor.model?.storageUri;
-};
-
-const getConnectionTypeObject = (
-  connectionTypeRef: string,
-  connectionTypes: ConnectionTypeConfigMapObj[],
-): ConnectionTypeConfigMapObj | undefined => {
-  const foundType = connectionTypes.find((ct) => ct.metadata.name === connectionTypeRef);
-  if (foundType) {
-    return foundType;
-  }
-  return undefined;
 };
 
 const extractAdditionalFields = (deployment: InferenceServiceKind): Record<string, string> => {
@@ -48,10 +35,9 @@ const extractAdditionalFields = (deployment: InferenceServiceKind): Record<strin
   return additionalFields;
 };
 
-export const extractKServeModelLocationData = (
-  deployment: { model: InferenceServiceKind },
-  connectionTypes: ConnectionTypeConfigMapObj[],
-): ModelLocationData => {
+export const extractKServeModelLocationData = (deployment: {
+  model: InferenceServiceKind;
+}): ModelLocationData => {
   const uri = getModelLocationUri(deployment.model);
   if (uri && isPVCUri(uri)) {
     return {
@@ -82,7 +68,6 @@ export const extractKServeModelLocationData = (
   return {
     type: ModelLocationType.NEW,
     fieldValues: { URI: uri },
-    connectionTypeObject: getConnectionTypeObject(ConnectionTypeRefs.URI, connectionTypes),
     additionalFields,
   };
 };

--- a/packages/kserve/src/modelLocationData.ts
+++ b/packages/kserve/src/modelLocationData.ts
@@ -1,0 +1,236 @@
+import {
+  Deployment,
+  ModelResourceType,
+  ServerResourceType,
+} from '@odh-dashboard/model-serving/extension-points';
+import { isPVCUri } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { KnownLabels, MetadataAnnotation } from '@odh-dashboard/internal/k8sTypes';
+import { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
+import { ModelServingCompatibleTypes } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
+import { getSecret } from '@odh-dashboard/internal/api/k8s/secrets';
+import {
+  ModelLocationData,
+  ModelLocationType,
+  ConnectionTypeRefs,
+} from '../../model-serving/src/components/deploymentWizard/fields/modelLocationFields/types';
+
+interface SecretData {
+  hasOwnerRef: boolean;
+  connectionTypeRef: string;
+  data: Record<string, string>;
+}
+
+const getSecretData = async (
+  secretName: string,
+  namespace: string,
+): Promise<SecretData | undefined> => {
+  try {
+    const secret = await getSecret(namespace, secretName);
+    return {
+      hasOwnerRef: !!secret.metadata.ownerReferences?.length,
+      connectionTypeRef:
+        secret.metadata.annotations?.['opendatahub.io/connection-type-ref'] ||
+        secret.metadata.annotations?.['opendatahub.io/connection-type'] ||
+        '',
+      data: Object.entries(secret.data || {}).reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: (() => {
+            const decoded = window.atob(value);
+            // Only parse if it looks like a JSON array (ex. OCI access types)
+            if (decoded.startsWith('[') && decoded.endsWith(']')) {
+              try {
+                return JSON.parse(decoded);
+              } catch {
+                return decoded;
+              }
+            }
+            return decoded;
+          })(),
+        }),
+        {},
+      ),
+    };
+  } catch (e) {
+    console.error('Failed to fetch secret:', e);
+    return undefined;
+  }
+};
+
+export const getModelLocationUri = (deployment: KServeDeployment): string | undefined => {
+  const {
+    model: {
+      spec: { predictor },
+    },
+  } = deployment;
+  return predictor.model?.storageUri;
+};
+const getConnectionTypeObject = (
+  connectionTypeRef: string,
+  connectionTypes: ConnectionTypeConfigMapObj[],
+): ConnectionTypeConfigMapObj => {
+  // Try to find the full connection type object first
+  const foundType = connectionTypes.find((ct) => ct.metadata.name === connectionTypeRef);
+  if (foundType) {
+    return foundType;
+  }
+
+  // Fall back to basic object for custom types
+  return {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: connectionTypeRef,
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        'opendatahub.io/connection-type': 'true',
+      },
+      annotations: {
+        'opendatahub.io/connection-type': connectionTypeRef,
+      },
+    },
+    data: {
+      fields: [],
+    },
+  };
+};
+
+const hasConnectionAnnotation = (deployment: KServeDeployment): string | undefined => {
+  const {
+    model: {
+      metadata: { annotations },
+    },
+  } = deployment;
+  return annotations?.[MetadataAnnotation.ConnectionName];
+};
+
+const extractAdditionalFields = (deployment: KServeDeployment): Record<string, string> => {
+  const additionalFields: Record<string, string> = {};
+  const {
+    model: {
+      spec: { predictor },
+    },
+  } = deployment;
+  const connectionType = predictor.model?.storage?.key
+    ? ModelServingCompatibleTypes.S3ObjectStorage
+    : predictor.imagePullSecrets?.length
+    ? ModelServingCompatibleTypes.OCI
+    : predictor.model?.storageUri && !isPVCUri(predictor.model.storageUri)
+    ? ModelServingCompatibleTypes.URI
+    : undefined;
+
+  if (connectionType === ModelServingCompatibleTypes.S3ObjectStorage) {
+    additionalFields.modelPath = predictor.model?.storage?.path || '';
+  }
+
+  if (connectionType === ModelServingCompatibleTypes.OCI) {
+    additionalFields.modelUri = predictor.model?.storageUri || '';
+  }
+
+  return additionalFields;
+};
+
+type KServeModelResource = ModelResourceType & {
+  spec: {
+    predictor: {
+      model?: {
+        storageUri?: string;
+        storage?: {
+          path?: string;
+          key?: string;
+        };
+      };
+      imagePullSecrets?: { name: string }[];
+    };
+  };
+  metadata: {
+    annotations?: {
+      [MetadataAnnotation.ConnectionName]?: string;
+    };
+  };
+};
+
+type KServeDeployment = Deployment<KServeModelResource, ServerResourceType> & {
+  connectionType?: ConnectionTypeConfigMapObj;
+};
+
+export const extractKServeModelLocationData = async (
+  deployment: KServeDeployment,
+  connectionTypes: ConnectionTypeConfigMapObj[],
+): Promise<ModelLocationData> => {
+  // Check for connection annotation first
+  const connectionAnnotation = hasConnectionAnnotation(deployment);
+  // Handle PVC/URI cases first (no connection needed)
+  const uri = getModelLocationUri(deployment);
+  if (uri && isPVCUri(uri)) {
+    return {
+      type: ModelLocationType.PVC,
+      fieldValues: { URI: uri },
+      additionalFields: {},
+    };
+  }
+
+  // If we have a connection annotation, use that
+  if (connectionAnnotation) {
+    const additionalFields = extractAdditionalFields(deployment);
+    const secretData = await getSecretData(
+      connectionAnnotation,
+      deployment.model.metadata.namespace,
+    );
+    if (secretData?.hasOwnerRef) {
+      // Secret has owner ref - show as new connection with prefilled data
+      return {
+        type: ModelLocationType.NEW,
+        fieldValues: secretData.data,
+        connectionTypeObject: getConnectionTypeObject(
+          secretData.connectionTypeRef,
+          connectionTypes,
+        ),
+        additionalFields,
+      };
+    }
+    // No owner ref - existing connection
+    return {
+      type: ModelLocationType.EXISTING,
+      connection: connectionAnnotation,
+      fieldValues: {},
+      additionalFields,
+    };
+  }
+
+  // Check for legacy connection methods in predictor
+  const {
+    model: {
+      spec: { predictor },
+    },
+  } = deployment;
+  const secretName = predictor.model?.storage?.key || predictor.imagePullSecrets?.[0]?.name;
+
+  if (secretName) {
+    const additionalFields = extractAdditionalFields(deployment);
+    return {
+      type: ModelLocationType.EXISTING,
+      connection: secretName,
+      fieldValues: {},
+      additionalFields,
+    };
+  }
+
+  // No connection - default to URI
+  if (uri) {
+    return {
+      type: ModelLocationType.NEW,
+      fieldValues: { URI: uri },
+      // Add connection type object for URI to preselect on edit
+      connectionTypeObject: getConnectionTypeObject(ConnectionTypeRefs.URI, connectionTypes),
+      additionalFields: {},
+    };
+  }
+
+  // Fallback
+  return {
+    type: ModelLocationType.NEW,
+    fieldValues: { URI: 'https://test' },
+    additionalFields: {},
+  };
+};

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -15,7 +15,6 @@ import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelSe
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
-import type { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import type { ModelLocationData } from '../src/components/deploymentWizard/fields/modelLocationFields/types';
 import type { UseModelDeploymentWizardState } from '../src/components/deploymentWizard/useDeploymentWizard';
 
@@ -150,9 +149,7 @@ export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deplo
     extractAiAssetData: CodeRef<
       (deployment: D) => { saveAsAiAsset: boolean; useCase: string } | null
     >;
-    extractModelLocationData: CodeRef<
-      (deployment: D, connectionTypes: ConnectionTypeConfigMapObj[]) => ModelLocationData | null
-    >;
+    extractModelLocationData: CodeRef<(deployment: D) => ModelLocationData | null>;
   }
 >;
 export const isModelServingDeploymentFormDataExtension = <D extends Deployment = Deployment>(

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -15,8 +15,8 @@ import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelSe
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
-import type { ModelLocationData } from 'src/components/deploymentWizard/fields/modelLocationFields/types';
 import type { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
+import type { ModelLocationData } from '../src/components/deploymentWizard/fields/modelLocationFields/types';
 import type { UseModelDeploymentWizardState } from '../src/components/deploymentWizard/useDeploymentWizard';
 
 export type DeploymentStatus = {
@@ -151,7 +151,10 @@ export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deplo
       (deployment: D) => { saveAsAiAsset: boolean; useCase: string } | null
     >;
     extractModelLocationData: CodeRef<
-      (deployment: D, connectionTypes: ConnectionTypeConfigMapObj[]) => ModelLocationData | null
+      (
+        deployment: D,
+        connectionTypes: ConnectionTypeConfigMapObj[],
+      ) => Promise<ModelLocationData | null>
     >;
   }
 >;

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -151,10 +151,7 @@ export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deplo
       (deployment: D) => { saveAsAiAsset: boolean; useCase: string } | null
     >;
     extractModelLocationData: CodeRef<
-      (
-        deployment: D,
-        connectionTypes: ConnectionTypeConfigMapObj[],
-      ) => Promise<ModelLocationData | null>
+      (deployment: D, connectionTypes: ConnectionTypeConfigMapObj[]) => ModelLocationData | null
     >;
   }
 >;

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -15,6 +15,8 @@ import type { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelSe
 import type { ToggleState } from '@odh-dashboard/internal/components/StateActionToggle';
 import type { ComponentCodeRef } from '@odh-dashboard/plugin-core';
 import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import type { ModelLocationData } from 'src/components/deploymentWizard/fields/modelLocationFields/types';
+import type { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import type { UseModelDeploymentWizardState } from '../src/components/deploymentWizard/useDeploymentWizard';
 
 export type DeploymentStatus = {
@@ -147,6 +149,9 @@ export type ModelServingDeploymentFormDataExtension<D extends Deployment = Deplo
     >;
     extractAiAssetData: CodeRef<
       (deployment: D) => { saveAsAiAsset: boolean; useCase: string } | null
+    >;
+    extractModelLocationData: CodeRef<
+      (deployment: D, connectionTypes: ConnectionTypeConfigMapObj[]) => ModelLocationData | null
     >;
   }
 >;

--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -138,6 +138,11 @@ export const mockDeploymentWizardState = (
           connections: [],
           setSelectedConnection: jest.fn(),
           selectedConnection: undefined,
+          isLoadingSecretData: true,
+          project: null,
+          connectionsLoaded: true,
+          connectionTypes: [],
+          connectionTypesLoaded: true,
         },
         k8sNameDesc: {
           data: mockK8sNameDescriptionFieldData(),

--- a/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
@@ -11,6 +11,9 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
+import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
+import { Connection } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
 import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
 import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
@@ -22,12 +25,19 @@ const CreateModelDeploymentPage: React.FC = () => {
 
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const currentProject = projects.find(byName(namespace));
+  const [connections, connectionsLoaded] = useServingConnections(
+    currentProject?.metadata.name ?? '',
+  );
+  const [connectionTypes] = useWatchConnectionTypes(true);
+  const [selectedConnection, setSelectedConnection] = React.useState<Connection | undefined>(
+    undefined,
+  );
 
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();
   const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);
 
-  if (!projectsLoaded || !clusterPlatformsLoaded) {
+  if (!projectsLoaded || !clusterPlatformsLoaded || !connectionsLoaded) {
     return (
       <Bullseye>
         <Spinner />
@@ -64,6 +74,10 @@ const CreateModelDeploymentPage: React.FC = () => {
         primaryButtonText="Deploy model"
         project={currentProject}
         modelServingPlatform={activePlatform}
+        connections={connections}
+        selectedConnection={selectedConnection}
+        connectionTypes={connectionTypes}
+        setSelectedConnection={setSelectedConnection}
       />
     </ModelDeploymentsProvider>
   );

--- a/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
@@ -12,12 +12,15 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
-import { useModelLocationData } from './fields/ModelLocationInputFields';
+import { useModelDeploymentWizard } from './useDeploymentWizard';
 import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
 import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
 import { ModelDeploymentsProvider } from '../../concepts/ModelDeploymentsContext';
 
 const CreateModelDeploymentPage: React.FC = () => {
+  const wizardState = useModelDeploymentWizard();
+  const { connectionsLoaded } = wizardState.state.modelLocationData;
+
   const { namespace } = useParams();
   const navigate = useNavigate();
 
@@ -27,8 +30,6 @@ const CreateModelDeploymentPage: React.FC = () => {
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();
   const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);
-
-  const { connectionsLoaded } = useModelLocationData(currentProject ?? null, undefined);
 
   if (!projectsLoaded || !clusterPlatformsLoaded || !connectionsLoaded) {
     return (

--- a/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
@@ -25,9 +25,7 @@ const CreateModelDeploymentPage: React.FC = () => {
 
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const currentProject = projects.find(byName(namespace));
-  const [connections, connectionsLoaded] = useServingConnections(
-    currentProject?.metadata.name ?? '',
-  );
+  const [connections, connectionsLoaded] = useServingConnections(currentProject?.metadata.name);
   const [connectionTypes] = useWatchConnectionTypes(true);
   const [selectedConnection, setSelectedConnection] = React.useState<Connection | undefined>(
     undefined,

--- a/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/CreateModelDeploymentPage.tsx
@@ -11,10 +11,8 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
-import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
-import { Connection } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
+import { useModelLocationData } from './fields/ModelLocationInputFields';
 import { useAvailableClusterPlatforms } from '../../concepts/useAvailableClusterPlatforms';
 import { useProjectServingPlatform } from '../../concepts/useProjectServingPlatform';
 import { ModelDeploymentsProvider } from '../../concepts/ModelDeploymentsContext';
@@ -25,15 +23,12 @@ const CreateModelDeploymentPage: React.FC = () => {
 
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const currentProject = projects.find(byName(namespace));
-  const [connections, connectionsLoaded] = useServingConnections(currentProject?.metadata.name);
-  const [connectionTypes] = useWatchConnectionTypes(true);
-  const [selectedConnection, setSelectedConnection] = React.useState<Connection | undefined>(
-    undefined,
-  );
 
   const { clusterPlatforms, clusterPlatformsLoaded, clusterPlatformsError } =
     useAvailableClusterPlatforms();
   const { activePlatform } = useProjectServingPlatform(currentProject, clusterPlatforms);
+
+  const { connectionsLoaded } = useModelLocationData(currentProject ?? null, undefined);
 
   if (!projectsLoaded || !clusterPlatformsLoaded || !connectionsLoaded) {
     return (
@@ -72,10 +67,6 @@ const CreateModelDeploymentPage: React.FC = () => {
         primaryButtonText="Deploy model"
         project={currentProject}
         modelServingPlatform={activePlatform}
-        connections={connections}
-        selectedConnection={selectedConnection}
-        connectionTypes={connectionTypes}
-        setSelectedConnection={setSelectedConnection}
       />
     </ModelDeploymentsProvider>
   );

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -15,7 +15,7 @@ import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { setupDefaults } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
-import { ModelDeploymentWizardData, useModelDeploymentWizard } from './useDeploymentWizard';
+import { ModelDeploymentWizardData } from './useDeploymentWizard';
 import {
   getModelTypeFromDeployment,
   getTokenAuthenticationFromDeployment,
@@ -106,9 +106,6 @@ const EditModelDeploymentContent: React.FC<{
   project: ProjectKind;
   modelServingPlatform: ModelServingPlatform;
 }> = ({ project, modelServingPlatform }) => {
-  const wizardState = useModelDeploymentWizard();
-  const { connectionTypes } = wizardState.state.modelLocationData;
-
   const { name: deploymentName } = useParams();
   const { deployments, loaded: deploymentsLoaded } = React.useContext(ModelDeploymentsContext);
   const { dashboardNamespace } = useDashboardNamespace();
@@ -130,8 +127,7 @@ const EditModelDeploymentContent: React.FC<{
     modelFormat: formDataExtension?.properties.extractModelFormat(deployment) ?? undefined,
     numReplicas: formDataExtension?.properties.extractReplicas(deployment) ?? undefined,
     modelLocationData:
-      formDataExtension?.properties.extractModelLocationData(deployment, connectionTypes) ??
-      undefined,
+      formDataExtension?.properties.extractModelLocationData(deployment) ?? undefined,
     externalRoute: getExternalRouteFromDeployment(deployment),
     tokenAuthentication: getTokenAuthenticationFromDeployment(deployment),
     runtimeArgs: formDataExtension?.properties.extractRuntimeArgs(deployment) ?? undefined,

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -174,7 +174,7 @@ const EditModelDeploymentContent: React.FC<{
       }
     };
     loadData();
-  }, [existingDeployment, formDataExtension]);
+  }, [existingDeployment, formDataExtension, connectionTypes]);
 
   const initialConnection = React.useMemo(() => {
     if (connectionsLoaded && formData?.modelLocationData?.type === ModelLocationType.EXISTING) {

--- a/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/EditModelDeploymentPage.tsx
@@ -14,14 +14,17 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { setupDefaults } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
+import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
 import ModelDeploymentWizard from './ModelDeploymentWizard';
 import { ModelDeploymentWizardData } from './useDeploymentWizard';
 import {
   getModelTypeFromDeployment,
-  setupModelLocationData,
   getTokenAuthenticationFromDeployment,
   getExternalRouteFromDeployment,
 } from './utils';
+import { ModelLocationType } from './fields/modelLocationFields/types';
 import { Deployment, isModelServingDeploymentFormDataExtension } from '../../../extension-points';
 import {
   ModelDeploymentsContext,
@@ -146,18 +149,55 @@ const EditModelDeploymentContent: React.FC<{
     },
   });
 
-  const formData = React.useMemo(() => {
-    if (existingDeployment) {
-      return extractFormDataFromDeployment(existingDeployment);
+  React.useEffect(() => {
+    const loadData = async () => {
+      if (existingDeployment && formDataExtension) {
+        const modelLocationData = await formDataExtension.properties.extractModelLocationData(
+          existingDeployment,
+          connectionTypes,
+        );
+        setFormData({
+          modelTypeField: getModelTypeFromDeployment(existingDeployment),
+          k8sNameDesc: setupDefaults({ initialData: existingDeployment.model }),
+          hardwareProfile:
+            formDataExtension.properties.extractHardwareProfileConfig(existingDeployment) ??
+            undefined,
+          modelFormat:
+            formDataExtension.properties.extractModelFormat(existingDeployment) ?? undefined,
+          modelLocationData: modelLocationData ?? undefined,
+          externalRoute: getExternalRouteFromDeployment(existingDeployment),
+          tokenAuthentication: getTokenAuthenticationFromDeployment(existingDeployment),
+          AiAssetData:
+            formDataExtension.properties.extractAiAssetData(existingDeployment) ?? undefined,
+        });
+        setDataLoaded(true);
+      }
+    };
+    loadData();
+  }, [existingDeployment, formDataExtension]);
+
+  const initialConnection = React.useMemo(() => {
+    if (connectionsLoaded && formData?.modelLocationData?.type === ModelLocationType.EXISTING) {
+      return connections.find(
+        (c) => getResourceNameFromK8sResource(c) === formData.modelLocationData?.connection,
+      );
     }
     return undefined;
-  }, [existingDeployment, extractFormDataFromDeployment]);
+  }, [connections, connectionsLoaded, formData?.modelLocationData]);
+
+  // Keep track of selected connection separate from form data
+  const [selectedConnection, setSelectedConnection] = React.useState(initialConnection);
+
+  // Update selected connection when initial data changes
+  React.useEffect(() => {
+    setSelectedConnection(initialConnection);
+  }, [initialConnection]);
 
   if (formDataExtensionErrors.length > 0) {
     return <ErrorContent error={formDataExtensionErrors[0]} />;
   }
 
-  if (!deploymentsLoaded || !formDataExtensionLoaded) {
+  if (!deploymentsLoaded || !formDataExtensionLoaded || !connectionsLoaded || !dataLoaded) {
     return (
       <Bullseye>
         <Spinner />
@@ -173,6 +213,10 @@ const EditModelDeploymentContent: React.FC<{
       existingData={formData ? { ...formData, isEditing: true } : { isEditing: true }}
       project={project}
       modelServingPlatform={modelServingPlatform}
+      connections={connections}
+      selectedConnection={selectedConnection}
+      connectionTypes={connectionTypes}
+      setSelectedConnection={setSelectedConnection}
     />
   );
 };

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -17,7 +17,6 @@ import { ModelSourceStepContent } from './steps/ModelSourceStep';
 import { WizardFooterWithDisablingNext } from './WizardFooterWithDisablingNext';
 import { AdvancedSettingsStepContent } from './steps/AdvancedOptionsStep';
 import { ModelDeploymentStepContent } from './steps/ModelDeploymentStep';
-import { ModelLocationType } from './fields/modelLocationFields/types';
 import { isModelServingDeploy } from '../../../extension-points';
 import { useResolvedPlatformExtension } from '../../concepts/extensionUtils';
 import { ModelServingPlatform } from '../../concepts/useProjectServingPlatform';
@@ -29,10 +28,6 @@ type ModelDeploymentWizardProps = {
   existingData?: ModelDeploymentWizardData;
   project: ProjectKind;
   modelServingPlatform: ModelServingPlatform;
-  connections: Connection[];
-  selectedConnection: Connection | undefined;
-  connectionTypes: ConnectionTypeConfigMapObj[];
-  setSelectedConnection: (connection: Connection | undefined) => void;
 };
 
 const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
@@ -42,10 +37,6 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
   existingData,
   project,
   modelServingPlatform,
-  connections,
-  selectedConnection,
-  connectionTypes,
-  setSelectedConnection,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -116,40 +107,11 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
     validation.isModelDeploymentStepValid,
   ]);
 
-  const updateSelectedConnection = React.useCallback(
-    (connection: Connection | undefined) => {
-      if (!connection) {
-        setSelectedConnection(undefined);
-        return;
-      }
-      const connectionTypeRef = getConnectionTypeRef(connection);
-      const selectedConnectionType = connectionTypes.find(
-        (ct) => ct.metadata.name === connectionTypeRef,
-      );
-      if (selectedConnectionType) {
-        setSelectedConnection(connection);
-        wizardState.state.modelLocationData.setData({
-          type: ModelLocationType.EXISTING,
-          connectionTypeObject: selectedConnectionType,
-          connection: getResourceNameFromK8sResource(connection),
-          fieldValues: {},
-          additionalFields: {},
-        });
-      }
-    },
-    [wizardState.state.modelLocationData.setData, setSelectedConnection, connectionTypes],
-  );
   return (
     <ApplicationsPage title={title} description={description} loaded empty={false}>
       <Wizard onClose={exitWizard} onSave={onSave} footer={<WizardFooterWithDisablingNext />}>
         <WizardStep name="Source model" id="source-model-step">
-          <ModelSourceStepContent
-            wizardState={wizardState}
-            validation={validation.modelSource}
-            connections={connections}
-            selectedConnection={selectedConnection}
-            setSelectedConnection={updateSelectedConnection}
-          />
+          <ModelSourceStepContent wizardState={wizardState} validation={validation.modelSource} />
         </WizardStep>
         <WizardStep
           name="Model deployment"

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -4,12 +4,6 @@ import { Wizard, WizardStep } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { getServingRuntimeFromTemplate } from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
-import {
-  Connection,
-  ConnectionTypeConfigMapObj,
-} from '@odh-dashboard/internal/concepts/connectionTypes/types';
-import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
-import { getConnectionTypeRef } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
 import { getDeploymentWizardExitRoute } from './utils';
 import { useModelDeploymentWizard, type ModelDeploymentWizardData } from './useDeploymentWizard';
 import { useModelDeploymentWizardValidation } from './useDeploymentWizardValidation';

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -118,11 +118,15 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
 
   const updateSelectedConnection = React.useCallback(
     (connection: Connection | undefined) => {
+      if (!connection) {
+        setSelectedConnection(undefined);
+        return;
+      }
       const connectionTypeRef = getConnectionTypeRef(connection);
       const selectedConnectionType = connectionTypes.find(
         (ct) => ct.metadata.name === connectionTypeRef,
       );
-      if (connection && selectedConnectionType) {
+      if (selectedConnectionType) {
         setSelectedConnection(connection);
         wizardState.state.modelLocationData.setData({
           type: ModelLocationType.EXISTING,

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -46,9 +46,6 @@ export const isValidModelLocationData = (
   modelLocationData?: ModelLocationData,
 ): boolean => {
   if (!modelLocationData) return false;
-  const isValidPvcUri = (uri: unknown): uri is string => {
-    return typeof uri === 'string' && isPVCUri(uri);
-  };
   switch (modelLocation) {
     case ModelLocationType.EXISTING:
       return (
@@ -61,8 +58,8 @@ export const isValidModelLocationData = (
         modelLocationData.type === ModelLocationType.PVC &&
         !!modelLocationData.additionalFields.pvcConnection &&
         !!modelLocationData.fieldValues.URI &&
-        isValidPvcUri(modelLocationData.fieldValues.URI) &&
-        modelLocationData.fieldValues.URI.startsWith(
+        isPVCUri(String(modelLocationData.fieldValues.URI)) &&
+        String(modelLocationData.fieldValues.URI).startsWith(
           `pvc://${modelLocationData.additionalFields.pvcConnection}/`,
         )
       );
@@ -151,13 +148,10 @@ export const ModelLocationInputFields: React.FC<ModelLocationInputFieldsProps> =
   modelLocationData,
   pvcs,
 }) => {
-  const isValidPvcUri = (uri: unknown): uri is string => {
-    return typeof uri === 'string' && isPVCUri(uri);
-  };
   const pvcNameFromUri: string | undefined = React.useMemo(() => {
     // Get the PVC name from the URI if it's a PVC URI
-    if (modelLocationData?.fieldValues.URI && isValidPvcUri(modelLocationData.fieldValues.URI)) {
-      return getPVCNameFromURI(modelLocationData.fieldValues.URI);
+    if (modelLocationData?.fieldValues.URI && isPVCUri(String(modelLocationData.fieldValues.URI))) {
+      return getPVCNameFromURI(String(modelLocationData.fieldValues.URI));
     }
     return undefined;
   }, [modelLocationData?.fieldValues.URI]);

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -7,7 +7,6 @@ import {
 } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import {
   getConnectionTypeRef,
-  isConnection,
   isModelServingCompatible,
   ModelServingCompatibleTypes,
   parseConnectionSecretValues,
@@ -22,7 +21,6 @@ import {
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
 import useServingConnections from '@odh-dashboard/internal/pages/projects/screens/detail/connections/useServingConnections';
 import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
-import { getSecret } from '@odh-dashboard/internal/api/k8s/secrets';
 import { ExistingConnectionField } from './modelLocationFields/ExistingConnectionField';
 import {
   ConnectionTypeRefs,
@@ -93,14 +91,12 @@ export const useModelLocationData = (
           return;
         }
 
-        const secret = await getSecret(project.metadata.name, connectionName.toString());
-        if (!isConnection(secret)) {
+        const secret = connections.find((c) => c.metadata.name === existingData.connection);
+        if (!secret) {
           return;
         }
 
-        const connectionTypeRef =
-          secret.metadata.annotations['opendatahub.io/connection-type-ref'] ||
-          secret.metadata.annotations['opendatahub.io/connection-type'];
+        const connectionTypeRef = getConnectionTypeRef(secret);
         const connectionType = connectionTypes.find((ct) => ct.metadata.name === connectionTypeRef);
         const values = parseConnectionSecretValues(secret, connectionType);
         const hasOwnerRef = !!secret.metadata.ownerReferences?.length;

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -52,15 +52,12 @@ export const useModelLocationData = (
     return undefined;
   }, [connections, connectionsLoaded, existingData]);
 
-  // For getting the initial connection
-  const loadedConnection = React.useMemo(() => initialConnection, [initialConnection]);
-
   // For user selecting a connection
   const [userSelectedConnection, setUserSelectedConnection] = React.useState<
     Connection | undefined
   >();
 
-  const selectedConnection = userSelectedConnection ?? loadedConnection;
+  const selectedConnection = userSelectedConnection ?? initialConnection;
 
   const updateSelectedConnection = React.useCallback(
     (connection: Connection | undefined) => {
@@ -270,36 +267,34 @@ export const ModelLocationInputFields: React.FC<ModelLocationInputFieldsProps> =
 
   if (modelLocation === ModelLocationType.PVC) {
     return (
-      <>
-        <PvcSelectField
-          pvcs={pvcs}
-          selectedPVC={selectedPVC}
-          pvcNameFromUri={pvcNameFromUri}
-          existingUriOption={modelLocationData?.fieldValues.URI?.toString()}
-          onSelect={(selection?: PersistentVolumeClaimKind | undefined) => {
-            setModelLocationData({
-              type: ModelLocationType.PVC,
-              fieldValues: {
-                URI: selection ? `pvc://${selection.metadata.name}/` : '',
-              },
-              additionalFields: {
-                pvcConnection: selection?.metadata.name ?? '',
-              },
-            });
-          }}
-          setModelUri={(uri: string) => {
-            setModelLocationData({
-              type: ModelLocationType.PVC,
-              fieldValues: {
-                URI: uri || '',
-              },
-              additionalFields: {
-                pvcConnection: modelLocationData?.additionalFields.pvcConnection ?? '',
-              },
-            });
-          }}
-        />
-      </>
+      <PvcSelectField
+        pvcs={pvcs}
+        selectedPVC={selectedPVC}
+        pvcNameFromUri={pvcNameFromUri}
+        existingUriOption={modelLocationData?.fieldValues.URI?.toString()}
+        onSelect={(selection?: PersistentVolumeClaimKind | undefined) => {
+          setModelLocationData({
+            type: ModelLocationType.PVC,
+            fieldValues: {
+              URI: selection ? `pvc://${selection.metadata.name}/` : '',
+            },
+            additionalFields: {
+              pvcConnection: selection?.metadata.name ?? '',
+            },
+          });
+        }}
+        setModelUri={(uri: string) => {
+          setModelLocationData({
+            type: ModelLocationType.PVC,
+            fieldValues: {
+              URI: uri || '',
+            },
+            additionalFields: {
+              pvcConnection: modelLocationData?.additionalFields.pvcConnection ?? '',
+            },
+          });
+        }}
+      />
     );
   }
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationInputFields.tsx
@@ -24,7 +24,11 @@ import useServingConnections from '@odh-dashboard/internal/pages/projects/screen
 import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import { getSecret } from '@odh-dashboard/internal/api/k8s/secrets';
 import { ExistingConnectionField } from './modelLocationFields/ExistingConnectionField';
-import { ModelLocationData, ModelLocationType } from './modelLocationFields/types';
+import {
+  ConnectionTypeRefs,
+  ModelLocationData,
+  ModelLocationType,
+} from './modelLocationFields/types';
 import NewConnectionField from './modelLocationFields/NewConnectionField';
 import { PvcSelectField } from './modelLocationFields/PVCSelectField';
 
@@ -67,10 +71,24 @@ export const useModelLocationData = (
         setIsStableState(true);
         return;
       }
+      if (existingData.type === ModelLocationType.NEW) {
+        // Setting connection type object as URI by default, get reset later if it's something else
+        const connectionTypeObject = connectionTypes.find(
+          (ct) => ct.metadata.name === ConnectionTypeRefs.URI,
+        );
+        if (connectionTypeObject) {
+          setModelLocationData({
+            ...existingData,
+            connectionTypeObject,
+          });
+        }
+        setIsStableState(true);
+        return;
+      }
 
       setIsStableState(false);
       try {
-        const connectionName = existingData.connection || existingData.fieldValues.URI;
+        const connectionName = existingData.connection;
         if (!connectionName) {
           return;
         }

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
@@ -20,7 +20,7 @@ import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
 import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import usePvcs from '@odh-dashboard/internal/pages/modelServing/usePvcs';
-import { ModelLocationInputFields } from './ModelLocationInputFields';
+import { ModelLocationInputFields, useModelLocationData } from './ModelLocationInputFields';
 import { ModelLocationData, ModelLocationType } from './modelLocationFields/types';
 
 // Schema
@@ -55,28 +55,27 @@ type ModelLocationSelectFieldProps = {
   modelLocation?: ModelLocationData['type'];
   validationProps?: FieldValidationProps;
   validationIssues?: ZodIssue[];
-  connections: Connection[];
   project: ProjectKind | null;
   setModelLocationData: (data: ModelLocationData | undefined) => void;
   resetModelLocationData: () => void;
   modelLocationData?: ModelLocationData;
-  selectedConnection: Connection | undefined;
-  setSelectedConnection: (connection: Connection | undefined) => void;
 };
 export const ModelLocationSelectField: React.FC<ModelLocationSelectFieldProps> = ({
   modelLocation,
   validationProps,
   validationIssues = [],
-  connections,
   project,
   setModelLocationData,
   resetModelLocationData,
   modelLocationData,
-  selectedConnection,
-  setSelectedConnection,
 }) => {
   const [modelServingConnectionTypes] = useWatchConnectionTypes(true);
   const pvcs = usePvcs(project?.metadata.name ?? '');
+  const { selectedConnection, connections, setSelectedConnection } = useModelLocationData(
+    project,
+    modelLocationData,
+  );
+
   const selectedConnectionType = React.useMemo(() => {
     if (modelLocationData?.type === ModelLocationType.NEW) {
       return modelLocationData.connectionTypeObject;

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { FormGroup, FormHelperText, HelperTextItem } from '@patternfly/react-core';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  Form,
+} from '@patternfly/react-core';
 import { z, type ZodIssue } from 'zod';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
 import { FieldValidationProps } from '@odh-dashboard/internal/hooks/useZodFormValidation';
@@ -11,8 +18,7 @@ import {
 import { getConnectionTypeRef } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
 import { getResourceNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import { useWatchConnectionTypes } from '@odh-dashboard/internal/utilities/useWatchConnectionTypes';
-import { LabeledConnection } from '@odh-dashboard/internal/pages/modelServing/screens/types';
-import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import { KnownLabels, ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { ModelLocationInputFields } from './ModelLocationInputFields';
 import { ModelLocationData, ModelLocationType } from './modelLocationFields/types';
 
@@ -35,12 +41,12 @@ export const isValidModelLocation = (value: string): value is ModelLocationField
 export type ModelLocationField = {
   data: ModelLocationFieldData | undefined;
   setData: (data: ModelLocationFieldData) => void;
-  connections: LabeledConnection[];
+  connections: Connection[];
   setSelectedConnection: (
-    connection: LabeledConnection | undefined,
+    connection: Connection | undefined,
     connectionTypes: ConnectionTypeConfigMapObj[],
   ) => void;
-  selectedConnection: LabeledConnection | undefined;
+  selectedConnection: Connection | undefined;
 };
 // Component
 
@@ -48,111 +54,121 @@ type ModelLocationSelectFieldProps = {
   modelLocation?: ModelLocationData['type'];
   validationProps?: FieldValidationProps;
   validationIssues?: ZodIssue[];
-  connections: LabeledConnection[];
+  connections: Connection[];
+  project: ProjectKind | null;
   setModelLocationData: (data: ModelLocationData | undefined) => void;
   resetModelLocationData: () => void;
   modelLocationData?: ModelLocationData;
-  initSelectedConnection: LabeledConnection | undefined;
+  selectedConnection: Connection | undefined;
+  setSelectedConnection: (connection: Connection | undefined) => void;
 };
 export const ModelLocationSelectField: React.FC<ModelLocationSelectFieldProps> = ({
   modelLocation,
   validationProps,
   validationIssues = [],
   connections,
+  project,
   setModelLocationData,
   resetModelLocationData,
   modelLocationData,
-  initSelectedConnection,
+  selectedConnection,
+  setSelectedConnection,
 }) => {
-  const [selectedConnectionState, setSelectedConnection] = React.useState<Connection | undefined>(
-    initSelectedConnection?.connection ?? undefined,
-  );
   const [modelServingConnectionTypes] = useWatchConnectionTypes(true);
   const selectedConnectionType = React.useMemo(() => {
     if (modelLocationData?.type === ModelLocationType.NEW) {
       return modelLocationData.connectionTypeObject;
     }
-    if (selectedConnectionState) {
+    if (selectedConnection) {
       return modelServingConnectionTypes.find(
-        (t) => getResourceNameFromK8sResource(t) === getConnectionTypeRef(selectedConnectionState),
+        (t) => getResourceNameFromK8sResource(t) === getConnectionTypeRef(selectedConnection),
       );
     }
     return undefined;
-  }, [modelLocationData, modelServingConnectionTypes, selectedConnectionState]);
+  }, [modelLocationData, modelServingConnectionTypes, selectedConnection]);
   return (
-    <FormGroup fieldId="model-location-select" label="Model location" isRequired>
-      <FormHelperText>
-        <HelperTextItem>Where is the model you want to deploy located?</HelperTextItem>
-      </FormHelperText>
-      <SimpleSelect
-        dataTestId="model-location-select"
-        options={[
-          { key: ModelLocationType.EXISTING, label: 'Existing connection' },
-          { key: ModelLocationType.PVC, label: 'Cluster storage' },
-          ...modelServingConnectionTypes.map((ct) => ({
-            key: ct.metadata.name,
-            label: ct.metadata.annotations?.['openshift.io/display-name'] || ct.metadata.name,
-            value: ModelLocationType.NEW,
-          })),
-        ]}
-        onChange={(key) => {
-          if (isValidModelLocation(key)) {
-            setModelLocationData({
-              type: key,
-              connectionTypeObject: {
-                apiVersion: 'v1',
-                kind: 'ConfigMap',
-                metadata: {
-                  name: '',
-                  labels: {
-                    [KnownLabels.DASHBOARD_RESOURCE]: 'true',
-                    'opendatahub.io/connection-type': 'true',
-                  },
-                },
-                data: { fields: [] },
-              },
-              fieldValues: {},
-              additionalFields: {},
-            });
-            setSelectedConnection(undefined);
-          } else {
-            const foundConnectionType = modelServingConnectionTypes.find(
-              (ct) => ct.metadata.name === key,
-            );
+    <Form maxWidth="450px">
+      <FormGroup fieldId="model-location-select" label="Model location" isRequired>
+        <FormHelperText>
+          <HelperTextItem>Where is the model you want to deploy located?</HelperTextItem>
+        </FormHelperText>
+        <Stack hasGutter>
+          <StackItem>
+            <SimpleSelect
+              dataTestId="model-location-select"
+              options={[
+                { key: ModelLocationType.EXISTING, label: 'Existing connection' },
+                { key: ModelLocationType.PVC, label: 'Cluster storage' },
+                ...modelServingConnectionTypes.map((ct) => ({
+                  key: ct.metadata.name,
+                  label: ct.metadata.annotations?.['openshift.io/display-name'] || ct.metadata.name,
+                  value: ModelLocationType.NEW,
+                })),
+              ]}
+              onChange={(key) => {
+                if (isValidModelLocation(key)) {
+                  setModelLocationData({
+                    type: key,
+                    connectionTypeObject: {
+                      apiVersion: 'v1',
+                      kind: 'ConfigMap',
+                      metadata: {
+                        name: '',
+                        labels: {
+                          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+                          'opendatahub.io/connection-type': 'true',
+                        },
+                      },
+                      data: { fields: [] },
+                    },
+                    fieldValues: {},
+                    additionalFields: {},
+                  });
+                  setSelectedConnection(undefined);
+                } else {
+                  const foundConnectionType = modelServingConnectionTypes.find(
+                    (ct) => ct.metadata.name === key,
+                  );
 
-            if (foundConnectionType) {
-              setModelLocationData({
-                type: ModelLocationType.NEW,
-                connectionTypeObject: foundConnectionType,
-                fieldValues: {},
-                additionalFields: {},
-              });
-            }
-          }
-        }}
-        onBlur={validationProps?.onBlur}
-        placeholder="Select model location"
-        value={
-          modelLocation === ModelLocationType.NEW && modelLocationData?.connectionTypeObject
-            ? modelLocationData.connectionTypeObject.metadata.name
-            : modelLocation
-        }
-        toggleProps={{ style: { minWidth: '450px' } }}
-      />
-      <ZodErrorHelperText zodIssue={validationIssues} />
-      {modelLocation && (
-        <ModelLocationInputFields
-          modelLocation={modelLocation}
-          connections={connections}
-          connectionTypes={modelServingConnectionTypes}
-          selectedConnection={selectedConnectionState}
-          setSelectedConnection={setSelectedConnection}
-          selectedConnectionType={selectedConnectionType}
-          setModelLocationData={setModelLocationData}
-          resetModelLocationData={resetModelLocationData}
-          modelLocationData={modelLocationData}
-        />
-      )}
-    </FormGroup>
+                  if (foundConnectionType) {
+                    setModelLocationData({
+                      type: ModelLocationType.NEW,
+                      connectionTypeObject: foundConnectionType,
+                      fieldValues: {},
+                      additionalFields: {},
+                    });
+                  }
+                }
+              }}
+              onBlur={validationProps?.onBlur}
+              placeholder="Select model location"
+              value={
+                modelLocation === ModelLocationType.NEW && modelLocationData?.connectionTypeObject
+                  ? modelLocationData.connectionTypeObject.metadata.name
+                  : modelLocation
+              }
+              toggleProps={{ style: { minWidth: '450px' } }}
+            />
+          </StackItem>
+          <ZodErrorHelperText zodIssue={validationIssues} />
+          {modelLocation && (
+            <StackItem>
+              <ModelLocationInputFields
+                modelLocation={modelLocation}
+                connections={connections}
+                connectionTypes={modelServingConnectionTypes}
+                selectedConnection={selectedConnection}
+                setSelectedConnection={setSelectedConnection}
+                selectedConnectionType={selectedConnectionType}
+                setModelLocationData={setModelLocationData}
+                resetModelLocationData={resetModelLocationData}
+                modelLocationData={modelLocationData}
+                project={project}
+              />
+            </StackItem>
+          )}
+        </Stack>
+      </FormGroup>
+    </Form>
   );
 };

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelLocationSelectField.tsx
@@ -5,7 +5,6 @@ import {
   HelperTextItem,
   Stack,
   StackItem,
-  Form,
 } from '@patternfly/react-core';
 import { z, type ZodIssue } from 'zod';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
@@ -120,71 +119,69 @@ export const ModelLocationSelectField: React.FC<ModelLocationSelectFieldProps> =
     return baseOptions;
   }, [baseOptions]);
   return (
-    <Form maxWidth="450px">
-      <FormGroup fieldId="model-location-select" label="Model location" isRequired>
-        <FormHelperText>
-          <HelperTextItem>Where is the model you want to deploy located?</HelperTextItem>
-        </FormHelperText>
-        <Stack hasGutter>
-          <StackItem>
-            <SimpleSelect
-              dataTestId="model-location-select"
-              options={selectOptions}
-              onChange={(key) => {
-                if (key === '__placeholder__') {
-                  return;
-                }
-                setSelectedConnection(undefined);
-                resetModelLocationData();
-                if (isValidModelLocation(key)) {
+    <FormGroup fieldId="model-location-select" label="Model location" isRequired>
+      <FormHelperText>
+        <HelperTextItem>Where is the model you want to deploy located?</HelperTextItem>
+      </FormHelperText>
+      <Stack hasGutter>
+        <StackItem>
+          <SimpleSelect
+            dataTestId="model-location-select"
+            options={selectOptions}
+            onChange={(key) => {
+              if (key === '__placeholder__') {
+                return;
+              }
+              setSelectedConnection(undefined);
+              resetModelLocationData();
+              if (isValidModelLocation(key)) {
+                setModelLocationData({
+                  type: key,
+                  fieldValues: {},
+                  additionalFields: {},
+                });
+              } else {
+                const foundConnectionType = modelServingConnectionTypes.find(
+                  (ct) => ct.metadata.name === key,
+                );
+                if (foundConnectionType) {
                   setModelLocationData({
-                    type: key,
+                    type: ModelLocationType.NEW,
+                    connectionTypeObject: foundConnectionType,
                     fieldValues: {},
                     additionalFields: {},
                   });
-                } else {
-                  const foundConnectionType = modelServingConnectionTypes.find(
-                    (ct) => ct.metadata.name === key,
-                  );
-                  if (foundConnectionType) {
-                    setModelLocationData({
-                      type: ModelLocationType.NEW,
-                      connectionTypeObject: foundConnectionType,
-                      fieldValues: {},
-                      additionalFields: {},
-                    });
-                  }
                 }
-              }}
-              onBlur={validationProps?.onBlur}
-              placeholder="Select model location"
-              value={
-                modelLocation === ModelLocationType.NEW && modelLocationData?.connectionTypeObject
-                  ? modelLocationData.connectionTypeObject.metadata.name
-                  : modelLocation
               }
-              toggleProps={{ style: { minWidth: '450px' } }}
+            }}
+            onBlur={validationProps?.onBlur}
+            placeholder="Select model location"
+            value={
+              modelLocation === ModelLocationType.NEW && modelLocationData?.connectionTypeObject
+                ? modelLocationData.connectionTypeObject.metadata.name
+                : modelLocation
+            }
+            toggleProps={{ style: { minWidth: '450px' } }}
+          />
+        </StackItem>
+        <ZodErrorHelperText zodIssue={validationIssues} />
+        {modelLocation && (
+          <StackItem>
+            <ModelLocationInputFields
+              modelLocation={modelLocation}
+              connections={connections}
+              connectionTypes={modelServingConnectionTypes}
+              selectedConnection={selectedConnection}
+              setSelectedConnection={setSelectedConnection}
+              selectedConnectionType={selectedConnectionType}
+              setModelLocationData={setModelLocationData}
+              resetModelLocationData={resetModelLocationData}
+              modelLocationData={modelLocationData}
+              pvcs={pvcs.data}
             />
           </StackItem>
-          <ZodErrorHelperText zodIssue={validationIssues} />
-          {modelLocation && (
-            <StackItem>
-              <ModelLocationInputFields
-                modelLocation={modelLocation}
-                connections={connections}
-                connectionTypes={modelServingConnectionTypes}
-                selectedConnection={selectedConnection}
-                setSelectedConnection={setSelectedConnection}
-                selectedConnectionType={selectedConnectionType}
-                setModelLocationData={setModelLocationData}
-                resetModelLocationData={resetModelLocationData}
-                modelLocationData={modelLocationData}
-                pvcs={pvcs.data}
-              />
-            </StackItem>
-          )}
-        </Stack>
-      </FormGroup>
-    </Form>
+        )}
+      </Stack>
+    </FormGroup>
   );
 };

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -1,0 +1,530 @@
+import React, { act } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { z } from 'zod';
+import { useWizardContext, useWizardFooter } from '@patternfly/react-core';
+import { renderHook } from '@odh-dashboard/jest-config/hooks';
+import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import { ConnectionTypeConfigMapObj } from '@odh-dashboard/internal/concepts/connectionTypes/types';
+import {
+  ModelLocationData as ModelLocationDataField,
+  ModelLocationType,
+} from '../modelLocationFields/types';
+import { isValidModelLocationData, useModelLocationData } from '../ModelLocationInputFields';
+import { ModelLocationSelectField } from '../ModelLocationSelectField';
+
+const modelLocationSchema = z.object({
+  modelLocationData: z.custom<ModelLocationDataField>((val) => {
+    if (!val) return false;
+    return isValidModelLocationData(val.type, val);
+  }),
+});
+
+jest.mock('@patternfly/react-core', () => ({
+  ...jest.requireActual('@patternfly/react-core'),
+  useWizardContext: jest.fn(),
+  useWizardFooter: jest.fn(),
+}));
+const mockUseWizardContext = useWizardContext as jest.MockedFunction<typeof useWizardContext>;
+const mockUseWizardFooter = useWizardFooter as jest.MockedFunction<typeof useWizardFooter>;
+const mockConnectionTypes: ConnectionTypeConfigMapObj[] = [
+  {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'uri-v1',
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        'opendatahub.io/connection-type': 'true',
+      },
+      annotations: {
+        'openshift.io/display-name': 'URI - v1',
+      },
+    },
+    data: {
+      fields: [
+        {
+          envVar: 'URI',
+          name: 'URI',
+          required: true,
+          type: 'uri',
+          properties: {},
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 's3',
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        'opendatahub.io/connection-type': 'true',
+      },
+    },
+    data: {
+      fields: [
+        {
+          envVar: 'AWS_ACCESS_KEY_ID',
+          name: 'AWS_ACCESS_KEY_ID',
+          required: true,
+          type: 'short-text',
+          properties: {},
+        },
+        {
+          envVar: 'AWS_SECRET_ACCESS_KEY',
+          name: 'AWS_SECRET_ACCESS_KEY',
+          required: true,
+          type: 'hidden',
+          properties: {},
+        },
+        {
+          envVar: 'AWS_S3_ENDPOINT',
+          name: 'AWS_S3_ENDPOINT',
+          required: true,
+          type: 'short-text',
+          properties: {},
+        },
+        {
+          envVar: 'AWS_S3_BUCKET',
+          name: 'AWS_S3_BUCKET',
+          required: true,
+          type: 'short-text',
+          properties: {},
+        },
+        {
+          envVar: 'AWS_DEFAULT_REGION',
+          name: 'AWS_DEFAULT_REGION',
+          required: false,
+          type: 'short-text',
+          properties: {},
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'oci',
+      labels: {
+        [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        'opendatahub.io/connection-type': 'true',
+      },
+    },
+    data: {
+      fields: [
+        {
+          envVar: 'ACCESS_TYPE',
+          name: 'ACCESS_TYPE',
+          required: false,
+          type: 'dropdown',
+          properties: {},
+        },
+        {
+          envVar: '.dockerconfigjson',
+          name: '.dockerconfigjson',
+          required: true,
+          type: 'file',
+          properties: {},
+        },
+        {
+          envVar: 'OCI_HOST',
+          name: 'OCI_HOST',
+          required: true,
+          type: 'short-text',
+          properties: {},
+        },
+      ],
+    },
+  },
+];
+jest.mock('@odh-dashboard/internal/utilities/useWatchConnectionTypes', () => ({
+  useWatchConnectionTypes: () => [mockConnectionTypes],
+}));
+describe('ModelLocationSelectField', () => {
+  const mockWizardContext = {
+    activeStep: { index: 1, name: 'test-step', id: 'test-step', parentId: undefined },
+    goToNextStep: jest.fn(),
+    goToPrevStep: jest.fn(),
+    close: jest.fn(),
+    steps: [],
+    footer: <div>Mock Footer</div>,
+    goToStepById: jest.fn(),
+    goToStepByName: jest.fn(),
+    goToStepByIndex: jest.fn(),
+    setFooter: jest.fn(),
+    getStep: jest.fn(),
+    setStep: jest.fn(),
+    currentStepIndex: 1,
+    hasBodyPadding: true,
+    shouldFocusContent: true,
+    mainWrapperRef: { current: null },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseWizardContext.mockReturnValue(mockWizardContext);
+    mockUseWizardFooter.mockImplementation(() => undefined);
+  });
+  describe('Schema validation', () => {
+    it('should validate new S3 connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.NEW,
+          connection: 'S3-connection',
+          fieldValues: {
+            AWS_S3_BUCKET: 'bucket',
+            AWS_S3_ENDPOINT: 'endpoint',
+            AWS_S3_REGION: 'region',
+            AWS_S3_ACCESS_KEY_ID: 'key',
+            AWS_S3_SECRET_ACCESS_KEY: 'secret',
+          },
+          additionalFields: {
+            modelPath: 'path',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate new OCI connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.NEW,
+          connection: 'OCI-connection',
+          fieldValues: {
+            OCI_HOST: 'host',
+            '.dockerconfigjson': 'secret',
+            ACCESS_TYPE: ['Pull'],
+          },
+          additionalFields: {
+            modelUri: 'oci://test',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate new URI connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: { type: ModelLocationType.NEW, fieldValues: { URI: 'uri://test' } },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate new PVC connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.PVC,
+          fieldValues: { URI: 'pvc://test/path' },
+          additionalFields: { pvcConnection: 'test' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate existing uri connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.EXISTING,
+          fieldValues: {},
+          connection: 'uri-connection',
+          additionalFields: { modelUri: 'uri://test' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate existing s3 connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.EXISTING,
+          fieldValues: {},
+          connection: 's3-connection',
+          additionalFields: { modelPath: 'path' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should validate existing oci connection', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: {
+          type: ModelLocationType.EXISTING,
+          fieldValues: {},
+          connection: 'oci-connection',
+          additionalFields: { modelUri: 'oci://test' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+    it('should reject invalid values', () => {
+      const result = modelLocationSchema.safeParse({
+        modelLocationData: { type: 'invalid' },
+      });
+      expect(result.success).toBe(false);
+    });
+    it('should show required error for undefined', () => {
+      const result = modelLocationSchema.safeParse(undefined);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Required');
+      }
+    });
+  });
+  describe('isValidModelLocationData', () => {
+    it('should return true for valid model location data', () => {
+      expect(
+        isValidModelLocationData(ModelLocationType.NEW, {
+          type: ModelLocationType.NEW,
+          fieldValues: {
+            URI: 'uri://test',
+          },
+          additionalFields: {},
+        }),
+      ).toBe(true);
+    });
+    it('should return false for invalid model location data', () => {
+      expect(
+        isValidModelLocationData(ModelLocationType.NEW, {
+          type: ModelLocationType.EXISTING,
+          fieldValues: {},
+          additionalFields: {},
+        }),
+      ).toBe(false);
+    });
+  });
+  describe('useModelLocationData hook', () => {
+    it('should initialize with undefined by default', () => {
+      const { result } = renderHook(() => useModelLocationData(null));
+      expect(result.current.data).toBeUndefined();
+    });
+    it('should initialize with existing data', () => {
+      const { result } = renderHook(() =>
+        useModelLocationData(null, {
+          type: ModelLocationType.NEW,
+          fieldValues: { URI: 'uri://test' },
+          additionalFields: {},
+        }),
+      );
+      expect(result.current.data).toEqual({
+        type: ModelLocationType.NEW,
+        fieldValues: { URI: 'uri://test' },
+        additionalFields: {},
+      });
+    });
+    it('should update model location data', () => {
+      const { result } = renderHook(() => useModelLocationData(null));
+      act(() => {
+        result.current.setData({
+          type: ModelLocationType.NEW,
+          fieldValues: { URI: 'uri://test' },
+          additionalFields: {},
+        });
+      });
+      expect(result.current.data).toEqual({
+        type: ModelLocationType.NEW,
+        fieldValues: { URI: 'uri://test' },
+        additionalFields: {},
+      });
+    });
+  });
+  describe('Component', () => {
+    const mockSetModelLocationData = jest.fn();
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it('should render with default props', () => {
+      render(
+        <ModelLocationSelectField
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+        />,
+      );
+      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByTestId('model-location-select')).toBeInTheDocument();
+    });
+    it('should render with selected value', () => {
+      render(
+        <ModelLocationSelectField
+          modelLocation={ModelLocationType.NEW}
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+          modelLocationData={{
+            type: ModelLocationType.NEW,
+            fieldValues: { URI: 'uri://test' },
+            additionalFields: {},
+            connectionTypeObject: {
+              apiVersion: 'v1',
+              kind: 'ConfigMap',
+              metadata: {
+                name: 'uri-v1',
+                labels: {
+                  [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+                  'opendatahub.io/connection-type': 'true',
+                },
+              },
+            },
+          }}
+        />,
+      );
+      expect(screen.getByTestId('model-location-select')).toBeInTheDocument();
+      expect(screen.getByTestId('field URI')).toHaveValue('uri://test');
+    });
+    it('should call setModelLocationData on valid location type selection', async () => {
+      render(
+        <ModelLocationSelectField
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+          modelLocationData={{
+            type: ModelLocationType.NEW,
+            fieldValues: { URI: 'https://test' },
+            additionalFields: {},
+            connectionTypeObject: {
+              apiVersion: 'v1',
+              kind: 'ConfigMap',
+              metadata: {
+                name: 'uri-v1',
+                labels: {
+                  [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+                  'opendatahub.io/connection-type': 'true',
+                },
+              },
+            },
+          }}
+        />,
+      );
+      const button = screen.getByTestId('model-location-select');
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      const option = screen.getByText('URI - v1');
+      await act(async () => {
+        fireEvent.click(option);
+      });
+      expect(mockSetModelLocationData).toHaveBeenCalledWith({
+        type: ModelLocationType.NEW,
+        connectionTypeObject: mockConnectionTypes[0],
+        fieldValues: {},
+        additionalFields: {},
+      });
+    });
+    it('should call setModelLocationData on valid URI location input', async () => {
+      render(
+        <ModelLocationSelectField
+          modelLocation={ModelLocationType.NEW}
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+          modelLocationData={{
+            type: ModelLocationType.NEW,
+            fieldValues: { URI: 'https://test' },
+            additionalFields: {},
+            connectionTypeObject: mockConnectionTypes[0],
+          }}
+        />,
+      );
+      const uriInput = screen.getByTestId('field URI');
+      expect(uriInput).toHaveValue('https://test');
+
+      await act(async () => {
+        fireEvent.change(uriInput, { target: { value: 'https://newtest' } });
+      });
+
+      expect(mockSetModelLocationData).toHaveBeenCalledWith({
+        type: ModelLocationType.NEW,
+        connectionTypeObject: mockConnectionTypes[0],
+        fieldValues: { URI: 'https://newtest' },
+        additionalFields: {},
+      });
+    });
+    it('should call setModelLocationData on valid S3 location input', async () => {
+      render(
+        <ModelLocationSelectField
+          modelLocation={ModelLocationType.NEW}
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+          modelLocationData={{
+            type: ModelLocationType.NEW,
+            fieldValues: {
+              AWS_S3_BUCKET: 'bucket',
+              AWS_S3_ENDPOINT: 'endpoint',
+              AWS_S3_REGION: 'region',
+              AWS_S3_ACCESS_KEY_ID: 'key',
+              AWS_S3_SECRET_ACCESS_KEY: 'secret',
+            },
+            additionalFields: { modelPath: 'path' },
+            connectionTypeObject: mockConnectionTypes[1],
+          }}
+        />,
+      );
+      const s3Input = screen.getByTestId('field AWS_S3_BUCKET');
+      expect(s3Input).toHaveValue('bucket');
+
+      await act(async () => {
+        fireEvent.change(s3Input, { target: { value: 'newbucket' } });
+      });
+      expect(mockSetModelLocationData).toHaveBeenCalledWith({
+        type: ModelLocationType.NEW,
+        connectionTypeObject: mockConnectionTypes[1],
+        fieldValues: {
+          AWS_S3_BUCKET: 'newbucket',
+          AWS_S3_ENDPOINT: 'endpoint',
+          AWS_S3_REGION: 'region',
+          AWS_S3_ACCESS_KEY_ID: 'key',
+          AWS_S3_SECRET_ACCESS_KEY: 'secret',
+        },
+        additionalFields: { modelPath: 'path' },
+      });
+    });
+    it('should call setModelLocationData on valid OCI location input', async () => {
+      render(
+        <ModelLocationSelectField
+          modelLocation={ModelLocationType.NEW}
+          setModelLocationData={mockSetModelLocationData}
+          connections={[]}
+          project={null}
+          resetModelLocationData={jest.fn()}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
+          modelLocationData={{
+            type: ModelLocationType.NEW,
+            fieldValues: {
+              OCI_HOST: 'host',
+              '.dockerconfigjson': 'secret',
+              ACCESS_TYPE: ['Pull'],
+            },
+            additionalFields: { modelUri: 'oci://test' },
+            connectionTypeObject: mockConnectionTypes[2],
+          }}
+        />,
+      );
+      const ociInput = screen.getByTestId('field OCI_HOST');
+      expect(ociInput).toHaveValue('host');
+
+      await act(async () => {
+        fireEvent.change(ociInput, { target: { value: 'newhost' } });
+      });
+      expect(mockSetModelLocationData).toHaveBeenCalledWith({
+        type: ModelLocationType.NEW,
+        connectionTypeObject: mockConnectionTypes[2],
+        fieldValues: { OCI_HOST: 'newhost', '.dockerconfigjson': 'secret', ACCESS_TYPE: ['Pull'] },
+        additionalFields: { modelUri: 'oci://test' },
+      });
+    });
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelLocationSelectField.test.tsx
@@ -333,11 +333,8 @@ describe('ModelLocationSelectField', () => {
       render(
         <ModelLocationSelectField
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
         />,
       );
       expect(screen.getByRole('button')).toBeInTheDocument();
@@ -348,11 +345,8 @@ describe('ModelLocationSelectField', () => {
         <ModelLocationSelectField
           modelLocation={ModelLocationType.NEW}
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
           modelLocationData={{
             type: ModelLocationType.NEW,
             fieldValues: { URI: 'uri://test' },
@@ -378,11 +372,8 @@ describe('ModelLocationSelectField', () => {
       render(
         <ModelLocationSelectField
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
           modelLocationData={{
             type: ModelLocationType.NEW,
             fieldValues: { URI: 'https://test' },
@@ -421,11 +412,8 @@ describe('ModelLocationSelectField', () => {
         <ModelLocationSelectField
           modelLocation={ModelLocationType.NEW}
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
           modelLocationData={{
             type: ModelLocationType.NEW,
             fieldValues: { URI: 'https://test' },
@@ -453,11 +441,8 @@ describe('ModelLocationSelectField', () => {
         <ModelLocationSelectField
           modelLocation={ModelLocationType.NEW}
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
           modelLocationData={{
             type: ModelLocationType.NEW,
             fieldValues: {
@@ -496,11 +481,8 @@ describe('ModelLocationSelectField', () => {
         <ModelLocationSelectField
           modelLocation={ModelLocationType.NEW}
           setModelLocationData={mockSetModelLocationData}
-          connections={[]}
           project={null}
           resetModelLocationData={jest.fn()}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
           modelLocationData={{
             type: ModelLocationType.NEW,
             fieldValues: {

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
@@ -13,10 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { PersistentVolumeClaimKind } from '@odh-dashboard/internal/k8sTypes';
 import { getModelServingPVCAnnotations } from '@odh-dashboard/internal/pages/modelServing/utils';
-import {
-  getModelPathFromUri,
-  getPVCNameFromURI,
-} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+import { getModelPathFromUri } from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
 
 type PVCInputFieldProps = {
   selectedPVC?: PersistentVolumeClaimKind;
@@ -48,38 +45,15 @@ export const PVCInputField: React.FC<PVCInputFieldProps> = ({
     return annotatedPath ?? '';
   };
 
-  // Get the PVC name from the URI
-  const pvcNameFromUri = React.useMemo(() => {
-    if (existingUriOption) {
-      return getPVCNameFromURI(existingUriOption);
-    }
-    return undefined;
-  }, [existingUriOption]);
-
-  // Whether the model path has been prefilled on initial load
-  const didInitialPrefill = React.useRef(false);
-
-  // Compute the model path based on selectedPVC and prefill logic
   const computedModelPath = React.useMemo(() => {
-    if (
-      !didInitialPrefill.current &&
-      initialModelPath &&
-      selectedPVC?.metadata.name === pvcNameFromUri
-    ) {
-      // Initial mount with original PVC: use URI path (what it was deployed with)
-      didInitialPrefill.current = true;
+    if (initialModelPath) {
       return initialModelPath;
     }
     if (selectedPVC) {
-      // Any other PVC selection: use PVC annotation path
       return getModelPath(selectedPVC);
     }
-    if (existingUriOption) {
-      // If the selected PVC doesn't exist, use the URI path (what it was deployed with)
-      return getModelPathFromUri(existingUriOption);
-    }
     return '';
-  }, [selectedPVC, initialModelPath, pvcNameFromUri]);
+  }, [initialModelPath, selectedPVC]);
 
   // If the user has manually edited the path, use the user input path instead of the computed path
   const [userHasEdited, setUserHasEdited] = React.useState(false);
@@ -117,10 +91,10 @@ export const PVCInputField: React.FC<PVCInputFieldProps> = ({
 
   // Validate model path when modelPath changes / is prefilled
   React.useEffect(() => {
-    handlePathChange(modelPath);
+    handlePathChange(computedModelPath);
     // Only run when selectedPVC or modelPath changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPVC, modelPath]);
+  }, [selectedPVC, computedModelPath]);
 
   return (
     <Stack hasGutter>

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import {
+  FormGroup,
+  InputGroupText,
+  TextInput,
+  InputGroupItem,
+  InputGroup,
+  HelperText,
+  HelperTextItem,
+  FormHelperText,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { PersistentVolumeClaimKind } from '@odh-dashboard/internal/k8sTypes';
+import { getModelServingPVCAnnotations } from '@odh-dashboard/internal/pages/modelServing/utils';
+import {
+  getModelPathFromUri,
+  getPVCNameFromURI,
+} from '@odh-dashboard/internal/pages/modelServing/screens/projects/utils';
+
+type PVCInputFieldProps = {
+  selectedPVC?: PersistentVolumeClaimKind;
+  selectedPVCName: string;
+  setModelUri: (uri: string) => void;
+  existingUriOption?: string;
+  setIsConnectionValid: (isValid: boolean) => void;
+};
+
+export const PVCInputField: React.FC<PVCInputFieldProps> = ({
+  selectedPVC,
+  selectedPVCName,
+  setModelUri,
+  existingUriOption,
+  setIsConnectionValid,
+}) => {
+  // Get the model path from the existing URI, if it's a PVC URI
+  const initialModelPath = React.useMemo(() => {
+    if (existingUriOption) {
+      return getModelPathFromUri(existingUriOption);
+    }
+    return undefined;
+  }, [existingUriOption]);
+
+  // Get the model path from the PVC annotation
+  const getModelPath = (pvc?: PersistentVolumeClaimKind): string => {
+    if (!pvc) {
+      return '';
+    }
+    const { modelPath: annotatedPath } = getModelServingPVCAnnotations(pvc);
+    return annotatedPath ?? '';
+  };
+
+  // Get the PVC name from the URI
+  const pvcNameFromUri = React.useMemo(() => {
+    if (existingUriOption) {
+      return getPVCNameFromURI(existingUriOption);
+    }
+    return undefined;
+  }, [existingUriOption]);
+
+  // Whether the model path has been prefilled on initial load
+  const didInitialPrefill = React.useRef(false);
+
+  // Compute the model path based on selectedPVC and prefill logic
+  const computedModelPath = React.useMemo(() => {
+    if (
+      !didInitialPrefill.current &&
+      initialModelPath &&
+      selectedPVC?.metadata.name === pvcNameFromUri
+    ) {
+      // Initial mount with original PVC: use URI path (what it was deployed with)
+      didInitialPrefill.current = true;
+      return initialModelPath;
+    }
+    if (selectedPVC) {
+      // Any other PVC selection: use PVC annotation path
+      return getModelPath(selectedPVC);
+    }
+    if (existingUriOption) {
+      // If the selected PVC doesn't exist, use the URI path (what it was deployed with)
+      return getModelPathFromUri(existingUriOption);
+    }
+    return '';
+  }, [selectedPVC, initialModelPath, pvcNameFromUri]);
+
+  // If the user has manually edited the path, use the user input path instead of the computed path
+  const [userHasEdited, setUserHasEdited] = React.useState(false);
+  // User input path
+  const [userModelPath, setUserModelPath] = React.useState('');
+  // The name of the previously selected PVC
+  const [lastPVCName, setLastPVCName] = React.useState(selectedPVC?.metadata.name);
+
+  // Reset userHasEdited when PVC changes
+  if (selectedPVC?.metadata.name !== lastPVCName) {
+    setUserHasEdited(false);
+    setLastPVCName(selectedPVC?.metadata.name);
+  }
+
+  // Use computed path unless user has manually edited
+  const modelPath = userHasEdited ? userModelPath : computedModelPath;
+  const pathRegex = React.useMemo(() => /^pvc:\/\/[a-zA-Z0-9-]+\/[^/\s][^\s]*$/, []);
+  const generateModelUri = (pvcName: string, path: string): string => `pvc://${pvcName}/${path}`;
+
+  const validateModelPath = (newPath: string): boolean => {
+    const uri = generateModelUri(selectedPVCName, newPath);
+    return pathRegex.test(uri);
+  };
+
+  const handlePathChange = (newPath: string) => {
+    const trimmedPath = newPath.trim();
+    setUserModelPath(trimmedPath);
+    setUserHasEdited(true);
+    if (trimmedPath && validateModelPath(trimmedPath)) {
+      setModelUri(generateModelUri(selectedPVCName, trimmedPath));
+      setIsConnectionValid(true);
+    } else {
+      setModelUri('');
+      setIsConnectionValid(false);
+    }
+  };
+
+  // Validate model path when modelPath changes / is prefilled
+  React.useEffect(() => {
+    handlePathChange(modelPath);
+    // Only run when selectedPVC or modelPath changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPVC, modelPath]);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Model path" isRequired>
+          <InputGroup>
+            <InputGroupText>pvc://{selectedPVCName}/</InputGroupText>
+            <InputGroupItem isFill>
+              <TextInput
+                id="folder-path"
+                aria-label="Model path"
+                data-testid="folder-path"
+                type="text"
+                value={modelPath}
+                isRequired
+                onChange={(e, value: string) => {
+                  handlePathChange(value);
+                }}
+                onBlur={() => {
+                  const trimmed = modelPath.trim();
+                  if (trimmed !== modelPath) {
+                    handlePathChange(trimmed);
+                  }
+                }}
+                onPaste={(e) => {
+                  const pastedText = e.clipboardData.getData('text').trim();
+                  handlePathChange(pastedText);
+                  e.preventDefault();
+                }}
+              />
+            </InputGroupItem>
+          </InputGroup>
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Enter a path to your model or a folder containing your model. The path cannot point to
+              a root folder.
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCInputField.tsx
@@ -23,7 +23,6 @@ type PVCInputFieldProps = {
   selectedPVCName: string;
   setModelUri: (uri: string) => void;
   existingUriOption?: string;
-  setIsConnectionValid: (isValid: boolean) => void;
 };
 
 export const PVCInputField: React.FC<PVCInputFieldProps> = ({
@@ -31,7 +30,6 @@ export const PVCInputField: React.FC<PVCInputFieldProps> = ({
   selectedPVCName,
   setModelUri,
   existingUriOption,
-  setIsConnectionValid,
 }) => {
   // Get the model path from the existing URI, if it's a PVC URI
   const initialModelPath = React.useMemo(() => {
@@ -112,10 +110,8 @@ export const PVCInputField: React.FC<PVCInputFieldProps> = ({
     setUserHasEdited(true);
     if (trimmedPath && validateModelPath(trimmedPath)) {
       setModelUri(generateModelUri(selectedPVCName, trimmedPath));
-      setIsConnectionValid(true);
     } else {
       setModelUri('');
-      setIsConnectionValid(false);
     }
   };
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCSelectField.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Alert, FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import TypeaheadSelect, {
+  TypeaheadSelectOption,
+} from '@odh-dashboard/internal/components/TypeaheadSelect';
+import { PersistentVolumeClaimKind } from '@odh-dashboard/internal/k8sTypes';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import { getModelServingPVCAnnotations } from '@odh-dashboard/internal/pages/modelServing/utils';
+import { AccessMode } from '@odh-dashboard/internal/pages/storageClasses/storageEnums';
+import { getPvcAccessMode } from '@odh-dashboard/internal/pages/projects/utils';
+import { PVCInputField } from './PVCInputField';
+
+type PvcSelectProps = {
+  pvcs?: PersistentVolumeClaimKind[];
+  selectedPVC?: PersistentVolumeClaimKind;
+  onSelect: (selection?: PersistentVolumeClaimKind | undefined) => void;
+  setModelUri: (uri: string) => void;
+  setIsConnectionValid: (isValid: boolean) => void;
+  pvcNameFromUri?: string;
+  existingUriOption?: string;
+};
+
+export const PvcSelectField: React.FC<PvcSelectProps> = ({
+  pvcs,
+  selectedPVC,
+  onSelect,
+  setModelUri,
+  setIsConnectionValid,
+  pvcNameFromUri,
+  existingUriOption,
+}) => {
+  // Check whether the PVC from URI exists
+  const pvcExists = React.useMemo(() => {
+    if (!pvcNameFromUri || !pvcs) {
+      return false; // If no PVC name from URI or no PVCs loaded, assume it doesn't exist
+    }
+    return Boolean(pvcs.some((pvc) => pvc.metadata.name === pvcNameFromUri) && pvcNameFromUri);
+  }, [pvcs, pvcNameFromUri]);
+
+  // Whether to show the PVC not founderror
+  const showPVCError = React.useMemo(
+    () => Boolean(existingUriOption && !pvcExists && pvcNameFromUri && !selectedPVC),
+    [existingUriOption, pvcExists, pvcNameFromUri, selectedPVC],
+  );
+
+  const options: TypeaheadSelectOption[] | undefined = React.useMemo(
+    () =>
+      pvcs?.map((pvc) => {
+        const displayName = getDisplayNameFromK8sResource(pvc);
+        const { modelPath: modelPathAnnotation, modelName } = getModelServingPVCAnnotations(pvc);
+        const isModelServingPVC = !!modelPathAnnotation || !!modelName;
+        return {
+          content: displayName,
+          value: pvc.metadata.name,
+          isSelected:
+            selectedPVC?.metadata.name === pvc.metadata.name ||
+            (pvc.metadata.name === pvcNameFromUri && !pvcExists && !selectedPVC),
+          description: isModelServingPVC
+            ? `Stored model: ${modelName ?? 'Model name not specified'}`
+            : undefined,
+        };
+      }),
+    [pvcs, selectedPVC, pvcNameFromUri, pvcExists],
+  );
+  const additionalOptions = React.useMemo(() => {
+    if (!pvcExists && pvcNameFromUri) {
+      return [
+        ...(options ?? []),
+        {
+          content: pvcNameFromUri || '',
+          value: pvcNameFromUri || '',
+          isSelected: !selectedPVC,
+        },
+      ];
+    }
+    return options;
+  }, [options, pvcNameFromUri, pvcExists, selectedPVC]);
+
+  const accessMode = selectedPVC ? getPvcAccessMode(selectedPVC) : undefined;
+
+  return (
+    <FormGroup label="Cluster storage" isRequired>
+      <Stack hasGutter>
+        <StackItem>
+          <TypeaheadSelect
+            placeholder="Select existing storage"
+            selectOptions={additionalOptions ?? []}
+            selected={
+              selectedPVC?.metadata.name ||
+              (!pvcExists && pvcNameFromUri ? pvcNameFromUri : undefined)
+            }
+            dataTestId="pvc-connection-selector"
+            onSelect={(_, selection) => {
+              const newlySelectedPVC = pvcs?.find((pvc) => pvc.metadata.name === selection);
+              onSelect(newlySelectedPVC);
+            }}
+          />
+        </StackItem>
+        {selectedPVC && accessMode !== AccessMode.RWX && (
+          <StackItem>
+            <Alert variant="warning" title="Storage access mode warning" isInline>
+              The access mode of the selected cluster storage is not <strong>ReadWriteMany</strong>.
+              This can prevent replicas from working as expected.
+            </Alert>
+          </StackItem>
+        )}
+        {showPVCError && !selectedPVC && (
+          <StackItem>
+            <Alert variant="warning" title="Cannot access cluster storage" isInline>
+              The selected <strong>{pvcNameFromUri}</strong> cluster storage has been deleted or
+              cannot be reached. Before redeploying the model, select or create a different source
+              model location.
+            </Alert>
+          </StackItem>
+        )}
+        {(selectedPVC || pvcNameFromUri) && (
+          <StackItem>
+            <PVCInputField
+              selectedPVC={selectedPVC}
+              selectedPVCName={selectedPVC?.metadata.name || pvcNameFromUri || ''}
+              existingUriOption={existingUriOption}
+              setModelUri={setModelUri}
+              setIsConnectionValid={setIsConnectionValid}
+            />
+          </StackItem>
+        )}
+      </Stack>
+    </FormGroup>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/PVCSelectField.tsx
@@ -15,7 +15,6 @@ type PvcSelectProps = {
   selectedPVC?: PersistentVolumeClaimKind;
   onSelect: (selection?: PersistentVolumeClaimKind | undefined) => void;
   setModelUri: (uri: string) => void;
-  setIsConnectionValid: (isValid: boolean) => void;
   pvcNameFromUri?: string;
   existingUriOption?: string;
 };
@@ -25,7 +24,6 @@ export const PvcSelectField: React.FC<PvcSelectProps> = ({
   selectedPVC,
   onSelect,
   setModelUri,
-  setIsConnectionValid,
   pvcNameFromUri,
   existingUriOption,
 }) => {
@@ -120,7 +118,6 @@ export const PvcSelectField: React.FC<PvcSelectProps> = ({
               selectedPVCName={selectedPVC?.metadata.name || pvcNameFromUri || ''}
               existingUriOption={existingUriOption}
               setModelUri={setModelUri}
-              setIsConnectionValid={setIsConnectionValid}
             />
           </StackItem>
         )}

--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/types.ts
@@ -17,12 +17,13 @@ export enum ModelLocationType {
 
 export type ModelLocationData = {
   type: ModelLocationType.EXISTING | ModelLocationType.NEW | ModelLocationType.PVC;
-  connectionTypeObject: ConnectionTypeConfigMapObj;
+  connectionTypeObject?: ConnectionTypeConfigMapObj;
   connection?: string;
   fieldValues: Record<string, ConnectionTypeValueType>;
   additionalFields: {
     // For S3 and OCI additional fields
     modelPath?: string;
     modelUri?: string;
+    pvcConnection?: string;
   };
 };

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { z } from 'zod';
 import { Form } from '@patternfly/react-core';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
-import { LabeledConnection } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { Connection } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import { modelTypeSelectFieldSchema, ModelTypeSelectField } from '../fields/ModelTypeSelectField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import { ModelLocationSelectField } from '../fields/ModelLocationSelectField';
@@ -23,13 +23,17 @@ export type ModelSourceStepData = z.infer<typeof modelSourceStepSchema>;
 type ModelSourceStepProps = {
   wizardState: UseModelDeploymentWizardState;
   validation: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
-  connections: LabeledConnection[] | undefined;
+  connections: Connection[];
+  selectedConnection: Connection | undefined;
+  setSelectedConnection: (connection: Connection | undefined) => void;
 };
 
 export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
   wizardState,
   validation,
   connections,
+  selectedConnection,
+  setSelectedConnection,
 }) => {
   return (
     <Form>
@@ -37,11 +41,13 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
         modelLocation={wizardState.state.modelLocationData.data?.type}
         validationProps={validation.getFieldValidationProps(['modelLocation', 'modelLocationData'])}
         validationIssues={validation.getFieldValidation(['modelLocation', 'modelLocationData'])}
-        connections={connections ?? []}
+        project={wizardState.state.modelLocationData.project}
+        connections={connections}
+        selectedConnection={selectedConnection}
+        modelLocationData={wizardState.state.modelLocationData.data}
+        setSelectedConnection={setSelectedConnection}
         setModelLocationData={wizardState.state.modelLocationData.setData}
         resetModelLocationData={() => wizardState.state.modelLocationData.setData(undefined)}
-        modelLocationData={wizardState.state.modelLocationData.data}
-        initSelectedConnection={wizardState.state.modelLocationData.selectedConnection}
       />
       <ModelTypeSelectField
         modelType={wizardState.state.modelType.data}

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { z } from 'zod';
-import { Form } from '@patternfly/react-core';
+import { Bullseye, Form, Spinner } from '@patternfly/react-core';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { modelTypeSelectFieldSchema, ModelTypeSelectField } from '../fields/ModelTypeSelectField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
@@ -28,6 +28,13 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
   wizardState,
   validation,
 }) => {
+  if (wizardState.state.modelLocationData.isLoadingSecretData) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
   return (
     <Form>
       <ModelLocationSelectField

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { z } from 'zod';
 import { Form } from '@patternfly/react-core';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
-import { Connection } from '@odh-dashboard/internal/concepts/connectionTypes/types';
 import { modelTypeSelectFieldSchema, ModelTypeSelectField } from '../fields/ModelTypeSelectField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import { ModelLocationSelectField } from '../fields/ModelLocationSelectField';
@@ -23,17 +22,11 @@ export type ModelSourceStepData = z.infer<typeof modelSourceStepSchema>;
 type ModelSourceStepProps = {
   wizardState: UseModelDeploymentWizardState;
   validation: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
-  connections: Connection[];
-  selectedConnection: Connection | undefined;
-  setSelectedConnection: (connection: Connection | undefined) => void;
 };
 
 export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
   wizardState,
   validation,
-  connections,
-  selectedConnection,
-  setSelectedConnection,
 }) => {
   return (
     <Form>
@@ -42,10 +35,7 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
         validationProps={validation.getFieldValidationProps(['modelLocation', 'modelLocationData'])}
         validationIssues={validation.getFieldValidation(['modelLocation', 'modelLocationData'])}
         project={wizardState.state.modelLocationData.project}
-        connections={connections}
-        selectedConnection={selectedConnection}
         modelLocationData={wizardState.state.modelLocationData.data}
-        setSelectedConnection={setSelectedConnection}
         setModelLocationData={wizardState.state.modelLocationData.setData}
         resetModelLocationData={() => wizardState.state.modelLocationData.setData(undefined)}
       />

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -93,7 +93,9 @@ describe('ModelSourceStep', () => {
     it('should render ModelTypeSelectField and ModelLocationSelectField', () => {
       render(
         <ModelSourceStepContent
-          wizardState={mockDeploymentWizardState()}
+          wizardState={mockDeploymentWizardState({
+            state: { modelLocationData: { isLoadingSecretData: false } },
+          })}
           validation={mockValidation}
         />,
       );
@@ -108,6 +110,7 @@ describe('ModelSourceStep', () => {
             data: ServingRuntimeModelType.GENERATIVE,
           },
           modelLocationData: {
+            isLoadingSecretData: false,
             data: {
               type: ModelLocationType.NEW,
               fieldValues: {

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -95,9 +95,6 @@ describe('ModelSourceStep', () => {
         <ModelSourceStepContent
           wizardState={mockDeploymentWizardState()}
           validation={mockValidation}
-          connections={[]}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
         />,
       );
       expect(screen.getByTestId('model-type-select')).toBeInTheDocument();
@@ -139,9 +136,6 @@ describe('ModelSourceStep', () => {
         <ModelSourceStepContent
           wizardState={wizardDataWithSelection}
           validation={mockValidation}
-          connections={[]}
-          selectedConnection={undefined}
-          setSelectedConnection={jest.fn()}
         />,
       );
       expect(screen.getByText('Generative AI model (e.g. LLM)')).toBeInTheDocument();

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/ModelSourceStep.test.tsx
@@ -6,9 +6,15 @@ import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { ModelSourceStepContent } from '../ModelSourceStep';
 import { modelTypeSelectFieldSchema } from '../../fields/ModelTypeSelectField';
 import { mockDeploymentWizardState } from '../../../../__tests__/mockUtils';
+import { isValidModelLocationData } from '../../fields/ModelLocationInputFields';
+import { ModelLocationData, ModelLocationType } from '../../fields/modelLocationFields/types';
 
 const modelSourceStepSchema = z.object({
   modelType: modelTypeSelectFieldSchema,
+  modelLocationData: z.custom<ModelLocationData>((val) => {
+    if (!val) return false;
+    return isValidModelLocationData(val.type, val);
+  }),
 });
 
 type ModelSourceStepData = z.infer<typeof modelSourceStepSchema>;
@@ -62,6 +68,15 @@ describe('ModelSourceStep', () => {
     it('should validate complete data', () => {
       const validData: ModelSourceStepData = {
         modelType: ServingRuntimeModelType.PREDICTIVE,
+        modelLocationData: {
+          type: ModelLocationType.PVC,
+          fieldValues: {
+            URI: 'pvc://test/test',
+          },
+          additionalFields: {
+            pvcConnection: 'test',
+          },
+        },
       };
       const result = modelSourceStepSchema.safeParse(validData);
       expect(result.success).toBe(true);
@@ -75,22 +90,48 @@ describe('ModelSourceStep', () => {
   });
 
   describe('Component', () => {
-    it('should render ModelTypeSelectField', () => {
+    it('should render ModelTypeSelectField and ModelLocationSelectField', () => {
       render(
         <ModelSourceStepContent
           wizardState={mockDeploymentWizardState()}
           validation={mockValidation}
           connections={[]}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
         />,
       );
       expect(screen.getByTestId('model-type-select')).toBeInTheDocument();
+      expect(screen.getByTestId('model-location-select')).toBeInTheDocument();
     });
 
-    it('should render with selected model type', () => {
+    it('should render with selected model type and model location', () => {
       const wizardDataWithSelection = mockDeploymentWizardState({
         state: {
           modelType: {
             data: ServingRuntimeModelType.GENERATIVE,
+          },
+          modelLocationData: {
+            data: {
+              type: ModelLocationType.NEW,
+              fieldValues: {
+                URI: 'https://test',
+              },
+              connectionTypeObject: {
+                apiVersion: 'v1',
+                kind: 'ConfigMap',
+                metadata: {
+                  name: 'uri-v1',
+                  labels: {
+                    'opendatahub.io/connection-type': 'true',
+                    'opendatahub.io/dashboard': 'true',
+                  },
+                  annotations: {
+                    'opendatahub.io/connection-type': 'uri - v1',
+                  },
+                },
+              },
+              additionalFields: {},
+            },
           },
         },
       });
@@ -99,9 +140,12 @@ describe('ModelSourceStep', () => {
           wizardState={wizardDataWithSelection}
           validation={mockValidation}
           connections={[]}
+          selectedConnection={undefined}
+          setSelectedConnection={jest.fn()}
         />,
       );
       expect(screen.getByText('Generative AI model (e.g. LLM)')).toBeInTheDocument();
+      expect(screen.getByTestId('field URI')).toHaveValue('https://test');
     });
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -144,10 +144,7 @@ export const useModelDeploymentWizard = (
       k8sNameDesc,
       hardwareProfileConfig,
       modelFormatState,
-      modelLocationData: {
-        ...modelLocationData,
-        connectionsLoaded: modelLocationData.connectionsLoaded,
-      },
+      modelLocationData,
       externalRoute,
       tokenAuthentication,
       numReplicas,

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -144,7 +144,10 @@ export const useModelDeploymentWizard = (
       k8sNameDesc,
       hardwareProfileConfig,
       modelFormatState,
-      modelLocationData,
+      modelLocationData: {
+        ...modelLocationData,
+        connectionsLoaded: modelLocationData.connectionsLoaded,
+      },
       externalRoute,
       tokenAuthentication,
       numReplicas,

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -1,11 +1,6 @@
-import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
 import { getTokenNames } from '@odh-dashboard/internal/pages/modelServing/utils';
 import { isValidModelType, type ModelTypeFieldData } from './fields/ModelTypeSelectField';
-import {
-  ConnectionTypeRefs,
-  ModelLocationType,
-  ModelLocationData,
-} from './fields/modelLocationFields/types';
+import { ModelLocationType, ModelLocationData } from './fields/modelLocationFields/types';
 import { type TokenAuthenticationFieldData } from './fields/TokenAuthenticationField';
 import type { Deployment, DeploymentEndpoint } from '../../../extension-points';
 
@@ -37,29 +32,7 @@ export const getModelTypeFromDeployment = (
 };
 
 export const isExistingModelLocation = (data?: ModelLocationData): data is ModelLocationData => {
-  return data?.type === 'existing';
-};
-
-export const setupModelLocationData = (): ModelLocationData => {
-  // TODO: Implement fully in next ticket RHOAIENG-32186
-  return {
-    type: ModelLocationType.NEW,
-    connectionTypeObject: {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: {
-        labels: {
-          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
-          'opendatahub.io/connection-type': 'true',
-        },
-        name: ConnectionTypeRefs.URI,
-      },
-    },
-    fieldValues: {
-      URI: 'https://test',
-    },
-    additionalFields: {},
-  };
+  return data?.type === ModelLocationType.EXISTING;
 };
 
 export const getExternalRouteFromDeployment = (deployment: Deployment): boolean => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAEING-32186](https://issues.redhat.com/browse/RHOAIENG-32186)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Adds tests
- Adds edit-prefill functionality
- Adds PVCs
- Adds model location data to deploy function
- Made a lil prettier

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test: (there's a lot let me know if you have any questions 😓 )
- There are a lot of connection types and additional complexity from the connections api
- I'd recommend adding a log to `ModelDeploymentWizard.tsx` `console.log(wizardState.state.modelLocationData.data);` and keeping an eye on it as you input data so you see the state updates correctly
- **Start with deploying**, select different location types (uri, s3, oci, existing, custom, cluster storage) and check the fields render correctly
- Check the validation is working in each type and enables the button (make sure you have a model type selected)
- Deploy with each one and check the network calls (note: don't be confused by the `inferenceService` yaml bc we're having that issue with `storageUri`, `storage.key`, `storage.path`, and `imagePullSecrets` being added correctly so refer to the network call instead)
- Also note that I haven't implemented the creation on connections yet that comes in the next ticket [RHOAIENG-32187](https://issues.redhat.com/browse/RHOAIENG-32187) which means that when deploying with a new connection it won't work (as in it won't put the new connection name in the connection api annotation bc we need to create that secret in the next ticket) should work for existing connections, PVC, and URI!



- **Now try editing** it's painful bc we need to account for the usual way of handling connections and the new connections api so you'll need to deploy a ton of models (do this from the modal)
- Ideally you have existing `s3`, `oci`, `uri`, and `pvc` models otherwise you'll run into issues with the missing `storageUri` etc problem and the wizard can't prefill correctly if that data is missing
- Get to the edit page with all of those and see them prefill with the data they were deployed with
- Now you can deploy some more or modify your existing ones to use the connections API
- All you have to do is add `opendatahub.io/connections: connection-name` to the `inferenceService` annotations
- Do that for `S3`, `OCI`, and `URI` (we dont make connections for `pvc`)
- If you find any of this is not working, double check the data you're looking for is actually present on the `inferenceService`
- Deploy a model from `uri` as `pvc://fake-pvc/fake-path` so you can edit it and see the 'pvc doesn't exist error'

I'm sure I'll think of more steps I'll just leave it as this for now
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit and mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Select model location from existing connections, a new URI, or cluster storage (PVC) with PVC selection and path input.
  - Automatically extracts model location when editing deployments.
  - Shows loading spinner while fetching secrets and clearer alerts when connection data isn’t available.
  - Warns when selected PVC access mode may be incompatible.
- Bug Fixes
  - More reliable model URI handling across create/edit flows with unified storage URI behavior.
- Tests
  - Added comprehensive tests for model location selection, validation, and PVC scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->