### PR TITLE
Fix the application crash when no uri present

### DIFF
--- a/packages/model-registry/upstream/frontend/src/odh/components/ModelCatalogDeployModalExtension.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/ModelCatalogDeployModalExtension.tsx
@@ -43,7 +43,7 @@ const ModelCatalogDeployModalExtension: React.FC<ModelCatalogDeployModalExtensio
     decodedParams.sourceId || '',
     encodeURIComponent(`${decodedParams.modelName}`),
   );
-  const uri = artifacts.items[0].uri;
+  const uri = artifacts.items.length > 0 ? artifacts.items[0].uri : '';
   const loaded = isModalAvailable && artifactLoaded && !artifactsLoadError;
 
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
this fixes the application from crashing we show inline error when artifacts route return error


https://github.com/user-attachments/assets/e98e7fb9-85e9-4d05-97db-8d25c09101d0


## How Has This Been Tested?
1. In /packages/model-registry/upstream/frontend, run `PORT=9100 make dev-start-federated INSECURE_SKIP_VERIFY=true`
2. Run dashboard frontend and backend seprately using `npm run start:dev`
3. Turn on model registry plugin dev flag

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
