### PR TITLE
fix:added rerouting fixes for dataset(global search) and transormation input link

### DIFF
--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/searchUtils.ts
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/searchUtils.ts
@@ -4,6 +4,7 @@ import {
   featureDataSourceRoute,
   featureViewRoute,
   featureServiceRoute,
+  featureDataSetRoute,
 } from '../../../routes';
 import type { ISearchItem } from '../hooks/useSearchHandlers';
 
@@ -24,6 +25,8 @@ export const getFeatureStoreRoute = (
       return featureViewRoute(name, project);
     case 'featureService':
       return featureServiceRoute(name, project);
+    case 'savedDataset':
+      return featureDataSetRoute(name, project);
     default:
       return `/develop-train/feature-store/${project}`;
   }

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewTransformation.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewTransformation.tsx
@@ -21,9 +21,11 @@ import React from 'react';
 import DashboardPopupIconButton from '@odh-dashboard/internal/concepts/dashboard/DashboardPopupIconButton';
 import { FeatureView, OnDemandFeatureView } from '../../../types/featureView';
 import FeatureStoreCodeBlock from '../../../components/FeatureStoreCodeBlock';
-import { featureDataSourceRoute } from '../../../routes';
+import { featureDataSourceRoute, featureViewRoute } from '../../../routes';
 import { useFeatureStoreProject } from '../../../FeatureStoreContext';
 import { formatOnDemandFeatureViewSources } from '../utils';
+
+type FormattedSource = ReturnType<typeof formatOnDemandFeatureViewSources>[number];
 
 type FeatureViewTransformationProps = {
   featureView: FeatureView;
@@ -35,21 +37,35 @@ type DetailsItemProps = {
   testId?: string;
   className?: string;
   project?: string;
+  sourceType?: FormattedSource['sourceType'];
 };
 
-const DetailsItem: React.FC<DetailsItemProps> = ({ label, value, testId, className, project }) => (
-  <DescriptionListGroup>
-    <DescriptionListTerm data-testid={testId ? `${testId}-label` : undefined}>
-      {label}
-    </DescriptionListTerm>
-    <DescriptionListDescription
-      data-testid={testId ? `${testId}-value` : undefined}
-      className={className}
-    >
-      <Link to={featureDataSourceRoute(project ?? '', value)}>{value}</Link>
-    </DescriptionListDescription>
-  </DescriptionListGroup>
-);
+const DetailsItem: React.FC<DetailsItemProps> = ({
+  label,
+  value,
+  testId,
+  className,
+  project,
+  sourceType,
+}) => {
+  const route =
+    sourceType === 'featureViewProjection'
+      ? featureViewRoute(value, project ?? '')
+      : featureDataSourceRoute(value, project ?? '');
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm data-testid={testId ? `${testId}-label` : undefined}>
+        {label}
+      </DescriptionListTerm>
+      <DescriptionListDescription
+        data-testid={testId ? `${testId}-value` : undefined}
+        className={className}
+      >
+        <Link to={route}>{value}</Link>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
 
 const isOnDemandFeatureView = (featureView: FeatureView): featureView is OnDemandFeatureView =>
   featureView.type === 'onDemandFeatureView';
@@ -146,6 +162,7 @@ const FeatureViewTransformation: React.FC<FeatureViewTransformationProps> = ({ f
                       }
                       value={source.name}
                       project={currentProject ?? ''}
+                      sourceType={source.sourceType}
                       testId={`feature-view-inputs-${source.sourceKey}`}
                     />
                     {source.sourceType === 'requestDataSource' && source.schema && (


### PR DESCRIPTION
Closes [RHOAIENG-35819](https://issues.redhat.com/browse/RHOAIENG-35819)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR contains the following fixes :

1. Dataset navigation from Global Search to the respective data set details page

https://github.com/user-attachments/assets/4fef47b9-2d02-4e65-ac5b-a2ef56b55a6a


2. Feature View Transformation input link routing.

https://github.com/user-attachments/assets/dccc8524-6f73-45d2-86cb-e753b0a86c59


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Search for a data set from the global search in feature store and you should be able to redirect.
2. Feature views Transformation links redirection fixes

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for navigating to saved datasets within the feature store.
  * Enhanced navigation to route to feature views in addition to existing data source links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->