### PR TITLE
Parametrize oauth-proxy image

### DIFF
--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - --pass-access-token
             - '--openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
             - --skip-auth-regex=^/metrics
-          image: oauth-proxy
+          image: $(oauth-proxy-image)
           ports:
             - containerPort: 8443
               name: dashboard-ui

--- a/manifests/core-bases/base/kustomization.yaml
+++ b/manifests/core-bases/base/kustomization.yaml
@@ -20,7 +20,3 @@ resources:
   - fetch-hardwares.rbac.yaml
   - fetch-nim-account.rbac.yaml
   - aggregate-permissions.rbac.yaml
-images:
-  - name: oauth-proxy
-    newName: registry.redhat.io/openshift4/ose-oauth-proxy
-    digest: sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695

--- a/manifests/odh/kustomization.yaml
+++ b/manifests/odh/kustomization.yaml
@@ -20,6 +20,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-dashboard-image
+  - name: oauth-proxy-image
+    objref:
+      kind: ConfigMap
+      name: odh-dashboard-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.oauth-proxy-image
   - name: section-title
     objref:
       kind: ConfigMap

--- a/manifests/odh/params.env
+++ b/manifests/odh/params.env
@@ -1,4 +1,5 @@
 # Injected variables from the Operator
 odh-dashboard-image=quay.io/opendatahub/odh-dashboard:main
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
 dashboard-url=https://www.redhat.com
 section-title=Open Data Hub

--- a/manifests/rhoai/addon/kustomization.yaml
+++ b/manifests/rhoai/addon/kustomization.yaml
@@ -19,6 +19,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-dashboard-image
+  - name: oauth-proxy-image
+    objref:
+      kind: ConfigMap
+      name: odh-dashboard-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.oauth-proxy-image
   - name: section-title
     objref:
       kind: ConfigMap

--- a/manifests/rhoai/addon/params.env
+++ b/manifests/rhoai/addon/params.env
@@ -1,4 +1,5 @@
 # Injected variables from the Operator
 odh-dashboard-image=quay.io/opendatahub/odh-dashboard:main
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
 dashboard-url=https://www.redhat.com
 section-title=OpenShift AI

--- a/manifests/rhoai/onprem/kustomization.yaml
+++ b/manifests/rhoai/onprem/kustomization.yaml
@@ -19,6 +19,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-dashboard-image
+  - name: oauth-proxy-image
+    objref:
+      kind: ConfigMap
+      name: odh-dashboard-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.oauth-proxy-image
   - name: section-title
     objref:
       kind: ConfigMap

--- a/manifests/rhoai/onprem/params.env
+++ b/manifests/rhoai/onprem/params.env
@@ -1,4 +1,5 @@
 # Injected variables from the Operator
 odh-dashboard-image=quay.io/opendatahub/odh-dashboard:main
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
 dashboard-url=https://www.redhat.com
 section-title=OpenShift AI


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Closes https://issues.redhat.com/browse/RHOAIENG-32247
Parametrize oauth proxy image, following the structure of https://github.com/opendatahub-io/kubeflow/pull/671/files

This pull request refactors how the `oauth-proxy` image is configured and injected throughout the manifests. Instead of hardcoding the image reference in multiple places, the image value is now centralized in environment parameter files and referenced dynamically via configuration. This improves maintainability and makes it easier to update the `oauth-proxy` image in the future.

**Centralized Image Configuration:**

* Added the `oauth-proxy-image` variable to `params.env` files for `odh`, `rhoai/addon`, and `rhoai/onprem`, specifying the image and digest in a single location. [[1]](diffhunk://#diff-496201f87ee1de19a7dfcaecdc84f90e7b382ec9fd8a1b61a892e1808d776065R3) [[2]](diffhunk://#diff-ff8ad32785e45b9b8a957b43be99b261ec52a5d95a69ff955d0f65008a860600R3)

**Dynamic Image Injection:**

* Updated `kustomization.yaml` files in `odh`, `rhoai/addon`, and `rhoai/onprem` to pull the `oauth-proxy-image` value from the `odh-dashboard-params` ConfigMap, enabling dynamic injection of the image reference. [[1]](diffhunk://#diff-65854bb4560d11b184e6a0b564310cb9ef11dd5a437a3a9c9493fd3824b6fbe2R24-R30) [[2]](diffhunk://#diff-c846d107f1002454689c2a95636333db6baefdabec16c056f267851c625638fbR22-R28)

**Deployment Manifest Update:**

* Modified `deployment.yaml` to use the `$(oauth-proxy-image)` variable for the `oauth-proxy` container image instead of a hardcoded value.

**Cleanup of Deprecated Configuration:**

* Removed the now-unnecessary `images` section from `core-bases/base/kustomization.yaml` that previously set the `oauth-proxy` image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OAuth-proxy image is now configurable via parameters across ODH and RHOAI (addon/on-prem), with a secure digest-pinned default.

- Refactor
  - Deployments now reference a parameterized OAuth-proxy image instead of a fixed value.
  - Removed base-level image overrides to rely on environment-specific parameters.

- Chores
  - Updated parameter sets and configuration to include the new OAuth-proxy image variable for consistent substitution across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->