### PR TITLE
test(e2e): Add GenAI Studio E2E test

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/pages/genAIStudio.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/genAIStudio.ts
@@ -1,0 +1,92 @@
+/**
+ * GenAI Studio Page Object
+ *
+ * Page object for GenAI Studio navigation and interactions.
+ * Follows the Page Object Model (POM) pattern for maintainability.
+ */
+class GenAIStudioPage {
+  /**
+   * Navigate to GenAI Studio playground
+   * @param namespace Optional namespace parameter
+   */
+  visit(namespace?: string): void {
+    const path = namespace
+      ? `/gen-ai-studio/playground/${namespace}`
+      : '/gen-ai-studio/playground';
+    cy.visit(path);
+    this.waitForPageLoad();
+  }
+
+  /**
+   * Wait for the GenAI Studio page to load
+   */
+  private waitForPageLoad(): void {
+    this.findPageTitle({ timeout: 30000 }).should('be.visible').and('contain.text', 'Playground');
+  }
+
+  /**
+   * Find the navigation link for GenAI Studio in the main navigation
+   */
+  findNavLink(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('nav-gen-ai-v3', { timeout: 30000 });
+  }
+
+  /**
+   * Find the page title element
+   */
+  findPageTitle(options?: Partial<Cypress.Timeoutable>): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('page-title', options);
+  }
+
+  /**
+   * Find the MCP servers panel/table
+   */
+  findMCPServersPanel(options?: Partial<Cypress.Timeoutable>): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('mcp-servers-panel-table', options);
+  }
+
+  /**
+   * Verify that the GenAI Studio navigation link is visible
+   */
+  verifyNavLinkVisible(): void {
+    this.findNavLink().should('exist').and('be.visible');
+  }
+
+  /**
+   * Click on the GenAI Studio navigation link
+   */
+  navigateViaNav(): void {
+    this.findNavLink().click();
+  }
+
+  /**
+   * Verify that the user is on the GenAI Studio page
+   * @param expectedNamespace Optional namespace to verify in the URL
+   */
+  verifyOnGenAIStudioPage(expectedNamespace?: string): void {
+    if (expectedNamespace) {
+      cy.location('pathname', { timeout: 30000 }).should((pathname) => {
+        expect([
+          `/gen-ai-studio/playground/${expectedNamespace}`,
+          '/gen-ai-studio/playground',
+          '/gen-ai-studio',
+        ]).to.include(pathname);
+      });
+    } else {
+      cy.location('pathname', { timeout: 30000 }).should((pathname) => {
+        expect(['/gen-ai-studio/playground', '/gen-ai-studio']).to.include(pathname);
+      });
+    }
+    this.waitForPageLoad();
+  }
+
+  /**
+   * Verify that the MCP servers panel is visible
+   */
+  verifyMCPServersPanelVisible(): void {
+    this.findMCPServersPanel({ timeout: 30000 }).should('exist').and('be.visible');
+  }
+}
+
+export const genAIStudioPage = new GenAIStudioPage();
+

