### PR TITLE
fix HMR for start:dev:ext

### DIFF
--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -103,7 +103,6 @@ module.exports = smp.wrap(
               {
                 context: ['/api', '/_mf', ...mfProxies],
                 target: `https://${dashboardHost}`,
-                secure: false,
                 changeOrigin: true,
                 headers,
               },
@@ -111,7 +110,6 @@ module.exports = smp.wrap(
                 context: ['/wss'],
                 target: `wss://${dashboardHost}`,
                 ws: true,
-                secure: false,
                 changeOrigin: true,
                 headers,
               },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-34915

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fix HMR for `npm run start:dev:ext`.

Since running `start:dev` worked with HRM, the issue stems from the webpack dev server proxy. Turns out that removing `secure: false` fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Start the frontend using `cd frontend && npm run start:dev:ext`.
- Make a local change to the code and observe the change hot reload in the browser without a page refresh.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A - dev setup only

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development proxy now uses default secure TLS for API and WebSocket connections when using an external cluster.
  * Removed explicit insecure setting for HTTP and WSS proxies in the dev environment, aligning with secure defaults.
  * Developers may need valid certificates for proxied requests during local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->