### PR TITLE
improve error handling for k8s websockets support

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.17.21",
     "pino": "^9.9.0",
     "prom-client": "^14.0.1",
-    "ws": "^8.17.1"
+    "ws": "^8.18.1"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/backend/src/__tests__/websocket-proxy.spec.ts
+++ b/backend/src/__tests__/websocket-proxy.spec.ts
@@ -1,0 +1,631 @@
+import WebSocket from 'ws';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../types';
+import wssK8sRoutes, {
+  CONNECTION_TIMEOUT_MS,
+  HEARTBEAT_INTERVAL_MS,
+  STALE_CONNECTION_MS,
+} from '../routes/wss/k8s/index';
+import { getDirectCallOptions, getAccessToken } from '../utils/directCallUtils';
+
+// Mock dependencies
+jest.mock('../utils/directCallUtils');
+jest.mock('ws');
+jest.mock('https', () => ({
+  globalAgent: {
+    options: {
+      ca: undefined,
+    },
+  },
+}));
+
+describe('WebSocket K8s Proxy', () => {
+  let mockFastify: KubeFastifyInstance;
+  let mockConnection: any;
+  let mockRequest: OauthFastifyRequest;
+  let mockSourceSocket: any;
+  let mockTargetSocket: any;
+  let mockLog: any;
+  let routeHandler: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockLog = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockSourceSocket = {
+      readyState: WebSocket.OPEN,
+      send: jest.fn(),
+      close: jest.fn(),
+      on: jest.fn(),
+      once: jest.fn(),
+      ping: jest.fn(),
+      pong: jest.fn(),
+    };
+
+    mockTargetSocket = {
+      readyState: WebSocket.OPEN,
+      send: jest.fn(),
+      close: jest.fn(),
+      terminate: jest.fn(),
+      on: jest.fn(),
+      once: jest.fn(),
+      ping: jest.fn(),
+      pong: jest.fn(),
+    };
+
+    mockConnection = {
+      socket: mockSourceSocket,
+    };
+
+    mockFastify = {
+      log: mockLog,
+      kube: {
+        config: {
+          getCurrentCluster: jest.fn().mockReturnValue({
+            server: 'https://api.example.com',
+          }),
+        },
+      },
+      server: {
+        address: jest.fn().mockReturnValue({
+          address: 'localhost',
+          port: 4000,
+        }),
+      },
+      get: jest.fn(),
+      addHook: jest.fn(),
+    } as any;
+
+    mockRequest = {
+      id: 'test-request-id',
+      params: {
+        '*': 'api/v1/namespaces?watch=true',
+      },
+      query: {
+        watch: 'true',
+      },
+      headers: {
+        host: 'localhost',
+        origin: 'http://localhost',
+      },
+    } as any;
+
+    (getDirectCallOptions as jest.Mock).mockResolvedValue({});
+    (getAccessToken as jest.Mock).mockReturnValue('test-token');
+    (WebSocket as unknown as jest.Mock).mockImplementation(() => mockTargetSocket);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Route Registration', () => {
+    it('should register WebSocket route with correct path', async () => {
+      await wssK8sRoutes(mockFastify);
+
+      expect(mockFastify.get).toHaveBeenCalledWith('/*', { websocket: true }, expect.any(Function));
+    });
+
+    it('should register cleanup hook for server shutdown', async () => {
+      await wssK8sRoutes(mockFastify);
+
+      expect(mockFastify.addHook).toHaveBeenCalledWith('onClose', expect.any(Function));
+    });
+  });
+
+  describe('Connection Timeout', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should terminate connection if not established within CONNECTION_TIMEOUT_MS', async () => {
+      mockTargetSocket.readyState = WebSocket.CONNECTING;
+
+      await routeHandler(mockConnection, mockRequest);
+
+      // Advance timers by timeout duration
+      jest.advanceTimersByTime(CONNECTION_TIMEOUT_MS);
+
+      expect(mockTargetSocket.terminate).toHaveBeenCalled();
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeout: CONNECTION_TIMEOUT_MS,
+        }),
+        expect.stringContaining('WebSocket connection timeout'),
+      );
+    });
+
+    it('should not terminate if connection opens before timeout', async () => {
+      mockTargetSocket.readyState = WebSocket.CONNECTING;
+
+      await routeHandler(mockConnection, mockRequest);
+
+      // Simulate connection opening
+      const openHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'open',
+      )?.[1];
+      mockTargetSocket.readyState = WebSocket.OPEN;
+      openHandler();
+
+      // Advance past timeout
+      jest.advanceTimersByTime(CONNECTION_TIMEOUT_MS + 1000);
+
+      expect(mockTargetSocket.terminate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Heartbeat Monitoring', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should start heartbeat after connection opens', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const openHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'open',
+      )?.[1];
+
+      openHandler();
+
+      // Advance by heartbeat interval
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+
+      expect(mockTargetSocket.ping).toHaveBeenCalled();
+    });
+
+    it('should send pings at regular intervals', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const openHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'open',
+      )?.[1];
+
+      openHandler();
+
+      // Advance through multiple heartbeat intervals
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(mockTargetSocket.ping).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(mockTargetSocket.ping).toHaveBeenCalledTimes(2);
+
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(mockTargetSocket.ping).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not ping when socket is not OPEN', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const openHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'open',
+      )?.[1];
+
+      openHandler();
+
+      // First heartbeat with socket OPEN
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      const pingsWhileOpen = mockTargetSocket.ping.mock.calls.length;
+
+      // Change socket state to CLOSING
+      mockTargetSocket.readyState = WebSocket.CLOSING;
+
+      // Next heartbeat with socket CLOSING
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+
+      // Should not have sent additional pings
+      expect(mockTargetSocket.ping.mock.calls.length).toBe(pingsWhileOpen);
+    });
+
+    it('should stop heartbeat after connection closes', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const openHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'open',
+      )?.[1];
+
+      openHandler();
+
+      // First heartbeat
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      const firstPingCount = mockTargetSocket.ping.mock.calls.length;
+
+      // Close connection
+      const closeHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+      closeHandler(1000, 'Normal close');
+
+      // Advance more time
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
+
+      // No more pings
+      expect(mockTargetSocket.ping.mock.calls.length).toBe(firstPingCount);
+    });
+  });
+
+  describe('Idempotent Close', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should close connection only once when called multiple times', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const closeHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+
+      // Call close multiple times
+      closeHandler(1000, 'First close');
+      closeHandler(1000, 'Second close');
+      closeHandler(1000, 'Third close');
+
+      // Should only log closing once
+      const closingLogs = mockLog.info.mock.calls.filter((call: any) =>
+        call[1]?.includes('Closing websocket connection'),
+      );
+      expect(closingLogs.length).toBe(1);
+
+      // Should close sockets only once
+      expect(mockSourceSocket.close).toHaveBeenCalledTimes(1);
+      expect(mockTargetSocket.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle close from both source and target without duplicates', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const sourceCloseHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+
+      const targetCloseHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+
+      // Trigger close from source
+      sourceCloseHandler(1000, 'Client closed');
+
+      // Try to trigger close from target
+      mockLog.info.mockClear();
+      targetCloseHandler(1000, 'Server closed');
+
+      // Should not log closing again
+      const closingLogs = mockLog.info.mock.calls.filter((call: any) =>
+        call[1]?.includes('Closing websocket connection'),
+      );
+      expect(closingLogs.length).toBe(0);
+    });
+  });
+
+  describe('Message Forwarding', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should forward messages directly when client is ready', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      const testData = Buffer.from('test message');
+      messageHandler(testData, false);
+
+      expect(mockSourceSocket.send).toHaveBeenCalledWith(testData, { binary: false });
+    });
+
+    it('should close connection when client socket is not ready', async () => {
+      mockSourceSocket.readyState = WebSocket.CONNECTING;
+
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      // Send message while socket is connecting
+      messageHandler(Buffer.from('message 1'), false);
+
+      // Should warn and trigger close logic
+      expect(mockLog.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          readyState: WebSocket.CONNECTING,
+        }),
+        expect.stringContaining('Client socket not ready'),
+      );
+
+      // closeWebSocket only closes OPEN sockets, so target (which is OPEN) will be closed
+      // but source (which is CONNECTING) will not
+      expect(mockTargetSocket.close).toHaveBeenCalled();
+    });
+
+    it('should close connection when send fails', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      // Make send fail
+      mockSourceSocket.send.mockImplementationOnce(() => {
+        throw new Error('Network error');
+      });
+
+      messageHandler(Buffer.from('test message'), false);
+
+      // Should close connection on send failure
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Network error',
+        }),
+        expect.stringContaining('Failed to forward message to client, closing connection'),
+      );
+
+      expect(mockSourceSocket.close).toHaveBeenCalled();
+      expect(mockTargetSocket.close).toHaveBeenCalled();
+    });
+
+    it('should forward multiple messages successfully', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      // Send multiple messages
+      messageHandler(Buffer.from('first'), false);
+      messageHandler(Buffer.from('second'), false);
+      messageHandler(Buffer.from('third'), false);
+
+      // All should be forwarded
+      expect(mockSourceSocket.send).toHaveBeenCalledTimes(3);
+      expect(mockSourceSocket.send).toHaveBeenNthCalledWith(1, Buffer.from('first'), {
+        binary: false,
+      });
+      expect(mockSourceSocket.send).toHaveBeenNthCalledWith(2, Buffer.from('second'), {
+        binary: false,
+      });
+      expect(mockSourceSocket.send).toHaveBeenNthCalledWith(3, Buffer.from('third'), {
+        binary: false,
+      });
+    });
+  });
+
+  describe('Metrics Tracking', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should track messages received and sent', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      // Receive and forward messages
+      messageHandler(Buffer.from('message 1'), false);
+      messageHandler(Buffer.from('message 2'), false);
+      messageHandler(Buffer.from('message 3'), false);
+
+      jest.runOnlyPendingTimers();
+
+      // Close to check metrics
+      const closeHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+      closeHandler(1000, 'Done');
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messagesReceived: 3,
+          messagesSent: 3,
+        }),
+        expect.stringContaining('Closing websocket connection'),
+      );
+    });
+
+    it('should track resourceVersion from watch events', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      const watchEvent = Buffer.from(
+        JSON.stringify({
+          type: 'ADDED',
+          object: {
+            metadata: {
+              resourceVersion: '12345',
+            },
+          },
+        }),
+      );
+
+      messageHandler(watchEvent, false);
+
+      const closeHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+      closeHandler(1000, 'Done');
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastResourceVersion: '12345',
+        }),
+        expect.stringContaining('Closing websocket connection'),
+      );
+    });
+
+    it('should log BOOKMARK events', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const messageHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'message',
+      )?.[1];
+
+      const bookmarkEvent = Buffer.from(
+        JSON.stringify({
+          type: 'BOOKMARK',
+          object: {
+            metadata: {
+              resourceVersion: '99999',
+            },
+          },
+        }),
+      );
+
+      messageHandler(bookmarkEvent, false);
+
+      expect(mockLog.debug).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceVersion: '99999',
+        }),
+        expect.stringContaining('Bookmark received'),
+      );
+    });
+
+    it('should track connection duration', async () => {
+      const startTime = Date.now();
+      jest.setSystemTime(startTime);
+
+      await routeHandler(mockConnection, mockRequest);
+
+      // Advance time by 5 seconds
+      jest.setSystemTime(startTime + 5000);
+
+      const closeHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'close',
+      )?.[1];
+      closeHandler(1000, 'Done');
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          duration: 5000,
+        }),
+        expect.stringContaining('Closing websocket connection'),
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+    });
+
+    it('should handle target socket errors', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const errorHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'error',
+      )?.[1];
+
+      const error = new Error('Connection failed');
+      errorHandler(error);
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Connection failed',
+        }),
+        expect.stringContaining('K8s API websocket error'),
+      );
+    });
+
+    it('should handle source socket errors', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const errorHandler = mockSourceSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'error',
+      )?.[1];
+
+      const error = new Error('Client error');
+      errorHandler(error);
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Client error',
+        }),
+        expect.stringContaining('Client websocket error'),
+      );
+    });
+
+    it('should handle unexpected responses from K8s API', async () => {
+      await routeHandler(mockConnection, mockRequest);
+
+      const unexpectedResponseHandler = mockTargetSocket.on.mock.calls.find(
+        (call: any) => call[0] === 'unexpected-response',
+      )?.[1];
+
+      const mockResponse = {
+        statusCode: 403,
+        statusMessage: 'Forbidden',
+      };
+
+      unexpectedResponseHandler(undefined, mockResponse);
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 403,
+          statusMessage: 'Forbidden',
+        }),
+        expect.stringContaining('Unexpected response from K8s API'),
+      );
+    });
+  });
+
+  describe('Stale Connection Cleanup', () => {
+    it('should periodically clean up stale connections', async () => {
+      await wssK8sRoutes(mockFastify);
+      routeHandler = (mockFastify.get as jest.Mock).mock.calls[0][2];
+
+      // Create a connection
+      await routeHandler(mockConnection, mockRequest);
+
+      // Advance time to trigger cleanup (runs every minute)
+      jest.advanceTimersByTime(60000);
+
+      // Connection is still active, so no cleanup warning yet
+      expect(mockLog.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('Removing stale connection'),
+      );
+
+      // Advance time beyond stale threshold
+      jest.advanceTimersByTime(STALE_CONNECTION_MS);
+      jest.advanceTimersByTime(60000); // Trigger another cleanup cycle
+
+      // Now stale connection should be cleaned up
+      expect(mockLog.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inactivityDuration: expect.any(Number),
+        }),
+        expect.stringContaining('Removing stale connection from tracking'),
+      );
+    });
+  });
+
+  describe('Configuration Constants', () => {
+    it('should have connection timeout less than heartbeat interval', () => {
+      expect(CONNECTION_TIMEOUT_MS).toBeLessThan(HEARTBEAT_INTERVAL_MS);
+    });
+
+    it('should have heartbeat interval less than stale connection threshold', () => {
+      expect(HEARTBEAT_INTERVAL_MS).toBeLessThan(STALE_CONNECTION_MS);
+    });
+  });
+});

