### PR TITLE
fix no projects

### DIFF
--- a/packages/gen-ai/frontend/src/app/EmptyStates/NoData.tsx
+++ b/packages/gen-ai/frontend/src/app/EmptyStates/NoData.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
 import emptyStateImage from '~/app/bgimages/empty-state.svg';
 
-type NoDataProps = {
+type ModelsEmptyStateProps = {
   title: string;
   description: React.ReactNode;
   actionButtonText?: React.ReactNode;
   handleActionButtonClick?: () => void;
 };
 
-const NoData: React.FC<NoDataProps> = ({
+const ModelsEmptyState: React.FC<ModelsEmptyStateProps> = ({
   title,
   description,
   actionButtonText,
@@ -34,4 +34,4 @@ const NoData: React.FC<NoDataProps> = ({
   </EmptyState>
 );
 
-export default NoData;
+export default ModelsEmptyState;

--- a/packages/gen-ai/frontend/src/app/GenAiCoreLoader.tsx
+++ b/packages/gen-ai/frontend/src/app/GenAiCoreLoader.tsx
@@ -35,7 +35,7 @@ const GenAiCoreLoader: React.FC<GenAiCoreLoaderProps> = ({
   if (namespaces.length === 0) {
     renderStateProps = {
       empty: true,
-      emptyStatePage: <GenAiCoreNoProjects getRedirectPath={getInvalidRedirectPath} />,
+      emptyStatePage: <GenAiCoreNoProjects />,
     };
   } else if (namespace) {
     const foundProject = namespaces.find((n) => n.name === namespace);

--- a/packages/gen-ai/frontend/src/app/GenAiCoreNoProjects.tsx
+++ b/packages/gen-ai/frontend/src/app/GenAiCoreNoProjects.tsx
@@ -1,31 +1,39 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateBody, EmptyStateFooter } from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
+import { Content } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import NewProjectButton from '@odh-dashboard/internal/pages/projects/screens/projects/NewProjectButton';
+import ModelsEmptyState from './EmptyStates/NoData';
 
-type GenAiCoreNoProjectsProps = {
-  getRedirectPath: (namespace: string) => string;
-};
-
-const GenAiCoreNoProjects: React.FC<GenAiCoreNoProjectsProps> = ({ getRedirectPath }) => {
+const GenAiCoreNoProjects: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <EmptyState
-      headingLevel="h4"
-      icon={WrenchIcon}
-      titleText="No data science projects"
-      data-testid="empty-state-title"
-    >
-      <EmptyStateBody>To use the playground, first create a data science project.</EmptyStateBody>
-      <EmptyStateFooter>
-        <NewProjectButton
-          closeOnCreate
-          onProjectCreated={(projectName) => navigate(getRedirectPath(projectName))}
-        />
-      </EmptyStateFooter>
-    </EmptyState>
+    <ModelsEmptyState
+      title="You must create a project to begin"
+      description={
+        <Content
+          style={{
+            textAlign: 'left',
+          }}
+        >
+          <Content component="p">To create a project:</Content>
+          <Content component="ol">
+            <Content component="li">
+              Go to the <b>Projects</b> page
+            </Content>
+            <Content component="li">
+              Select <b>Create new project</b>
+            </Content>
+            <Content component="li">
+              Complete the steps to create a project then come back here
+            </Content>
+          </Content>
+        </Content>
+      }
+      actionButtonText="Go to Projects page"
+      handleActionButtonClick={() => {
+        navigate(`/projects`);
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-38114

## Description
Handle the No projects state
<img width="1179" height="802" alt="Screenshot 2025-11-12 at 12 46 03 PM" src="https://github.com/user-attachments/assets/65dcbd0b-0fd4-41df-893d-6a8cc69e8d3c" />

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
login through non admin user having no project access , check for the empty state and the on clicking Go to projects redirects you to the Project Page
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
will be covered in coming mocked test
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for empty state management in projects.
  * Streamlined navigation flow when no projects are available.

* **Chores**
  * Updated component structure and naming conventions for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->