### PR TITLE
[fix] Remove safety provider from configmap and verify if token exists

### DIFF
--- a/packages/gen-ai/bff/internal/constants/configmap_templates.go
+++ b/packages/gen-ai/bff/internal/constants/configmap_templates.go
@@ -27,14 +27,6 @@ providers:
         type: sqlite
         namespace: null
         db_path: /opt/app-root/src/.llama/distributions/rh/milvus_registry.db
-  safety:
-  - provider_id: trustyai_fms
-    provider_type: remote::trustyai_fms
-    module: llama_stack_provider_trustyai_fms==0.2.2
-    config:
-      orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=http://localhost}
-      ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
-      shields: {}
   agents:
   - provider_id: meta-reference
     provider_type: inline::meta-reference


### PR DESCRIPTION
1. For models WITH service account tokens: The code finds the actual secret and references it properly
2. For models WITHOUT service account tokens: The code uses a default "fake" token value instead of trying to reference a non-existent secret
3. For models with missing secrets: The code gracefully falls back to the default token

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation resilience by verifying Kubernetes secrets before use and gracefully falling back to a default token when missing, avoiding setup failures.
  * Clarified runtime behavior and warnings when tokens are present versus when fallbacks are applied.

* **Chores**
  * Removed the safety provider from the Llama Stack configuration template, simplifying the default configuration.
  * Refined logging to better indicate when secrets are found, missing, or when default tokens are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->