### PR TITLE
Fix:added fix for lineage node popover in feature view section

### DIFF
--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewLineage.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewLineage.tsx
@@ -14,6 +14,7 @@ const FeatureViewLineage: React.FC<FeatureViewLineageProps> = ({ featureView }) 
     <FeatureStoreLineageComponent
       project={currentProject}
       featureViewName={featureView.spec.name}
+      featureViewType={featureView.type}
       height="100%"
     />
   );

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -16,10 +16,12 @@ import {
 } from '../../utils/lineageDataConverter';
 import { FeatureStoreLineageSearchFilters } from '../../types/toolbarTypes';
 import { FeatureStoreLineage, FeatureViewLineage } from '../../types/lineage';
+import { FeatureView } from '../../types/featureView';
 
 interface FeatureStoreLineageComponentProps {
   project?: string;
   featureViewName?: string;
+  featureViewType?: FeatureView['type'];
   emptyStateTitle?: string;
   emptyStateMessage?: string;
   height?: string;
@@ -28,6 +30,7 @@ interface FeatureStoreLineageComponentProps {
 const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> = ({
   project,
   featureViewName,
+  featureViewType,
   emptyStateTitle = 'Select a feature store repository',
   emptyStateMessage = 'Select a feature store repository to view its lineage.',
   height = '100%',
@@ -88,6 +91,7 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           lineageData as FeatureViewLineage,
           featureViewName,
+          featureViewType,
         );
 
         const filteredResult = applyLineageFilters(baseResult, {
@@ -130,6 +134,7 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
     hideNodesWithoutRelationships,
     searchFilters,
     featureViewName,
+    featureViewType,
   ]);
 
   // Trigger centering when filters change - but only after data is processed
@@ -167,7 +172,7 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
   );
 
   const PopoverComponent = (props: Parameters<typeof FeatureStoreLineageNodePopover>[0]) => (
-    <FeatureStoreLineageNodePopover {...props} />
+    <FeatureStoreLineageNodePopover {...props} featureViewName={featureViewName} />
   );
 
   return (

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
@@ -27,6 +27,7 @@ export interface FeatureStoreLineageNodePopoverProps {
   node: LineageNode | null;
   isVisible: boolean;
   onClose: () => void;
+  featureViewName?: string;
 }
 
 const getFsObjectTypeLabel = (fsObjectType: FsObjectType): string => {
@@ -59,6 +60,7 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
   node,
   isVisible,
   onClose,
+  featureViewName,
 }) => {
   const { currentProject } = useFeatureStoreProject();
   const navigate = useNavigate();
@@ -150,19 +152,26 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
           onMouseDown={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >
-          <FlexItem>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                const route = goToDetailsPage(node, currentProject);
-                if (route) {
-                  navigate(route);
-                }
-              }}
-            >
-              View {getFsObjectTypeLabel(node.fsObjectTypes)} page
-            </Button>
-          </FlexItem>
+          {/* Hide CTA button only if this is a feature view node matching the current page's feature view */}
+          {!(
+            node.fsObjectTypes === 'feature_view' &&
+            featureViewName &&
+            node.name === featureViewName
+          ) && (
+            <FlexItem>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const route = goToDetailsPage(node, currentProject);
+                  if (route) {
+                    navigate(route);
+                  }
+                }}
+              >
+                View {getFsObjectTypeLabel(node.fsObjectTypes)} page
+              </Button>
+            </FlexItem>
+          )}
           {node.fsObjectTypes === 'feature_view' && (
             <FlexItem>
               <Button

--- a/packages/feature-store/src/utils/lineageDataConverter.ts
+++ b/packages/feature-store/src/utils/lineageDataConverter.ts
@@ -10,6 +10,26 @@ import { Entity } from '../types/entities';
 import { DataSource } from '../types/dataSources';
 import { FeatureService } from '../types/featureServices';
 import { FeatureStoreRelationship } from '../types/global';
+import { FeatureView } from '../types/featureView';
+
+const getLineageFeatureViewInfo = (lineageFeatureView: LineageFeatureView) => {
+  if ('featureView' in lineageFeatureView) {
+    return {
+      spec: lineageFeatureView.featureView.spec,
+      type: 'featureView' as const,
+    };
+  }
+  if ('onDemandFeatureView' in lineageFeatureView) {
+    return {
+      spec: lineageFeatureView.onDemandFeatureView.spec,
+      type: 'onDemandFeatureView' as const,
+    };
+  }
+  return {
+    spec: lineageFeatureView.streamFeatureView.spec,
+    type: 'streamFeatureView' as const,
+  };
+};
 
 /**
  * Converts Feature Store lineage data to generic lineage visualization format
@@ -67,35 +87,24 @@ export const convertFeatureStoreLineageToVisualizationData = (
   );
 
   actualFeatureViews.forEach((lineageFeatureView: LineageFeatureView) => {
-    const { name, description, features } =
-      'featureView' in lineageFeatureView
-        ? lineageFeatureView.featureView.spec
-        : 'onDemandFeatureView' in lineageFeatureView
-        ? lineageFeatureView.onDemandFeatureView.spec
-        : lineageFeatureView.streamFeatureView.spec;
-    const type =
-      'featureView' in lineageFeatureView
-        ? 'batch_feature_view'
-        : 'onDemandFeatureView' in lineageFeatureView
-        ? 'on_demand_feature_view'
-        : 'stream_feature_view';
+    const { spec, type: featureViewType } = getLineageFeatureViewInfo(lineageFeatureView);
+    const config = getObjectTypeConfig(featureViewType);
+    const { name, description, features } = spec;
+
+    if (!config) {
+      return;
+    }
 
     addNode({
       id: `featureview-${name}`,
-      label: `${
-        type === 'batch_feature_view'
-          ? 'Batch'
-          : type === 'on_demand_feature_view'
-          ? 'On demand'
-          : 'Stream'
-      } Feature View: ${name}`,
-      fsObjectTypes: 'feature_view',
-      entityType: type,
+      label: `${config.labelPrefix}: ${name}`,
+      fsObjectTypes: config.fsObjectType,
+      entityType: config.entityType,
       features,
       name,
       description,
       truncateLength: 40,
-      layer: 2, // Position feature views in layer 2 (third from left)
+      layer: config.layer, // Position feature views in layer 2 (third from left all feature view types use layer 2)
     });
   });
 
@@ -252,6 +261,7 @@ export const convertFeatureStoreLineageToVisualizationData = (
 export const convertFeatureViewLineageToVisualizationData = (
   featureViewLineage: FeatureViewLineage,
   featureViewName: string,
+  featureViewType?: FeatureView['type'],
 ): LineageData => {
   const nodes: LineageNode[] = [];
   const edges: LineageEdge[] = [];
@@ -272,11 +282,16 @@ export const convertFeatureViewLineageToVisualizationData = (
     const isCurrentFeatureView = obj.type.includes('featureView') && obj.name === featureViewName;
     const layer = getObjectLayer(obj.type, isCurrentFeatureView);
 
+    const objectTypeForLabel = isCurrentFeatureView && featureViewType ? featureViewType : obj.type;
+
     nodes.push({
       id: mapObjectToNodeId(obj) || key,
-      label: getObjectLabel(obj.type, obj.name),
+      label: getObjectLabel(objectTypeForLabel, obj.name),
       fsObjectTypes: mapTypeToFsObjectType(obj.type),
-      entityType: mapTypeToEntityType(obj.type),
+      entityType:
+        isCurrentFeatureView && featureViewType
+          ? mapTypeToEntityType(featureViewType)
+          : mapTypeToEntityType(obj.type),
       name: obj.name,
       truncateLength: 30,
       layer,


### PR DESCRIPTION
Closes [RHOAIENG-37935](https://issues.redhat.com/browse/RHOAIENG-37935)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR fixes the following:
1.  feature view type mismatch between lineage graph node and detail page header. 
2. Feature views now correctly display their type (Batch/On-Demand/Stream) in the lineage graph header title for the lineage node popover on detail pages, 
3. We hide the redirect CTA button when viewing the current feature view's own node. (based on this [Figma](https://www.figma.com/design/LmI633EHMv48MWUr5MXnsi/Feature-Store---GA?node-id=4570-91980&t=76U0pTtvajJDPZtg-4))
<img width="3024" height="1592" alt="image" src="https://github.com/user-attachments/assets/8fe9aba4-93ac-4694-b9b2-b29802e59ebd" />

<img width="2952" height="1540" alt="image" src="https://github.com/user-attachments/assets/ae34d09d-fdcc-407a-b99a-c0aa50abe86a" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the feature view lineage section Feature view from side nave> feature view> lineage tab

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NA

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [X] Included tags to the UX team if it was a UI/UX change.

@yannnz

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant navigation in the lineage view by hiding the navigation button when viewing the details of a feature view that is already displayed on the current page.

* **Refactor**
  * Improved the lineage data processing to better handle feature view context, streamlining how lineage information is converted and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->