### PR TITLE
Add networking to allow connection in rhoai

### DIFF
--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../core-bases/base
   - federation-configmap.yaml
+  - networkpolicy.yaml
 configMapGenerator:
   - name: modular-architecture-params
     env: params.env

--- a/manifests/modular-architecture/networkpolicy.yaml
+++ b/manifests/modular-architecture/networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: odh-dashboard-allow-ports
+spec:
+  podSelector:
+    matchLabels:
+      deployment: odh-dashboard
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+        - port: 8043
+          protocol: TCP
+      # Empty 'from' means allow from all sources to these ports.

--- a/manifests/rhoai/shared/base/kustomization.yaml
+++ b/manifests/rhoai/shared/base/kustomization.yaml
@@ -66,5 +66,11 @@ patchesJson6902:
       version: v1
       kind: Route
       name: odh-dashboard
+  - path: networkpolicy.yaml
+    target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+      name: odh-dashboard-allow-ports
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/shared/base/networkpolicy.yaml
+++ b/manifests/rhoai/shared/base/networkpolicy.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard-allow-ports
+- op: replace
+  path: /spec/podSelector/matchLabels/deployment
+  value: rhods-dashboard


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Create a Network Rule in RHOAI to allow connection between main dashboard and pods since the namespace is restricted.

This pull request introduces a new `NetworkPolicy` to restrict ingress traffic to the dashboard pods in the modular architecture, and ensures it is properly applied and patched in both the modular and shared base configurations. The main focus is on improving network security and aligning resource naming conventions.

**Network Policy Addition and Configuration:**

* Added a new `networkpolicy.yaml` manifest in `manifests/modular-architecture`, defining a `NetworkPolicy` that allows ingress traffic only on ports 8443 and 8043 to pods labeled with `deployment: odh-dashboard`. This policy allows traffic from all sources to these ports.
* Updated `manifests/modular-architecture/kustomization.yaml` to include the new `networkpolicy.yaml` in the list of managed resources, ensuring it is deployed as part of the modular architecture stack.

**Patch and Naming Consistency:**

* Added a patch entry for `networkpolicy.yaml` in `manifests/rhoai/shared/base/kustomization.yaml`, targeting the `odh-dashboard-allow-ports` `NetworkPolicy`, to ensure the policy is correctly customized in the shared base configuration.
* Created a patch file `manifests/rhoai/shared/base/networkpolicy.yaml` to rename the `NetworkPolicy` and its pod selector from `odh-dashboard-allow-ports`/`odh-dashboard` to `rhods-dashboard-allow-ports`/`rhods-dashboard`, aligning with the shared base resource naming conventions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Create an overlay for rhoai running this in root -> ustomize build manifests/rhoai/addon/ > deployment.yaml
2. Search the network policy generated, it should look like this
```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    app: rhods-dashboard
    app.kubernetes.io/part-of: rhods-dashboard
  name: rhods-dashboard-allow-ports
spec:
  ingress:
  - ports:
    - port: 8443
      protocol: TCP
    - port: 8043
      protocol: TCP
  podSelector:
    matchLabels:
      app: rhods-dashboard
      app.kubernetes.io/part-of: rhods-dashboard
      deployment: rhods-dashboard
  policyTypes:
  - Ingress
```
4. Apply this NetworkPolicy to the rhoai 2.25 release. After refreshing both Model Catalog and Model Registry should be enabled.

<img width="1728" height="962" alt="Screenshot 2025-09-25 at 14 04 39" src="https://github.com/user-attachments/assets/76b69661-4bde-4e54-a749-072bdbbe0ef0" />
<img width="1728" height="964" alt="Screenshot 2025-09-25 at 14 04 03" src="https://github.com/user-attachments/assets/61616dc7-2a45-4c69-a081-e6e3b803cae2" />
<img width="1728" height="962" alt="Screenshot 2025-09-25 at 14 04 57" src="https://github.com/user-attachments/assets/5a4298d5-ff4a-4f43-a59d-b689799c89b8" />


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [X] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
