### PR TITLE
Don't use PORT env var in MR upstream webpack proxy config

### DIFF
--- a/packages/model-registry/upstream/frontend/config/dotenv.js
+++ b/packages/model-registry/upstream/frontend/config/dotenv.js
@@ -156,7 +156,7 @@ const setupDotenvFilesForEnv = ({ env }) => {
   const PORT = process.env.PORT || '9000';
   const PROXY_PROTOCOL = process.env.PROXY_PROTOCOL || 'http';
   const PROXY_HOST = process.env.PROXY_HOST || 'localhost';
-  const PROXY_PORT = process.env.PROXY_PORT || process.env.PORT || 4000;
+  const PROXY_PORT = process.env.PROXY_PORT || 4000;
   const DEV_MODE = process.env.DEV_MODE || undefined;
   const OUTPUT_ONLY = process.env._OUTPUT_ONLY === 'true';
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When running the MR BFF/UI locally using `PORT=9100 make dev-start-federated`, that `PORT` env var was making its way down to both BFF and frontend and the frontend was trying to proxy to itself instead of the BFF. This PORT var is not needed in the frontend proxy anyway, the default of 4000 is what is needed in dev and prod and it can still be overridden by `PROXY_PORT`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally ran ODH + MR (all frontends and backends local) using the [method from this doc](https://docs.google.com/document/d/1vP0B2KeF_XL6PSPN4h-LsBzoTES_Y3YlosFl_pN6rkw/edit?tab=t.0). Enabled the MR plugin flag using the feature flags editor, and verified that the KF MR and MC pages are working as expected.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated environment behavior: the frontend proxy now defaults to port 4000 when PROXY_PORT is unset (it no longer falls back to PORT). Standardizes the dev proxy port—update local scripts or env files if needed. Set PROXY_PORT to override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->