### PR TITLE
NIM - increase timeout for odh-enabled-modal__progress-title to not exist

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/nim/testEnableNIM.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/nim/testEnableNIM.cy.ts
@@ -157,8 +157,8 @@ function executeNIMTestSteps(): void {
   nimCard.getNIMSubmit().click();
   cy.step('Wait for validation to complete and verify the validation message');
   nimCard.getProgressTitle().should('contain', 'Contacting NVIDIA to validate the license key');
-  // Wait for validation to complete (up to 120 seconds for NVIDIA API call with network issues)
-  nimCard.getProgressTitle({ timeout: 120000 }).should('not.exist');
+  // Wait for validation to complete (up to 180 seconds for NVIDIA API call with network issues)
+  nimCard.getProgressTitle({ timeout: 180000 }).should('not.exist');
   cy.step('Check for success notification');
   toastNotifications
     .findToastNotification(0)


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-34177 -->

## Description
This PR increases the timeout for waiting on `odh-enabled-modal__progress-title` to not exist in the NIM enablement test from 120 seconds to 180 seconds.

**Background:**
This issue resolved on its own, but the timeout increase was made to improve test stability for future runs. The additional time accounts for potential network latency when validating the NVIDIA license key via their API.

**Changes:**
- Increased timeout from 120s to 180s (50% increase) for the progress title element check in `testEnableNIM.cy.ts`
- Updated comment to reflect the new timeout value

## How Has This Been Tested?
This is a test timeout adjustment only. No functional changes to the codebase. The change increases the wait time for an existing Cypress test assertion that waits for the progress modal to disappear after NVIDIA license key validation.

The test file is: `frontend/src/__tests__/cypress/cypress/tests/e2e/nim/testEnableNIM.cy.ts`

## Test Impact
- Modified existing Cypress E2E test timeout value
- No new tests added as this is a timeout adjustment to an existing test
- The test will now wait up to 180 seconds (previously 120 seconds) for the progress modal to disappear

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [x] N/A - Test-only change, no UI modifications

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`