### PR TITLE
fix: Retrieve clusterDomain on startup

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/client.go
@@ -35,7 +35,4 @@ type KubernetesClientInterface interface {
 
 	// ConfigMap operations
 	GetConfigMap(ctx context.Context, identity *integrations.RequestIdentity, namespace string, name string) (*corev1.ConfigMap, error)
-
-	// Cluster information
-	GetClusterDomain(ctx context.Context) (string, error)
 }

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -115,6 +115,49 @@ func (kc *TokenKubernetesClient) IsClusterAdmin(ctx context.Context, identity *i
 	return true, nil
 }
 
+// GetClusterDomainUsingServiceAccount retrieves cluster domain using the pod's service account
+func GetClusterDomainUsingServiceAccount(ctx context.Context, logger *slog.Logger) (string, error) {
+	// Use in-cluster config (pod's service account)
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return "", err
+	}
+
+	// Query ingresses.config.openshift.io/cluster using service account
+	config := rest.CopyConfig(cfg)
+	config.APIPath = "/apis"
+	config.GroupVersion = &schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return "", err
+	}
+
+	result := restClient.Get().Resource("ingresses").Name("cluster").Do(ctx)
+	rawBytes, err := result.Raw()
+	if err != nil {
+		return "", err
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(rawBytes, &obj); err != nil {
+		return "", err
+	}
+
+	spec, ok := obj["spec"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid ingress config: missing spec")
+	}
+
+	domain, ok := spec["domain"].(string)
+	if !ok || domain == "" {
+		return "", fmt.Errorf("invalid ingress config: missing domain")
+	}
+
+	return domain, nil
+}
+
 func newTokenKubernetesClient(token string, logger *slog.Logger, envConfig config.EnvConfig) (*TokenKubernetesClient, error) {
 	baseConfig, err := helper.GetKubeconfig()
 	if err != nil {
@@ -1489,54 +1532,4 @@ func loadLlamaStackConfig(ctx context.Context, kc *TokenKubernetesClient, identi
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 	return &config, nil
-}
-
-// GetClusterDomain retrieves the cluster domain from the ingresses.config.openshift.io/cluster resource
-func (kc *TokenKubernetesClient) GetClusterDomain(ctx context.Context) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	// Create a REST client specifically configured for the config.openshift.io API
-	config := rest.CopyConfig(kc.Config)
-	config.APIPath = "/apis"
-	config.GroupVersion = &schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
-	restClient, err := rest.RESTClientFor(config)
-	if err != nil {
-		kc.Logger.Error("failed to create REST client for cluster domain query", "error", err)
-		return "", fmt.Errorf("failed to create REST client: %w", err)
-	}
-
-	// Query the ingresses.config.openshift.io/cluster resource
-	result := restClient.Get().
-		Resource("ingresses").
-		Name("cluster").
-		Do(ctx)
-
-	rawBytes, err := result.Raw()
-	if err != nil {
-		kc.Logger.Debug("failed to get cluster ingress config", "error", err)
-		return "", fmt.Errorf("failed to get cluster domain: %w", err)
-	}
-
-	// Parse the JSON response
-	var obj map[string]interface{}
-	if err := json.Unmarshal(rawBytes, &obj); err != nil {
-		return "", fmt.Errorf("failed to parse ingress config response: %w", err)
-	}
-
-	// Extract the domain from spec.domain
-	spec, ok := obj["spec"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid ingress config structure: missing spec")
-	}
-
-	domain, ok := spec["domain"].(string)
-	if !ok || domain == "" {
-		return "", fmt.Errorf("invalid ingress config structure: missing or empty domain")
-	}
-
-	kc.Logger.Debug("discovered cluster domain", "domain", domain)
-	return domain, nil
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
