### PR TITLE
Add Delete Action for LLMd

### DIFF
--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -80,7 +80,7 @@ const extensions: (
     },
   },
   {
-    type: 'model-serving.platform/delete-modal',
+    type: 'model-serving.platform/delete-deployment',
     properties: {
       platform: KSERVE_ID,
       onDelete: () => import('./src/deployments').then((m) => m.deleteDeployment),

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -2,6 +2,7 @@ import type {
   DeployedModelServingDetails,
   ModelServingDeploymentFormDataExtension,
   ModelServingPlatformWatchDeploymentsExtension,
+  ModelServingDeleteModal,
 } from '@odh-dashboard/model-serving/extension-points';
 import type { LLMdDeployment } from '../src/types';
 
@@ -11,6 +12,7 @@ const extensions: (
   | ModelServingPlatformWatchDeploymentsExtension<LLMdDeployment>
   | DeployedModelServingDetails<LLMdDeployment>
   | ModelServingDeploymentFormDataExtension<LLMdDeployment>
+  | ModelServingDeleteModal<LLMdDeployment>
 )[] = [
   {
     type: 'model-serving.platform/watch-deployments',
@@ -36,6 +38,15 @@ const extensions: (
       extractModelFormat: () =>
         import('../src/deployments/model').then((m) => m.extractModelFormat),
       extractReplicas: () => import('../src/deployments/hardware').then((m) => m.extractReplicas),
+    },
+  },
+  {
+    type: 'model-serving.platform/delete-deployment',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      onDelete: () => import('../src/deployments').then((m) => m.deleteDeployment),
+      title: 'Delete model deployment?',
+      submitButtonLabel: 'Delete model deployment',
     },
   },
 ];

--- a/packages/llmd-serving/src/deployments.ts
+++ b/packages/llmd-serving/src/deployments.ts
@@ -1,0 +1,17 @@
+import { k8sDeleteResource, K8sStatus } from '@openshift/dynamic-plugin-sdk-utils';
+import { Deployment } from '@odh-dashboard/model-serving/extension-points';
+import { LLMInferenceServiceModel, type LLMdDeployment } from './types';
+import { LLMD_SERVING_ID } from '../extensions/extensions';
+
+export const isLLMdDeployment = (deployment: Deployment): deployment is LLMdDeployment =>
+  deployment.modelServingPlatformId === LLMD_SERVING_ID;
+
+export const deleteDeployment = async (deployment: LLMdDeployment): Promise<void> => {
+  await k8sDeleteResource<typeof LLMInferenceServiceModel, K8sStatus>({
+    model: LLMInferenceServiceModel,
+    queryOptions: {
+      name: deployment.model.metadata.name,
+      ns: deployment.model.metadata.namespace,
+    },
+  });
+};

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -185,7 +185,7 @@ export const isModelServingDeploymentsTableExtension = <D extends Deployment = D
   extension.type === 'model-serving.deployments-table';
 
 export type ModelServingDeleteModal<D extends Deployment = Deployment> = Extension<
-  'model-serving.platform/delete-modal',
+  'model-serving.platform/delete-deployment',
   {
     platform: D['modelServingPlatformId'];
     onDelete: CodeRef<(deployment: D) => Promise<void>>;
@@ -197,7 +197,7 @@ export type ModelServingDeleteModal<D extends Deployment = Deployment> = Extensi
 export const isModelServingDeleteModal = <D extends Deployment = Deployment>(
   extension: Extension,
 ): extension is ModelServingDeleteModal<D> =>
-  extension.type === 'model-serving.platform/delete-modal';
+  extension.type === 'model-serving.platform/delete-deployment';
 
 export type ModelServingMetricsExtension<D extends Deployment = Deployment> = Extension<
   'model-serving.metrics',

--- a/packages/model-serving/src/components/deleteModal/DeleteModelServingModal.tsx
+++ b/packages/model-serving/src/components/deleteModal/DeleteModelServingModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import DeleteModal from '@odh-dashboard/internal/pages/projects/components/DeleteModal';
 import {
@@ -50,24 +49,20 @@ const DeleteModelServingModal: React.FC<DeleteModelServingModalProps> = ({
     setError(undefined);
   };
 
-  return !deleteModalLoaded || !deleteModal ? (
-    <Bullseye>
-      <Spinner />
-    </Bullseye>
-  ) : (
-    getDisplayNameFromK8sResource(deployment.model) && (
-      <DeleteModal
-        title={deleteModal.properties.title}
-        onClose={() => onBeforeClose(false)}
-        submitButtonLabel={deleteModal.properties.submitButtonLabel}
-        onDelete={onDelete}
-        deleting={isDeleting}
-        error={error}
-        deleteName={getDisplayNameFromK8sResource(deployment.model)}
-      >
-        This action cannot be undone.
-      </DeleteModal>
-    )
-  );
+  return !deleteModalLoaded || !deleteModal
+    ? null
+    : getDisplayNameFromK8sResource(deployment.model) && (
+        <DeleteModal
+          title={deleteModal.properties.title}
+          onClose={() => onBeforeClose(false)}
+          submitButtonLabel={deleteModal.properties.submitButtonLabel}
+          onDelete={onDelete}
+          deleting={isDeleting}
+          error={error}
+          deleteName={getDisplayNameFromK8sResource(deployment.model)}
+        >
+          This action cannot be undone.
+        </DeleteModal>
+      );
 };
 export default DeleteModelServingModal;


### PR DESCRIPTION
Closes: [RHOAIENG-32271](https://issues.redhat.com/browse/RHOAIENG-32271)

## Description
Allows you to delete a llm-d deployment. Also updates instances of `delete-modal` to be `delete-deployment`.

## How Has This Been Tested?
Tested locally. Manually deploy an llm-d deployment on your project
```
apiVersion: serving.kserve.io/v1alpha1
kind: LLMInferenceService
metadata:
  name: facebook-opt-125m-single
spec:
  model:
    uri: hf://facebook/opt-125m
    name: facebook/opt-125m
  replicas: 1
  router:
    scheduler: { }
    route: { }
    gateway: { }
  template:
    containers:
      - name: main
        image: quay.io/pierdipi/vllm-cpu:latest
        env:
          - name: VLLM_LOGGING_LEVEL
            value: DEBUG
        resources:
          limits:
            cpu: '1'
            memory: 10Gi
          requests:
            cpu: '100m'
            memory: 8Gi
        livenessProbe:
          initialDelaySeconds: 30
          periodSeconds: 30
          timeoutSeconds: 30
          failureThreshold: 5
``` 
You should be able to delete the deployment in the kebab options 

## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to delete LLMd model deployments directly from the platform.
  - Unified delete action across model-serving platforms for a consistent experience.

- Style
  - Streamlined delete dialog behavior: removed intermediate loading spinner; dialog appears when ready.

- Refactor
  - Harmonized delete integration to ensure consistent delete prompts and actions across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->