### PR TITLE
RHOAIENG-27684: The workbench image column shows Deleted label after RHOAI upgrade

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -292,6 +292,7 @@ const initIntercepts = ({
         ? []
         : [
             mockNotebookK8sResource({
+              lastImageSelection: `${imageStreamName}:${imageStreamTag}`,
               opts: {
                 spec: {
                   template: {

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/useNotebookImageData.spec.ts
@@ -11,7 +11,7 @@ describe('getNotebookImageData', () => {
     const notebook = mockNotebookK8sResource({
       image:
         'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
-      lastImageSelection: 'jupyter-datascience-notebook',
+      lastImageSelection: 'jupyter-datascience-notebook:1.2',
     });
     const images = [
       mockImageStreamK8sResource({
@@ -31,7 +31,7 @@ describe('getNotebookImageData', () => {
     const tagName = '2024.1';
     const notebook = mockNotebookK8sResource({
       image: `image-registry.openshift-image-registry.svc:5000/opendatahub/${imageName}:${tagName}`,
-      lastImageSelection: 'jupyter-datascience-notebook',
+      lastImageSelection: `${imageName}:${tagName}`,
     });
     const images = [
       mockImageStreamK8sResource({
@@ -52,7 +52,7 @@ describe('getNotebookImageData', () => {
     const notebook = mockNotebookK8sResource({
       image:
         'quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75',
-      lastImageSelection: 'jupyter-datascience-notebook',
+      lastImageSelection: 'jupyter-datascience-notebook:1.2',
     });
     const images = [
       mockImageStreamK8sResource({
@@ -78,7 +78,7 @@ describe('getNotebookImageData', () => {
     const displayName = 'Jupyter Data Science Notebook';
     const notebook = mockNotebookK8sResource({
       image: `image-registry.openshift-image-registry.svc:5000/opendatahub/${imageName}:${tagName}`,
-      lastImageSelection: 'jupyter-datascience-notebook',
+      lastImageSelection: `${imageName}:${tagName}`,
     });
     const images = [
       mockImageStreamK8sResource({
@@ -137,7 +137,7 @@ describe('getNotebookImageData', () => {
     const imageName = 'jupyter-datascience-notebook';
     const imageSha = 'sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75';
     const notebook = mockNotebookK8sResource({
-      lastImageSelection: `${imageName}:${imageSha}`,
+      lastImageSelection: `${imageName}:1.2`,
       image: `quay.io/opendatahub/${imageName}@${imageSha}`,
     });
     const images = [

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
@@ -20,7 +20,6 @@ const useNotebookImage = (
   }
 
   const { imageDisplayName, imageStatus } = data;
-  console.log('imageStatus', imageStatus);
 
   // if the image is deleted, return the image name if it is available (based on notebook annotations)
   if (imageStatus === NotebookImageStatus.DELETED) {

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImage.ts
@@ -20,6 +20,7 @@ const useNotebookImage = (
   }
 
   const { imageDisplayName, imageStatus } = data;
+  console.log('imageStatus', imageStatus);
 
   // if the image is deleted, return the image name if it is available (based on notebook annotations)
   if (imageStatus === NotebookImageStatus.DELETED) {

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -105,10 +105,8 @@ const getNotebookImageInternalRegistry = (
   versionName: string,
 ): NotebookImageData[0] => {
   const imageStream = images.find((image) => image.metadata.name === imageName);
-  console.log('imageStream', imageStream);
 
   if (!imageStream || isNotebookImageDeleted(notebook, imageStream)) {
-    console.log('notebook', notebook);
     // Get the image display name from the notebook metadata if we can't find the image stream. (this is a fallback and could still be undefined)
     return getDeletedImageData(
       notebook.metadata.annotations?.['opendatahub.io/image-display-name'],

--- a/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
+++ b/frontend/src/pages/projects/screens/detail/notebooks/useNotebookImageData.ts
@@ -235,7 +235,7 @@ const getImageStatus = (
 ): NotebookImageStatus | undefined => {
   if (
     imageVersion.annotations?.['opendatahub.io/image-tag-outdated'] === 'true' ||
-    isNotedbookImageOutdated(notebook, imageStream)
+    isNotebookImageOutdated(notebook, imageStream)
   ) {
     return NotebookImageStatus.DEPRECATED;
   }
@@ -250,14 +250,15 @@ const findNoteBookImageTag = (notebook: NotebookKind, imageStream: ImageStreamKi
     notebook.metadata.annotations?.['notebooks.opendatahub.io/last-image-selection']?.split(':') ??
     [];
 
-  return imageStream.spec.tags?.some(
-    (imageTags) =>
-      imageStream.metadata.name === lastImageSelectionName &&
-      imageTags.name === lastImageSelectionTag,
+  if (imageStream.metadata.name !== lastImageSelectionName) {
+    return false;
+  }
+  return (
+    imageStream.spec.tags?.some((imageTags) => imageTags.name === lastImageSelectionTag) ?? false
   );
 };
 
-const isNotedbookImageOutdated = (notebook: NotebookKind, imageStream: ImageStreamKind) =>
+const isNotebookImageOutdated = (notebook: NotebookKind, imageStream: ImageStreamKind) =>
   !findNotebookImageCommit(notebook, imageStream) && !isBYONImageStream(imageStream);
 
 const isNotebookImageDeleted = (notebook: NotebookKind, imageStream: ImageStreamKind) =>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
**JIRA:** https://issues.redhat.com/browse/RHOAIENG-27684

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

I have fixed the logic to check if the notebook image has been deleted and added additional logic to check if the image has been updated/outdated.

https://github.com/user-attachments/assets/d7731fba-1a45-4419-80ef-3e00e7d7fd52

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Install the RHOAI 2.21
2. Create a DS project and create a Standard Data Science workbench there with version 2025.1
3. Perform upgrade to RHOAI 2.22
4. You should see `Deprecated` instead of the `Deleted` label in the RHOAI Dashboard for the running workbench.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Fixed tests and updated deleted, deprecated test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer notebook image status labels — shows “Deprecated” for commit/tag mismatches and “Deleted” when the selected tag is missing; updated displayed names.

* **Bug Fixes**
  * More accurate deprecation/deletion detection by honoring the notebook’s last image selection (name:tag) and BYON-aware checks across all resolution paths.
  * Consistent image status evaluation so detail and workbench views reflect tag/commit state.

* **Tests**
  * Updated unit and E2E mocks/assertions to use explicit image tag/version selections and cover deprecated vs deleted scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->