### PR TITLE
Add existing resource and hardware profile resource merging logic in useHardwareProfileConfig

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -182,4 +182,398 @@ describe('useHardwareProfileConfig', () => {
       useExistingSettings: false,
     });
   });
+
+  it('should merge new identifiers from updated hardware profile with existing resources', () => {
+    const hardwareProfile = mockHardwareProfile({
+      name: 'updated-profile',
+      identifiers: [
+        {
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          displayName: 'CPU',
+          defaultCount: '2',
+        },
+        {
+          identifier: 'memory',
+          minCount: '1Gi',
+          maxCount: '8Gi',
+          displayName: 'Memory',
+          defaultCount: '4Gi',
+        },
+        {
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 2,
+          displayName: 'GPU',
+          defaultCount: 1,
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[hardwareProfile], true, undefined]);
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('updated-profile', existingResources);
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBe(hardwareProfile);
+    expect(state.initialHardwareProfile).toBe(hardwareProfile);
+    expect(state.formData.useExistingSettings).toBe(false);
+
+    // Resources should be merged: existing CPU/Memory preserved, new GPU added with default value
+    expect(state.formData.resources).toEqual({
+      requests: {
+        cpu: '2',
+        memory: '4Gi',
+        'nvidia.com/gpu': 1,
+      },
+      limits: {
+        cpu: '2',
+        memory: '4Gi',
+        'nvidia.com/gpu': 1,
+      },
+    });
+  });
+
+  it('should clear notebook resources when hardware profile has all identifiers removed', () => {
+    const emptyProfile = mockHardwareProfile({
+      name: 'empty-profile',
+      identifiers: [],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[emptyProfile], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('empty-profile', existingResources);
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBe(emptyProfile);
+    expect(state.initialHardwareProfile).toBe(emptyProfile);
+    expect(state.formData.useExistingSettings).toBe(false);
+
+    // Resources should be cleared since profile has no identifiers
+    expect(state.formData.resources).toEqual({
+      requests: {},
+      limits: {},
+    });
+  });
+
+  it('should not change existing resources when hardware profile matches container resources', () => {
+    const profile = mockHardwareProfile({
+      name: 'standard-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profile], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('standard-profile', existingResources);
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBe(profile);
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    });
+  });
+
+  it('should add new GPU identifier when admin adds it to hardware profile', () => {
+    // Admin adds GPU to profile after workload creation
+    const profileWithGPU = mockHardwareProfile({
+      name: 'profile-with-gpu',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profileWithGPU], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('profile-with-gpu', existingResources);
+    const state = renderResult.result.current;
+
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+    });
+  });
+
+  it('should remove orphaned identifiers when admin removes them from hardware profile', () => {
+    // Admin removes memory and GPU, only CPU remains
+    const profileCpuOnly = mockHardwareProfile({
+      name: 'cpu-only-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profileCpuOnly], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('cpu-only-profile', existingResources);
+    const state = renderResult.result.current;
+
+    // Only CPU should remain, orphans removed
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '2' },
+      limits: { cpu: '2' },
+    });
+  });
+
+  it('should clear all resources when admin removes all identifiers from hardware profile', () => {
+    const emptyProfile = mockHardwareProfile({
+      name: 'empty-profile',
+      identifiers: [],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[emptyProfile], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('empty-profile', existingResources);
+    const state = renderResult.result.current;
+
+    expect(state.formData.resources).toEqual({
+      requests: {},
+      limits: {},
+    });
+  });
+
+  it('should preserve customized resources when hardware profile has not changed', () => {
+    // User customized CPU to 4 and memory to 8Gi (defaults were 2, 4Gi)
+    const profile = mockHardwareProfile({
+      name: 'standard-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profile], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '4', memory: '8Gi' }, // User customized values
+      limits: { cpu: '4', memory: '8Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('standard-profile', existingResources);
+    const state = renderResult.result.current;
+
+    // Customized values should be preserved
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '4', memory: '8Gi' },
+      limits: { cpu: '4', memory: '8Gi' },
+    });
+  });
+
+  it('should preserve customized resources and add new GPU when admin adds identifier', () => {
+    // User had customized CPU and memory, admin adds GPU
+    const profileWithGPU = mockHardwareProfile({
+      name: 'profile-with-gpu',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 1,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profileWithGPU], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '4', memory: '8Gi' }, // User customized values
+      limits: { cpu: '4', memory: '8Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('profile-with-gpu', existingResources);
+    const state = renderResult.result.current;
+
+    // Customizations preserved, GPU added with default
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 1 },
+    });
+  });
+
+  it('should preserve only customized CPU when admin removes other identifiers', () => {
+    // User had customized all three, admin removes memory and GPU
+    const profileCpuOnlyCustomized = mockHardwareProfile({
+      name: 'cpu-only-profile-customized',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profileCpuOnlyCustomized], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 2 }, // All customized
+      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 2 },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)(
+      'cpu-only-profile-customized',
+      existingResources,
+    );
+    const state = renderResult.result.current;
+
+    // Only customized CPU preserved, orphans removed
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '4' },
+      limits: { cpu: '4' },
+    });
+  });
+
+  it('should clear all customized resources when admin removes all identifiers', () => {
+    // User had customizations, admin removes all identifiers
+    const emptyProfile = mockHardwareProfile({
+      name: 'empty-profile',
+      identifiers: [],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[emptyProfile], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '4', memory: '8Gi' }, // User customized
+      limits: { cpu: '4', memory: '8Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)('empty-profile', existingResources);
+    const state = renderResult.result.current;
+
+    // All resources cleared, customizations lost
+    expect(state.formData.resources).toEqual({
+      requests: {},
+      limits: {},
+    });
+  });
+
+  it('should preserve customized resources when admin changes min/max/default constraints', () => {
+    // User customized to cpu: 4, admin changes constraints (user value still valid)
+    const profileWithNewConstraints = mockHardwareProfile({
+      name: 'updated-constraints-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '2',
+          maxCount: '6',
+          defaultCount: '3',
+        }, // Changed from 1-8, default 2
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '4Gi',
+          maxCount: '12Gi',
+          defaultCount: '6Gi',
+        }, // Changed from 2-16, default 4
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue([[profileWithNewConstraints], true, undefined]);
+
+    const existingResources = {
+      requests: { cpu: '4', memory: '8Gi' }, // User customized (still within new ranges)
+      limits: { cpu: '4', memory: '8Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)(
+      'updated-constraints-profile',
+      existingResources,
+    );
+    const state = renderResult.result.current;
+
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '4', memory: '8Gi' },
+      limits: { cpu: '4', memory: '8Gi' },
+    });
+  });
 });

