### PR TITLE
Fix : Hide the feature store Integration tab when feature store is removed/disabled

### DIFF
--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -112,7 +112,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
           'feast-configs-registry',
         );
 
-        if (!feastConfig.data?.namespaces) {
+        if (!feastConfig || !feastConfig.data?.namespaces) {
           return reply.send({
             clientConfigs: [],
             namespaces: [],

--- a/frontend/src/__tests__/cypress/cypress/pages/featureStoreIntegration.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/featureStoreIntegration.ts
@@ -1,0 +1,142 @@
+import { TableRow } from './components/table';
+
+class FeatureStoreConfigRow extends TableRow {
+  findCheckbox() {
+    return this.find().find('input[type="checkbox"]');
+  }
+
+  shouldHaveConfigName(name: string) {
+    this.find().contains(name).should('exist');
+    return this;
+  }
+
+  shouldHaveProject(project: string) {
+    this.find().contains(project).should('exist');
+    return this;
+  }
+
+  selectConfig() {
+    this.findCheckbox().check();
+    return this;
+  }
+
+  shouldBeAccessible() {
+    this.findCheckbox().should('not.be.disabled');
+    return this;
+  }
+
+  shouldBeInaccessible() {
+    this.findCheckbox().should('be.disabled');
+    return this;
+  }
+
+  hoverOverCheckbox() {
+    // PatternFly Tooltip wraps the checkbox in a trigger element
+    // We need to hover over the tooltip's trigger wrapper, not the disabled checkbox itself
+    // The tooltip trigger is typically a span or div that wraps the checkbox
+    this.findCheckbox().parent().trigger('mouseenter', { force: true });
+    return this;
+  }
+}
+
+class FeatureStoreIntegration {
+  findEmptyState() {
+    return cy.findByTestId('empty-state-feature-store');
+  }
+
+  findTable() {
+    return cy.findByTestId('feature-store-table');
+  }
+
+  findTableHeaderButton(name: string) {
+    return this.findTable().find('thead').findByRole('button', { name });
+  }
+
+  findErrorState() {
+    return cy.findByTestId('error-state-feature-store');
+  }
+
+  findNameFilter() {
+    return cy.findByTestId('name-filter');
+  }
+
+  findFilterDropdown() {
+    return cy.findByTestId('feature-store-filter-dropdown');
+  }
+
+  selectFilterType(filterType: string) {
+    this.findFilterDropdown().click();
+    cy.findByRole('menuitem', { name: filterType }).click();
+    return this;
+  }
+
+  findProjectFilter() {
+    return cy.findByTestId('project-filter');
+  }
+
+  findShowOnlyAccessibleToggle() {
+    return cy.pfSwitch('show-only-accessible-toggle');
+  }
+
+  toggleShowOnlyAccessible() {
+    this.findShowOnlyAccessibleToggle().click();
+    return this;
+  }
+
+  findCodeBlockCopyButton() {
+    return cy.findByTestId('code-block-copy-button');
+  }
+
+  findCodeBlockContent() {
+    return cy.get('#code-block-content pre');
+  }
+
+  findPythonScriptHeading() {
+    return cy.findByText('Python script');
+  }
+
+  findSelectConfigmapsText() {
+    return cy.findByText('Select configmaps');
+  }
+
+  findTooltip() {
+    return cy.findByRole('tooltip');
+  }
+
+  findClearFiltersButton() {
+    return cy.findByRole('button', { name: 'Clear all filters' });
+  }
+
+  clearFilters() {
+    this.findClearFiltersButton().click();
+    return this;
+  }
+
+  getConfigRow(configName: string) {
+    return new FeatureStoreConfigRow(() =>
+      this.findTable().find('tbody').contains('tr', configName).should('exist'),
+    );
+  }
+
+  shouldHaveConfigCount(count: number) {
+    this.findTable().find('tbody tr').should('have.length', count);
+    return this;
+  }
+
+  shouldShowConfig(configName: string) {
+    cy.findByText(configName).should('exist');
+    return this;
+  }
+
+  shouldNotShowConfig(configName: string) {
+    cy.findByText(configName).should('not.exist');
+    return this;
+  }
+
+  shouldShowSuccessMessage(message: string) {
+    cy.findByText(message, { timeout: 5000 }).should('exist');
+    return this;
+  }
+}
+
+export const featureStoreIntegration = new FeatureStoreIntegration();

--- a/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
+++ b/frontend/src/__tests__/cypress/cypress/support/commands/odh.ts
@@ -919,6 +919,21 @@ declare global {
           response: OdhResponse<ProjectList>,
         ) => Cypress.Chainable<null>) &
         ((
+          type: 'GET /api/featurestores/workbench-integration',
+          response: OdhResponse<{
+            clientConfigs: Array<{
+              namespace: string;
+              configName: string;
+              configMap: ConfigMapKind | null;
+              hasAccessToFeatureStore: boolean;
+            }>;
+            namespaces: Array<{
+              namespace: string;
+              clientConfigs: string[];
+            }>;
+          }>,
+        ) => Cypress.Chainable<null>) &
+        ((
           type: 'GET /api/k8s/apis/feast.dev/v1alpha1/namespaces/*/featurestores',
           options: {
             query?: { labelSelector: string };

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/projectDetails.cy.ts
@@ -67,6 +67,7 @@ type HandlersProps = {
   pipelineServerErrorMessage?: string;
   rejectAddSupportServingPlatformProject?: boolean;
   disableWorkbenches?: boolean;
+  disableFeatureStore?: boolean;
   namespace?: string;
   disableKueue?: boolean;
   inferenceServices?: InferenceServiceKind[];
@@ -91,6 +92,7 @@ const initIntercepts = ({
   pipelineServerErrorMessage,
   rejectAddSupportServingPlatformProject = false,
   disableWorkbenches = false,
+  disableFeatureStore = false,
   namespace = 'test-project',
   disableKueue = true,
   inferenceServices = [],
@@ -118,6 +120,9 @@ const initIntercepts = ({
         [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
         [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
         [DataScienceStackComponent.MODEL_REGISTRY]: { managementState: 'Managed' },
+        [DataScienceStackComponent.FEAST_OPERATOR]: {
+          managementState: disableFeatureStore ? 'Removed' : 'Managed',
+        },
       },
     }),
   );
@@ -146,6 +151,7 @@ const initIntercepts = ({
       disableKServe,
       disableNIMModelServing: disableNIMConfig,
       disableKueue,
+      disableFeatureStore,
     }),
   );
   if (pipelineServerInstalled) {
@@ -681,6 +687,20 @@ describe('Project Details', () => {
       // 3. Verify deploy model button is disabled
       projectDetails.visitSection('test-project', 'model-server');
       cy.findByTestId('deploy-button').should('have.attr', 'aria-disabled', 'true');
+    });
+  });
+
+  describe('Feature Store disabled', () => {
+    beforeEach(() => {
+      initIntercepts({
+        disableFeatureStore: true,
+      });
+      initModelServingIntercepts({});
+    });
+
+    it('should hide feature store tab when feature store is disabled', () => {
+      projectDetails.visit('test-project');
+      projectDetails.findTab('Feature store integration').should('not.exist');
     });
   });
 });

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/featureStoreConfig.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/featureStoreConfig.cy.ts
@@ -1,0 +1,289 @@
+import { mockDashboardConfig, mockK8sResourceList, mockProjectK8sResource } from '#~/__mocks__';
+import { mockConfigMap } from '#~/__mocks__/mockConfigMap';
+import { mockDscStatus } from '#~/__mocks__/mockDscStatus';
+import { projectDetails } from '#~/__tests__/cypress/cypress/pages/projects';
+import { featureStoreIntegration } from '#~/__tests__/cypress/cypress/pages/featureStoreIntegration';
+import { ProjectModel } from '#~/__tests__/cypress/cypress/utils/models';
+import { DataScienceStackComponent } from '#~/concepts/areas/types';
+import type { ConfigMapKind } from '#~/k8sTypes';
+
+const mockFeatureStoreConfigMap = (
+  options: {
+    name?: string;
+    namespace?: string;
+    project?: string;
+    hasAccess?: boolean;
+    creationTimestamp?: string;
+  } = {},
+): ConfigMapKind => {
+  const {
+    name = 'feature-store-config',
+    namespace = 'test-project',
+    project = 'my-feature-store',
+    creationTimestamp = '2023-01-01T00:00:00Z',
+  } = options;
+
+  const yamlContent = `project: ${project}
+repository: https://github.com/my-org/my-feature-store
+branch: main
+`;
+
+  const configMap = mockConfigMap({
+    name,
+    namespace,
+    data: {
+      'feature_store.yaml': yamlContent,
+    },
+  });
+
+  configMap.metadata.creationTimestamp = creationTimestamp;
+
+  return configMap;
+};
+
+const mockFeatureStoreResponse = (
+  configs: Array<{
+    namespace: string;
+    configName: string;
+    configMap: ConfigMapKind;
+    hasAccessToFeatureStore: boolean;
+  }> = [],
+) => ({
+  clientConfigs: configs,
+  namespaces: configs.map((config) => ({
+    namespace: config.namespace,
+    clientConfigs: [config.configName],
+  })),
+});
+
+const initIntercepts = ({
+  isEmpty = false,
+  disableFeatureStore = false,
+  configs = [],
+}: {
+  isEmpty?: boolean;
+  disableFeatureStore?: boolean;
+  configs?: Array<{
+    name?: string;
+    namespace?: string;
+    project?: string;
+    hasAccess?: boolean;
+    creationTimestamp?: string;
+  }>;
+} = {}) => {
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: 'test-project' })]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.FEAST_OPERATOR]: {
+          managementState: disableFeatureStore ? 'Removed' : 'Managed',
+        },
+      },
+    }),
+  );
+
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableFeatureStore,
+    }),
+  );
+
+  if (disableFeatureStore) {
+    cy.interceptOdh('GET /api/featurestores/workbench-integration', mockFeatureStoreResponse([]));
+  } else {
+    const mockConfigs = isEmpty
+      ? []
+      : configs.map((config) => ({
+          namespace: config.namespace || 'test-project',
+          configName: config.name || 'feature-store-config',
+          configMap: mockFeatureStoreConfigMap(config),
+          hasAccessToFeatureStore: config.hasAccess !== false,
+        }));
+
+    cy.interceptOdh(
+      'GET /api/featurestores/workbench-integration',
+      mockFeatureStoreResponse(mockConfigs),
+    );
+  }
+};
+
+describe('Feature Store Config', () => {
+  it('should show empty state when no feature store configs exist', () => {
+    initIntercepts({ isEmpty: true });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findEmptyState().should('exist');
+  });
+
+  it('should display feature store configs table', () => {
+    const configs = [
+      {
+        name: 'config-1',
+        project: 'project-1',
+        hasAccess: true,
+        creationTimestamp: '2023-01-01T00:00:00Z',
+      },
+      {
+        name: 'config-2',
+        project: 'project-2',
+        hasAccess: false,
+        creationTimestamp: '2023-01-02T00:00:00Z',
+      },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.shouldShowConfig('config-1');
+    featureStoreIntegration.shouldShowConfig('config-2');
+    featureStoreIntegration.getConfigRow('config-1').shouldHaveProject('project-1');
+    featureStoreIntegration.getConfigRow('config-2').shouldHaveProject('project-2');
+  });
+
+  it('should filter configs by name', () => {
+    const configs = [
+      { name: 'alpha-config', project: 'alpha-project' },
+      { name: 'beta-config', project: 'beta-project' },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.findNameFilter().type('alpha');
+    featureStoreIntegration.shouldShowConfig('alpha-config');
+    featureStoreIntegration.shouldNotShowConfig('beta-config');
+  });
+
+  it('should filter configs by project', () => {
+    const configs = [
+      { name: 'config-1', project: 'alpha-project' },
+      { name: 'config-2', project: 'beta-project' },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.selectFilterType('Associated Feature Store Repository');
+    featureStoreIntegration.findProjectFilter().type('alpha');
+    featureStoreIntegration.shouldShowConfig('config-1');
+    featureStoreIntegration.shouldNotShowConfig('config-2');
+  });
+
+  it('should toggle show only accessible configs', () => {
+    const configs = [
+      { name: 'accessible-config', hasAccess: true },
+      { name: 'inaccessible-config', hasAccess: false },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.shouldShowConfig('accessible-config');
+    featureStoreIntegration.shouldShowConfig('inaccessible-config');
+    featureStoreIntegration.toggleShowOnlyAccessible();
+    featureStoreIntegration.shouldShowConfig('accessible-config');
+    featureStoreIntegration.shouldNotShowConfig('inaccessible-config');
+  });
+
+  it('should disable selection for inaccessible configs', () => {
+    const configs = [
+      { name: 'accessible-config', hasAccess: true },
+      { name: 'inaccessible-config', hasAccess: false },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.getConfigRow('accessible-config').shouldBeAccessible();
+    featureStoreIntegration.getConfigRow('inaccessible-config').shouldBeInaccessible();
+  });
+
+  it('should generate Python script when configs are selected', () => {
+    const configs = [
+      { name: 'config-1', project: 'project-1', hasAccess: true },
+      { name: 'config-2', project: 'project-2', hasAccess: true },
+    ];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.findPythonScriptHeading().should('exist');
+    featureStoreIntegration.findSelectConfigmapsText().should('exist');
+    cy.get('#code-block-copy-button', { timeout: 10000 }).should('exist').and('be.disabled');
+    featureStoreIntegration.getConfigRow('config-1').selectConfig();
+    featureStoreIntegration.findSelectConfigmapsText().should('not.exist');
+    featureStoreIntegration.findCodeBlockCopyButton().should('exist').and('not.be.disabled');
+    featureStoreIntegration
+      .findCodeBlockContent()
+      .should('not.be.empty')
+      .and('contain.text', 'config_1')
+      .and('contain.text', 'project-1')
+      .and('contain.text', 'FeatureStore')
+      .and('contain.text', 'import');
+  });
+
+  it('should copy Python script to clipboard', () => {
+    const configs = [{ name: 'config-1', project: 'project-1', hasAccess: true }];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration.getConfigRow('config-1').selectConfig();
+    featureStoreIntegration.findSelectConfigmapsText().should('not.exist');
+    cy.window().then((win) => {
+      cy.stub(win.navigator.clipboard, 'writeText').resolves();
+    });
+
+    featureStoreIntegration.findCodeBlockCopyButton().click();
+    featureStoreIntegration.shouldShowSuccessMessage('Successfully copied to clipboard!');
+  });
+
+  it('should show tooltip for inaccessible configs', () => {
+    const configs = [{ name: 'inaccessible-config', hasAccess: false }];
+
+    initIntercepts({ configs });
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+
+    featureStoreIntegration.findTable().should('exist');
+    featureStoreIntegration
+      .getConfigRow('inaccessible-config')
+      .shouldBeInaccessible()
+      .hoverOverCheckbox();
+
+    featureStoreIntegration
+      .findTooltip()
+      .should('contain.text', 'Contact your admin to request permission');
+  });
+
+  it('should handle API errors gracefully', () => {
+    initIntercepts({ disableFeatureStore: false });
+
+    cy.intercept('GET', '/api/featurestores/workbench-integration', {
+      statusCode: 500,
+      body: { error: 'Internal server error' },
+    });
+
+    projectDetails.visit('test-project');
+    projectDetails.findTab('Feature store integration').click();
+    featureStoreIntegration.findErrorState().should('exist');
+  });
+});

--- a/frontend/src/pages/projects/featureStoreConfig/FeatureStoreIntegration.tsx
+++ b/frontend/src/pages/projects/featureStoreConfig/FeatureStoreIntegration.tsx
@@ -15,9 +15,10 @@ import {
   CodeBlockAction,
   ClipboardCopyButton,
   Popover,
+  Button,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { CodeIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { CodeIcon, OutlinedQuestionCircleIcon, CopyIcon } from '@patternfly/react-icons';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import { ProjectSectionID } from '#~/pages/projects/screens/detail/types';
 import DashboardPopupIconButton from '#~/concepts/dashboard/DashboardPopupIconButton';
@@ -68,11 +69,9 @@ const FeatureStoreIntegration: React.FC = () => {
   };
 
   const { clientConfigs, namespaces } = featureStoreData;
-
   const isLoading = !loaded && !error;
   const hasError = !!error;
   const isEmpty = !hasError && clientConfigs.length === 0 && namespaces.length === 0;
-
   if (isLoading) {
     return (
       <Bullseye>
@@ -98,21 +97,33 @@ const FeatureStoreIntegration: React.FC = () => {
           }}
           actions={
             <CodeBlockAction>
-              <ClipboardCopyButton
-                id="code-block-copy-button"
-                textId="code-block-content"
-                aria-label="Copy to clipboard"
-                onClick={() => onCopyClick(codeBlockContent)}
-                entryDelay={100}
-                exitDelay={copied ? 1500 : 600}
-                maxWidth="110px"
-                variant="plain"
-                onTooltipHidden={() => setCopied(false)}
-                className="pf-m-color-subtle"
-                disabled={selectedConfigs.length === 0}
-              >
-                {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
-              </ClipboardCopyButton>
+              {selectedConfigs.length === 0 ? (
+                <Button
+                  data-testid="code-block-copy-button"
+                  id="code-block-copy-button"
+                  aria-label="Copy to clipboard"
+                  variant="plain"
+                  className="pf-m-color-subtle"
+                  isDisabled
+                  icon={<CopyIcon />}
+                />
+              ) : (
+                <ClipboardCopyButton
+                  data-testid="code-block-copy-button"
+                  id="code-block-copy-button"
+                  textId="code-block-content"
+                  aria-label="Copy to clipboard"
+                  onClick={() => onCopyClick(codeBlockContent)}
+                  entryDelay={100}
+                  exitDelay={copied ? 1500 : 600}
+                  maxWidth="110px"
+                  variant="plain"
+                  onTooltipHidden={() => setCopied(false)}
+                  className="pf-m-color-subtle"
+                >
+                  {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+                </ClipboardCopyButton>
+              )}
             </CodeBlockAction>
           }
         >

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -49,6 +49,7 @@ const ProjectDetails: React.FC = () => {
   const biasMetricsAreaAvailable = useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;
   const projectSharingEnabled = useIsAreaAvailable(SupportedArea.DS_PROJECTS_PERMISSIONS).status;
   const pipelinesEnabled = useIsAreaAvailable(SupportedArea.DS_PIPELINES).status;
+  const featureStoreEnabled = useIsAreaAvailable(SupportedArea.FEATURE_STORE).status;
   const deploymentsTab = useDeploymentsTab();
   const [searchParams, setSearchParams] = useSearchParams();
   const state = searchParams.get('section');
@@ -175,11 +176,15 @@ const ProjectDetails: React.FC = () => {
               title: 'Connections',
               component: <ConnectionsList />,
             },
-            {
-              id: ProjectSectionID.FEATURE_STORE,
-              title: 'Feature store integration',
-              component: <FeatureStoreIntegration />,
-            },
+            ...(featureStoreEnabled
+              ? [
+                  {
+                    id: ProjectSectionID.FEATURE_STORE,
+                    title: 'Feature store integration',
+                    component: <FeatureStoreIntegration />,
+                  },
+                ]
+              : []),
             ...(projectSharingEnabled && allowCreate
               ? [
                   {
@@ -202,6 +207,7 @@ const ProjectDetails: React.FC = () => {
           [
             allowCreate,
             biasMetricsAreaAvailable,
+            featureStoreEnabled,
             pipelinesEnabled,
             projectSharingEnabled,
             workbenchEnabled,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR does the following:

1. Handles the case when no configmaps are present which was causing an error 

<img width="2992" height="1556" alt="image" src="https://github.com/user-attachments/assets/2d7ba2f9-5cb9-435c-84d2-556ec766acbf" />
<img width="3004" height="1566" alt="image" src="https://github.com/user-attachments/assets/56879696-c043-4533-8b81-cf7e3b422747" />

2. Hide the Feature store integration tab when the feature store is removed/disabled

<img width="2982" height="1560" alt="image" src="https://github.com/user-attachments/assets/b1a8256a-96c6-4936-8ac1-5472be5ecd20" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. This has been tested on two clusters one razz(where there is no setup for feature store and there are no configmaps present ) and green scrum( where the feature store is removed from the DSC and hence the tab is hidden based on useArea)
(Requires running both backend and frontend )
2. Added cypress test cases
## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Added cypress test cases 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Feature Store integration for projects with configuration management and filtering capabilities.
  * Improved copy button UI to display disabled state when no configurations are selected.

* **Bug Fixes**
  * Fixed potential runtime errors by adding null safety checks for feature store configuration.

* **Tests**
  * Added comprehensive test coverage for Feature Store configuration workflows including filtering, accessibility, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->