### PR TITLE
fix: Handle provider-prefixed model IDs in GetModelProviderInfo

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/testdata/test_llama_stack_config.yaml
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/testdata/test_llama_stack_config.yaml
@@ -28,6 +28,13 @@ providers:
     config:
       url: https://us-south.ml.cloud.ibm.com/ml/v1
       api_key: ${env.WATSONX_API_KEY:=fake-key}
+  - provider_id: maas-vllm-inference-1
+    provider_type: remote::vllm
+    config:
+      url: http://maas.apps.rosa.crimson-demo.g9ax.p3.openshiftapps.com/llm/facebook-opt-125m-simulated/v1
+      max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
+      api_token: ${env.VLLM_API_TOKEN_1:=fake}
+      tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   vector_io:
   - provider_id: milvus
     provider_type: inline::milvus
@@ -122,6 +129,11 @@ models:
 
     model_id: granite-3.1-8b-instruct
     provider_id: maas-watsonx
+    model_type: llm
+  -
+    metadata: {}
+    model_id: facebook/opt-125m
+    provider_id: maas-vllm-inference-1
     model_type: llm
 
 shields: []


### PR DESCRIPTION
- Updated parseModelProviderFromYAML to support both model ID formats:
  * Direct: facebook/opt-125m
  * Provider-prefixed: maas-vllm-inference-1/facebook/opt-125m
- Added test cases for provider-prefixed model IDs
- Added test data for facebook/opt-125m MaaS model

This fixes the 'provider not found for model' error when requests include the provider_id prefix in the model identifier.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for provider-prefixed model identifiers (providerID/modelID) while preserving the original model ID
  * Added a remote vLLM provider option with configurable endpoint, token, max tokens, and TLS verification

* **Behavior Changes**
  * MaaS token injection now triggers based solely on the model ID prefix; non-MaaS IDs skip injection and emit reduced debug logging

* **Tests**
  * Added tests covering provider-prefixed IDs, MaaS mappings, slashed IDs, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->