### PR TITLE
feat: Change TrustyAIService API from v1alpha1 to v1

### DIFF
--- a/backend/src/routes/api/service/trustyai/index.ts
+++ b/backend/src/routes/api/service/trustyai/index.ts
@@ -4,7 +4,7 @@ import { proxyService } from '../../../../utils/proxy';
 export default proxyService<TrustyAIKind>(
   {
     apiGroup: 'trustyai.opendatahub.io',
-    apiVersion: 'v1alpha1',
+    apiVersion: 'v1',
     kind: 'TrustyAIService',
     plural: 'trustyaiservices',
   },

--- a/frontend/src/__mocks__/mockTrustyAIServiceK8sResource.ts
+++ b/frontend/src/__mocks__/mockTrustyAIServiceK8sResource.ts
@@ -11,7 +11,7 @@ export const mockTrustyAIServiceForDbK8sResource = ({
   creationTimestamp = new Date().toISOString(),
   namespace = 'test-project',
 }: MockTrustyAIServiceK8sResourceOptions): TrustyAIKind => ({
-  apiVersion: 'trustyai.opendatahub.io.trustyai.opendatahub.io/v1alpha1',
+  apiVersion: 'trustyai.opendatahub.io.trustyai.opendatahub.io/v1',
   kind: 'TrustyAIService',
   metadata: {
     name: 'trustyai-service',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
@@ -468,7 +468,7 @@ describe('Model Metrics', () => {
 
     cy.wait('@installTrustyAI').then((interception) => {
       expect(interception.request.body).to.containSubset({
-        apiVersion: 'trustyai.opendatahub.io/v1alpha1',
+        apiVersion: 'trustyai.opendatahub.io/v1',
         kind: 'TrustyAIService',
         metadata: {
           name: 'trustyai-service',

--- a/frontend/src/api/models/odh.ts
+++ b/frontend/src/api/models/odh.ts
@@ -50,7 +50,7 @@ export const ModelRegistryModel: K8sModelCommon = {
 };
 
 export const TrustyAIApplicationsModel: K8sModelCommon = {
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1',
   apiGroup: 'trustyai.opendatahub.io',
   kind: 'TrustyAIService',
   plural: 'trustyaiservices',


### PR DESCRIPTION
## Description

Refer to [RHOAIENG-35645](https://issues.redhat.com/browse/RHOAIENG-35645).

Replace TrustyAIService `v1alpha1` K8s API with `v1`.
Since the `v1` API is a drop-in replacement for `v1alpha1`, this change does not affect the Dashboard's functionality or the tests structure or scope.

## How Has This Been Tested?

* Unit tests
* Front-end tests

## Test Impact

No new tests needed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None; no UI or behavioral changes.
- Chores
  - Upgraded TrustyAI Service API from v1alpha1 to v1 across app to align with current cluster versions and improve compatibility.
- Tests
  - Updated mocks and Cypress tests to use the new TrustyAI API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->