### PR TITLE
Remove ordering functionality from legacy profiles table

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTable.tsx
@@ -111,7 +111,9 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
     () =>
       hardwareProfileColumns.filter(
         (column) =>
-          (isMigratedTable && column.field !== 'last_modified') ||
+          (isMigratedTable &&
+            column.field !== 'last_modified' &&
+            column.field !== 'drag-drop-handle') ||
           (!isMigratedTable && column.field !== 'source'),
       ),
     [isMigratedTable],
@@ -126,7 +128,7 @@ const HardwareProfilesTable: React.FC<HardwareProfilesTableProps> = ({
     filteredColumns,
     [],
     undefined,
-    true,
+    !isMigratedTable,
   );
   const displayedHardwareProfiles = transformData(orderedHardwareProfiles);
   const currentOrder = displayedHardwareProfiles.map((profile) => profile.metadata.name);

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -85,8 +85,7 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
       <Tr
         key={hardwareProfile.metadata.name}
         id={hardwareProfile.metadata.name}
-        draggable
-        {...props}
+        {...(!migrationAction && { draggable: true, ...props })}
       >
         <Td
           expand={{
@@ -96,11 +95,13 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
             onToggle: onToggleExpansion,
           }}
         />
-        <Td
-          draggableRow={{
-            id: `draggable-row-${hardwareProfile.metadata.name}`,
-          }}
-        />
+        {!migrationAction && (
+          <Td
+            draggableRow={{
+              id: `draggable-row-${hardwareProfile.metadata.name}`,
+            }}
+          />
+        )}
         <Td dataLabel="Name">
           <TableRowTitleDescription
             title={<Truncate content={getHardwareProfileDisplayName(hardwareProfile)} />}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Since legacy hardware profiles will still be available for 2.25, we need to remove the ordering functionality from its table since it will interfere with the hardware profile table ordering. The table ordering was implemented without taking the legacy table into account. 

https://github.com/user-attachments/assets/a2461088-62fc-46af-9d8c-7fdad9165450


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create legacy hardware profiles by either creating accelerator profiles or adding container sizes in odh-dashboard-config
- Go to Settings > Hardware Profiles
- Check that the legacy profiles table does not support ordering, while the hardware profiles table does

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