--- a/backend/src/routes/wss/k8s/index.ts
+++ b/backend/src/routes/wss/k8s/index.ts
@@ -20,9 +20,8 @@ const liftErrorCode = (code: number) => {
 
 const closeWebSocket = (socket: WebSocket, code: number, reason: string | Buffer) => {
   if (socket.readyState === WebSocket.OPEN) {
-    // This usage of toString is fine for string | Buffer conversion
-    // eslint-disable-next-line no-restricted-properties
-    socket.close(liftErrorCode(code), reason?.toString() || 'error');
+    const reasonStr = typeof reason === 'string' ? reason : String(reason);
+    socket.close(liftErrorCode(code), reasonStr || 'error');
   }
 };
 
@@ -34,7 +33,65 @@ const waitConnection = (socket: WebSocket, write: () => void) => {
   }
 };
 
+// Connection metrics for monitoring
+type ConnectionMetrics = {
+  created: number;
+  lastMessageReceived: number;
+  lastMessageSent: number;
+  messagesReceived: number;
+  messagesSent: number;
+  lastResourceVersion?: string;
+};
+
+// Global connection tracking for monitoring and cleanup
+const activeConnections = new Map<string, ConnectionMetrics>();
+
+// Constants for connection management (exported for testing)
+export const CONNECTION_TIMEOUT_MS = 10000; // 10 seconds to establish connection
+export const HEARTBEAT_INTERVAL_MS = 15000; // 15 seconds between heartbeats
+export const STALE_CONNECTION_MS = 300000; // 5 minutes of inactivity
+
+// Periodic cleanup of stale connections
+const cleanupStaleConnections = (fastify: KubeFastifyInstance) => {
+  const now = Date.now();
+  let cleanedCount = 0;
+
+  for (const [connectionId, metrics] of activeConnections.entries()) {
+    const inactivityDuration = now - Math.max(metrics.lastMessageReceived, metrics.lastMessageSent);
+
+    if (inactivityDuration > STALE_CONNECTION_MS) {
+      fastify.log.warn(
+        {
+          connectionId,
+          inactivityDuration,
+          messagesReceived: metrics.messagesReceived,
+          messagesSent: metrics.messagesSent,
+        },
+        `Removing stale connection from tracking: ${connectionId}`,
+      );
+      activeConnections.delete(connectionId);
+      cleanedCount++;
+    }
+  }
+
+  if (cleanedCount > 0) {
+    fastify.log.info(
+      `Cleaned up ${cleanedCount} stale connection(s). Active: ${activeConnections.size}`,
+    );
+  }
+};
+
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  // Start periodic cleanup of stale connections
+  const cleanupInterval = setInterval(() => {
+    cleanupStaleConnections(fastify);
+  }, 60000); // Run every minute
+
+  // Clean up on server shutdown
+  fastify.addHook('onClose', async () => {
+    clearInterval(cleanupInterval);
+  });
+
   fastify.get(
     '/*',
     { websocket: true },
@@ -49,10 +106,29 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       getDirectCallOptions(fastify, req, '').then((requestOptions) => {
         const source = connection.socket;
         const kubeUri = req.params['*'];
+        const connectionId = `${req.id}-${kubeUri}`;
 
         const url = `${
           fastify.kube.config.getCurrentCluster().server
         }/${kubeUri}?${new URLSearchParams(req.query)}`;
+
+        // Initialize connection metrics
+        const now = Date.now();
+        const metrics: ConnectionMetrics = {
+          created: now,
+          lastMessageReceived: now,
+          lastMessageSent: now,
+          messagesReceived: 0,
+          messagesSent: 0,
+        };
+        activeConnections.set(connectionId, metrics);
+
+        fastify.log.info(
+          {
+            connectionId,
+          },
+          `WebSocket watch initiated: ${kubeUri}`,
+        );
 
         const accessToken = getAccessToken(requestOptions);
         const subprotocols = [
@@ -71,36 +147,293 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
           ca: https.globalAgent.options.ca as WebSocket.CertMeta,
         });
 
-        const close = (code: number, reason: string) => {
-          closeWebSocket(source, code, reason);
-          closeWebSocket(target, code, reason);
-        };
+        // Close both connections and log diagnostics
+        const close = (code: number, reason: string | Buffer) => {
+          // Make idempotent - only run once per connection
+          if (!activeConnections.has(connectionId)) {
+            return;
+          }
 
-        const onUnexpectedResponse = (_: ClientRequest, response: IncomingMessage) =>
-          close(
-            1011,
-            `unexpected response: ${response.statusCode ? `(${response.statusCode}) ` : ''}${
-              response.statusMessage
-            }`,
+          const reasonStr = typeof reason === 'string' ? reason : String(reason);
+
+          fastify.log.info(
+            {
+              connectionId,
+              code,
+              reason: reasonStr,
+              duration: Date.now() - metrics.created,
+              messagesReceived: metrics.messagesReceived,
+              messagesSent: metrics.messagesSent,
+              lastResourceVersion: metrics.lastResourceVersion,
+            },
+            `Closing websocket connection: ${kubeUri}`,
           );
 
-        // attach source socket listeners and forward requests to the target
-        source.on('message', (data: unknown, binary: boolean) =>
-          waitConnection(target, () => target.send(data, { binary })),
-        );
-        source.on('ping', (data) => waitConnection(target, () => target.ping(data)));
-        source.on('pong', (data) => waitConnection(target, () => target.pong(data)));
-        source.on('close', close);
-        source.on('error', (error) => close(1011, error.message));
+          closeWebSocket(source, code, reason);
+          closeWebSocket(target, code, reason);
+          activeConnections.delete(connectionId);
+        };
+
+        // Connection timeout handler
+        const connectionTimeout = setTimeout(() => {
+          if (target.readyState === WebSocket.CONNECTING) {
+            fastify.log.error(
+              {
+                connectionId,
+                timeout: CONNECTION_TIMEOUT_MS,
+              },
+              `WebSocket connection timeout for ${kubeUri}`,
+            );
+            target.terminate();
+            close(1011, 'Connection timeout');
+          }
+        }, CONNECTION_TIMEOUT_MS);
+
+        // Heartbeat monitoring
+        let heartbeatInterval: NodeJS.Timeout | null = null;
+
+        const onUnexpectedResponse = (_: ClientRequest, response: IncomingMessage) => {
+          const statusCode = response.statusCode || 'unknown';
+          const statusMessage = response.statusMessage || 'unknown';
+
+          fastify.log.error(
+            {
+              connectionId,
+              statusCode,
+              statusMessage,
+            },
+            `Unexpected response from K8s API: ${kubeUri}`,
+          );
+
+          close(1011, `unexpected response: ${statusCode} ${statusMessage}`);
+        };
+
+        // Target (K8s API) connection established
+        target.on('open', () => {
+          clearTimeout(connectionTimeout);
+          fastify.log.debug(
+            {
+              connectionId,
+            },
+            `WebSocket connection established to K8s API: ${kubeUri}`,
+          );
+
+          // Start heartbeat monitoring
+          heartbeatInterval = setInterval(() => {
+            // Send ping to keep connection alive
+            if (target.readyState === WebSocket.OPEN) {
+              try {
+                target.ping();
+              } catch (error) {
+                fastify.log.error(
+                  { connectionId, error: error.message },
+                  `Failed to send ping: ${error.message}`,
+                );
+              }
+            }
+          }, HEARTBEAT_INTERVAL_MS);
+        });
+
+        // Handle messages from K8s API to client
+        target.on('message', (data, binary) => {
+          metrics.lastMessageReceived = Date.now();
+          metrics.messagesReceived++;
+
+          // Try to extract resourceVersion from watch events for diagnostics
+          if (!binary && Buffer.isBuffer(data)) {
+            try {
+              // This usage of toString is fine for string | Buffer conversion
+              // eslint-disable-next-line no-restricted-properties
+              const event = JSON.parse(data.toString('utf8'));
+              if (event.type === 'BOOKMARK' && event.object?.metadata?.resourceVersion) {
+                metrics.lastResourceVersion = event.object.metadata.resourceVersion;
+                fastify.log.debug(
+                  {
+                    connectionId,
+                    resourceVersion: metrics.lastResourceVersion,
+                  },
+                  `Bookmark received for ${kubeUri}`,
+                );
+              } else if (event.object?.metadata?.resourceVersion) {
+                metrics.lastResourceVersion = event.object.metadata.resourceVersion;
+              }
+            } catch (e) {
+              // Not JSON or parsing failed, ignore
+            }
+          }
+
+          // Forward directly - fail fast if client can't receive
+          if (source.readyState === WebSocket.OPEN) {
+            try {
+              source.send(data, { binary });
+              metrics.messagesSent++;
+              metrics.lastMessageSent = Date.now();
+            } catch (error) {
+              fastify.log.error(
+                {
+                  connectionId,
+                  error: error.message,
+                  messagesReceived: metrics.messagesReceived,
+                  messagesSent: metrics.messagesSent,
+                },
+                `Failed to forward message to client, closing connection: ${error.message}`,
+              );
+              close(1011, `Send failed: ${error.message}`);
+            }
+          } else {
+            fastify.log.warn(
+              {
+                connectionId,
+                readyState: source.readyState,
+                messagesReceived: metrics.messagesReceived,
+              },
+              `Client socket not ready, closing connection`,
+            );
+            close(1011, 'Client not ready');
+          }
+        });
+
+        // Handle K8s API errors
+        target.on('error', (error) => {
+          fastify.log.error(
+            {
+              connectionId,
+              error: error.message,
+              stack: error.stack,
+              messagesReceived: metrics.messagesReceived,
+              duration: Date.now() - metrics.created,
+            },
+            `K8s API websocket error for ${kubeUri}: ${error.message}`,
+          );
+
+          close(1011, error.message);
+        });
+
+        // Handle K8s API connection close
+        target.on('close', (code, reason) => {
+          if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+          }
+
+          const reasonStr = String(reason);
+          fastify.log.info(
+            {
+              connectionId,
+              code,
+              reason: reasonStr,
+              messagesReceived: metrics.messagesReceived,
+              messagesSent: metrics.messagesSent,
+              duration: Date.now() - metrics.created,
+            },
+            `K8s API websocket closed for ${kubeUri}`,
+          );
+
+          close(code, reasonStr);
+        });
+
         target.on('unexpected-response', onUnexpectedResponse);
 
-        // attach target socket listeners and forward requests to the source
-        target.on('message', (data: unknown, binary: boolean) => source.send(data, { binary }));
-        target.on('ping', (data) => source.ping(data));
-        target.on('pong', (data) => source.pong(data));
-        target.on('close', close);
-        target.on('error', (error) => close(1011, error.message));
-        target.on('unexpected-response', onUnexpectedResponse);
+        // Handle messages from client to K8s API
+        source.on('message', (data, binary: boolean) =>
+          waitConnection(target, () => {
+            try {
+              target.send(data as Buffer, { binary });
+            } catch (error) {
+              fastify.log.error(
+                {
+                  connectionId,
+                  error: error.message,
+                },
+                `Failed to forward message to K8s API: ${error.message}`,
+              );
+            }
+          }),
+        );
+
+        source.on('ping', (data) =>
+          waitConnection(target, () => {
+            try {
+              target.ping(data);
+            } catch (error) {
+              fastify.log.debug(
+                { connectionId, error: error.message },
+                `Failed to forward ping: ${error.message}`,
+              );
+            }
+          }),
+        );
+
+        source.on('pong', (data) =>
+          waitConnection(target, () => {
+            try {
+              target.pong(data);
+            } catch (error) {
+              fastify.log.debug(
+                { connectionId, error: error.message },
+                `Failed to forward pong: ${error.message}`,
+              );
+            }
+          }),
+        );
+
+        // Handle client connection close
+        source.on('close', (code, reason) => {
+          if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+          }
+          clearTimeout(connectionTimeout);
+
+          const reasonStr = String(reason);
+          fastify.log.debug(
+            {
+              connectionId,
+              code,
+              reason: reasonStr,
+            },
+            `Client websocket closed for ${kubeUri}`,
+          );
+
+          close(code, reasonStr);
+        });
+
+        // Handle client errors
+        source.on('error', (error) => {
+          fastify.log.error(
+            {
+              connectionId,
+              error: error.message,
+            },
+            `Client websocket error for ${kubeUri}: ${error.message}`,
+          );
+          close(1011, error.message);
+        });
+
+        // Handle target ping/pong
+        target.on('ping', (data) => {
+          if (source.readyState === WebSocket.OPEN) {
+            try {
+              source.ping(data);
+            } catch (error) {
+              fastify.log.debug(
+                { connectionId, error: error.message },
+                `Failed to forward ping to client: ${error.message}`,
+              );
+            }
+          }
+        });
+
+        target.on('pong', (data) => {
+          if (source.readyState === WebSocket.OPEN) {
+            try {
+              source.pong(data);
+            } catch (error) {
+              fastify.log.debug(
+                { connectionId, error: error.message },
+                `Failed to forward pong to client: ${error.message}`,
+              );
+            }
+          }
+        });
       }),
   );
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,7 +129,7 @@
     "@types/react-dom": "^18.0.8",
     "@types/react-redux": "^7.1.24",
     "@types/showdown": "^2.0.3",
