### PR TITLE
Fix llama model and aaa model matching issues

### DIFF
--- a/packages/gen-ai/frontend/src/__mocks__/mockLlamaStackModels.ts
+++ b/packages/gen-ai/frontend/src/__mocks__/mockLlamaStackModels.ts
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
 
-import { LlamaModel } from '~/app/types';
+import { LlamaModelResponse } from '~/app/types';
 
-export const mockLlamaModels: LlamaModel[] = [
+export const mockLlamaModels: LlamaModelResponse[] = [
   {
     id: 'ollama/llama3.2:3b',
     object: 'model',

--- a/packages/gen-ai/frontend/src/app/AIAssets/AIAssetsModelsTab.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/AIAssetsModelsTab.tsx
@@ -4,7 +4,6 @@ import { Namespace } from 'mod-arch-core';
 import { useNavigate } from 'react-router-dom';
 import ModelsEmptyState from '~/app/EmptyStates/NoData';
 import { LlamaModel, AIModel } from '~/app/types';
-import { genAiChatPlaygroundRoute } from '~/app/utilities/routes';
 import useFetchLSDStatus from '~/app/hooks/useFetchLSDStatus';
 import AIModelsTable from './components/AIModelsTable';
 
@@ -25,15 +24,6 @@ const AIAssetsModelsTab: React.FC<AIAssetsModelsTabProps> = ({
 }) => {
   const navigate = useNavigate();
   const { data: lsdStatus } = useFetchLSDStatus(namespace?.name);
-
-  const handleTryInPlayground = (model: AIModel) => {
-    // Navigate to playground with the selected model
-    navigate(genAiChatPlaygroundRoute(namespace?.name), {
-      state: {
-        model: model.model_name,
-      },
-    });
-  };
 
   if (!loaded) {
     return (
@@ -79,12 +69,7 @@ const AIAssetsModelsTab: React.FC<AIAssetsModelsTabProps> = ({
   }
 
   return (
-    <AIModelsTable
-      models={models}
-      playgroundModels={playgroundModels}
-      onTryInPlayground={handleTryInPlayground}
-      lsdStatus={lsdStatus}
-    />
+    <AIModelsTable models={models} playgroundModels={playgroundModels} lsdStatus={lsdStatus} />
   );
 };
 

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -3,9 +3,12 @@ import { Button, Truncate, Label, ButtonVariant } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { ResourceNameTooltip, TableRowTitleDescription, TruncatedText } from 'mod-arch-shared';
+import { useNavigate } from 'react-router-dom';
 import { AIModel, LlamaModel, LlamaStackDistributionModel } from '~/app/types';
 import { convertAIModelToK8sResource } from '~/app/utilities/utils';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
+import { genAiChatPlaygroundRoute } from '~/app/utilities/routes';
+import { GenAiContext } from '~/app/context/GenAiContext';
 import AIModelsTableRowEndpoint from './AIModelsTableRowEndpoint';
 
 type AIModelTableRowProps = {
@@ -13,7 +16,6 @@ type AIModelTableRowProps = {
   model: AIModel;
   models: AIModel[];
   playgroundModels: LlamaModel[];
-  onTryInPlayground: (model: AIModel) => void;
 };
 
 const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
@@ -21,10 +23,10 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
   model,
   models,
   playgroundModels,
-  onTryInPlayground,
 }) => {
-  const playgroundModelIds = new Set(playgroundModels.map((m) => m.id));
-  const isPlaygroundModel = playgroundModelIds.has(model.model_name);
+  const navigate = useNavigate();
+  const { namespace } = React.useContext(GenAiContext);
+  const enabledModel = playgroundModels.find((m) => m.modelId === model.model_id);
   const [isConfigurationModalOpen, setIsConfigurationModalOpen] = React.useState(false);
 
   return (
@@ -66,8 +68,17 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
           )}
         </Td>
         <Td dataLabel="Playground">
-          {isPlaygroundModel ? (
-            <Button variant={ButtonVariant.secondary} onClick={() => onTryInPlayground(model)}>
+          {enabledModel ? (
+            <Button
+              variant={ButtonVariant.secondary}
+              onClick={() =>
+                navigate(genAiChatPlaygroundRoute(namespace?.name), {
+                  state: {
+                    model: enabledModel.id,
+                  },
+                })
+              }
+            >
               Try in playground
             </Button>
           ) : (

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTable.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTable.tsx
@@ -28,7 +28,6 @@ import AIModelTableRow from './AIModelTableRow';
 type AIModelsTableProps = {
   models: AIModel[];
   playgroundModels: LlamaModel[];
-  onTryInPlayground: (model: AIModel) => void;
   lsdStatus: LlamaStackDistributionModel | null;
 };
 
@@ -47,12 +46,7 @@ export const AIModelStatusPopoverContent: React.ReactNode = (
   </Content>
 );
 
-const AIModelsTable: React.FC<AIModelsTableProps> = ({
-  models,
-  playgroundModels,
-  onTryInPlayground,
-  lsdStatus,
-}) => {
+const AIModelsTable: React.FC<AIModelsTableProps> = ({ models, playgroundModels, lsdStatus }) => {
   const { filterData, onFilterUpdate, onClearFilters, filteredModels } = useAIModelsFilter(models);
 
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
@@ -239,7 +233,6 @@ const AIModelsTable: React.FC<AIModelsTableProps> = ({
           model={model}
           models={models}
           playgroundModels={playgroundModels}
-          onTryInPlayground={onTryInPlayground}
         />
       )}
     />

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -11,7 +11,7 @@ import {
   EmptyStateActions,
 } from '@patternfly/react-core';
 import { ApplicationsPage } from 'mod-arch-shared';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import ChatbotEmptyState from '~/app/EmptyStates/NoData';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -26,7 +26,6 @@ const ChatbotMain: React.FunctionComponent = () => {
     lsdStatus,
     lsdStatusLoaded,
     lsdStatusError,
-    setSelectedModel,
     refresh,
     aiModels,
     aiModelsLoaded,
@@ -40,14 +39,6 @@ const ChatbotMain: React.FunctionComponent = () => {
   const [isViewCodeModalOpen, setIsViewCodeModalOpen] = React.useState(false);
   const [configurationModalOpen, setConfigurationModalOpen] = React.useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
-  const location = useLocation();
-  const selectedAAModel = location.state?.model;
-
-  React.useEffect(() => {
-    if (selectedAAModel) {
-      setSelectedModel(selectedAAModel);
-    }
-  }, [selectedAAModel, setSelectedModel]);
 
   return (
     <>

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -10,6 +10,7 @@ import {
   MessageBar,
   MessageBox,
 } from '@patternfly/chatbot';
+import { useLocation } from 'react-router-dom';
 import { useUserContext } from '~/app/context/UserContext';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { DEFAULT_SYSTEM_INSTRUCTIONS } from './const';
@@ -35,8 +36,15 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   setIsViewCodeModalOpen,
 }) => {
   const { username } = useUserContext();
-  const { models, modelsLoaded, selectedModel, setSelectedModel, lastInput, setLastInput } =
-    React.useContext(ChatbotContext);
+  const {
+    models,
+    modelsLoaded,
+    aiModels,
+    selectedModel,
+    setSelectedModel,
+    lastInput,
+    setLastInput,
+  } = React.useContext(ChatbotContext);
 
   const [systemInstruction, setSystemInstruction] = React.useState<string>(
     DEFAULT_SYSTEM_INSTRUCTIONS,
@@ -45,11 +53,21 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   const [temperature, setTemperature] = React.useState<number>(0.1);
   const [topP, setTopP] = React.useState<number>(0.1);
 
+  const location = useLocation();
+  const selectedAAModel = location.state?.model;
+
   React.useEffect(() => {
     if (modelsLoaded && models.length > 0 && !selectedModel) {
-      setSelectedModel(models[0]?.id);
+      if (selectedAAModel) {
+        setSelectedModel(selectedAAModel);
+        // Clear the location state after setting the selected model
+        // so that when refreshing the page, the selected model is not passed again
+        window.history.replaceState({}, '');
+      } else {
+        setSelectedModel(models[0].id);
+      }
     }
-  }, [modelsLoaded, models, selectedModel, setSelectedModel]);
+  }, [modelsLoaded, models, selectedModel, setSelectedModel, aiModels, selectedAAModel]);
 
   // Custom hooks for managing different aspects of the chatbot
   const alertManagement = useAlertManagement();

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ModelDetailsDropdown.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ModelDetailsDropdown.tsx
@@ -7,6 +7,7 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { getLlamaModelDisplayName } from '~/app/utilities';
 
 interface ModelDetailsDropdownProps {
   selectedModel: string;
@@ -17,7 +18,7 @@ const ModelDetailsDropdown: React.FunctionComponent<ModelDetailsDropdownProps> =
   selectedModel,
   onModelChange,
 }) => {
-  const { models } = React.useContext(ChatbotContext);
+  const { models, aiModels } = React.useContext(ChatbotContext);
   const [isOpen, setIsOpen] = React.useState(false);
 
   const placeholder = models.length === 0 ? 'No models available' : 'Select a model';
@@ -46,7 +47,7 @@ const ModelDetailsDropdown: React.FunctionComponent<ModelDetailsDropdownProps> =
           onClick={() => setIsOpen(!isOpen)}
           isExpanded={isOpen}
         >
-          {selectedModel || placeholder}
+          {getLlamaModelDisplayName(selectedModel, aiModels) || placeholder}
         </MenuToggle>
       )}
       shouldFocusToggleOnSelect
@@ -54,7 +55,7 @@ const ModelDetailsDropdown: React.FunctionComponent<ModelDetailsDropdownProps> =
       <DropdownList style={{ maxHeight: '300px', overflowY: 'auto' }}>
         {models.map((option) => (
           <DropdownItem value={option.id} key={option.id}>
-            {option.id}
+            {getLlamaModelDisplayName(option.id, aiModels)}
           </DropdownItem>
         ))}
       </DropdownList>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -34,8 +34,8 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
 
   const preSelectedModels = React.useMemo(() => {
     if (existingModels && existingModels.length > 0) {
-      const existingModelsSet = new Set(existingModels.map((model) => model.id));
-      const existingAIModels = allModels.filter((model) => existingModelsSet.has(model.model_name));
+      const existingModelsSet = new Set(existingModels.map((model) => model.modelId));
+      const existingAIModels = allModels.filter((model) => existingModelsSet.has(model.model_id));
 
       if (extraSelectedModels && extraSelectedModels.length > 0) {
         const extraSelectedModelsSet = new Set(

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -15,6 +15,7 @@ jest.mock('~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationTab
 
 const createAIModel = (overrides: Partial<AIModel>): AIModel => ({
   model_name: 'model-name',
+  model_id: overrides.model_name || 'model-name',
   display_name: 'Display Name',
   description: 'desc',
   endpoints: [],
@@ -63,8 +64,8 @@ describe('ChatbotConfigurationModal preSelectedModels', () => {
 
   test('uses existing models only when provided (mapped by id ↔ model_name)', () => {
     const existing: LlamaModel[] = [
-      { id: 'mA', object: 'model', created: Date.now(), owned_by: 'x' },
-      { id: 'mC', object: 'model', created: Date.now(), owned_by: 'x' },
+      { id: 'pA/mA', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mA' },
+      { id: 'pA/mC', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mC' },
     ];
 
     renderModal({ allModels, existingModels: existing });
@@ -74,9 +75,9 @@ describe('ChatbotConfigurationModal preSelectedModels', () => {
 
   test('uses only available existing models (Running status)', () => {
     const existing: LlamaModel[] = [
-      { id: 'mA', object: 'model', created: Date.now(), owned_by: 'x' },
-      { id: 'mC', object: 'model', created: Date.now(), owned_by: 'x' },
-      { id: 'mD', object: 'model', created: Date.now(), owned_by: 'x' },
+      { id: 'pA/mA', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mA' },
+      { id: 'pA/mC', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mC' },
+      { id: 'pA/mD', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mD' },
     ];
 
     renderModal({ allModels, existingModels: existing });
@@ -86,8 +87,8 @@ describe('ChatbotConfigurationModal preSelectedModels', () => {
 
   test('merges extraSelectedModels and existingModels with duplicates by model_name', () => {
     const existing: LlamaModel[] = [
-      { id: 'mA', object: 'model', created: Date.now(), owned_by: 'x' },
-      { id: 'mC', object: 'model', created: Date.now(), owned_by: 'x' },
+      { id: 'pA/mA', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mA' },
+      { id: 'pA/mC', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mC' },
     ];
     const extra = [aiB];
 
@@ -98,8 +99,8 @@ describe('ChatbotConfigurationModal preSelectedModels', () => {
 
   test('merges extraSelectedModels and existingModels with duplicates by model_name', () => {
     const existing: LlamaModel[] = [
-      { id: 'mA', object: 'model', created: Date.now(), owned_by: 'x' },
-      { id: 'mC', object: 'model', created: Date.now(), owned_by: 'x' },
+      { id: 'pA/mA', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mA' },
+      { id: 'pA/mC', object: 'model', created: Date.now(), owned_by: 'x', modelId: 'mC' },
     ];
     const extra = [aiB, aiA]; // includes mA to validate dedupe preference for extra
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useSourceManagement.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useSourceManagement.ts
@@ -186,9 +186,6 @@ const useSourceManagement = ({
           // Refresh the uploaded files list
           onFileUploadComplete?.();
         } catch (error) {
-          // eslint-disable-next-line no-console
-          console.error('Upload failed:', error);
-
           // Update the file status to failed
           setFilesWithSettings((prev) =>
             prev.map((fileWithSettings) =>

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchLlamaModels.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchLlamaModels.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FetchStateCallbackPromise, FetchStateObject, useFetchState } from 'mod-arch-core';
 import { getModels } from '~/app/services/llamaStackService';
 import { LlamaModel } from '~/app/types';
+import { splitLlamaModelId } from '~/app/utilities/utils';
 
 const useFetchLlamaModels = (
   selectedProject?: string,
@@ -14,7 +15,11 @@ const useFetchLlamaModels = (
     if (lsdNotReady) {
       return Promise.reject(new Error('LSD is not ready'));
     }
-    return getModels(selectedProject);
+    const models = await getModels(selectedProject);
+    return models.map((model) => ({
+      ...model,
+      modelId: splitLlamaModelId(model.id).id,
+    }));
   }, [selectedProject, lsdNotReady]);
 
   const [data, loaded, error, refresh] = useFetchState(fetchLlamaModels, [], {

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -22,6 +22,7 @@ import {
   SimplifiedResponseData,
   VectorStore,
   VectorStoreFile,
+  LlamaModelResponse,
 } from '~/app/types';
 import { URL_PREFIX, extractMCPToolCallData } from '~/app/utilities';
 
@@ -73,7 +74,7 @@ const transformBackendResponse = (backendResponse: BackendResponseData): Simplif
  * @returns Promise<LlamaModel[]> - Array of available models with their metadata
  * @throws Error - When the API request fails or returns an error response
  */
-export const getModels = (namespace: string): Promise<LlamaModel[]> => {
+export const getModels = (namespace: string): Promise<LlamaModelResponse[]> => {
   const url = `${URL_PREFIX}/api/v1/lsd/models?namespace=${namespace}`;
   return axiosInstance
     .get(url)

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -1,10 +1,14 @@
 export type LlamaModelType = 'llm' | 'embedding';
 
-export type LlamaModel = {
+export type LlamaModelResponse = {
   id: string;
   object: string;
   created: number;
   owned_by: string;
+};
+
+export type LlamaModel = LlamaModelResponse & {
+  modelId: string;
 };
 
 export type FileCounts = {
@@ -250,6 +254,7 @@ export type LlamaStackDistributionModel = {
 
 export interface AAModelResponse {
   model_name: string;
+  model_id: string;
   serving_runtime: string;
   api_protocol: string;
   version: string;

--- a/packages/gen-ai/frontend/src/app/utilities/utils.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/utils.ts
@@ -10,3 +10,23 @@ export const convertAIModelToK8sResource = (model: AIModel): K8sResourceCommon =
     name: model.model_name,
   },
 });
+
+export const splitLlamaModelId = (llamaModelId: string): { providerId: string; id: string } => {
+  const [providerId, id] = llamaModelId.split('/');
+  if (!providerId || !id) {
+    return { providerId: '', id: llamaModelId };
+  }
+  return { providerId, id };
+};
+
+export const getLlamaModelDisplayName = (modelId: string, aiModels: AIModel[]): string => {
+  const { id, providerId } = splitLlamaModelId(modelId);
+  const enabledModel = aiModels.find((aiModel) => aiModel.model_id === id);
+  if (!enabledModel) {
+    return modelId;
+  }
+  if (!providerId) {
+    return enabledModel.display_name;
+  }
+  return `${providerId}/${enabledModel.display_name}`;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-35392

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fix some existing issues.

Now the `Try in playground` button will correctly show when the model is already configured in the playground, clicking on it will navigate to the playground page with the model auto-selected
<img width="1512" height="758" alt="Screenshot 2025-10-03 at 4 17 50 PM" src="https://github.com/user-attachments/assets/196a235c-fb87-48a1-9808-1ac0afb2907e" />

The update configuration modal will correctly pre-selected the existing models
<img width="1512" height="758" alt="Screenshot 2025-10-03 at 4 18 38 PM" src="https://github.com/user-attachments/assets/590a20b8-8461-422c-a031-8b4865a76194" />

The dropdown for model selection in the side panel will show `<provider_id>/<display_name>` to better match the name when user configures the playground
<img width="376" height="164" alt="Screenshot 2025-10-03 at 4 19 21 PM" src="https://github.com/user-attachments/assets/0682b3e8-d9be-415d-b7d8-eab0b0818784" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cconfigure a playground with more than one model.
Test `Try in playground` and `Add to playground` button on the AI assets page.
Test update playground function to see if it's auto-selected.
Try to give the models a display name by editing the name on the model deployments page and see if the display name is respected in the playground model selection

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Deep-linking to the Chat Playground now preselects a model via navigation state; eligible models open directly in the playground.

- Bug Fixes
  - More reliable model detection during configuration pre-selection and clearer behavior when no project is selected.
  - Removed noisy console error during file upload failure handling.

- Style
  - Model selector and dropdown show friendly display names instead of raw IDs for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->