### PR TITLE
added error boundary for chunk load errors

### DIFF
--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from './app/ThemeContext';
 import SDKInitialize from './SDKInitialize';
 import { BrowserStorageContextProvider } from './components/browserStorage/BrowserStorageContext';
 import ErrorBoundary from './components/error/ErrorBoundary';
+import RouteErrorElement from './components/error/RouteErrorElement';
 import { ReduxContext } from './redux/context';
 
 // Creates a data router using createBrowserRouter
@@ -23,6 +24,7 @@ const router = createBrowserRouter([
         </BrowserStorageContextProvider>
       </SDKInitialize>
     ),
+    errorElement: <RouteErrorElement />,
   },
 ]);
 

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Button, Split, SplitItem, Title } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
 import ErrorDetails from './ErrorDetails';
+import ErrorFallbackLayout from './ErrorFallbackLayout';
 import UpdateState from './UpdateState';
 
 type ErrorBoundaryProps = {
@@ -51,42 +50,14 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       }
       return (
         <div className="pf-v6-u-p-lg" data-testid="error-boundary">
-          <Split>
-            <SplitItem isFilled>
-              <Title headingLevel="h1" className="pf-v6-u-mb-sm">
-                An error occurred
-              </Title>
-              <p className="pf-v6-u-mb-md">
-                Try{' '}
-                <Button
-                  data-testid="reload-link"
-                  variant="link"
-                  isInline
-                  onClick={() => window.location.reload()}
-                >
-                  reloading
-                </Button>{' '}
-                the page if there was a recent update.
-              </p>
-            </SplitItem>
-            <SplitItem>
-              <Button
-                icon={<TimesIcon />}
-                data-testid="close-error-button"
-                variant="plain"
-                aria-label="Close"
-                onClick={() => {
-                  this.setState({ hasError: false });
-                }}
-              />
-            </SplitItem>
-          </Split>
-          <ErrorDetails
-            title={error.name}
-            errorMessage={error.message}
-            componentStack={errorInfo.componentStack || ''}
-            stack={error.stack}
-          />
+          <ErrorFallbackLayout onClose={() => this.setState({ hasError: false })}>
+            <ErrorDetails
+              title={error.name}
+              errorMessage={error.message}
+              componentStack={errorInfo.componentStack || ''}
+              stack={error.stack}
+            />
+          </ErrorFallbackLayout>
         </div>
       );
     }

