### PR TITLE
Fix conditional hook invocation in useHardwareProfileBindingState

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileBindingState.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileBindingState.ts
@@ -18,14 +18,14 @@ export const useHardwareProfileBindingState = (
     resource?.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'] ||
     dashboardNamespace;
 
-  if (!hardwareProfileName || !hardwareProfileNamespace) {
-    return [null, true, undefined];
-  }
-
   const [profile, loaded, loadError] = useHardwareProfile(
     hardwareProfileNamespace,
     hardwareProfileName,
   );
+
+  if (!hardwareProfileName || !hardwareProfileNamespace) {
+    return [null, true, undefined];
+  }
 
   if (loadError) {
     const bindingState: HardwareProfileBindingStateInfo | null =

--- a/frontend/src/pages/hardwareProfiles/useHardwareProfile.ts
+++ b/frontend/src/pages/hardwareProfiles/useHardwareProfile.ts
@@ -12,9 +12,10 @@ const useHardwareProfile = (
   name?: string,
 ): FetchState<HardwareProfileKind | null> => {
   const callback = React.useCallback<FetchStateCallbackPromise<HardwareProfileKind | null>>(() => {
-    if (!name) {
-      return Promise.reject(new NotReadyError('Hardware profile name is missing'));
+    if (!name || !namespace) {
+      return Promise.reject(new NotReadyError('Hardware profile name or namespace is missing'));
     }
+
     return getHardwareProfile(name, namespace);
   }, [name, namespace]);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-36164

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The application was crashing with React error .
In `useHardwareProfileBindingState.ts`, the `useHardwareProfile` hook was called conditionally after an early return statement:
```
if (!hardwareProfileName || !hardwareProfileNamespace) {
  return [null, true, undefined];
}
```
When `hardwareProfileName` or `hardwareProfileNamespace` changed between renders, the number of hooks executed would change, breaking React's internal hook tracking mechanism.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a notebook, attach a hardware profile, start the notebook
- Delete the hardware profile
- Go back to the notebook, and click edit. Should see "Use existing settings" in the hardware profile section. 
- Resubmit the form, should get the stack trace above

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading hardware profiles by validating both name and namespace before fetching.
  * Prevents erroneous requests and potential errors when either value is missing, ensuring a consistent loading state and safer handling.
  * Users should experience fewer interruptions or crashes when navigating to hardware profile details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->