### PR TITLE
Feat(RHOAIENG-50647):Added kueue status icons with content changes

### DIFF
--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -1,3 +1,14 @@
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InProgressIcon,
+  OutlinedClockIcon,
+} from '@patternfly/react-icons';
+import {
+  t_global_color_status_warning_300 as WarningColorDesign,
+  t_global_text_color_status_danger_default as DangerColor,
+} from '@patternfly/react-tokens';
 import type { WorkloadCondition, WorkloadKind } from '#~/k8sTypes';
 import { getKueueWorkloadStatusWithMessage, getKueueStatusInfo } from '#~/concepts/kueue';
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
@@ -325,55 +336,82 @@ describe('getKueueWorkloadStatusWithMessage', () => {
 describe('getKueueStatusInfo', () => {
   it('should return correct info for Queued', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Queued);
-    expect(info.label).toBe('Queued');
-    expect(info.color).toBe('grey');
-    expect(info.IconComponent).toBeDefined();
+    expect(info).toEqual({
+      label: 'Queued',
+      color: 'grey',
+      IconComponent: OutlinedClockIcon,
+      contentColor: WarningColorDesign.var,
+    });
   });
 
   it('should return correct info for Failed', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Failed);
-    expect(info.label).toBe('Failed');
-    expect(info.status).toBe('danger');
-    expect(info.color).toBe('red');
+    expect(info).toEqual({
+      label: 'Failed',
+      status: 'danger',
+      color: 'red',
+      IconComponent: ExclamationCircleIcon,
+      contentColor: DangerColor.var,
+    });
   });
 
   it('should return correct info for Preempted', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Preempted);
-    expect(info.label).toBe('Preempted');
-    expect(info.status).toBe('warning');
-    expect(info.color).toBe('orange');
+    expect(info).toEqual({
+      label: 'Preempted',
+      color: 'orange',
+      status: 'warning',
+      IconComponent: ExclamationTriangleIcon,
+      contentColor: WarningColorDesign.var,
+    });
   });
 
   it('should return correct info for Inadmissible', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Inadmissible);
-    expect(info.label).toBe('Inadmissible');
-    expect(info.status).toBe('warning');
-    expect(info.color).toBe('orange');
+    expect(info).toEqual({
+      label: 'Inadmissible',
+      color: 'orange',
+      status: 'warning',
+      IconComponent: ExclamationTriangleIcon,
+      contentColor: WarningColorDesign.var,
+    });
   });
 
   it('should return correct info for Running', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Running);
-    expect(info.label).toBe('Running');
-    expect(info.color).toBe('blue');
+    expect(info).toEqual({
+      label: 'Running',
+      color: 'blue',
+      IconComponent: InProgressIcon,
+    });
   });
 
   it('should return correct info for Admitted', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Admitted);
-    expect(info.label).toBe('Starting');
-    expect(info.color).toBe('blue');
-    expect(info.iconClassName).toBe('odh-u-spin');
+    expect(info).toEqual({
+      label: 'Starting',
+      color: 'blue',
+      IconComponent: InProgressIcon,
+      iconClassName: 'odh-u-spin',
+    });
   });
 
   it('should return correct info for Succeeded', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Succeeded);
-    expect(info.label).toBe('Complete');
-    expect(info.status).toBe('success');
-    expect(info.color).toBe('green');
+    expect(info).toEqual({
+      label: 'Complete',
+      status: 'success',
+      color: 'green',
+      IconComponent: CheckCircleIcon,
+    });
   });
 
   it('should return default for unknown status', () => {
     const info = getKueueStatusInfo('Unknown' as KueueWorkloadStatus);
-    expect(info.label).toBe('Unknown');
-    expect(info.color).toBe('grey');
+    expect(info).toEqual({
+      label: 'Unknown',
+      color: 'grey',
+      IconComponent: OutlinedClockIcon,
+    });
   });
 });

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -5,6 +5,10 @@ import {
   InProgressIcon,
   OutlinedClockIcon,
 } from '@patternfly/react-icons';
