### PR TITLE
Remove delete button for the OOTB hardware profile

### DIFF
--- a/frontend/src/__mocks__/mockHardwareProfile.ts
+++ b/frontend/src/__mocks__/mockHardwareProfile.ts
@@ -20,7 +20,7 @@ type MockResourceConfigType = {
   description?: string;
   enabled?: boolean;
   nodeSelector?: NodeSelector;
-  schedulingType?: SchedulingType;
+  schedulingType?: SchedulingType | '';
   localQueueName?: string;
   priorityClass?: string;
   tolerations?: Toleration[];
@@ -88,21 +88,23 @@ export const mockHardwareProfile = ({
   },
   spec: {
     identifiers,
-    scheduling: {
-      type: schedulingType,
-      ...(schedulingType === SchedulingType.QUEUE && {
-        kueue: {
-          localQueueName,
-          priorityClass,
-        },
-      }),
-      ...(schedulingType === SchedulingType.NODE && {
-        node: {
-          ...(nodeSelector ? { nodeSelector } : {}),
-          tolerations,
-        },
-      }),
-    },
+    ...(schedulingType && {
+      scheduling: {
+        type: schedulingType,
+        ...(schedulingType === SchedulingType.QUEUE && {
+          kueue: {
+            localQueueName,
+            priorityClass,
+          },
+        }),
+        ...(schedulingType === SchedulingType.NODE && {
+          node: {
+            ...(nodeSelector ? { nodeSelector } : {}),
+            tolerations,
+          },
+        }),
+      },
+    }),
   },
 });
 
@@ -340,3 +342,42 @@ export const mockProjectScopedHardwareProfiles = [
     ],
   }),
 ];
+
+export const mockDefaultHardwareProfile = mockHardwareProfile({
+  name: 'default-profile',
+  namespace: 'opendatahub',
+  displayName: 'default-profile',
+  description:
+    'Provides a baseline hardware profile with 2 CPUs and 4Gi memory by default, adjustable up to 4 CPUs and 8Gi memory.',
+  identifiers: [
+    {
+      displayName: 'CPU',
+      identifier: 'cpu',
+      minCount: '1',
+      maxCount: '4',
+      defaultCount: '2',
+      resourceType: IdentifierResourceType.CPU,
+    },
+    {
+      displayName: 'Memory',
+      identifier: 'memory',
+      minCount: '2Gi',
+      maxCount: '8Gi',
+      defaultCount: '4Gi',
+      resourceType: IdentifierResourceType.MEMORY,
+    },
+  ],
+  annotations: {
+    'internal.config.kubernetes.io/previousKinds': 'HardwareProfile',
+    'internal.config.kubernetes.io/previousNames': 'default-profile',
+    'internal.config.kubernetes.io/previousNamespaces': 'opendatahub',
+    'opendatahub.io/dashboard-feature-visibility': '[]',
+    'opendatahub.io/disabled': 'false',
+    'opendatahub.io/managed': 'false',
+  },
+  labels: {
+    'app.kubernetes.io/part-of': 'hardwareprofile',
+    'app.opendatahub.io/hardwareprofile': 'true',
+  },
+  schedulingType: '',
+});

--- a/frontend/src/__tests__/cypress/cypress/pages/components/table.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/components/table.ts
@@ -16,8 +16,9 @@ export class TableRow extends Contextual<HTMLTableRowElement> {
     return this;
   }
 
-  findKebabAction(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findKebabAction(name).should('exist').and('be.visible');
+  findKebabAction(name: string, verify = true): Cypress.Chainable<JQuery<HTMLElement>> {
+    const kebabAction = this.find().findKebabAction(name);
+    return verify ? kebabAction.should('exist').and('be.visible') : kebabAction;
   }
 
   findKebab(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
@@ -1,5 +1,5 @@
 import { hardwareProfile } from '#~/__tests__/cypress/cypress/pages/hardwareProfile';
-import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import { mockDefaultHardwareProfile, mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { deleteModal } from '#~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import {
   HardwareProfileModel,
@@ -184,6 +184,29 @@ describe('Hardware Profile', () => {
           },
         ]);
       });
