### PR TITLE
Prevent container sizes from displaying as project-scoped

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -23,7 +23,10 @@ import {
   TemplateModel,
 } from '#~/__tests__/cypress/cypress/utils/models';
 import { ServingRuntimeModelType, ServingRuntimePlatform } from '#~/types';
-import { mockGlobalScopedHardwareProfiles } from '#~/__mocks__/mockHardwareProfile';
+import {
+  mockGlobalScopedHardwareProfiles,
+  mockProjectScopedHardwareProfiles,
+} from '#~/__mocks__/mockHardwareProfile';
 import { mockConnectionTypeConfigMap } from '../../../../../../__mocks__/mockConnectionType';
 
 const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) => {
@@ -66,6 +69,11 @@ const initIntercepts = ({ modelType }: { modelType?: ServingRuntimeModelType }) 
   cy.interceptK8sList(
     { model: HardwareProfileModel, ns: 'opendatahub' },
     mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+  );
+
+  cy.interceptK8sList(
+    { model: HardwareProfileModel, ns: 'test-project' },
+    mockK8sResourceList(mockProjectScopedHardwareProfiles),
   );
 
   cy.interceptK8sList(

--- a/frontend/src/pages/hardwareProfiles/migration/useMigratedHardwareProfiles.ts
+++ b/frontend/src/pages/hardwareProfiles/migration/useMigratedHardwareProfiles.ts
@@ -5,6 +5,7 @@ import useAcceleratorProfiles from '#~/pages/notebookController/screens/server/u
 import { SchedulingType, Toleration, TolerationEffect, TolerationOperator } from '#~/types';
 import { DEFAULT_NOTEBOOK_SIZES } from '#~/pages/notebookController/const';
 import { DEFAULT_MODEL_SERVER_SIZES } from '#~/concepts/modelServing/modelServingSizesUtils';
+import { useDashboardNamespace } from '#~/redux/selectors';
 
 import { useApplicationSettings } from '#~/app/useApplicationSettings';
 import {
@@ -23,6 +24,7 @@ const useMigratedHardwareProfiles = (
   refresh: () => Promise<void>;
   getMigrationAction: (name: string) => MigrationAction | undefined;
 } => {
+  const { dashboardNamespace } = useDashboardNamespace();
   const {
     dashboardConfig,
     refresh: refreshDashboardConfig,
@@ -125,6 +127,10 @@ const useMigratedHardwareProfiles = (
       migratedAcceleratorProfiles.push(newNotebooksProfile, newServingProfile);
     });
 
+    if (namespace !== dashboardNamespace) {
+      return [migratedAcceleratorProfiles, migrationMapBuilder];
+    }
+
     // migrate notebook container sizes
     const migratedNotebookContainerSizes = notebookContainerSizes.map((size, index) => {
       const name = `${size.name}-notebooks-${getUUIDSuffix(size.name)}`;
@@ -216,6 +222,7 @@ const useMigratedHardwareProfiles = (
     acceleratorProfiles,
     dashboardConfig,
     namespace,
+    dashboardNamespace,
     loadedAcceleratorProfiles,
     refreshAcceleratorProfiles,
     refreshDashboardConfig,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-37391

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Container sizes defined in OdhDashboardConfig (notebookSizes and modelServerSizes) were appearing as both global-scoped and project-scoped hardware profiles in the hardware profiles form.
<img width="801" height="416" alt="image" src="https://github.com/user-attachments/assets/896cca01-9a71-4fe6-bb83-38602ca7d35f" />

<img width="789" height="424" alt="image" src="https://github.com/user-attachments/assets/3abaea65-c58a-4f34-8ce0-b88abb92374d" />

After fixing the bug:
<img width="908" height="336" alt="image" src="https://github.com/user-attachments/assets/ea34b2c6-7e09-42cd-b514-6f09af835031" />

The issue was in `useMigratedHardwareProfiles`, it would return migrated container sizes regardless of the namespace even though container sizes should be considered global-scoped. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This should be tested in RHOAI 2.25. 
- With the hardware profile feature disabled, create global-scoped and project-scoped accelerator profiles.
- Check that `OdhDashboardConfig` contains container sizes under `notebookSizes` and `modelServerSizes` fields
     - If not, here's a template that can be copied into it: https://gist.github.com/nananosirova/ced66a93cdbbb3335f4f171f08dad3e1 
- Navigate to project workbenches / model serving
- Check the hardware profiles dropdown
     - Verify that the container sizes only show up in the global scoped section of the hardware profiles dropdown 
- Regression testing: verify that container size to hardware profile migration works correctly 

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
