### PR TITLE
dw permission ux fix

### DIFF
--- a/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
+++ b/frontend/src/concepts/distributedWorkloads/DistributedWorkloadsContext.tsx
@@ -10,11 +10,13 @@ import { useMakeFetchObject } from '#~/utilities/useMakeFetchObject';
 import {
   DEFAULT_DW_PROJECT_CURRENT_METRICS,
   DWProjectCurrentMetrics,
+  getGenericErrorCode,
   useDWProjectCurrentMetrics,
 } from '#~/api';
 import { RefreshIntervalValue } from '#~/concepts/metrics/const';
 import { MetricsCommonContext } from '#~/concepts/metrics/MetricsCommonContext';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
+import PermissionsNotSet from './PermissionsNotSet';
 import useClusterQueues from './useClusterQueues';
 import useLocalQueues from './useLocalQueues';
 import useWorkloads from './useWorkloads';
@@ -103,6 +105,11 @@ export const DistributedWorkloadsContextProvider =
     )?.error;
 
     if (fetchError) {
+      const errorCode = getGenericErrorCode(fetchError);
+      if (errorCode === 403) {
+        return <PermissionsNotSet />;
+      }
+
       return (
         <Bullseye>
           <Alert title="Workload metrics load error" variant="danger" isInline>

--- a/frontend/src/concepts/distributedWorkloads/PermissionsNotSet.tsx
+++ b/frontend/src/concepts/distributedWorkloads/PermissionsNotSet.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
+import { WrenchIcon } from '@patternfly/react-icons';
+import WhosMyAdministrator from '#~/components/WhosMyAdministrator.tsx';
+
+const PermissionsNotSet: React.FC = () => (
+  <EmptyState headingLevel="h4" icon={WrenchIcon} titleText="Request Distributed Workloads access">
+    <EmptyStateBody>
+      To monitor your distributed workload metrics, request that your administrator grant you access
+      to this page.
+    </EmptyStateBody>
+    <EmptyStateFooter>
+      <WhosMyAdministrator />
+    </EmptyStateFooter>
+  </EmptyState>
+);
+
+export default PermissionsNotSet;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-35109

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Distributed Workloads needed to update the way permissions is propagated throughout the cluster which exposed Dashboard to a new UX flow that needs to be handled. Not-yet configured DW permissions.

This adds that UX flow page for when permissions (403) gaps happen for a project/user.

<img width="1609" height="571" alt="image" src="https://github.com/user-attachments/assets/81892984-018b-4eec-8001-bf68e0f7083b" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the cluster -- setting up Kueue & viewing the Distributed Workloads page with a basic user (aka not a cluster-admin) -- so permissions can be invoked against it. 

If you're running an older ODH cluster -- you'll want to spin down the operator and delete the `kueue-batch-user-role` cluster role. ODH should get this update soon.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A -- just a new condition in rendering

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Request Distributed Workloads access” screen when access is restricted, replacing the generic error alert.
  * Provides clear guidance on how to obtain access and includes a shortcut to identify the appropriate administrator.
  * Improves clarity for permission-related issues while preserving the existing experience for all other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->