### PR TITLE
fix: use pull_request_target to access secrets from fork PRs

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -7,10 +7,9 @@ name: Cypress e2e Test
 # This workflow runs on pull_request events and waits for test.yml to complete successfully.
 # It uses concurrency control to ensure only the latest E2E run executes for each PR/branch.
 # This approach ensures E2E checks appear in the PR's checks section.
-
 on:
-  # Trigger on PR events to show up as PR checks
-  pull_request:
+  # Use pull_request_target to access secrets even from fork PRs
+  pull_request_target:
     types: [opened, synchronize, reopened]
   # Allow manual trigger for testing/debugging
   workflow_dispatch:
@@ -159,8 +158,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # For pull_request events, checkout the PR head
+          # For pull_request_target, explicitly checkout the PR head (from fork)
+          # This is safe because we only run after test.yml passes
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Fetch from the fork repository if it's a fork PR
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Restore npm dependencies cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Description
- Change trigger from pull_request to pull_request_target
- Runs in base repo context (has access to all secrets)

## How Has This Been Tested?
- This is a minor change to switch branch trigger - the actual validation will happen once merged to Main 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve pull request testing and access to build secrets in fork-based contributions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->