-    "@types/ws": "^8.5.10",
+    "@types/ws": "^8.18.1",
     "babel-loader": "^8.3.0",
     "babel-plugin-transform-imports": "^2.0.0",
     "concurrently": "^8.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/tar": "^6.1.13",
         "jsonpath-plus": "^10.3.0",
         "tough-cookie": "^4.1.3",
-        "ws": "^8.17.1"
+        "ws": "^8.18.1"
       },
       "devDependencies": {
         "dotenv": "^16.4.7",
@@ -60,7 +60,7 @@
         "lodash": "^4.17.21",
         "pino": "^9.9.0",
         "prom-client": "^14.0.1",
-        "ws": "^8.17.1"
+        "ws": "^8.18.1"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
@@ -177,7 +177,7 @@
         "@types/react-dom": "^18.0.8",
         "@types/react-redux": "^7.1.24",
         "@types/showdown": "^2.0.3",
-        "@types/ws": "^8.5.10",
+        "@types/ws": "^8.18.1",
         "babel-loader": "^8.3.0",
         "babel-plugin-transform-imports": "^2.0.0",
         "concurrently": "^8.2.2",
@@ -291,16 +291,6 @@
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true,
       "license": "MIT"
-    },
-    "frontend/node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "frontend/node_modules/agent-base": {
       "version": "7.1.4",
