### PR TITLE
Deprecate notebookSizes, modelServerSizes, notebookTolerationSettings, AP and HWP feature flags and add validations

### DIFF
--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -73,8 +73,10 @@ spec:
                       type: boolean
                     disableAcceleratorProfiles:
                       type: boolean
+                      description: 'DEPRECATED: Accelerator Profiles are replaced by Hardware Profiles. This field will be removed in a future version.'
                     disableHardwareProfiles:
                       type: boolean
+                      description: "DEPRECATED: Hardware Profiles are GA and cannot be disabled via this field. This field will be removed in a future version."
                     disableDistributedWorkloads:
                       type: boolean
                     disableModelCatalog:
@@ -97,6 +99,11 @@ spec:
                       type: boolean
                     disableFeatureStore:
                       type: boolean
+                  x-kubernetes-validations:
+                    - rule: '!has(self.disableAcceleratorProfiles) || self.disableAcceleratorProfiles == oldSelf.disableAcceleratorProfiles'
+                      message: 'DEPRECATED: spec.dashboardConfig.disableAcceleratorProfiles must be removed or left unchanged.'
+                    - rule: '!has(self.disableHardwareProfiles) || self.disableHardwareProfiles == oldSelf.disableHardwareProfiles'
+                      message: 'DEPRECATED: spec.dashboardConfig.disableHardwareProfiles must be removed or left unchanged.'
                 # TODO: Remove before going to v1
                 groupsConfig:
                   description: 'Ignored -- See "Auth" Resource'
@@ -112,8 +119,9 @@ spec:
                   x-kubernetes-validations:
                     - rule: self == oldSelf
                       message: Can no longer modify group configurations here, see the Auth resource instead
-                # Hardware Profiles going GA will help remove these
+                # Remove notebookSizes in a future version
                 notebookSizes:
+                  description: 'DEPRECATED: Please use Hardware Profiles instead. This field will be removed in a future version.'
                   type: array
                   items:
                     type: object
@@ -140,8 +148,12 @@ spec:
                                 type: string
                               memory:
                                 type: string
-                # Hardware Profiles going GA will help remove these
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: 'This field is DEPRECATED and must either be removed or left unchanged. Please use Hardware Profiles instead.'
+                # Remove modelServerSizes in a future version
                 modelServerSizes:
+                  description: 'DEPRECATED: Please use Hardware Profiles instead. This field will be removed in a future version.'
                   type: array
                   items:
                     type: object
@@ -168,6 +180,9 @@ spec:
                                 type: string
                               memory:
                                 type: string
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: 'This field is DEPRECATED and must either be removed or left unchanged. Please use Hardware Profiles instead.'
                 # May get impacted by Notebooks 2.0
                 notebookController:
                   description: 'Jupyter tile configurations'
@@ -186,12 +201,16 @@ spec:
                     pvcSize:
                       type: string
                     notebookTolerationSettings:
+                      description: 'DEPRECATED: Please use Hardware Profiles to set tolerations instead. This field will be removed in a future version.'
                       type: object
                       properties:
                         enabled:
                           type: boolean
                         key:
                           type: string
+                      x-kubernetes-validations:
+                        - rule: self == oldSelf
+                          message: 'This field is DEPRECATED and must either be removed or left unchanged. Please use Hardware Profiles to set tolerations instead.'
                     storageClassName:
                       type: string
                 # Likely needs a better spot to exist -- hard to do granular permissions

--- a/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
+++ b/manifests/rhoai/shared/odhdashboardconfig/odhdashboardconfig.yaml
@@ -13,64 +13,6 @@ spec:
     enabled: true
     pvcSize: "20Gi"
     notebookNamespace: rhods-notebooks
-  notebookSizes:
-    - name: Small
-      resources:
-        requests:
-          memory: 8Gi
-          cpu: "1"
-        limits:
-          memory: 8Gi
-          cpu: "2"
-    - name: Medium
-      resources:
-        requests:
-          memory: 24Gi
-          cpu: "3"
-        limits:
-          memory: 24Gi
-          cpu: "6"
-    - name: Large
-      resources:
-        requests:
-          memory: 56Gi
-          cpu: "7"
-        limits:
-          memory: 56Gi
-          cpu: "14"
-    - name: X Large
-      resources:
-        requests:
-          memory: 120Gi
-          cpu: "15"
-        limits:
-          memory: 120Gi
-          cpu: "30"
-  modelServerSizes:
-  - name: Small
-    resources:
-      limits:
-        cpu: "2"
-        memory: 8Gi
-      requests:
-        cpu: "1"
-        memory: 4Gi
-  - name: Medium
-    resources:
-      limits:
-        cpu: "8"
-        memory: 10Gi
-      requests:
-        cpu: "4"
-        memory: 8Gi
-  - name: Large
-    resources:
-      limits:
-        cpu: "10"
-        memory: 20Gi
-      requests:
-        cpu: "6"
-        memory: 16Gi
   templateOrder: []
   templateDisablement: []
   hardwareProfileOrder: []


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-35025

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Since hardware profiles are going GA, we need to deprecate `notebookSizes` and `modelServerSizes` container size fields and the `notebookTolerationSettings` field from `OdhDashboardConfig` and add validations. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In the console:
- Ensure that the `odh-dashboard-config` CR has the fields `notebookSizes`, `modelServerSizes` and `notebookController.notebookTolerationSettings` set. If not, [here's an example you can create.](https://gist.github.com/nananosirova/10c48f480cdc85835a063636c7a655f8) 
- Set `devFlags` in the DSC to:
```
devFlags:
  manifests:
    - contextDir: manifests
      sourcePath: ''
      uri: 'https://github.com/nananosirova/odh-dashboard/tarball/RHOAIENG-35025'
```
- Verify that the `OdhDashboardConfig` CRD was been updated
- Try to modify `notebookSizes`. Modifying it without setting it to `[]` or removing it completely yields this error:
<img width="955" height="102" alt="image" src="https://github.com/user-attachments/assets/bcb75e3d-088b-4da8-ac83-974b4a9e4ebc" />
- Try to modify `modelServerSizes`. Modifying it without setting it to `[]` or removing it completely yields this error:
<img width="1002" height="91" alt="image" src="https://github.com/user-attachments/assets/21b034f3-ba86-45e3-b9ea-a7c10388c866" />
- Try to modify `notebookTolerationSettings`. Modifying it without setting it to `{}` or removing it completely yields this error:
<img width="946" height="93" alt="image" src="https://github.com/user-attachments/assets/90f10d8c-af7a-4576-81db-6ab17c1dae26" />
- Changing any other field yields this warning:
<img width="605" height="246" alt="image" src="https://github.com/user-attachments/assets/45b4a687-c6bb-4270-8841-4aaae2d8441e" />

In a cluster with RHOAI installed:
- Set the devFlags in the DSC as shown above
- Delete the pre-existing `odh-dashboard-config` CR if present. A new one should get created. 
- Verify that the fields `notebookSizes`, `modelServerSizes` and `notebookTolerationSettings` are missing in the newly created `odh-dashboard-config`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested with above. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked legacy notebook and model-server size settings, and accelerator/hardware-disable flags, as deprecated; validations now prevent changes or enforce removal.  
  * Removed predefined notebook/model-server size blocks from shared configuration; toleration settings deprecated with validations to preserve unchanged behavior only.

* **Documentation**
  * Added deprecation notices and guidance to use Hardware Profiles instead of notebookSizes, modelServerSizes, accelerator/hardware-disable flags, and notebook toleration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->