--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -135,7 +135,6 @@ export const useHardwareProfileConfig = (
   const isFormDataValid = React.useMemo(() => isHardwareProfileConfigValid(formData), [formData]);
 
   const { dashboardNamespace } = useDashboardNamespace();
-
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const { kueueFilteringState } = useKueueConfiguration(currentProject);
 
@@ -167,7 +166,10 @@ export const useHardwareProfileConfig = (
         }
 
         initialHardwareProfile.current = selectedProfile;
-        setFormData('resources', resources);
+        const mergedResources = selectedProfile
+          ? mergeProfileIdentifiersIntoResources(resources, selectedProfile)
+          : resources;
+        setFormData('resources', mergedResources);
         setFormData('useExistingSettings', !selectedProfile);
         setFormData('selectedProfile', selectedProfile);
       }
@@ -210,5 +212,46 @@ export const useHardwareProfileConfig = (
     resetFormData,
     profilesLoaded,
     profilesLoadError,
+  };
+};
+
+const mergeProfileIdentifiersIntoResources = (
+  existingResources: ContainerResources,
+  hardwareProfile: HardwareProfileKind,
+): ContainerResources => {
+  if (!hardwareProfile.spec.identifiers || hardwareProfile.spec.identifiers.length === 0) {
+    return { requests: {}, limits: {} };
+  }
+  const profileResources = getContainerResourcesFromHardwareProfile(hardwareProfile);
+  const profileIdentifierKeys = new Set(
+    hardwareProfile.spec.identifiers.map((id) => id.identifier),
+  );
+  const mergedRequests = { ...(existingResources.requests || {}) };
+  const mergedLimits = { ...(existingResources.limits || {}) };
+
+  Object.keys(mergedRequests).forEach((key) => {
+    if (!profileIdentifierKeys.has(key)) {
+      delete mergedRequests[key];
+    }
+  });
+  Object.keys(mergedLimits).forEach((key) => {
+    if (!profileIdentifierKeys.has(key)) {
+      delete mergedLimits[key];
+    }
+  });
+
+  hardwareProfile.spec.identifiers.forEach((identifier) => {
+    if (!(identifier.identifier in mergedRequests)) {
+      mergedRequests[identifier.identifier] =
+        profileResources.requests?.[identifier.identifier] ?? identifier.defaultCount;
+    }
+    if (!(identifier.identifier in mergedLimits)) {
+      mergedLimits[identifier.identifier] =
+        profileResources.limits?.[identifier.identifier] ?? identifier.defaultCount;
+    }
+  });
+  return {
+    requests: mergedRequests,
+    limits: mergedLimits,
   };
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-36026

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In the scenario when:
- A user creates a workload with a hardware profile
- An admin later modifies the hardware profile (adds GPU, removes memory, etc.)
- The user edits their workload

The edit modal will show validation errors because of the mismatch between existing workload resources and hardware profile resources. To mitigate this, resource merging logic was added to `useHardwareProfileConfig` to handle scenarios where hardware profiles are updated after workloads (notebooks, model servers) have been created. The new logic preserves existing user customizations while syncing with hardware profile changes.

- Merges new identifiers into existing resources
- Clears resources when profile becomes empty
- Preserves existing resources when profile matches
- Adds GPU when admin updates profile
- Removes orphaned identifiers (memory, GPU) when admin removes them
- Clears all resources when all identifiers are removed
- Preserves customized values
- Handles customizations when admin adds or removes identifiers
- Preserves customizations when admin changes constraints

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a notebook / model server and attach a hardware profile with cpu/memory only
- Start the notebook / model server
- Edit the hardware profile, add a GPU node resource
- Go back edit the notebook / model server
- There shouldn't be any validation errors in the hardware profiles section of the edit modal

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resources now automatically align with the selected hardware profile’s identifiers; new identifiers (e.g., GPUs) are added with sensible defaults and removed identifiers are cleared.
  * Preserves user-customized resource values when switching or updating profiles, including when profile constraints change.

* **Tests**
  * Expanded test coverage validating merging, clearing, and preservation of customized resources across many hardware profile update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->