### PR TITLE
set default retries for mock tests to 2

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -135,7 +135,9 @@ export default defineConfig({
         if (results.video) {
           // Do we have failures for any retry attempts?
           const failures = results.tests.some((test) =>
-            test.attempts.some((attempt) => attempt.state === 'failed'),
+            test.attempts[config.env.MOCK ? 'every' : 'some'](
+              (attempt) => attempt.state === 'failed',
+            ),
           );
           if (!failures) {
             // delete the video if the spec passed and no tests retried

--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -164,7 +164,7 @@ export default defineConfig({
       const retryConfig =
         config.env.CY_RETRY !== undefined
           ? { runMode: Math.max(0, parseInt(config.env.CY_RETRY) || 0), openMode: 0 }
-          : !config.env.CY_MOCK && !config.env.CY_RECORD
+          : !config.env.CY_RECORD
           ? { runMode: 2, openMode: 0 }
           : config.retries;
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-27680

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Sets the number of test retries to `2` for mock tests.

After investigating `ChunkLoadError` for cypress mock tests, I could not find any valid reason the test would fail and then subsequently pass. The `ChunkLoadError` is a result of a failure of the http server to serve the JS file. I downloaded the cached build and the file which failed to load was present in the static files. Therefore the file should have been served.

Updating retries as an attempt to see if a test can pass after encountering these errors.

To save on storage, the videos are deleted unless all retry attempts have failed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test retry behavior now depends only on recording mode by default, removing mock-mode influence for more predictable retries.
  * Test artifact retention (e.g., videos) behavior changed: when mock mode is enabled all attempts must fail to mark a spec as failed for deletion, otherwise a single failed attempt suffices — affecting which artifacts are kept or removed.
  * Improves consistency between local and CI test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->