### PR TITLE
fix(RHOAIENG-26908): Fix manageAcceleratorProfiles.cy.ts race condition

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts
@@ -167,6 +167,8 @@ describe('Manage Accelerator Profile', () => {
   it('edit page has expected values', () => {
     initIntercepts({});
     editAcceleratorProfile.visit('test-accelerator');
+
+    // Wait for form to be populated with accelerator profile data
     editAcceleratorProfile.k8sNameDescription
       .findDisplayNameInput()
       .should('have.value', 'Test Accelerator');
@@ -174,6 +176,9 @@ describe('Manage Accelerator Profile', () => {
     editAcceleratorProfile.k8sNameDescription
       .findDescriptionInput()
       .should('have.value', 'Test description');
+
+    // Wait for toleration table to be populated before checking row data
+    cy.findByTestId('toleration-table').should('be.visible');
     editAcceleratorProfile
       .getRow('nvidia.com/gpu')
       .shouldHaveEffect('NoSchedule')


### PR DESCRIPTION
## Summary
This PR fixes the flaky Cypress test in `manageAcceleratorProfiles.cy.ts` that was failing due to race conditions when checking form values and toleration table data.

## Test plan
[Checklist of TODOs for testing the pull request...]
- [ ] Run the specific test: `npx cypress run --spec "cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts"`
- [ ] Verify "edit page has expected values" test passes consistently
- [ ] Confirm no race conditions when checking toleration table data

## Additional details
**Jira**: [RHOAIENG-26908](https://issues.redhat.com/browse/RHOAIENG-26908)

**Problem**: The test was flaking because it was checking toleration row data immediately after visiting the edit page, before the form was fully populated with data from the accelerator profile.

**Solution**: Added explicit wait for the toleration table to be visible before checking row data. This ensures the form and table are fully loaded before making assertions.

**Files changed**:
- `src/__tests__/cypress/cypress/tests/mocked/acceleratorProfiles/manageAcceleratorProfiles.cy.ts` - Fixed form loading race condition

🤖 Generated with [Claude Code](https://claude.ai/code)