--- a/frontend/src/components/error/ErrorDetails.tsx
+++ b/frontend/src/components/error/ErrorDetails.tsx
@@ -12,7 +12,7 @@ import {
 type ErrorDetailsProps = {
   title: string;
   errorMessage?: string;
-  componentStack: string;
+  componentStack?: string;
   stack?: string;
 };
 
@@ -34,20 +34,22 @@ const ErrorDetails: React.FC<ErrorDetailsProps> = ({
         </DescriptionListGroup>
       ) : null}
 
-      <DescriptionListGroup>
-        <DescriptionListTerm>Component trace:</DescriptionListTerm>
-        <DescriptionListDescription>
-          <ClipboardCopy
-            isExpanded
-            isCode
-            hoverTip="Copy"
-            clickTip="Copied"
-            variant={ClipboardCopyVariant.expansion}
-          >
-            {componentStack.trim()}
-          </ClipboardCopy>
-        </DescriptionListDescription>
-      </DescriptionListGroup>
+      {componentStack ? (
+        <DescriptionListGroup>
+          <DescriptionListTerm>Component trace:</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              isExpanded
+              isCode
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant={ClipboardCopyVariant.expansion}
+            >
+              {componentStack.trim()}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      ) : null}
 
       {stack ? (
         <DescriptionListGroup>

--- a/frontend/src/components/error/ErrorFallbackLayout.tsx
+++ b/frontend/src/components/error/ErrorFallbackLayout.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Button, Split, SplitItem, Title } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+
+type ErrorFallbackLayoutProps = {
+  onClose?: () => void;
+  reloadButtonTestId?: string;
+  closeButtonTestId?: string;
+  children?: React.ReactNode;
+};
+
+const ErrorFallbackLayout: React.FC<ErrorFallbackLayoutProps> = ({
+  onClose,
+  reloadButtonTestId = 'reload-link',
+  closeButtonTestId = 'close-error-button',
+  children,
+}) => (
+  <>
+    <Split>
+      <SplitItem isFilled>
+        <Title headingLevel="h1" className="pf-v6-u-mb-sm">
+          An error occurred
+        </Title>
+        <p className="pf-v6-u-mb-md">
+          Try{' '}
+          <Button
+            data-testid={reloadButtonTestId}
+            variant="link"
+            isInline
+            onClick={() => window.location.reload()}
+          >
+            reloading
+          </Button>{' '}
+          the page if there was a recent update.
+        </p>
+      </SplitItem>
+      {onClose ? (
+        <SplitItem>
+          <Button
+            icon={<TimesIcon />}
+            data-testid={closeButtonTestId}
+            variant="plain"
+            aria-label="Close"
+            onClick={onClose}
+          />
+        </SplitItem>
+      ) : null}
+    </Split>
+    {children}
+  </>
+);
+
+export default ErrorFallbackLayout;

--- a/frontend/src/components/error/RouteErrorElement.tsx
+++ b/frontend/src/components/error/RouteErrorElement.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { PageSection } from '@patternfly/react-core';
+import { useRouteError } from 'react-router-dom';
+import ErrorDetails from './ErrorDetails';
+import ErrorFallbackLayout from './ErrorFallbackLayout';
+import { getRouteErrorDetails, isChunkLoadError } from './routeErrorUtils';
+import UpdateState from './UpdateState';
+
+const RouteErrorElement: React.FC = () => {
+  const error = useRouteError();
+  const [showErrorDetails, setShowErrorDetails] = React.useState(false);
+  const { title, errorMessage, stack } = getRouteErrorDetails(error);
+
+  if (isChunkLoadError(error) && !showErrorDetails) {
+    return <UpdateState onClose={() => setShowErrorDetails(true)} />;
+  }
+
+  return (
+    <PageSection
+      hasBodyWrapper={false}
+      className="pf-v6-u-p-lg"
+      data-testid="router-error-boundary"
+    >
+      <ErrorFallbackLayout reloadButtonTestId="router-reload-link">
+        <ErrorDetails title={title} errorMessage={errorMessage} stack={stack} />
+      </ErrorFallbackLayout>
+    </PageSection>
+  );
+};
+
+export default RouteErrorElement;

--- a/frontend/src/components/error/RouteErrorElement.tsx
+++ b/frontend/src/components/error/RouteErrorElement.tsx
@@ -11,6 +11,10 @@ const RouteErrorElement: React.FC = () => {
   const [showErrorDetails, setShowErrorDetails] = React.useState(false);
   const { title, errorMessage, stack } = getRouteErrorDetails(error);
 
+  React.useEffect(() => {
+    setShowErrorDetails(false);
+  }, [error]);
+
   if (isChunkLoadError(error) && !showErrorDetails) {
     return <UpdateState onClose={() => setShowErrorDetails(true)} />;
   }

--- a/frontend/src/components/error/__tests__/ErrorDetails.spec.tsx
+++ b/frontend/src/components/error/__tests__/ErrorDetails.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ErrorDetails from '#~/components/error/ErrorDetails';
+
+describe('ErrorDetails', () => {
+  it('should render description, component trace, and stack trace', () => {
+    render(
+      <ErrorDetails
+        title="ChunkLoadError"
+        errorMessage="Loading chunk 145 failed"
+        componentStack={'\n at App\n at NavSidebar'}
+        stack={'ChunkLoadError: Loading chunk 145 failed\n at __webpack_require__'}
+      />,
+    );
+
+    expect(screen.getByText('ChunkLoadError')).toBeInTheDocument();
+    expect(screen.getByText('Description:')).toBeInTheDocument();
+    expect(screen.getByText('Loading chunk 145 failed')).toBeInTheDocument();
+    expect(screen.getByText('Component trace:')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/at App\s+at NavSidebar/)).toBeInTheDocument();
+    expect(screen.getByText('Stack trace:')).toBeInTheDocument();
+  });
+
+  it('should omit component trace when componentStack is not provided', () => {
+    render(<ErrorDetails title="Route error" errorMessage="Unknown route error" />);
+
+    expect(screen.getByText('Route error')).toBeInTheDocument();
+    expect(screen.getByText('Unknown route error')).toBeInTheDocument();
+    expect(screen.queryByText('Component trace:')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/error/__tests__/ErrorFallbackLayout.spec.tsx
+++ b/frontend/src/components/error/__tests__/ErrorFallbackLayout.spec.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { act } from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import ErrorFallbackLayout from '#~/components/error/ErrorFallbackLayout';
+
+describe('ErrorFallbackLayout', () => {
+  it('should reload the page when reload link is clicked', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: jest.fn() },
+    });
+
+    render(<ErrorFallbackLayout />);
+
+    const reloadButton = screen.getByTestId('reload-link');
+    act(() => reloadButton.click());
+
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+
+  it('should render and handle close button when onClose is provided', () => {
+    const onClose = jest.fn();
+
+    render(
+      <ErrorFallbackLayout onClose={onClose}>
+        <div>details</div>
+      </ErrorFallbackLayout>,
+    );
+
+    expect(screen.getByText('details')).toBeInTheDocument();
+    const closeButton = screen.getByTestId('close-error-button');
+    act(() => closeButton.click());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render close button when onClose is not provided', () => {
+    render(<ErrorFallbackLayout />);
+
+    expect(screen.queryByTestId('close-error-button')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/error/__tests__/RouteErrorElement.spec.tsx
+++ b/frontend/src/components/error/__tests__/RouteErrorElement.spec.tsx
@@ -40,6 +40,29 @@ describe('RouteErrorElement', () => {
     expect(screen.getByText('Loading chunk 145 failed')).toBeInTheDocument();
   });
 
+  it('should reset to update state when route error changes', () => {
+    let currentError: unknown = Object.assign(new Error('Loading chunk 145 failed'), {
+      name: 'ChunkLoadError',
+    });
+    useRouteErrorMock.mockImplementation(() => currentError);
+
+    const { rerender } = render(<RouteErrorElement />);
+    expect(screen.getByTestId('error-update-state')).toBeInTheDocument();
+
+    act(() => {
+      screen.getByTestId('show-error-button').click();
+    });
+    expect(screen.getByTestId('router-error-boundary')).toBeInTheDocument();
+
+    currentError = Object.assign(new Error('Loading chunk src_images_icons_Settings failed'), {
+      name: 'ChunkLoadError',
+    });
+    rerender(<RouteErrorElement />);
+
+    expect(screen.getByTestId('error-update-state')).toBeInTheDocument();
+    expect(screen.queryByTestId('router-error-boundary')).not.toBeInTheDocument();
+  });
+
   it('should render route error fallback for non-chunk errors', () => {
     useRouteErrorMock.mockReturnValue(new Error('regular route error'));
 

--- a/frontend/src/components/error/__tests__/RouteErrorElement.spec.tsx
+++ b/frontend/src/components/error/__tests__/RouteErrorElement.spec.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { act } from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { useRouteError } from 'react-router-dom';
+import RouteErrorElement from '#~/components/error/RouteErrorElement';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useRouteError: jest.fn(),
+}));
+
+const useRouteErrorMock = jest.mocked(useRouteError);
+
+describe('RouteErrorElement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: jest.fn() },
+    });
+  });
+
+  it('should render update state for ChunkLoadError and show details when requested', async () => {
+    const error = new Error('Loading chunk 145 failed');
+    error.name = 'ChunkLoadError';
+    useRouteErrorMock.mockReturnValue(error);
+
+    render(<RouteErrorElement />);
+
+    expect(screen.getByTestId('error-update-state')).toBeInTheDocument();
+    expect(screen.queryByTestId('router-error-boundary')).not.toBeInTheDocument();
+
+    const showErrorButton = screen.getByTestId('show-error-button');
+    act(() => showErrorButton.click());
+
+    expect(screen.queryByTestId('error-update-state')).not.toBeInTheDocument();
+    expect(screen.getByTestId('router-error-boundary')).toBeInTheDocument();
+    expect(screen.getByText('ChunkLoadError')).toBeInTheDocument();
+    expect(screen.getByText('Loading chunk 145 failed')).toBeInTheDocument();
+  });
+
+  it('should render route error fallback for non-chunk errors', () => {
+    useRouteErrorMock.mockReturnValue(new Error('regular route error'));
+
+    render(<RouteErrorElement />);
+
+    expect(screen.queryByTestId('error-update-state')).not.toBeInTheDocument();
+    expect(screen.getByTestId('router-error-boundary')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('regular route error')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
+++ b/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
@@ -27,6 +27,20 @@ describe('isChunkLoadError', () => {
 });
 
 describe('getRouteErrorDetails', () => {
+  it('should return route error response string data as message', () => {
+    const routeErrorResponse = {
+      status: 500,
+      statusText: 'Server Error',
+      data: 'Backend unavailable',
+      internal: false,
+    };
+
+    expect(getRouteErrorDetails(routeErrorResponse)).toEqual({
+      title: '500 Server Error',
+      errorMessage: 'Backend unavailable',
+    });
+  });
+
   it('should return route error response details', () => {
     const routeErrorResponse = {
       status: 404,

--- a/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
+++ b/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
@@ -1,0 +1,50 @@
+import { getRouteErrorDetails, isChunkLoadError } from '#~/components/error/routeErrorUtils';
+
+describe('isChunkLoadError', () => {
+  it('should return true when error name is ChunkLoadError', () => {
+    const error = new Error('network failure');
+    error.name = 'ChunkLoadError';
+
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it('should return true when message matches webpack chunk failure pattern', () => {
+    const error = new Error('Loading chunk 145 failed.');
+
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it('should return false for non-chunk errors', () => {
+    expect(isChunkLoadError(new Error('regular error'))).toBe(false);
+    expect(isChunkLoadError('ChunkLoadError')).toBe(false);
+  });
+});
+
+describe('getRouteErrorDetails', () => {
+  it('should return title, message, and stack for Error input', () => {
+    const error = new Error('boom');
+    error.name = 'TypeError';
+
+    const result = getRouteErrorDetails(error);
+
+    expect(result).toEqual({
+      title: 'TypeError',
+      errorMessage: 'boom',
+      stack: error.stack,
+    });
+  });
+
+  it('should return route error details for string input', () => {
+    expect(getRouteErrorDetails('failed to render')).toEqual({
+      title: 'Route error',
+      errorMessage: 'failed to render',
+    });
+  });
+
+  it('should return unknown route error fallback', () => {
+    expect(getRouteErrorDetails({ some: 'object' })).toEqual({
+      title: 'Route error',
+      errorMessage: 'Unknown route error',
+    });
+  });
+});

--- a/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
+++ b/frontend/src/components/error/__tests__/routeErrorUtils.spec.ts
@@ -14,6 +14,12 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError(error)).toBe(true);
   });
 
+  it('should return true when message contains a named chunk id', () => {
+    const error = new Error('Loading chunk src_images_icons_SettingsNavIcon_tsx failed.');
+
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
   it('should return false for non-chunk errors', () => {
     expect(isChunkLoadError(new Error('regular error'))).toBe(false);
     expect(isChunkLoadError('ChunkLoadError')).toBe(false);
@@ -21,6 +27,20 @@ describe('isChunkLoadError', () => {
 });
 
 describe('getRouteErrorDetails', () => {
+  it('should return route error response details', () => {
+    const routeErrorResponse = {
+      status: 404,
+      statusText: 'Not Found',
+      data: { message: 'Project does not exist' },
+      internal: false,
+    };
+
+    expect(getRouteErrorDetails(routeErrorResponse)).toEqual({
+      title: '404 Not Found',
+      errorMessage: 'Project does not exist',
+    });
+  });
+
   it('should return title, message, and stack for Error input', () => {
     const error = new Error('boom');
     error.name = 'TypeError';

--- a/frontend/src/components/error/routeErrorUtils.ts
+++ b/frontend/src/components/error/routeErrorUtils.ts
@@ -1,0 +1,29 @@
+export const isChunkLoadError = (error: unknown): error is Error =>
+  error instanceof Error &&
+  (error.name === 'ChunkLoadError' ||
+    /ChunkLoadError/i.test(error.message) ||
+    /Loading chunk [\d]+ failed/i.test(error.message));
+
+export const getRouteErrorDetails = (
+  error: unknown,
+): { title: string; errorMessage?: string; stack?: string } => {
+  if (error instanceof Error) {
+    return {
+      title: error.name,
+      errorMessage: error.message,
+      stack: error.stack,
+    };
+  }
+
+  if (typeof error === 'string') {
+    return {
+      title: 'Route error',
+      errorMessage: error,
+    };
+  }
+
+  return {
+    title: 'Route error',
+    errorMessage: 'Unknown route error',
+  };
+};

--- a/frontend/src/components/error/routeErrorUtils.ts
+++ b/frontend/src/components/error/routeErrorUtils.ts
@@ -1,12 +1,32 @@
+import { isRouteErrorResponse } from 'react-router-dom';
+
+const hasMessageField = (value: unknown): value is { message: unknown } =>
+  typeof value === 'object' && value !== null && 'message' in value;
+
 export const isChunkLoadError = (error: unknown): error is Error =>
   error instanceof Error &&
   (error.name === 'ChunkLoadError' ||
     /ChunkLoadError/i.test(error.message) ||
-    /Loading chunk [\d]+ failed/i.test(error.message));
+    /Loading chunk \S+ failed/i.test(error.message));
 
 export const getRouteErrorDetails = (
   error: unknown,
 ): { title: string; errorMessage?: string; stack?: string } => {
+  if (isRouteErrorResponse(error)) {
+    const title = `${error.status} ${error.statusText}`.trim();
+    let dataMessage: string | undefined;
+    if (typeof error.data === 'string') {
+      dataMessage = error.data;
+    } else if (hasMessageField(error.data)) {
+      dataMessage = String(error.data.message);
+    }
+
+    return {
+      title: title || 'Route error',
+      errorMessage: dataMessage || error.statusText || 'Route request failed',
+    };
+  }
+
   if (error instanceof Error) {
     return {
       title: error.name,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-38136

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

We catch the chunk layer or any other errors that occur outside of the `<App />` layer.

<img width="1705" height="806" alt="Screenshot 2026-02-23 at 3 27 42 PM" src="https://github.com/user-attachments/assets/900d49af-8fbb-46d0-8522-4677937821e6" />
<img width="1705" height="806" alt="Screenshot 2026-02-23 at 3 27 52 PM" src="https://github.com/user-attachments/assets/1deb2ecc-48e5-4daa-9de6-4947dba284e0" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In the network request tab, block a `NavItem` `*.js` file request since it is blocked outside of our normal `ErrorBoundary`. An example `*.js` request to block is the one in the screenshot.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route errors now show a dedicated error UI with a reload action and an optional close control.
  * Chunk-load failures present an initial update state that can reveal full error details.

* **Refactor**
  * Error presentation consolidated into a reusable fallback layout for consistent behavior.
  * Component trace is now optional and shown only when available.

* **Tests**
  * Added unit tests covering error layouts, detail rendering, and chunk-load scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->