### PR TITLE
feat: Remove CodeFlare component from DSC v2 migration

### DIFF
--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -94,11 +94,11 @@ describe('AboutDialog', () => {
     };
     dscStatus = {
       components: {
-        [DataScienceStackComponent.CODE_FLARE]: {
+        [DataScienceStackComponent.K_SERVE]: {
           releases: [
             {
-              name: 'CodeFlare operator',
-              repoUrl: 'https://github.com/project-codeflare/codeflare-operator',
+              name: 'KServe',
+              repoUrl: 'https://github.com/kserve/kserve',
               version: '1.12.0',
             },
           ],
@@ -163,7 +163,7 @@ describe('AboutDialog', () => {
     expect(componentReleasesTableHeader.textContent).toContain('ODH');
     expect(componentReleasesTableRows).not.toHaveLength(0);
     const hasComponentReleasesMetadata = componentReleasesTableRows.some(
-      (row) => row.textContent.includes('CodeFlare') && row.textContent.includes('1.12.0'),
+      (row) => row.textContent.includes('KServe') && row.textContent.includes('1.12.0'),
     );
     expect(hasComponentReleasesMetadata).toBe(true);
   });
@@ -210,7 +210,7 @@ describe('AboutDialog', () => {
     expect(componentReleasesTableHeader.textContent).toContain('RHOAI');
     expect(componentReleasesTableRows).not.toHaveLength(0);
     const hasComponentReleasesMetadata = componentReleasesTableRows.some(
-      (row) => row.textContent.includes('CodeFlare') && row.textContent.includes('1.12.0'),
+      (row) => row.textContent.includes('KServe') && row.textContent.includes('1.12.0'),
     );
     expect(hasComponentReleasesMetadata).toBe(true);
   });

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -215,7 +215,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
 
 /** Maps each DataScienceStackComponent to its human-readable name **/
 export const DataScienceStackComponentMap: Record<string, string> = {
-  [DataScienceStackComponent.CODE_FLARE]: 'CodeFlare',
   [DataScienceStackComponent.DASHBOARD]: 'Dashboard',
   [DataScienceStackComponent.DS_PIPELINES]: 'Pipelines',
   [DataScienceStackComponent.KUEUE]: 'Kueue',

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -90,11 +90,10 @@ export enum SupportedArea {
 
 export type SupportedAreaType = SupportedArea | string;
 
-/** The possible V1 component names that are used as keys in the `components` object of the DSC Status.
- * Each component's key (e.g., 'codeflare', 'dashboard', etc.) maps to a specific component status.
+/** The possible V2 component names that are used as keys in the `components` object of the DSC Status.
+ * Each component's key (e.g., 'kserve', 'dashboard', etc.) maps to a specific component status.
  **/
 export enum DataScienceStackComponent {
-  CODE_FLARE = 'codeflare',
   DASHBOARD = 'dashboard',
   DS_PIPELINES = 'datasciencepipelines',
   K_SERVE = 'kserve',


### PR DESCRIPTION
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-36720

## Description
This PR removes CodeFlare component references as part of the DSC v1 to v2 migration. CodeFlare is deprecated and not available in DSC v2.

**What changed:**
- Remove `CODE_FLARE` from `DataScienceStackComponent` enum in `types.ts`
- Remove CodeFlare from `DataScienceStackComponentMap` in `const.ts`
- Update `AboutDialog` test to use `K_SERVE` instead of removed `CODE_FLARE` component
- Replace 'CodeFlare' with 'KServe' in test assertions
- Update component comment from "V1 component names" to "V2 component names" and remove 'codeflare' example

**Why:** CodeFlare is deprecated in DSC v2 and needs to be removed from the component system.

**Scope:** This is intentionally focused ONLY on CodeFlare removal. Other DSC v1→v2 changes (StackCapability removal, ModelMesh cleanup, StackComponent→DataScienceStackComponent migration) are deferred to subsequent PRs to keep reviews manageable.

**Follow-up PRs:**
1. ✅ This PR: CodeFlare removal  
2. 🔄 Next: Serverless + ServiceMesh removal
3. 🔄 Then: ModelMesh removal

## How Has This Been Tested?
- Manually verified TypeScript compilation succeeds with no errors
- Confirmed all linting checks pass
- Verified AboutDialog test changes are syntactically correct
- Tested that enum and mapping changes don't break existing functionality
- Confirmed no CodeFlare references remain in the changed files

## Test Impact
- **Updated tests:** `AboutDialog.spec.tsx` - Changed from testing CodeFlare component to KServe component
- **Test rationale:** The test validates that component release metadata displays correctly. Since CodeFlare component is removed, the test now validates KServe component instead, maintaining the same test coverage
- **No new tests needed:** This is a removal/cleanup change that doesn't introduce new functionality requiring additional test coverage

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * KServe component is now available in the data science stack.
* **Bug Fixes / UI**
  * Status and metadata displays now show KServe instead of the previous component name.
* **Chores**
  * Removed the old component label from listings to reflect updated component naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->