### PR TITLE
fix: broken model urls and failure to get inference service

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -726,6 +726,7 @@ benchmarks: []
 tool_groups:
 - toolgroup_id: builtin::rag
   provider_id: rag-runtime
+external_providers_dir: /opt/app-root/.llama/providers.d
 server:
   port: 8321`, providersYAML, modelsYAML)
 
@@ -735,7 +736,8 @@ server:
 // getModelDetailsFromServingRuntime queries the serving runtime and inference service
 // to get detailed model configuration information
 func (kc *TokenKubernetesClient) getModelDetailsFromServingRuntime(ctx context.Context, namespace string, modelID string) (map[string]interface{}, error) {
-	targetISVC, err := kc.findInferenceServiceByName(ctx, namespace, modelID)
+	// Find InferenceService by name
+	targetISVC, err := kc.findInferenceServiceByModelName(ctx, namespace, modelID)
 	if err != nil {
 		kc.Logger.Error("failed to find InferenceService for model", "modelID", modelID, "error", err)
 		return nil, fmt.Errorf("InferenceService for model '%s' not found: %w", modelID, err)
@@ -743,23 +745,35 @@ func (kc *TokenKubernetesClient) getModelDetailsFromServingRuntime(ctx context.C
 
 	// Extract the internal URL from the InferenceService status
 	// Use Status.URL which is already the internal HTTP address
-	if targetISVC.Status.URL == nil {
+	if targetISVC.Status.Address.URL == nil {
 		kc.Logger.Error("InferenceService has no internal URL", "name", targetISVC.Name, "namespace", namespace)
 		return nil, fmt.Errorf("InferenceService '%s' has no internal URL - service may not be ready", targetISVC.Name)
 	}
 
-	// Convert URL pointer to string
-	internalURL := targetISVC.Status.URL.String()
+	// When routes are enabled, the Status.URL is the route URL, not the internal URL so we use the Address.URL
+	internalURL := targetISVC.Status.Address.URL.URL()
+	currentPort := internalURL.Port()
+	hostname := internalURL.Hostname()
 
-	// Check if port is already present (look for :port pattern after the hostname)
-	// We need to check for :port after the hostname, not just any colon (http:// has a colon)
-	if !strings.Contains(internalURL, ".svc.cluster.local:") {
-		internalURL = internalURL + ":80"
+	// Auth Inference Services should always have the auth annotation and include the 8443 port
+	if targetISVC.Annotations["security.opendatahub.io/enable-auth"] == "true" {
+		if currentPort != "8443" {
+			internalURL.Host = hostname + ":8443"
+		}
+	} else {
+		// For non-auth services, ensure http scheme and 8080 port
+		if internalURL.Scheme == "https" {
+			internalURL.Scheme = "http"
+		}
+		if currentPort != "8080" {
+			internalURL.Host = hostname + ":8080"
+		}
 	}
 
+	internalURLStr := internalURL.String()
 	// Add /v1 suffix if not present
-	if !strings.HasSuffix(internalURL, "/v1") {
-		internalURL = internalURL + "/v1"
+	if !strings.HasSuffix(internalURLStr, "/v1") {
+		internalURLStr = internalURLStr + "/v1"
 	}
 
 	// Extract additional metadata from the InferenceService
@@ -782,12 +796,12 @@ func (kc *TokenKubernetesClient) getModelDetailsFromServingRuntime(ctx context.C
 		"provider_id":  providerID,
 		"model_type":   modelType,
 		"metadata":     metadata,
-		"endpoint_url": internalURL,
+		"endpoint_url": internalURLStr,
 	}, nil
 }
 
-// findInferenceServiceByName finds an InferenceService by its k8s name
-func (kc *TokenKubernetesClient) findInferenceServiceByName(ctx context.Context, namespace, modelName string) (*kservev1beta1.InferenceService, error) {
+// findInferenceServiceByModelName finds an InferenceService by its display name annotation
+func (kc *TokenKubernetesClient) findInferenceServiceByModelName(ctx context.Context, namespace, modelName string) (*kservev1beta1.InferenceService, error) {
 	// List all InferenceServices in the namespace
 	var isvcList kservev1beta1.InferenceServiceList
 	err := kc.Client.List(ctx, &isvcList, client.InNamespace(namespace))
@@ -796,15 +810,15 @@ func (kc *TokenKubernetesClient) findInferenceServiceByName(ctx context.Context,
 		return nil, fmt.Errorf("failed to list InferenceServices in namespace %s: %w", namespace, err)
 	}
 
-	// Find InferenceService with matching k8s name
+	// Find InferenceService with name matching the model name
 	for _, isvc := range isvcList.Items {
 		if isvc.Name == modelName {
-			kc.Logger.Info("found InferenceService by name", "modelName", modelName, "isvcName", isvc.Name, "namespace", namespace)
+			kc.Logger.Info("found InferenceService by model name", "modelName", modelName, "isvcName", isvc.Name, "namespace", namespace)
 			return &isvc, nil
 		}
 	}
 
-	return nil, fmt.Errorf("InferenceService with name '%s' not found in namespace %s", modelName, namespace)
+	return nil, fmt.Errorf("InferenceService with model name '%s' not found in namespace %s", modelName, namespace)
 }
 
 func (kc *TokenKubernetesClient) DeleteLlamaStackDistribution(ctx context.Context, identity *integrations.RequestIdentity, namespace string, name string) (*lsdapi.LlamaStackDistribution, error) {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixed model URLs being incorrectly configured and choosing to match the inference service name with the model name rather than display name as it si
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test rag playground creation:
ODH root .env.local file:
``` bash
APP_ENV=local
OC_URL=****
OC_PROJECT=****
OC_USER=****
OC_PASSWORD=****
ODH_APP=****
```

Gen-AI BFF run:
``` bash
cd packages/gen-ai/bff
AUTH_METHOD=user_token 
AUTH_TOKEN_HEADER=Authorization AUTH_TOKEN_PREFIX="Bearer " 
make run STATIC_ASSETS_DIR=../frontend/dist
```

Gen-AI frontend, ODH backend, and ODH backend:
``` bash
cd packages/gen-ai/frontend/
npm run start:dev
```

``` bash
cd backend
npm run start:dev
```

``` bash
cd frontend
npm run start:dev
```

Create a model deployment and a Rag Playground after enabling the genai plugin feature flag
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Generated configs now include an external providers directory for easier provider integration.

- Bug Fixes
  - Model lookup now matches by model name for more reliable resolution and clearer messages.
  - Improved endpoint handling: prefer service address, handle missing internal URLs, adjust host/port and scheme based on route/auth settings, and construct stable endpoint URLs including API path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->