### PR TITLE
[fix] Add check to ensure we don't install LSD twice

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
@@ -154,59 +154,89 @@ func (m *TokenKubernetesClientMock) GetUser(ctx context.Context, identity *integ
 
 // GetLlamaStackDistributions returns mock LSD list for testing
 func (m *TokenKubernetesClientMock) GetLlamaStackDistributions(ctx context.Context, identity *integrations.RequestIdentity, namespace string) (*lsdapi.LlamaStackDistributionList, error) {
-	// Return empty list for mock-test-namespace-1 to test empty state
+	// Special case: mock-test-namespace-1 should always return empty list for testing empty state
 	if namespace == "mock-test-namespace-1" {
 		return &lsdapi.LlamaStackDistributionList{
 			Items: []lsdapi.LlamaStackDistribution{},
 		}, nil
 	}
 
-	// For all other namespaces, return mock LSD data
-	return &lsdapi.LlamaStackDistributionList{
-		Items: []lsdapi.LlamaStackDistribution{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "mock-lsd",
-					Annotations: map[string]string{
-						"openshift.io/display-name": "mock-lsd-display-name",
-					},
-					Labels: map[string]string{
-						"opendatahub.io/dashboard": "true",
-					},
-				},
-				Status: lsdapi.LlamaStackDistributionStatus{
-					Phase: lsdapi.LlamaStackDistributionPhaseReady,
-					Version: lsdapi.VersionInfo{
-						LlamaStackServerVersion: "v0.2.0",
-					},
-					ServiceURL: "http://mock-lsd.test-namespace.svc.cluster.local:8321",
-					DistributionConfig: lsdapi.DistributionConfig{
-						ActiveDistribution: "mock-distribution",
-						Providers: []lsdapi.ProviderInfo{
-							{
-								ProviderID:   "mock-provider",
-								ProviderType: "mock-type",
-								API:          "mock-api",
-							},
+	// For other namespaces, first try to query the real cluster for LSD resources
+	var lsdList lsdapi.LlamaStackDistributionList
+	err := m.Client.List(ctx, &lsdList, client.InNamespace(namespace))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LlamaStackDistributions: %w", err)
+	}
+
+	// If we found real LSD resources in the cluster, return them
+	if len(lsdList.Items) > 0 {
+		return &lsdList, nil
+	}
+
+	// For namespaces that should return mock LSD data (for testing existing LSD scenarios)
+	if namespace == "mock-test-namespace-2" || namespace == "test-namespace" {
+		return &lsdapi.LlamaStackDistributionList{
+			Items: []lsdapi.LlamaStackDistribution{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mock-lsd",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"openshift.io/display-name": "mock-lsd-display-name",
 						},
-						AvailableDistributions: map[string]string{
-							"mock-distribution": "mock-image:latest",
+						Labels: map[string]string{
+							"opendatahub.io/dashboard": "true",
+						},
+					},
+					Status: lsdapi.LlamaStackDistributionStatus{
+						Phase: lsdapi.LlamaStackDistributionPhaseReady,
+						Version: lsdapi.VersionInfo{
+							LlamaStackServerVersion: "v0.2.0",
+						},
+						ServiceURL: "http://mock-lsd.test-namespace.svc.cluster.local:8321",
+						DistributionConfig: lsdapi.DistributionConfig{
+							ActiveDistribution: "mock-distribution",
+							Providers: []lsdapi.ProviderInfo{
+								{
+									ProviderID:   "mock-provider",
+									ProviderType: "mock-type",
+									API:          "mock-api",
+								},
+							},
+							AvailableDistributions: map[string]string{
+								"mock-distribution": "mock-image:latest",
+							},
 						},
 					},
 				},
 			},
-		},
+		}, nil
+	}
+
+	// For all other namespaces, return empty list (no existing LSDs)
+	return &lsdapi.LlamaStackDistributionList{
+		Items: []lsdapi.LlamaStackDistribution{},
 	}, nil
 }
 
 func (m *TokenKubernetesClientMock) InstallLlamaStackDistribution(ctx context.Context, identity *integrations.RequestIdentity, namespace string, models []string) (*lsdapi.LlamaStackDistribution, error) {
+	// Check if LSD already exists in the namespace
+	existingLSDList, err := m.GetLlamaStackDistributions(ctx, identity, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing LlamaStackDistribution: %w", err)
+	}
+
+	if len(existingLSDList.Items) > 0 {
+		return nil, fmt.Errorf("LlamaStackDistribution already exists in namespace %s", namespace)
+	}
+
 	// First ensure the namespace exists
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
 	}
-	err := m.Client.Create(ctx, ns)
+	err = m.Client.Create(ctx, ns)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("failed to create namespace %s: %w", namespace, err)
 	}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -406,6 +406,16 @@ func (kc *TokenKubernetesClient) InstallLlamaStackDistribution(ctx context.Conte
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
+	// Check if LSD already exists in the namespace
+	existingLSDList, err := kc.GetLlamaStackDistributions(ctx, identity, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing LlamaStackDistribution: %w", err)
+	}
+
+	if len(existingLSDList.Items) > 0 {
+		return nil, fmt.Errorf("LlamaStackDistribution already exists in namespace %s", namespace)
+	}
+
 	// Step 1: Create LlamaStackDistribution resource first
 
 	configMapName := "llama-stack-config"


### PR DESCRIPTION
Add check to ensure we don't end up installing LSD more than once

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate LlamaStackDistribution installs with a clear “already exists in namespace” error.
  - Now checks the cluster for existing distributions before install and consistently handles absent resources; test/mock namespaces are treated specially to avoid false positives.

- Tests
  - Expanded coverage for existing-distribution, install, and delete flows.
  - Uses per-test, time-based namespaces and updated test assertions to isolate runs and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->