### PR TITLE
fix(RHOAIENG-34165): Fix pipelines test flake with disabled button race condition

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -92,7 +92,7 @@ class PipelineImportModal extends Modal {
   }
 
   submit(): void {
-    this.findSubmitButton().click();
+    this.findSubmitButton().should('be.enabled').click();
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -87,7 +87,7 @@ class PipelineImportModal extends Modal {
   }
 
   submit(): void {
-    this.findSubmitButton().click();
+    this.findSubmitButton().should('be.enabled').click();
   }
 
   mockCreatePipelineVersion(params: CreatePipelineVersionKFData, namespace: string) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-34165

## Description
Fixed a race condition in the pipelines.cy.ts test where the test was failing because it tried to click a disabled submit button in pipeline import modals. The button becomes disabled during file upload processing and the test was clicking it before it was re-enabled.

## How Has This Been Tested?
- Added `.should('be.enabled')` check before clicking submit buttons in both PipelineImportModal and PipelineVersionImportModal
- This ensures the button is fully enabled and ready for interaction before attempting to click
- Test now waits for file upload processing to complete before submission

## Test Impact
- Eliminates race condition where submit button was clicked while disabled
- Improves test reliability and reduces false positives in CI/CD
- No functional changes to the application itself

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`.