--- a/frontend/src/__tests__/cypress/cypress/tests/e2e/genAI/testGenAIStudioAccess.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/e2e/genAI/testGenAIStudioAccess.cy.ts
@@ -1,0 +1,74 @@
+import { HTPASSWD_CLUSTER_ADMIN_USER } from '#~/__tests__/cypress/cypress/utils/e2eUsers';
+import {
+  enableGenAiStudio,
+  disableGenAiStudio,
+  isGenAiStudioEnabled,
+} from '#~/__tests__/cypress/cypress/utils/oc_commands/genAiStudioCommands';
+import { genAIStudioPage } from '#~/__tests__/cypress/cypress/pages/genAIStudio';
+
+/**
+ * GenAI Studio Access Test
+ *
+ * This test verifies the GenAI Studio feature can be enabled and accessed:
+ * 1. Enables GenAI Studio via OdhDashboardConfig patch
+ * 2. Verifies the GenAI Studio navigation is available
+ * 3. Tests navigation to the GenAI Studio
+ * 4. Validates the GenAI Studio page loads correctly
+ *
+ * Prerequisites:
+ * - User must have admin access to patch OdhDashboardConfig
+ * - The odh-dashboard-config must exist in APPLICATIONS_NAMESPACE
+ * - Test variables must be configured with correct cluster details
+ */
+describe('Verify GenAI Studio Access', () => {
+  before(() => {
+    cy.step('Enable GenAI Studio feature');
+    enableGenAiStudio().then(() => {
+      cy.step('Verify GenAI Studio is enabled in cluster config');
+      isGenAiStudioEnabled().should('eq', true);
+    });
+  });
+
+  after(() => {
+    cy.step('Disable GenAI Studio feature');
+    disableGenAiStudio();
+  });
+
+  it(
+    'should access GenAI Studio when enabled',
+    { tags: ['@GenAI', '@Sanity', '@SanitySet1'] },
+    function accessGenAiStudio() {
+      cy.step('Login to the application with GenAI dev feature flag');
+      cy.visitWithLogin('/?devFeatureFlags=genAiStudio=true', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      cy.step('Verify GenAI Studio navigation is visible');
+      genAIStudioPage.verifyNavLinkVisible();
+
+      cy.step('Click on GenAI Studio navigation');
+      genAIStudioPage.navigateViaNav();
+
+      cy.step('Verify navigation to GenAI Studio playground');
+      genAIStudioPage.verifyOnGenAIStudioPage();
+
+      cy.step('Test completed - GenAI Studio is accessible');
+    },
+  );
+
+  it(
+    'should display MCP servers panel in playground',
+    { tags: ['@GenAI', '@MCPServers'] },
+    function verifyMCPServersPanel() {
+      cy.step('Navigate to GenAI Studio playground with dev feature flag');
+      cy.visit('/gen-ai-studio/playground?devFeatureFlags=genAiStudio=true');
+
+      cy.step('Wait for page to load');
+      genAIStudioPage.findPageTitle({ timeout: 30000 }).should('be.visible');
+
+      cy.step('Verify MCP servers panel exists');
+      genAIStudioPage.verifyMCPServersPanelVisible();
+
+      cy.step('Test completed - MCP servers panel is visible');
+    },
+  );
+});
+

--- a/frontend/src/__tests__/cypress/cypress/utils/oc_commands/genAiStudioCommands.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/oc_commands/genAiStudioCommands.ts
@@ -1,0 +1,67 @@
+import type { CommandLineResult } from '#~/__tests__/cypress/cypress/types';
+
+/**
+ * Enables GenAI Studio by patching the OdhDashboardConfig.
+ * This function patches the odh-dashboard-config in the applications namespace
+ * to enable the genAiStudio feature flag.
+ *
+ * @param namespace The namespace where the dashboard config is located (defaults to APPLICATIONS_NAMESPACE from test variables)
+ * @returns A Cypress chainable that resolves to the command result
+ */
+export const enableGenAiStudio = (
+  namespace?: string,
+): Cypress.Chainable<CommandLineResult> => {
+  const applicationsNamespace = namespace || Cypress.env('APPLICATIONS_NAMESPACE');
+  const patchCommand = `oc patch odhdashboardconfig odh-dashboard-config -n ${applicationsNamespace} --type merge -p '{"spec":{"dashboardConfig":{"genAiStudio":true}}}'`;
+
+  return cy.exec(patchCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      throw new Error(`Failed to enable GenAI Studio: ${result.stderr}`);
+    }
+    return result;
+  });
+};
+
+/**
+ * Disables GenAI Studio by patching the OdhDashboardConfig.
+ * This function patches the odh-dashboard-config in the applications namespace
+ * to disable the genAiStudio feature flag.
+ *
+ * @param namespace The namespace where the dashboard config is located (defaults to APPLICATIONS_NAMESPACE from test variables)
+ * @returns A Cypress chainable that resolves to the command result
+ */
+export const disableGenAiStudio = (
+  namespace?: string,
+): Cypress.Chainable<CommandLineResult> => {
+  const applicationsNamespace = namespace || Cypress.env('APPLICATIONS_NAMESPACE');
+  const patchCommand = `oc patch odhdashboardconfig odh-dashboard-config -n ${applicationsNamespace} --type merge -p '{"spec":{"dashboardConfig":{"genAiStudio":false}}}'`;
+
+  return cy.exec(patchCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      throw new Error(`Failed to disable GenAI Studio: ${result.stderr}`);
+    }
+    return result;
+  });
+};
+
+/**
+ * Checks if GenAI Studio is enabled by querying the OdhDashboardConfig.
+ *
+ * @param namespace The namespace where the dashboard config is located (defaults to APPLICATIONS_NAMESPACE from test variables)
+ * @returns A Cypress chainable that resolves to true if GenAI Studio is enabled, false otherwise
+ */
+export const isGenAiStudioEnabled = (
+  namespace?: string,
+): Cypress.Chainable<boolean> => {
+  const applicationsNamespace = namespace || Cypress.env('APPLICATIONS_NAMESPACE');
+  const checkCommand = `oc get odhdashboardconfig odh-dashboard-config -n ${applicationsNamespace} -o jsonpath='{.spec.dashboardConfig.genAiStudio}'`;
+
+  return cy.exec(checkCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.code !== 0) {
+      return false;
+    }
+    const isEnabled = result.stdout.trim() === 'true';
+    return isEnabled;
+  });
+};
+


### PR DESCRIPTION
- Created E2E test for GenAI Studio access and functionality
- Added utility functions for enabling/disabling GenAI Studio via OdhDashboardConfig
- Created page object for GenAI Studio interactions
- Tests verify GenAI Studio navigation and MCP servers panel
- Uses devFeatureFlags=genAiStudio=true for enabling feature
- Follows Cypress E2E guidelines: page objects, no cy.wait(), proper test structure
- Tags: @GenAI, @Sanity, @SanitySet1, @MCPServers

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