+    });
+
+    it('should not show the delete action button for the default profile, but should for regular profiles', () => {
+      cy.interceptK8sList(
+        { model: HardwareProfileModel, ns: 'opendatahub' },
+        mockK8sResourceList([
+          mockDefaultHardwareProfile,
+          mockHardwareProfile({
+            name: 'custom-profile',
+            displayName: 'Custom Profile',
+          }),
+        ]),
+      );
+      hardwareProfile.visit();
+
+      // Default profile should not have delete option
+      hardwareProfile
+        .getRow('default-profile')
+        .findKebabAction('Delete', false)
+        .should('not.exist');
+
+      // Custom profile should have delete option
+      hardwareProfile.getRow('Custom Profile').findKebabAction('Delete').should('exist');
     });
   });
 

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -28,6 +28,7 @@ import {
   createHardwareProfileWarningTitle,
   getHardwareProfileDescription,
   getHardwareProfileDisplayName,
+  isDefaultHardwareProfile,
   validateProfileWarning,
 } from '#~/pages/hardwareProfiles/utils';
 import { HardwareProfileModel } from '#~/api';
@@ -201,16 +202,20 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
                 verbModelAccess('create', HardwareProfileModel),
               ),
               ...useKebabAccessAllowed([], verbModelAccess('create', HardwareProfileModel)),
-              ...useKebabAccessAllowed(
-                [
-                  { isSeparator: true },
-                  {
-                    title: 'Delete',
-                    onClick: () => handleDelete(hardwareProfile),
-                  },
-                ],
-                verbModelAccess('delete', HardwareProfileModel),
-              ),
+              ...(!isDefaultHardwareProfile(hardwareProfile)
+                ? [
+                    ...useKebabAccessAllowed(
+                      [
+                        { isSeparator: true },
+                        {
+                          title: 'Delete',
+                          onClick: () => handleDelete(hardwareProfile),
+                        },
+                      ],
+                      verbModelAccess('delete', HardwareProfileModel),
+                    ),
+                  ]
+                : []),
             ]}
           />
         </Td>

--- a/frontend/src/pages/hardwareProfiles/const.tsx
+++ b/frontend/src/pages/hardwareProfiles/const.tsx
@@ -161,3 +161,5 @@ export const DEFAULT_HARDWARE_PROFILE_FORM_DATA: HardwareProfileFormData = {
 
 export const CPU_MEMORY_MISSING_WARNING =
   'It is not recommended to remove the last CPU or Memory resource. Resources that use this hardware profile will schedule, but will be very unstable due to not having any lower or upper resource bounds.';
+
+export const DEFAULT_PROFILE_NAME = 'default-profile';

--- a/frontend/src/pages/hardwareProfiles/utils.ts
+++ b/frontend/src/pages/hardwareProfiles/utils.ts
@@ -11,6 +11,7 @@ import {
   splitValueUnit,
   UnitOption,
 } from '#~/utilities/valueUnits';
+import { DEFAULT_PROFILE_NAME } from '#~/pages/hardwareProfiles/const.tsx';
 import { DEFAULT_CPU_IDENTIFIER, DEFAULT_MEMORY_IDENTIFIER } from './nodeResource/const';
 import { hasCPUandMemory } from './manage/ManageNodeResourceSection';
 import { createHardwareProfileWarningSchema } from './manage/validationUtils';
@@ -199,6 +200,12 @@ export const isHardwareProfileValid = (hardwareProfile: HardwareProfileKind): bo
 export const getHardwareProfileDisplayName = (hardwareProfile: HardwareProfileKind): string =>
   hardwareProfile.metadata.annotations?.[DisplayNameAnnotation.ODH_DISP_NAME] ||
   hardwareProfile.metadata.name;
+
+export const getHardwareProfileCrName = (hardwareProfile: HardwareProfileKind): string =>
+  hardwareProfile.metadata.name;
+
+export const isDefaultHardwareProfile = (hardwareProfile: HardwareProfileKind): boolean =>
+  getHardwareProfileCrName(hardwareProfile) === DEFAULT_PROFILE_NAME;
 
 export const getHardwareProfileDescription = (
   hardwareProfile: HardwareProfileKind,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-35038
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Since the OOTB hardware profile will be recreated when deleted, we should be removing the Delete button.

https://github.com/user-attachments/assets/2241cbb9-39f9-4219-8012-f7bea3b76657

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Either install the [latest operator](https://quay.io/opendatahub/odh-dashboard:main) or create [this hardware profile](https://gist.github.com/nananosirova/5c3b01da5f7194a14d76a9a32af37a5e).
Then log in as a project admin, go to Settings > Environment Setup > Hardware profiles, find the `default-profile` profile from the table and check that the Delete action in the kebab dropdown is missing. Check that it's there for non-default hardware profiles. 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added mock test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default hardware profile is now protected from deletion; the Delete action is hidden for it in the table.
- Tests
  - Added end-to-end coverage ensuring the default profile cannot be deleted while custom profiles can.
  - Made action lookup in tests optionally skip automatic visibility assertions to support flexible checks.
- Refactor
  - Introduced utilities and a constant for identifying the default profile to standardize behavior across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->