### PR TITLE
fix(RHOAIENG-14566): Fix projectList test flake with notebook expansion race condition

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -273,6 +273,8 @@ describe('Data science projects details', () => {
     projectListPage.visit();
     const projectTableRow = projectListPage.getProjectRow('Test Project');
     projectTableRow.findNotebookColumnExpander().click();
+    // Wait for notebook table to be visible after expansion
+    projectTableRow.findNotebookTable().should('be.visible');
     const notebookRows = projectTableRow.getNotebookRows();
     notebookRows.should('have.length', 1);
   });
@@ -318,6 +320,8 @@ describe('Data science projects details', () => {
     projectListPage.visit();
     const projectTableRow = projectListPage.getProjectRow('Test Project');
     projectTableRow.findNotebookColumnExpander().click();
+    // Wait for notebook table to be visible after expansion
+    projectTableRow.findNotebookTable().should('be.visible');
     const notebookRows = projectTableRow.getNotebookRows();
     notebookRows.should('have.length', 1);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-14566

## Description
Fixed a race condition in the projectList.cy.ts test where the test was failing because it tried to access notebook rows immediately after clicking the notebook column expander, without waiting for the expansion animation to complete and the notebook table to become visible.

The error was: "Unable to find an element by: [data-testid=\"project-notebooks-table\"]" which occurred because the test clicked the expander and immediately tried to access the notebook table before it was fully expanded.

## How Has This Been Tested?
- Added `.should('be.visible')` wait for notebook table after clicking the expander button
- Fixed the race condition in both test cases that use notebook expansion:
  - "should show list of workbenches when the column is expanded"
  - "should open the modal to stop workbench when user stops the workbench"
- Test now waits for the expansion animation to complete before proceeding

## Test Impact
- Eliminates race condition in notebook table expansion
- Improves test reliability and reduces false positives in CI/CD
- No functional changes to the application itself

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`.