### PR TITLE
feat: Add temporary username-based vectorstore isolation and file enr…

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -177,6 +177,7 @@ func (app *App) Routes() http.Handler {
 
 	// Vector Store Files (LlamaStack)
 	apiRouter.GET(constants.VectorStoreFilesListPath, app.RequireAccessToService(app.AttachNamespace(app.AttachLlamaStackClient(app.LlamaStackListVectorStoreFilesHandler))))
+	apiRouter.POST(constants.VectorStoreFilesUploadPath, app.RequireAccessToService(app.AttachNamespace(app.AttachLlamaStackClient(app.LlamaStackUploadFileHandler)))) // Alias to FilesUploadPath
 	apiRouter.DELETE(constants.VectorStoreFilesDeletePath, app.RequireAccessToService(app.AttachNamespace(app.AttachLlamaStackClient(app.LlamaStackDeleteVectorStoreFileHandler))))
 
 	// Code Exporter (Template-only)

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +11,9 @@ import (
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/openai/openai-go/v2"
+	"github.com/opendatahub-io/gen-ai/internal/constants"
+	"github.com/opendatahub-io/gen-ai/internal/integrations"
 	"github.com/opendatahub-io/gen-ai/internal/integrations/llamastack"
 )
 
@@ -23,9 +28,43 @@ type CreateVectorStoreRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
+// TEMPORARY: hashUsername creates a deterministic hash for username-based vectorstore isolation
+// TODO: Remove this function when proper multi-tenant vectorstore support is implemented
+func hashUsername(username string) string {
+	hash := sha256.Sum256([]byte(username))
+	// Use first 128 bits (16 bytes) results in 32 hex characters instead of 64
+	return hex.EncodeToString(hash[:16])
+}
+
 // LlamaStackListVectorStoresHandler handles GET /gen-ai/api/v1/vectorstores
+// TEMPORARY: This handler implements username-based vectorstore isolation by filtering
+// the list to return only the vectorstore matching the hashed username.
+// TODO: Replace with proper multi-tenant vectorstore support when available
 func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
+
+	// TEMPORARY: Get username from context for vectorstore isolation
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*integrations.RequestIdentity)
+	if !ok || identity == nil {
+		app.unauthorizedResponse(w, r, errors.New("user identity not found in context"))
+		return
+	}
+
+	// Get the Kubernetes client to fetch username (uses identity from context)
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	// Fetch the username from the Kubernetes API
+	username, err := client.GetUser(ctx, identity)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	hashedUsername := hashUsername(username)
 
 	// Parse query parameters
 	params := llamastack.ListVectorStoresParams{}
@@ -44,14 +83,47 @@ func (app *App) LlamaStackListVectorStoresHandler(w http.ResponseWriter, r *http
 		params.Order = order
 	}
 
+	// Get all vectorstores
 	vectorStores, err := app.repositories.VectorStores.ListVectorStores(ctx, params)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 
+	// TEMPORARY: Filter vectorstores to find the one matching hashed username
+	var userVectorStore *openai.VectorStore
+	foundUserVectorStore := false
+
+	for i := range vectorStores {
+		if vectorStores[i].Name == hashedUsername {
+			userVectorStore = &vectorStores[i]
+			foundUserVectorStore = true
+			break
+		}
+	}
+
+	// TEMPORARY: If no vectorstore found for this user, create one automatically
+	if !foundUserVectorStore {
+		createParams := llamastack.CreateVectorStoreParams{
+			Name: hashedUsername,
+			Metadata: map[string]string{
+				"created_by": "auto-provisioning",
+				"username":   username,
+			},
+		}
+
+		newVectorStore, err := app.repositories.VectorStores.CreateVectorStore(ctx, createParams)
+		if err != nil {
+			app.serverErrorResponse(w, r, err)
+			return
+		}
+
+		userVectorStore = newVectorStore
+	}
+
+	// TEMPORARY: Return only the user's vectorstore as a single-item array
 	response := VectorStoresResponse{
-		Data: vectorStores,
+		Data: []openai.VectorStore{*userVectorStore},
 	}
 
 	err = app.WriteJSON(w, http.StatusOK, response, nil)
@@ -173,9 +245,42 @@ func (app *App) LlamaStackListVectorStoreFilesHandler(w http.ResponseWriter, r *
 		return
 	}
 
