### PR TITLE
Fix model registry e2e test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/modelRegistry/testRegisterModel.cy.ts
@@ -199,6 +199,9 @@ describe('[Product Bug: RHOAIENG-35821] Verify models can be registered in a mod
       registerVersionPage
         .findFormField(VersionFormFieldSelector.SOURCE_MODEL_FORMAT_VERSION)
         .type(testData.formatVersion3_0);
+      registerVersionPage
+        .findFormField(VersionFormFieldSelector.LOCATION_PATH)
+        .type(testData.objectStoragePath);
 
       cy.step('Configure URI location for the new version');
       registerVersionPage.findFormField(VersionFormFieldSelector.LOCATION_TYPE_URI).click();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
This PR aims to fix the model registry e2e test for testRegisterModel file.
The fix for testArchiveModels is done in upstream PR: https://github.com/kubeflow/model-registry/pull/1872
once we sync, it should be fixed there.

## How Has This Been Tested?
run the e2e tests against cluster.

## Test Impact

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for model registry version registration flows to validate object storage path configuration in both registration pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->