### PR TITLE
Current URI Reselect Bug Fix

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/ConnectionSection.tsx
@@ -506,7 +506,7 @@ export const ConnectionSection: React.FC<Props> = ({
             }
           />
         </>
-      ) : pvcs && pvcs.length === 0 ? ( // No connections and no pvcs: auto-show the new connection field
+      ) : pvcs && pvcs.length === 0 && !existingUriOption ? ( // No connections, no pvcs, no existing URI: auto-show the new connection field (not the radio)
         <FormGroup
           name="new-connection"
           id="new-connection"
@@ -536,7 +536,7 @@ export const ConnectionSection: React.FC<Props> = ({
           </Stack>
         </FormGroup>
       ) : (
-        // No connections, but there are pvcs show the new connection radio and pvc radio
+        // No connections, but there are pvcs show the new connection radio
         <Radio
           name="new-connection-radio"
           id="new-connection-radio"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-37366](https://issues.redhat.com/browse/RHOAIENG-37366)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
In the old modal, if you had no connections and no pvcs, and tried to deploy with an existing uri (like from the catalog) it would show the existing uri option, then the new connection option
But if you picked a new connection type, then it wouldn't let you reselect the current uri option

Also it was strange not showing the new connection field as a radio option when there was still an existing uri radio so that got updated and also fixed the bug.

Before: 
<img width="825" height="238" alt="Screenshot 2025-10-27 at 4 20 24 PM" src="https://github.com/user-attachments/assets/17244b8c-43ea-4ba4-822d-437d0df091b0" />


After:
<img width="561" height="184" alt="Screenshot 2025-10-27 at 4 02 45 PM" src="https://github.com/user-attachments/assets/99611053-66e1-4ab2-853a-ad16b13cb6ad" />



https://github.com/user-attachments/assets/4e2282ca-118d-4616-ac13-858b277d4107



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- deploy from catalog and pick a project without pvc or connections
- select new connection, reselect current uri, etc
- mess around with different projects with/without connections and pvcs

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
