### PR TITLE
restore lexicographic sort to navigation group

### DIFF
--- a/frontend/src/app/navigation/__tests__/NavSection.spec.tsx
+++ b/frontend/src/app/navigation/__tests__/NavSection.spec.tsx
@@ -1271,7 +1271,7 @@ describe('NavSection', () => {
           title: 'Without Group',
           href: '/withoutGroup',
           section: 'settings',
-          // No group property (should use default '8_default')
+          // No group property (should use default)
         },
         flags: {},
       };
@@ -1287,7 +1287,7 @@ describe('NavSection', () => {
         await userEvent.setup().click(expandButton);
       }
 
-      // Child with group should come first (1_early < 8_default)
+      // Child with group should come first
       await waitFor(() => {
         const items = screen.getAllByRole('link');
         expect(items[0]).toHaveTextContent('With Group');

--- a/frontend/src/app/navigation/utils.ts
+++ b/frontend/src/app/navigation/utils.ts
@@ -1,26 +1,7 @@
 import { NavExtension } from '@odh-dashboard/plugin-core/extension-points';
 
-const DEFAULT_GROUP = '8_default';
+const DEFAULT_GROUP = '5_default';
 
-/** Comparison function for navigation items sorting. */
-export const compareNavItemGroups = <T extends NavExtension>(a: T, b: T): number => {
-  const groupA = a.properties.group || DEFAULT_GROUP;
-  const groupB = b.properties.group || DEFAULT_GROUP;
-
-  // Extract numeric prefix and suffix for proper sorting
-  const extractParts = (group: string) => {
-    const match = group.match(/^(\d+)_(.*)$/);
-    return match ? { num: parseInt(match[1], 10), suffix: match[2] } : { num: 0, suffix: group };
-  };
-
-  const partsA = extractParts(groupA);
-  const partsB = extractParts(groupB);
-
-  // First compare by numeric prefix
-  if (partsA.num !== partsB.num) {
-    return partsA.num - partsB.num;
-  }
-
-  // If numeric parts are equal, compare by suffix
-  return partsA.suffix.localeCompare(partsB.suffix);
-};
+/** Lexicographic comparison function for navigation items sorting. */
+export const compareNavItemGroups = <T extends NavExtension>(a: T, b: T): number =>
+  (a.properties.group || DEFAULT_GROUP).localeCompare(b.properties.group || DEFAULT_GROUP);

--- a/packages/plugin-core/src/extension-points/navigation.ts
+++ b/packages/plugin-core/src/extension-points/navigation.ts
@@ -40,7 +40,7 @@ export type NavItemProperties = {
   section?: string;
   /** Adds data attributes to the DOM. */
   dataAttributes?: { [key: string]: string };
-  /** Group are used to sort items lexographically. Unspecified items will be sorted into the '5_default' group. */
+  /** Group are used to sort items lexicographically. Unspecified items will be sorted into the '5_default' group. */
   group?: string;
   /** Icon reference for this item. */
   iconRef?: ComponentCodeRef;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-35033

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

PR https://github.com/opendatahub-io/odh-dashboard/pull/4678 changed the sorting algorithm for navigational groups. However this change was unnecessary and more restrictive. Lexicographical sort allows us infinite control over inserting navigation items anywhere. The is more flexible than numerical sorting because one cannot insert a new item between items `1` and `2` without changing `2` => `3` and any cascading change afterwards. With lexicographic search we can simply do insert a nav item with group `11` which then falls between `11`.

Note that since the sort order change, adopters have already resorted to numeric sorting and therefore changing to 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually inspected navigation of core and modules with every feature turned on to validate that navigation sorting remains the same.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation sorting simplified to a consistent lexicographic comparison, improving group ordering reliability and updating the default-group fallback behavior.

* **Documentation**
  * Fixed spelling of "lexicographically" in public-facing navigation docs.

* **Tests**
  * Updated test descriptions to reflect default grouping behavior without exposing internal default labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->