### PR TITLE
add llamastackoperator to mapping

### DIFF
--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -35,7 +35,7 @@ const isFlagOn = (flag: string, flagState: FlagState): 'on' | 'off' => {
   return enabled ? 'on' : 'off';
 };
 
-export const stackToStatusKey: Partial<Record<StackComponent, DataScienceStackComponent>> = {
+export const stackToStatusKey: Record<StackComponent, DataScienceStackComponent> = {
   [StackComponent.CODE_FLARE]: DataScienceStackComponent.CODE_FLARE,
   [StackComponent.DS_PIPELINES]: DataScienceStackComponent.DS_PIPELINES,
   [StackComponent.K_SERVE]: DataScienceStackComponent.K_SERVE,
@@ -48,6 +48,7 @@ export const stackToStatusKey: Partial<Record<StackComponent, DataScienceStackCo
   [StackComponent.TRAINING_OPERATOR]: DataScienceStackComponent.TRAINING_OPERATOR,
   [StackComponent.MODEL_REGISTRY]: DataScienceStackComponent.MODEL_REGISTRY,
   [StackComponent.FEAST_OPERATOR]: DataScienceStackComponent.FEAST_OPERATOR,
+  [StackComponent.LLAMA_STACK_OPERATOR]: DataScienceStackComponent.LLAMA_STACK_OPERATOR,
 };
 
 export const isAreaAvailable = (


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The `stackToStatusKey` missed the inclusion of the `StackComponent.LLAMA_STACK_OPERATOR`. Added the missing component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally try to access gen ai plugin ui which depends on the llamastackoperator component

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Llama Stack Operator component in the stack configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->