### PR TITLE
fix: Allow regular users to list namespaces in AI Playground (#5327)

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -235,7 +235,7 @@ func (app *App) Routes() http.Handler {
 	apiRouter.GET(constants.ModelsAAPath, app.AttachNamespace(app.RequireAccessToService(app.ModelsAAHandler)))
 
 	// Settings path namespace endpoints. This endpoint will get all the namespaces
-	apiRouter.GET(constants.NamespacesPath, app.RequireAccessToService(app.RequireNamespaceListAccess(app.GetNamespaceHandler)))
+	apiRouter.GET(constants.NamespacesPath, app.RequireAccessToService(app.GetNamespaceHandler))
 
 	// Identity
 	apiRouter.GET(constants.UserPath, app.RequireAccessToService(app.GetCurrentUserHandler))


### PR DESCRIPTION
## Description

**Fixes:** https://issues.redhat.com/browse/RHOAIENG-37725

Cherry-pick of #5327 to v3.0.0-fixes branch for code freeze.

### Problem
Regular users couldn't access the AI Playground because the BFF attempted to list all namespaces cluster-wide, which requires cluster-admin permissions.

### Solution
Use OpenShift Projects API for regular users, which automatically filters to accessible projects only.

### Changes
1. Updated `GetNamespaces()` to support both admin and regular user paths
2. Removed `RequireNamespaceListAccess` middleware
3. Updated namespace route

### Testing
Verified on live cluster:
- Admin user: Returns all namespaces
- Regular user: Returns only accessible projects

---

(cherry picked from commit cda8cd29f)