### PR TITLE
feat: Propagate Authorization Bearer token to OpenAI client

### DIFF
--- a/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
@@ -112,7 +112,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock123abc456def", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -148,7 +148,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock123abc456def", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -185,7 +185,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock123abc456def", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -215,7 +215,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock123abc456def", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -248,7 +248,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock123abc456def", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -302,7 +302,7 @@ func TestLlamaStackUploadFileHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 		rr := httptest.NewRecorder()
@@ -341,7 +341,7 @@ func TestLlamaStackListFilesHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -375,7 +375,7 @@ func TestLlamaStackListFilesHandler(t *testing.T) {
 
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -402,7 +402,7 @@ func TestLlamaStackListFilesHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, constants.FilesListPath+"?namespace=default&limit=invalid", nil)
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -428,7 +428,7 @@ func TestLlamaStackDeleteFileHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, constants.FilesDeletePath+"?namespace=default&file_id=file-test123", nil)
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -457,7 +457,7 @@ func TestLlamaStackDeleteFileHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodDelete, constants.FilesDeletePath+"?namespace=default", nil)
 		// Simulate AttachNamespace and AttachLlamaStackClient middleware
 		ctx := context.WithValue(req.Context(), constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token-mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/lsd_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_models_handler_test.go
@@ -37,7 +37,7 @@ func TestLlamaStackModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -64,7 +64,7 @@ func TestLlamaStackModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -109,7 +109,7 @@ func TestLlamaStackModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -137,7 +137,7 @@ func TestLlamaStackModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add namespace to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "mock-test-namespace-3")
 		req = req.WithContext(ctx)
