### PR TITLE
parent orphaned nav items to the end of the list

### DIFF
--- a/frontend/src/app/navigation/ExtensibleNav.tsx
+++ b/frontend/src/app/navigation/ExtensibleNav.tsx
@@ -3,7 +3,7 @@ import { Nav, NavList } from '@patternfly/react-core';
 import { isNavExtension, NavExtension } from '@odh-dashboard/plugin-core/extension-points';
 import { useExtensions } from '@odh-dashboard/plugin-core';
 import { NavItem } from './NavItem';
-import { compareNavItemGroups } from './utils';
+import { getTopLevelExtensions } from './utils';
 
 type Props = {
   label: string;
@@ -11,10 +11,7 @@ type Props = {
 
 export const ExtensibleNav: React.FC<Props> = ({ label }) => {
   const extensions = useExtensions<NavExtension>(isNavExtension);
-  const topLevelExtensions = React.useMemo(
-    () => extensions.filter((e) => !e.properties.section).toSorted(compareNavItemGroups),
-    [extensions],
-  );
+  const topLevelExtensions = React.useMemo(() => getTopLevelExtensions(extensions), [extensions]);
 
   return (
     <Nav aria-label={label}>

--- a/frontend/src/app/navigation/__tests__/utils.spec.ts
+++ b/frontend/src/app/navigation/__tests__/utils.spec.ts
@@ -1,0 +1,226 @@
+import {
+  NavExtension,
+  HrefNavItemExtension,
+  NavSectionExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { compareNavItemGroups, getTopLevelExtensions } from '#~/app/navigation/utils';
+
+// Test helpers
+const createNavItem = (id: string, group?: string, section?: string): HrefNavItemExtension => ({
+  type: 'app.navigation/href',
+  properties: {
+    id,
+    title: `Title ${id}`,
+    label: `Label ${id}`,
+    href: `/path/${id}`,
+    ...(group && { group }),
+    ...(section && { section }),
+  },
+});
+
+const createNavSection = (id: string, group?: string): NavSectionExtension => ({
+  type: 'app.navigation/section',
+  properties: {
+    id,
+    title: `Title ${id}`,
+    label: `Section ${id}`,
+    ...(group && { group }),
+  },
+});
+
+describe('compareNavItemGroups', () => {
+  it('should compare items with different groups lexicographically', () => {
+    const itemA = createNavItem('a', '1_first');
+    const itemB = createNavItem('b', '2_second');
+
+    expect(compareNavItemGroups(itemA, itemB)).toBeLessThan(0);
+    expect(compareNavItemGroups(itemB, itemA)).toBeGreaterThan(0);
+  });
+
+  it('should return 0 for items with the same group', () => {
+    const itemA = createNavItem('a', '1_first');
+    const itemB = createNavItem('b', '1_first');
+
+    expect(compareNavItemGroups(itemA, itemB)).toBe(0);
+  });
+
+  it('should use default group for items without group property', () => {
+    const itemA = createNavItem('a');
+    const itemB = createNavItem('b');
+
+    expect(compareNavItemGroups(itemA, itemB)).toBe(0);
+  });
+
+  it('should compare items with default group against items with explicit group', () => {
+    const itemWithoutGroup = createNavItem('a');
+    const itemWithGroup = createNavItem('b', '1_first');
+
+    // '5_default' (default group) should come after '1_first'
+    expect(compareNavItemGroups(itemWithGroup, itemWithoutGroup)).toBeLessThan(0);
+    expect(compareNavItemGroups(itemWithoutGroup, itemWithGroup)).toBeGreaterThan(0);
+  });
+
+  it('should handle undefined group property consistently', () => {
+    const itemA = createNavItem('a', undefined);
+    const itemB = createNavItem('b', undefined);
+
+    expect(compareNavItemGroups(itemA, itemB)).toBe(0);
+  });
+
+  it('should work with nav sections as well', () => {
+    const sectionA = createNavSection('section-a', '1_first');
+    const sectionB = createNavSection('section-b', '2_second');
+
+    expect(compareNavItemGroups(sectionA, sectionB)).toBeLessThan(0);
+    expect(compareNavItemGroups(sectionB, sectionA)).toBeGreaterThan(0);
+  });
+});
+
+describe('getTopLevelExtensions', () => {
+  it('should return top-level extensions without section', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('item1'),
+      createNavItem('item2'),
+      createNavSection('section1'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.properties.id)).toEqual(['item1', 'item2', 'section1']);
+  });
+
+  it('should sort top-level extensions by group', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('item3', '3_third'),
+      createNavItem('item1', '1_first'),
+      createNavItem('item2', '2_second'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result.map((e) => e.properties.id)).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  it('should exclude extensions with valid sections', () => {
+    const extensions: NavExtension[] = [
+      createNavSection('section1'),
+      createNavItem('item1', '1_first', 'section1'),
+      createNavItem('item2', '2_second'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.properties.id)).toEqual(['item2', 'section1']);
+  });
+
+  it('should include orphaned extensions (with non-existent section)', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('item1', '1_first'),
+      createNavItem('orphan1', '2_second', 'nonexistent-section'),
+      createNavItem('orphan2', '3_third', 'nonexistent-section'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.properties.id)).toEqual(['item1', 'orphan1', 'orphan2']);
+  });
+
+  it('should group and sort orphaned extensions by section', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('orphan1', '2_second', 'section-a'),
+      createNavItem('orphan2', '1_first', 'section-a'),
+      createNavItem('orphan3', '2_second', 'section-b'),
+      createNavItem('orphan4', '1_first', 'section-b'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    // Should maintain section grouping and sort within each group
+    expect(result).toHaveLength(4);
+    expect(result.map((e) => e.properties.id)).toEqual([
+      'orphan2',
+      'orphan1',
+      'orphan4',
+      'orphan3',
+    ]);
+  });
+
+  it('should handle mixed top-level, valid sectioned, and orphaned extensions', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('top1', '2_second'),
+      createNavSection('valid-section', '1_first'),
+      createNavItem('valid1', '3_third', 'valid-section'),
+      createNavItem('orphan1', '4_fourth', 'nonexistent'),
+      createNavItem('top2', '1_first'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    // Should include: top2, top1, valid-section, orphan1
+    expect(result).toHaveLength(4);
+    expect(result.map((e) => e.properties.id)).toEqual([
+      'valid-section',
+      'top2',
+      'top1',
+      'orphan1',
+    ]);
+  });
+
+  it('should handle extensions without group (using default group)', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('item1', '1_first'),
+      createNavItem('item2'), // No group, should use default '5_default'
+      createNavItem('item3', '9_last'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result.map((e) => e.properties.id)).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  it('should handle empty extensions array', () => {
+    const result = getTopLevelExtensions([]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle array with only sections', () => {
+    const extensions: NavExtension[] = [
+      createNavSection('section1', '2_second'),
+      createNavSection('section2', '1_first'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.properties.id)).toEqual(['section2', 'section1']);
+  });
+
+  it('should handle multiple orphaned groups with complex sorting', () => {
+    const extensions: NavExtension[] = [
+      createNavItem('top1', '1_first'),
+      createNavItem('orphan-a1', '3_third', 'section-a'),
+      createNavItem('orphan-a2', '2_second', 'section-a'),
+      createNavItem('orphan-b1', '2_second', 'section-b'),
+      createNavItem('orphan-b2', '1_first', 'section-b'),
+      createNavItem('orphan-c1', '1_first', 'section-c'),
+      createNavItem('top2', '9_last'),
+    ];
+
+    const result = getTopLevelExtensions(extensions);
+
+    expect(result).toHaveLength(7);
+    expect(result.map((e) => e.properties.id)).toEqual([
+      'top1',
+      'top2',
+      'orphan-a2',
+      'orphan-a1',
+      'orphan-b2',
+      'orphan-b1',
+      'orphan-c1',
+    ]);
+  });
+});

--- a/frontend/src/app/navigation/utils.ts
+++ b/frontend/src/app/navigation/utils.ts
@@ -1,7 +1,43 @@
-import { NavExtension } from '@odh-dashboard/plugin-core/extension-points';
+import { isNavSectionExtension, NavExtension } from '@odh-dashboard/plugin-core/extension-points';
 
 const DEFAULT_GROUP = '5_default';
 
 /** Lexicographic comparison function for navigation items sorting. */
 export const compareNavItemGroups = <T extends NavExtension>(a: T, b: T): number =>
   (a.properties.group || DEFAULT_GROUP).localeCompare(b.properties.group || DEFAULT_GROUP);
+
+export const getTopLevelExtensions = <E extends NavExtension>(extensions: E[]): E[] => {
+  // Get all section IDs that exist
+  const existingSectionIds = new Set(
+    extensions.filter((e) => isNavSectionExtension(e)).map((e) => e.properties.id),
+  );
+
+  // Filter top-level extensions (no section)
+  const topLevel = extensions.filter((e) => !e.properties.section).toSorted(compareNavItemGroups);
+
+  // Find extensions with sections that don't exist
+  const orphanedExtensions = extensions.filter(
+    (e) => e.properties.section && !existingSectionIds.has(e.properties.section),
+  );
+
+  // Group orphaned extensions by their section ID
+  const orphanedBySection = new Map<string, E[]>();
+  orphanedExtensions.forEach((ext) => {
+    const sectionId = ext.properties.section;
+    if (sectionId) {
+      let sections = orphanedBySection.get(sectionId);
+      if (!sections) {
+        sections = [];
+        orphanedBySection.set(sectionId, sections);
+      }
+      sections.push(ext);
+    }
+  });
+
+  // Sort each group and flatten
+  const sortedOrphaned = Array.from(orphanedBySection.values())
+    .map((group) => group.toSorted(compareNavItemGroups))
+    .flat();
+
+  return [...topLevel, ...sortedOrphaned];
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When running a local dev env with a limited set of plugin packages, certain nav items may not show up because the group to which they want to contribute to are not present. As a fallback, these orphaned nav items are now appended to the end of the list.

No affect in production as all packages will be present.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test running dev env with a single package.
`PLUGIN_PACKAGES="@odh-dashboard/model-serving" npm run start:dev:ext`

Note that all federated modules are still loaded. In a followup we may choose to limit modules by the same env var.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized top-level navigation extraction and orphan grouping to improve maintainability and ensure deterministic ordering; visible navigation output and public component behavior remain unchanged.

* **Tests**
  * Added comprehensive tests for navigation utilities covering grouping, sorting, orphan/section handling, default behaviors, and various edge cases to ensure stable ordering and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->