### PR TITLE
migrate usage of dsc installedComponents to managementState

### DIFF
--- a/backend/src/__tests__/resourceUtils.spec.ts
+++ b/backend/src/__tests__/resourceUtils.spec.ts
@@ -12,7 +12,6 @@ describe('resourceUtils', () => {
           status: 'True',
         },
       ],
-      installedComponents: {},
       phase: 'Running',
       release: {
         name,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1000,16 +1000,6 @@ export enum KnownLabels {
   KUEUE_MANAGED = 'kueue.openshift.io/managed',
 }
 
-type ComponentNames =
-  | 'codeflare'
-  | 'data-science-pipelines-operator'
-  | 'kserve'
-  | 'model-mesh'
-  // Bug: https://github.com/opendatahub-io/opendatahub-operator/issues/641
-  | 'odh-dashboard'
-  | 'ray'
-  | 'workbenches';
-
 export type DataScienceClusterKindStatus = {
   components?: {
     modelregistry?: {
@@ -1020,7 +1010,6 @@ export type DataScienceClusterKindStatus = {
     };
   };
   conditions: K8sCondition[];
-  installedComponents: { [key in ComponentNames]?: boolean };
   phase?: string;
   release?: {
     name: string;

--- a/frontend/src/__mocks__/mockDsc.ts
+++ b/frontend/src/__mocks__/mockDsc.ts
@@ -19,7 +19,7 @@ export const mockDsc = ({
   },
   spec: {
     components: {
-      aipipelines: {
+      datasciencepipelines: {
         managementState: 'Managed',
       },
       kserve: {

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -1,6 +1,7 @@
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
 import {
+  DataScienceStackComponent,
   StackCapability,
   StackComponent,
   SupportedArea,
@@ -58,6 +59,63 @@ describe('isAreaAvailable', () => {
 
   describe('v2 Operator', () => {
     describe('flags and cluster states', () => {
+      it('converts installedComponents to managementState', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          // simulate Managed state by setting installedComponents true (mock synthesizes managementState)
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
+          mockDsciStatus({}),
+        );
+
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+      it('should support managementState Unmanaged in area availability checks', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Unmanaged' },
+            },
+          }),
+          mockDsciStatus({}),
+        );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+
+      it('should support managementState Managed in area availability checks', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+            },
+          }),
+          mockDsciStatus({}),
+        );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+
+      it('should support managementState Removed in area availability checks', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Removed' },
+            },
+          }),
+          mockDsciStatus({}),
+        );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: false });
+        expect(isAvailable.status).toBe(false);
+      });
+
       it('should enable area (flag true, cluster true)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.DS_PIPELINES,

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -107,13 +107,13 @@ export enum StackComponent {
   LLAMA_STACK_OPERATOR = 'llamastackoperator',
 }
 
-/** The possible component names that are used as keys in the `components` object of the DSC Status.
+/** The possible V1 component names that are used as keys in the `components` object of the DSC Status.
  * Each component's key (e.g., 'codeflare', 'dashboard', etc.) maps to a specific component status.
  **/
 export enum DataScienceStackComponent {
   CODE_FLARE = 'codeflare',
   DASHBOARD = 'dashboard',
-  DS_PIPELINES = 'aipipelines',
+  DS_PIPELINES = 'datasciencepipelines',
   K_SERVE = 'kserve',
   KUEUE = 'kueue',
   MODEL_MESH_SERVING = 'modelmeshserving',
@@ -123,6 +123,7 @@ export enum DataScienceStackComponent {
   TRAINING_OPERATOR = 'trainingoperator',
   TRUSTY_AI = 'trustyai',
   WORKBENCHES = 'workbenches',
+  LLAMA_STACK_OPERATOR = 'llamastackoperator',
 }
 
 /** Capabilities of the Operator. Part of the DSCI Status. */

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -3,7 +3,13 @@ import {
   DataScienceClusterInitializationKindStatus,
   DataScienceClusterKindStatus,
 } from '#~/k8sTypes';
-import { IsAreaAvailableStatus, FeatureFlag, SupportedAreaType } from './types';
+import {
+  IsAreaAvailableStatus,
+  FeatureFlag,
+  SupportedAreaType,
+  StackComponent,
+  DataScienceStackComponent,
+} from './types';
 import { definedFeatureFlags, SupportedAreasStateMap } from './const';
 
 export const isDefinedFeatureFlag = (key: string): key is FeatureFlag =>
@@ -29,6 +35,21 @@ const isFlagOn = (flag: string, flagState: FlagState): 'on' | 'off' => {
   return enabled ? 'on' : 'off';
 };
 
+export const stackToStatusKey: Partial<Record<StackComponent, DataScienceStackComponent>> = {
+  [StackComponent.CODE_FLARE]: DataScienceStackComponent.CODE_FLARE,
+  [StackComponent.DS_PIPELINES]: DataScienceStackComponent.DS_PIPELINES,
+  [StackComponent.K_SERVE]: DataScienceStackComponent.K_SERVE,
+  [StackComponent.MODEL_MESH]: DataScienceStackComponent.MODEL_MESH_SERVING,
+  [StackComponent.DASHBOARD]: DataScienceStackComponent.DASHBOARD,
+  [StackComponent.RAY]: DataScienceStackComponent.RAY,
+  [StackComponent.WORKBENCHES]: DataScienceStackComponent.WORKBENCHES,
+  [StackComponent.TRUSTY_AI]: DataScienceStackComponent.TRUSTY_AI,
+  [StackComponent.KUEUE]: DataScienceStackComponent.KUEUE,
+  [StackComponent.TRAINING_OPERATOR]: DataScienceStackComponent.TRAINING_OPERATOR,
+  [StackComponent.MODEL_REGISTRY]: DataScienceStackComponent.MODEL_REGISTRY,
+  [StackComponent.FEAST_OPERATOR]: DataScienceStackComponent.FEAST_OPERATOR,
+};
+
 export const isAreaAvailable = (
   area: SupportedAreaType,
   dashboardConfigSpec: DashboardConfigKind['spec'],
@@ -39,6 +60,17 @@ export const isAreaAvailable = (
     flagState: getFlags(dashboardConfigSpec),
   },
 ): IsAreaAvailableStatus => {
+  const isComponentInstalled = (component: StackComponent): boolean => {
+    if (!dscStatus?.components) {
+      return false;
+    }
+    const statusKey = stackToStatusKey[component];
+    if (!statusKey) {
+      return false;
+    }
+    const state = dscStatus.components[statusKey]?.managementState;
+    return state === 'Managed' || state === 'Unmanaged';
+  };
   const { devFlags, featureFlags, requiredComponents, reliantAreas, requiredCapabilities } =
     options.internalStateMap[area];
 
@@ -80,7 +112,7 @@ export const isAreaAvailable = (
   const requiredComponentsState =
     requiredComponents && dscStatus
       ? requiredComponents.reduce<IsAreaAvailableStatus['requiredComponents']>(
-          (acc, component) => ({ ...acc, [component]: dscStatus.installedComponents?.[component] }),
+          (acc, component) => ({ ...acc, [component]: isComponentInstalled(component) }),
           {},
         )
       : null;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1401,13 +1401,15 @@ export type K8sResourceListResult<TResource extends Partial<K8sResourceCommon>> 
   };
 };
 
+export type ManagementState = 'Managed' | 'Unmanaged' | 'Removed';
+
 /** Represents a component in the DataScienceCluster. */
 export type DataScienceClusterComponent = {
   /**
    * The management state of the component (e.g., Managed, Removed).
    * Indicates whether the component is being actively managed or not.
    */
-  managementState?: 'Managed' | 'Removed';
+  managementState?: ManagementState;
 };
 
 /** Defines a DataScienceCluster with various components. */
@@ -1453,7 +1455,7 @@ export type DataScienceClusterComponentStatus = {
    * The management state of the component (e.g., Managed, Removed).
    * Indicates whether the component is being actively managed or not.
    */
-  managementState?: 'Managed' | 'Removed';
+  managementState?: ManagementState;
 
   /**
    * List of releases for the component.
@@ -1493,13 +1495,18 @@ export type DataScienceClusterKindStatus = {
     };
   };
   conditions: K8sCondition[];
-  installedComponents?: { [key in StackComponent]?: boolean };
   phase?: string;
   release?: {
     name: string;
     version: string;
   };
 };
+
+/**
+ * @deprecated The operator no longer exposes installedComponents.
+ * Use DataScienceClusterKindStatus.components.*.managementState instead.
+ */
+export type DataScienceClusterInstalledComponents = { [key in StackComponent]?: boolean };
 
 export type DataScienceClusterInitializationKindStatus = {
   conditions: K8sCondition[];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-35530

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
DSC `installedComponents` is deprecated and requested to be removed for 3.0 pending Dashboard stop using this API.

This change replaces usage of `installedComponents` with `managementState` and assumes a value of `Managed` or `Unmanaged` represents an installed value of `true` with everything else being `false`.

Mocking the DSC continues to support the `installedComponents` property for the sake of compatibility with our tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Component installation state now represented per-component (instead of a single combined field).
  * Added support for an "Unmanaged" component state in addition to "Managed" and "Removed".
  * Renamed the pipelines component key to "datasciencepipelines" and added a new "llamastackoperator" component.

* **Tests**
  * Added coverage for component-state translation and handling of Managed/Unmanaged/Removed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->