+	// Enrich each vectorstore file with filename information
+	enrichedFiles := make([]map[string]interface{}, len(result))
+	for i, vsFile := range result {
+		// Convert VectorStoreFile to map for enrichment
+		enrichedFile := map[string]interface{}{
+			"id":                vsFile.ID,
+			"created_at":        vsFile.CreatedAt,
+			"last_error":        vsFile.LastError,
+			"object":            vsFile.Object,
+			"status":            vsFile.Status,
+			"usage_bytes":       vsFile.UsageBytes,
+			"vector_store_id":   vsFile.VectorStoreID,
+			"attributes":        vsFile.Attributes,
+			"chunking_strategy": vsFile.ChunkingStrategy,
+		}
+
+		// Fetch file details to get filename
+		fileDetails, err := app.repositories.Files.GetFile(ctx, vsFile.ID)
+		if err != nil {
+			// If we can't get file details, log but continue without filename
+			app.logger.Warn("Failed to fetch file details for enrichment",
+				"file_id", vsFile.ID,
+				"error", err)
+		} else {
+			// Add filename and other useful file metadata
+			enrichedFile["filename"] = fileDetails.Filename
+			enrichedFile["bytes"] = fileDetails.Bytes
+			enrichedFile["purpose"] = fileDetails.Purpose
+		}
+
+		enrichedFiles[i] = enrichedFile
+	}
+
 	// Use envelope pattern for consistent response structure
 	response := VectorStoreFilesListResponse{
-		Data: result,
+		Data: enrichedFiles,
 	}
 
 	err = app.WriteJSON(w, http.StatusOK, response, nil)
@@ -185,6 +290,10 @@ func (app *App) LlamaStackListVectorStoreFilesHandler(w http.ResponseWriter, r *
 }
 
 // LlamaStackDeleteVectorStoreFileHandler handles DELETE /gen-ai/api/v1/lsd/vectorstores/files/delete.
+// TEMPORARY: This handler cascades the delete - it removes the file from the vectorstore
+// AND deletes the actual file. This provides cleanup behavior until proper file lifecycle
+// management is implemented.
+// TODO: Replace with proper file lifecycle management when vectorstore sharing is supported
 func (app *App) LlamaStackDeleteVectorStoreFileHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
@@ -202,10 +311,22 @@ func (app *App) LlamaStackDeleteVectorStoreFileHandler(w http.ResponseWriter, r 
 		return
 	}
 
+	// Step 1: Remove file from vectorstore
 	err := app.repositories.VectorStores.DeleteVectorStoreFile(ctx, vectorStoreID, fileID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
+	}
+
+	// TEMPORARY: Step 2 - Also delete the actual file
+	// This provides cascading delete behavior until proper file sharing is supported
+	err = app.repositories.Files.DeleteFile(ctx, fileID)
+	if err != nil {
+		// Log the error but don't fail the request since the file was already removed from vectorstore
+		app.logger.Warn("Failed to delete file after removing from vectorstore",
+			"file_id", fileID,
+			"vector_store_id", vectorStoreID,
+			"error", err)
 	}
 
 	// Return success response