+import {
+  t_global_color_status_warning_300 as WarningColorDesign,
+  t_global_text_color_status_danger_default as DangerColor,
+} from '@patternfly/react-tokens';
 import type { WorkloadCondition, WorkloadKind } from '#~/k8sTypes';
 
 import {
@@ -120,13 +124,19 @@ export const getKueueWorkloadStatusWithMessage = (
 export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo => {
   switch (status) {
     case KueueWorkloadStatus.Queued:
-      return { label: 'Queued', color: 'grey', IconComponent: OutlinedClockIcon };
+      return {
+        label: 'Queued',
+        color: 'grey',
+        IconComponent: OutlinedClockIcon,
+        contentColor: WarningColorDesign.var,
+      };
     case KueueWorkloadStatus.Failed:
       return {
         label: 'Failed',
         status: 'danger',
         color: 'red',
         IconComponent: ExclamationCircleIcon,
+        contentColor: DangerColor.var,
       };
     case KueueWorkloadStatus.Preempted:
       return {
@@ -134,6 +144,7 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
         color: 'orange',
         status: 'warning',
         IconComponent: ExclamationTriangleIcon,
+        contentColor: WarningColorDesign.var,
       };
     case KueueWorkloadStatus.Inadmissible:
       return {
@@ -141,6 +152,7 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
         color: 'orange',
         status: 'warning',
         IconComponent: ExclamationTriangleIcon,
+        contentColor: WarningColorDesign.var,
       };
     case KueueWorkloadStatus.Running:
       return { label: 'Running', color: 'blue', IconComponent: InProgressIcon };

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -22,6 +22,7 @@ export type KueueStatusInfo = {
   color?: LabelProps['color'];
   IconComponent: ComponentType<SVGProps<SVGSVGElement>>;
   iconClassName?: string;
+  contentColor?: string;
 };
 
 /**

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -29,16 +29,12 @@ import {
   Title,
 } from '@patternfly/react-core';
 import {
-  t_global_icon_color_brand_default as BrandIconColor,
   t_global_icon_size_font_md as InfoIconSize,
   t_global_spacer_xs as ExtraSmallSpacerSize,
-  t_global_text_color_regular as RegularColor,
   t_global_text_color_disabled as DisabledColor,
-  t_global_text_color_status_danger_default as DangerColor,
   t_global_text_color_status_info_default as InfoColor,
-  t_global_text_color_status_warning_default as WarningColor,
 } from '@patternfly/react-tokens';
-import { InfoCircleIcon, InProgressIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { EventStatus, NotebookStatus, ProgressionStepTitles } from '#~/types';
 import { EventKind, NotebookKind } from '#~/k8sTypes';
 import { useNotebookProgress } from '#~/utilities/notebookControllerUtils';
@@ -54,6 +50,7 @@ import {
 } from '#~/concepts/kueue/types';
 import EventLog from '#~/concepts/k8s/EventLog/EventLog';
 import NotebookStatusLabel from './NotebookStatusLabel';
+import { getStatusLineIconAndColor } from './utils';
 import './StartNotebookModal.scss';
 
 const KUEUE_QUEUE_LABEL = 'kueue.x-k8s.io/queue-name';
@@ -172,17 +169,11 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
       return null;
     }
 
-    let color: string;
-    switch (spawnStatus?.status) {
-      case AlertVariant.danger:
-        color = DangerColor.var;
-        break;
-      case AlertVariant.warning:
-        color = WarningColor.var;
-        break;
-      default:
-        color = RegularColor.var;
-    }
+    const { IconComponent, color, iconClassName } = getStatusLineIconAndColor({
+      notebookStatus,
+      kueueStatus,
+      inProgress,
+    });
 
     const kueueTitle = showKueueMessage ? kueueStatus.message?.trim() || kueueStatus.status : null;
     const workbenchTitle =
@@ -196,13 +187,13 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
 
     return (
       <StackItem>
-        <Flex gap={{ default: 'gapSm' }}>
-          {(!spawnStatus || spawnStatus.status === AlertVariant.info) && inProgress ? (
-            <FlexItem>
-              <InProgressIcon style={{ color: BrandIconColor.var }} className="odh-u-spin" />
+        <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'nowrap' }}>
+          {IconComponent ? (
+            <FlexItem flex={{ default: 'flexNone' }}>
+              <IconComponent style={{ color }} className={iconClassName} />
             </FlexItem>
           ) : null}
-          <FlexItem>
+          <FlexItem flex={{ default: 'flex_1' }} style={{ minWidth: 0 }}>
             <Content style={{ color }} data-testid="notebook-latest-status">
               {title}
             </Content>

--- a/frontend/src/concepts/notebooks/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/notebooks/__tests__/utils.spec.ts
@@ -1,0 +1,229 @@
+import { InProgressIcon } from '@patternfly/react-icons';
+import { t_global_text_color_regular as RegularColor } from '@patternfly/react-tokens';
+import { EventStatus } from '#~/types';
+import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
+import type { KueueStatusInfo } from '#~/concepts/kueue/types';
+import { getKueueStatusInfo } from '#~/concepts/kueue';
+import { getStatusLineIconAndColor } from '#~/concepts/notebooks/utils';
+
+jest.mock('#~/concepts/kueue', () => ({
+  ...jest.requireActual('#~/concepts/kueue'),
+  getKueueStatusInfo: jest.fn(),
+}));
+
+const getKueueStatusInfoMock = jest.mocked(getKueueStatusInfo);
+
+const mockKueueStatusInfo = (overrides?: Partial<KueueStatusInfo>): KueueStatusInfo => ({
+  label: 'MockLabel',
+  IconComponent: InProgressIcon,
+  contentColor: '--mock-color',
+  iconClassName: 'mock-class',
+  ...overrides,
+});
+
+const makeNotebookStatus = (status: EventStatus) => ({
+  currentStatus: status,
+  currentEvent: '',
+  currentEventReason: '',
+  currentEventDescription: '',
+});
+
+describe('getStatusLineIconAndColor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getKueueStatusInfoMock.mockReturnValue(mockKueueStatusInfo());
+  });
+
+  describe('when kueueStatus is present and eventStatus is not ERROR', () => {
+    it('should return icon info from kueueStatus', () => {
+      const result = getStatusLineIconAndColor({
+        kueueStatus: { status: KueueWorkloadStatus.Queued },
+        notebookStatus: makeNotebookStatus(EventStatus.INFO),
+        inProgress: false,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Queued);
+      expect(result).toEqual({
+        IconComponent: InProgressIcon,
+        color: '--mock-color',
+        iconClassName: 'mock-class',
+      });
+    });
+
+    it('should use RegularColor when contentColor is undefined', () => {
+      getKueueStatusInfoMock.mockReturnValue(mockKueueStatusInfo({ contentColor: undefined }));
+
+      const result = getStatusLineIconAndColor({
+        kueueStatus: { status: KueueWorkloadStatus.Running },
+        inProgress: false,
+      });
+
+      expect(result.color).toBe(RegularColor.var);
+    });
+
+    it('should take precedence over inProgress', () => {
+      const result = getStatusLineIconAndColor({
+        kueueStatus: { status: KueueWorkloadStatus.Queued },
+        inProgress: true,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Queued);
+      expect(result.IconComponent).toBe(InProgressIcon);
+    });
+
+    it.each([
+      EventStatus.INFO,
+      EventStatus.SUCCESS,
+      EventStatus.WARNING,
+      EventStatus.PENDING,
+      EventStatus.IN_PROGRESS,
+    ])('should use kueueStatus when eventStatus is %s', (eventStatus) => {
+      getStatusLineIconAndColor({
+        kueueStatus: { status: KueueWorkloadStatus.Admitted },
+        notebookStatus: makeNotebookStatus(eventStatus),
+        inProgress: false,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Admitted);
+    });
+  });
+
+  describe('when kueueStatus is present but eventStatus is ERROR', () => {
+    it('should ignore kueueStatus and resolve from notebook ERROR as Failed', () => {
+      const result = getStatusLineIconAndColor({
+        kueueStatus: { status: KueueWorkloadStatus.Queued },
+        notebookStatus: makeNotebookStatus(EventStatus.ERROR),
+        inProgress: false,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Failed);
+      expect(result).toEqual({
+        IconComponent: InProgressIcon,
+        color: '--mock-color',
+        iconClassName: 'mock-class',
+      });
+    });
+  });
+
+  describe('when kueueStatus is absent, resolving from notebook eventStatus', () => {
+    it('should map ERROR to KueueWorkloadStatus.Failed', () => {
+      getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.ERROR),
+        inProgress: false,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Failed);
+    });
+
+    it('should map WARNING to KueueWorkloadStatus.Preempted', () => {
+      getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.WARNING),
+        inProgress: false,
+      });
+
+      expect(getKueueStatusInfoMock).toHaveBeenCalledWith(KueueWorkloadStatus.Preempted);
+    });
+
+    it('should use RegularColor when contentColor is undefined for resolved notebook status', () => {
+      getKueueStatusInfoMock.mockReturnValue(mockKueueStatusInfo({ contentColor: undefined }));
+
+      const result = getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.ERROR),
+        inProgress: false,
+      });
+
+      expect(result.color).toBe(RegularColor.var);
+    });
+  });
+
+  describe('when inProgress is true and eventStatus allows it', () => {
+    it('should return InProgressIcon when eventStatus is undefined', () => {
+      const result = getStatusLineIconAndColor({
+        inProgress: true,
+      });
+
+      expect(result).toEqual({
+        IconComponent: InProgressIcon,
+        color: RegularColor.var,
+        iconClassName: 'odh-u-spin',
+      });
+      expect(getKueueStatusInfoMock).not.toHaveBeenCalled();
+    });
+
+    it('should return InProgressIcon when eventStatus is INFO', () => {
+      const result = getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.INFO),
+        inProgress: true,
+      });
+
+      expect(result).toEqual({
+        IconComponent: InProgressIcon,
+        color: RegularColor.var,
+        iconClassName: 'odh-u-spin',
+      });
+    });
+
+    it('should return InProgressIcon when eventStatus is SUCCESS', () => {
+      const result = getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.SUCCESS),
+        inProgress: true,
+      });
+
+      expect(result).toEqual({
+        IconComponent: InProgressIcon,
+        color: RegularColor.var,
+        iconClassName: 'odh-u-spin',
+      });
+    });
+  });
+
+  describe('default fallback', () => {
+    it('should return null icon when no conditions match', () => {
+      const result = getStatusLineIconAndColor({
+        inProgress: false,
+      });
+
+      expect(result).toEqual({
+        IconComponent: null,
+        color: RegularColor.var,
+      });
+    });
+
+    it('should return null icon when eventStatus is INFO and not inProgress', () => {
+      const result = getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.INFO),
+        inProgress: false,
+      });
+
+      expect(result).toEqual({
+        IconComponent: null,
+        color: RegularColor.var,
+      });
+    });
+
+    it('should return null icon when eventStatus is SUCCESS and not inProgress', () => {
+      const result = getStatusLineIconAndColor({
+        notebookStatus: makeNotebookStatus(EventStatus.SUCCESS),
+        inProgress: false,
+      });
+
+      expect(result).toEqual({
+        IconComponent: null,
+        color: RegularColor.var,
+      });
+    });
+
+    it('should return null icon when notebookStatus is null', () => {
+      const result = getStatusLineIconAndColor({
+        notebookStatus: null,
+        kueueStatus: null,
+        inProgress: false,
+      });
+
+      expect(result).toEqual({
+        IconComponent: null,
+        color: RegularColor.var,
+      });
+    });
+  });
+});

--- a/frontend/src/concepts/notebooks/utils.ts
+++ b/frontend/src/concepts/notebooks/utils.ts
@@ -1,11 +1,22 @@
+import type { ComponentType, SVGProps } from 'react';
 import React from 'react';
+import { InProgressIcon } from '@patternfly/react-icons';
+import { t_global_text_color_regular as RegularColor } from '@patternfly/react-tokens';
 import { HardwareProfileFeatureVisibility, NotebookKind } from '#~/k8sTypes.ts';
-import { Notebook } from '#~/types';
+import { EventStatus, Notebook, type NotebookStatus } from '#~/types';
 import {
   useAssignHardwareProfile,
   UseAssignHardwareProfileResult,
 } from '#~/concepts/hardwareProfiles/useAssignHardwareProfile.ts';
+import { getKueueStatusInfo } from '#~/concepts/kueue';
+import { KueueWorkloadStatus, type KueueWorkloadStatusWithMessage } from '#~/concepts/kueue/types';
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
+
+export type StatusLineIconResult = {
+  IconComponent: ComponentType<SVGProps<SVGSVGElement>> | null;
+  color: string;
+  iconClassName?: string;
+};
 
 /**
  * In v3.0, the accessing of a Workbench will be assuming a shared gateway route with Dashboard.
@@ -43,3 +54,48 @@ export const useNotebookHardwareProfile = <T extends NotebookKind | Notebook>(
     paths,
   });
 };
+
+export function getStatusLineIconAndColor(params: {
+  notebookStatus?: NotebookStatus | null;
+  kueueStatus?: KueueWorkloadStatusWithMessage | null;
+  inProgress: boolean;
+}): StatusLineIconResult {
+  const { notebookStatus, kueueStatus, inProgress } = params;
+  const eventStatus = notebookStatus?.currentStatus;
+
+  if (kueueStatus?.status && eventStatus !== EventStatus.ERROR) {
+    const info = getKueueStatusInfo(kueueStatus.status);
+    return {
+      IconComponent: info.IconComponent,
+      color: info.contentColor ?? RegularColor.var,
+      iconClassName: info.iconClassName,
+    };
+  }
+
+  const resolvedFromNotebook: KueueWorkloadStatus | null =
+    eventStatus === EventStatus.ERROR
+      ? KueueWorkloadStatus.Failed
+      : eventStatus === EventStatus.WARNING
+      ? KueueWorkloadStatus.Preempted
+      : null;
+  if (resolvedFromNotebook) {
+    const info = getKueueStatusInfo(resolvedFromNotebook);
+    return {
+      IconComponent: info.IconComponent,
+      color: info.contentColor ?? RegularColor.var,
+      iconClassName: info.iconClassName,
+    };
+  }
+
+  if (
+    (!eventStatus || eventStatus === EventStatus.INFO || eventStatus === EventStatus.SUCCESS) &&
+    inProgress
+  ) {
+    return {
+      IconComponent: InProgressIcon,
+      color: RegularColor.var,
+      iconClassName: 'odh-u-spin',
+    };
+  }
+  return { IconComponent: null, color: RegularColor.var };
+}

--- a/frontend/src/concepts/notebooks/utils.ts
+++ b/frontend/src/concepts/notebooks/utils.ts
@@ -72,14 +72,14 @@ export function getStatusLineIconAndColor(params: {
     };
   }
 
-  const resolvedFromNotebook: KueueWorkloadStatus | null =
+  const resolvedEventStatus: KueueWorkloadStatus | null =
     eventStatus === EventStatus.ERROR
       ? KueueWorkloadStatus.Failed
       : eventStatus === EventStatus.WARNING
       ? KueueWorkloadStatus.Preempted
       : null;
-  if (resolvedFromNotebook) {
-    const info = getKueueStatusInfo(resolvedFromNotebook);
+  if (resolvedEventStatus) {
+    const info = getKueueStatusInfo(resolvedEventStatus);
     return {
       IconComponent: info.IconComponent,
       color: info.contentColor ?? RegularColor.var,

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -56,7 +56,6 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
   const { kueueStatusByNotebookName } = React.useContext(ProjectDetailsContext);
   const { notebook, isStarting, isRunning, isStopping, runningPodUid } = notebookState;
   const kueueStatus = kueueStatusByNotebookName[notebook.metadata.name] ?? null;
-  console.log('kueueStatus in NotebookStateStatus', kueueStatus);
   const [unstableNotebookStatus, events] = useNotebookStatus(
     isStarting,
     notebook,

--- a/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
+++ b/frontend/src/pages/projects/notebook/NotebookStateStatus.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
-import {
-  t_global_text_color_regular as RegularColor,
-  t_global_text_color_status_danger_default as DangerColor,
-  t_global_text_color_status_warning_default as WarningColor,
-} from '@patternfly/react-tokens';
+import { Button, capitalize, Flex, FlexItem } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 import { EventStatus, NotebookStatus } from '#~/types';
 import { useDeepCompareMemoize } from '#~/utilities/useDeepCompareMemoize';
 import { useNotebookStatus } from '#~/utilities/notebookControllerUtils';
 import StartNotebookModal from '#~/concepts/notebooks/StartNotebookModal';
 import NotebookStatusLabel from '#~/concepts/notebooks/NotebookStatusLabel';
+import { getStatusLineIconAndColor } from '#~/concepts/notebooks/utils';
 import {
   KUEUE_STATUSES_OVERRIDE_WORKBENCH,
   type KueueWorkloadStatusWithMessage,
@@ -31,23 +27,6 @@ type GetStatusSubtitleParams = {
   notebookStatus: NotebookStatus | null;
   kueueStatus: KueueWorkloadStatusWithMessage | null;
 };
-
-const getNotebookStatusColor = (notebookStatus?: NotebookStatus | null) =>
-  notebookStatus?.currentStatus === EventStatus.ERROR
-    ? DangerColor.var
-    : notebookStatus?.currentStatus === EventStatus.WARNING
-    ? WarningColor.var
-    : RegularColor.var;
-
-const getNotebookStatusTextDecoration = (
-  notebookStatus?: NotebookStatus | null,
-  isStarting?: boolean,
-) =>
-  isStarting ||
-  notebookStatus?.currentStatus === EventStatus.ERROR ||
-  notebookStatus?.currentStatus === EventStatus.WARNING
-    ? undefined
-    : 'none';
 
 export const getStatusSubtitle = ({
   isStarting,
@@ -77,6 +56,7 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
   const { kueueStatusByNotebookName } = React.useContext(ProjectDetailsContext);
   const { notebook, isStarting, isRunning, isStopping, runningPodUid } = notebookState;
   const kueueStatus = kueueStatusByNotebookName[notebook.metadata.name] ?? null;
+  console.log('kueueStatus in NotebookStateStatus', kueueStatus);
   const [unstableNotebookStatus, events] = useNotebookStatus(
     isStarting,
     notebook,
@@ -114,9 +94,14 @@ const NotebookStateStatus: React.FC<NotebookStateStatusProps> = ({
         </FlexItem>
         {statusSubtitle != null ? (
           <UnderlinedTruncateButton
-            content={statusSubtitle}
-            color={getNotebookStatusColor(notebookStatus)}
-            textDecoration={getNotebookStatusTextDecoration(notebookStatus, isStarting)}
+            content={capitalize(statusSubtitle)}
+            color={
+              getStatusLineIconAndColor({
+                notebookStatus,
+                kueueStatus,
+                inProgress: isStarting || isStopping,
+              }).color
+            }
             onClick={() => setStartModalOpen(true)}
           />
         ) : null}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
closes 

1. [RHOAIENG-50647](https://issues.redhat.com/browse/RHOAIENG-50647)
2. [RHOAIENG-47112](https://issues.redhat.com/browse/RHOAIENG-47112) Content changes

changes based on UX comments on this PR [6250 - Kueue status](https://github.com/opendatahub-io/odh-dashboard/pull/6250)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
WIP : updating the description shortly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
