### PR TITLE
fix: Allow regular users to list namespaces in AI Playground

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -235,7 +235,7 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(constants.ModelsAAPath, app.AttachNamespace(app.RequireAccessToService(app.ModelsAAHandler)))
 
 	// Settings path namespace endpoints. This endpoint will get all the namespaces
-	apiRouter.GET(constants.NamespacesPath, app.RequireAccessToService(app.RequireNamespaceListAccess(app.GetNamespaceHandler)))
+	apiRouter.GET(constants.NamespacesPath, app.RequireAccessToService(app.GetNamespaceHandler))
 
 	// Identity
 	apiRouter.GET(constants.UserPath, app.RequireAccessToService(app.GetCurrentUserHandler))


### PR DESCRIPTION
## Description

**Fixes:** https://issues.redhat.com/browse/RHOAIENG-37725

### Problem
Regular users couldn't access the AI Playground because the BFF attempted to list all namespaces cluster-wide, which requires cluster-admin permissions. This resulted in 403 Forbidden errors for regular users.

### Solution
Use OpenShift Projects API for regular users, which automatically filters to accessible projects only.

**Implementation:**
- Admin users: Try cluster-wide namespace list first (fast path)
- Regular users: Fall back to OpenShift Projects API (project.openshift.io/v1)
- Uses controller-runtime unstructured client

### Changes
1. Updated `GetNamespaces()` in `token_k8s_client.go` to support both admin and regular user paths
2. Removed `RequireNamespaceListAccess` middleware (too restrictive)
3. Updated namespace route in `app.go`

### Security
All endpoints remain protected:
- Bearer token authentication required
- SAR checks enforced for namespace access
- OpenShift Projects API provides automatic filtering

---

## How Has This Been Tested?

**Manual testing on live OpenShift cluster:**
- Admin user: Returns all 28 namespaces
- Regular user (ldap-user1): Returns 2 accessible namespaces
- Verified regular users can now access AI Playground

---

## Test Impact

Existing unit tests cover the functionality. No new tests needed as the changes only modify internal implementation of `GetNamespaces()` without changing its interface or contract.

---

## Request review criteria:

Self checklist:
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

---

## Related
Follows SAR validation patterns from PR #5152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced namespace access control in Settings/Namespaces endpoint with improved user-level permission verification
  - Namespace retrieval now respects individual user permissions with intelligent fallback mechanisms for multi-tenant environments

* **Refactor**
  - Streamlined internal namespace access verification and retrieval workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->