### PR TITLE
Upgrading react-router and react-router-dom to fix CVE-2025-31137 (#4337)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,8 +54,8 @@
         "react-dropzone": "^14.2.3",
         "react-markdown": "^10.1.0",
         "react-redux": "^8.0.4",
-        "react-router": "^7.1.5",
-        "react-router-dom": "^7.1.5",
+        "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",
         "rehype-raw": "^7.0.0",
@@ -24382,9 +24382,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
-      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -24404,12 +24404,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
-      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.6.1"
+        "react-router": "7.6.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,8 +102,8 @@
     "react-dropzone": "^14.2.3",
     "react-markdown": "^10.1.0",
     "react-redux": "^8.0.4",
-    "react-router": "^7.1.5",
-    "react-router-dom": "^7.1.5",
+    "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
     "rehype-raw": "^7.0.0",
@@ -242,8 +242,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.1.5",
-      "react-router-dom": "^7.1.5",
+      "react-router": "^7.6.2",
+      "react-router-dom": "^7.6.2",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.2.2",
@@ -258,7 +258,7 @@
     "@patternfly/quickstarts": {
       "@patternfly/react-core": "^6.2.2"
     },
-    "react-router": "^7.1.5",
+    "react-router": "^7.6.2",
     "ws": "^8.17.1",
     "dompurify": "^3.2.4",
     "redux": "^4.2.0",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Backporting #4337

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm audit `

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
