### PR TITLE
Use kubeRBACProxy instead of oauthProxy in the spec when creating/editing modelregistries

### DIFF
--- a/frontend/src/__mocks__/mockModelRegistry.ts
+++ b/frontend/src/__mocks__/mockModelRegistry.ts
@@ -41,7 +41,7 @@ export const mockModelRegistry = ({
     spec: {
       grpc: {},
       rest: {},
-      oauthProxy: {},
+      kubeRBACProxy: {},
       mysql: {
         database: 'model-registry',
         host: 'model-registry-db',

--- a/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/model_registry.yaml
+++ b/frontend/src/__tests__/cypress/cypress/fixtures/resources/yaml/model_registry.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   grpc: {}
   rest: {}
-  oauthProxy: {}
+  kubeRBACProxy: {}
   mysql:
     host: model-registry-db
     port: 3306

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1521,7 +1521,7 @@ export type ModelRegistryKind = K8sResourceCommon & {
   spec: {
     grpc: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
     rest: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
-    oauthProxy: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
+    kubeRBACProxy: Record<string, never>; // Empty object at create time, properties here aren't used by the UI
   } & EitherNotBoth<
     {
       mysql?: {

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -181,7 +181,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
           },
         },
         spec: {
-          oauthProxy: {},
+          kubeRBACProxy: {},
           mysql: {
             host,
             port: Number(port),
@@ -227,7 +227,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
           },
         },
         spec: {
-          oauthProxy: {},
+          kubeRBACProxy: {},
           grpc: {},
           rest: {},
           mysql: {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Resolves https://issues.redhat.com/browse/RHOAIENG-36462
Resolves https://issues.redhat.com/browse/RHOAIENG-36399

The MR operator has switched from using `oauthProxy` in its spec to `kubeRBACProxy`, but the dashboard still creates MRs using `oauthProxy` in the spec. This works fine for creating model registries because the operator migrates under the hood, but when updating MRs the dashboard attempts to reinsert `oauthProxy` and this fails because it's invalid to have both in the spec.

This PR replaces `oauthProxy` with `kubeRBACProxy` when we construct the API requests to create and update MRs. The value remains the same `{}`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Try to update a model registry on the model registry settings page, e.g. by editing its description. Make sure it submits correctly.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Updates mocks, doesn't affect test logic.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ModelRegistry proxy configuration field naming for consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->