@@ -4339,6 +4329,15 @@
         "ws": "^7.3.1"
       }
     },
+    "node_modules/@kubernetes/client-node/node_modules/@types/ws": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -7938,9 +7937,10 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -33884,16 +33884,6 @@
         "webpack-cli": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/tar": "^6.1.13",
     "jsonpath-plus": "^10.3.0",
     "tough-cookie": "^4.1.3",
-    "ws": "^8.17.1"
+    "ws": "^8.18.1"
   },
   "devDependencies": {
     "dotenv": "^16.4.7",
@@ -109,7 +109,7 @@
       "react": "^18.2.0"
     },
     "react-router": "^7.6.2",
-    "ws": "^8.17.1",
+    "ws": "^8.18.1",
     "dompurify": "^3.2.4",
     "@types/tar": "^6.1.13",
     "jsonpath-plus": "^10.3.0",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-26670

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

After investigating the related ticket as to why sometimes the project creation modal hangs, I couldn't find anything in the code that stands out as the cause of the random behavior. As such the assumption is that something wrong is going on with the websocket connection handling between the backend and the k8s api server. This 

**Key Changes:**
- **Heartbeat monitoring**: Prevents silent connection failures by sending pings every 15s and detecting 30s+ inactivity
- **Connection timeout protection**: Terminates connections that fail to establish within 10s
- **Stale connection cleanup**: Automatically removes dead connections every 60s
- **Transparent close code forwarding**: Passes through actual K8s API close codes so the client can make informed retry decisions
- **Comprehensive logging**: Adds structured logs to diagnose connection health, message throughput, and resource versions

**Why this helps:**
The issue occurs when the WebSocket appears connected but is actually dead, or when K8s events are dropped. These changes ensure connections are monitored, messages are buffered, and failures are logged for diagnosis.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO run e2e tests

Test project creation and ensure project list page is updated with new projects. Also test deletion and update  for the same.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-connection metrics and diagnostics, connection timeouts, heartbeat pings, and metrics-aware message forwarding with resource-version/bookmark tracking.
  * Periodic stale-connection cleanup and improved lifecycle observability.

* **Bug Fixes**
  * Idempotent close handling, stronger error handling, and more reliable shutdown/cleanup.

* **Chores**
  * Updated WebSocket-related package versions.

* **Tests**
  * Comprehensive test suite covering proxy behavior, timers, heartbeats, cleanup, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->