### PR TITLE
Remove API Protocol column from deployments table

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -174,7 +174,10 @@ describe('Model Serving LLMD', () => {
         .findExternalServicePopover()
         .findByText('http://us-east-1.elb.amazonaws.com/test-project/facebook-opt-125m-single')
         .should('exist');
-      row.findAPIProtocol().should('have.text', 'REST');
+      row
+        .findExternalServicePopover()
+        .findByTestId('api-protocol-label')
+        .should('have.text', 'REST');
       row.findLastDeployed().should('have.text', '17 Mar 2023');
       row.findStatusLabel('Started');
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -22,9 +22,9 @@ import InferenceServiceEndpoint from './InferenceServiceEndpoint';
 import InferenceServiceProject from './InferenceServiceProject';
 import InferenceServiceStatus from './InferenceServiceStatus';
 import InferenceServiceServingRuntime from './InferenceServiceServingRuntime';
-import InferenceServiceAPIProtocol from './InferenceServiceAPIProtocol';
 import { ColumnField } from './data';
 import InferenceServiceLastDeployed from './InferenceServiceLastDeployed';
+import InferenceServiceAPIProtocol from './InferenceServiceAPIProtocol';
 
 type InferenceServiceTableRowProps = {
   obj: InferenceServiceKind;

--- a/packages/model-serving/src/components/deployments/DeploymentEndpointsPopupButton.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentEndpointsPopupButton.tsx
@@ -12,6 +12,9 @@ import {
   HelperText,
   HelperTextItem,
   Skeleton,
+  Label,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
 import { DeploymentEndpoint } from '../../../extension-points';
 
@@ -44,11 +47,13 @@ const EndpointListItem: React.FC<{ endpoint: DeploymentEndpoint }> = ({ endpoint
 type DeploymentEndpointsPopupButtonProps = {
   endpoints?: DeploymentEndpoint[];
   loading: boolean;
+  apiProtocol?: string;
 };
 
 export const DeploymentEndpointsPopupButton: React.FC<DeploymentEndpointsPopupButtonProps> = ({
   endpoints,
   loading,
+  apiProtocol,
 }) => {
   if (loading) {
     return <Skeleton />;
@@ -73,7 +78,18 @@ export const DeploymentEndpointsPopupButton: React.FC<DeploymentEndpointsPopupBu
   return (
     <Popover
       data-testid={hasExternalEndpoints ? 'external-service-popover' : 'internal-service-popover'}
-      headerContent="Inference endpoints"
+      headerContent={
+        <Flex>
+          <FlexItem>Inference endpoints</FlexItem>
+          {apiProtocol && (
+            <FlexItem>
+              <Label data-testid="api-protocol-label" color="yellow">
+                {apiProtocol}
+              </Label>
+            </FlexItem>
+          )}
+        </Flex>
+      }
       aria-label={hasExternalEndpoints ? 'External Service Info' : 'Internal Service Info'}
       hasAutoWidth
       bodyContent={

--- a/packages/model-serving/src/components/deployments/DeploymentStatus.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatus.tsx
@@ -26,6 +26,7 @@ const DeploymentStatus: React.FC<DeploymentStatusProps> = ({ deployment, stopped
     <DeploymentEndpointsPopupButton
       endpoints={deployment.endpoints}
       loading={stoppedStates?.isStarting ?? false}
+      apiProtocol={deployment.apiProtocol}
     />
   );
 };

--- a/packages/model-serving/src/components/deployments/DeploymentsTable.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentsTable.tsx
@@ -35,11 +35,6 @@ const genericColumns: SortableData<Deployment>[] = [
     sortable: false,
   },
   {
-    label: 'API protocol',
-    field: 'apiProtocol',
-    sortable: false,
-  },
-  {
     field: 'hardwareProfile',
     label: 'Hardware profile',
     sortable: false,

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -70,8 +70,6 @@ describe('DeploymentsTableRow', () => {
     expect(screen.getByRole('button', { name: 'More info' })).toBeInTheDocument();
     // Inference endpoint Column
     expect(screen.getByText('Failed to get endpoint for this deployed model.')).toBeInTheDocument();
-    // API protocol Column
-    expect(screen.getByText('Not defined')).toBeInTheDocument();
     // Status Column
     expect(screen.getByText('Inference Service Status')).toBeInTheDocument();
 
@@ -226,26 +224,39 @@ describe('DeploymentsTableRow', () => {
       expect(screen.getByText('https://internal-endpoint.com')).toBeInTheDocument();
       expect(screen.getByText('https://external-endpoint.com')).toBeInTheDocument();
     });
-  });
 
-  it('should render the row with an api protocol', () => {
-    render(
-      <table>
-        <tbody>
-          <DeploymentRow
-            deployment={mockDeployment({
-              server: undefined,
-              apiProtocol: 'REST',
-            })}
-            platformColumns={[]}
-            onDelete={onDelete}
-            onEdit={onEdit}
-            rowIndex={0}
-          />
-        </tbody>
-      </table>,
-    );
+    it('should render the row with API protocol', async () => {
+      render(
+        <table>
+          <tbody>
+            <DeploymentRow
+              deployment={mockDeployment({
+                apiProtocol: 'REST',
+                endpoints: [
+                  {
+                    type: 'internal',
+                    name: 'test-endpoint',
+                    url: 'https://internal-endpoint.com',
+                  },
+                ],
+              })}
+              platformColumns={[]}
+              onDelete={onDelete}
+              onEdit={onEdit}
+              rowIndex={0}
+            />
+          </tbody>
+        </table>,
+      );
 
-    expect(screen.getByText('REST')).toBeInTheDocument();
+      const button = screen.getByRole('button', { name: 'Internal endpoint' });
+      expect(button).toBeInTheDocument();
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(screen.getByText('https://internal-endpoint.com')).toBeInTheDocument();
+      expect(screen.getByTestId('api-protocol-label')).toBeInTheDocument();
+      expect(screen.getByTestId('api-protocol-label')).toHaveTextContent('REST');
+    });
   });
 });

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Td, Tbody } from '@patternfly/react-table';
-import { Label, Content, ContentVariants } from '@patternfly/react-core';
 import ResourceActionsColumn from '@odh-dashboard/internal/components/ResourceActionsColumn';
 import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
@@ -109,13 +108,6 @@ export const DeploymentRow: React.FC<{
             deployment={deployment}
             stoppedStates={deployment.status?.stoppedStates}
           />
-        </Td>
-        <Td dataLabel="API protocol">
-          {deployment.apiProtocol ? (
-            <Label color="yellow">{deployment.apiProtocol}</Label>
-          ) : (
-            <Content component={ContentVariants.small}>Not defined</Content>
-          )}
         </Td>
         <DeploymentHardwareProfileCell deployment={deployment} />
         <Td dataLabel="Last deployed">


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-34023
## Description
Remove the API Protocol column from the deployments table and add it to the Inference Endpoints popover

<img width="2147" height="388" alt="Screenshot From 2025-10-21 11-41-27" src="https://github.com/user-attachments/assets/a7122e98-ef66-48c8-9d3d-d7446d2f02dc" />

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Go to projects table and deploy a model
See no api protocol column and check the label is in the endpoints popover

do the same for global deployments table

Not sure how this affects situations where you have NIM and kserve in the global page :thinking: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Probably need to update tests here some more
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved API protocol out of the deployments table column and now shows as a labeled badge inside the Inference endpoints popup, streamlining the table layout and consolidating endpoint details.

* **Tests**
  * Updated unit and end-to-end tests to assert the API protocol label within the endpoints popup/button UI instead of the removed table column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->