### PR TITLE
fix: NIM model is not shown in the project after enabling NIM

### DIFF
--- a/frontend/src/concepts/integrations/__tests__/useComponentIntegrationsStatus.spec.ts
+++ b/frontend/src/concepts/integrations/__tests__/useComponentIntegrationsStatus.spec.ts
@@ -7,6 +7,7 @@ jest.mock('#~/utilities/useFetch');
 jest.mock('#~/services/componentsServices');
 jest.mock('#~/services/integrationAppService');
 jest.mock('#~/utilities/utils.ts');
+jest.mock('#~/redux/hooks');
 
 const mockUseFetch = jest.requireMock('#~/utilities/useFetch').default;
 const mockFetchComponents = jest.requireMock('#~/services/componentsServices').fetchComponents;
@@ -14,6 +15,7 @@ const mockGetIntegrationAppEnablementStatus = jest.requireMock(
   '#~/services/integrationAppService',
 ).getIntegrationAppEnablementStatus;
 const mockIsIntegrationApp = jest.requireMock('#~/utilities/utils.ts').isIntegrationApp;
+const mockUseAppSelector = jest.requireMock('#~/redux/hooks').useAppSelector;
 
 describe('useComponentIntegrationsStatus', () => {
   const mockIntegrationStatus: IntegrationAppStatus = {
@@ -25,6 +27,7 @@ describe('useComponentIntegrationsStatus', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAppSelector.mockReturnValue(0);
   });
 
   it('should return empty object when no integration apps exist', () => {
@@ -95,6 +98,6 @@ describe('useComponentIntegrationsStatus', () => {
 
     renderHook(() => useComponentIntegrationsStatus());
 
-    expect(mockUseFetch).toHaveBeenCalledWith(expect.any(Function), []);
+    expect(mockUseFetch).toHaveBeenCalledWith(expect.any(Function), {});
   });
 });

--- a/frontend/src/concepts/integrations/useComponentIntegrationsStatus.ts
+++ b/frontend/src/concepts/integrations/useComponentIntegrationsStatus.ts
@@ -4,10 +4,13 @@ import { fetchComponents } from '#~/services/componentsServices';
 import { getIntegrationAppEnablementStatus } from '#~/services/integrationAppService';
 import { IntegrationAppStatus } from '#~/types';
 import { isIntegrationApp } from '#~/utilities/utils';
+import { useAppSelector } from '#~/redux/hooks';
 
 export const useComponentIntegrationsStatus = (): FetchStateObject<
   Record<string, IntegrationAppStatus>
 > => {
+  const forceUpdate = useAppSelector((state) => state.forceComponentsUpdate);
+
   const fetchCallbackPromise = React.useCallback(async () => {
     const result = await fetchComponents(false);
     const integrations = result.filter((c) => c.spec.internalRoute);
@@ -26,7 +29,7 @@ export const useComponentIntegrationsStatus = (): FetchStateObject<
     const statuses = await Promise.all(promises);
 
     return Object.assign({}, ...statuses);
-  }, []);
+  }, [forceUpdate]);
 
-  return useFetch(fetchCallbackPromise, []);
+  return useFetch(fetchCallbackPromise, {});
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/NVPE-365
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
**Problem**
When users enable NIM from Applications → Explore → NIM → Enable, the NIM model serving platform card doesn't appear in Data Science Projects → Project Details → Overview → Serve models section. Users must manually refresh the page to see the NIM option.

**Solution**
Modified `useComponentIntegrationsStatus` hook to listen to the Redux `forceComponentsUpdate` action that's dispatched when NIM is enabled. 
Result: NIM platform card now appears immediately after enabling without requiring a page reload.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NIM should be disabled first.
1. Go to Applications -> Explore -> Enable NIM
2. Go to Data schience projects -> create a project
3. Explore what Serve models types enabled and NIM should be one of them.

https://github.com/user-attachments/assets/84860903-9823-475d-b6b9-76831292f90d


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
