### PR TITLE
fix: cypress workflow trigger only on /run-e2e-tests-gh comments

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -17,8 +17,6 @@ jobs:
   check-comment:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/run-e2e-tests-gh') }}
-    outputs:
-      should-run: 'true'
     steps:
       - run: echo "E2E tests requested via /run-e2e-tests-gh comment"
 


### PR DESCRIPTION
## Description
- Add check-comment job to validate magic comment before proceeding
- Make all jobs depend on check-comment to prevent execution on regular comments
- Fix cleanup-server to only run when E2E tests actually executed
- Eliminates noise from bot comments and regular PR discussions in Actions history

Workflow now only runs when explicitly requested via /run-e2e-tests-gh comment

## How Has This Been Tested?
- GH Actions

## Test Impact
- None - this is a test pipeline

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Add on-demand E2E test triggering via PR comment (e.g., “/run-e2e-tests-gh”) to run tests only when requested.
  - Preserve test tag selection while gating automatic E2E execution to reduce unnecessary runs.

- Chores
  - Improve CI job orchestration and dependencies for clearer sequencing.
  - Adjust cleanup to run only when E2E tests actually execute, avoiding unnecessary teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->