--- a/packages/gen-ai/bff/internal/constants/api_constants.go
+++ b/packages/gen-ai/bff/internal/constants/api_constants.go
@@ -22,6 +22,7 @@ const (
 	FilesUploadPath                   = ApiPathPrefix + "/lsd/files/upload"
 	FilesDeletePath                   = ApiPathPrefix + "/lsd/files/delete"
 	VectorStoreFilesListPath          = ApiPathPrefix + "/lsd/vectorstores/files"
+	VectorStoreFilesUploadPath        = ApiPathPrefix + "/lsd/vectorstores/files/upload"
 	VectorStoreFilesDeletePath        = ApiPathPrefix + "/lsd/vectorstores/files/delete"
 	LlamaStackDistributionStatusPath  = ApiPathPrefix + "/lsd/status"
 	LlamaStackDistributionInstallPath = ApiPathPrefix + "/lsd/install"

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -522,6 +522,20 @@ func (c *LlamaStackClient) ListFiles(ctx context.Context, params ListFilesParams
 	return filesPage.Data, nil
 }
 
+// GetFile retrieves a file by ID.
+func (c *LlamaStackClient) GetFile(ctx context.Context, fileID string) (*openai.FileObject, error) {
+	if fileID == "" {
+		return nil, fmt.Errorf("fileID is required")
+	}
+
+	file, err := c.client.Files.Get(ctx, fileID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file: %w", err)
+	}
+
+	return file, nil
+}
+
 // DeleteFile deletes a file by ID.
 func (c *LlamaStackClient) DeleteFile(ctx context.Context, fileID string) error {
 	if fileID == "" {

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
@@ -16,6 +16,7 @@ type LlamaStackClientInterface interface {
 	DeleteVectorStore(ctx context.Context, vectorStoreID string) error
 	UploadFile(ctx context.Context, params UploadFileParams) (*FileUploadResult, error)
 	ListFiles(ctx context.Context, params ListFilesParams) ([]openai.FileObject, error)
+	GetFile(ctx context.Context, fileID string) (*openai.FileObject, error)
 	DeleteFile(ctx context.Context, fileID string) error
 	ListVectorStoreFiles(ctx context.Context, vectorStoreID string, params ListVectorStoreFilesParams) ([]openai.VectorStoreFile, error)
 	DeleteVectorStoreFile(ctx context.Context, vectorStoreID, fileID string) error

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_mock.go
@@ -571,6 +571,63 @@ func (m *MockLlamaStackClient) ListFiles(ctx context.Context, params llamastack.
 	}, nil
 }
 
+// GetFile returns mock file details by ID
+func (m *MockLlamaStackClient) GetFile(ctx context.Context, fileID string) (*openai.FileObject, error) {
+	if fileID == "" {
+		return nil, fmt.Errorf("fileID is required")
+	}
+
+	// Return mock file details based on ID
+	mockFiles := map[string]openai.FileObject{
+		"file-mock123abc456def": {
+			ID:        "file-mock123abc456def",
+			Object:    "file",
+			Bytes:     1024,
+			CreatedAt: 1755721386,
+			Filename:  "mock_document.txt",
+			Purpose:   "assistants",
+		},
+		"file-mock789ghi012jkl": {
+			ID:        "file-mock789ghi012jkl",
+			Object:    "file",
+			Bytes:     2048,
+			CreatedAt: 1755721400,
+			Filename:  "mock_data.pdf",
+			Purpose:   "assistants",
+		},
+		"file-f76dd7ebee5c48048f3b97b44dff6b97": {
+			ID:        "file-f76dd7ebee5c48048f3b97b44dff6b97",
+			Object:    "file",
+			Bytes:     14522,
+			CreatedAt: 1759415698,
+			Filename:  "test_document_1.pdf",
+			Purpose:   "assistants",
+		},
+		"file-7376f43495fa4b4a8f6dbe93bbe9f187": {
+			ID:        "file-7376f43495fa4b4a8f6dbe93bbe9f187",
+			Object:    "file",
+			Bytes:     14522,
+			CreatedAt: 1759415696,
+			Filename:  "test_document_2.pdf",
+			Purpose:   "assistants",
+		},
+	}
+
+	if file, exists := mockFiles[fileID]; exists {
+		return &file, nil
+	}
+
+	// Return generic mock file for unknown IDs
+	return &openai.FileObject{
+		ID:        fileID,
+		Object:    "file",
+		Bytes:     1024,
+		CreatedAt: 1759412258,
+		Filename:  "unknown_file.txt",
+		Purpose:   "assistants",
+	}, nil
+}
+
 // DeleteFile returns success for mock deletion
 func (m *MockLlamaStackClient) DeleteFile(ctx context.Context, fileID string) error {
 	if fileID == "" {

--- a/packages/gen-ai/bff/internal/repositories/lsd_files.go
+++ b/packages/gen-ai/bff/internal/repositories/lsd_files.go
@@ -46,6 +46,20 @@ func (r *FilesRepository) ListFiles(ctx context.Context, params llamastack.ListF
 	return client.ListFiles(ctx, params)
 }
 
+// GetFile retrieves a file by ID.
+// The LlamaStack client is expected to be in the context (created by AttachLlamaStackClient middleware).
+func (r *FilesRepository) GetFile(ctx context.Context, fileID string) (*openai.FileObject, error) {
+	// Get ready-to-use LlamaStack client from context using helper
+	client, err := helper.GetContextLlamaStackClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Repository layer can add transformation logic here if needed
+	// For now, direct passthrough from client to handler
+	return client.GetFile(ctx, fileID)
+}
+
 // DeleteFile deletes a file by ID.
 // The LlamaStack client is expected to be in the context (created by AttachLlamaStackClient middleware).
 func (r *FilesRepository) DeleteFile(ctx context.Context, fileID string) error {

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -465,6 +465,7 @@ paths:
       summary: List Vector Stores
       description: Gets a list of vector stores with optional pagination and sorting.
     post:
+      deprecated: true
       tags:
         - VectorStores
       security:
@@ -544,6 +545,7 @@ paths:
       Lists all files with optional filtering by purpose, limit, and sorting.
       Requires namespace parameter for proper multi-tenant isolation.
     get:
+      deprecated: true
       tags:
         - Files
       security:
@@ -603,6 +605,7 @@ paths:
       Supports custom chunking strategies for optimal document processing and RAG performance.
       Requires namespace parameter for proper multi-tenant isolation.
     post:
+      deprecated: true
       tags:
         - Files
       security:
@@ -642,6 +645,7 @@ paths:
       Note that this does not automatically remove the file from vector stores it may be associated with.
       Requires namespace parameter for proper multi-tenant isolation.
     delete:
+      deprecated: true
       tags:
         - Files
       security:
@@ -740,11 +744,53 @@ paths:
       summary: List Vector Store Files
       description: Gets a list of files in a vector store with optional filtering and pagination.
 
-  /gen-ai/api/v1/lsd/vectorstores/files/delete:
-    summary: Remove file from vector store
+  /gen-ai/api/v1/lsd/vectorstores/files/upload:
+    summary: Upload files to vector stores (alias endpoint)
     description: >-
-      Removes a file from a specific vector store. This operation removes the file association
-      and embeddings from the vector store but does not delete the original file from storage.
+      Alias endpoint for file upload that provides a more intuitive vectorstore-centric path.
+      This endpoint is functionally identical to /gen-ai/api/v1/lsd/files/upload.
+      Uploads a file and automatically adds it to the specified vector store.
+      Supports custom chunking strategies for optimal document processing and RAG performance.
+      Requires namespace parameter for proper multi-tenant isolation.
+    post:
+      tags:
+        - VectorStores
+      security:
+        - Bearer: []
+      parameters:
+        - name: namespace
+          in: query
+          description: Kubernetes namespace for file upload context
+          required: true
+          schema:
+            type: string
+            example: 'default'
+      requestBody:
+        description: Multipart form with file and vector store information
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FileUploadRequest'
+        required: true
+      responses:
+        '201':
+          $ref: '#/components/responses/FileUploadResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      operationId: uploadVectorStoreFile
+      summary: Upload File to Vector Store (Alias)
+      description: Alias endpoint - uploads a file and adds it to the specified vector store. Identical to /lsd/files/upload.
+
+  /gen-ai/api/v1/lsd/vectorstores/files/delete:
+    summary: Remove file from vector store and delete file (temporary cascading delete)
+    description: >-
+      Removes a file from a specific vector store and also deletes the actual file from storage.
+      TEMPORARY: This endpoint performs cascading delete (vectorstore removal + file deletion) 
+      until proper file lifecycle management and sharing is implemented.
       Requires namespace parameter for proper multi-tenant isolation.
     delete:
       tags:


### PR DESCRIPTION
## Description

This PR implements temporary username-based vectorstore isolation for the Gen-AI BFF API. These changes provide a working multi-tenant solution while proper vectorstore sharing and lifecycle management is being developed.

**Key Changes:**

1. **Username-based Vectorstore Isolation** - The `/lsd/vectorstores` endpoint now:
   - Extracts the authenticated username from the Kubernetes token
   - Generates a deterministic SHA256 hash (truncated to 32 chars) as the vectorstore name
   - Filters the vectorstore list to return only the user's vectorstore
   - Auto-provisions a new vectorstore if none exists for the user

2. **Enhanced Vectorstore Files API** - The `/lsd/vectorstores/files` endpoint now enriches responses with:
   - `filename` - Retrieved from file metadata via `GetFile()` 
   - `bytes` - File size
   - `purpose` - File purpose
   
3. **Cascading Delete** - The `/lsd/vectorstores/files/delete` endpoint now:
   - Removes the file from the vectorstore
   - Also deletes the actual file from storage (cascading delete)
   - Provides complete cleanup in a single operation

4. **Improved API Organization:**
   - Added `/lsd/vectorstores/files/upload` as an alias to `/lsd/files/upload` for better API consistency
   - Deprecated legacy `/lsd/files/*` endpoints in OpenAPI spec
   - Vectorstore-centric API is now the primary interface

**⚠️ All changes are marked as TEMPORARY** with clear `// TODO:` comments for easy identification and removal when proper multi-tenant support is implemented.

## How Has This Been Tested?

- **Manual Testing**: Tested all endpoints with `curl` against a running LlamaStack instance in `team-crimson` namespace
  - Verified username-based isolation works correctly
  - Confirmed auto-provisioning creates vectorstores with hashed usernames
  - Validated filename enrichment adds correct file metadata
  - Tested cascading delete removes both vectorstore file and actual file

- **Unit Tests**: Updated all vectorstore handler tests to work with new behavior
  - Added `RequestIdentity` to test contexts
  - Updated test expectations for filtered/auto-provisioned vectorstores
  - All 7 vectorstore tests passing

- **Code Quality**: 
  - `golangci-lint run ./...` - 0 issues
  - All existing API tests still passing

## Test Impact

- **Unit Tests**: All existing tests updated and passing
  - `TestLlamaStackListVectorStoresHandler` - 7 test cases ✅
  - `TestLlamaStackListVectorStoreFilesHandler` - Enhanced with filename validation
  - `TestLlamaStackDeleteVectorStoreFileHandler` - Updated for cascading delete

- **Added Functionality**:
  - New `GetFile()` method with mock implementation
  - Enhanced mock client with file ID to filename mappings
  - Repository layer now supports file metadata retrieval

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`