### PR TITLE
Update deployment secret creation name source

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -47,17 +47,17 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
   const secretName = React.useMemo(() => {
     return (
       wizardState.state.modelLocationData.data?.connection ??
-      wizardState.state.createConnectionData.data.nameDesc?.name ??
+      wizardState.state.createConnectionData.data.nameDesc?.k8sName.value ??
       getGeneratedSecretName()
     );
   }, [
     wizardState.state.modelLocationData.data?.connection,
-    wizardState.state.createConnectionData.data.nameDesc?.name,
+    wizardState.state.createConnectionData.data.nameDesc?.k8sName.value,
   ]);
 
   React.useEffect(() => {
     const current = wizardState.state.createConnectionData.data.nameDesc;
-    if (current?.name !== secretName) {
+    if (current?.k8sName.value !== secretName) {
       wizardState.state.createConnectionData.setData({
         ...wizardState.state.createConnectionData.data,
         nameDesc: {

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -62,7 +62,7 @@ export const handleConnectionCreation = async (
       return getGeneratedSecretName();
     }
     // Otherwise, reuse whatever was passed or saved
-    return secretName ?? createConnectionData.nameDesc?.name ?? getGeneratedSecretName();
+    return secretName ?? createConnectionData.nameDesc?.k8sName.value ?? getGeneratedSecretName();
   })();
 
   const description = createConnectionData.nameDesc?.description ?? '';
@@ -95,11 +95,6 @@ export const handleConnectionCreation = async (
       annotations: {
         ...newConnection.metadata.annotations,
         'opendatahub.io/connection-type-protocol': protocolType,
-        // Add display name annotation if it differs from the k8s name and the user is saving the connection
-        ...(createConnectionData.nameDesc?.name !== createConnectionData.nameDesc?.k8sName.value &&
-        createConnectionData.saveConnection
-          ? { 'opendatahub.io/display-name': createConnectionData.nameDesc?.name }
-          : {}),
       },
     },
   };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes usages of `name` and uses `k8sName.value` instead when setting `secretName` for saved connections
`name` is meant for display name
also removed the addition of the `description` annotation bc the `assembleConnectionSecret` function does that already

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
no tests changed

to test:
- deploy a model with non-existing connection and save the secret with a name k8s won't accept like `name test !@#$%123`
- deployment should not fail
- secret should be created with `name test !@#$%123` in the display name annotation and the translated k8s-friendly version as the actual k8s name `name-test-123`
- the deployment's connection annotation should have the k8s-friendly version in it `name-test-123`

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret names now consistently use the Kubernetes-compliant name, improving reliability when creating or updating connections.
  * The deployment wizard correctly detects and applies name changes.
  * Removed automatic display-name annotation on saved connections to avoid inconsistencies between display and resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->