### PR TITLE
[feat] Add deletion endpoint for LSD

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -171,6 +171,9 @@ func (app *App) Routes() http.Handler {
 	// Llama Stack Distribution install endpoint
 	apiRouter.POST(constants.LlamaStackDistributionInstallPath, app.RequireAccessToService(app.AttachNamespace(app.LlamaStackDistributionInstallHandler)))
 
+	// Llama Stack Distribution delete endpoint
+	apiRouter.DELETE(constants.LlamaStackDistributionDeletePath, app.RequireAccessToService(app.AttachNamespace(app.LlamaStackDistributionDeleteHandler)))
+
 	// MCP Client endpoints
 	apiRouter.GET(constants.MCPToolsPath, app.RequireAccessToService(app.MCPToolsHandler))
 	apiRouter.GET(constants.MCPStatusPath, app.RequireAccessToService(app.MCPStatusHandler))

--- a/packages/gen-ai/bff/internal/api/llamastack_distribution_handler_delete.go
+++ b/packages/gen-ai/bff/internal/api/llamastack_distribution_handler_delete.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
+	"github.com/opendatahub-io/gen-ai/internal/models"
+)
+
+type LlamaStackDistributionDeleteEnvelope Envelope[*models.LlamaStackDistributionDeleteResponse, None]
+
+func (app *App) LlamaStackDistributionDeleteHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := r.Context().Value(constants.NamespaceQueryParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in the context"))
+		return
+	}
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing RequestIdentity in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	var deleteRequest models.LlamaStackDistributionDeleteRequest
+	if r.Body == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("request body is required"))
+		return
+	}
+	if err := json.NewDecoder(r.Body).Decode(&deleteRequest); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid JSON in request body: %w", err))
+		return
+	}
+
+	// Validate that the lsd name which is to be deleted is not empty
+	if len(deleteRequest.Name) == 0 {
+		app.badRequestResponse(w, r, fmt.Errorf("lsd name cannot be empty"))
+		return
+	}
+
+	response, err := app.repositories.LlamaStackDistribution.DeleteLlamaStackDistribution(client, ctx, identity, namespace, deleteRequest.Name)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	// Send success response
+	envelope := LlamaStackDistributionDeleteEnvelope{
+		Data: response,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(envelope); err != nil {
+		app.logger.Error("error encoding response", "error", err)
+	}
+}

--- a/packages/gen-ai/bff/internal/api/llamastack_distribution_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/llamastack_distribution_handler_test.go
@@ -227,7 +227,7 @@ func TestLlamaStackDistributionInstallHandler(t *testing.T) {
 		dataMap, ok := data.(map[string]interface{})
 		assert.True(t, ok, "Data should be a map")
 
-		assert.Equal(t, "lsd-genai-playground", dataMap["name"])
+		assert.Equal(t, "mock-lsd", dataMap["name"])
 		assert.Equal(t, "200", dataMap["httpStatus"])
 	})
 
