### PR TITLE
Deploy modal existing cluster storage bug fix (main)

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -505,45 +505,8 @@ export const ConnectionSection: React.FC<Props> = ({
               )
             }
           />
-          {(pvcs && pvcs.length > 0) || pvcNameFromUri ? (
-            <Radio
-              label="Existing cluster storage"
-              name="pvc-serving-radio"
-              id="pvc-serving-radio"
-              data-testid="pvc-serving-radio"
-              isChecked={data.storage.type === InferenceServiceStorageType.PVC_STORAGE}
-              onChange={() => {
-                setConnection(undefined);
-                setData('storage', {
-                  ...data.storage,
-                  type: InferenceServiceStorageType.PVC_STORAGE,
-                  uri: undefined,
-                  alert: undefined,
-                });
-              }}
-              body={
-                data.storage.type === InferenceServiceStorageType.PVC_STORAGE && (
-                  <PvcSelect
-                    pvcs={pvcs}
-                    selectedPVC={selectedPVC}
-                    onSelect={(selection?: PersistentVolumeClaimKind | undefined) => {
-                      setData('storage', {
-                        ...data.storage,
-                        type: InferenceServiceStorageType.PVC_STORAGE,
-                        pvcConnection: selection?.metadata.name ?? '',
-                      });
-                    }}
-                    setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
-                    setIsConnectionValid={setIsConnectionValid}
-                    existingUriOption={existingUriOption}
-                    pvcNameFromUri={pvcNameFromUri}
-                  />
-                )
-              }
-            />
-          ) : null}
         </>
-      ) : pvcs && pvcs.length === 0 ? ( // No connections and no pvcs
+      ) : pvcs && pvcs.length === 0 ? ( // No connections and no pvcs: auto-show the new connection field
         <FormGroup
           name="new-connection"
           id="new-connection"
@@ -573,13 +536,12 @@ export const ConnectionSection: React.FC<Props> = ({
           </Stack>
         </FormGroup>
       ) : (
-        // No connections, but there are pvcs
+        // No connections, but there are pvcs show the new connection radio and pvc radio
         <Radio
           name="new-connection-radio"
           id="new-connection-radio"
           data-testid="new-connection-radio"
           label="Create connection"
-          className="pf-v6-u-mb-lg"
           isChecked={data.storage.type === InferenceServiceStorageType.NEW_STORAGE}
           onChange={() => {
             setConnection(undefined);
@@ -622,6 +584,43 @@ export const ConnectionSection: React.FC<Props> = ({
           }
         />
       )}
+      {(pvcs && pvcs.length > 0) || pvcNameFromUri ? (
+        <Radio
+          label="Existing cluster storage"
+          name="pvc-serving-radio"
+          id="pvc-serving-radio"
+          data-testid="pvc-serving-radio"
+          isChecked={data.storage.type === InferenceServiceStorageType.PVC_STORAGE}
+          onChange={() => {
+            setConnection(undefined);
+            setData('storage', {
+              ...data.storage,
+              type: InferenceServiceStorageType.PVC_STORAGE,
+              uri: undefined,
+              alert: undefined,
+            });
+          }}
+          body={
+            data.storage.type === InferenceServiceStorageType.PVC_STORAGE && (
+              <PvcSelect
+                pvcs={pvcs}
+                selectedPVC={selectedPVC}
+                onSelect={(selection?: PersistentVolumeClaimKind | undefined) => {
+                  setData('storage', {
+                    ...data.storage,
+                    type: InferenceServiceStorageType.PVC_STORAGE,
+                    pvcConnection: selection?.metadata.name ?? '',
+                  });
+                }}
+                setModelUri={(uri) => setData('storage', { ...data.storage, uri })}
+                setIsConnectionValid={setIsConnectionValid}
+                existingUriOption={existingUriOption}
+                pvcNameFromUri={pvcNameFromUri}
+              />
+            )
+          }
+        />
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAEING-36757](https://issues.redhat.com/browse/RHOAIENG-36757)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If you didn't have any connections the "existing cluster storage" option wasn't showing up even if you had PVCs

This wasn't an issue in the wizard, its in the old modal but we still have it for model catalog and registry for the time being


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- This wasn't an issue in the wizard, its in the old modal
- Easiest way to check is from model catalog, pick a model and select a project that has PVCs but no connections
- The existing connection option should not show up but the existing cluster storage should

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved storage option selection flow in Inference Service configuration
  * Existing cluster storage option now displays contextually when PVCs are available or derivable from connection details
  * Streamlined storage selection interface for better clarity and usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->