@@ -178,7 +178,7 @@ func TestLlamaStackModelsHandlerWithFilteredModelKeywords(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
@@ -53,7 +53,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -112,7 +112,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -200,7 +200,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -233,7 +233,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -268,7 +268,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -339,7 +339,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -442,7 +442,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -477,7 +477,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -515,7 +515,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -556,7 +556,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -583,7 +583,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -628,7 +628,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -666,7 +666,7 @@ func TestLlamaStackCreateResponseHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachLlamaStackClient middleware: create client and add to context
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -60,7 +60,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -96,7 +96,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -124,7 +124,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -152,7 +152,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -180,7 +180,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -197,7 +197,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -217,7 +217,7 @@ func TestLlamaStackListVectorStoresHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -265,7 +265,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -305,7 +305,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -338,7 +338,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -371,7 +371,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -401,7 +401,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -436,7 +436,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -481,7 +481,7 @@ func TestLlamaStackCreateVectorStoreHandler(t *testing.T) {
 
 		// Simulate middleware: add RequestIdentity and LlamaStack client to context
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
@@ -522,7 +522,7 @@ func TestLlamaStackDeleteVectorStoreHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -553,7 +553,7 @@ func TestLlamaStackDeleteVectorStoreHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -593,7 +593,7 @@ func TestLlamaStackListVectorStoreFilesHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -629,7 +629,7 @@ func TestLlamaStackListVectorStoreFilesHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -658,7 +658,7 @@ func TestLlamaStackListVectorStoreFilesHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -674,7 +674,7 @@ func TestLlamaStackListVectorStoreFilesHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -702,7 +702,7 @@ func TestLlamaStackDeleteVectorStoreFileHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -733,7 +733,7 @@ func TestLlamaStackDeleteVectorStoreFileHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 
@@ -749,7 +749,7 @@ func TestLlamaStackDeleteVectorStoreFileHandler(t *testing.T) {
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
 		ctx = context.WithValue(ctx, constants.NamespaceQueryParameterKey, "default")
-		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, false, nil)
+		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.TestLlamaStackURL, "token_mock", false, nil)
 		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, llamaStackClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/maas_models_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/maas_models_handler_test.go
@@ -33,7 +33,7 @@ func TestMaaSModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware: create client and add to context
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -69,7 +69,7 @@ func TestMaaSModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -103,7 +103,7 @@ func TestMaaSModelsHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/maas_tokens_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/maas_tokens_handler_test.go
@@ -35,7 +35,7 @@ func TestMaaSIssueTokenHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -67,7 +67,7 @@ func TestMaaSIssueTokenHandler(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -94,7 +94,7 @@ func TestMaaSIssueTokenHandler(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -109,7 +109,7 @@ func TestMaaSIssueTokenHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -149,7 +149,7 @@ func TestMaaSRevokeAllTokensHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 
@@ -170,7 +170,7 @@ func TestMaaSRevokeAllTokensHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Simulate AttachMaaSClient middleware
-		maasClient := app.maasClientFactory.CreateClient("", "", false, nil)
+		maasClient := app.maasClientFactory.CreateClient("", "token_mock", false, nil)
 		ctx := context.WithValue(req.Context(), constants.MaaSClientKey, maasClient)
 		req = req.WithContext(ctx)
 

--- a/packages/gen-ai/bff/internal/api/middleware_test.go
+++ b/packages/gen-ai/bff/internal/api/middleware_test.go
@@ -27,7 +27,7 @@ type CapturingMockClientFactory struct {
 	CapturedURL string
 }
 
-func (f *CapturingMockClientFactory) CreateClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.CertPool) llamastack.LlamaStackClientInterface {
+func (f *CapturingMockClientFactory) CreateClient(baseURL string, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) llamastack.LlamaStackClientInterface {
 	f.CapturedURL = baseURL
 	return lsmocks.NewMockLlamaStackClient()
 }

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client.go
@@ -25,7 +25,7 @@ type LlamaStackClient struct {
 }
 
 // NewLlamaStackClient creates a new client configured for Llama Stack.
-func NewLlamaStackClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.CertPool) *LlamaStackClient {
+func NewLlamaStackClient(baseURL string, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) *LlamaStackClient {
 	tlsConfig := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
 	if rootCAs != nil {
 		tlsConfig.RootCAs = rootCAs
@@ -40,7 +40,7 @@ func NewLlamaStackClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.
 
 	client := openai.NewClient(
 		option.WithBaseURL(baseURL+"/v1/openai/v1"),
-		option.WithAPIKey("none"),
+		option.WithAPIKey(authToken),
 		option.WithHTTPClient(httpClient),
 	)
 

--- a/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/llamastack_client_factory.go
@@ -28,7 +28,7 @@ type LlamaStackClientInterface interface {
 
 // LlamaStackClientFactory interface for creating LlamaStack clients
 type LlamaStackClientFactory interface {
-	CreateClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.CertPool) LlamaStackClientInterface
+	CreateClient(baseURL string, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) LlamaStackClientInterface
 }
 
 // RealClientFactory creates real LlamaStack clients
@@ -40,6 +40,6 @@ func NewRealClientFactory() LlamaStackClientFactory {
 }
 
 // CreateClient creates a new real LlamaStack client with the given parameters
-func (f *RealClientFactory) CreateClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.CertPool) LlamaStackClientInterface {
-	return NewLlamaStackClient(baseURL, insecureSkipVerify, rootCAs)
+func (f *RealClientFactory) CreateClient(baseURL string, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) LlamaStackClientInterface {
+	return NewLlamaStackClient(baseURL, authToken, insecureSkipVerify, rootCAs)
 }

--- a/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_factory_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/llamastack/lsmocks/llamastack_client_factory_mock.go
@@ -22,7 +22,7 @@ func (f *MockClientFactory) SetMockClient(client *MockLlamaStackClient) {
 }
 
 // CreateClient creates a new mock LlamaStack client (ignores all parameters since it's a mock)
-func (f *MockClientFactory) CreateClient(baseURL string, insecureSkipVerify bool, rootCAs *x509.CertPool) llamastack.LlamaStackClientInterface {
+func (f *MockClientFactory) CreateClient(baseURL string, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) llamastack.LlamaStackClientInterface {
 	if f.mockClient != nil {
 		return f.mockClient
 	}


### PR DESCRIPTION
- Updated LlamaStackClientFactory interface to accept authToken parameter
- Modified NewLlamaStackClient to accept and use auth token
- Updated OpenAI client initialization to use provided auth token
- Updated real and mock client factories to implement new interface
- Modified middleware to pass auth token from request identity

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced authentication token handling in API client initialization. Authentication tokens are now properly passed through the client factory, enabling authenticated requests to LlamaStack services. This improves security and request handling across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->