### PR TITLE
add scripts for running dev e2e

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "clean": "rm -f ../logs/adminActivity.log",
     "start": "NODE_ENV=production node ./dist/server.js --log=1 --registry=localhost:50051",
     "start:dev": "npm run clean && export NODE_TLS_REJECT_UNAUTHORIZED=0 && export NODE_ENV=development && nodemon src/server.ts --log=1 --registry=localhost:50051",
+    "start:dev:wait": "npx wait-on -i 1000 http://localhost:4000",
     "debug": "npm run tsc && export NODE_TLS_REJECT_UNAUTHORIZED=0 && export NODE_ENV=development && node --inspect ./dist/server.js --log=1 --registry=localhost:50051",
     "build-only": "tsc -p . && node ./dist/server.js --log=1 --registry=localhost:50051 --buildonly",
     "build": "run-s build:clean tsc:prod",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "format": "prettier --write \"./**/*.ts\" \"./**/*.tsx\" \"./**/*.scss\"",
     "lint:goal": "eslint --config ./.eslintrc.goal.js --ext .json,.js,.ts,.jsx,.tsx ./src ",
     "start:dev": "webpack serve --hot --color --config ./config/webpack.dev.js",
+    "start:dev:wait": "npx wait-on -i 1000 http://localhost:4010",
     "start:dev:mf": "MF_UPDATE_TYPES=true npm run start:dev",
     "start:dev:ext": "EXT_CLUSTER=true npm run start:dev",
     "test": "run-s test:lint test:type-check test:unit test:cypress-ci",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35066,7 +35066,15 @@
     },
     "packages/llmd-serving": {
       "name": "@odh-dashboard/llmd-serving",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/model-serving": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*"
+      }
     },
     "packages/lm-eval": {
       "name": "@odh-dashboard/lm-eval",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,10 @@
     "cypress:server:dev": "turbo run cypress:server:dev",
     "cypress:server:build": "turbo run cypress:server:build",
     "cypress:server:build:coverage": "turbo run cypress:server:build:coverage",
-    "postinstall": "turbo run install:module --ui=stream"
+    "postinstall": "turbo run install:module --ui=stream",
+    "test-e2e:dev": "concurrently --hide=0 -k -s first \"turbo run start:dev\" \"turbo run start:dev:wait && npm run test:cypress:e2e --prefix frontend\"",
+    "start:dev": "turbo run start:dev",
+    "start:dev:ext": "turbo run start:dev:ext"
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.12.2",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -13,7 +13,10 @@
     "cypress:server:build:coverage": "COVERAGE=true npm run cypress:server:build",
     "cypress:server": "cd upstream/frontend && serve ./public-cypress -p 9100 -s -L",
     "cypress:server:dev": "cd upstream/frontend && DEPLOYMENT_MODE=federated PORT=9100 npm run start:dev",
-    "cypress:server:wait": "npx wait-on -i 1000 http://localhost:9100"
+    "cypress:server:wait": "npx wait-on -i 1000 http://localhost:9100",
+    "start:dev": "cd upstream && PORT=9100 make dev-start-federated",
+    "start:dev:ext": "cd upstream/frontend && DEPLOYMENT_MODE=federated PORT=9100 npm run start:dev",
+    "start:dev:wait": "npx wait-on -i 1000 http://localhost:9100"
   },
   "subtree": {
     "repo": "https://github.com/kubeflow/model-registry.git",

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -1,6 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalDependencies": [".env*"],
+  "envMode": "loose",
   "tasks": {
     "includeDependenciesAsInputs": {},
     "build": {
@@ -34,6 +36,18 @@
       "cache": false
     },
 
+    "start:dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "start:dev:wait": {
+      "cache": false
+    },
+    "start:dev:ext": {
+      "cache": false,
+      "persistent": true
+    },
+
     // Cypress tasks
     "cypress:server:build": {
       // no caching until we can optimize the dependency graph
@@ -59,7 +73,7 @@
 
     /*
      * TODO waiting for feature https://github.com/vercel/turborepo/discussions/10495
-     * Workaround: use `concurrently` through package.json. See "test-mocked" script.
+     * Workaround: use `concurrently` through package.json.
      */
     // "cypress:run:mock": {
     //   "dependsOn": ["cypress:server:wait"],


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-33269

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds npm scripts for running dev and e2e with modules.

The commands simply provide a way to run the various dev envs from multiple packages using turbo.

Like all new command scripts recently added, the names are chosen to not clash and to not perform any clean up of existing scripts. In future we will revisit all scripts to remove / rename as needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally:
- `npm run start:dev`: starts the typical dev env with both backend and frontends
- `npm run start:dev:ext`: starts the dev env with frontend only for use with external cluster
- `npm run test-e2e:dev`: starts dev env and runs e2e tests concurrently.
  - Tested with custom inputs `CY_TEST_CONFIG=<path to test-variables.yml> CY_TEST_TAGS=<some tags> npm run test-e2e:dev`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added an end-to-end workflow that waits for dev servers to be ready before running Cypress, improving reliability.
- Chores
  - Added development startup and readiness-wait scripts across root, frontend, backend, and packages for streamlined local and federated dev.
  - Introduced task orchestration entries and global Turbo settings for persistent dev processes and readiness checks.
  - Minor cleanup of an internal Cypress workaround comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->