### PR TITLE
fix start:dev:ext with psi clusters

### DIFF
--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -103,12 +103,14 @@ module.exports = smp.wrap(
               {
                 context: ['/api', '/_mf', ...mfProxies],
                 target: `https://${dashboardHost}`,
+                secure: false,
                 changeOrigin: true,
                 headers,
               },
               {
-                context: ['/wss'],
+                context: ['/wss/k8s'],
                 target: `wss://${dashboardHost}`,
+                secure: false,
                 ws: true,
                 changeOrigin: true,
                 headers,
@@ -121,7 +123,7 @@ module.exports = smp.wrap(
               target: `http://0.0.0.0:${BACKEND_PORT}`,
             },
             {
-              context: ['/wss'],
+              context: ['/wss/k8s'],
               target: `ws://0.0.0.0:${BACKEND_PORT}`,
               ws: true,
             },


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-34915

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
https://github.com/opendatahub-io/odh-dashboard/pull/4997 was an attempt to fix HMR not working with `start:dev:ext`. While this worked with targeting a ROSA cluster, when running with a PSI cluster the dev workspace failed to load entirely.

Turns out the fix wasn't so much about the `secure` property but rather a conflict with HMR an websockets. Although it's still not entirely clear to me why since HMR uses the `/ws` path. But qualifying the the proxy context with `/wss/k8s` seems to fix hmr with ROSA clusters and therefore we can reinstate `secure: false` to fix PSI clusters.

Note that we use websockets for projects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Login to a ROSA cluster and then repeat with a PSI cluster:
- `npm run start:dev:ext`.
- Make a change and observe hot module reloading work to update the page without a full page refresh
- Try again with `npm run start:dev`

Testing web sockets still work for project updates.
- open two windows to the projects list page
- create a project in one window
- observe the project immediately appear in the other window
- delete the project
- observe the update immediately in the other window

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved WebSocket connectivity issues in development by updating proxy paths and permitting non-secure connections where needed, improving live updates during local runs.

* **Chores**
  * Aligned development proxy settings with current backend endpoints and protocols to ensure smoother behavior of the dev server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->