### PR TITLE
e2e tests: Increase time to click Import Pipeline button to 5 mins

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/Pipelines/testSchedulePipeline.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/Pipelines/testSchedulePipeline.cy.ts
@@ -56,7 +56,7 @@ describe('Verify that a pipeline can be scheduled to run', { testIsolation: fals
       projectListPage.findProjectLink(projectName).click();
 
       cy.step('Import a pipeline by URL');
-      projectDetails.findImportPipelineButton(180000).click();
+      projectDetails.findImportPipelineButton(300000).click();
       pipelineImportModal.findPipelineNameInput().type(pipelineName);
       pipelineImportModal.findPipelineDescriptionInput().type(pipelineDescription);
       pipelineImportModal.findImportPipelineRadio().click();


### PR DESCRIPTION
## Description
In testSchedulePipeline test, increase the "Import Pipeline" button timeout to 5 minutes, as it's the max it can take:
<img width="582" height="280" alt="image" src="https://github.com/user-attachments/assets/c8449108-38eb-4d66-a802-cf5860d461d0" />


## How Has This Been Tested?
job/dashboard-tests/3437 
<img width="1180" height="168" alt="image" src="https://github.com/user-attachments/assets/67181f2e-5e37-4c34-9b9e-9868170a9de1" />



## Test Impact
Increase a timeout

## Request review criteria:


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for pipeline import functionality by adjusting timeout settings to handle slower loading conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->