### PR TITLE
Revert 85a6f357d

### DIFF
--- a/backend/src/__tests__/resourceUtils.spec.ts
+++ b/backend/src/__tests__/resourceUtils.spec.ts
@@ -12,7 +12,6 @@ describe('resourceUtils', () => {
           status: 'True',
         },
       ],
-      components: {},
       phase: 'Running',
       release: {
         name,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -972,32 +972,12 @@ export enum KnownLabels {
   KUEUE_MANAGED = 'kueue.openshift.io/managed',
 }
 
-export type ManagementState = 'Managed' | 'Unmanaged' | 'Removed';
-
-// Base component status shared by all components
-export type DataScienceClusterComponentStatus = {
-  managementState?: ManagementState;
-  releases?: Array<{
-    name: string;
-    version?: string;
-    repoUrl?: string;
-  }>;
-};
-
 export type DataScienceClusterKindStatus = {
   components?: {
-    [key: string]: DataScienceClusterComponentStatus;
-  } & {
-    /** Status of KServe, including deployment mode and serverless configuration. */
-    kserve?: DataScienceClusterComponentStatus & {
-      defaultDeploymentMode?: string;
-      serverlessMode?: string;
-    };
-    /** Status of Model Registry, including its namespace configuration. */
-    modelregistry?: DataScienceClusterComponentStatus & {
+    modelregistry?: {
       registriesNamespace?: string;
     };
-    workbenches?: DataScienceClusterComponentStatus & {
+    workbenches?: {
       workbenchNamespace?: string;
     };
   };
@@ -1005,7 +985,6 @@ export type DataScienceClusterKindStatus = {
   phase?: string;
   release?: {
     name: string;
-    version?: string;
   };
 };
 

--- a/frontend/src/__mocks__/mockDscStatus.ts
+++ b/frontend/src/__mocks__/mockDscStatus.ts
@@ -1,11 +1,17 @@
-import { DataScienceClusterKindStatus, K8sCondition } from '#~/k8sTypes';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import {
+  DataScienceClusterInstalledComponents,
+  DataScienceClusterKindStatus,
+  K8sCondition,
+} from '#~/k8sTypes';
+import { DataScienceStackComponent, StackComponent } from '#~/concepts/areas/types';
 import { DataScienceStackComponentMap } from '#~/concepts/areas/const';
+import { stackToStatusKey } from '#~/concepts/areas/utils';
 
 export type MockDscStatus = {
   components?: DataScienceClusterKindStatus['components'];
   conditions?: K8sCondition[];
   phase?: string;
+  installedComponents?: DataScienceClusterInstalledComponents;
   release?: {
     name: string;
     version: string;
@@ -14,16 +20,7 @@ export type MockDscStatus = {
 
 export const mockDscStatus = ({
   components = {
-    // Dynamically create all components with default 'Managed' state
-    ...Object.fromEntries(
-      Object.values(DataScienceStackComponent).map((component) => [
-        component,
-        { managementState: 'Managed' },
-      ]),
-    ),
-    // Override specific components with additional fields
     [DataScienceStackComponent.MODEL_REGISTRY]: {
-      managementState: 'Managed',
       registriesNamespace: 'odh-model-registries',
       releases: [
         {
@@ -34,7 +31,6 @@ export const mockDscStatus = ({
       ],
     },
     [DataScienceStackComponent.K_SERVE]: {
-      managementState: 'Managed',
       releases: [
         {
           name: 'KServe',
@@ -44,15 +40,34 @@ export const mockDscStatus = ({
       ],
     },
     [DataScienceStackComponent.WORKBENCHES]: {
-      managementState: 'Managed',
       workbenchNamespace: 'openshift-ai-notebooks',
     },
   },
+  installedComponents = Object.values(StackComponent).reduce(
+    (acc, component) => ({ ...acc, [component]: true }),
+    {},
+  ),
   conditions = [],
   phase = 'Ready',
   release = { name: 'Open Data Hub', version: '2.28.0' },
 }: MockDscStatus): DataScienceClusterKindStatus => ({
-  components,
+  components: (() => {
+    // Map StackComponent -> DataScienceStackComponent ComponentName keys
+
+    const result = { ...components };
+    // Synthesize components managementState from installedComponents for compatibility
+    Object.entries(installedComponents).forEach(([stackKey, isInstalled]) => {
+      const statusKey = stackToStatusKey[stackKey as StackComponent];
+      if (statusKey) {
+        const prev = result[statusKey] || {};
+        result[statusKey] = {
+          managementState: isInstalled ? 'Managed' : 'Removed',
+          ...prev,
+        };
+      }
+    });
+    return result;
+  })(),
   conditions: [
     ...[
       {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/clusterSettings/clusterSettings.cy.ts
@@ -13,7 +13,7 @@ import {
   asClusterAdminUser,
   asProjectAdminUser,
 } from '#~/__tests__/cypress/cypress/utils/mockUsers';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import { StackComponent } from '#~/concepts/areas/types';
 import { mockK8sResourceList } from '#~/__mocks__';
 import { DataScienceClusterModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { mockDsc } from '#~/__mocks__/mockDsc';
@@ -35,10 +35,7 @@ describe('Cluster Settings', () => {
     cy.interceptOdh(
       'GET /api/dsc/status',
       mockDscStatus({
-        components: {
-          [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-          [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-        },
+        installedComponents: { [StackComponent.K_SERVE]: true, [StackComponent.MODEL_MESH]: true },
       }),
     );
     cy.interceptOdh('GET /api/cluster-settings', mockClusterSettings({}));

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -19,7 +19,6 @@ import {
   WorkloadModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { RefreshIntervalTitle } from '#~/concepts/metrics/types';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const mockContainer: PodContainer = {
   env: [],
@@ -103,11 +102,7 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.KUEUE]: {
-          managementState: isKueueInstalled ? 'Managed' : 'Removed',
-        },
-      },
+      installedComponents: { kueue: isKueueInstalled },
     }),
   );
   cy.interceptOdh(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSet.cy.ts
@@ -18,7 +18,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -29,8 +28,8 @@ const initCommonIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSources.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureDataSources.cy.ts
@@ -16,7 +16,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -27,8 +26,8 @@ const initCommonIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureEntities.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureEntities.cy.ts
@@ -18,7 +18,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -29,8 +28,8 @@ const initCommonIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureMetrics.cy.ts
@@ -16,7 +16,6 @@ import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/m
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
 import { featureMetricsOverview } from '#~/__tests__/cypress/cypress/pages/featureStore/featureMetrics';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -26,8 +25,8 @@ const initCommonIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureServiceDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureServiceDetails.cy.ts
@@ -16,7 +16,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -27,8 +26,8 @@ const initIntercept = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureServices.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureServices.cy.ts
@@ -11,7 +11,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -21,8 +20,8 @@ const initIntercept = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureViews.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/featureViews.cy.ts
@@ -11,7 +11,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -21,8 +20,8 @@ const initIntercept = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/features.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/featureStore/features.cy.ts
@@ -12,7 +12,6 @@ import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import { ProjectModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import { asClusterAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { mockProjectK8sResource } from '#~/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const k8sNamespace = 'default';
 const fsName = 'demo';
@@ -103,8 +102,8 @@ const initIntercept = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      installedComponents: {
+        feastoperator: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -33,7 +33,6 @@ import { workbenchPage, editSpawnerPage } from '#~/__tests__/cypress/cypress/pag
 import { hardwareProfileSection } from '#~/__tests__/cypress/cypress/pages/components/HardwareProfileSection';
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import type { PodKind } from '#~/k8sTypes';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   isEmpty?: boolean;
@@ -64,8 +63,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+      installedComponents: {
+        workbenches: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/home/homeModelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/home/homeModelCatalog.cy.ts
@@ -16,7 +16,6 @@ import {
   mockModelRegistryService,
 } from '#~/__mocks__';
 import { mockCatalogModel } from '#~/__mocks__/mockCatalogModel';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   modelRegistries?: K8sResourceCommon[];
@@ -37,8 +36,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/lmEval/lmEvalTestUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/lmEval/lmEvalTestUtils.ts
@@ -6,7 +6,6 @@ import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServi
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { mockConfigMap } from '#~/__mocks__/mockConfigMap';
 import { LMEvalModel, ProjectModel, ConfigMapModel } from '#~/api/models';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 export const createVLLMInferenceService = (
   name: string,
@@ -35,11 +34,7 @@ export const setupBasicMocks = (namespace: string): void => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-        [DataScienceStackComponent.TRUSTY_AI]: { managementState: 'Managed' },
-      },
+      installedComponents: { kserve: true, 'model-mesh': true, trustyai: true },
     }),
   );
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -20,7 +20,6 @@ import { mockModelRegistryService } from '#~/__mocks__/mockModelRegistryService'
 import { mockK8sResourceList } from '#~/__mocks__/mockK8sResourceList';
 import type { ModelCatalogSource } from '#~/concepts/modelCatalog/types';
 import { appChrome } from '#~/__tests__/cypress/cypress/pages/appChrome';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   modelRegistries?: K8sResourceCommon[];
@@ -42,8 +41,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelDetailsPage.cy.ts
@@ -15,7 +15,6 @@ import { verifyRelativeURL } from '#~/__tests__/cypress/cypress/utils/url';
 import { mockCatalogModel } from '#~/__mocks__/mockCatalogModel';
 import { mockModelCatalogSource } from '#~/__mocks__/mockModelCatalogSource';
 import type { ModelCatalogSource } from '#~/concepts/modelCatalog/types';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   modelRegistries?: ServiceKind[];
@@ -38,8 +37,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/registerCatalogModel.cy.ts
@@ -26,7 +26,6 @@ import {
   FormFieldSelector,
   registerModelPage,
 } from '#~/__tests__/cypress/cypress/pages/modelRegistry/registerModelPage';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const existingModelName = 'model1';
 const MODEL_REGISTRY_API_VERSION = 'v1alpha3';
@@ -48,8 +47,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelRegistry.cy.ts
@@ -25,7 +25,6 @@ import {
 } from '#~/concepts/modelRegistry/types';
 import type { ModelRegistry } from '#~/k8sTypes';
 import { appChrome } from '#~/__tests__/cypress/cypress/pages/appChrome';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const MODEL_REGISTRY_API_VERSION = 'v1';
 
@@ -129,8 +128,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionArchive.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionArchive.cy.ts
@@ -22,7 +22,6 @@ import { modelVersionArchive } from '#~/__tests__/cypress/cypress/pages/modelReg
 import { modelRegistry } from '#~/__tests__/cypress/cypress/pages/modelRegistry';
 import { mockModelRegistry, mockModelRegistryService } from '#~/__mocks__/mockModelRegistryService';
 import { KnownLabels } from '#~/k8sTypes';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const MODEL_REGISTRY_API_VERSION = 'v1';
 
@@ -83,8 +82,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/modelVersion/modelVersionDetails.cy.ts
@@ -32,7 +32,6 @@ import { modelServingGlobal } from '#~/__tests__/cypress/cypress/pages/modelServ
 import { ModelRegistryMetadataType } from '#~/concepts/modelRegistry/types';
 import { KnownLabels } from '#~/k8sTypes';
 import { asProjectEditUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const MODEL_REGISTRY_API_VERSION = 'v1';
 const mockModelVersions = mockModelVersion({
@@ -167,8 +166,8 @@ const initIntercepts = (
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        'model-registry-operator': true,
       },
     }),
   );
@@ -448,9 +447,9 @@ describe('Model version details', () => {
       cy.interceptOdh(
         'GET /api/dsc/status',
         mockDscStatus({
-          components: {
-            [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
-            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+          installedComponents: {
+            'model-registry-operator': true,
+            'data-science-pipelines-operator': true,
           },
         }),
       );
@@ -543,9 +542,9 @@ describe('Model version details', () => {
       cy.interceptOdh(
         'GET /api/dsc/status',
         mockDscStatus({
-          components: {
-            [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
-            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+          installedComponents: {
+            'model-registry-operator': true,
+            'data-science-pipelines-operator': true,
           },
         }),
       );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerModel.cy.ts
@@ -8,7 +8,7 @@ import {
   mockSecretK8sResource,
 } from '#~/__mocks__';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import { StackComponent } from '#~/concepts/areas/types';
 import { ProjectModel, SecretModel, ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import {
   FormFieldSelector,
@@ -40,9 +40,9 @@ const initIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        [StackComponent.MODEL_REGISTRY]: true,
+        [StackComponent.MODEL_MESH]: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerVersion.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistry/registerVersion.cy.ts
@@ -1,6 +1,6 @@
 import { mockDashboardConfig, mockDscStatus, mockK8sResourceList } from '#~/__mocks__';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import { StackComponent } from '#~/concepts/areas/types';
 import { ServiceModel } from '#~/__tests__/cypress/cypress/utils/models';
 import {
   FormFieldSelector,
@@ -31,9 +31,9 @@ const initIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        [StackComponent.MODEL_REGISTRY]: true,
+        [StackComponent.MODEL_MESH]: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -5,7 +5,7 @@ import {
   mockK8sResourceList,
 } from '#~/__mocks__';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import { StackComponent } from '#~/concepts/areas/types';
 import {
   FormFieldSelector,
   modelRegistrySettings,
@@ -57,12 +57,9 @@ const setupMocksForMRSettingAccess = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.MODEL_REGISTRY]: {
-          managementState: 'Managed',
-          registriesNamespace: 'odh-model-registries',
-        },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        [StackComponent.MODEL_REGISTRY]: true,
+        [StackComponent.MODEL_MESH]: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelMetrics.cy.ts
@@ -57,7 +57,6 @@ import {
   mockNimMetricsConfigMap,
 } from '#~/__mocks__/mockKserveMetricsConfigMap';
 import { mockOdhApplication } from '#~/__mocks__/mockOdhApplication';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   disablePerformanceMetrics?: boolean;
@@ -106,11 +105,7 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-        [DataScienceStackComponent.TRUSTY_AI]: { managementState: 'Managed' },
-      },
+      installedComponents: { kserve: true, 'model-mesh': true, trustyai: true },
     }),
   );
   cy.interceptOdh(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -35,7 +35,6 @@ import {
   mockModelServingFields,
   mockOciConnectionTypeConfigMap,
 } from '#~/__mocks__/mockConnectionType';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 import {
   mockCustomSecretK8sResource,
   mockURISecretK8sResource,
@@ -54,9 +53,9 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Removed' },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': false,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingGlobal.cy.ts
@@ -48,7 +48,6 @@ import {
 } from '#~/__mocks__/mockHardwareProfile';
 import { initInterceptsForAllProjects } from '#~/__tests__/cypress/cypress/utils/servingUtils';
 import { nimDeployModal } from '#~/__tests__/cypress/cypress/pages/components/NIMDeployModal';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   disableKServeConfig?: boolean;
@@ -79,9 +78,9 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -35,7 +35,6 @@ import {
   mockCustomSecretK8sResource,
   mockSecretK8sResource,
 } from '#~/__mocks__/mockSecretK8sResource';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const initIntercepts = ({
   llmInferenceServices = [],
@@ -49,9 +48,9 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Removed' },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': false,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -39,7 +39,7 @@ import type {
 import { DeploymentMode } from '#~/k8sTypes';
 import { ServingRuntimePlatform } from '#~/types';
 import { deleteModal } from '#~/__tests__/cypress/cypress/pages/components/DeleteModal';
-import { StackCapability, DataScienceStackComponent } from '#~/concepts/areas/types';
+import { StackCapability } from '#~/concepts/areas/types';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
 import {
   HardwareProfileModel,
@@ -135,11 +135,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-        ...DscComponents,
-      },
+      components: DscComponents,
+      installedComponents: { kserve: true, 'model-mesh': true },
     }),
   );
   cy.interceptOdh(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineDeleteRuns.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/runs/pipelineDeleteRuns.cy.ts
@@ -29,15 +29,12 @@ import {
   buildMockPipelineVersions,
   buildMockRecurringRunKF,
 } from '#~/__mocks__';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const initIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-      },
+      installedComponents: { 'data-science-pipelines-operator': true },
     }),
   );
 

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -31,7 +31,6 @@ import {
 import { deleteModal } from '#~/__tests__/cypress/cypress/pages/components/DeleteModal';
 import { RecurringRunStatus } from '#~/concepts/pipelines/kfTypes';
 import { initMlmdIntercepts } from '#~/__tests__/cypress/cypress/tests/mocked/pipelines/mlmdUtils';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const projectId = 'test-project';
 const mockPipeline = buildMockPipeline({
@@ -77,9 +76,7 @@ const initIntercepts = () => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-      },
+      installedComponents: { 'data-science-pipelines-operator': true },
     }),
   );
   cy.interceptK8sList(

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -48,7 +48,6 @@ import { mockNimAccount } from '#~/__mocks__/mockNimAccount';
 import { mockOdhApplication } from '#~/__mocks__/mockOdhApplication';
 import { mockModelRegistryService } from '#~/__mocks__/mockModelRegistryService';
 import type { InferenceServiceKind, ServingRuntimeKind } from '#~/k8sTypes';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 type HandlersProps = {
   isEmpty?: boolean;
@@ -118,14 +117,12 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.WORKBENCHES]: {
-          managementState: disableWorkbenches ? 'Removed' : 'Managed',
-        },
-        [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        workbenches: !disableWorkbenches,
+        'data-science-pipelines-operator': true,
+        kserve: true,
+        'model-mesh': true,
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -18,7 +18,6 @@ import { mockSelfSubjectAccessReview } from '#~/__mocks__/mockSelfSubjectAccessR
 import { asProjectAdminUser } from '#~/__tests__/cypress/cypress/utils/mockUsers';
 import { notebookConfirmModal } from '#~/__tests__/cypress/cypress/pages/workbench';
 import { testPagination } from '#~/__tests__/cypress/cypress/utils/pagination';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 const mockProject = mockProjectK8sResource({ description: 'Mock description' });
 const initIntercepts = () => {
@@ -360,12 +359,12 @@ describe('Projects details', () => {
       cy.interceptOdh(
         'GET /api/dsc/status',
         mockDscStatus({
-          components: {
-            [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Removed' },
-            [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-            [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-            [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
-            [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+          installedComponents: {
+            workbenches: false,
+            'data-science-pipelines-operator': true,
+            kserve: true,
+            'model-mesh': true,
+            'model-registry-operator': true,
           },
         }),
       );

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -48,7 +48,6 @@ import type { HardwareProfileKind, NotebookKind, PodKind } from '#~/k8sTypes';
 import type { EnvironmentFromVariable } from '#~/pages/projects/types';
 import { SpawnerPageSectionID } from '#~/pages/projects/screens/spawner/types';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums.ts';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 import { hardwareProfileSection } from '../../../../pages/components/HardwareProfileSection.ts';
 
 const configYamlPath = '../../__mocks__/mock-upload-configmap.yaml';
@@ -166,8 +165,8 @@ const initIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+      installedComponents: {
+        workbenches: true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/modelServingUtils.ts
@@ -25,10 +25,10 @@ import {
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { ConnectionTypeFieldType } from '#~/concepts/connectionTypes/types';
 import { ServingRuntimePlatform } from '#~/types';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 export const initDeployPrefilledModelIntercepts = ({
   modelMeshInstalled = true,
+  kServeInstalled = true,
   disableProjectScoped = true,
   isEmpty = false,
 }: {
@@ -49,12 +49,10 @@ export const initDeployPrefilledModelIntercepts = ({
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: {
-          managementState: modelMeshInstalled ? 'Managed' : 'Removed',
-        },
-        [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+      installedComponents: {
+        kserve: kServeInstalled,
+        'model-mesh': modelMeshInstalled,
+        'model-registry-operator': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
@@ -33,7 +33,6 @@ import {
 import type { InferenceServiceKind } from '#~/k8sTypes';
 import { mockNimAccount } from '#~/__mocks__/mockNimAccount';
 import { mockOdhApplication } from '#~/__mocks__/mockOdhApplication';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 /* ###################################################
    ###### Interception Initialization Utilities ######
@@ -48,9 +47,9 @@ export const initInterceptsToEnableNim = ({ hasAllModels = false }: EnableNimCon
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': true,
       },
     }),
   );

--- a/frontend/src/__tests__/cypress/cypress/utils/servingUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/servingUtils.ts
@@ -25,15 +25,14 @@ import {
   SecretModel,
   ServingRuntimeModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
-import { DataScienceStackComponent } from '#~/concepts/areas/types';
 
 export const initInterceptsForAllProjects = (): void => {
   cy.interceptOdh(
     'GET /api/dsc/status',
     mockDscStatus({
-      components: {
-        [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.MODEL_MESH_SERVING]: { managementState: 'Managed' },
+      installedComponents: {
+        kserve: true,
+        'model-mesh': true,
       },
     }),
   );

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -1,8 +1,9 @@
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
 import {
-  StackCapability,
   DataScienceStackComponent,
+  StackCapability,
+  StackComponent,
   SupportedArea,
   SupportedComponentFlagValue,
 } from '#~/concepts/areas/types';
@@ -58,7 +59,34 @@ describe('isAreaAvailable', () => {
 
   describe('v2 Operator', () => {
     describe('flags and cluster states', () => {
-      it('should enable area (flag true, cluster true)', () => {
+      it('converts installedComponents to managementState', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          // simulate Managed state by setting installedComponents true (mock synthesizes managementState)
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
+          mockDsciStatus({}),
+        );
+
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+      it('should support managementState Unmanaged in area availability checks', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Unmanaged' },
+            },
+          }),
+          mockDsciStatus({}),
+        );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+
+      it('should support managementState Managed in area availability checks', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: false }).spec,
@@ -69,109 +97,107 @@ describe('isAreaAvailable', () => {
           }),
           mockDsciStatus({}),
         );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
+        expect(isAvailable.status).toBe(true);
+      });
+
+      it('should support managementState Removed in area availability checks', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({
+            components: {
+              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Removed' },
+            },
+          }),
+          mockDsciStatus({}),
+        );
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: false });
+        expect(isAvailable.status).toBe(false);
+      });
+
+      it('should enable area (flag true, cluster true)', () => {
+        const isAvailable = isAreaAvailable(
+          SupportedArea.DS_PIPELINES,
+          mockDashboardConfig({ disablePipelines: false }).spec,
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
+          mockDsciStatus({}),
+        );
 
         expect(isAvailable.status).toBe(true);
         expect(isAvailable.featureFlags).toEqual({ disablePipelines: 'on' });
         expect(isAvailable.reliantAreas).toBe(null);
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.DS_PIPELINES]: true,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
       });
 
       it('should disable area (flag true, cluster false)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: false }).spec,
-          mockDscStatus({
-            components: {
-              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Removed' },
-            },
-          }),
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: false } }),
           mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
         expect(isAvailable.featureFlags).toEqual({ disablePipelines: 'on' });
         expect(isAvailable.reliantAreas).toBe(null);
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.DS_PIPELINES]: false,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: false });
       });
 
       it('should disable area (flag false, cluster true)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: true }).spec,
-          mockDscStatus({
-            components: {
-              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
-            },
-          }),
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: true } }),
           mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
         expect(isAvailable.featureFlags).toEqual({ disablePipelines: 'off' });
         expect(isAvailable.reliantAreas).toBe(null);
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.DS_PIPELINES]: true,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: true });
       });
 
       it('should disable area (flag false, cluster false)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.DS_PIPELINES,
           mockDashboardConfig({ disablePipelines: true }).spec,
-          mockDscStatus({
-            components: {
-              [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Removed' },
-            },
-          }),
+          mockDscStatus({ installedComponents: { [StackComponent.DS_PIPELINES]: false } }),
           mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
         expect(isAvailable.featureFlags).toEqual({ disablePipelines: 'off' });
         expect(isAvailable.reliantAreas).toBe(null);
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.DS_PIPELINES]: false,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.DS_PIPELINES]: false });
       });
 
       it('should enable area (no flag, cluster true)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.WORKBENCHES,
           mockDashboardConfig({}).spec,
-          mockDscStatus({
-            components: { [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' } },
-          }),
+          mockDscStatus({ installedComponents: { [StackComponent.WORKBENCHES]: true } }),
           mockDsciStatus({}),
         );
 
         expect(isAvailable.status).toBe(true);
         expect(isAvailable.featureFlags).toBe(null);
         expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.DS_PROJECTS_VIEW]: true });
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.WORKBENCHES]: true,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.WORKBENCHES]: true });
       });
 
       it('should disable area (no flag, cluster false)', () => {
         const isAvailable = isAreaAvailable(
           SupportedArea.WORKBENCHES,
           mockDashboardConfig({}).spec,
-          mockDscStatus({
-            components: { [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Removed' } },
-          }),
+          mockDscStatus({ installedComponents: { [StackComponent.WORKBENCHES]: false } }),
           mockDsciStatus({}),
         );
 
         expect(isAvailable.status).not.toBe(true);
         expect(isAvailable.featureFlags).toBe(null);
         expect(isAvailable.reliantAreas).toEqual({ [SupportedArea.DS_PROJECTS_VIEW]: true });
-        expect(isAvailable.requiredComponents).toEqual({
-          [DataScienceStackComponent.WORKBENCHES]: false,
-        });
+        expect(isAvailable.requiredComponents).toEqual({ [StackComponent.WORKBENCHES]: false });
       });
     });
 
@@ -245,8 +271,8 @@ describe('isAreaAvailable', () => {
           SupportedArea.K_SERVE_AUTH,
           mockDashboardConfig({ disableKServeAuth: false }).spec,
           mockDscStatus({
-            components: {
-              [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+            installedComponents: {
+              [StackComponent.K_SERVE]: true,
             },
           }),
           mockDsciStatus({
@@ -282,8 +308,8 @@ describe('isAreaAvailable', () => {
           SupportedArea.K_SERVE_AUTH,
           mockDashboardConfig({ disableKServeAuth: false }).spec,
           mockDscStatus({
-            components: {
-              [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+            installedComponents: {
+              [StackComponent.K_SERVE]: true,
             },
           }),
           mockDsciStatus({

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -1,6 +1,7 @@
 import { DashboardCommonConfig } from '#~/k8sTypes';
 import {
   StackCapability,
+  StackComponent,
   SupportedArea,
   SupportedAreasState,
   DataScienceStackComponent,
@@ -94,7 +95,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.DS_PIPELINES]: {
     featureFlags: ['disablePipelines'],
-    requiredComponents: [DataScienceStackComponent.DS_PIPELINES],
+    requiredComponents: [StackComponent.DS_PIPELINES],
   },
   [SupportedArea.HOME]: {
     featureFlags: ['disableHome'],
@@ -128,7 +129,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MODEL_MESH]: {
     featureFlags: ['disableModelMesh'],
-    requiredComponents: [DataScienceStackComponent.MODEL_MESH_SERVING],
+    requiredComponents: [StackComponent.MODEL_MESH],
   },
   [SupportedArea.MODEL_SERVING]: {
     featureFlags: ['disableModelServing'],
@@ -138,12 +139,12 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.WORKBENCHES]: {
     // featureFlags: [], // TODO: We want to disable, no flag exists today
-    requiredComponents: [DataScienceStackComponent.WORKBENCHES],
+    requiredComponents: [StackComponent.WORKBENCHES],
     reliantAreas: [SupportedArea.DS_PROJECTS_VIEW],
   },
   [SupportedArea.BIAS_METRICS]: {
     featureFlags: ['disableTrustyBiasMetrics'],
-    requiredComponents: [DataScienceStackComponent.TRUSTY_AI],
+    requiredComponents: [StackComponent.TRUSTY_AI],
     reliantAreas: [SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.PERFORMANCE_METRICS]: {
@@ -151,16 +152,16 @@ export const SupportedAreasStateMap: SupportedAreasState = {
     reliantAreas: [SupportedArea.MODEL_SERVING],
   },
   [SupportedArea.TRUSTY_AI]: {
-    requiredComponents: [DataScienceStackComponent.TRUSTY_AI],
+    requiredComponents: [StackComponent.TRUSTY_AI],
     reliantAreas: [SupportedArea.BIAS_METRICS],
   },
   [SupportedArea.DISTRIBUTED_WORKLOADS]: {
     featureFlags: ['disableDistributedWorkloads'],
-    requiredComponents: [DataScienceStackComponent.KUEUE],
+    requiredComponents: [StackComponent.KUEUE],
   },
   [SupportedArea.KUEUE]: {
     featureFlags: ['disableKueue'],
-    requiredComponents: [DataScienceStackComponent.KUEUE],
+    requiredComponents: [StackComponent.KUEUE],
   },
   [SupportedArea.MODEL_CATALOG]: {
     featureFlags: ['disableModelCatalog'],
@@ -168,7 +169,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MODEL_REGISTRY]: {
     featureFlags: ['disableModelRegistry'],
-    requiredComponents: [DataScienceStackComponent.MODEL_REGISTRY],
+    requiredComponents: [StackComponent.MODEL_REGISTRY],
   },
   [SupportedArea.SERVING_RUNTIME_PARAMS]: {
     featureFlags: ['disableServingRuntimeParams'],
@@ -204,14 +205,11 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.FEATURE_STORE]: {
     featureFlags: ['disableFeatureStore'],
-    requiredComponents: [DataScienceStackComponent.FEAST_OPERATOR],
+    requiredComponents: [StackComponent.FEAST_OPERATOR],
   },
   [SupportedArea.MODEL_TRAINING]: {
     featureFlags: ['disableModelTraining'],
-    requiredComponents: [
-      DataScienceStackComponent.TRAINING_OPERATOR,
-      DataScienceStackComponent.KUEUE,
-    ],
+    requiredComponents: [StackComponent.TRAINING_OPERATOR, StackComponent.KUEUE],
   },
 };
 

--- a/frontend/src/concepts/areas/index.ts
+++ b/frontend/src/concepts/areas/index.ts
@@ -8,5 +8,5 @@
   determine the state we are in.
 */
 export { default as AreaComponent, conditionalArea } from './AreaComponent';
-export { DataScienceStackComponent, SupportedArea } from './types';
+export { SupportedArea, StackComponent } from './types';
 export { default as useIsAreaAvailable } from './useIsAreaAvailable';

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -15,7 +15,7 @@ export type IsAreaAvailableStatus = {
   devFlags: { [key in string]?: 'on' | 'off' } | null; // simplified. `disableX` flags are weird to read
   featureFlags: { [key in FeatureFlag]?: 'on' | 'off' } | null; // simplified. `disableX` flags are weird to read
   reliantAreas: { [key in SupportedAreaType]?: boolean } | null; // only needs 1 to be true
-  requiredComponents: { [key in DataScienceStackComponent]?: boolean } | null;
+  requiredComponents: { [key in StackComponent]?: boolean } | null;
   requiredCapabilities: { [key in StackCapability]?: boolean } | null;
   customCondition: (conditionFunc: CustomConditionFunction) => boolean;
 };
@@ -89,6 +89,23 @@ export enum SupportedArea {
 }
 
 export type SupportedAreaType = SupportedArea | string;
+/** Components deployed by the Operator. Part of the DSC Status. */
+export enum StackComponent {
+  CODE_FLARE = 'codeflare',
+  DS_PIPELINES = 'data-science-pipelines-operator',
+  K_SERVE = 'kserve',
+  MODEL_MESH = 'model-mesh',
+  // Bug: https://github.com/opendatahub-io/opendatahub-operator/issues/641
+  DASHBOARD = 'odh-dashboard',
+  RAY = 'ray',
+  WORKBENCHES = 'workbenches',
+  TRUSTY_AI = 'trustyai',
+  KUEUE = 'kueue',
+  TRAINING_OPERATOR = 'trainingoperator',
+  MODEL_REGISTRY = 'model-registry-operator',
+  FEAST_OPERATOR = 'feastoperator',
+  LLAMA_STACK_OPERATOR = 'llamastackoperator',
+}
 
 /** The possible V1 component names that are used as keys in the `components` object of the DSC Status.
  * Each component's key (e.g., 'codeflare', 'dashboard', etc.) maps to a specific component status.
@@ -173,7 +190,7 @@ export type SupportedComponentFlagValue = {
        * can prevent the feature flag from enabling the item. Omit to not be reliant on a backend
        * component.
        */
-      requiredComponents: DataScienceStackComponent[];
+      requiredComponents: StackComponent[];
     }
   >
 >;

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -3,7 +3,13 @@ import {
   DataScienceClusterInitializationKindStatus,
   DataScienceClusterKindStatus,
 } from '#~/k8sTypes';
-import { IsAreaAvailableStatus, FeatureFlag, SupportedAreaType } from './types';
+import {
+  IsAreaAvailableStatus,
+  FeatureFlag,
+  SupportedAreaType,
+  StackComponent,
+  DataScienceStackComponent,
+} from './types';
 import { definedFeatureFlags, SupportedAreasStateMap } from './const';
 
 export const isDefinedFeatureFlag = (key: string): key is FeatureFlag =>
@@ -29,6 +35,22 @@ const isFlagOn = (flag: string, flagState: FlagState): 'on' | 'off' => {
   return enabled ? 'on' : 'off';
 };
 
+export const stackToStatusKey: Partial<Record<StackComponent, DataScienceStackComponent>> = {
+  [StackComponent.CODE_FLARE]: DataScienceStackComponent.CODE_FLARE,
+  [StackComponent.DS_PIPELINES]: DataScienceStackComponent.DS_PIPELINES,
+  [StackComponent.K_SERVE]: DataScienceStackComponent.K_SERVE,
+  [StackComponent.MODEL_MESH]: DataScienceStackComponent.MODEL_MESH_SERVING,
+  [StackComponent.DASHBOARD]: DataScienceStackComponent.DASHBOARD,
+  [StackComponent.RAY]: DataScienceStackComponent.RAY,
+  [StackComponent.WORKBENCHES]: DataScienceStackComponent.WORKBENCHES,
+  [StackComponent.TRUSTY_AI]: DataScienceStackComponent.TRUSTY_AI,
+  [StackComponent.KUEUE]: DataScienceStackComponent.KUEUE,
+  [StackComponent.TRAINING_OPERATOR]: DataScienceStackComponent.TRAINING_OPERATOR,
+  [StackComponent.MODEL_REGISTRY]: DataScienceStackComponent.MODEL_REGISTRY,
+  [StackComponent.FEAST_OPERATOR]: DataScienceStackComponent.FEAST_OPERATOR,
+  [StackComponent.LLAMA_STACK_OPERATOR]: DataScienceStackComponent.LLAMA_STACK_OPERATOR,
+};
+
 export const isAreaAvailable = (
   area: SupportedAreaType,
   dashboardConfigSpec: DashboardConfigKind['spec'],
@@ -39,6 +61,17 @@ export const isAreaAvailable = (
     flagState: getFlags(dashboardConfigSpec),
   },
 ): IsAreaAvailableStatus => {
+  const isComponentInstalled = (component: StackComponent): boolean => {
+    if (!dscStatus?.components) {
+      return false;
+    }
+    const statusKey = stackToStatusKey[component];
+    if (!statusKey) {
+      return false;
+    }
+    const state = dscStatus.components[statusKey]?.managementState;
+    return state === 'Managed' || state === 'Unmanaged';
+  };
   const { devFlags, featureFlags, requiredComponents, reliantAreas, requiredCapabilities } =
     options.internalStateMap[area];
 
@@ -80,12 +113,7 @@ export const isAreaAvailable = (
   const requiredComponentsState =
     requiredComponents && dscStatus
       ? requiredComponents.reduce<IsAreaAvailableStatus['requiredComponents']>(
-          (acc, component) => ({
-            ...acc,
-            [component]:
-              dscStatus.components?.[component]?.managementState === 'Managed' ||
-              dscStatus.components?.[component]?.managementState === 'Unmanaged',
-          }),
+          (acc, component) => ({ ...acc, [component]: isComponentInstalled(component) }),
           {},
         )
       : null;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1,7 +1,7 @@
 import { K8sResourceCommon, MatchExpression } from '@openshift/dynamic-plugin-sdk-utils';
 import { EitherNotBoth } from '@openshift/dynamic-plugin-sdk';
 import { AwsKeys } from '#~/pages/projects/dataConnections/const';
-import type { DataScienceStackComponent } from '#~/concepts/areas/types';
+import { DataScienceStackComponent, StackComponent } from '#~/concepts/areas/types';
 import { AccessMode } from '#~/pages/storageClasses/storageEnums';
 import {
   ContainerResourceAttributes,
@@ -1501,6 +1501,12 @@ export type DataScienceClusterKindStatus = {
     version: string;
   };
 };
+
+/**
+ * @deprecated The operator no longer exposes installedComponents.
+ * Use DataScienceClusterKindStatus.components.*.managementState instead.
+ */
+export type DataScienceClusterInstalledComponents = { [key in StackComponent]?: boolean };
 
 export type DataScienceClusterInitializationKindStatus = {
   conditions: K8sCondition[];

--- a/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
+++ b/frontend/src/pages/modelServing/useServingPlatformStatuses.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DataScienceStackComponent, SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
+import { StackComponent, SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { ServingPlatformStatuses } from '#~/pages/modelServing/screens/types';
 import { useIsNIMAvailable } from '#~/pages/modelServing/screens/projects/useIsNIMAvailable';
 
@@ -10,9 +10,8 @@ const useServingPlatformStatuses = (
   const modelMeshStatus = useIsAreaAvailable(SupportedArea.MODEL_MESH);
   const kServeEnabled = kServeStatus.status;
   const modelMeshEnabled = modelMeshStatus.status;
-  const kServeInstalled = !!kServeStatus.requiredComponents?.[DataScienceStackComponent.K_SERVE];
-  const modelMeshInstalled =
-    !!modelMeshStatus.requiredComponents?.[DataScienceStackComponent.MODEL_MESH_SERVING];
+  const kServeInstalled = !!kServeStatus.requiredComponents?.[StackComponent.K_SERVE];
+  const modelMeshInstalled = !!modelMeshStatus.requiredComponents?.[StackComponent.MODEL_MESH];
   const [isNIMAvailable, , , refreshNIMAvailability] = useIsNIMAvailable();
 
   React.useEffect(() => {

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -1,4 +1,4 @@
-import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { StackComponent } from '@odh-dashboard/internal/concepts/areas/types';
 import type {
   NavExtension,
   RouteExtension,
@@ -21,7 +21,7 @@ const extensions: (NavExtension | RouteExtension | AreaExtension | AIAssetsTabEx
     type: 'app.area',
     properties: {
       id: PLUGIN_GEN_AI,
-      requiredComponents: [DataScienceStackComponent.LLAMA_STACK_OPERATOR],
+      requiredComponents: [StackComponent.LLAMA_STACK_OPERATOR],
       devFlags: ['Gen AI plugin'],
     },
   },

--- a/packages/model-serving/extensions/odh.ts
+++ b/packages/model-serving/extensions/odh.ts
@@ -7,10 +7,7 @@ import type {
 } from '@odh-dashboard/plugin-core/extension-points';
 // Allow this import as it consists of types and enums only.
 // eslint-disable-next-line no-restricted-syntax
-import {
-  DataScienceStackComponent,
-  SupportedArea,
-} from '@odh-dashboard/internal/concepts/areas/types';
+import { StackComponent, SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 
 const PLUGIN_MODEL_SERVING = SupportedArea.K_SERVE;
 
@@ -31,7 +28,7 @@ const extensions: (
     properties: {
       id: PLUGIN_MODEL_SERVING,
       featureFlags: ['disableKServe'],
-      requiredComponents: [DataScienceStackComponent.K_SERVE],
+      requiredComponents: [StackComponent.K_SERVE],
       reliantAreas: [SupportedArea.MODEL_SERVING],
     },
   },


### PR DESCRIPTION
reverts 85a6f357d which got accidentally merged

https://github.com/opendatahub-io/odh-dashboard/pull/5251 was put on hold but it seems the merge bot already had it in queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal component status tracking and type definitions to improve system maintainability.
  * Simplified data structures for component installation and management state representation.
  * Updated test infrastructure to align with refactored type system.

No user-facing changes or new functionality in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->