### PR TITLE
Remove andrewballantyne from reviewers groups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -36,7 +36,6 @@ aliases:
     - Griffin-Sullivan
     - andrewballantyne
   connections-reviewers:
-    - andrewballantyne
     - ashley-o0o
     - emilys314
     - Griffin-Sullivan
@@ -71,7 +70,6 @@ aliases:
     - Griffin-Sullivan
     - andrewballantyne
   model-serving-metrics-reviewers:
-    - andrewballantyne
     - ashley-o0o
     - emilys314
     - Griffin-Sullivan


### PR DESCRIPTION
I don't have time to participate in generic PR reviews anymore and we have a great series of senior developers to take over these kind of aspects. My involvement will need to be more focused and opinionated by the team.

**Why not leave and ignore auto-reviewers?** Leaving my name on these lists makes it harder for the bot to find a good active reviewer. This may not be useful for everyone, but it cannot be a bad thing to remove my name from the pool when I'll ignore 100% of the auto suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal reviewer group assignments.

---

**Note:** This release contains only internal administrative updates with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->