### PR TITLE
fix:added fix for features being represented as data sources

### DIFF
--- a/packages/feature-store/src/utils/lineageDataConverter.ts
+++ b/packages/feature-store/src/utils/lineageDataConverter.ts
@@ -263,12 +263,19 @@ export const convertFeatureViewLineageToVisualizationData = (
     const sourceKey = `${relationship.source.type}-${relationship.source.name}`;
     const targetKey = `${relationship.target.type}-${relationship.target.name}`;
 
-    uniqueObjects.set(sourceKey, relationship.source);
-    uniqueObjects.set(targetKey, relationship.target);
+    if (relationship.source.name && !uniqueObjects.has(sourceKey)) {
+      uniqueObjects.set(sourceKey, relationship.source);
+    }
+    if (relationship.target.name && !uniqueObjects.has(targetKey)) {
+      uniqueObjects.set(targetKey, relationship.target);
+    }
   });
 
   // Create nodes for each unique object
   uniqueObjects.forEach((obj, key) => {
+    if (obj.type === 'feature') {
+      return;
+    }
     const isCurrentFeatureView = obj.type.includes('featureView') && obj.name === featureViewName;
     const layer = getObjectLayer(obj.type, isCurrentFeatureView);
 
@@ -288,6 +295,9 @@ export const convertFeatureViewLineageToVisualizationData = (
   // Create edges from relationships
   featureViewLineage.relationships.forEach(
     (relationship: FeatureStoreRelationship, index: number) => {
+      if (relationship.source.type === 'feature' || relationship.target.type === 'feature') {
+        return;
+      }
       const sourceId = mapObjectToNodeId(relationship.source);
       const targetId = mapObjectToNodeId(relationship.target);
 


### PR DESCRIPTION
Closes [RHOAIENG-37938](https://issues.redhat.com/browse/RHOAIENG-37938)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR adds fixes for the  lineage graph incorrectly displaying features as data source nodes by filtering out features from node creation (now matches the 

<img width="2988" height="1558" alt="image" src="https://github.com/user-attachments/assets/abaaa0e0-7483-435a-89a2-e7389c88ed50" />

<img width="2970" height="1538" alt="image" src="https://github.com/user-attachments/assets/d616500a-b49b-461d-a6e9-8278da88a5d7" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the feature view lineage section Feature view from side nave> feature view> lineage tab

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NA as its a visual change to match not showing features on the lineage to match the overview page lineage.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@yannnz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries appearing in lineage visualization
  * Improved lineage data accuracy by filtering unnecessary data types from display
  * Enhanced edge connections in lineage diagrams for more accurate relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->