### PR TITLE
[WIP] Clean actions cache workflow

### DIFF
--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 1000 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,15 @@ jobs:
         uses: actions/cache@v4
         id: modules-cache
         with:
-          lookup-only: true
           path: |
             ~/.cache/Cypress
             **/node_modules
           key: ${{ steps.key.outputs.modules-cache-key }}
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        if: steps.modules-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
-        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Check for uncommitted changes
@@ -52,11 +49,12 @@ jobs:
           path: |
             ~/.cache/Cypress
             **/node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-all-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ needs.Setup.outputs.modules-cache-key }}
       - name: Cache turbo
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.turbo
+          path: |
+            **/.turbo
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-type-check
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
@@ -78,11 +76,12 @@ jobs:
           path: |
             ~/.cache/Cypress
             **/node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-all-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ needs.Setup.outputs.modules-cache-key }}
       - name: Cache turbo
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.turbo
+          path: |
+            **/.turbo
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-lint
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
@@ -108,7 +107,8 @@ jobs:
       - name: Cache turbo
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.turbo
+          path: |
+            **/.turbo
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-unit-tests
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

An actions to clean up github actions cache when a PR closes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
