### PR TITLE
Removal of top_p field from model details

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -51,7 +51,6 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   );
   const [isStreamingEnabled, setIsStreamingEnabled] = React.useState<boolean>(true);
   const [temperature, setTemperature] = React.useState<number>(0.1);
-  const [topP, setTopP] = React.useState<number>(0.1);
 
   const location = useLocation();
   const selectedAAModel = location.state?.model;
@@ -96,7 +95,6 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     username,
     isStreamingEnabled,
     temperature,
-    topP,
     currentVectorStoreId: fileManagement.currentVectorStoreId,
   });
 
@@ -140,8 +138,6 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
       onStreamingToggle={setIsStreamingEnabled}
       temperature={temperature}
       onTemperatureChange={setTemperature}
-      topP={topP}
-      onTopPChange={setTopP}
     />
   );
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -43,8 +43,6 @@ interface ChatbotSettingsPanelProps {
   onStreamingToggle: (enabled: boolean) => void;
   temperature: number;
   onTemperatureChange: (value: number) => void;
-  topP: number;
-  onTopPChange: (value: number) => void;
 }
 
 const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> = ({
@@ -59,8 +57,6 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
   onStreamingToggle,
   temperature,
   onTemperatureChange,
-  topP,
-  onTopPChange,
 }) => {
   const accordionState = useAccordionState();
   const { selectedServersCount, saveSelectedServersToPlayground } = useMCPSelectionContext();
@@ -106,15 +102,6 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
                   value={temperature}
                   onChange={onTemperatureChange}
                 />
-
-                <ModelParameterFormGroup
-                  fieldId="top-p"
-                  label="Top P"
-                  helpText="This controls nucleus sampling for more focused responses."
-                  value={topP}
-                  onChange={onTopPChange}
-                />
-
                 <FormGroup fieldId="streaming">
                   <Switch
                     id="streaming-switch"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ModelParameterFormGroup.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ModelParameterFormGroup.spec.tsx
@@ -65,35 +65,4 @@ describe('ModelParameterFormGroup', () => {
 
     expect(mockOnChange).toHaveBeenCalled();
   });
-
-  it('respects custom props and renders with correct attributes', () => {
-    const customProps = {
-      ...defaultProps,
-      fieldId: 'top-p',
-      label: 'Top P',
-      min: 0.1,
-      max: 2.0,
-      step: 0.05,
-      value: 0.8,
-    };
-
-    render(<ModelParameterFormGroup {...customProps} />);
-
-    // Check custom label
-    expect(screen.getByText('Top P')).toBeInTheDocument();
-
-    // Check slider attributes
-    const slider = screen.getByRole('slider');
-    expect(slider).toHaveAttribute('aria-valuemin', '0.1');
-    expect(slider).toHaveAttribute('aria-valuemax', '2');
-    expect(slider).toHaveAttribute('aria-valuenow', '0.8');
-
-    // Check text input attributes
-    const textInput = screen.getByRole('spinbutton');
-    expect(textInput).toHaveAttribute('id', 'top-p-input');
-    expect(textInput).toHaveAttribute('min', '0.1');
-    expect(textInput).toHaveAttribute('max', '2');
-    expect(textInput).toHaveAttribute('step', '0.05');
-    expect(textInput).toHaveValue(0.8);
-  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
@@ -109,7 +109,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -138,7 +137,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -176,7 +174,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -203,7 +200,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -226,7 +222,6 @@ describe('useChatbotMessages', () => {
           instructions: '',
           stream: false,
           temperature: 0.7,
-          top_p: 0.9,
         },
         'test-namespace',
       );
@@ -243,7 +238,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -273,7 +267,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: false,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -302,7 +295,6 @@ describe('useChatbotMessages', () => {
           instructions: '',
           stream: false,
           temperature: 0.7,
-          top_p: 0.9,
         },
         'test-namespace',
       );
@@ -319,7 +311,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -348,7 +339,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -372,7 +362,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -402,7 +391,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: 'vs_current_store_123',
         }),
       );
@@ -426,7 +414,6 @@ describe('useChatbotMessages', () => {
           instructions: '',
           stream: false,
           temperature: 0.7,
-          top_p: 0.9,
         },
         'test-namespace',
       );
@@ -445,7 +432,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -498,7 +484,6 @@ describe('useChatbotMessages', () => {
           isRawUploaded: true,
           isStreamingEnabled: false,
           temperature: 0.7,
-          topP: 0.9,
           currentVectorStoreId: null,
         }),
       );
@@ -528,7 +513,6 @@ describe('useChatbotMessages', () => {
             isRawUploaded: true,
             isStreamingEnabled: false,
             temperature: 0.7,
-            topP: 0.9,
             currentVectorStoreId: null,
           }),
         { initialProps: { modelId: 'model-1' } },
@@ -577,7 +561,6 @@ describe('useChatbotMessages', () => {
             isRawUploaded: true,
             isStreamingEnabled: false,
             temperature: 0.7,
-            topP: 0.9,
             currentVectorStoreId: null,
           }),
         { initialProps: { systemInstruction: 'Be concise.' } },

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -39,7 +39,6 @@ interface UseChatbotMessagesProps {
   username?: string;
   isStreamingEnabled: boolean;
   temperature: number;
-  topP: number;
   currentVectorStoreId: string | null;
 }
 
@@ -51,7 +50,6 @@ const useChatbotMessages = ({
   username,
   isStreamingEnabled,
   temperature,
-  topP,
   currentVectorStoreId,
 }: UseChatbotMessagesProps): UseChatbotMessagesReturn => {
   const [messages, setMessages] = React.useState<MessageProps[]>([initialBotMessage()]);
@@ -159,7 +157,6 @@ const useChatbotMessages = ({
         instructions: systemInstruction,
         stream: isStreamingEnabled,
         temperature,
-        top_p: topP,
         ...(mcpServers.length > 0 && { mcp_servers: mcpServers }),
       };
 

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -82,7 +82,6 @@ export type CreateResponseRequest = {
   vector_store_ids?: string[];
   chat_context?: ChatContextMessage[];
   temperature?: number;
-  top_p?: number;
   instructions?: string;
   stream?: boolean;
   mcp_servers?: MCPServerConfig[];


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-35593

## Description
This PR removes top_p field (and all references to it) as it's is not available in the Responses API. 

<img width="387" height="561" alt="Screenshot 2025-10-07 at 12 24 12" src="https://github.com/user-attachments/assets/96e6abd1-5587-419b-8b41-935b0ab87c65" />

<img width="658" height="233" alt="Screenshot 2025-10-07 at 12 25 41" src="https://github.com/user-attachments/assets/ef98a1dd-da68-4e8d-bb11-5234b2c67b60" />

## How Has This Been Tested?
Yes, tested by making sure that the top_p is not sent in the request payload.

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the Top P setting from the Chatbot settings panel and request flow, simplifying configuration. Users will no longer see or adjust Top P in the UI.
- Tests
  - Updated unit tests to reflect the removal of the Top P parameter and its related UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->