### PR TITLE
fix(RHOAIENG-16110): Fix modelVersionDeploy test flake with dropdown selection race condition

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/modelRegistry/modelVersionDeployModal.ts
@@ -11,11 +11,17 @@ class ModelVersionDeployModal extends Modal {
 
   selectProjectByName(name: string) {
     this.findProjectSelector().click();
+    // Wait for the project selector menu to be visible and populated
+    cy.findByTestId('deploy-model-project-selector-menuList').should('be.visible');
     cy.findByTestId('deploy-model-project-selector-search').fill(name);
-    cy.findByTestId('deploy-model-project-selector-menuList')
-      .contains('button', name)
-      .should('be.visible')
-      .click();
+    // Wait for the specific project option to be available before clicking
+    // Try both button and option selectors to handle different UI implementations
+    cy.findByTestId('deploy-model-project-selector-menuList').within(() => {
+      cy.get('button, [role="option"]')
+        .contains(name)
+        .should('be.visible')
+        .click();
+    });
   }
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-16110

## Description
Fixed a race condition in the modelVersionDeploy.cy.ts test where the test was failing because it tried to select a project from the dropdown before the dropdown was fully loaded and populated.

The error was: "Unable to find an accessible element with the role 'option' and name 'KServe project'" which occurred because the test clicked the dropdown and immediately tried to select an option before the dropdown menu was ready.

## How Has This Been Tested?
- Added wait for project selector menu to be visible before proceeding with selection
- Enhanced the selector to handle both button and option role elements to accommodate different UI implementations
- Test now waits for dropdown to be fully loaded before attempting to select options

## Test Impact
- Eliminates race condition in project dropdown selection
- Improves test reliability by ensuring dropdown is ready before interaction
- No functional changes to the application itself

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`.