### PR TITLE
Fix hwp hook (#4964)

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfiles.tsx
@@ -59,7 +59,11 @@ const HardwareProfiles: React.FC = () => {
   const isEmpty = allMigratedHardwareProfiles.length === 0;
   const warningMessages = generateWarningForHardwareProfiles(allMigratedHardwareProfiles);
 
-  const serverHardwareProfileOrder = dashboardConfig?.spec.hardwareProfileOrder || [];
+  const serverHardwareProfileOrder = React.useMemo(
+    () => dashboardConfig?.spec.hardwareProfileOrder || [],
+    [dashboardConfig?.spec.hardwareProfileOrder],
+  );
+
   const [optimisticHardwareProfileOrder, setOptimisticHardwareProfileOrder] = React.useState<
     string[]
   >(serverHardwareProfileOrder);
@@ -74,7 +78,7 @@ const HardwareProfiles: React.FC = () => {
       setOptimisticHardwareProfileOrder(hwpNameOrder);
       try {
         await patchDashboardConfigHardwareProfileOrder(hwpNameOrder, dashboardNamespace);
-        return await refreshDashboardConfig();
+        await refreshDashboardConfig();
       } catch (error) {
         // Revert optimistic state on error
         setOptimisticHardwareProfileOrder(serverHardwareProfileOrder);


### PR DESCRIPTION
(cherry picked from commit 02cc5317086b2728e7390a8871617175fd60695d)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-34837

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Cherry-picked from https://github.com/opendatahub-io/odh-dashboard/pull/4964

Fix re-render loop that blocked navigation out of the hardware profiles page. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the hardware profiles page, create hardware profiles, change their order around in the table, and navigate to another page. 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
