### PR TITLE
fix: increase file upload timeout for large PDFs

### DIFF
--- a/packages/gen-ai/bff/cmd/main.go
+++ b/packages/gen-ai/bff/cmd/main.go
@@ -70,8 +70,8 @@ func main() {
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      app.Routes(),
 		IdleTimeout:  time.Minute,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		ReadTimeout:  8 * time.Minute, // Allow larger file uploads (up to 10MB)
+		WriteTimeout: 8 * time.Minute, // Allow longer processing time for large PDFs
 		ErrorLog:     slog.NewLogLogger(logger.Handler(), slog.LevelError),
 	}
 

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
@@ -32,6 +33,7 @@ func NewLlamaStackClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
+		Timeout: 8 * time.Minute, // Overall request timeout (matches server WriteTimeout)
 	}
 
 	client := openai.NewClient(


### PR DESCRIPTION
## Description

Fixes file upload timeout errors for large PDFs (>2MB) in Gen-AI vector stores.

**Problem:**
We were experiencing proxy timeout errors when uploading PDFs larger than 2MB to vector stores. The files were successfully uploaded and processed by LlamaStack, but the BFF server and HTTP client were timing out after 30 seconds during the embedding generation phase. Testing showed that a 2.2MB PDF takes ~96 seconds to fully process (upload + embedding generation).

**Solution:**
Increased timeouts from 30 seconds to 8 minutes to accommodate the synchronous embedding generation process:
- BFF Server: `ReadTimeout` and `WriteTimeout` increased from 30s to 8 minutes
- LlamaStack HTTP Client: Added 8-minute timeout (was previously unset/infinite)

**Performance Data:**
- 2MB PDF: ~90-100 seconds (previously timing out at 30s)
- 10MB PDF: Estimated 7-8 minutes (now within timeout limit)

Files will now upload successfully without showing errors to users, even for large documents up to 10MB.

## How Has This Been Tested?

**Manual Testing:**
- Uploaded 2.2MB pdf file to vector store
- Verified upload completes successfully in ~96 seconds
- Confirmed file appears in vector store with `completed` status
- Verified LlamaStack logs show successful embedding generation

**Test Environment:**
- Local BFF connected to ROSA cluster LlamaStack instance
- Embedding model: `granite-embedding-125m`
- Namespace: `crimson-demo`

## Test Impact

No automated tests added for this change as it involves:
- HTTP timeout configuration (difficult to test in unit tests)
- Long-running operations (embedding generation on real PDFs)
- Integration with external LlamaStack service

The change is a configuration-only update with no logic changes. Manual testing confirms the fix works as expected.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

---

**Related Work:**
- Tech debt ticket for async upload implementation to follow
- No breaking changes or API modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased server read and write timeouts to 8 minutes to prevent premature disconnections during large uploads and long-running AI operations.
  * Aligned outbound request timeout to 8 minutes for more reliable third-party integrations under heavy processing.
  * Improves stability on slow networks, reducing intermittent timeouts and failed requests during extended operations.
  * Enhances overall reliability for users running complex or high-latency tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->