### PR TITLE
Update default port for genai since module federation port was updated

### DIFF
--- a/packages/gen-ai/frontend/config/dotenv.js
+++ b/packages/gen-ai/frontend/config/dotenv.js
@@ -153,7 +153,7 @@ const setupDotenvFilesForEnv = ({ env }) => {
   const COMMON_DIR = path.resolve(RELATIVE_DIRNAME, process.env.COMMON_DIR || '../common');
   const DIST_DIR = path.resolve(RELATIVE_DIRNAME, process.env.DIST_DIR || TS_OUT_DIR || 'public');
   const HOST = process.env.HOST ? '0.0.0.0' : 'localhost';
-  const PORT = process.env.PORT || '9002';
+  const PORT = process.env.PORT || '9102';
   const PROXY_PROTOCOL = process.env.PROXY_PROTOCOL || 'http';
   const PROXY_HOST = process.env.PROXY_HOST || 'localhost';
   const PROXY_PORT = process.env.PROXY_PORT || 8080;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Since the port in module federation config was updated to `9102`, updating the default port for genai.