### PR TITLE
[Cherrypick 2.x] bugfix: add networking to allow connection in rhoai

### DIFF
--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../core-bases/base
   - federation-configmap.yaml
+  - networkpolicy.yaml
 configMapGenerator:
   - name: modular-architecture-params
     env: params.env

--- a/manifests/modular-architecture/networkpolicy.yaml
+++ b/manifests/modular-architecture/networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: odh-dashboard-allow-ports
+spec:
+  podSelector:
+    matchLabels:
+      deployment: odh-dashboard
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+        - port: 8043
+          protocol: TCP
+      # Empty 'from' means allow from all sources to these ports.

--- a/manifests/rhoai/shared/base/kustomization.yaml
+++ b/manifests/rhoai/shared/base/kustomization.yaml
@@ -66,5 +66,11 @@ patchesJson6902:
       version: v1
       kind: Route
       name: odh-dashboard
+  - path: networkpolicy.yaml
+    target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+      name: odh-dashboard-allow-ports
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/shared/base/networkpolicy.yaml
+++ b/manifests/rhoai/shared/base/networkpolicy.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: rhods-dashboard-allow-ports
+- op: replace
+  path: /spec/podSelector/matchLabels/deployment
+  value: rhods-dashboard


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Cherrypicks changes from #4995, see that PR for details

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manifest change only, and this merge results in the same manifests that were already tested for #4995

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