@@ -300,5 +300,300 @@ func TestLlamaStackDistributionInstallHandler(t *testing.T) {
 
 		assert.Equal(t, "400", errorMap["code"])
 		assert.Contains(t, errorMap["message"], "missing namespace in the context")
+	})
+}
+
+func TestLlamaStackDistributionDeleteHandler(t *testing.T) {
+	// Setup test environment (takes ~1-2 seconds)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testEnv, ctrlClient, err := k8smocks.SetupEnvTest(k8smocks.TestEnvInput{
+		Users:  k8smocks.DefaultTestUsers,
+		Logger: slog.Default(),
+		Ctx:    ctx,
+		Cancel: cancel,
+	})
+	require.NoError(t, err)
+	defer func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Logf("Failed to stop test environment: %v", err)
+		}
+	}() // Cleanup happens automatically
+
+	// Create mock factory (instant)
+	k8sFactory, err := k8smocks.NewTokenClientFactory(ctrlClient, testEnv.Config, slog.Default())
+	require.NoError(t, err)
+
+	// Create test app with real mock infrastructure
+	app := App{
+		config: config.EnvConfig{
+			Port: 4000,
+		},
+		kubernetesClientFactory: k8sFactory,
+		repositories:            repositories.NewRepositories(), // No LlamaStack client needed for this test
+	}
+
+	// Test successful deletion
+	t.Run("should delete LSD successfully with valid display name", func(t *testing.T) {
+		// First, install an LSD to have something to delete
+		installRequestBody := map[string]interface{}{
+			"models": []string{"llama-3-2-3b-instruct"},
+		}
+		installJsonBody, err := json.Marshal(installRequestBody)
+		require.NoError(t, err)
+
+		installReq, err := http.NewRequest(http.MethodPost, "/gen-ai/api/v1/llamastack-distribution/install", bytes.NewReader(installJsonBody))
+		require.NoError(t, err)
+		installReq.Header.Set("Content-Type", "application/json")
+
+		// Add namespace and identity to context
+		installCtx := context.Background()
+		installCtx = context.WithValue(installCtx, constants.NamespaceQueryParameterKey, "test-namespace")
+		installCtx = context.WithValue(installCtx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		installReq = installReq.WithContext(installCtx)
+
+		installRr := httptest.NewRecorder()
+		app.LlamaStackDistributionInstallHandler(installRr, installReq, nil)
+		require.Equal(t, http.StatusOK, installRr.Code, "Install should succeed first")
+
+		// Now test deletion
+		deleteRequestBody := map[string]interface{}{
+			"name": "mock-lsd-display-name", // This matches the display name in the mock
+		}
+		deleteJsonBody, err := json.Marshal(deleteRequestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", bytes.NewReader(deleteJsonBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add namespace and identity to context
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-namespace")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		rs := rr.Result()
+		defer func() { _ = rs.Body.Close() }()
+
+		body, err := io.ReadAll(rs.Body)
+		assert.NoError(t, err)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(body, &response)
+		assert.NoError(t, err)
+
+		// Debug: Print the response to see what we're getting
+		t.Logf("Response body: %s", string(body))
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		data, exists := response["data"]
+		assert.True(t, exists, "Response should contain 'data' field")
+
+		dataMap, ok := data.(map[string]interface{})
+		assert.True(t, ok, "Data should be a map")
+
+		assert.Equal(t, "LlamaStackDistribution deleted successfully", dataMap["data"])
+	})
+
+	// Test error case - missing request body
+	t.Run("should return error when request body is missing", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", nil)
+		assert.NoError(t, err)
+
+		// Add namespace and identity to context
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-namespace")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		errorData, exists := response["error"]
+		assert.True(t, exists, "Response should contain 'error' field")
+
+		errorMap, ok := errorData.(map[string]interface{})
+		assert.True(t, ok, "Error should be a map")
+
+		assert.Equal(t, "400", errorMap["code"])
+		assert.Contains(t, errorMap["message"], "request body is required")
+	})
+
+	// Test error case - empty name
+	t.Run("should return error when name is empty", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"name": "",
+		}
+		jsonBody, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", bytes.NewReader(jsonBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add namespace and identity to context
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-namespace")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		errorData, exists := response["error"]
+		assert.True(t, exists, "Response should contain 'error' field")
+
+		errorMap, ok := errorData.(map[string]interface{})
+		assert.True(t, ok, "Error should be a map")
+
+		assert.Equal(t, "400", errorMap["code"])
+		assert.Contains(t, errorMap["message"], "lsd name cannot be empty")
+	})
+
+	// Test error case - missing namespace
+	t.Run("should return error when namespace is missing from context", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"name": "test-lsd",
+		}
+		jsonBody, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", bytes.NewReader(jsonBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add identity to context but no namespace
+		ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		errorData, exists := response["error"]
+		assert.True(t, exists, "Response should contain 'error' field")
+
+		errorMap, ok := errorData.(map[string]interface{})
+		assert.True(t, ok, "Error should be a map")
+
+		assert.Equal(t, "400", errorMap["code"])
+		assert.Contains(t, errorMap["message"], "missing namespace in the context")
+	})
+
+	// Test error case - LSD not found
+	t.Run("should return error when LSD with display name is not found", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"name": "non-existent-lsd",
+		}
+		jsonBody, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", bytes.NewReader(jsonBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add namespace and identity to context
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "test-namespace")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		errorData, exists := response["error"]
+		assert.True(t, exists, "Response should contain 'error' field")
+
+		errorMap, ok := errorData.(map[string]interface{})
+		assert.True(t, ok, "Error should be a map")
+
+		assert.Equal(t, "400", errorMap["code"])
+		assert.Contains(t, errorMap["message"], "LlamaStackDistribution with display name 'non-existent-lsd' not found")
+	})
+
+	// Test error case - empty namespace (no LSDs)
+	t.Run("should return error when no LSDs found in namespace", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"name": "any-lsd",
+		}
+		jsonBody, err := json.Marshal(requestBody)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "/gen-ai/api/v1/llamastack-distribution/delete", bytes.NewReader(jsonBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		// Use empty namespace (mock-test-namespace-1 returns empty LSD list)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-1")
+		ctx = context.WithValue(ctx, constants.RequestIdentityKey, &integrations.RequestIdentity{
+			Token: "FAKE_BEARER_TOKEN",
+		})
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+
+		app.LlamaStackDistributionDeleteHandler(rr, req, nil)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		assert.NoError(t, err)
+
+		errorData, exists := response["error"]
+		assert.True(t, exists, "Response should contain 'error' field")
+
+		errorMap, ok := errorData.(map[string]interface{})
+		assert.True(t, ok, "Error should be a map")
+
+		assert.Equal(t, "400", errorMap["code"])
+		assert.Contains(t, errorMap["message"], "no LlamaStackDistribution found in namespace mock-test-namespace-1 with OpenDataHubDashboardLabelKey annotation")
 	})
 }

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -21,6 +21,7 @@ const (
 	NamespacesPath                    = ApiPathPrefix + "/namespaces"
 	LlamaStackDistributionStatusPath  = ApiPathPrefix + "/llamastack-distribution/status"
 	LlamaStackDistributionInstallPath = ApiPathPrefix + "/llamastack-distribution/install"
+	LlamaStackDistributionDeletePath  = ApiPathPrefix + "/llamastack-distribution/delete"
 	UserPath                          = ApiPathPrefix + "/user"
 
 	// MCP (Model Context Protocol) endpoint paths

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/client.go
@@ -28,6 +28,8 @@ type KubernetesClientInterface interface {
 
 	InstallLlamaStackDistribution(ctx context.Context, identity *integrations.RequestIdentity, namespace string, models []string) (*lsdapi.LlamaStackDistribution, error)
 
+	DeleteLlamaStackDistribution(ctx context.Context, identity *integrations.RequestIdentity, namespace string, name string) (*lsdapi.LlamaStackDistribution, error)
+
 	// ConfigMap operations
 	GetConfigMap(ctx context.Context, identity *integrations.RequestIdentity, namespace string, name string) (*corev1.ConfigMap, error)
 }

--- a/packages/gen-ai/bff/internal/models/llamastack_distribution.go
+++ b/packages/gen-ai/bff/internal/models/llamastack_distribution.go
@@ -34,3 +34,11 @@ type ErrorResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 }
+
+type LlamaStackDistributionDeleteRequest struct {
+	Name string `json:"name"`
+}
+
+type LlamaStackDistributionDeleteResponse struct {
+	Data string `json:"data"`
+}

