### PR TITLE
Fix optional chaining for access mode settings in StorageClassEditModal and utils

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -70,7 +70,7 @@ export type StorageClassConfig = {
   isDefault: boolean;
   lastModified: string;
   description?: string;
-  accessModeSettings: AccessModeSettings;
+  accessModeSettings?: AccessModeSettings;
 };
 
 export enum MetadataAnnotation {

--- a/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassEditModal.tsx
@@ -250,7 +250,7 @@ export const StorageClassEditModal: React.FC<StorageClassEditModalProps> = ({
                   data-testid={`edit-sc-access-mode-checkbox-${modeName.toLowerCase()}`}
                   onChange={(_, enabled) => {
                     if (modeName === AccessMode.RWX) {
-                      if (!enabled && storageClassConfig?.accessModeSettings[AccessMode.RWX]) {
+                      if (!enabled && storageClassConfig?.accessModeSettings?.[AccessMode.RWX]) {
                         setShowAccessModeAlert(true);
                       } else {
                         setShowAccessModeAlert(false);

--- a/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
+++ b/frontend/src/pages/storageClasses/StorageClassesTableRow.tsx
@@ -174,7 +174,7 @@ export const StorageClassesTableRow: React.FC<StorageClassesTableRowProps> = ({ 
                           {Object.values(AccessMode)
                             .filter(
                               (accessMode) =>
-                                storageClassConfig.accessModeSettings[accessMode] === true ||
+                                storageClassConfig.accessModeSettings?.[accessMode] === true ||
                                 accessMode === AccessMode.RWO,
                             )
                             .map((accessMode) => (

--- a/frontend/src/pages/storageClasses/utils.ts
+++ b/frontend/src/pages/storageClasses/utils.ts
@@ -31,7 +31,7 @@ export const getPossibleStorageClassAccessModes = (
   // RWO is always supported
   const adminSupportedAccessModes = Object.values(AccessMode).filter(
     (mode) =>
-      selectedStorageClassConfig?.accessModeSettings[mode] === true || mode === AccessMode.RWO,
+      selectedStorageClassConfig?.accessModeSettings?.[mode] === true || mode === AccessMode.RWO,
   );
   return { selectedStorageClassConfig, adminSupportedAccessModes };
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-34959

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
fixes access to non defined param in storage classes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. edit storage class metadata and remove accessModeSettings from the json blob
2. edit a cluster storage pvc that uses that storage class
3. no more error

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
should FIX tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
