### PR TITLE
Fix location clearing

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/ExistingConnectionField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/modelLocationFields/ExistingConnectionField.tsx
@@ -90,7 +90,11 @@ export const ExistingConnectionField: React.FC<ExistingConnectionFieldProps> = (
             toggleWidth="450px"
             selectOptions={options}
             onSelect={(_, value) => {
-              if (modelLocationData) {
+              if (
+                modelLocationData &&
+                (!selectedConnection ||
+                  getResourceNameFromK8sResource(selectedConnection) !== value)
+              ) {
                 resetModelLocationData();
               }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes[ [RHOAIENG-36407](https://issues.redhat.com//browse/RHOAIENG-36407)](https://issues.redhat.com/browse/RHOAIENG-36407)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
There was a bug where if you only had one connection it clears the selection when you navigate back a page

When there's only one connection it preselects and was calling the `onSelect` which reset the `modelLocationData`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- Go to deploy a model (make sure the project only has one connection)
- Select "existing connection" and it will preselect the connection
- Fill out model format 
- Go to the next page in the wizard
- Navigate back to the model source page
- The selection should still be 'existing connection' with the one connection selected
- Can check on edit and multiple connections but the selection should be stable between the pages

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment wizard connection selection behavior to prevent unnecessary clearing of model location data when reselecting the same connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->