### PR TITLE
fix: Redact sensitive MCP and LlamaStack headers from logs

### DIFF
--- a/packages/gen-ai/bff/internal/helpers/logging.go
+++ b/packages/gen-ai/bff/internal/helpers/logging.go
@@ -39,6 +39,8 @@ var sensitiveHeaders = []string{
 	"X-Auth-Request-Groups",
 	"X-Envoy-Peer-Metadata",
 	"X-Envoy-Peer-Metadata-Id",
+	"X-Llamastack-Provider-Data",
+	"X-Mcp-Bearer",
 }
 
 func isSensitiveHeader(h string) bool {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-38054

## Description

This PR fixes a **critical security vulnerability** where authentication tokens and credentials were being exposed in plain text in the gen-ai BFF logs.

### Problem
While the BFF properly redacted `Authorization` and `Cookie` headers, it failed to redact several other headers containing sensitive authentication data:
- `X-Mcp-Bearer` - Contains GitHub Personal Access Tokens (PATs) for MCP server authentication
- `X-Llamastack-Provider-Data` - Contains LlamaStack provider credentials

These tokens were being logged in plain text when DEBUG logging was enabled, creating a security risk if logs were accessed by unauthorized parties or stored in log aggregation systems.

### Solution
Added `X-Mcp-Bearer` and `X-Llamastack-Provider-Data` to the `sensitiveHeaders` list in `packages/gen-ai/bff/internal/helpers/logging.go`. 

**Technical details:**
- Header names use Go's canonical form (e.g., `X-Mcp-Bearer` instead of `X-MCP-Bearer`)
- The existing `http.CanonicalHeaderKey()` function ensures case-insensitive matching
- Headers are now redacted as `[REDACTED]` in all log output

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has added tests or explained why testing cannot be added (uses existing test infrastructure)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [N/A] Included any necessary screenshots or gifs if it was a UI change
- [N/A] Included tags to the UX team if it was a UI/UX change

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`