### PR TITLE
RHOAIENG-34758: Update MCP Default NS to Dashboard NS

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -34,10 +34,19 @@ type App struct {
 	kubernetesClientFactory k8s.KubernetesClientFactory
 	llamaStackClientFactory llamastack.LlamaStackClientFactory
 	mcpClientFactory        mcp.MCPClientFactory
+	dashboardNamespace      string
 }
 
 func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	logger.Info("Initializing app with config", slog.Any("config", cfg))
+
+	// Detect dashboard namespace
+	dashboardNamespace, err := helper.GetCurrentNamespace()
+	if err != nil {
+		logger.Warn("Failed to detect dashboard namespace, using default", "error", err, "default", "opendatahub")
+		dashboardNamespace = "opendatahub"
+	}
+	logger.Info("Detected dashboard namespace", "namespace", dashboardNamespace)
 
 	// Initialize LlamaStack client factory - clients will be created per request
 	var llamaStackClientFactory llamastack.LlamaStackClientFactory
@@ -101,6 +110,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		kubernetesClientFactory: k8sFactory,
 		llamaStackClientFactory: llamaStackClientFactory,
 		mcpClientFactory:        mcpFactory,
+		dashboardNamespace:      dashboardNamespace,
 	}
 	return app, nil
 }

--- a/packages/gen-ai/bff/internal/api/mcp_helpers.go
+++ b/packages/gen-ai/bff/internal/api/mcp_helpers.go
@@ -78,12 +78,13 @@ func (app *App) findMCPServerConfig(
 	k8sClient kubernetes.KubernetesClientInterface,
 	identity *integrations.RequestIdentity,
 	decodedURL string,
+	dashboardNamespace string,
 ) (genaiassets.MCPServerConfig, error) {
 	servers, err := app.repositories.MCPClient.GetMCPServersFromConfig(
 		k8sClient,
 		ctx,
 		identity,
-		constants.MCPServerNamespace,
+		dashboardNamespace,
 		constants.MCPServerName,
 	)
 	if err != nil {

--- a/packages/gen-ai/bff/internal/api/mcp_helpers_test.go
+++ b/packages/gen-ai/bff/internal/api/mcp_helpers_test.go
@@ -352,7 +352,7 @@ func TestFindMCPServerConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config, err := app.findMCPServerConfig(testCtx, k8sClient, identity, tc.decodedURL)
+			config, err := app.findMCPServerConfig(testCtx, k8sClient, identity, tc.decodedURL, "test-dashboard-namespace")
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -653,7 +653,7 @@ func TestMCPHelpersIntegration(t *testing.T) {
 		assert.Equal(t, "FAKE_BEARER_TOKEN", identity.Token)
 
 		// Step 3: Find server config
-		config, err := app.findMCPServerConfig(testCtx, k8sClient, identity, decodedURL)
+		config, err := app.findMCPServerConfig(testCtx, k8sClient, identity, decodedURL, "test-dashboard-namespace")
 		require.NoError(t, err)
 		assert.Equal(t, serverURL, config.URL)
 	})

--- a/packages/gen-ai/bff/internal/api/mcp_list_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_list_handler.go
@@ -56,11 +56,11 @@ func (app *App) MCPListHandler(w http.ResponseWriter, r *http.Request, ps httpro
 		k8sClient,
 		ctx,
 		identity,
-		constants.MCPServerNamespace,
+		app.dashboardNamespace,
 		constants.MCPServerName,
 	)
 	if err != nil {
-		app.handleConfigMapError(w, r, err, constants.MCPServerName, constants.MCPServerNamespace)
+		app.handleConfigMapError(w, r, err, constants.MCPServerName, app.dashboardNamespace)
 		return
 	}
 

--- a/packages/gen-ai/bff/internal/api/mcp_list_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/mcp_list_handler_test.go
@@ -54,6 +54,7 @@ func TestMCPListHandler(t *testing.T) {
 		repositories:            repositories.NewRepositoriesWithMCP(mockMCPFactory, logger),
 		kubernetesClientFactory: mockK8sFactory,
 		mcpClientFactory:        mockMCPFactory,
+		dashboardNamespace:      "opendatahub",
 	}
 
 	t.Run("should return list of MCP servers successfully", func(t *testing.T) {

--- a/packages/gen-ai/bff/internal/api/mcp_status_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_status_handler.go
@@ -25,7 +25,7 @@ func (app *App) MCPStatusHandler(w http.ResponseWriter, r *http.Request, ps http
 		return
 	}
 
-	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL)
+	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
 	if err != nil {
 		app.notFoundResponse(w, r)
 		return

--- a/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
+++ b/packages/gen-ai/bff/internal/api/mcp_tools_handler.go
@@ -25,7 +25,7 @@ func (app *App) MCPToolsHandler(w http.ResponseWriter, r *http.Request, ps httpr
 		return
 	}
 
-	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL)
+	serverConfig, err := app.findMCPServerConfig(ctx, k8sClient, identity, decodedURL, app.dashboardNamespace)
 	if err != nil {
 		app.notFoundResponse(w, r)
 		return

--- a/packages/gen-ai/bff/internal/constants/mcp.go
+++ b/packages/gen-ai/bff/internal/constants/mcp.go
@@ -2,8 +2,7 @@ package constants
 
 // MCP Servers List
 const (
-	MCPServerName      = "gen-ai-aa-mcp-servers"
-	MCPServerNamespace = "mcp-servers"
+	MCPServerName = "gen-ai-aa-mcp-servers"
 )
 
 // MCP Transport Types

--- a/packages/gen-ai/bff/internal/helpers/namespace.go
+++ b/packages/gen-ai/bff/internal/helpers/namespace.go
@@ -1,0 +1,43 @@
+package helper
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	// ServiceAccountNamespaceFile is the path to the namespace file in Kubernetes pods
+	ServiceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// GetCurrentNamespace detects the current namespace where the application is running
+// This follows the same logic as the main ODH dashboard backend:
+// 1. In-cluster: Read from service account namespace file
+// 2. Dev mode: Use OC_PROJECT environment variable
+// 3. Fallback: Use provided default or "opendatahub"
+func GetCurrentNamespace() (string, error) {
+	// Try to read from service account namespace file (in-cluster)
+	if _, err := os.Stat(ServiceAccountNamespaceFile); err == nil {
+		data, err := os.ReadFile(ServiceAccountNamespaceFile)
+		if err != nil {
+			return "", err
+		}
+		namespace := strings.TrimSpace(string(data))
+		if namespace != "" {
+			return namespace, nil
+		}
+	}
+
+	// Try environment variable (dev mode)
+	if envNamespace := os.Getenv("OC_PROJECT"); envNamespace != "" {
+		return envNamespace, nil
+	}
+
+	// Try NAMESPACE environment variable (common in containerized environments)
+	if envNamespace := os.Getenv("NAMESPACE"); envNamespace != "" {
+		return envNamespace, nil
+	}
+
+	// Default fallback
+	return "opendatahub", nil
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-34758

Added Logic to get the `DASHBOARD_NAMESPACE` used by the ODH Dashboard to store all Configs.

The MCP Servers ConfigMap will be also stored here.


Logic behind fetching the current `DASHBOARD_NAMESPACE`:

This follows the same logic as the main ODH dashboard backend:
1. In-cluster: Read from service account namespace file
2. Dev mode: Use OC_PROJECT environment variable
3. Fallback: Use provided default or "opendatahub"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically detects the dashboard namespace across environments with sensible fallbacks (in-cluster, env vars, default).
- Improvements
  - MCP discovery and related endpoints now use the detected namespace, improving compatibility across installations.
  - Adds warning/info logs when detecting and applying the namespace for better observability.
- Tests
  - Updated tests to accommodate namespace-aware calls and initialization.
- Chores
  - Removed reliance on a fixed namespace constant in favor of dynamic detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->