### PR TITLE
Notebooks annotations

### DIFF
--- a/backend/src/utils/notebookUtils.ts
+++ b/backend/src/utils/notebookUtils.ts
@@ -235,7 +235,6 @@ export const assembleNotebook = async (
         'opendatahub.io/dashboard': 'true',
       },
       annotations: {
-        'notebooks.opendatahub.io/oauth-logout-url': `${url}/notebook-controller/${translatedUsername}/home`,
         'notebooks.opendatahub.io/last-size-selection': lastSizeSelection,
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'opendatahub.io/username': username,
@@ -266,8 +265,7 @@ export const assembleNotebook = async (
                   --ServerApp.token=''
                   --ServerApp.password=''
                   --ServerApp.base_url=/notebook/${namespace}/${name}
-                  --ServerApp.quit_button=False
-                  --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${url}","hub_prefix":"/notebook-controller/${translatedUsername}"}`,
+                  --ServerApp.quit_button=False`,
                 },
                 {
                   name: 'JUPYTER_IMAGE',

--- a/frontend/src/__mocks__/mockNotebookK8sResource.ts
+++ b/frontend/src/__mocks__/mockNotebookK8sResource.ts
@@ -71,8 +71,6 @@ export const mockNotebookK8sResource = ({
           'notebooks.opendatahub.io/inject-auth': 'true',
           'notebooks.opendatahub.io/last-image-selection': lastImageSelection,
           'notebooks.opendatahub.io/last-size-selection': 'Small',
-          'notebooks.opendatahub.io/oauth-logout-url':
-            'http://localhost:4010/projects/project?notebookLogout=workbench',
           'opendatahub.io/username': user,
           'openshift.io/description': description,
           'openshift.io/display-name': displayName,
@@ -121,7 +119,7 @@ export const mockNotebookK8sResource = ({
                   {
                     name: 'NOTEBOOK_ARGS',
                     value:
-                      '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
+                      "--ServerApp.port=8888\n                  --ServerApp.token=''\n                  --ServerApp.password=''\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False",
                   },
                   {
                     name: 'JUPYTER_IMAGE',

--- a/frontend/src/__mocks__/mockPodK8sResource.ts
+++ b/frontend/src/__mocks__/mockPodK8sResource.ts
@@ -100,7 +100,7 @@ export const mockPodK8sResource = ({
           {
             name: 'NOTEBOOK_ARGS',
             value:
-              '--ServerApp.port=8888\n                  --ServerApp.token=\'\'\n                  --ServerApp.password=\'\'\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False\n                  --ServerApp.tornado_settings={"user":"user","hub_host":"http://localhost:4010","hub_prefix":"/projects/project"}',
+              "--ServerApp.port=8888\n                  --ServerApp.token=''\n                  --ServerApp.password=''\n                  --ServerApp.base_url=/notebook/project/workbench\n                  --ServerApp.quit_button=False",
           },
           {
             name: 'JUPYTER_IMAGE',

--- a/frontend/src/api/k8s/notebooks.ts
+++ b/frontend/src/api/k8s/notebooks.ts
@@ -71,9 +71,6 @@ export const assembleNotebook = (
 
   const translatedUsername = usernameTranslate(username);
 
-  const location = new URL(window.location.href);
-  const { origin } = location;
-
   let volumes: Volume[] | undefined = formVolumes && [...formVolumes];
   let volumeMounts: VolumeMount[] | undefined = formVolumeMounts && [...formVolumeMounts];
   if (canEnablePipelines) {
@@ -131,7 +128,6 @@ export const assembleNotebook = (
         ...acceleratorProfileNamespace,
         'openshift.io/display-name': notebookName.trim(),
         'openshift.io/description': description || '',
-        'notebooks.opendatahub.io/oauth-logout-url': `${origin}/projects/${projectName}?notebookLogout=${notebookId}`,
         'notebooks.opendatahub.io/last-size-selection': lastSizeSelection || '',
         'notebooks.opendatahub.io/last-image-selection': imageSelection,
         'notebooks.opendatahub.io/inject-auth': 'true',
@@ -164,8 +160,7 @@ export const assembleNotebook = (
                   --ServerApp.token=''
                   --ServerApp.password=''
                   --ServerApp.base_url=/notebook/${projectName}/${notebookId}
-                  --ServerApp.quit_button=False
-                  --ServerApp.tornado_settings={"user":"${translatedUsername}","hub_host":"${origin}","hub_prefix":"/projects/${projectName}"}`,
+                  --ServerApp.quit_button=False`,
                 },
                 {
                   name: 'JUPYTER_IMAGE',

--- a/frontend/src/concepts/__tests__/mockNotebookStates.ts
+++ b/frontend/src/concepts/__tests__/mockNotebookStates.ts
@@ -15,8 +15,6 @@ const notebook: NotebookKind = {
       'notebooks.opendatahub.io/inject-auth': 'true',
       'notebooks.opendatahub.io/last-image-selection': 'tensorflow:2024.2',
       'notebooks.opendatahub.io/last-size-selection': 'Large',
-      'notebooks.opendatahub.io/oauth-logout-url':
-        'http://localhost:4010/projects/testing?notebookLogout=test-workbench',
       'opendatahub.io/accelerator-name': '',
       'opendatahub.io/image-display-name': 'TensorFlow',
       'opendatahub.io/username': 'cluster-admin',


### PR DESCRIPTION
The jira issues affected:
* https://issues.redhat.com/browse/RHOAIENG-34310
* https://issues.redhat.com/browse/RHAIENG-1439 (https://issues.redhat.com/browse/RHAIENG-1452)

Relates to the following PRs:
* #5076 (just remotely as it's a Gateway API work)
* #5083 (can be considered as previous to this one)
* opendatahub-io/kubeflow#698 (implements relevant changes to the notebook controller component)

## Description
This contains two changes that relate to the ODH/RHOAI 3.0 release and move to the Gateway API. Both changes affects just the Notebooks component (workbenches):

[feat] update annotation name to inject auth proxy for workbenches
This is necessary after the change in notebook controller code when
migrated to the Gateway API and kube-rbac-proxy sidecar for ODH/RHOAI
3.0. The annotation name was changed in the notebook controller name
so we need to update it here too.

[feat] update Notebook annotations - don't pass the logout url annotation
With the move to the Gateway API, we decided to use single domain name
for now. This means same domain for all Notebook instances and as such,
SSO works for all of them including the Dashboard. We decided to remove
the Log out functionality from the Notebook instances. This decision
may be revisited in the future if we decide to move to the multiple
domain approach.

For this change, we stop passing down the relevant annotation with the
URL used for the logout operation.

We also updated the arguments provided for the Jupyterlab app in the
workbench removing the `--ServerApp.tornado_settings` parameter. This
change will remove the presence of the `File -> Log Out` and `File ->
Shut Down` options from the Jupyterlab menu.


## How Has This Been Tested?
I build the image from my changes and applied it on my OpenShift cluster where I checked that the changes propagate as expected and the Notebook instance creation works as expected with the desired changes in behavior - the `File -> Log Out` button is missing in Jupyterlab IDE.

## Test Impact
Based on the changes, I didn't create any new test, just amended the existing so they pass.
I also updated lines to make linter happy again.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized notebook auth annotation to use inject-auth and removed legacy OAuth logout URL and origin-dependent values.
  * Simplified notebook server startup arguments by removing hub/tornado-specific settings.

* **Tests**
  * Updated mocks and test fixtures to match the new auth annotation and streamlined server arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->