### PR TITLE
feat: Add previous response ID support for conversation continuity

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -301,6 +301,8 @@ type CreateResponseParams struct {
 	Instructions string
 	// Tools contains MCP server configurations for tool-enabled responses.
 	Tools []MCPServerParam
+	// PreviousResponseID links this response to a previous response for conversation continuity.
+	PreviousResponseID string
 }
 
 // prepareResponseParams validates input parameters and prepares the API parameters for response creation.
@@ -417,6 +419,11 @@ func (c *LlamaStackClient) prepareResponseParams(params CreateResponseParams) (*
 		apiParams.Tools = tools
 	}
 
+	// Set previous response ID if provided
+	if params.PreviousResponseID != "" {
+		apiParams.PreviousResponseID = openai.String(params.PreviousResponseID)
+	}
+
 	return apiParams, nil
 }
 
@@ -458,6 +465,20 @@ func (c *LlamaStackClient) DeleteVectorStore(ctx context.Context, vectorStoreID 
 	}
 
 	return nil
+}
+
+// GetResponse retrieves a response by ID for validation purposes.
+func (c *LlamaStackClient) GetResponse(ctx context.Context, responseID string) (*responses.Response, error) {
+	if responseID == "" {
+		return nil, fmt.Errorf("responseID is required")
+	}
+
+	response, err := c.client.Responses.Get(ctx, responseID, responses.ResponseGetParams{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response: %w", err)
+	}
+
+	return response, nil
 }
 
 // ListFiles retrieves files with optional filtering parameters.

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
@@ -21,6 +21,7 @@ type LlamaStackClientInterface interface {
 	DeleteVectorStoreFile(ctx context.Context, vectorStoreID, fileID string) error
 	CreateResponse(ctx context.Context, params CreateResponseParams) (*responses.Response, error)
 	CreateResponseStream(ctx context.Context, params CreateResponseParams) (*ssestream.Stream[responses.ResponseStreamEventUnion], error)
+	GetResponse(ctx context.Context, responseID string) (*responses.Response, error)
 }
 
 // LlamaStackClientFactory interface for creating LlamaStack clients

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_factory_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_factory_mock.go
@@ -5,14 +5,24 @@ import (
 )
 
 // MockClientFactory creates mock LlamaStack clients following the model registry pattern
-type MockClientFactory struct{}
+type MockClientFactory struct {
+	mockClient *MockLlamaStackClient
+}
 
 // NewMockClientFactory creates a factory for mock LlamaStack clients
-func NewMockClientFactory() llamastack.LlamaStackClientFactory {
+func NewMockClientFactory() *MockClientFactory {
 	return &MockClientFactory{}
+}
+
+// SetMockClient sets a specific mock client to be returned by CreateClient
+func (f *MockClientFactory) SetMockClient(client *MockLlamaStackClient) {
+	f.mockClient = client
 }
 
 // CreateClient creates a new mock LlamaStack client (ignores baseURL for mocks)
 func (f *MockClientFactory) CreateClient(baseURL string) llamastack.LlamaStackClientInterface {
+	if f.mockClient != nil {
+		return f.mockClient
+	}
 	return NewMockLlamaStackClient()
 }

--- a/packages/gen-ai/bff/internal/repositories/lsd_responses.go
+++ b/packages/gen-ai/bff/internal/repositories/lsd_responses.go
@@ -50,3 +50,16 @@ func (r *ResponsesRepository) CreateResponseStream(ctx context.Context, params l
 func (r *ResponsesRepository) GetClient(ctx context.Context) (llamastack.LlamaStackClientInterface, error) {
 	return helper.GetContextLlamaStackClient(ctx)
 }
+
+// GetResponse retrieves a response by ID for validation purposes
+func (r *ResponsesRepository) GetResponse(ctx context.Context, responseID string) (*responses.Response, error) {
+	// Get ready-to-use LlamaStack client from context using helper
+	client, err := helper.GetContextLlamaStackClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Repository layer can add transformation logic here if needed
+	// For now, direct passthrough from client to handler
+	return client.GetResponse(ctx, responseID)
+}

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -1678,7 +1678,13 @@ components:
               content: 'Artificial intelligence (AI) is a branch of computer science that aims to create machines capable of intelligent behavior, learning, and decision-making.'
             - role: 'user'
               content: 'Can you give me some examples?'
-          description: Full conversation history for multi-turn conversations
+          description: >-
+            Full conversation history for multi-turn conversations. Each message includes role (user/assistant)
+            and content. The system will use this context to maintain conversation flow and provide
+            contextually relevant responses. Messages should be ordered chronologically.
+            
+            **Note**: Cannot be used together with `previous_response_id`. Use either manual conversation history
+            via `chat_context` or automatic conversation threading via `previous_response_id`.
 
         # === GENERATION PARAMETERS ===
         temperature:
@@ -1719,6 +1725,16 @@ components:
                 Authorization: 'Bearer github_token_456'
                 X-API-Version: 'v1'
           description: MCP server configurations for external tool access. Each server can have its own authentication headers and provides multiple tools.
+        previous_response_id:
+          type: string
+          example: 'resp-abc123-def456'
+          description: >-
+            Optional reference to a previous response ID for conversation continuity and thread tracking.
+            When provided, the system validates that the response exists and links the new response to it.
+            This enables conversation threading and context reconstruction from response chains.
+            
+            **Note**: Cannot be used together with `chat_context`. Use either manual conversation history
+            via `chat_context` or automatic conversation threading via `previous_response_id`.
 
     # Clean Response Schema - Preserves LlamaStack Structure
     ResponseData:
@@ -1752,6 +1768,13 @@ components:
           items:
             $ref: '#/components/schemas/OutputItem'
           description: Array of output items (messages, tool calls, etc.)
+        previous_response_id:
+          type: string
+          example: 'resp-xyz789-abc123'
+          description: >-
+            Reference to the previous response ID in the conversation thread.
+            Only present when the request included a previous_response_id parameter.
+            Enables conversation continuity and thread tracking.
 
     OutputItem:
       type: object


### PR DESCRIPTION
feat: Add previous response ID support for conversation continuity ([RHOAIENG-35191](https://issues.redhat.com//browse/RHOAIENG-35191))
## Description

* feat: Add previous_response_id parameter to responses API for conversation threading
* feat: Add response validation and linking logic in handler and repository layers
* feat: Update LlamaStack client to pass previous_response_id to API
* feat: Add backward compatibility validation preventing chat_context and previous_response_id together
* test: Add comprehensive unit tests for response linking functionality
* docs: Update OpenAPI specification with new parameter and mutual exclusivity notes
* feat: Add mock client support for testing previous response ID functionality

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
```
curl -X 'POST' \
  'http://localhost:8080/gen-ai/api/v1/lsd/responses?namespace=llamastack' \
  -H 'accept: text/event-stream' \
  -H 'Authorization: Bearer sha256~cp8SZnWl1bUsk_9g-34YM52NDZmVjRxlgRKyMusEGio' \
  -H 'Content-Type: application/json' \
  -d '{
  
  "input": "Tell me about artificial intelligence",
  "instructions": "You are a helpful AI assistant that provides detailed explanations.",
  "model": "meta-llama/Llama-3.2-3B-Instruct",
  "previous_response_id": "",
  "stream": false,
  "temperature": 0.7,
  "top_p": 0.9
}'

```
get the `id` from the response and use it as `previous_response_id` in the subsequent request:

```
{
  
  "input": "What is the opposite of it?",
  "instructions": "You are a helpful AI assistant that provides detailed explanations.",
  "model": "meta-llama/Llama-3.2-3B-Instruct",
  "previous_response_id": "resp-dcad0e92-90b9-44aa-b11f-0146d074ec57",
  "stream": false,
  "temperature": 0.7,
  "top_p": 0.9
}
```




## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
unit tests and manual tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added previous_response_id to requests and responses to link a reply to a prior one, supporting threaded conversations.
  - Works in both streaming and non-streaming responses.
  - Validation enforces that previous_response_id cannot be used with chat_context and must reference an accessible response.

- Documentation
  - OpenAPI updated to include previous_response_id across relevant schemas and document mutual exclusivity with chat_context.

- Tests
  - Added comprehensive tests covering valid/invalid previous_response_id, mutual exclusivity errors, status codes, and payload propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->