--- a/packages/gen-ai/bff/internal/repositories/llamastack_distribution.go
+++ b/packages/gen-ai/bff/internal/repositories/llamastack_distribution.go
@@ -79,3 +79,25 @@ func (r *LlamaStackDistributionRepository) InstallLlamaStackDistribution(
 
 	return installModel, nil
 }
+
+// DeleteLlamaStackDistribution deletes a LlamaStackDistribution with the specified name
+func (r *LlamaStackDistributionRepository) DeleteLlamaStackDistribution(
+	client kubernetes.KubernetesClientInterface,
+	ctx context.Context,
+	identity *integrations.RequestIdentity,
+	namespace string,
+	name string,
+) (*models.LlamaStackDistributionDeleteResponse, error) {
+	// Call the Kubernetes client to delete the LSD (validation logic is now in the client)
+	_, err := client.DeleteLlamaStackDistribution(ctx, identity, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the response model
+	deleteModel := &models.LlamaStackDistributionDeleteResponse{
+		Data: "LlamaStackDistribution deleted successfully",
+	}
+
+	return deleteModel, nil
+}


### PR DESCRIPTION
This PR implements a new DELETE endpoint for LlamaStack Distribution (LSD) management, allowing users to delete LSD instances by their display name.

New API Endpoint
- DELETE /gen-ai/api/v1/llamastack-distribution/delete
- Deletes LSD by display name with proper validation
- Returns structured success/error responses

Example deletion request:

curl -X DELETE \
  -H "Authorization: Bearer <token>" \ -H "Content-Type: application/json" \ -d '{"name": "lsd-genai-playground"}' \ "http://localhost:8080/gen-ai/api/v1/llamastack-distribution/delete?namespace=models"

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
