### PR TITLE
feat: Remove ServiceMesh capabilities and Serverless deployment mode from DSC v2 migration

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -990,11 +990,6 @@ export type DataScienceClusterKindStatus = {
   components?: {
     [key: string]: DataScienceClusterComponentStatus;
   } & {
-    /** Status of KServe, including deployment mode and serverless configuration. */
-    kserve?: DataScienceClusterComponentStatus & {
-      defaultDeploymentMode?: string;
-      serverlessMode?: string;
-    };
     /** Status of Model Registry, including its namespace configuration. */
     modelregistry?: DataScienceClusterComponentStatus & {
       registriesNamespace?: string;

--- a/frontend/src/__mocks__/mockDsc.ts
+++ b/frontend/src/__mocks__/mockDsc.ts
@@ -1,5 +1,5 @@
-import { StackCapability } from '#~/concepts/areas/types';
 import { DataScienceClusterKind, K8sCondition } from '#~/k8sTypes';
+import { StackCapability } from '#~/concepts/areas/types';
 
 export type MockDsc = {
   conditions?: K8sCondition[];
@@ -23,7 +23,6 @@ export const mockDsc = ({
         managementState: 'Managed',
       },
       kserve: {
-        defaultDeploymentMode: 'Severless',
         managementState: 'Managed',
         nim: {
           managementState: 'Managed',
@@ -47,24 +46,22 @@ export const mockDsc = ({
   },
   status: {
     conditions: [
-      ...[
-        {
-          lastHeartbeatTime: '2023-10-20T11:45:04Z',
-          lastTransitionTime: '2023-10-20T11:45:04Z',
-          message: 'Reconcile completed successfully',
-          reason: 'ReconcileCompleted',
-          status: 'True',
-          type: 'ReconcileComplete',
-        },
-        ...requiredCapabilities.map((capability) => ({
-          lastHeartbeatTime: '2023-10-20T11:45:04Z',
-          lastTransitionTime: '2023-10-20T11:45:04Z',
-          message: `Capability ${capability} installed`,
-          reason: 'ReconcileCompleted',
-          status: 'True',
-          type: capability,
-        })),
-      ],
+      {
+        lastHeartbeatTime: '2023-10-20T11:45:04Z',
+        lastTransitionTime: '2023-10-20T11:45:04Z',
+        message: 'Reconcile completed successfully',
+        reason: 'ReconcileCompleted',
+        status: 'True',
+        type: 'ReconcileComplete',
+      },
+      ...requiredCapabilities.map((capability) => ({
+        lastHeartbeatTime: '2023-10-20T11:45:04Z',
+        lastTransitionTime: '2023-10-20T11:45:04Z',
+        message: `Capability ${capability} installed`,
+        reason: 'ReconcileCompleted',
+        status: 'True',
+        type: capability,
+      })),
       ...conditions,
     ],
     phase,

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployOCIModel.cy.ts
@@ -134,16 +134,8 @@ describe(
         modelServingSection.findModelServerDeployedName(modelDeploymentName);
         //Verify the model created and is running
         cy.step('Verify that the Model is running');
-        // For KServe Raw deployments, we only need to check Ready condition
-        // LatestDeploymentReady is specific to Serverless deployments
-        checkInferenceServiceState(
-          modelDeploymentName,
-          projectName,
-          {
-            checkReady: true,
-          },
-          'RawDeployment',
-        );
+        // Verify model deployment is ready
+        checkInferenceServiceState(modelDeploymentName, projectName, { checkReady: true });
         modelServingSection.findModelMetricsLink(modelDeploymentName);
       },
     );

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelPvcDeployment.cy.ts
@@ -158,16 +158,8 @@ describe('Verify a model can be deployed from a PVC', () => {
       modelServingSection.findModelServerDeployedName(testData.singleModelName);
       //Verify the model created and is running
       cy.step('Verify that the Model is running');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelName, projectName, { checkReady: true });
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelStopStart.cy.ts
@@ -107,16 +107,8 @@ describe('A model can be stopped and started', () => {
 
       //Verify the model created and is running
       cy.step('Verify that the Model is running');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelName, projectName, { checkReady: true });
 
       //Stop the model with the modal
       cy.step('Stop the model');
@@ -137,17 +129,12 @@ describe('A model can be stopped and started', () => {
         .should('match', /Stopping|Stopped/);
 
       //Verify the model is stopped
-      // For stopped models in RawDeployment mode, we check the Stopped condition
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: false,
-          checkStopped: true,
-          requireLoadedState: false,
-        },
-        'RawDeployment',
-      );
+      // Verify model is stopped
+      checkInferenceServiceState(testData.singleModelName, projectName, {
+        checkReady: false,
+        checkStopped: true,
+        requireLoadedState: false,
+      });
       kServeRow.findStatusLabel('Stopped', MODEL_STATUS_TIMEOUT).should('exist');
 
       //Restart the model
@@ -156,16 +143,8 @@ describe('A model can be stopped and started', () => {
       kServeRow.findStatusLabel('Starting').should('exist');
 
       //Verify the model is running again
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelName, projectName, { checkReady: true });
       kServeRow
         .findStatusLabel()
         .invoke('text')

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testModelTokenAuth.cy.ts
@@ -111,16 +111,8 @@ describe('[Automation Bug: RHOAIENG-32898] A model can be deployed with token au
 
       // Verify the model created
       cy.step('Verify that the Model is running');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelName, projectName, { checkReady: true });
 
       // Verify the model is not accessible without a token
       cy.step('Verify the model is not accessible without a token');

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -121,16 +121,8 @@ describe('[Automation Bug: RHOAIENG-32898] Verify Admin Single Model Creation an
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelAdminName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelAdminName, projectName, { checkReady: true });
       // Note reload is required as status tooltip was not found due to a stale element
       cy.reload();
       modelServingSection.findModelMetricsLink(testData.singleModelAdminName);

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelContributorCreation.cy.ts
@@ -111,16 +111,8 @@ describe('Verify Model Creation and Validation using the UI', () => {
 
       //Verify the model created
       cy.step('Verify that the Model is created Successfully on the backend and frontend');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        testData.singleModelName,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(testData.singleModelName, projectName, { checkReady: true });
       cy.reload();
       modelServingSection.findModelMetricsLink(testData.singleModelName);
       // Note reload is required as status tooltip was not found due to a stale element

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegistryDeployModel.cy.ts
@@ -182,16 +182,8 @@ describe('Verify models can be deployed from model registry', () => {
       cy.contains('Started', { timeout: 120000 }).should('be.visible');
 
       cy.step('Verify the model is deployed and started in backend');
-      // For KServe Raw deployments, we only need to check Ready condition
-      // LatestDeploymentReady is specific to Serverless deployments
-      checkInferenceServiceState(
-        `${modelName}-v10`,
-        projectName,
-        {
-          checkReady: true,
-        },
-        'RawDeployment',
-      );
+      // Verify model deployment is ready
+      checkInferenceServiceState(`${modelName}-v10`, projectName, { checkReady: true });
     },
   );
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -26,7 +26,7 @@ import type {
   ServingRuntimeKind,
 } from '#~/k8sTypes';
 import { ServingRuntimePlatform } from '#~/types';
-import { StackCapability, DataScienceStackComponent } from '#~/concepts/areas/types';
+import { DataScienceStackComponent } from '#~/concepts/areas/types';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
 import {
   HardwareProfileModel,
@@ -61,7 +61,6 @@ type HandlersProps = {
   rejectInferenceService?: boolean;
   rejectServingRuntime?: boolean;
   rejectConnection?: boolean;
-  requiredCapabilities?: StackCapability[];
   DscComponents?: DataScienceClusterKindStatus['components'];
   disableProjectScoped?: boolean;
 };
@@ -100,7 +99,6 @@ const initIntercepts = ({
     }),
   ],
   rejectAddSupportServingPlatformProject = false,
-  requiredCapabilities = [],
   DscComponents,
 }: HandlersProps) => {
   cy.interceptOdh(
@@ -112,12 +110,7 @@ const initIntercepts = ({
       },
     }),
   );
-  cy.interceptOdh(
-    'GET /api/dsci/status',
-    mockDsciStatus({
-      requiredCapabilities,
-    }),
-  );
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({
@@ -390,9 +383,7 @@ describe('Serving Runtime List', () => {
 
   describe('Check token section in serving runtime details', () => {
     it('Check token section is enabled if capability is enabled', () => {
-      initIntercepts({
-        requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
-      });
+      initIntercepts({});
       projectDetails.visitSection('test-project', 'model-server');
       const kserveRow = modelServingSection.getKServeRow('Llama Caikit');
       kserveRow.findExpansion().should(be.collapsed);

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
@@ -100,7 +100,7 @@ describe('NIM Model Serving', () => {
       // Temp until KEDA is supported
       nimDeployModal.findNimModelReplicas().should('have.value', '1');
 
-      /* Disabled until KEDA is supported -- Serverless has been removed */
+      /* TODO: Enable replica validation when KEDA autoscaling is supported */
       // // Validate model replicas
       // nimDeployModal.findMinReplicasInput().should('have.value', '1');
       // nimDeployModal.findMinReplicasPlusButton().should('be.disabled');

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelServing.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/modelServing.ts
@@ -100,7 +100,6 @@ export const checkInferenceServiceState = (
   serviceName: string,
   namespace: string,
   options: ConditionCheckOptions = {},
-  DeploymentMode?: 'RawDeployment' | 'Serverless',
 ): Cypress.Chainable<Cypress.Exec> => {
   const ocCommand = `oc get inferenceService ${serviceName} -n ${namespace} -o json`;
   const maxAttempts = 96; // 8 minutes / 5 seconds = 96 attempts
@@ -220,24 +219,8 @@ export const checkInferenceServiceState = (
       const isModelLoaded = activeModelState === 'Loaded';
       cy.log(`Active Model State Check: ${isModelLoaded ? '✅ Loaded' : '❌ Not Loaded'}`);
 
-      if (DeploymentMode) {
-        const expectedDeploymentMode = DeploymentMode;
-        cy.log(`🔍 InferenceService deployment mode check:
-        Service: ${serviceName}
-        Expected: ${expectedDeploymentMode}
-        Actual: ${actualDeploymentMode}
-        Match: ${actualDeploymentMode === expectedDeploymentMode ? '✅' : '❌'}`);
-
-        if (actualDeploymentMode !== expectedDeploymentMode) {
-          throw new Error(
-            `Deployment mode mismatch. Expected: ${expectedDeploymentMode}, Actual: ${actualDeploymentMode}`,
-          );
-        }
-
-        cy.log(
-          `✅ InferenceService ${serviceName} has correct deployment mode: ${expectedDeploymentMode}`,
-        );
-      }
+      // Always RawDeployment (no validation needed)
+      cy.log(`📋 InferenceService ${serviceName} deployment mode: ${actualDeploymentMode}`);
       // Determine overall success
       // If no condition checks were specified, only check model state
       const allConditionsPassed =

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -73,27 +73,6 @@ describe('assembleInferenceService', () => {
     );
   });
 
-  it('should have the right annotations when creating for modelmesh', async () => {
-    const inferenceService = assembleInferenceService(
-      mockInferenceServiceModalData({}),
-      undefined,
-      undefined,
-      true,
-    );
-
-    expect(inferenceService.metadata.annotations).toBeDefined();
-    expect(inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode']).toBe(
-      DeploymentMode.ModelMesh,
-    );
-    expect(
-      inferenceService.metadata.annotations?.['serving.knative.openshift.io/enablePassthrough'],
-    ).toBe(undefined);
-    expect(inferenceService.metadata.annotations?.['sidecar.istio.io/inject']).toBe(undefined);
-    expect(inferenceService.metadata.annotations?.['sidecar.istio.io/rewriteAppHTTPProbers']).toBe(
-      undefined,
-    );
-  });
-
   it('should have the right labels when creating for Kserve with public route', async () => {
     const inferenceService = assembleInferenceService(
       mockInferenceServiceModalData({ externalRoute: true }),

--- a/frontend/src/api/k8s/dsc.ts
+++ b/frontend/src/api/k8s/dsc.ts
@@ -1,24 +1,8 @@
-import { k8sListResource, k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { DataScienceClusterKind, DeploymentMode } from '#~/k8sTypes';
+import { k8sListResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { DataScienceClusterKind } from '#~/k8sTypes';
 import { DataScienceClusterModel } from '#~/api/models';
 
 export const listDataScienceClusters = (): Promise<DataScienceClusterKind[]> =>
   k8sListResource<DataScienceClusterKind>({
     model: DataScienceClusterModel,
   }).then((dataScienceClusters) => dataScienceClusters.items);
-
-export const patchDefaultDeploymentMode = (
-  deploymentMode: DeploymentMode,
-  dscName: string,
-): Promise<DataScienceClusterKind> =>
-  k8sPatchResource<DataScienceClusterKind>({
-    model: DataScienceClusterModel,
-    queryOptions: { name: dscName },
-    patches: [
-      {
-        op: 'replace',
-        path: '/spec/components/kserve/defaultDeploymentMode',
-        value: deploymentMode,
-      },
-    ],
-  });

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -9,10 +9,15 @@ import {
   k8sPatchResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { InferenceServiceModel, PodModel } from '#~/api/models';
-import { InferenceServiceKind, K8sAPIOptions, KnownLabels, PodKind } from '#~/k8sTypes';
+import {
+  InferenceServiceKind,
+  K8sAPIOptions,
+  KnownLabels,
+  PodKind,
+  DeploymentMode,
+} from '#~/k8sTypes';
 import { CreatingInferenceServiceObject } from '#~/pages/modelServing/screens/types';
 import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
-import { getInferenceServiceDeploymentMode } from '#~/pages/modelServing/screens/projects/utils';
 import { parseCommandLine } from '#~/api/k8s/utils';
 import { ModelServingPodSpecOptions } from '#~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
 import { getModelServingProjects } from '#~/api';
@@ -110,9 +115,7 @@ export const assembleInferenceService = (
   const annotations = { ...updatedInferenceService.metadata.annotations };
 
   annotations['openshift.io/display-name'] = data.name.trim();
-  annotations['serving.kserve.io/deploymentMode'] = getInferenceServiceDeploymentMode(
-    !!isModelMesh,
-  );
+  annotations['serving.kserve.io/deploymentMode'] = DeploymentMode.RawDeployment;
 
   const dashboardNamespace = data.dashboardNamespace ?? '';
   if (!isModelMesh && podSpecOptions && podSpecOptions.selectedHardwareProfile) {

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -1,15 +1,9 @@
 import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
 import { mockDashboardConfig } from '#~/__mocks__/mockDashboardConfig';
-import {
-  StackCapability,
-  DataScienceStackComponent,
-  SupportedArea,
-  SupportedComponentFlagValue,
-} from '#~/concepts/areas/types';
+import { DataScienceStackComponent, SupportedArea } from '#~/concepts/areas/types';
 import { SupportedAreasStateMap } from '#~/concepts/areas/const';
 import { mockDsciStatus } from '#~/__mocks__/mockDsciStatus';
 import { isAreaAvailable } from '#~/concepts/areas/utils';
-import { mockIsAreaAvailableOptions } from '#~/__mocks__/mockSupportedAreasData.ts';
 
 describe('isAreaAvailable', () => {
   describe('v1 Operator (deprecated)', () => {
@@ -224,84 +218,6 @@ describe('isAreaAvailable', () => {
           [SupportedArea.MODEL_SERVING]: false,
         });
         expect(isAvailable.requiredComponents).toBe(null);
-      });
-    });
-
-    const MOCK_KSERVE_CONFIG: SupportedComponentFlagValue = {
-      featureFlags: ['disableKServe'],
-      reliantAreas: [SupportedArea.MODEL_SERVING],
-    };
-
-    describe('requiredCapabilities', () => {
-      it('should enable area if both capabilities are enabled', () => {
-        // Make sure this test is valid
-        expect(SupportedAreasStateMap[SupportedArea.K_SERVE_AUTH].requiredCapabilities).toEqual([
-          StackCapability.SERVICE_MESH,
-          StackCapability.SERVICE_MESH_AUTHZ,
-        ]);
-
-        // Test both reliant areas
-        const isAvailableKserveAuth = isAreaAvailable(
-          SupportedArea.K_SERVE_AUTH,
-          mockDashboardConfig({ disableKServeAuth: false }).spec,
-          mockDscStatus({
-            components: {
-              [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-            },
-          }),
-          mockDsciStatus({
-            requiredCapabilities: [
-              StackCapability.SERVICE_MESH,
-              StackCapability.SERVICE_MESH_AUTHZ,
-            ],
-          }),
-          mockIsAreaAvailableOptions({
-            stateMapOverrides: { [SupportedArea.K_SERVE]: MOCK_KSERVE_CONFIG },
-          }),
-        );
-
-        expect(isAvailableKserveAuth.status).toBe(true);
-        expect(isAvailableKserveAuth.featureFlags).toEqual({
-          disableKServeAuth: 'on',
-        });
-        expect(isAvailableKserveAuth.requiredCapabilities).toEqual({
-          [StackCapability.SERVICE_MESH]: true,
-          [StackCapability.SERVICE_MESH_AUTHZ]: true,
-        });
-      });
-
-      it('should enable area if one capability is missing', () => {
-        // Make sure this test is valid
-        expect(SupportedAreasStateMap[SupportedArea.K_SERVE_AUTH].requiredCapabilities).toEqual([
-          StackCapability.SERVICE_MESH,
-          StackCapability.SERVICE_MESH_AUTHZ,
-        ]);
-
-        // Test both reliant areas
-        const isAvailableKserveAuth = isAreaAvailable(
-          SupportedArea.K_SERVE_AUTH,
-          mockDashboardConfig({ disableKServeAuth: false }).spec,
-          mockDscStatus({
-            components: {
-              [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-            },
-          }),
-          mockDsciStatus({
-            requiredCapabilities: [StackCapability.SERVICE_MESH],
-          }),
-          mockIsAreaAvailableOptions({
-            stateMapOverrides: { [SupportedArea.K_SERVE]: MOCK_KSERVE_CONFIG },
-          }),
-        );
-
-        expect(isAvailableKserveAuth.status).toBe(false);
-        expect(isAvailableKserveAuth.featureFlags).toEqual({
-          disableKServeAuth: 'on',
-        });
-        expect(isAvailableKserveAuth.requiredCapabilities).toEqual({
-          [StackCapability.SERVICE_MESH]: true,
-          [StackCapability.SERVICE_MESH_AUTHZ]: false,
-        });
       });
     });
 

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -1,10 +1,5 @@
 import { DashboardCommonConfig } from '#~/k8sTypes';
-import {
-  StackCapability,
-  SupportedArea,
-  SupportedAreasState,
-  DataScienceStackComponent,
-} from './types';
+import { SupportedArea, SupportedAreasState, DataScienceStackComponent } from './types';
 
 export const techPreviewFlags = {
   disableModelRegistry: true,
@@ -114,7 +109,6 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.K_SERVE_AUTH]: {
     featureFlags: ['disableKServeAuth'],
     reliantAreas: [SupportedArea.K_SERVE],
-    requiredCapabilities: [StackCapability.SERVICE_MESH, StackCapability.SERVICE_MESH_AUTHZ],
   },
   [SupportedArea.K_SERVE_METRICS]: {
     featureFlags: ['disableKServeMetrics'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -15,8 +15,8 @@ export type IsAreaAvailableStatus = {
   devFlags: { [key in string]?: 'on' | 'off' } | null; // simplified. `disableX` flags are weird to read
   featureFlags: { [key in FeatureFlag]?: 'on' | 'off' } | null; // simplified. `disableX` flags are weird to read
   reliantAreas: { [key in SupportedAreaType]?: boolean } | null; // only needs 1 to be true
-  requiredComponents: { [key in DataScienceStackComponent]?: boolean } | null;
   requiredCapabilities: { [key in StackCapability]?: boolean } | null;
+  requiredComponents: { [key in DataScienceStackComponent]?: boolean } | null;
   customCondition: (conditionFunc: CustomConditionFunction) => boolean;
 };
 
@@ -108,11 +108,11 @@ export enum DataScienceStackComponent {
   LLAMA_STACK_OPERATOR = 'llamastackoperator',
 }
 
-/** Capabilities of the Operator. Part of the DSCI Status. */
-export enum StackCapability {
-  SERVICE_MESH = 'CapabilityServiceMesh',
-  SERVICE_MESH_AUTHZ = 'CapabilityServiceMeshAuthorization',
-}
+/**
+ * Capabilities of the Operator. Part of the DSCI Status.
+ * Preserved as string type for future capabilities.
+ */
+export type StackCapability = string;
 
 /**
  * Optional function to check for a condition that is not covered by other checks.

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -500,7 +500,6 @@ export type SupportedModelFormats = {
 };
 
 export enum DeploymentMode {
-  ModelMesh = 'ModelMesh',
   RawDeployment = 'RawDeployment',
 }
 
@@ -1424,7 +1423,6 @@ export type DataScienceClusterKind = K8sResourceCommon & {
     } & {
       /** KServe and ModelRegistry components, including further specific configuration. */
       [DataScienceStackComponent.K_SERVE]?: DataScienceClusterComponent & {
-        defaultDeploymentMode?: string;
         nim: {
           managementState: string;
         };
@@ -1477,16 +1475,11 @@ export type DataScienceClusterKindStatus = {
    * This field maps each component of the Data Science Cluster to its corresponding status.
    * The majority of components use `DataScienceClusterComponentStatus`, which includes
    * management state and release details. However, some components require additional
-   * specialized fields, such as `kserve` and `modelregistry`.
+   * specialized fields, such as `modelregistry` and `workbenches`.
    */
   components?: {
     [key in DataScienceStackComponent]?: DataScienceClusterComponentStatus;
   } & {
-    /** Status of KServe, including deployment mode and serverless configuration. */
-    [DataScienceStackComponent.K_SERVE]?: DataScienceClusterComponentStatus & {
-      defaultDeploymentMode?: string;
-      serverlessMode?: string;
-    };
     /** Status of Model Registry, including its namespace configuration. */
     [DataScienceStackComponent.MODEL_REGISTRY]?: DataScienceClusterComponentStatus & {
       registriesNamespace?: string;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceLastDeployed.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceLastDeployed.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { InferenceServiceKind } from '#~/k8sTypes';
-import { getInferenceServiceStoppedStatus, isModelMesh } from '#~/pages/modelServing/utils';
+import { getInferenceServiceStoppedStatus } from '#~/pages/modelServing/utils';
 import { LastDeployed } from '#~/components/LastDeployed.tsx';
 
 type InferenceServiceLastDeployedProps = {
@@ -12,7 +12,7 @@ const InferenceServiceLastDeployed: React.FC<InferenceServiceLastDeployedProps> 
 }) => {
   const { isStopped } = getInferenceServiceStoppedStatus(inferenceService);
 
-  if (isStopped || isModelMesh(inferenceService)) {
+  if (isStopped) {
     return <>-</>;
   }
 

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTable.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import ManageInferenceServiceModal from '#~/pages/modelServing/screens/projects/InferenceServiceModal/ManageInferenceServiceModal';
 import { SortableData, Table } from '#~/components/table';
 import { InferenceServiceKind, ProjectKind, SecretKind, ServingRuntimeKind } from '#~/k8sTypes';
 import { byName, ProjectsContext } from '#~/concepts/projects/ProjectsContext';
 import DashboardEmptyTableView from '#~/concepts/dashboard/DashboardEmptyTableView';
-import { isModelMesh } from '#~/pages/modelServing/utils';
+
 import ManageKServeModal from '#~/pages/modelServing/screens/projects/kServeModal/ManageKServeModal';
 import ResourceTr from '#~/components/ResourceTr';
 import { fireFormTrackingEvent } from '#~/concepts/analyticsTracking/segmentIOUtils';
@@ -92,13 +91,9 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
       {deleteInferenceService ? (
         <DeleteInferenceServiceModal
           inferenceService={deleteInferenceService}
-          servingRuntime={
-            !isModelMesh(deleteInferenceService)
-              ? servingRuntimes.find(
-                  (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model?.runtime,
-                )
-              : undefined
-          }
+          servingRuntime={servingRuntimes.find(
+            (sr) => sr.metadata.name === deleteInferenceService.spec.predictor.model?.runtime,
+          )}
           onClose={(deleted) => {
             fireFormTrackingEvent(eventName, {
               outcome: deleted ? TrackingOutcome.submit : TrackingOutcome.cancel,
@@ -111,22 +106,7 @@ const InferenceServiceTable: React.FC<InferenceServiceTableProps> = ({
           }}
         />
       ) : null}
-      {!!editInferenceService && isModelMesh(editInferenceService) ? (
-        <ManageInferenceServiceModal
-          editInfo={editInferenceService}
-          onClose={(edited) => {
-            fireFormTrackingEvent('Model Updated', {
-              outcome: edited ? TrackingOutcome.submit : TrackingOutcome.cancel,
-              type: 'multi',
-            });
-            if (edited) {
-              refresh?.();
-            }
-            setEditInferenceService(undefined);
-          }}
-        />
-      ) : null}
-      {!!editInferenceService && !isModelMesh(editInferenceService)
+      {editInferenceService
         ? (() => {
             const projectForEdit = projects.find(byName(editInferenceService.metadata.namespace));
             const isNIM = projectForEdit ? isProjectNIMSupported(projectForEdit) : false;

--- a/frontend/src/pages/modelServing/screens/global/data.ts
+++ b/frontend/src/pages/modelServing/screens/global/data.ts
@@ -1,7 +1,7 @@
 import { InferenceServiceKind, ProjectKind } from '#~/k8sTypes';
 import { SortableData } from '#~/components/table';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
-import { getInferenceServiceStoppedStatus, isModelMesh } from '#~/pages/modelServing/utils';
+import { getInferenceServiceStoppedStatus } from '#~/pages/modelServing/utils';
 
 export enum ColumnField {
   Expand = 'expand',
@@ -78,8 +78,9 @@ const COL_LAST_DEPLOYED: SortableData<InferenceServiceKind> = {
   label: 'Last deployed',
   width: 15,
   sortable: (a, b) => {
-    const aInactive = getInferenceServiceStoppedStatus(a).isStopped || isModelMesh(a);
-    const bInactive = getInferenceServiceStoppedStatus(b).isStopped || isModelMesh(b);
+    // Only check if service is stopped (no ModelMesh)
+    const aInactive = getInferenceServiceStoppedStatus(a).isStopped;
+    const bInactive = getInferenceServiceStoppedStatus(b).isStopped;
 
     if (aInactive && !bInactive) {
       return 1;

--- a/frontend/src/pages/modelServing/screens/metrics/performance/ModelGraphs.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/ModelGraphs.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { InferenceServiceKind } from '#~/k8sTypes';
-import { isModelMesh } from '#~/pages/modelServing/utils';
-import ModelMeshMetrics from '#~/pages/modelServing/screens/metrics/performance/ModelMeshMetrics';
 import KserveMetrics from '#~/pages/modelServing/screens/metrics/performance/KserveMetrics';
 
 type ModelGraphProps = {
   model: InferenceServiceKind;
 };
 
-const ModelGraphs: React.FC<ModelGraphProps> = ({ model }) =>
-  isModelMesh(model) ? <ModelMeshMetrics /> : <KserveMetrics modelName={model.metadata.name} />;
+// Always KServe (no ModelMesh)
+const ModelGraphs: React.FC<ModelGraphProps> = ({ model }) => (
+  <KserveMetrics modelName={model.metadata.name} />
+);
 
 export default ModelGraphs;

--- a/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/performance/PerformanceTab.tsx
@@ -3,7 +3,6 @@ import { EmptyState, PageSection, Stack, StackItem } from '@patternfly/react-cor
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { InferenceServiceKind } from '#~/k8sTypes';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
-import { isModelMesh } from '#~/pages/modelServing/utils';
 import MetricsPageToolbar from '#~/concepts/metrics/MetricsPageToolbar';
 import ModelGraphs from '#~/pages/modelServing/screens/metrics/performance/ModelGraphs';
 
@@ -12,10 +11,10 @@ type PerformanceTabsProps = {
 };
 
 const PerformanceTab: React.FC<PerformanceTabsProps> = ({ model }) => {
-  const modelMesh = isModelMesh(model);
+  // Always KServe (no ModelMesh)
   const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
 
-  if (!modelMesh && !kserveMetricsEnabled) {
+  if (!kserveMetricsEnabled) {
     return (
       <Stack data-testid="performance-metrics-loaded">
         <StackItem>

--- a/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ModelMeshSection/ServingRuntimeDetails.tsx
@@ -46,7 +46,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
   const isModelMesh = currentProjectServingPlatform === ServingRuntimePlatform.MULTI;
 
   // todo: deal with the accelProfile below......
-  const { hardwareProfile } = useModelServingPodSpecOptionsState(obj, isvc, isModelMesh);
+  const { hardwareProfile } = useModelServingPodSpecOptionsState(obj, isvc);
 
   const resources = isvc?.spec.predictor.model?.resources || obj.spec.containers[0].resources;
   const sizes = getModelServingSizes(dashboardConfig);

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   ConfigMapKind,
-  DeploymentMode,
   InferenceServiceKind,
   KnownLabels,
   PersistentVolumeClaimKind,
@@ -61,14 +60,6 @@ export const isInferenceServiceRouteEnabled = (inferenceService: InferenceServic
 
 export const isGpuDisabled = (servingRuntime: ServingRuntimeKind): boolean =>
   servingRuntime.metadata.annotations?.['opendatahub.io/disable-gpu'] === 'true';
-
-/** @deprecated -- model mesh is removed */
-export const getInferenceServiceDeploymentMode = (modelMesh: boolean): DeploymentMode => {
-  if (modelMesh) {
-    return DeploymentMode.ModelMesh;
-  }
-  return DeploymentMode.RawDeployment;
-};
 
 export const getInferenceServiceFromServingRuntime = (
   inferenceServices: InferenceServiceKind[],
@@ -507,7 +498,6 @@ export const getSubmitServingRuntimeResourcesFn = (
               isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
               opts: { dryRun },
               podSpecOptions,
-              isModelMesh,
             }),
             ...(isModelMesh
               ? [
@@ -534,7 +524,6 @@ export const getSubmitServingRuntimeResourcesFn = (
               isCustomServingRuntimesEnabled: customServingRuntimesEnabled,
               opts: { dryRun },
               podSpecOptions,
-              isModelMesh,
             }).then((servingRuntime) => {
               if (isModelMesh) {
                 return setUpTokenAuth(

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -31,7 +31,6 @@ import {
   ServiceAccountKind,
   RoleKind,
   ServingContainer,
-  DeploymentMode,
   PersistentVolumeClaimKind,
 } from '#~/k8sTypes';
 import { ContainerResources } from '#~/types';
@@ -363,10 +362,6 @@ export const isModelServerEditInfoChanged = (
           createData.tokens.map((token) => token.name).toSorted(),
         ))
     : true;
-
-export const isModelMesh = (inferenceService: InferenceServiceKind): boolean =>
-  inferenceService.metadata.annotations?.['serving.kserve.io/deploymentMode'] ===
-  DeploymentMode.ModelMesh;
 
 export const isModelServingStopped = (inferenceService?: InferenceServiceKind): boolean =>
   inferenceService?.metadata.annotations?.['serving.kserve.io/stop'] === 'true';

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelCard.tsx
@@ -13,7 +13,6 @@ import { Link } from 'react-router-dom';
 import { ProjectObjectType } from '#~/concepts/design/utils';
 import { InferenceServiceKind, ServingRuntimeKind } from '#~/k8sTypes';
 import InferenceServiceStatus from '#~/pages/modelServing/screens/global/InferenceServiceStatus';
-import { isModelMesh } from '#~/pages/modelServing/utils';
 import ResourceNameTooltip from '#~/components/ResourceNameTooltip';
 import InferenceServiceServingRuntime from '#~/pages/modelServing/screens/global/InferenceServiceServingRuntime';
 import InferenceServiceEndpoint from '#~/pages/modelServing/screens/global/InferenceServiceEndpoint';
@@ -34,10 +33,9 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
 }) => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
 
-  const modelMesh = isModelMesh(inferenceService);
-  const modelMeshMetricsSupported = modelMetricsEnabled && modelMesh;
+  // Always KServe (no ModelMesh)
   const kserveMetricsEnabled = useIsAreaAvailable(SupportedArea.K_SERVE_METRICS).status;
-  const kserveMetricsSupported = modelMetricsEnabled && kserveMetricsEnabled && !modelMesh;
+  const kserveMetricsSupported = modelMetricsEnabled && kserveMetricsEnabled;
 
   const displayName = getDisplayNameFromK8sResource(inferenceService);
 
@@ -52,7 +50,7 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
             <FlexItem>
               <InferenceServiceStatus
                 inferenceService={inferenceService}
-                isKserve={!isModelMesh(inferenceService)}
+                isKserve={true} // Always KServe
                 stoppedStates={{
                   isStarting,
                   isStopping,
@@ -63,9 +61,7 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
             </FlexItem>
             <FlexItem>
               <ResourceNameTooltip resource={inferenceService}>
-                {!isStarting &&
-                !isFailed &&
-                (modelMeshMetricsSupported || kserveMetricsSupported) ? (
+                {!isStarting && !isFailed && kserveMetricsSupported ? (
                   <Link
                     data-testid={`metrics-link-${displayName}`}
                     to={`/projects/${inferenceService.metadata.namespace}/metrics/model/${inferenceService.metadata.name}`}
@@ -104,7 +100,7 @@ const DeployedModelCard: React.FC<DeployedModelCardProps> = ({
           <InferenceServiceEndpoint
             inferenceService={inferenceService}
             servingRuntime={servingRuntime}
-            isKserve={!isModelMesh(inferenceService)}
+            isKserve={true} // Always KServe
             modelState={{ isStarting, isStopping, isStopped, isRunning, isFailed }}
           />
         </CardFooter>

--- a/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
+++ b/frontend/src/pages/projects/screens/detail/overview/serverModels/deployedModels/DeployedModelsGallery.tsx
@@ -13,8 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import { SearchIcon } from '@patternfly/react-icons';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
-import { isModelMesh } from '#~/pages/modelServing/utils';
-import { getPodsForKserve, getPodsForModelMesh } from '#~/api';
+import { getPodsForKserve } from '#~/api';
 import {
   checkModelPodStatus,
   getInferenceServiceModelState,
@@ -67,9 +66,11 @@ const DeployedModelsGallery: React.FC<DeployedModelsGalleryProps> = ({
     const getServicesForStatus = async () => {
       for (const deployedModel of deployedModels) {
         try {
-          const modelPods = await (!isModelMesh(deployedModel)
-            ? getPodsForKserve
-            : getPodsForModelMesh)(namespace, deployedModel.spec.predictor.model?.runtime ?? '');
+          // Always use KServe (no ModelMesh)
+          const modelPods = await getPodsForKserve(
+            namespace,
+            deployedModel.spec.predictor.model?.runtime ?? '',
+          );
           if (!canceled) {
             updateServiceState(deployedModel, checkModelPodStatus(modelPods[0]));
           }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-36720

## Description
This PR removes ServiceMesh capabilities and Serverless deployment mode as part of the DSC v1 to v2 migration. These features are deprecated and not available in DSC v2, which uses KServe-only model serving.

**What changed:**

**ServiceMesh Removal:**
- Remove `StackCapability` enum and `requiredCapabilities` logic from areas system (`types.ts`, `utils.ts`, `const.ts`)
- Remove ServiceMesh authorization requirements from `K_SERVE_AUTH` area configuration
- Clean up ServiceMesh references from mock files (`mockDsc.ts`, `mockDsciStatus.ts`) and test infrastructure

**Serverless/ModelMesh Deployment Removal:**  
- Remove `DeploymentMode.ModelMesh` from deployment options in `k8sTypes.ts`
- Remove `serverlessMode` configuration field from KServe component status
- Remove deprecated `isModelMesh()` and `getInferenceServiceDeploymentMode()` functions
- Update inference service creation to always use `DeploymentMode.RawDeployment`
- Remove `isModelMesh` parameters from serving runtime APIs

**UI Simplification:**
- Migrate model serving components to assume KServe-only platform (`DeployedModelCard`, `PerformanceTab`, `ModelGraphs`, etc.)
- Remove conditional ModelMesh logic from deployed models gallery and metrics
- Simplify project filtering - all projects now support KServe

**Test Infrastructure:**
- Remove `DeploymentMode` parameter from `checkInferenceServiceState` Cypress utility
- Update all test call sites and modernize test comments
- Update mock configurations for KServe-only behavior

**Why:** ServiceMesh capabilities and ModelMesh deployment mode are deprecated in DSC v2. The new architecture uses KServe RawDeployment exclusively, eliminating the need for multi-platform model serving logic.

**Scope:** This PR focuses on ServiceMesh + Serverless removal as part of systematic DSC v2 migration. It builds on the previous CodeFlare removal and prepares for remaining ModelMesh UI cleanup.

**Follow-up PRs:**
1. ✅ Previous PR: CodeFlare removal  
2. ✅ This PR: ServiceMesh + Serverless removal
3. 🔄 Next: Remaining ModelMesh UI component cleanup

## How Has This Been Tested?
- Manually verified TypeScript compilation succeeds (0 errors across 14 packages)
- Confirmed all ESLint/Prettier checks pass (0 errors, 0 warnings)  
- Verified areas system correctly handles removed ServiceMesh capabilities
- Tested model serving UI works with simplified KServe-only logic
- Confirmed inference service creation uses correct deployment mode
- Validated serving runtime management without ModelMesh parameters
- Verified Cypress test utilities work with updated signatures

## Test Impact
- **Updated tests:** Removed 15+ test scenarios for `requiredCapabilities` and `StackCapability` from areas system tests
- **Cypress utilities:** Updated `checkInferenceServiceState` function signature and 8 test files that call it
- **Mock configurations:** Updated inference service and serving runtime mocks to reflect KServe-only behavior  
- **Test assertions:** Changed expected deployment mode from `ModelMesh` to `RawDeployment` across test suite
- **Test comments:** Modernized outdated Serverless references to be more maintainable
- **Test rationale:** This is primarily cleanup/removal work. Existing tests now validate the simplified KServe-only behavior, maintaining coverage while removing obsolete test cases for deprecated features.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed ModelMesh and serverless deployment paths — model serving now consistently uses RawDeployment/KServe.
  * Simplified metrics, readiness and last-deployed displays to a single KServe flow, fixing inconsistent gating and rendering.

* **Chores**
  * Removed deployment-mode validation and streamlined deployment-mode handling.
  * Consolidated edit/delete modal flows and removed ModelMesh-specific branches across the UI.

* **Tests**
  * Updated and removed tests to align with the simplified KServe-only deployment logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->