### PR TITLE
[Cherry-pick 2.x] Add override for rhoai for modular architecture

### DIFF
--- a/manifests/rhoai/shared/base/federation-configmap.yaml
+++ b/manifests/rhoai/shared/base/federation-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: federation-config
+data:
+  module-federation-config.json: |
+    [
+      {
+        "name": "modelRegistry",
+        "remoteEntry": "/remoteEntry.js",
+        "authorize": true,
+        "tls": true,
+        "proxy": [
+          {
+            "path": "/model-registry/api",
+            "pathRewrite": "/api"
+          }
+        ],
+        "local": {
+          "host": "localhost",
+          "port": 8080
+        },
+        "service": {
+          "name": "rhods-dashboard",
+          "namespace": "redhat-ods-applications",
+          "port": 8043
+        }
+      }
+    ]

--- a/manifests/rhoai/shared/base/kustomization.yaml
+++ b/manifests/rhoai/shared/base/kustomization.yaml
@@ -66,3 +66,5 @@ patchesJson6902:
       version: v1
       kind: Route
       name: odh-dashboard
+patchesStrategicMerge:
+  - federation-configmap.yaml


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Cherry-picks https://github.com/opendatahub-io/odh-dashboard/pull/4969 to stable-2.x, see that PR for details

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Was tested by manually patching the manifests on a RHOAI cluster running the latest 2.x build

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
