### PR TITLE
chore(deps): Upgrade axios to 1.12.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,7 @@
         "@patternfly/react-virtualized-extension": "^6.0.0",
         "@segment/analytics-next": "^1.72.0",
         "@types/classnames": "^2.3.1",
-        "axios": "^1.6.4",
+        "axios": "^1.12.0",
         "classnames": "^2.2.6",
         "compare-versions": "^3.6.0",
         "dompurify": "^3.2.4",
@@ -8456,9 +8456,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,7 @@
     "@patternfly/react-virtualized-extension": "^6.0.0",
     "@segment/analytics-next": "^1.72.0",
     "@types/classnames": "^2.3.1",
-    "axios": "^1.6.4",
+    "axios": "^1.12.0",
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",
     "dompurify": "^3.2.4",


### PR DESCRIPTION
Upgrade axios from 1.6.4 to 1.12.0 to address security vulnerability.

Related Jira: [RHOAIENG-34291](https://issues.redhat.com//browse/RHOAIENG-34291)
Target Release: RHOAI 2.22.3

I have tested the build locally and dashboard is running with these updates.