### PR TITLE
Restore and deprecate disableFineTuning field in OdhDashboardConfig CRD

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -536,6 +536,11 @@ const applyFeatureLockouts = (config: DashboardConfig): DashboardConfig => ({
        * Model Mesh is removed in v3.0
        */
       disableModelMesh: true,
+
+      /**
+       * Fine Tuning feature is no longer supported
+       */
+      disableFineTuning: true,
     },
   },
 });

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -77,6 +77,9 @@ spec:
                     disableHardwareProfiles:
                       type: boolean
                       description: 'DEPRECATED: Hardware Profiles are GA and cannot be disabled via this field. This field will be removed in a future version.'
+                    disableFineTuning:
+                      type: boolean
+                      description: 'DEPRECATED: This field is no longer used and will be removed in a future version.'
                     disableDistributedWorkloads:
                       type: boolean
                     disableModelCatalog:
@@ -108,6 +111,8 @@ spec:
                       message: 'DEPRECATED: spec.dashboardConfig.disableAcceleratorProfiles must be removed or left unchanged.'
                     - rule: '!has(self.disableHardwareProfiles) || self.disableHardwareProfiles == oldSelf.disableHardwareProfiles'
                       message: 'DEPRECATED: spec.dashboardConfig.disableHardwareProfiles must be removed or left unchanged.'
+                    - rule: '!has(self.disableFineTuning) || self.disableFineTuning == oldSelf.disableFineTuning'
+                      message: 'DEPRECATED: spec.dashboardConfig.disableFineTuning must be removed or left unchanged.'
                 # TODO: Remove before going to v1
                 groupsConfig:
                   description: 'Ignored -- See "Auth" Resource'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-38112

cherry pick of this https://github.com/opendatahub-io/odh-dashboard/pull/5352

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
