### PR TITLE
Update status labels

### DIFF
--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -203,7 +203,7 @@ export const mockWorkloadK8sResource = ({
   },
   status: {
     conditions: mockStatus
-      ? mockStatusEmptyWorkload
+      ? mockStatusEmptyWorkload && mockStatus === WorkloadStatusType.Complete
         ? mockWorkloadEmptySucceedCondition[WorkloadStatusType.Complete]
         : mockWorkloadStatusConditions[mockStatus]
       : [],

--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -76,7 +76,7 @@ const mockWorkloadStatusConditions: Record<WorkloadStatusType, WorkloadCondition
       type: 'Evicted',
     },
   ],
-  Succeeded: [
+  Complete: [
     {
       lastTransitionTime: '2024-03-18T19:15:28Z',
       message: 'Quota reserved in ClusterQueue cluster-queue',
@@ -124,9 +124,9 @@ const mockWorkloadStatusConditions: Record<WorkloadStatusType, WorkloadCondition
   ],
 };
 
-const mockWorkloadEmptySucceedCondition: Record<WorkloadStatusType.Succeeded, WorkloadCondition[]> =
+const mockWorkloadEmptySucceedCondition: Record<WorkloadStatusType.Complete, WorkloadCondition[]> =
   {
-    [WorkloadStatusType.Succeeded]: [
+    [WorkloadStatusType.Complete]: [
       {
         lastTransitionTime: '2024-03-18T19:15:28Z',
         message: 'Quota reserved in ClusterQueue cluster-queue',
@@ -164,7 +164,7 @@ export const mockWorkloadK8sResource = ({
   namespace = 'test-project',
   ownerKind = WorkloadOwnerType.Job,
   ownerName,
-  mockStatus = WorkloadStatusType.Succeeded,
+  mockStatus = WorkloadStatusType.Complete,
   podSets = [],
   mockStatusEmptyWorkload = false,
 }: MockResourceConfigType): WorkloadKind => ({
@@ -204,7 +204,7 @@ export const mockWorkloadK8sResource = ({
   status: {
     conditions: mockStatus
       ? mockStatusEmptyWorkload
-        ? mockWorkloadEmptySucceedCondition[WorkloadStatusType.Succeeded]
+        ? mockWorkloadEmptySucceedCondition[WorkloadStatusType.Complete]
         : mockWorkloadStatusConditions[mockStatus]
       : [],
   },

--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -124,7 +124,7 @@ const mockWorkloadStatusConditions: Record<WorkloadStatusType, WorkloadCondition
   ],
 };
 
-const mockWorkloadEmptySucceedCondition: Record<WorkloadStatusType.Complete, WorkloadCondition[]> =
+const mockWorkloadEmptyCompleteCondition: Record<WorkloadStatusType.Complete, WorkloadCondition[]> =
   {
     [WorkloadStatusType.Complete]: [
       {
@@ -204,7 +204,7 @@ export const mockWorkloadK8sResource = ({
   status: {
     conditions: mockStatus
       ? mockStatusEmptyWorkload && mockStatus === WorkloadStatusType.Complete
-        ? mockWorkloadEmptySucceedCondition[WorkloadStatusType.Complete]
+        ? mockWorkloadEmptyCompleteCondition[WorkloadStatusType.Complete]
         : mockWorkloadStatusConditions[mockStatus]
       : [],
   },

--- a/frontend/src/components/DocCardBadges.tsx
+++ b/frontend/src/components/DocCardBadges.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Label, LabelGroup, Tooltip } from '@patternfly/react-core';
-import { SyncAltIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { InProgressIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { QuickStartContext, QuickStartContextValues } from '@patternfly/quickstarts';
 import { OdhDocument, OdhDocumentType } from '#~/types';
 import { getQuickStartCompletionStatus, CompletionStatusEnum } from '#~/utilities/quickStartUtils';
@@ -45,17 +45,17 @@ const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
         </Label>
       ) : null}
       {completionStatus === CompletionStatusEnum.InProgress ? (
-        <Label variant="outline" color="purple" icon={<SyncAltIcon />}>
+        <Label variant="outline" color="blue" icon={<InProgressIcon />}>
           In Progress
         </Label>
       ) : null}
       {completionStatus === CompletionStatusEnum.Success ? (
-        <Label variant="outline" color="green" icon={<CheckCircleIcon />}>
+        <Label variant="outline" status="success" icon={<CheckCircleIcon />}>
           Complete
         </Label>
       ) : null}
       {completionStatus === CompletionStatusEnum.Failed ? (
-        <Label variant="outline" color="red" icon={<ExclamationCircleIcon />}>
+        <Label variant="outline" status="danger" icon={<ExclamationCircleIcon />}>
           Failed
         </Label>
       ) : null}

--- a/frontend/src/components/DocCardBadges.tsx
+++ b/frontend/src/components/DocCardBadges.tsx
@@ -45,7 +45,7 @@ const DocCardBadges: React.FC<DocCardBadgesProps> = ({ odhDoc }) => {
         </Label>
       ) : null}
       {completionStatus === CompletionStatusEnum.InProgress ? (
-        <Label variant="outline" color="blue" icon={<InProgressIcon />}>
+        <Label variant="outline" status="info" icon={<InProgressIcon />}>
           In Progress
         </Label>
       ) : null}

--- a/frontend/src/components/OdhExploreCardTypeBadge.tsx
+++ b/frontend/src/components/OdhExploreCardTypeBadge.tsx
@@ -28,7 +28,7 @@ const OdhExploreCardTypeBadge: React.FC<OdhExploreCardTypeBadgeProps> = ({
 
   return (
     <Tooltip content={content}>
-      <Label className={isDisabled ? 'pf-m-disabled' : undefined} tabIndex={0} variant="outline">
+      <Label className={isDisabled ? 'pf-m-disabled' : undefined} tabIndex={0}>
         {category}
       </Label>
     </Tooltip>

--- a/frontend/src/components/__tests__/DocCardBadges.spec.tsx
+++ b/frontend/src/components/__tests__/DocCardBadges.spec.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QuickStartContext } from '@patternfly/quickstarts';
+import { OdhDocument, OdhDocumentType } from '#~/types';
+import { CompletionStatusEnum } from '#~/utilities/quickStartUtils';
+import DocCardBadges from '#~/components/DocCardBadges';
+
+jest.mock('#~/utilities/quickStartUtils', () => ({
+  ...jest.requireActual('#~/utilities/quickStartUtils'),
+  getQuickStartCompletionStatus: jest.fn(),
+}));
+
+const mockGetQuickStartCompletionStatus = jest.mocked(
+  jest.requireMock<typeof import('#~/utilities/quickStartUtils')>('#~/utilities/quickStartUtils')
+    .getQuickStartCompletionStatus,
+);
+
+const createDoc = (
+  type: OdhDocumentType = OdhDocumentType.Documentation,
+  name = 'test-doc',
+  durationMinutes?: number,
+): OdhDocument =>
+  ({
+    metadata: { name },
+    spec: {
+      type,
+      displayName: 'Test Doc',
+      description: 'desc',
+      durationMinutes,
+    },
+  } as unknown as OdhDocument);
+
+const renderWithContext = (odhDoc: OdhDocument) => {
+  const contextValue = {
+    allQuickStarts: [{ metadata: { name: odhDoc.metadata.name }, spec: { tasks: [] }, status: {} }],
+    activeQuickStartID: '',
+    allQuickStartStates: {},
+    setActiveQuickStart: jest.fn(),
+    restartQuickStart: jest.fn(),
+    setQuickStartTaskNumber: jest.fn(),
+    setQuickStartTaskStatus: jest.fn(),
+    setAllQuickStartStates: jest.fn(),
+    getQuickStartForId: jest.fn(),
+  };
+
+  return render(
+    <QuickStartContext.Provider value={contextValue as never}>
+      <DocCardBadges odhDoc={odhDoc} />
+    </QuickStartContext.Provider>,
+  );
+};
+
+describe('DocCardBadges', () => {
+  beforeEach(() => {
+    mockGetQuickStartCompletionStatus.mockReturnValue(undefined);
+  });
+
+  it('should render documentation type label', () => {
+    renderWithContext(createDoc(OdhDocumentType.Documentation));
+    expect(screen.getByText('Documentation')).toBeInTheDocument();
+  });
+
+  it('should render duration label when duration is provided', () => {
+    renderWithContext(createDoc(OdhDocumentType.Documentation, 'doc', 15));
+    expect(screen.getByText('15 minutes')).toBeInTheDocument();
+  });
+
+  it('should render "In Progress" label with info status for in-progress quickstart', () => {
+    mockGetQuickStartCompletionStatus.mockReturnValue(CompletionStatusEnum.InProgress);
+    renderWithContext(createDoc(OdhDocumentType.QuickStart, 'qs-in-progress'));
+    const inProgressLabel = screen.getByText('In Progress').closest('.pf-v6-c-label');
+    expect(inProgressLabel).toHaveClass('pf-m-info');
+    expect(inProgressLabel).toHaveClass('pf-m-outline');
+  });
+
+  it('should render "Complete" label with success status for completed quickstart', () => {
+    mockGetQuickStartCompletionStatus.mockReturnValue(CompletionStatusEnum.Success);
+    renderWithContext(createDoc(OdhDocumentType.QuickStart, 'qs-complete'));
+    const completeLabel = screen.getByText('Complete').closest('.pf-v6-c-label');
+    expect(completeLabel).toHaveClass('pf-m-success');
+    expect(completeLabel).toHaveClass('pf-m-outline');
+  });
+
+  it('should render "Failed" label with danger status for failed quickstart', () => {
+    mockGetQuickStartCompletionStatus.mockReturnValue(CompletionStatusEnum.Failed);
+    renderWithContext(createDoc(OdhDocumentType.QuickStart, 'qs-failed'));
+    const failedLabel = screen.getByText('Failed').closest('.pf-v6-c-label');
+    expect(failedLabel).toHaveClass('pf-m-danger');
+    expect(failedLabel).toHaveClass('pf-m-outline');
+  });
+});

--- a/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
+++ b/frontend/src/concepts/__tests__/StartNotebookModal.spec.tsx
@@ -122,7 +122,7 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusRunning');
+    expect(header).toHaveTextContent('Workbench statusReady');
 
     // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');
@@ -147,7 +147,7 @@ describe('Start Notebook modal', () => {
 
     // Validate the header contents
     const header = screen.getByTestId('notebook-status-modal-header');
-    expect(header).toHaveTextContent('Workbench statusRunning');
+    expect(header).toHaveTextContent('Workbench statusReady');
 
     // Validate the steps
     const stepper = screen.getByTestId('notebook-startup-steps');

--- a/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/distributedWorkloads/__tests__/utils.spec.ts
@@ -33,7 +33,7 @@ describe('getStatusInfo', () => {
     testWorkloadStatus(WorkloadStatusType.Admitted, 'The workload is admitted');
     testWorkloadStatus(WorkloadStatusType.Running, 'The workload is running');
     testWorkloadStatus(WorkloadStatusType.Evicted, 'The workload is evicted');
-    testWorkloadStatus(WorkloadStatusType.Succeeded, 'Job finished successfully');
+    testWorkloadStatus(WorkloadStatusType.Complete, 'Job finished successfully');
     testWorkloadStatus(WorkloadStatusType.Failed, 'There was an error');
     testWorkloadStatus(null, 'No message'); // Falls back to Pending with no conditions
   });
@@ -41,15 +41,15 @@ describe('getStatusInfo', () => {
   it('provides correct info for completed workload', () => {
     const wl = mockWorkloadK8sResource({ k8sName: 'test-workload' });
     const info = getStatusInfo(wl);
-    expect(info.color).toBe('green');
+    expect(info.labelStatus).toBe('success');
     expect(info.message).toBe('Job finished successfully');
-    expect(info.status).toBe('Succeeded');
+    expect(info.status).toBe('Complete');
   });
   it('should return "Finished" when status is Succeeded and message is "No message"', () => {
     const wl = mockWorkloadK8sResource({
       k8sName: 'test-workload',
       mockStatusEmptyWorkload: true,
-      mockStatus: WorkloadStatusType.Succeeded,
+      mockStatus: WorkloadStatusType.Complete,
     });
     const info = getStatusInfo(wl);
     expect(getWorkloadStatusMessage(info)).toEqual('Finished');
@@ -61,7 +61,7 @@ describe('getStatusCounts', () => {
     const workloads = [
       mockWorkloadK8sResource({
         k8sName: 'test-workload',
-        mockStatus: WorkloadStatusType.Succeeded,
+        mockStatus: WorkloadStatusType.Complete,
       }),
       mockWorkloadK8sResource({
         k8sName: 'test-workload-2',
@@ -100,7 +100,7 @@ describe('getStatusCounts', () => {
       Pending: 2,
       Running: 2,
       Evicted: 1,
-      Succeeded: 1,
+      Complete: 1,
       Failed: 1,
     });
   });

--- a/frontend/src/concepts/distributedWorkloads/utils.tsx
+++ b/frontend/src/concepts/distributedWorkloads/utils.tsx
@@ -6,8 +6,7 @@ import {
   InProgressIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
-  UploadIcon,
-  BanIcon,
+  CheckIcon,
 } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 import {
@@ -42,7 +41,7 @@ export enum WorkloadStatusType {
   Admitted = 'Admitted',
   Running = 'Running',
   Evicted = 'Evicted',
-  Succeeded = 'Succeeded',
+  Complete = 'Complete',
   Failed = 'Failed',
 }
 
@@ -55,29 +54,30 @@ export type TopWorkloadUsageType = {
 export type WorkloadStatusInfo = {
   status: WorkloadStatusType;
   message: string;
-  color: LabelProps['color'];
+  color?: LabelProps['color'];
+  labelStatus?: LabelProps['status'];
   chartColor: string;
   icon: React.ComponentClass<SVGIconProps>;
 };
 
 export const WorkloadStatusColorAndIcon: Record<
   WorkloadStatusType,
-  Pick<WorkloadStatusInfo, 'color' | 'chartColor' | 'icon'>
+  Pick<WorkloadStatusInfo, 'color' | 'labelStatus' | 'chartColor' | 'icon'>
 > = {
   Pending: {
-    color: 'teal',
+    color: 'purple',
     chartColor: chartColorCyan.value,
     icon: PendingIcon,
   },
   Inadmissible: {
-    color: 'orangered',
+    labelStatus: 'warning',
     chartColor: chartColorGold.value,
     icon: ExclamationTriangleIcon,
   },
   Admitted: {
-    color: 'purple',
+    color: 'grey',
     chartColor: chartColorPurple.value,
-    icon: UploadIcon,
+    icon: CheckIcon,
   },
   Running: {
     color: 'blue',
@@ -85,17 +85,17 @@ export const WorkloadStatusColorAndIcon: Record<
     icon: InProgressIcon,
   },
   Evicted: {
-    color: 'grey',
+    labelStatus: 'warning',
     chartColor: chartColorBlack.value,
-    icon: BanIcon,
+    icon: ExclamationTriangleIcon,
   },
-  Succeeded: {
-    color: 'green',
+  Complete: {
+    labelStatus: 'success',
     chartColor: chartColorGreen.value,
     icon: CheckCircleIcon,
   },
   Failed: {
-    color: 'red',
+    labelStatus: 'danger',
     chartColor: chartColorRed.value,
     icon: ExclamationCircleIcon,
   },
@@ -106,7 +106,7 @@ export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo => {
   // Order matters here: The first matching condition in this order will be used for the current status.
   const statusesInEvalOrder: WorkloadStatusType[] = [
     WorkloadStatusType.Failed,
-    WorkloadStatusType.Succeeded,
+    WorkloadStatusType.Complete,
     WorkloadStatusType.Evicted,
     WorkloadStatusType.Inadmissible,
     WorkloadStatusType.Pending,
@@ -120,7 +120,7 @@ export const getStatusInfo = (wl: WorkloadKind): WorkloadStatusInfo => {
         type === 'Finished' &&
         /error|failed|rejected/.test(`${message} ${reason}`.toLowerCase()),
     ),
-    Succeeded: conditions?.find(
+    Complete: conditions?.find(
       ({ type, status, message, reason }) =>
         status === 'True' &&
         type === 'Finished' &&
@@ -154,7 +154,7 @@ export const getStatusCounts = (workloads: WorkloadKind[]): WorkloadStatusCounts
     Admitted: 0,
     Running: 0,
     Evicted: 0,
-    Succeeded: 0,
+    Complete: 0,
     Failed: 0,
   };
   workloads.forEach((wl) => {
@@ -271,7 +271,7 @@ export const getWorkloadStatusMessage = (statusInfo: WorkloadStatusInfo): string
   const DEFAULT_MESSAGE = 'No message';
   const SUCCESS_MESSAGE = 'Finished';
   const isSuccessWithNoMessage =
-    statusInfo.status === WorkloadStatusType.Succeeded && statusInfo.message === DEFAULT_MESSAGE;
+    statusInfo.status === WorkloadStatusType.Complete && statusInfo.message === DEFAULT_MESSAGE;
 
   return isSuccessWithNoMessage ? SUCCESS_MESSAGE : statusInfo.message;
 };

--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -334,21 +334,18 @@ describe('getKueueStatusInfo', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Failed);
     expect(info.label).toBe('Failed');
     expect(info.status).toBe('danger');
-    expect(info.color).toBe('red');
   });
 
   it('should return correct info for Preempted', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Preempted);
     expect(info.label).toBe('Preempted');
     expect(info.status).toBe('warning');
-    expect(info.color).toBe('orange');
   });
 
   it('should return correct info for Inadmissible', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Inadmissible);
     expect(info.label).toBe('Inadmissible');
     expect(info.status).toBe('warning');
-    expect(info.color).toBe('orange');
   });
 
   it('should return correct info for Running', () => {
@@ -368,7 +365,6 @@ describe('getKueueStatusInfo', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Succeeded);
     expect(info.label).toBe('Complete');
     expect(info.status).toBe('success');
-    expect(info.color).toBe('green');
   });
 
   it('should return default for unknown status', () => {

--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -94,7 +94,7 @@ describe('getKueueWorkloadStatusWithMessage', () => {
     expect(result.status).toBe(KueueWorkloadStatus.Preempted);
   });
 
-  it('should return Succeeded when Finished with success reason', () => {
+  it('should return Complete when Finished with success reason', () => {
     const workload = workloadWithConditions([
       {
         type: 'Finished',
@@ -105,10 +105,10 @@ describe('getKueueWorkloadStatusWithMessage', () => {
       },
     ]);
     const result = getKueueWorkloadStatusWithMessage(workload);
-    expect(result.status).toBe(KueueWorkloadStatus.Succeeded);
+    expect(result.status).toBe(KueueWorkloadStatus.Complete);
   });
 
-  it('should return Succeeded when Finished with reason that matches neither failure nor success (fallback)', () => {
+  it('should return Complete when Finished with reason that matches neither failure nor success (fallback)', () => {
     const workload = workloadWithConditions([
       {
         type: 'Finished',
@@ -119,10 +119,10 @@ describe('getKueueWorkloadStatusWithMessage', () => {
       },
     ]);
     const result = getKueueWorkloadStatusWithMessage(workload);
-    expect(result.status).toBe(KueueWorkloadStatus.Succeeded);
+    expect(result.status).toBe(KueueWorkloadStatus.Complete);
   });
 
-  it('should return Succeeded when Finished with JobFinished reason (fallback)', () => {
+  it('should return Complete when Finished with JobFinished reason (fallback)', () => {
     const workload = workloadWithConditions([
       {
         type: 'Finished',
@@ -133,7 +133,7 @@ describe('getKueueWorkloadStatusWithMessage', () => {
       },
     ]);
     const result = getKueueWorkloadStatusWithMessage(workload);
-    expect(result.status).toBe(KueueWorkloadStatus.Succeeded);
+    expect(result.status).toBe(KueueWorkloadStatus.Complete);
   });
 
   it('should return Failed when Finished with timeout in message', () => {
@@ -182,7 +182,7 @@ describe('getKueueWorkloadStatusWithMessage', () => {
       },
     ]);
     const result = getKueueWorkloadStatusWithMessage(workload);
-    expect(result.status).toBe(KueueWorkloadStatus.Succeeded);
+    expect(result.status).toBe(KueueWorkloadStatus.Complete);
     expect(result.message).toContain('successfully');
   });
 
@@ -361,8 +361,8 @@ describe('getKueueStatusInfo', () => {
     expect(info.iconClassName).toBe('odh-u-spin');
   });
 
-  it('should return correct info for Succeeded', () => {
-    const info = getKueueStatusInfo(KueueWorkloadStatus.Succeeded);
+  it('should return correct info for Complete', () => {
+    const info = getKueueStatusInfo(KueueWorkloadStatus.Complete);
     expect(info.label).toBe('Complete');
     expect(info.status).toBe('success');
   });

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -134,15 +134,15 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
     case KueueWorkloadStatus.Preempted:
       return {
         label: 'Preempted',
-        color: 'orange',
         status: 'warning',
+        color: 'orange',
         IconComponent: ExclamationTriangleIcon,
       };
     case KueueWorkloadStatus.Inadmissible:
       return {
         label: 'Inadmissible',
-        color: 'orange',
         status: 'warning',
+        color: 'orange',
         IconComponent: ExclamationTriangleIcon,
       };
     case KueueWorkloadStatus.Running:

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -103,7 +103,7 @@ export const getKueueWorkloadStatusWithMessage = (
     { condition: Inadmissible, status: KueueWorkloadStatus.Inadmissible },
     { condition: Evicted, status: KueueWorkloadStatus.Preempted },
     { condition: Preempted, status: KueueWorkloadStatus.Preempted },
-    { condition: Succeeded, status: KueueWorkloadStatus.Succeeded },
+    { condition: Succeeded, status: KueueWorkloadStatus.Complete },
     { condition: Running, status: KueueWorkloadStatus.Running },
     { condition: Admitted, status: KueueWorkloadStatus.Admitted },
     { condition: Pending, status: KueueWorkloadStatus.Queued },
@@ -151,7 +151,7 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
         IconComponent: InProgressIcon,
         iconClassName: 'odh-u-spin',
       };
-    case KueueWorkloadStatus.Succeeded:
+    case KueueWorkloadStatus.Complete:
       return {
         label: 'Complete',
         status: 'success',

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -128,21 +128,18 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
       return {
         label: 'Failed',
         status: 'danger',
-        color: 'red',
         IconComponent: ExclamationCircleIcon,
       };
     case KueueWorkloadStatus.Preempted:
       return {
         label: 'Preempted',
         status: 'warning',
-        color: 'orange',
         IconComponent: ExclamationTriangleIcon,
       };
     case KueueWorkloadStatus.Inadmissible:
       return {
         label: 'Inadmissible',
         status: 'warning',
-        color: 'orange',
         IconComponent: ExclamationTriangleIcon,
       };
     case KueueWorkloadStatus.Running:
@@ -158,7 +155,6 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
       return {
         label: 'Complete',
         status: 'success',
-        color: 'green',
         IconComponent: CheckCircleIcon,
       };
     default:

--- a/frontend/src/concepts/kueue/types.ts
+++ b/frontend/src/concepts/kueue/types.ts
@@ -8,7 +8,7 @@ export enum KueueWorkloadStatus {
   Inadmissible = 'Inadmissible',
   Running = 'Running',
   Admitted = 'Admitted',
-  Succeeded = 'Succeeded',
+  Complete = 'Complete',
 }
 
 export type KueueWorkloadStatusWithMessage = {
@@ -35,5 +35,5 @@ export const KUEUE_STATUSES_OVERRIDE_WORKBENCH: KueueWorkloadStatus[] = [
   KueueWorkloadStatus.Inadmissible,
   KueueWorkloadStatus.Failed,
   KueueWorkloadStatus.Preempted,
-  KueueWorkloadStatus.Succeeded,
+  KueueWorkloadStatus.Complete,
 ];

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -82,6 +82,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
           label: 'Starting',
           color: 'blue',
           icon: <InProgressIcon className="odh-u-spin" />,
+          message: 'Model deployment is starting.',
         };
       case ModelDeploymentState.FAILED_TO_LOAD:
         return {

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import { Icon, Label, LabelProps, Popover } from '@patternfly/react-core';
 import {
+  CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
   OffIcon,
   OutlinedQuestionCircleIcon,
-  PlayIcon,
-  SyncAltIcon,
 } from '@patternfly/react-icons';
 import { ModelDeploymentState } from '#~/pages/modelServing/screens/types';
 import { ToggleState } from '#~/components/StateActionToggle';
 
 type ModelStatusIconProps = {
   state: ModelDeploymentState;
-  defaultHeaderContent?: string;
   bodyContent?: string;
   isCompact?: boolean;
   onClick?: LabelProps['onClick'];
@@ -23,7 +21,6 @@ type ModelStatusIconProps = {
 
 export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   state,
-  defaultHeaderContent = 'Status',
   bodyContent = '',
   isCompact,
   onClick,
@@ -43,7 +40,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Stopped',
         color: 'grey',
         icon: <OffIcon />,
-        message: 'Offline and not using resources. To use the model, restart it.',
+        message:
+          'The model deployment is intentionally inactive and is not using any compute resources (scaled to zero pods). It is not serving requests, but its configuration is preserved. A "Starting" process is required to make it "Ready" again.',
       };
     }
 
@@ -51,8 +49,9 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       return {
         label: 'Stopping',
         color: 'grey',
-        icon: <SyncAltIcon className="odh-u-spin" />,
-        message: 'Model deployment is stopping.',
+        icon: <InProgressIcon className="odh-u-spin" />,
+        message:
+          'The system is in the process of shutting down the model deployment. This can be triggered by a user request to stop the model, an update to the deployment, or an automated scale-down-to-zero process to conserve resources when the model is not in use.',
       };
     }
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
@@ -65,7 +64,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Starting',
         color: 'blue',
         icon: <InProgressIcon className="odh-u-spin" />,
-        message: 'Model deployment is starting.',
+        message:
+          "The system is in the process of deploying the model. This state includes all the startup tasks, such as provisioning resources (like pods), pulling the model's container image, loading the model into memory, and running initial health checks.",
       };
     }
 
@@ -74,25 +74,32 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       case ModelDeploymentState.LOADED:
       case ModelDeploymentState.STANDBY:
         return {
-          label: 'Started',
+          label: 'Ready',
           status: 'success',
-          icon: <PlayIcon />,
-          message: 'Model deployment is active.',
+          icon: <CheckCircleIcon />,
+          message:
+            'The model deployment is fully operational and healthy. It has successfully started, passed all its health checks, and is actively able to receive and respond to inference requests.',
         };
       case ModelDeploymentState.FAILED_TO_LOAD:
         return {
           label: 'Failed',
           status: 'danger',
           icon: <ExclamationCircleIcon />,
+          message:
+            "The deployment encountered a critical error and cannot run. This could be due to various reasons, such as a missing model file, an error in the model's code, insufficient resources (like memory or GPU), or a persistent container crash (CrashLoopBackOff). The deployment will not serve requests until the underlying issue is fixed.",
         };
       case ModelDeploymentState.UNKNOWN:
         return {
-          label: defaultHeaderContent || 'Status',
+          label: 'Unknown',
           color: 'grey',
           icon: <OutlinedQuestionCircleIcon />,
+          message:
+            "The system cannot determine the current state of the model deployment. This often occurs when the controlling components lose communication with the model's pods or during the initial moments of startup before a 'Starting' or 'Ready' status can be established. It can also indicate an underlying problem with the cluster or networking.",
         };
     }
-  }, [state, defaultHeaderContent, stoppedStates]);
+  }, [state, stoppedStates]);
+
+  const resolvedBodyContent = bodyContent.trim() || statusSettings.message;
 
   return (
     <Popover
@@ -100,8 +107,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       className="odh-u-scrollable"
       position="top"
       headerContent={statusSettings.label}
-      bodyContent={statusSettings.message || bodyContent}
-      isVisible={bodyContent ? undefined : false}
+      bodyContent={resolvedBodyContent}
+      isVisible={resolvedBodyContent ? undefined : false}
     >
       {hideLabel ? (
         <Icon

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -71,12 +71,17 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
     // Only check the state if not stopped
     switch (state) {
       case ModelDeploymentState.LOADED:
-      case ModelDeploymentState.STANDBY:
         return {
           label: 'Ready',
           status: 'success',
           icon: <CheckCircleIcon />,
           message: 'Model deployment is active.',
+        };
+      case ModelDeploymentState.STANDBY:
+        return {
+          label: 'Starting',
+          color: 'blue',
+          icon: <InProgressIcon className="odh-u-spin" />,
         };
       case ModelDeploymentState.FAILED_TO_LOAD:
         return {

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -12,6 +12,7 @@ import { ToggleState } from '#~/components/StateActionToggle';
 
 type ModelStatusIconProps = {
   state: ModelDeploymentState;
+  defaultHeaderContent?: string;
   bodyContent?: string;
   isCompact?: boolean;
   onClick?: LabelProps['onClick'];
@@ -21,6 +22,7 @@ type ModelStatusIconProps = {
 
 export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
   state,
+  defaultHeaderContent = 'Status',
   bodyContent = '',
   isCompact,
   onClick,
@@ -40,8 +42,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Stopped',
         color: 'grey',
         icon: <OffIcon />,
-        message:
-          'The model deployment is intentionally inactive and is not using any compute resources (scaled to zero pods). It is not serving requests, but its configuration is preserved. A "Starting" process is required to make it "Ready" again.',
+        message: 'Offline and not using resources. To use the model, restart it.',
       };
     }
 
@@ -50,8 +51,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Stopping',
         color: 'grey',
         icon: <InProgressIcon className="odh-u-spin" />,
-        message:
-          'The system is in the process of shutting down the model deployment. This can be triggered by a user request to stop the model, an update to the deployment, or an automated scale-down-to-zero process to conserve resources when the model is not in use.',
+        message: 'Model deployment is stopping.',
       };
     }
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.
@@ -64,8 +64,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Starting',
         color: 'blue',
         icon: <InProgressIcon className="odh-u-spin" />,
-        message:
-          "The system is in the process of deploying the model. This state includes all the startup tasks, such as provisioning resources (like pods), pulling the model's container image, loading the model into memory, and running initial health checks.",
+        message: 'Model deployment is starting.',
       };
     }
 
@@ -77,29 +76,22 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
           label: 'Ready',
           status: 'success',
           icon: <CheckCircleIcon />,
-          message:
-            'The model deployment is fully operational and healthy. It has successfully started, passed all its health checks, and is actively able to receive and respond to inference requests.',
+          message: 'Model deployment is active.',
         };
       case ModelDeploymentState.FAILED_TO_LOAD:
         return {
           label: 'Failed',
           status: 'danger',
           icon: <ExclamationCircleIcon />,
-          message:
-            "The deployment encountered a critical error and cannot run. This could be due to various reasons, such as a missing model file, an error in the model's code, insufficient resources (like memory or GPU), or a persistent container crash (CrashLoopBackOff). The deployment will not serve requests until the underlying issue is fixed.",
         };
       case ModelDeploymentState.UNKNOWN:
         return {
-          label: 'Unknown',
+          label: defaultHeaderContent || 'Status',
           color: 'grey',
           icon: <OutlinedQuestionCircleIcon />,
-          message:
-            "The system cannot determine the current state of the model deployment. This often occurs when the controlling components lose communication with the model's pods or during the initial moments of startup before a 'Starting' or 'Ready' status can be established. It can also indicate an underlying problem with the cluster or networking.",
         };
     }
-  }, [state, stoppedStates]);
-
-  const resolvedBodyContent = bodyContent.trim() || statusSettings.message;
+  }, [state, defaultHeaderContent, stoppedStates]);
 
   return (
     <Popover
@@ -107,8 +99,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       className="odh-u-scrollable"
       position="top"
       headerContent={statusSettings.label}
-      bodyContent={resolvedBodyContent}
-      isVisible={resolvedBodyContent ? undefined : false}
+      bodyContent={statusSettings.message || bodyContent}
+      isVisible={bodyContent ? undefined : false}
     >
       {hideLabel ? (
         <Icon

--- a/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
+++ b/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
@@ -89,6 +89,7 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
 
   return (
     <Label
+      variant={onClick ? 'filled' : 'outline'}
       isCompact={isCompact}
       color={labelSettings.color}
       status={labelSettings.status}

--- a/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
+++ b/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { Label, LabelProps } from '@patternfly/react-core';
 import {
+  CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
   OffIcon,
-  PlayIcon,
-  SyncAltIcon,
 } from '@patternfly/react-icons';
 import { EventStatus, NotebookStatus } from '#~/types';
 import { getKueueStatusInfo } from '#~/concepts/kueue';
@@ -44,14 +43,18 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
 
   const labelSettings = React.useMemo<StatusLabelSettings>(() => {
     if (isError) {
-      return { label: 'Failed', status: 'danger', icon: <ExclamationCircleIcon /> };
+      return {
+        label: 'Failed',
+        status: 'danger',
+        icon: <ExclamationCircleIcon />,
+      };
     }
 
     if (isStopping) {
       return {
         label: 'Stopping',
         color: 'grey',
-        icon: <SyncAltIcon className="odh-u-spin" />,
+        icon: <InProgressIcon className="odh-u-spin" />,
       };
     }
     if (kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_WORKBENCH.includes(kueueStatus.status)) {
@@ -71,9 +74,17 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
       };
     }
     if (isRunning) {
-      return { label: 'Running', status: 'success', icon: <PlayIcon /> };
+      return {
+        label: 'Ready',
+        status: 'success',
+        icon: <CheckCircleIcon />,
+      };
     }
-    return { label: 'Stopped', color: 'grey', icon: <OffIcon /> };
+    return {
+      label: 'Stopped',
+      color: 'grey',
+      icon: <OffIcon />,
+    };
   }, [kueueStatus, isError, isRunning, isStarting, isStopping]);
 
   return (

--- a/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
+++ b/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
@@ -103,11 +103,11 @@ describe('NotebookStatusLabel', () => {
     expect(getStatusLabel()).toBe('Complete');
   });
 
-  it('should show Running when isRunning and no kueue override', () => {
+  it('should show Ready when isRunning and no kueue override', () => {
     render(
       <NotebookStatusLabel isStarting={false} isStopping={false} isRunning kueueStatus={null} />,
     );
-    expect(getStatusLabel()).toBe('Running');
+    expect(getStatusLabel()).toBe('Ready');
   });
 
   it('should show Stopped when not starting, stopping, or running and no kueue status', () => {

--- a/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
+++ b/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
@@ -67,13 +67,13 @@ describe('NotebookStatusLabel', () => {
     expect(getStatusLabel()).toBe('Stopping');
   });
 
-  it('should show Stopping when isStopping even if kueueStatus is Succeeded', () => {
+  it('should show Stopping when isStopping even if kueueStatus is Complete', () => {
     render(
       <NotebookStatusLabel
         isStarting={false}
         isStopping
         isRunning={false}
-        kueueStatus={{ status: KueueWorkloadStatus.Succeeded }}
+        kueueStatus={{ status: KueueWorkloadStatus.Complete }}
       />,
     );
     expect(getStatusLabel()).toBe('Stopping');
@@ -97,7 +97,7 @@ describe('NotebookStatusLabel', () => {
         isStarting={false}
         isStopping={false}
         isRunning={false}
-        kueueStatus={{ status: KueueWorkloadStatus.Succeeded }}
+        kueueStatus={{ status: KueueWorkloadStatus.Complete }}
       />,
     );
     expect(getStatusLabel()).toBe('Complete');

--- a/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
+++ b/frontend/src/concepts/notebooks/__tests__/NotebookStatusLabel.spec.tsx
@@ -5,9 +5,10 @@ import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 import NotebookStatusLabel from '#~/concepts/notebooks/NotebookStatusLabel';
 
 const getStatusLabel = () => screen.getByTestId('notebook-status-text').textContent;
+const getStatusLabelElement = () => screen.getByTestId('notebook-status-text');
 
 describe('NotebookStatusLabel', () => {
-  it('should show Failed when notebook has error status', () => {
+  it('should show Failed with danger status when notebook has error status', () => {
     render(
       <NotebookStatusLabel
         isStarting={false}
@@ -22,6 +23,7 @@ describe('NotebookStatusLabel', () => {
       />,
     );
     expect(getStatusLabel()).toBe('Failed');
+    expect(getStatusLabelElement()).toHaveClass('pf-m-danger');
   });
 
   it('should show Queued when isStarting and kueueStatus is Queued (kueue status takes precedence)', () => {
@@ -36,11 +38,12 @@ describe('NotebookStatusLabel', () => {
     expect(getStatusLabel()).toBe('Queued');
   });
 
-  it('should show Starting when isStarting and kueueStatus is null', () => {
+  it('should show Starting with blue color when isStarting and kueueStatus is null', () => {
     render(
       <NotebookStatusLabel isStarting isStopping={false} isRunning={false} kueueStatus={null} />,
     );
     expect(getStatusLabel()).toBe('Starting');
+    expect(getStatusLabelElement()).toHaveClass('pf-m-blue');
   });
 
   it('should show Starting when isStarting and kueueStatus is Running (Running not in override list)', () => {
@@ -65,6 +68,8 @@ describe('NotebookStatusLabel', () => {
       />,
     );
     expect(getStatusLabel()).toBe('Stopping');
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-success');
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-danger');
   });
 
   it('should show Stopping when isStopping even if kueueStatus is Complete', () => {
@@ -91,7 +96,7 @@ describe('NotebookStatusLabel', () => {
     expect(getStatusLabel()).toBe('Queued');
   });
 
-  it('should show Complete when not starting or stopping and kueueStatus is Succeeded', () => {
+  it('should show Complete with success status when kueueStatus is Complete', () => {
     render(
       <NotebookStatusLabel
         isStarting={false}
@@ -101,16 +106,18 @@ describe('NotebookStatusLabel', () => {
       />,
     );
     expect(getStatusLabel()).toBe('Complete');
+    expect(getStatusLabelElement()).toHaveClass('pf-m-success');
   });
 
-  it('should show Ready when isRunning and no kueue override', () => {
+  it('should show Ready with success status when isRunning and no kueue override', () => {
     render(
       <NotebookStatusLabel isStarting={false} isStopping={false} isRunning kueueStatus={null} />,
     );
     expect(getStatusLabel()).toBe('Ready');
+    expect(getStatusLabelElement()).toHaveClass('pf-m-success');
   });
 
-  it('should show Stopped when not starting, stopping, or running and no kueue status', () => {
+  it('should show Stopped with no semantic status when not starting, stopping, or running', () => {
     render(
       <NotebookStatusLabel
         isStarting={false}
@@ -120,5 +127,28 @@ describe('NotebookStatusLabel', () => {
       />,
     );
     expect(getStatusLabel()).toBe('Stopped');
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-success');
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-danger');
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-info');
+  });
+
+  it('should use outline variant when onClick is not provided', () => {
+    render(
+      <NotebookStatusLabel isStarting={false} isStopping={false} isRunning kueueStatus={null} />,
+    );
+    expect(getStatusLabelElement()).toHaveClass('pf-m-outline');
+  });
+
+  it('should use filled variant when onClick is provided', () => {
+    render(
+      <NotebookStatusLabel
+        isStarting={false}
+        isStopping={false}
+        isRunning
+        kueueStatus={null}
+        onClick={jest.fn()}
+      />,
+    );
+    expect(getStatusLabelElement()).not.toHaveClass('pf-m-outline');
   });
 });

--- a/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
@@ -34,7 +34,12 @@ const PipelineRunTypeLabel: React.FC<PipelineRunTypeLabelProps> = ({
     {isModelRegistered && (
       <>
         {' '}
-        <Label variant="outline" color="green" isCompact={isCompact} data-testid="model-registered-label">
+        <Label
+          variant="outline"
+          color="green"
+          isCompact={isCompact}
+          data-testid="model-registered-label"
+        >
           Model registered
         </Label>
       </>

--- a/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
@@ -34,7 +34,7 @@ const PipelineRunTypeLabel: React.FC<PipelineRunTypeLabelProps> = ({
     {isModelRegistered && (
       <>
         {' '}
-        <Label color="green" isCompact={isCompact} data-testid="model-registered-label">
+        <Label variant="outline" color="green" isCompact={isCompact} data-testid="model-registered-label">
           Model registered
         </Label>
       </>

--- a/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineRunTypeLabel.tsx
@@ -36,7 +36,7 @@ const PipelineRunTypeLabel: React.FC<PipelineRunTypeLabelProps> = ({
         {' '}
         <Label
           variant="outline"
-          color="green"
+          status="success"
           isCompact={isCompact}
           data-testid="model-registered-label"
         >

--- a/frontend/src/concepts/pipelines/content/__tests__/PipelineDetailsTitle.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/PipelineDetailsTitle.spec.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  PipelineRunKF,
+  StorageStateKF,
+  RuntimeStateKF,
+  runtimeStateLabels,
+} from '#~/concepts/pipelines/kfTypes';
+import PipelineDetailsTitle from '#~/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle';
+
+const createRun = (overrides: Partial<PipelineRunKF> = {}): PipelineRunKF => ({
+  created_at: '2023-09-05T16:23:25Z',
+  storage_state: StorageStateKF.AVAILABLE,
+  finished_at: '2023-09-05T16:24:34Z',
+  run_id: 'test-run-id',
+  display_name: 'test-run',
+  scheduled_at: '1970-01-01T00:00:00Z',
+  service_account: 'pipeline-runner',
+  state: RuntimeStateKF.SUCCEEDED,
+  experiment_id: 'experiment-id',
+  pipeline_version_reference: {
+    pipeline_id: 'pipeline-id',
+    pipeline_version_id: 'version-id',
+  },
+  runtime_config: { parameters: {}, pipeline_root: '' },
+  run_details: { pipeline_context_id: '', pipeline_run_context_id: '', task_details: [] },
+  recurring_run_id: '',
+  state_history: [],
+  ...overrides,
+});
+
+describe('PipelineDetailsTitle', () => {
+  it('should render the run display name', () => {
+    render(<PipelineDetailsTitle run={createRun({ display_name: 'My Pipeline Run' })} />);
+    expect(screen.getByText('My Pipeline Run')).toBeInTheDocument();
+  });
+
+  it('should render status icon with success status for succeeded run', () => {
+    render(
+      <PipelineDetailsTitle run={createRun({ state: RuntimeStateKF.SUCCEEDED })} statusIcon />,
+    );
+    const statusLabel = screen.getByTestId('status-icon');
+    expect(statusLabel).toHaveTextContent(runtimeStateLabels[RuntimeStateKF.SUCCEEDED]);
+    expect(statusLabel).toHaveClass('pf-m-success');
+    expect(statusLabel).toHaveClass('pf-m-outline');
+  });
+
+  it('should render status icon with danger status for failed run', () => {
+    render(<PipelineDetailsTitle run={createRun({ state: RuntimeStateKF.FAILED })} statusIcon />);
+    const statusLabel = screen.getByTestId('status-icon');
+    expect(statusLabel).toHaveTextContent(runtimeStateLabels[RuntimeStateKF.FAILED]);
+    expect(statusLabel).toHaveClass('pf-m-danger');
+  });
+
+  it('should render "Model registered" label with success status when isRegistered is true', () => {
+    render(<PipelineDetailsTitle run={createRun()} isRegistered />);
+    const modelLabels = screen.getAllByText('Model registered');
+    const modelLabel = modelLabels[0].closest('.pf-v6-c-label');
+    expect(modelLabel).toHaveClass('pf-m-success');
+    expect(modelLabel).toHaveClass('pf-m-outline');
+  });
+
+  it('should not render "Model registered" label when isRegistered is false', () => {
+    render(<PipelineDetailsTitle run={createRun()} />);
+    expect(screen.queryByText('Model registered')).not.toBeInTheDocument();
+  });
+
+  it('should render "Archived" label when run is archived', () => {
+    render(<PipelineDetailsTitle run={createRun({ storage_state: StorageStateKF.ARCHIVED })} />);
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
+  it('should not render status icon when statusIcon is false', () => {
+    render(<PipelineDetailsTitle run={createRun()} />);
+    expect(screen.queryByTestId('status-icon')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/concepts/pipelines/content/__tests__/PipelineRunTypeLabel.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/PipelineRunTypeLabel.spec.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  PipelineRunKF,
+  PipelineRecurringRunKF,
+  StorageStateKF,
+  RuntimeStateKF,
+} from '#~/concepts/pipelines/kfTypes';
+import PipelineRunTypeLabel from '#~/concepts/pipelines/content/PipelineRunTypeLabel';
+
+const baseRun: PipelineRunKF = {
+  created_at: '2023-09-05T16:23:25Z',
+  storage_state: StorageStateKF.AVAILABLE,
+  finished_at: '2023-09-05T16:24:34Z',
+  run_id: 'test-run-id',
+  display_name: 'test-run',
+  scheduled_at: '1970-01-01T00:00:00Z',
+  service_account: 'pipeline-runner',
+  state: RuntimeStateKF.SUCCEEDED,
+  experiment_id: 'experiment-id',
+  pipeline_version_reference: {
+    pipeline_id: 'pipeline-id',
+    pipeline_version_id: 'version-id',
+  },
+  runtime_config: { parameters: {}, pipeline_root: '' },
+  run_details: { pipeline_context_id: '', pipeline_run_context_id: '', task_details: [] },
+  recurring_run_id: '',
+  state_history: [],
+};
+
+const recurringRun: PipelineRecurringRunKF = {
+  ...baseRun,
+  recurring_run_id: 'recurring-run-id',
+} as unknown as PipelineRecurringRunKF;
+
+describe('PipelineRunTypeLabel', () => {
+  it('should render "One-off" label for a non-recurring run', () => {
+    render(<PipelineRunTypeLabel run={baseRun} />);
+    expect(screen.getByText('One-off')).toBeInTheDocument();
+  });
+
+  it('should render "Recurring" label for a recurring run', () => {
+    render(<PipelineRunTypeLabel run={recurringRun} />);
+    expect(screen.getByText('Recurring')).toBeInTheDocument();
+  });
+
+  it('should render "Model registered" label with success status when isModelRegistered is true', () => {
+    render(<PipelineRunTypeLabel run={baseRun} isModelRegistered />);
+    const modelLabel = screen.getByTestId('model-registered-label');
+    expect(modelLabel).toHaveTextContent('Model registered');
+    expect(modelLabel).toHaveClass('pf-m-success');
+    expect(modelLabel).toHaveClass('pf-m-outline');
+  });
+
+  it('should not render "Model registered" label when isModelRegistered is false', () => {
+    render(<PipelineRunTypeLabel run={baseRun} isModelRegistered={false} />);
+    expect(screen.queryByTestId('model-registered-label')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable camelcase*/
 import {
+  AngleDoubleRightIcon,
   BanIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
+  OutlinedQuestionCircleIcon,
+  PauseCircleIcon,
   PendingIcon,
-  QuestionCircleIcon,
 } from '@patternfly/react-icons';
 import React from 'react';
 import {
@@ -58,13 +60,12 @@ const createRun = (state: RuntimeStateKF | string): PipelineRunKF =>
 
 describe('computeRunStatus', () => {
   it('should check for run status when run status is undefined', () => {
-    const UNKNOWN_ICON = <QuestionCircleIcon />;
-    const UNKNOWN_STATUS = 'warning';
+    const UNKNOWN_ICON = <OutlinedQuestionCircleIcon />;
     const UNKNOWN_LABEL = '-';
     const runStatus = computeRunStatus(createRun('-'));
     expect(runStatus.label).toBe(UNKNOWN_LABEL);
     expect(runStatus.icon).toStrictEqual(UNKNOWN_ICON);
-    expect(runStatus.status).toBe(UNKNOWN_STATUS);
+    expect(runStatus.color).toBe('grey');
   });
 
   it('should check for Started run status', () => {
@@ -94,17 +95,49 @@ describe('computeRunStatus', () => {
     expect(runStatus.details).toBe(run.error?.message);
   });
 
+  it('should check for Skipped run status', () => {
+    const runStatus = computeRunStatus(createRun(RuntimeStateKF.SKIPPED));
+    expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.SKIPPED]);
+    expect(runStatus.icon).toStrictEqual(<AngleDoubleRightIcon />);
+    expect(runStatus.status).toBe('success');
+    expect(runStatus.labelStatus).toBe('success');
+  });
+
+  it('should check for Canceling run status', () => {
+    const runStatus = computeRunStatus(createRun(RuntimeStateKF.CANCELING));
+    expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.CANCELING]);
+    expect(runStatus.icon).toStrictEqual(<InProgressIcon />);
+    expect(runStatus.color).toBe('grey');
+  });
+
   it('should check for Canceled run status', () => {
     const runStatus = computeRunStatus(createRun(RuntimeStateKF.CANCELED));
     expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.CANCELED]);
     expect(runStatus.icon).toStrictEqual(<BanIcon />);
+    expect(runStatus.color).toBe('grey');
+  });
+
+  it('should check for Paused run status', () => {
+    const runStatus = computeRunStatus(createRun(RuntimeStateKF.PAUSED));
+    expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.PAUSED]);
+    expect(runStatus.icon).toStrictEqual(<PauseCircleIcon />);
+    expect(runStatus.color).toBe('grey');
+  });
+
+  it('should check for Pending run status color', () => {
+    const runStatus = computeRunStatus(createRun(RuntimeStateKF.PENDING));
+    expect(runStatus.color).toBe('purple');
+  });
+
+  it('should check for Running run status color', () => {
+    const runStatus = computeRunStatus(createRun(RuntimeStateKF.RUNNING));
+    expect(runStatus.color).toBe('blue');
   });
 
   it('should check for default run status', () => {
-    const UNKNOWN_ICON = <QuestionCircleIcon />;
-    const UNKNOWN_STATUS = 'warning';
+    const UNKNOWN_ICON = <OutlinedQuestionCircleIcon />;
     const runStatus = computeRunStatus(createRun('warning'));
-    expect(runStatus.status).toBe(UNKNOWN_STATUS);
+    expect(runStatus.color).toBe('grey');
     expect(runStatus.icon).toStrictEqual(UNKNOWN_ICON);
   });
 });

--- a/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/__tests__/utils.spec.tsx
@@ -85,6 +85,7 @@ describe('computeRunStatus', () => {
     expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.SUCCEEDED]);
     expect(runStatus.icon).toStrictEqual(<CheckCircleIcon />);
     expect(runStatus.status).toBe('success');
+    expect(runStatus.labelStatus).toBe('success');
   });
 
   it('should check for Failed run status', () => {
@@ -92,6 +93,7 @@ describe('computeRunStatus', () => {
     expect(runStatus.label).toBe(runtimeStateLabels[RuntimeStateKF.FAILED]);
     expect(runStatus.icon).toStrictEqual(<ExclamationCircleIcon />);
     expect(runStatus.status).toBe('danger');
+    expect(runStatus.labelStatus).toBe('danger');
     expect(runStatus.details).toBe(run.error?.message);
   });
 

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -48,7 +48,7 @@ const PipelineDetailsTitle: React.FC<RecurringRunTitleProps> = ({
         )}
         {isRegistered && (
           <SplitItem>
-            <Label variant="outline" color="green">
+            <Label variant="outline" status="success">
               Model registered
             </Label>
           </SplitItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -35,14 +35,22 @@ const PipelineDetailsTitle: React.FC<RecurringRunTitleProps> = ({
         )}
         {statusIcon && (
           <SplitItem>
-            <Label variant="outline" color={color} status={labelStatus} icon={icon} data-testid="status-icon">
+            <Label
+              variant="outline"
+              color={color}
+              status={labelStatus}
+              icon={icon}
+              data-testid="status-icon"
+            >
               {label}
             </Label>
           </SplitItem>
         )}
         {isRegistered && (
           <SplitItem>
-            <Label variant="outline" color="green">Model registered</Label>
+            <Label variant="outline" color="green">
+              Model registered
+            </Label>
           </SplitItem>
         )}
         {isArchived && (

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -17,7 +17,7 @@ const PipelineDetailsTitle: React.FC<RecurringRunTitleProps> = ({
   pipelineRunLabel,
   isRegistered,
 }) => {
-  const { icon, label, color } = computeRunStatus(run);
+  const { icon, label, color, labelStatus } = computeRunStatus(run);
 
   const isArchived = run.storage_state === StorageStateKF.ARCHIVED;
 
@@ -35,7 +35,7 @@ const PipelineDetailsTitle: React.FC<RecurringRunTitleProps> = ({
         )}
         {statusIcon && (
           <SplitItem>
-            <Label color={color} icon={icon} data-testid="status-icon">
+            <Label color={color} status={labelStatus} icon={icon} data-testid="status-icon">
               {label}
             </Label>
           </SplitItem>

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/PipelineDetailsTitle.tsx
@@ -35,19 +35,19 @@ const PipelineDetailsTitle: React.FC<RecurringRunTitleProps> = ({
         )}
         {statusIcon && (
           <SplitItem>
-            <Label color={color} status={labelStatus} icon={icon} data-testid="status-icon">
+            <Label variant="outline" color={color} status={labelStatus} icon={icon} data-testid="status-icon">
               {label}
             </Label>
           </SplitItem>
         )}
         {isRegistered && (
           <SplitItem>
-            <Label color="green">Model registered</Label>
+            <Label variant="outline" color="green">Model registered</Label>
           </SplitItem>
         )}
         {isArchived && (
           <SplitItem>
-            <Label>Archived</Label>
+            <Label variant="outline">Archived</Label>
           </SplitItem>
         )}
       </Split>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -38,7 +38,7 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
       </SplitItem>
       {isExperimentArchived && (
         <SplitItem>
-          <Label isCompact>Archived</Label>
+          <Label variant="outline" isCompact>Archived</Label>
         </SplitItem>
       )}
     </Split>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -38,7 +38,9 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
       </SplitItem>
       {isExperimentArchived && (
         <SplitItem>
-          <Label variant="outline" isCompact>Archived</Label>
+          <Label variant="outline" isCompact>
+            Archived
+          </Label>
         </SplitItem>
       )}
     </Split>

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -16,7 +16,6 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { printSeconds, relativeDuration, relativeTime } from '#~/utilities/time';
 import {
   PipelineRunKF,
-  runtimeStateLabels,
   PipelineRecurringRunKF,
   RecurringRunStatus as RecurringRunStatusType,
   ExperimentKF,
@@ -45,21 +44,22 @@ export const RunStatus: RunUtil<{ hasNoLabel?: boolean; isCompact?: boolean }> =
   const { icon, status, color, labelStatus, label, details, createdAt } = computeRunStatus(run);
   const tooltipContent: React.ReactNode = details;
 
-  if (hasNoLabel && !tooltipContent) {
+  if (hasNoLabel) {
     const iconContent = (
       <Icon isInline status={status}>
         {icon}
       </Icon>
     );
 
-    // If we are just an icon with no tooltip -- make it the status for ease of understanding
     return (
       <Tooltip
         content={
-          <Stack>
-            <StackItem>{`Status: ${runtimeStateLabels[run.state]}`}</StackItem>
-            <StackItem>{`Started: ${createdAt ?? ''}`}</StackItem>
-          </Stack>
+          tooltipContent || (
+            <Stack>
+              <StackItem>{`Status: ${label}`}</StackItem>
+              <StackItem>{`Started: ${createdAt ?? ''}`}</StackItem>
+            </Stack>
+          )
         }
       >
         {iconContent}

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -43,28 +43,41 @@ export const RunStatus: RunUtil<{ hasNoLabel?: boolean; isCompact?: boolean }> =
   run,
 }) => {
   const { icon, status, color, labelStatus, label, details, createdAt } = computeRunStatus(run);
-  let tooltipContent: React.ReactNode = details;
-  let content = (
-    <Label variant="outline" color={color} status={labelStatus} icon={icon} isCompact={isCompact}>
-      {label}
-    </Label>
-  );
+  const tooltipContent: React.ReactNode = details;
 
   if (hasNoLabel && !tooltipContent) {
-    content = (
+    const iconContent = (
       <Icon isInline status={status}>
         {icon}
       </Icon>
     );
 
     // If we are just an icon with no tooltip -- make it the status for ease of understanding
-    tooltipContent = (
-      <Stack>
-        <StackItem>{`Status: ${runtimeStateLabels[run.state]}`}</StackItem>
-        <StackItem>{`Started: ${createdAt ?? ''}`}</StackItem>
-      </Stack>
+    return (
+      <Tooltip
+        content={
+          <Stack>
+            <StackItem>{`Status: ${runtimeStateLabels[run.state]}`}</StackItem>
+            <StackItem>{`Started: ${createdAt ?? ''}`}</StackItem>
+          </Stack>
+        }
+      >
+        {iconContent}
+      </Tooltip>
     );
   }
+
+  const content = (
+    <Label
+      variant={tooltipContent ? 'filled' : 'outline'}
+      color={color}
+      status={labelStatus}
+      icon={icon}
+      isCompact={isCompact}
+    >
+      {label}
+    </Label>
+  );
 
   if (tooltipContent) {
     return <Tooltip content={tooltipContent}>{content}</Tooltip>;

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -45,7 +45,7 @@ export const RunStatus: RunUtil<{ hasNoLabel?: boolean; isCompact?: boolean }> =
   const { icon, status, color, labelStatus, label, details, createdAt } = computeRunStatus(run);
   let tooltipContent: React.ReactNode = details;
   let content = (
-    <Label color={color} status={labelStatus} icon={icon} isCompact={isCompact}>
+    <Label variant="outline" color={color} status={labelStatus} icon={icon} isCompact={isCompact}>
       {label}
     </Label>
   );

--- a/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/renderUtils.tsx
@@ -42,10 +42,10 @@ export const RunStatus: RunUtil<{ hasNoLabel?: boolean; isCompact?: boolean }> =
   isCompact = true,
   run,
 }) => {
-  const { icon, status, color, label, details, createdAt } = computeRunStatus(run);
+  const { icon, status, color, labelStatus, label, details, createdAt } = computeRunStatus(run);
   let tooltipContent: React.ReactNode = details;
   let content = (
-    <Label color={color} icon={icon} isCompact={isCompact}>
+    <Label color={color} status={labelStatus} icon={icon} isCompact={isCompact}>
       {label}
     </Label>
   );

--- a/frontend/src/concepts/pipelines/content/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/utils.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import {
+  AngleDoubleRightIcon,
   BanIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
+  OutlinedQuestionCircleIcon,
+  PauseCircleIcon,
   PendingIcon,
-  QuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { Icon, LabelProps } from '@patternfly/react-core';
 import {
@@ -30,12 +32,11 @@ export type RunStatusDetails = {
   createdAt?: string;
 };
 
-const UNKNOWN_ICON = <QuestionCircleIcon />;
-const UNKNOWN_STATUS = 'warning';
+const UNKNOWN_ICON = <OutlinedQuestionCircleIcon />;
 
 export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails => {
   if (!run) {
-    return { icon: UNKNOWN_ICON, status: UNKNOWN_STATUS, label: '-' };
+    return { icon: UNKNOWN_ICON, color: 'grey', label: '-' };
   }
   let icon: React.ReactNode;
   let status: React.ComponentProps<typeof Icon>['status'];
@@ -60,7 +61,9 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
       label = runtimeStateLabels[RuntimeStateKF.RUNNING];
       break;
     case RuntimeStateKF.SKIPPED:
-      icon = <CheckCircleIcon />;
+      icon = <AngleDoubleRightIcon />;
+      status = 'success';
+      labelStatus = 'success';
       label = runtimeStateLabels[RuntimeStateKF.SKIPPED];
       break;
     case RuntimeStateKF.SUCCEEDED:
@@ -87,13 +90,13 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
       label = runtimeStateLabels[RuntimeStateKF.CANCELED];
       break;
     case RuntimeStateKF.PAUSED:
-      icon = <BanIcon />;
+      icon = <PauseCircleIcon />;
       color = 'grey';
       label = runtimeStateLabels[RuntimeStateKF.PAUSED];
       break;
     default:
       icon = UNKNOWN_ICON;
-      status = UNKNOWN_STATUS;
+      color = 'grey';
       label = run.state;
       details = run.state;
   }

--- a/frontend/src/concepts/pipelines/content/utils.tsx
+++ b/frontend/src/concepts/pipelines/content/utils.tsx
@@ -6,7 +6,6 @@ import {
   InProgressIcon,
   PendingIcon,
   QuestionCircleIcon,
-  SyncAltIcon,
 } from '@patternfly/react-icons';
 import { Icon, LabelProps } from '@patternfly/react-core';
 import {
@@ -25,6 +24,7 @@ export type RunStatusDetails = {
   icon: React.ReactNode;
   label: PipelineRunKF['state'] | string;
   color?: LabelProps['color'];
+  labelStatus?: LabelProps['status'];
   status?: React.ComponentProps<typeof Icon>['status'];
   details?: string;
   createdAt?: string;
@@ -39,6 +39,7 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
   }
   let icon: React.ReactNode;
   let status: React.ComponentProps<typeof Icon>['status'];
+  let labelStatus: LabelProps['status'];
   let details: string | undefined;
   let label: string;
   let color: LabelProps['color'];
@@ -50,6 +51,7 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
     case RuntimeStateKF.RUNTIME_STATE_UNSPECIFIED:
     case undefined:
       icon = <PendingIcon />;
+      color = 'purple';
       label = runtimeStateLabels[RuntimeStateKF.PENDING];
       break;
     case RuntimeStateKF.RUNNING:
@@ -64,27 +66,29 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
     case RuntimeStateKF.SUCCEEDED:
       icon = <CheckCircleIcon />;
       status = 'success';
-      color = 'green';
+      labelStatus = 'success';
       label = runtimeStateLabels[RuntimeStateKF.SUCCEEDED];
       break;
     case RuntimeStateKF.FAILED:
       icon = <ExclamationCircleIcon />;
       status = 'danger';
-      color = 'red';
+      labelStatus = 'danger';
       label = runtimeStateLabels[RuntimeStateKF.FAILED];
       details = run.error?.message;
       break;
     case RuntimeStateKF.CANCELING:
-      icon = <SyncAltIcon />;
+      icon = <InProgressIcon />;
+      color = 'grey';
       label = runtimeStateLabels[RuntimeStateKF.CANCELING];
       break;
     case RuntimeStateKF.CANCELED:
       icon = <BanIcon />;
-      color = 'orangered';
+      color = 'grey';
       label = runtimeStateLabels[RuntimeStateKF.CANCELED];
       break;
     case RuntimeStateKF.PAUSED:
       icon = <BanIcon />;
+      color = 'grey';
       label = runtimeStateLabels[RuntimeStateKF.PAUSED];
       break;
     default:
@@ -94,7 +98,7 @@ export const computeRunStatus = (run?: PipelineRunKF | null): RunStatusDetails =
       details = run.state;
   }
 
-  return { icon, label, color, status, details, createdAt };
+  return { icon, label, color, labelStatus, status, details, createdAt };
 };
 
 export const getPipelineAndVersionDeleteString = (

--- a/frontend/src/concepts/pipelines/kfTypes.ts
+++ b/frontend/src/concepts/pipelines/kfTypes.ts
@@ -436,7 +436,7 @@ export const runtimeStateLabels = {
   [RuntimeStateKF.RUNTIME_STATE_UNSPECIFIED]: 'Unspecified',
   [RuntimeStateKF.PENDING]: 'Pending',
   [RuntimeStateKF.RUNNING]: 'Running',
-  [RuntimeStateKF.SUCCEEDED]: 'Succeeded',
+  [RuntimeStateKF.SUCCEEDED]: 'Complete',
   [RuntimeStateKF.SKIPPED]: 'Skipped',
   [RuntimeStateKF.FAILED]: 'Failed',
   [RuntimeStateKF.CANCELING]: 'Canceling',

--- a/frontend/src/concepts/topology/NodeStatusIcon.tsx
+++ b/frontend/src/concepts/topology/NodeStatusIcon.tsx
@@ -46,12 +46,11 @@ const NodeStatusIcon: React.FC<{ runStatus: RuntimeStateKF | string }> = ({ runS
       label = runtimeStateLabels[RuntimeStateKF.FAILED];
       break;
     case runtimeStateLabels[RuntimeStateKF.CANCELING]:
-      icon = <BanIcon />;
+      icon = <InProgressIcon />;
       label = runtimeStateLabels[RuntimeStateKF.CANCELING];
       break;
     case runtimeStateLabels[RuntimeStateKF.CANCELED]:
       icon = <BanIcon />;
-      status = 'warning';
       label = runtimeStateLabels[RuntimeStateKF.CANCELED];
       break;
     case runtimeStateLabels[RuntimeStateKF.PAUSED]:

--- a/frontend/src/concepts/topology/NodeStatusIcon.tsx
+++ b/frontend/src/concepts/topology/NodeStatusIcon.tsx
@@ -5,60 +5,48 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
-  OutlinedWindowRestoreIcon,
-  PauseCircleIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
+import { RunStatus } from '@patternfly/react-topology';
 import { Icon, Tooltip } from '@patternfly/react-core';
-import { RuntimeStateKF, runtimeStateLabels } from '#~/concepts/pipelines/kfTypes';
+import { runtimeStateLabels, RuntimeStateKF } from '#~/concepts/pipelines/kfTypes';
 
-const NodeStatusIcon: React.FC<{ runStatus: RuntimeStateKF | string }> = ({ runStatus }) => {
+const NodeStatusIcon: React.FC<{ runStatus: RunStatus | string }> = ({ runStatus }) => {
   let icon: React.ReactNode;
   let status: React.ComponentProps<typeof Icon>['status'];
   let label: string;
 
   switch (runStatus) {
-    case runtimeStateLabels[RuntimeStateKF.PENDING]:
-    case runtimeStateLabels[RuntimeStateKF.RUNTIME_STATE_UNSPECIFIED]:
+    case RunStatus.Pending:
+    case RunStatus.Idle:
       icon = <PendingIcon />;
       label = runtimeStateLabels[RuntimeStateKF.PENDING];
       break;
-    case runtimeStateLabels[RuntimeStateKF.RUNNING]:
+    case RunStatus.Running:
+    case RunStatus.InProgress:
       icon = <InProgressIcon />;
       status = 'info';
       label = runtimeStateLabels[RuntimeStateKF.RUNNING];
       break;
-    case runtimeStateLabels[RuntimeStateKF.CACHED]:
-      icon = <OutlinedWindowRestoreIcon />;
-      status = 'success';
-      label = runtimeStateLabels[RuntimeStateKF.CACHED];
-      break;
-    case runtimeStateLabels[RuntimeStateKF.SKIPPED]:
+    case RunStatus.Skipped:
       icon = <AngleDoubleRightIcon />;
       status = 'success';
       label = runtimeStateLabels[RuntimeStateKF.SKIPPED];
       break;
-    case runtimeStateLabels[RuntimeStateKF.SUCCEEDED]:
+    case RunStatus.Succeeded:
       icon = <CheckCircleIcon />;
       status = 'success';
       label = runtimeStateLabels[RuntimeStateKF.SUCCEEDED];
       break;
-    case runtimeStateLabels[RuntimeStateKF.FAILED]:
+    case RunStatus.Failed:
+    case RunStatus.FailedToStart:
       icon = <ExclamationCircleIcon />;
       status = 'danger';
       label = runtimeStateLabels[RuntimeStateKF.FAILED];
       break;
-    case runtimeStateLabels[RuntimeStateKF.CANCELING]:
-      icon = <InProgressIcon />;
-      label = runtimeStateLabels[RuntimeStateKF.CANCELING];
-      break;
-    case runtimeStateLabels[RuntimeStateKF.CANCELED]:
+    case RunStatus.Cancelled:
       icon = <BanIcon />;
       label = runtimeStateLabels[RuntimeStateKF.CANCELED];
-      break;
-    case runtimeStateLabels[RuntimeStateKF.PAUSED]:
-      icon = <PauseCircleIcon />;
-      label = runtimeStateLabels[RuntimeStateKF.PAUSED];
       break;
     case undefined:
     default:

--- a/frontend/src/concepts/topology/NodeStatusIcon.tsx
+++ b/frontend/src/concepts/topology/NodeStatusIcon.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {
+  AngleDoubleRightIcon,
+  BanIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
-  BanIcon,
   InProgressIcon,
   OutlinedWindowRestoreIcon,
+  PauseCircleIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
 import { Icon, Tooltip } from '@patternfly/react-core';
@@ -32,7 +34,8 @@ const NodeStatusIcon: React.FC<{ runStatus: RuntimeStateKF | string }> = ({ runS
       label = runtimeStateLabels[RuntimeStateKF.CACHED];
       break;
     case runtimeStateLabels[RuntimeStateKF.SKIPPED]:
-      icon = <CheckCircleIcon />;
+      icon = <AngleDoubleRightIcon />;
+      status = 'success';
       label = runtimeStateLabels[RuntimeStateKF.SKIPPED];
       break;
     case runtimeStateLabels[RuntimeStateKF.SUCCEEDED]:
@@ -54,7 +57,7 @@ const NodeStatusIcon: React.FC<{ runStatus: RuntimeStateKF | string }> = ({ runS
       label = runtimeStateLabels[RuntimeStateKF.CANCELED];
       break;
     case runtimeStateLabels[RuntimeStateKF.PAUSED]:
-      icon = <BanIcon />;
+      icon = <PauseCircleIcon />;
       label = runtimeStateLabels[RuntimeStateKF.PAUSED];
       break;
     case undefined:

--- a/frontend/src/concepts/topology/__tests__/NodeStatusIcon.spec.tsx
+++ b/frontend/src/concepts/topology/__tests__/NodeStatusIcon.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { RunStatus } from '@patternfly/react-topology';
+import NodeStatusIcon from '#~/concepts/topology/NodeStatusIcon';
+
+describe('NodeStatusIcon', () => {
+  it('should render icon for RunStatus.Pending', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Pending} />);
+    expect(container.querySelector('.pf-v6-c-icon')).toBeInTheDocument();
+  });
+
+  it('should render icon for RunStatus.Idle', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Idle} />);
+    expect(container.querySelector('.pf-v6-c-icon')).toBeInTheDocument();
+  });
+
+  it('should render with info status for RunStatus.Running', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Running} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-info');
+  });
+
+  it('should render with info status for RunStatus.InProgress', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.InProgress} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-info');
+  });
+
+  it('should render with success status for RunStatus.Skipped', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Skipped} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-success');
+  });
+
+  it('should render with success status for RunStatus.Succeeded', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Succeeded} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-success');
+  });
+
+  it('should render with danger status for RunStatus.Failed', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Failed} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-danger');
+  });
+
+  it('should render with danger status for RunStatus.FailedToStart', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.FailedToStart} />);
+    expect(container.querySelector('.pf-v6-c-icon__content')).toHaveClass('pf-m-danger');
+  });
+
+  it('should render with no status modifier for RunStatus.Cancelled', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Cancelled} />);
+    const content = container.querySelector('.pf-v6-c-icon__content');
+    expect(content).not.toHaveClass('pf-m-info');
+    expect(content).not.toHaveClass('pf-m-success');
+    expect(content).not.toHaveClass('pf-m-danger');
+  });
+
+  it('should render with no status modifier for RunStatus.Pending', () => {
+    const { container } = render(<NodeStatusIcon runStatus={RunStatus.Pending} />);
+    const content = container.querySelector('.pf-v6-c-icon__content');
+    expect(content).not.toHaveClass('pf-m-info');
+    expect(content).not.toHaveClass('pf-m-success');
+    expect(content).not.toHaveClass('pf-m-danger');
+  });
+
+  it('should render with no status modifier for unknown status', () => {
+    const { container } = render(<NodeStatusIcon runStatus="unknown-status" />);
+    const content = container.querySelector('.pf-v6-c-icon__content');
+    expect(content).not.toHaveClass('pf-m-info');
+    expect(content).not.toHaveClass('pf-m-success');
+    expect(content).not.toHaveClass('pf-m-danger');
+  });
+});

--- a/frontend/src/pages/BYONImages/BYONImageHardwareProfiles.tsx
+++ b/frontend/src/pages/BYONImages/BYONImageHardwareProfiles.tsx
@@ -69,7 +69,6 @@ const BYONImageHardwareProfiles: React.FC<BYONImageHardwareProfilesProps> = ({
           >
             <Label
               color="blue"
-              variant="outline"
               render={({ className, content }) => (
                 <Link
                   to={`/settings/environment-setup/workbench-images/hardware-profile/create?${new URLSearchParams(

--- a/frontend/src/pages/distributedWorkloads/components/WorkloadStatusLabel.tsx
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadStatusLabel.tsx
@@ -6,7 +6,7 @@ import { getStatusInfo } from '#~/concepts/distributedWorkloads/utils';
 export const WorkloadStatusLabel: React.FC<{ workload: WorkloadKind }> = ({ workload }) => {
   const statusInfo = getStatusInfo(workload);
   return (
-    <Label color={statusInfo.color} icon={<statusInfo.icon />}>
+    <Label color={statusInfo.color} status={statusInfo.labelStatus} icon={<statusInfo.icon />}>
       {statusInfo.status}
     </Label>
   );

--- a/frontend/src/pages/distributedWorkloads/components/WorkloadStatusLabel.tsx
+++ b/frontend/src/pages/distributedWorkloads/components/WorkloadStatusLabel.tsx
@@ -6,7 +6,12 @@ import { getStatusInfo } from '#~/concepts/distributedWorkloads/utils';
 export const WorkloadStatusLabel: React.FC<{ workload: WorkloadKind }> = ({ workload }) => {
   const statusInfo = getStatusInfo(workload);
   return (
-    <Label color={statusInfo.color} status={statusInfo.labelStatus} icon={<statusInfo.icon />}>
+    <Label
+      variant="outline"
+      color={statusInfo.color}
+      status={statusInfo.labelStatus}
+      icon={<statusInfo.icon />}
+    >
       {statusInfo.status}
     </Label>
   );

--- a/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
+++ b/frontend/src/pages/distributedWorkloads/global/projectMetrics/sections/TopResourceConsumingWorkloads.tsx
@@ -139,7 +139,7 @@ export const TopResourceConsumingWorkloads: React.FC = () => {
     !topWorkloadsByUsage.memoryBytesUsed.totalUsage
   ) {
     const workloadStatuses = [];
-    if (workloads.data.some((wl) => getStatusInfo(wl).status === WorkloadStatusType.Succeeded)) {
+    if (workloads.data.some((wl) => getStatusInfo(wl).status === WorkloadStatusType.Complete)) {
       workloadStatuses.push('completed');
     }
     if (workloads.data.some((wl) => getStatusInfo(wl).status === WorkloadStatusType.Failed)) {

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -19,9 +19,9 @@ enum ModelRegistryStatus {
 }
 
 enum ModelRegistryStatusLabel {
-  Progressing = 'Starting',
-  Available = 'Ready',
-  Degrading = 'Stopping',
+  Progressing = 'Progressing',
+  Available = 'Available',
+  Degrading = 'Degrading',
   Unavailable = 'Unavailable',
 }
 
@@ -43,7 +43,6 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     }, {}) ?? {};
   let statusLabel: string = ModelRegistryStatusLabel.Progressing;
   let icon = <InProgressIcon />;
-  let color: React.ComponentProps<typeof Label>['color'] = 'blue';
   let status: React.ComponentProps<typeof Label>['status'];
   let popoverMessages: string[] = [];
   let popoverTitle = '';
@@ -72,27 +71,25 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     ) {
       statusLabel = ModelRegistryStatusLabel.Unavailable;
       icon = <ExclamationTriangleIcon />;
-      color = undefined;
       status = 'warning';
     }
     // Degrading
     else if (degradedCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Degrading;
       icon = <InProgressIcon className="odh-u-spin" />;
-      color = 'grey';
       popoverTitle = 'Service is degrading';
     }
     // Available
     else if (availableCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Available;
       icon = <CheckCircleIcon />;
-      color = undefined;
       status = 'success';
     }
     // Progressing
     else if (progressCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Progressing;
       icon = <InProgressIcon className="odh-u-spin" />;
+      status = 'info';
     }
   }
   // Handle popover logic for Unavailable status
@@ -135,7 +132,6 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
         : {})}
       data-testid="model-registry-label"
       icon={icon}
-      color={color}
       status={status}
       isCompact
     >

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -19,9 +19,9 @@ enum ModelRegistryStatus {
 }
 
 enum ModelRegistryStatusLabel {
-  Progressing = 'Progressing',
-  Available = 'Available',
-  Degrading = 'Degrading',
+  Progressing = 'Starting',
+  Available = 'Ready',
+  Degrading = 'Stopping',
   Unavailable = 'Unavailable',
 }
 
@@ -43,6 +43,7 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     }, {}) ?? {};
   let statusLabel: string = ModelRegistryStatusLabel.Progressing;
   let icon = <InProgressIcon />;
+  let color: React.ComponentProps<typeof Label>['color'] = 'blue';
   let status: React.ComponentProps<typeof Label>['status'];
   let popoverMessages: string[] = [];
   let popoverTitle = '';
@@ -71,25 +72,27 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     ) {
       statusLabel = ModelRegistryStatusLabel.Unavailable;
       icon = <ExclamationTriangleIcon />;
+      color = undefined;
       status = 'warning';
     }
     // Degrading
     else if (degradedCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Degrading;
       icon = <InProgressIcon className="odh-u-spin" />;
+      color = 'grey';
       popoverTitle = 'Service is degrading';
     }
     // Available
     else if (availableCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Available;
       icon = <CheckCircleIcon />;
+      color = undefined;
       status = 'success';
     }
     // Progressing
     else if (progressCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Progressing;
       icon = <InProgressIcon className="odh-u-spin" />;
-      status = 'info';
     }
   }
   // Handle popover logic for Unavailable status
@@ -132,6 +135,7 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
         : {})}
       data-testid="model-registry-label"
       icon={icon}
+      color={color}
       status={status}
       isCompact
     >

--- a/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
+++ b/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
@@ -158,7 +158,7 @@ describe('ModelRegistryTableRowStatus', () => {
     ).toBeVisible();
   });
 
-  it('renders "Ready" status', () => {
+  it('renders "Available" status', () => {
     render(
       <ModelRegistryTableRowStatus
         conditions={[
@@ -167,9 +167,9 @@ describe('ModelRegistryTableRowStatus', () => {
         ]}
       />,
     );
-    expect(screen.getByText('Ready')).toBeVisible();
+    expect(screen.getByText('Available')).toBeVisible();
   });
-  it('renders "Starting" status when Degraded is True and Available is False', async () => {
+  it('renders "Progressing" status', async () => {
     const user = userEvent.setup();
 
     render(
@@ -198,7 +198,7 @@ describe('ModelRegistryTableRowStatus', () => {
     ).toBeVisible();
     expect(screen.getByText('Some unavailable message')).toBeVisible();
   });
-  it('renders "Stopping" status', async () => {
+  it('renders "Degrading" status', async () => {
     const user = userEvent.setup();
 
     render(
@@ -212,7 +212,7 @@ describe('ModelRegistryTableRowStatus', () => {
       />,
     );
 
-    const label = screen.getByText('Stopping');
+    const label = screen.getByText('Degrading');
     expect(label).toBeVisible();
 
     await user.click(label);
@@ -221,7 +221,7 @@ describe('ModelRegistryTableRowStatus', () => {
     expect(degradingText).toBeInTheDocument();
   });
 
-  it('renders "Starting" status when popover message contains "ContainerCreating"', async () => {
+  it('renders "Progressing" status when popover message contains "ContainerCreating"', async () => {
     render(
       <ModelRegistryTableRowStatus
         conditions={[
@@ -235,17 +235,17 @@ describe('ModelRegistryTableRowStatus', () => {
       />,
     );
 
-    expect(screen.getByText('Starting')).toBeVisible();
+    expect(screen.getByText('Progressing')).toBeVisible();
   });
 
-  it('renders "Starting" status when conditions are empty', () => {
+  it('renders "Progressing" status when conditions are empty', () => {
     render(<ModelRegistryTableRowStatus conditions={[]} />);
-    expect(screen.getByText('Starting')).toBeVisible();
+    expect(screen.getByText('Progressing')).toBeVisible();
   });
 
-  it('renders "Starting" status when conditions are undefined', () => {
+  it('renders "Progressing" status when conditions are undefined', () => {
     render(<ModelRegistryTableRowStatus conditions={undefined} />);
-    expect(screen.getByText('Starting')).toBeVisible();
+    expect(screen.getByText('Progressing')).toBeVisible();
   });
 
   it('renders "Unavailable" with multiple messages in popover', async () => {

--- a/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
+++ b/frontend/src/pages/modelRegistrySettings/__tests__/ModelRegistryTableRowStatus.spec.tsx
@@ -158,7 +158,7 @@ describe('ModelRegistryTableRowStatus', () => {
     ).toBeVisible();
   });
 
-  it('renders "Available" status', () => {
+  it('renders "Ready" status', () => {
     render(
       <ModelRegistryTableRowStatus
         conditions={[
@@ -167,9 +167,9 @@ describe('ModelRegistryTableRowStatus', () => {
         ]}
       />,
     );
-    expect(screen.getByText('Available')).toBeVisible();
+    expect(screen.getByText('Ready')).toBeVisible();
   });
-  it('renders "Progressing" status', async () => {
+  it('renders "Starting" status when Degraded is True and Available is False', async () => {
     const user = userEvent.setup();
 
     render(
@@ -198,7 +198,7 @@ describe('ModelRegistryTableRowStatus', () => {
     ).toBeVisible();
     expect(screen.getByText('Some unavailable message')).toBeVisible();
   });
-  it('renders "Degrading" status', async () => {
+  it('renders "Stopping" status', async () => {
     const user = userEvent.setup();
 
     render(
@@ -212,7 +212,7 @@ describe('ModelRegistryTableRowStatus', () => {
       />,
     );
 
-    const label = screen.getByText('Degrading');
+    const label = screen.getByText('Stopping');
     expect(label).toBeVisible();
 
     await user.click(label);
@@ -221,7 +221,7 @@ describe('ModelRegistryTableRowStatus', () => {
     expect(degradingText).toBeInTheDocument();
   });
 
-  it('renders "Progressing" status when popover message contains "ContainerCreating"', async () => {
+  it('renders "Starting" status when popover message contains "ContainerCreating"', async () => {
     render(
       <ModelRegistryTableRowStatus
         conditions={[
@@ -235,17 +235,17 @@ describe('ModelRegistryTableRowStatus', () => {
       />,
     );
 
-    expect(screen.getByText('Progressing')).toBeVisible();
+    expect(screen.getByText('Starting')).toBeVisible();
   });
 
-  it('renders "Progressing" status when conditions are empty', () => {
+  it('renders "Starting" status when conditions are empty', () => {
     render(<ModelRegistryTableRowStatus conditions={[]} />);
-    expect(screen.getByText('Progressing')).toBeVisible();
+    expect(screen.getByText('Starting')).toBeVisible();
   });
 
-  it('renders "Progressing" status when conditions are undefined', () => {
+  it('renders "Starting" status when conditions are undefined', () => {
     render(<ModelRegistryTableRowStatus conditions={undefined} />);
-    expect(screen.getByText('Progressing')).toBeVisible();
+    expect(screen.getByText('Starting')).toBeVisible();
   });
 
   it('renders "Unavailable" with multiple messages in popover', async () => {

--- a/frontend/src/pages/modelServing/screens/ServingRuntimeVersionStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/ServingRuntimeVersionStatus.tsx
@@ -54,7 +54,7 @@ const ServingRuntimeVersionStatus: React.FC<ServingRuntimeVersionStatusProps> = 
       >
         <Label
           data-testid="serving-runtime-version-status-label"
-          color={isOutdated ? 'yellow' : 'green'}
+          status={isOutdated ? 'warning' : 'success'}
           icon={isOutdated ? <ExclamationTriangleIcon /> : <CheckCircleIcon />}
           isCompact
         >

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -25,14 +25,7 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   const state = getInferenceServiceModelState(inferenceService, modelPodStatus);
   const bodyContent = getInferenceServiceStatusMessage(inferenceService, modelPodStatus);
 
-  return (
-    <ModelStatusIcon
-      state={state}
-      defaultHeaderContent="Inference Service Status"
-      bodyContent={bodyContent}
-      stoppedStates={stoppedStates}
-    />
-  );
+  return <ModelStatusIcon state={state} bodyContent={bodyContent} stoppedStates={stoppedStates} />;
 };
 
 export default InferenceServiceStatus;

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceStatus.tsx
@@ -25,7 +25,14 @@ const InferenceServiceStatus: React.FC<InferenceServiceStatusProps> = ({
   const state = getInferenceServiceModelState(inferenceService, modelPodStatus);
   const bodyContent = getInferenceServiceStatusMessage(inferenceService, modelPodStatus);
 
-  return <ModelStatusIcon state={state} bodyContent={bodyContent} stoppedStates={stoppedStates} />;
+  return (
+    <ModelStatusIcon
+      state={state}
+      defaultHeaderContent="Inference Service Status"
+      bodyContent={bodyContent}
+      stoppedStates={stoppedStates}
+    />
+  );
 };
 
 export default InferenceServiceStatus;

--- a/frontend/src/pages/pipelines/global/experiments/ExperimentPipelineRuns.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/ExperimentPipelineRuns.tsx
@@ -36,7 +36,7 @@ const ExperimentPipelineRuns: PipelineCoreDetailsPageComponent = ({ breadcrumbPa
           <BreadcrumbItem>
             <Truncate content={experiment?.display_name || 'Loading...'} />
           </BreadcrumbItem>
-          {isExperimentArchived && <Label>Archived</Label>}
+          {isExperimentArchived && <Label variant="outline">Archived</Label>}
         </PipelineContextBreadcrumb>
       }
     >

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetailsTitle.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetailsTitle.tsx
@@ -17,7 +17,9 @@ const ArtifactDetailsTitle: React.FC<ArtifactDetailsTitleProps> = ({
       </SplitItem>
       {isArtifactModelRegistered && (
         <SplitItem>
-          <Label variant="outline" color="green">Registered</Label>
+          <Label variant="outline" color="green">
+            Registered
+          </Label>
         </SplitItem>
       )}
     </Split>

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetailsTitle.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactDetails/ArtifactDetailsTitle.tsx
@@ -17,7 +17,7 @@ const ArtifactDetailsTitle: React.FC<ArtifactDetailsTitleProps> = ({
       </SplitItem>
       {isArtifactModelRegistered && (
         <SplitItem>
-          <Label color="green">Registered</Label>
+          <Label variant="outline" color="green">Registered</Label>
         </SplitItem>
       )}
     </Split>

--- a/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTableRow.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/artifacts/ArtifactsTableRow.tsx
@@ -31,7 +31,7 @@ const ArtifactsTableRow: React.FC<ArtifactsTableRowProps> = ({ artifact }) => {
           {isArtifactModelRegistered && (
             <>
               {' '}
-              <Label color="green" isCompact data-testid="model-registered-label">
+              <Label variant="outline" color="green" isCompact data-testid="model-registered-label">
                 Registered
               </Label>
             </>

--- a/frontend/src/pages/pipelines/global/experiments/executions/ExecutionStatus.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/ExecutionStatus.tsx
@@ -60,7 +60,7 @@ export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({ status, isComp
   }
 
   return (
-    <Label color={color} status={statusProp} icon={icon} isCompact={isCompact}>
+    <Label variant="outline" color={color} status={statusProp} icon={icon} isCompact={isCompact}>
       {label}
     </Label>
   );

--- a/frontend/src/pages/pipelines/global/experiments/executions/ExecutionStatus.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/executions/ExecutionStatus.tsx
@@ -6,8 +6,8 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
+  OutlinedQuestionCircleIcon,
   OutlinedWindowRestoreIcon,
-  PendingIcon,
 } from '@patternfly/react-icons';
 
 import { Execution } from '#~/third_party/mlmd';
@@ -19,27 +19,28 @@ type ExecutionStatusProps = {
 
 export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({ status, isCompact }) => {
   let color: LabelProps['color'];
+  let statusProp: LabelProps['status'];
   let icon: React.ReactNode;
   let label: string;
 
   switch (status) {
     case Execution.State.COMPLETE:
-      color = 'green';
+      statusProp = 'success';
       icon = <CheckCircleIcon />;
       label = 'Complete';
       break;
     case Execution.State.CACHED:
-      color = 'green';
+      statusProp = 'success';
       icon = <OutlinedWindowRestoreIcon />;
       label = 'Cached';
       break;
     case Execution.State.CANCELED:
-      color = 'orangered';
+      color = 'grey';
       icon = <BanIcon />;
       label = 'Canceled';
       break;
     case Execution.State.FAILED:
-      color = 'red';
+      statusProp = 'danger';
       icon = <ExclamationCircleIcon />;
       label = 'Failed';
       break;
@@ -49,15 +50,17 @@ export const ExecutionStatus: React.FC<ExecutionStatusProps> = ({ status, isComp
       label = 'Running';
       break;
     case Execution.State.NEW:
-      icon = <PendingIcon />;
-      label = 'Pending';
+      color = 'purple';
+      label = 'New';
       break;
     default:
+      color = 'grey';
+      icon = <OutlinedQuestionCircleIcon />;
       label = 'Unknown';
   }
 
   return (
-    <Label color={color} icon={icon} isCompact={isCompact}>
+    <Label color={color} status={statusProp} icon={icon} isCompact={isCompact}>
       {label}
     </Label>
   );

--- a/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/ClusterStorageTableRow.tsx
@@ -98,7 +98,7 @@ const ClusterStorageTableRow: React.FC<ClusterStorageTableRowProps> = ({
         ) : (
           <>
             {obj.notebookDisplayName ?? obj.name}{' '}
-            <Label isCompact color="green">
+            <Label isCompact variant="outline" status="success">
               Connected
             </Label>
           </>

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -114,9 +114,10 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
                   <Tooltip content="This storage class is deleted.">
                     <Label
                       data-testid="storage-class-deleted"
+                      variant="outline"
                       isCompact
                       icon={<ExclamationTriangleIcon />}
-                      color="yellow"
+                      status="warning"
                     >
                       Deleted
                     </Label>
@@ -129,9 +130,10 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
                     >
                       <Label
                         data-testid="storage-class-deprecated"
+                        variant="outline"
                         isCompact
                         icon={<ExclamationTriangleIcon />}
-                        color="yellow"
+                        status="warning"
                       >
                         Deprecated
                       </Label>

--- a/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/storage/StorageTableRow.tsx
@@ -114,7 +114,6 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
                   <Tooltip content="This storage class is deleted.">
                     <Label
                       data-testid="storage-class-deleted"
-                      variant="outline"
                       isCompact
                       icon={<ExclamationTriangleIcon />}
                       status="warning"
@@ -130,7 +129,6 @@ const StorageTableRow: React.FC<StorageTableRowProps> = ({
                     >
                       <Label
                         data-testid="storage-class-deprecated"
-                        variant="outline"
                         isCompact
                         icon={<ExclamationTriangleIcon />}
                         status="warning"

--- a/frontend/src/pages/projects/screens/spawner/imageSelector/ImageVersionSelector.tsx
+++ b/frontend/src/pages/projects/screens/spawner/imageSelector/ImageVersionSelector.tsx
@@ -75,7 +75,8 @@ const ImageVersionSelector: React.FC<ImageVersionSelectorProps> = ({
                 <Label
                   data-testid="notebook-image-availability"
                   isCompact
-                  color="green"
+                  variant="outline"
+                  status="success"
                   icon={<CheckCircleIcon />}
                 >
                   Latest

--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
@@ -63,7 +63,7 @@ const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({ run, namespace 
     </Td>
     <Td dataLabel={automlRunsColumns[3].label}>
       {run.state ? (
-        <Label isCompact {...getStatusLabelProps(run.state)}>
+        <Label variant="outline" isCompact {...getStatusLabelProps(run.state)}>
           {run.state}
         </Label>
       ) : (

--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
@@ -34,14 +34,15 @@ export const getStatusLabelProps = (
     return { status: 'danger' };
   }
   if (s === RUN_STATE.RUNNING || s.includes(RUN_STATE.RUNNING)) {
-    return { status: 'info' };
+    return { color: 'blue' };
   }
-  if (
-    s === RUN_STATE.INCOMPLETE ||
-    s === RUN_STATE.PENDING ||
-    s === RUN_STATE.PAUSED ||
-    s.includes(RUN_STATE.PENDING)
-  ) {
+  if (s === RUN_STATE.PENDING || s.includes(RUN_STATE.PENDING)) {
+    return { color: 'purple' };
+  }
+  if (s === RUN_STATE.SKIPPED || s.includes(RUN_STATE.SKIPPED)) {
+    return { status: 'success' };
+  }
+  if (s === RUN_STATE.INCOMPLETE) {
     return { status: 'warning' };
   }
   return { color: 'grey' };

--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/__tests__/AutomlRunsTableRow.spec.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/__tests__/AutomlRunsTableRow.spec.tsx
@@ -32,18 +32,18 @@ describe('getStatusLabelProps', () => {
     expect(getStatusLabelProps('CUSTOM_FAILED')).toEqual({ status: 'danger' });
   });
 
-  it('should return info status for RUNNING', () => {
-    expect(getStatusLabelProps('RUNNING')).toEqual({ status: 'info' });
-    expect(getStatusLabelProps('running')).toEqual({ status: 'info' });
+  it('should return blue color for RUNNING', () => {
+    expect(getStatusLabelProps('RUNNING')).toEqual({ color: 'blue' });
+    expect(getStatusLabelProps('running')).toEqual({ color: 'blue' });
   });
 
-  it('should return info status when state includes running', () => {
-    expect(getStatusLabelProps('STILL_RUNNING')).toEqual({ status: 'info' });
+  it('should return blue color when state includes running', () => {
+    expect(getStatusLabelProps('STILL_RUNNING')).toEqual({ color: 'blue' });
   });
 
-  it('should return warning status for PENDING', () => {
-    expect(getStatusLabelProps('PENDING')).toEqual({ status: 'warning' });
-    expect(getStatusLabelProps('pending')).toEqual({ status: 'warning' });
+  it('should return purple color for PENDING', () => {
+    expect(getStatusLabelProps('PENDING')).toEqual({ color: 'purple' });
+    expect(getStatusLabelProps('pending')).toEqual({ color: 'purple' });
   });
 
   it('should return warning status for INCOMPLETE', () => {
@@ -51,16 +51,17 @@ describe('getStatusLabelProps', () => {
     expect(getStatusLabelProps('incomplete')).toEqual({ status: 'warning' });
   });
 
-  it('should return warning status when state includes pending', () => {
-    expect(getStatusLabelProps('AWAITING_PENDING')).toEqual({ status: 'warning' });
+  it('should return purple color when state includes pending', () => {
+    expect(getStatusLabelProps('AWAITING_PENDING')).toEqual({ color: 'purple' });
   });
 
-  it('should return warning status for PAUSED', () => {
-    expect(getStatusLabelProps('PAUSED')).toEqual({ status: 'warning' });
+  it('should return grey color for PAUSED', () => {
+    expect(getStatusLabelProps('PAUSED')).toEqual({ color: 'grey' });
   });
 
-  it('should return grey color for SKIPPED', () => {
-    expect(getStatusLabelProps('SKIPPED')).toEqual({ color: 'grey' });
+  it('should return success status for SKIPPED', () => {
+    expect(getStatusLabelProps('SKIPPED')).toEqual({ status: 'success' });
+    expect(getStatusLabelProps('skipped')).toEqual({ status: 'success' });
   });
 
   it('should return grey color for CANCELLED', () => {

--- a/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
+++ b/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
@@ -57,7 +57,7 @@ const AutoragRunsTableRow: React.FC<AutoragRunsTableRowProps> = ({ run, namespac
     </Td>
     <Td dataLabel={autoragRunsColumns[3].label}>
       {run.state ? (
-        <Label isCompact {...getStatusLabelProps(run.state)}>
+        <Label variant="outline" isCompact {...getStatusLabelProps(run.state)}>
           {run.state}
         </Label>
       ) : (

--- a/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
+++ b/packages/autorag/frontend/src/app/components/AutoragRunsTable/AutoragRunsTableRow.tsx
@@ -33,9 +33,12 @@ const getStatusLabelProps = (
     return { status: 'danger' };
   }
   if (s === RUN_STATE.RUNNING || s.includes(RUN_STATE.RUNNING)) {
-    return { status: 'info' };
+    return { color: 'blue' };
   }
-  if (s === RUN_STATE.INCOMPLETE || s === RUN_STATE.PENDING || s.includes(RUN_STATE.PENDING)) {
+  if (s === RUN_STATE.PENDING || s.includes(RUN_STATE.PENDING)) {
+    return { color: 'purple' };
+  }
+  if (s === RUN_STATE.INCOMPLETE) {
     return { status: 'warning' };
   }
   return { color: 'grey' };

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testDeployLLMDServing.cy.ts
@@ -172,7 +172,7 @@ describe('A user can deploy an LLMD model', () => {
 
       cy.step('Verify the model Row');
       const llmdRow = modelServingGlobal.getDeploymentRow(modelName);
-      llmdRow.findStatusLabel(ModelStateLabel.STARTED).should('exist');
+      llmdRow.findStatusLabel(ModelStateLabel.READY).should('exist');
       llmdRow.findServingRuntime().should('have.text', servingRuntime);
       llmdRow.findKebab().click();
       inferenceServiceActions.findDeleteInferenceServiceAction().click();
@@ -219,7 +219,7 @@ describe('A user can deploy an LLMD model', () => {
       checkLLMInferenceServiceState(yamlEditorModelName, projectName, { checkReady: true });
 
       cy.step('Verify the model Row');
-      llmdRow.findStatusLabel(ModelStateLabel.STARTED).should('exist');
+      llmdRow.findStatusLabel(ModelStateLabel.READY).should('exist');
       llmdRow.findKebab().click();
       inferenceServiceActions.findEditInferenceServiceAction().click();
       modelServingWizard.findYAMLEditFallbackAlert().should('exist');

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/models/testSingleModelAdminCreation.cy.ts
@@ -195,7 +195,7 @@ describe('Verify Admin Single Model Creation and Validation using the UI', () =>
       kServeRow
         .findStatusLabel()
         .invoke('text')
-        .should('match', new RegExp(`${ModelStateLabel.STARTING}|${ModelStateLabel.STARTED}`));
+        .should('match', new RegExp(`${ModelStateLabel.STARTING}|${ModelStateLabel.READY}`));
 
       //Verify external access still works after restart
       cy.step('Verify the model is still accessible externally after restart');

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchControlSuite.cy.ts
@@ -103,7 +103,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(controlSuiteTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use the dynamic image name verification based on what was actually selected
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -118,7 +118,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
             // Restart workbench and confirm initiation
             cy.step('Restart workbench and validate it starts successfully');
             notebookRow.findNotebookStopToggle().click();
-            notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+            notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
             // Delete workbench
             cy.step('Delete workbench and confirm deleteion');
@@ -188,7 +188,7 @@ describe('Start, Stop, Launch and Delete a Workbench in RHOAI', () => {
           // Start the Workbench and validate it has started successfully
           cy.step('Restart the workbench and confirm the workbench has started successfully');
           workbenchStatusModal.findStartWorkbenchFooterButton().click();
-          workbenchStatusModal.getNotebookStatus(NotebookStatusLabel.Running, 120000);
+          workbenchStatusModal.getNotebookStatus(NotebookStatusLabel.Ready, 120000);
         },
       );
     },

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchCreation.cy.ts
@@ -115,7 +115,7 @@ describe('Create, Delete and Edit - Workbench Tests', () => {
           // Wait for workbench to run
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use dynamic image name verification based on what was actually selected
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueue.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchKueue.cy.ts
@@ -87,7 +87,7 @@ describe('Workbench Kueue Integration Tests', () => {
 
       cy.step('Wait for workbench to reach Running status');
       const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 300000);
+      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 300000);
 
       cy.step('Verify Kueue Workload CR exists and is admitted');
       verifyWorkloadAdmitted(projectName);

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStatus.cy.ts
@@ -89,7 +89,7 @@ describe('Workbenches - status tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(projectDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use dynamic image name verification based on what was actually selected
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -100,7 +100,7 @@ describe('Workbenches - status tests', () => {
               'Click on Running status, validate the Running status and navigate to the Progress tab',
             );
             notebookRow.findHaveNotebookStatusText().click();
-            workbenchStatusModal.getNotebookStatus(NotebookStatusLabel.Running);
+            workbenchStatusModal.getNotebookStatus(NotebookStatusLabel.Ready);
 
             // Click on the Events log and validate that successful list messages display.
             cy.step('Navigate to Events Tab and verify successful event messages are displayed');

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -97,7 +97,7 @@ describe('Workbenches - variable tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use dynamic image name verification for first workbench
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -136,7 +136,7 @@ describe('Workbenches - variable tests', () => {
                 cy.step(`Wait for workbench ${workbenchName2} to display a "Running" status`);
                 const notebookRow2 = workbenchPage.getNotebookRow(workbenchName2);
                 notebookRow2.findNotebookDescription(testData.wbVariablesTestDescription);
-                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
                 // Use dynamic image name verification for second workbench
                 getImageStreamDisplayName(selectedImageStream2).then((displayName2) => {
@@ -207,7 +207,7 @@ describe('Workbenches - variable tests', () => {
           cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use dynamic image name verification for first workbench
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
@@ -246,7 +246,7 @@ describe('Workbenches - variable tests', () => {
                 cy.step(`Wait for workbench ${workbenchName2} to display a "Running" status`);
                 const notebookRow2 = workbenchPage.getNotebookRow(workbenchName2);
                 notebookRow2.findNotebookDescription(testData.wbVariablesTestDescription);
-                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
                 // Use dynamic image name verification for second workbench
                 getImageStreamDisplayName(selectedImageStream2).then((displayName2) => {

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/workbenches.cy.ts
@@ -137,7 +137,7 @@ describe('Workbench and PVSs tests', () => {
 
           cy.step(`Wait for Workbench ${workbenchName} to display a "Running" status`);
           const notebookRow = workbenchPage.getNotebookRow(workbenchName);
-          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
           // Use dynamic image name verification based on what was actually selected
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {

--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testDeleteAppliedHardwareProfile.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testDeleteAppliedHardwareProfile.cy.ts
@@ -95,7 +95,7 @@ describe('Delete Hardware Profile applied to a resource', () => {
       cy.step(`Wait for workbench ${testData.workbenchName} to display a "Running" status`);
       const notebookRow = workbenchPage.getNotebookRow(testData.workbenchName);
       notebookRow.findNotebookDescription(projectDescription);
-      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
       // Validate that the toleration applied earlier displays in the newly created pod
       cy.step('Validate the Tolerations for the pod include the applied toleration');
@@ -146,7 +146,7 @@ describe('Delete Hardware Profile applied to a resource', () => {
       cy.step('Verify workbench is still running after hardware profile deletion');
       const workbenchRow = workbenchPage.getNotebookRow(testData.workbenchName);
       workbenchRow.findNotebookDescription(projectDescription);
-      workbenchRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 30000);
+      workbenchRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 30000);
 
       // Verify the Hardware profile column shows "Deleted" badge
       cy.step(`Verify Hardware profile column shows "${testData.deletedStatusBadge}" badge`);

--- a/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/hardwareProfiles/testWorkbenchTolerations.cy.ts
@@ -98,7 +98,7 @@ describe('Workbenches - tolerations tests', () => {
       cy.step(`Wait for workbench ${testData.workbenchName} to display a "Running" status`);
       const notebookRow = workbenchPage.getNotebookRow(testData.workbenchName);
       notebookRow.findNotebookDescription(projectDescription);
-      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
       // Validate that the toleration applied earlier displays in the newly created pod
       cy.step('Validate the Tolerations for the pod include the newly added toleration');
@@ -172,7 +172,7 @@ describe('Workbenches - tolerations tests', () => {
       cy.step(`Restart workbench ${testData.workbenchName} and validate it has been started`);
       const notebookRow = workbenchPage.getNotebookRow(testData.workbenchName);
       notebookRow.findNotebookStopToggle().click();
-      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Running, 120000);
+      notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
       cy.reload();
 
       // Validate that the toleration applied earlier still displays in the pod

--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -79,7 +79,7 @@ const initIntercepts = ({
       k8sName: 'test-workload-finished',
       ownerKind: WorkloadOwnerType.Job,
       ownerName: 'test-workload-finished-job',
-      mockStatus: WorkloadStatusType.Succeeded,
+      mockStatus: WorkloadStatusType.Complete,
       podSets: [mockPodset, mockPodset],
     }),
     mockWorkloadK8sResource({
@@ -93,14 +93,14 @@ const initIntercepts = ({
       k8sName: 'test-workload-spinning-down-both',
       ownerKind: WorkloadOwnerType.RayCluster,
       ownerName: 'test-workload-spinning-down-both-rc',
-      mockStatus: WorkloadStatusType.Succeeded,
+      mockStatus: WorkloadStatusType.Complete,
       podSets: [mockPodset, mockPodset],
     }),
     mockWorkloadK8sResource({
       k8sName: 'test-workload-spinning-down-cpu-only',
       ownerKind: WorkloadOwnerType.RayCluster,
       ownerName: 'test-workload-spinning-down-cpu-only-rc',
-      mockStatus: WorkloadStatusType.Succeeded,
+      mockStatus: WorkloadStatusType.Complete,
       podSets: [mockPodset, mockPodset],
     }),
   ],
@@ -401,7 +401,7 @@ describe('Workload Status tab', () => {
 
     const statusOverview = globalDistributedWorkloads.findStatusOverviewCard();
     statusOverview.should('exist');
-    statusOverview.findByText('Succeeded: 3').should('exist');
+    statusOverview.findByText('Complete: 3').should('exist');
   });
 
   it('Should render the status overview chart with pending fallback statuses', () => {

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -189,7 +189,7 @@ describe('Model Serving LLMD', () => {
         .findByTestId('api-protocol-label')
         .should('have.text', 'REST');
       row.findLastDeployed().should('have.text', '17 Mar 2023');
-      row.findStatusLabel('Started');
+      row.findStatusLabel('Ready');
 
       // expanded section of the row
       row.findToggleButton('llmd-serving').click();

--- a/packages/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/runtime/servingRuntimeList.cy.ts
@@ -626,7 +626,7 @@ describe('Serving Runtime List', () => {
       projectDetails.visitSection('test-project', 'model-server');
 
       const kserveRow = modelServingSection.getKServeRow('test-model');
-      kserveRow.findStatusLabel(ModelStateLabel.STARTED);
+      kserveRow.findStatusLabel(ModelStateLabel.READY);
 
       const stoppedInferenceService = mockInferenceServiceK8sResource({
         name: 'test-model',
@@ -708,7 +708,7 @@ describe('Serving Runtime List', () => {
       kserveRow.findStateActionToggle().should('have.text', ModelStateToggleLabel.START).click();
       cy.reload();
       cy.wait(['@startModelPatch', '@getStartedModel']);
-      kserveRow.findStatusLabel(ModelStateLabel.STARTED);
+      kserveRow.findStatusLabel(ModelStateLabel.READY);
       kserveRow.findStateActionToggle().should('have.text', ModelStateToggleLabel.STOP);
     });
 

--- a/packages/cypress/cypress/tests/mocked/modelTraining/modelTraining.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelTraining/modelTraining.cy.ts
@@ -302,7 +302,7 @@ const mockWorkloads = mockTrainJobs.map((job) => {
   if (jobStatus === TrainingJobState.FAILED) {
     workloadStatus = WorkloadStatusType.Failed;
   } else if (jobStatus === TrainingJobState.SUCCEEDED) {
-    workloadStatus = WorkloadStatusType.Succeeded;
+    workloadStatus = WorkloadStatusType.Complete;
   } else if (jobStatus === TrainingJobState.PENDING) {
     workloadStatus = WorkloadStatusType.Pending;
   } else if (jobStatus === TrainingJobState.PAUSED) {

--- a/packages/cypress/cypress/tests/mocked/modelTraining/modelTrainingPauseResume.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelTraining/modelTrainingPauseResume.cy.ts
@@ -103,7 +103,7 @@ const mockWorkloads = mockTrainJobs.map((job) => {
   if (jobStatus === TrainingJobState.FAILED) {
     workloadStatus = WorkloadStatusType.Failed;
   } else if (jobStatus === TrainingJobState.SUCCEEDED) {
-    workloadStatus = WorkloadStatusType.Succeeded;
+    workloadStatus = WorkloadStatusType.Complete;
   } else if (jobStatus === TrainingJobState.PAUSED) {
     workloadStatus = WorkloadStatusType.Running;
     workloadSpec = { active: false };

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -1194,7 +1194,7 @@ describe('Workbench page', () => {
     notebookRow.find().findByText('Test Image').should('exist');
     notebookRow.findProjectScopedLabel().should('exist');
     notebookRow.shouldHaveHardwareProfile('Small');
-    notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
+    notebookRow.findHaveNotebookStatusText().should('have.text', 'Ready');
     notebookRow.findNotebookRouteLink().should('not.have.attr', 'aria-disabled');
   });
 
@@ -1333,7 +1333,7 @@ describe('Workbench page', () => {
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
     notebookRow.shouldHaveNotebookImageName('Test Image');
     notebookRow.shouldHaveHardwareProfile('Small');
-    notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
+    notebookRow.findHaveNotebookStatusText().should('have.text', 'Ready');
     notebookRow.findNotebookRouteLink().should('not.have.attr', 'aria-disabled');
 
     //Name sorting
@@ -2555,11 +2555,11 @@ describe('Workbench page', () => {
     );
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
+    notebookRow.findHaveNotebookStatusText().should('have.text', 'Ready');
     notebookRow.findHaveNotebookStatusText().click();
 
     workbenchStatusModal.find().should('be.visible');
-    workbenchStatusModal.getNotebookStatus('Running');
+    workbenchStatusModal.getNotebookStatus('Ready');
 
     workbenchStatusModal.findProgressTab().should('be.visible').click();
     workbenchStatusModal.findProgressSteps().should('exist');
@@ -2574,7 +2574,7 @@ describe('Workbench page', () => {
     initKueueEnabledForStatusModal();
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
+    notebookRow.findHaveNotebookStatusText().should('have.text', 'Ready');
     notebookRow.findHaveNotebookStatusText().click();
 
     workbenchStatusModal.find().should('be.visible');
@@ -2587,7 +2587,7 @@ describe('Workbench page', () => {
     initKueueEnabledForStatusModal();
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-    notebookRow.findHaveNotebookStatusText().should('have.text', 'Running');
+    notebookRow.findHaveNotebookStatusText().should('have.text', 'Ready');
     notebookRow.findHaveNotebookStatusText().click();
 
     workbenchStatusModal.find().should('be.visible');

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -529,7 +529,7 @@ export const AccessModeLabelMap: Record<AccessMode, string> = {
 };
 
 export enum NotebookStatusLabel {
-  Running = 'Running',
+  Ready = 'Ready',
   Starting = 'Starting',
   Stopping = 'Stopping',
   Stopped = 'Stopped',

--- a/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
@@ -66,6 +66,7 @@ const EvaluationStatusLabel: React.FC<EvaluationStatusLabelProps> = ({ state, me
 
   const label = (
     <Label
+      variant="outline"
       color={config.color}
       status={config.status}
       icon={<Icon isInline>{config.icon}</Icon>}

--- a/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
@@ -1,56 +1,56 @@
 import * as React from 'react';
-import { Icon, Label, Popover, Stack, StackItem } from '@patternfly/react-core';
+import { Icon, Label, LabelProps, Popover, Stack, StackItem } from '@patternfly/react-core';
 import {
+  BanIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
-  PausedIcon,
   PendingIcon,
-  StopCircleIcon,
 } from '@patternfly/react-icons';
 import { EvaluationJobState } from '~/app/types';
 
 type StatusConfig = {
   label: string;
-  color: React.ComponentProps<typeof Label>['color'];
+  color?: LabelProps['color'];
+  status?: LabelProps['status'];
   icon: React.ReactNode;
 };
 
 const statusMap: Record<EvaluationJobState, StatusConfig> = {
   pending: {
     label: 'Pending',
-    color: 'grey',
+    color: 'purple',
     icon: <PendingIcon />,
   },
   running: {
-    label: 'In progress',
+    label: 'Running',
     color: 'blue',
     icon: <InProgressIcon />,
   },
   completed: {
-    label: 'Completed',
-    color: 'green',
+    label: 'Complete',
+    status: 'success',
     icon: <CheckCircleIcon />,
   },
   failed: {
     label: 'Failed',
-    color: 'red',
+    status: 'danger',
     icon: <ExclamationCircleIcon />,
   },
   cancelled: {
-    label: 'Cancelled',
+    label: 'Canceled',
     color: 'grey',
-    icon: <StopCircleIcon />,
+    icon: <BanIcon />,
   },
   stopping: {
-    label: 'Stopping',
-    color: 'blue',
-    icon: <PausedIcon />,
+    label: 'Canceling',
+    color: 'grey',
+    icon: <InProgressIcon />,
   },
   stopped: {
-    label: 'Stopped',
+    label: 'Canceled',
     color: 'grey',
-    icon: <StopCircleIcon />,
+    icon: <BanIcon />,
   },
 };
 
@@ -66,6 +66,7 @@ const EvaluationStatusLabel: React.FC<EvaluationStatusLabelProps> = ({ state, me
   const label = (
     <Label
       color={config.color}
+      status={config.status}
       icon={<Icon isInline>{config.icon}</Icon>}
       data-testid={`status-label-${state}`}
       {...(hasPopover

--- a/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   InProgressIcon,
+  OffIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
 import { EvaluationJobState } from '~/app/types';
@@ -43,14 +44,14 @@ const statusMap: Record<EvaluationJobState, StatusConfig> = {
     icon: <BanIcon />,
   },
   stopping: {
-    label: 'Canceling',
+    label: 'Stopping',
     color: 'grey',
-    icon: <InProgressIcon />,
+    icon: <InProgressIcon className="odh-u-spin" />,
   },
   stopped: {
-    label: 'Canceled',
+    label: 'Stopped',
     color: 'grey',
-    icon: <BanIcon />,
+    icon: <OffIcon />,
   },
 };
 

--- a/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
@@ -5,12 +5,12 @@ import EvaluationStatusLabel from '~/app/components/EvaluationStatusLabel';
 
 const EXPECTED_LABELS: Record<EvaluationJobState, string> = {
   pending: 'Pending',
-  running: 'In progress',
-  completed: 'Completed',
+  running: 'Running',
+  completed: 'Complete',
   failed: 'Failed',
-  cancelled: 'Cancelled',
-  stopping: 'Stopping',
-  stopped: 'Stopped',
+  cancelled: 'Canceled',
+  stopping: 'Canceling',
+  stopped: 'Canceled',
 };
 
 describe('EvaluationStatusLabel', () => {

--- a/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
@@ -1,16 +1,23 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { LabelProps } from '@patternfly/react-core';
 import { EvaluationJobState } from '~/app/types';
 import EvaluationStatusLabel from '~/app/components/EvaluationStatusLabel';
 
-const EXPECTED_LABELS: Record<EvaluationJobState, string> = {
-  pending: 'Pending',
-  running: 'Running',
-  completed: 'Complete',
-  failed: 'Failed',
-  cancelled: 'Canceled',
-  stopping: 'Stopping',
-  stopped: 'Stopped',
+type ExpectedLabelConfig = {
+  text: string;
+  color?: LabelProps['color'];
+  status?: LabelProps['status'];
+};
+
+const EXPECTED_LABELS: Record<EvaluationJobState, ExpectedLabelConfig> = {
+  pending: { text: 'Pending', color: 'purple' },
+  running: { text: 'Running', color: 'blue' },
+  completed: { text: 'Complete', status: 'success' },
+  failed: { text: 'Failed', status: 'danger' },
+  cancelled: { text: 'Canceled', color: 'grey' },
+  stopping: { text: 'Stopping', color: 'grey' },
+  stopped: { text: 'Stopped', color: 'grey' },
 };
 
 describe('EvaluationStatusLabel', () => {
@@ -18,12 +25,36 @@ describe('EvaluationStatusLabel', () => {
 
   it.each(states)('should render the correct label for "%s" state', (state) => {
     render(<EvaluationStatusLabel state={state} />);
-    expect(screen.getByTestId(`status-label-${state}`)).toHaveTextContent(EXPECTED_LABELS[state]);
+    expect(screen.getByTestId(`status-label-${state}`)).toHaveTextContent(
+      EXPECTED_LABELS[state].text,
+    );
   });
 
   it.each(states)('should render a test id for "%s" state', (state) => {
     render(<EvaluationStatusLabel state={state} />);
     expect(screen.getByTestId(`status-label-${state}`)).toBeInTheDocument();
+  });
+
+  it.each(states)('should render the correct color or status class for "%s" state', (state) => {
+    render(<EvaluationStatusLabel state={state} />);
+    const label = screen.getByTestId(`status-label-${state}`);
+    const { color, status } = EXPECTED_LABELS[state];
+    if (status) {
+      expect(label).toHaveClass(`pf-m-${status}`);
+    } else if (color && color !== 'grey') {
+      expect(label).toHaveClass(`pf-m-${color}`);
+    }
+
+    if (!status && (!color || color === 'grey')) {
+      expect(label).not.toHaveClass('pf-m-success');
+      expect(label).not.toHaveClass('pf-m-danger');
+      expect(label).not.toHaveClass('pf-m-info');
+    }
+  });
+
+  it.each(states)('should render with outline variant for "%s" state', (state) => {
+    render(<EvaluationStatusLabel state={state} />);
+    expect(screen.getByTestId(`status-label-${state}`)).toHaveClass('pf-m-outline');
   });
 
   it('should show a popover with the error message when failed label is clicked', () => {

--- a/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
+++ b/packages/eval-hub/frontend/src/app/components/__tests__/EvaluationStatusLabel.spec.tsx
@@ -9,8 +9,8 @@ const EXPECTED_LABELS: Record<EvaluationJobState, string> = {
   completed: 'Complete',
   failed: 'Failed',
   cancelled: 'Canceled',
-  stopping: 'Canceling',
-  stopped: 'Canceled',
+  stopping: 'Stopping',
+  stopped: 'Stopped',
 };
 
 describe('EvaluationStatusLabel', () => {

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -111,19 +111,28 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
           <TruncatedText maxLines={2} content={model.usecase} />
         </Td>
         <Td dataLabel="Status">
-          {model.status === 'Running' ? (
-            <Label status="success" variant="outline">
-              Ready
-            </Label>
-          ) : model.status === 'Stop' ? (
-            <Label status="danger" variant="outline">
-              Inactive
-            </Label>
-          ) : (
-            <Label color="grey" icon={<OutlinedQuestionCircleIcon />}>
-              Unknown
-            </Label>
-          )}
+          {(() => {
+            switch (model.status) {
+              case 'Running':
+                return (
+                  <Label status="success" variant="outline">
+                    Ready
+                  </Label>
+                );
+              case 'Stop':
+                return (
+                  <Label status="danger" variant="outline">
+                    Inactive
+                  </Label>
+                );
+              default:
+                return (
+                  <Label variant="outline" color="grey" icon={<OutlinedQuestionCircleIcon />}>
+                    Unknown
+                  </Label>
+                );
+            }
+          })()}
         </Td>
         <Td dataLabel="Endpoints">
           {model.externalEndpoint || model.internalEndpoint ? (

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
@@ -23,25 +23,25 @@ const MCPServerStatus: React.FC<MCPServerStatusProps> = ({
     switch (status) {
       case 'connected':
         return (
-          <Label status="success" icon={<CheckCircleIcon />}>
+          <Label variant="outline" status="success" icon={<CheckCircleIcon />}>
             Active
           </Label>
         );
       case 'auth_required':
         return (
-          <Label status="warning" icon={<InfoCircleIcon />}>
+          <Label variant="outline" status="warning" icon={<InfoCircleIcon />}>
             Token Required
           </Label>
         );
       case 'unreachable':
         return (
-          <Label status="danger" icon={<ExclamationCircleIcon />}>
+          <Label variant="outline" status="danger" icon={<ExclamationCircleIcon />}>
             Error
           </Label>
         );
       default:
         return (
-          <Label color="grey" icon={<QuestionCircleIcon />}>
+          <Label variant="outline" color="grey" icon={<QuestionCircleIcon />}>
             Unknown
           </Label>
         );

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
@@ -23,25 +23,25 @@ const MCPServerStatus: React.FC<MCPServerStatusProps> = ({
     switch (status) {
       case 'connected':
         return (
-          <Label variant="outline" status="success" icon={<CheckCircleIcon />}>
+          <Label status="success" icon={<CheckCircleIcon />}>
             Active
           </Label>
         );
       case 'auth_required':
         return (
-          <Label variant="outline" status="warning" icon={<InfoCircleIcon />}>
+          <Label status="warning" icon={<InfoCircleIcon />}>
             Token Required
           </Label>
         );
       case 'unreachable':
         return (
-          <Label variant="outline" status="danger" icon={<ExclamationCircleIcon />}>
+          <Label status="danger" icon={<ExclamationCircleIcon />}>
             Error
           </Label>
         );
       default:
         return (
-          <Label variant="outline" color="grey" icon={<QuestionCircleIcon />}>
+          <Label color="grey" icon={<QuestionCircleIcon />}>
             Unknown
           </Label>
         );
@@ -51,12 +51,7 @@ const MCPServerStatus: React.FC<MCPServerStatusProps> = ({
   if (isLoading || status === 'checking') {
     return (
       <Tooltip content="Checking connection status...">
-        <Label
-          color="teal"
-          variant="outline"
-          icon={<Spinner size="sm" />}
-          data-testid="mcp-server-status-badge"
-        >
+        <Label color="teal" icon={<Spinner size="sm" />} data-testid="mcp-server-status-badge">
           Loading
         </Label>
       </Tooltip>

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServerStatus.tsx
@@ -23,19 +23,19 @@ const MCPServerStatus: React.FC<MCPServerStatusProps> = ({
     switch (status) {
       case 'connected':
         return (
-          <Label color="green" icon={<CheckCircleIcon />}>
+          <Label status="success" icon={<CheckCircleIcon />}>
             Active
           </Label>
         );
       case 'auth_required':
         return (
-          <Label color="yellow" icon={<InfoCircleIcon />}>
+          <Label status="warning" icon={<InfoCircleIcon />}>
             Token Required
           </Label>
         );
       case 'unreachable':
         return (
-          <Label color="red" icon={<ExclamationCircleIcon />}>
+          <Label status="danger" icon={<ExclamationCircleIcon />}>
             Error
           </Label>
         );

--- a/packages/maas/frontend/src/app/pages/api-keys/allKeys/ApiKeysTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/allKeys/ApiKeysTableRow.tsx
@@ -1,10 +1,26 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { capitalize, Label } from '@patternfly/react-core';
+import { capitalize, Label, LabelProps } from '@patternfly/react-core';
+import { BanIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
-import { APIKey, SubscriptionDetail } from '~/app/types/api-key';
+import { APIKey, APIKeyStatus, SubscriptionDetail } from '~/app/types/api-key';
 import { apiKeyColumns } from './columns';
 import SubscriptionCell from './SubscriptionCell';
+
+const getApiKeyStatusProps = (
+  status: APIKeyStatus,
+): { icon: React.ReactNode; status?: LabelProps['status']; color?: LabelProps['color'] } => {
+  switch (status) {
+    case 'active':
+      return { icon: <CheckCircleIcon />, status: 'success' };
+    case 'expired':
+      return { icon: <ExclamationCircleIcon />, status: 'danger' };
+    case 'revoked':
+      return { icon: <BanIcon />, color: 'grey' };
+    default:
+      return { icon: undefined, color: 'grey' };
+  }
+};
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
@@ -35,11 +51,7 @@ const ApiKeysTableRow: React.FC<ApiKeysTableRowProps> = ({
       />
     </Td>
     <Td dataLabel={apiKeyColumns[1].label}>
-      <Label
-        color={
-          apiKey.status === 'active' ? 'green' : apiKey.status === 'expired' ? 'red' : 'purple'
-        }
-      >
+      <Label variant="outline" {...getApiKeyStatusProps(apiKey.status)}>
         {capitalize(apiKey.status)}
       </Label>
     </Td>

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -64,7 +64,7 @@ export enum ModelStateLabel {
   STOPPED = 'Stopped',
   STOPPING = 'Stopping',
   STARTING = 'Starting',
-  STARTED = 'Started',
+  READY = 'Ready',
   RUNNING = 'Running',
   FAILED_TO_LOAD = 'Failed to load',
 }

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -161,7 +161,7 @@ describe('DeploymentsTableRow', () => {
       </table>,
     );
 
-    expect(screen.getByText('Started')).toBeInTheDocument();
+    expect(screen.getByText('Ready')).toBeInTheDocument();
   });
 
   describe('Inference endpoints', () => {

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -112,7 +112,7 @@ describe('DeploymentsTableRow', () => {
     // Inference endpoint Column
     expect(screen.getByText('Failed to get endpoint for this deployed model.')).toBeInTheDocument();
     // Status Column
-    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByText('Inference Service Status')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Kebab toggle' }));

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentsTableRow.spec.tsx
@@ -112,7 +112,7 @@ describe('DeploymentsTableRow', () => {
     // Inference endpoint Column
     expect(screen.getByText('Failed to get endpoint for this deployed model.')).toBeInTheDocument();
     // Status Column
-    expect(screen.getByText('Inference Service Status')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Kebab toggle' }));

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -150,7 +150,6 @@ export const DeploymentRow: React.FC<{
           <ModelStatusIcon
             state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
             bodyContent={deployment.status?.message}
-            defaultHeaderContent="Inference Service Status"
             stoppedStates={deployment.status?.stoppedStates}
           />
         </Td>

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -150,6 +150,7 @@ export const DeploymentRow: React.FC<{
           <ModelStatusIcon
             state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
             bodyContent={deployment.status?.message}
+            defaultHeaderContent="Inference Service Status"
             stoppedStates={deployment.status?.stoppedStates}
           />
         </Td>

--- a/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
+++ b/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
@@ -66,7 +66,6 @@ describe('getStatusInfo', () => {
     const result = getStatusInfo(TrainingJobState.SUCCEEDED);
     expect(result.label).toBe('Complete');
     expect(result.status).toBe('success');
-    expect(result.color).toBe('green');
     expect(result.alertTitle).toBe('Job Complete');
     expect(result.alertVariant).toBeDefined();
   });
@@ -75,7 +74,6 @@ describe('getStatusInfo', () => {
     const result = getStatusInfo(TrainingJobState.FAILED);
     expect(result.label).toBe('Failed');
     expect(result.status).toBe('danger');
-    expect(result.color).toBe('red');
     expect(result.alertTitle).toBe('Job Failed');
     expect(result.alertVariant).toBeDefined();
   });
@@ -103,7 +101,6 @@ describe('getStatusInfo', () => {
     const result = getStatusInfo(TrainingJobState.INADMISSIBLE);
     expect(result.label).toBe('Inadmissible');
     expect(result.status).toBe('warning');
-    expect(result.color).toBe('orange');
     expect(result.alertTitle).toBe('Job Inadmissible');
   });
 
@@ -111,7 +108,6 @@ describe('getStatusInfo', () => {
     const result = getStatusInfo(TrainingJobState.PREEMPTED);
     expect(result.label).toBe('Preempted');
     expect(result.status).toBe('warning');
-    expect(result.color).toBe('orange');
     expect(result.alertTitle).toBe('Job Preempted');
   });
 
@@ -130,7 +126,7 @@ describe('getStatusInfo', () => {
   it('should return correct info for UNKNOWN status', () => {
     const result = getStatusInfo(TrainingJobState.UNKNOWN);
     expect(result.label).toBe('Unknown');
-    expect(result.status).toBe('warning');
+    expect(result.color).toBe('grey');
   });
 });
 

--- a/packages/model-training/src/global/trainingJobList/components/TrainingJobStatus.tsx
+++ b/packages/model-training/src/global/trainingJobList/components/TrainingJobStatus.tsx
@@ -43,6 +43,7 @@ const TrainingJobStatus = ({
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }}>
       <FlexItem>
         <Label
+          variant={onClick ? 'filled' : 'outline'}
           isCompact={isCompact}
           status={statusInfo.status}
           color={statusInfo.color}

--- a/packages/model-training/src/global/trainingJobList/utils.ts
+++ b/packages/model-training/src/global/trainingJobList/utils.ts
@@ -73,7 +73,6 @@ export const getStatusInfo = (
       return {
         status: 'success',
         label: 'Complete',
-        color: 'green',
         IconComponent: CheckCircleIcon,
         alertTitle: 'Job Complete',
         alertVariant: AlertVariant.success,
@@ -82,7 +81,6 @@ export const getStatusInfo = (
       return {
         status: 'danger',
         label: 'Failed',
-        color: 'red',
         IconComponent: ExclamationCircleIcon,
         alertTitle: 'Job Failed',
         alertVariant: AlertVariant.danger,
@@ -132,7 +130,6 @@ export const getStatusInfo = (
     case TrainingJobState.PREEMPTED:
       return {
         label: 'Preempted',
-        color: 'orange',
         status: 'warning',
         IconComponent: ExclamationTriangleIcon,
         alertTitle: 'Job Preempted',
@@ -141,7 +138,6 @@ export const getStatusInfo = (
     case TrainingJobState.INADMISSIBLE:
       return {
         label: 'Inadmissible',
-        color: 'orange',
         status: 'warning',
         IconComponent: ExclamationTriangleIcon,
         alertTitle: 'Job Inadmissible',

--- a/packages/model-training/src/global/trainingJobList/utils.ts
+++ b/packages/model-training/src/global/trainingJobList/utils.ts
@@ -4,11 +4,12 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   InProgressIcon,
+  OutlinedClockIcon,
+  OutlinedQuestionCircleIcon,
+  PauseCircleIcon,
+  PauseIcon,
   PendingIcon,
   PlayIcon,
-  PauseIcon,
-  OutlinedClockIcon,
-  PauseCircleIcon,
 } from '@patternfly/react-icons';
 import { AlertVariant, LabelProps } from '@patternfly/react-core';
 import { WorkloadCondition } from '@odh-dashboard/internal/k8sTypes';
@@ -152,8 +153,8 @@ export const getStatusInfo = (
     default:
       return {
         label: 'Unknown',
-        status: 'warning',
-        IconComponent: ExclamationCircleIcon,
+        color: 'grey',
+        IconComponent: OutlinedQuestionCircleIcon,
       };
   }
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-38486

## Description

Standardizes PatternFly `Label` usage for status indicators across the entire dashboard to align with RHOAI design guidelines and PatternFly v6 best practices.

<img width="1920" height="993" alt="distributed-workloads-all-statuses" src="https://github.com/user-attachments/assets/13e3a2d4-ecd8-4607-be21-83eb09281c81" />
<img width="1940" height="1580" alt="gen-ai-models-all-statuses" src="https://github.com/user-attachments/assets/63b7c49b-c0df-4afb-918d-aabfcbe6f85e" />
<img width="1920" height="993" alt="lm-eval-all-statuses" src="https://github.com/user-attachments/assets/e04878ee-c288-41be-9123-702f3176982a" />
<img width="1920" height="993" alt="maas-api-keys-all-statuses" src="https://github.com/user-attachments/assets/c0018d1a-21b3-4a69-b095-07c034bc15b9" />
<img width="1920" height="993" alt="model-serving-all-statuses" src="https://github.com/user-attachments/assets/27ace60d-4498-4529-a48a-365b99b260fa" />
<img width="1920" height="993" alt="model-training-all-statuses" src="https://github.com/user-attachments/assets/2cd14c95-1647-4796-b027-54f8da01c16c" />
<img width="1920" height="993" alt="pipeline-runs-all-statuses" src="https://github.com/user-attachments/assets/a200f247-b2f7-438d-bb34-8251c95cf1d8" />
<img width="1920" height="993" alt="workbench-notebook-all-statuses" src="https://github.com/user-attachments/assets/d6c47a72-4222-45e2-b567-797adb102db6" />

### Changes

**Semantic status props** — Replaced `color="green"` / `color="red"` / `color="yellow"` with `status="success"` / `status="danger"` / `status="warning"` for labels that represent health/outcome states (e.g., Running, Failed, Succeeded, Connected, Active/Inactive).

**Outlined variant for non-interactive labels** — Added `variant="outline"` to all status labels that are display-only (not clickable/popover-triggering), per PF v6 convention where filled labels imply interactivity.

**Icon standardization** — Replaced outdated icons with consistent status icons:
- `SyncAltIcon` → `InProgressIcon` for in-progress states
- `PlayIcon` → `InProgressIcon` for running states
- Added missing icons where other states in the same component had them

**Label text normalization** — Aligned display text to use consistent terminology across components:
- "Succeeded" → "Complete" (pipelines)
- "Running" → "Ready" (model serving)

### Files touched (59 files across 6 commits)

| Area | Key files |
|---|---|
| **Notebooks** | `NotebookStatusLabel.tsx` |
| **Pipelines** | `PipelineRunTypeLabel.tsx`, `PipelineDetailsTitle.tsx`, `renderUtils.tsx`, `utils.tsx`, `ExecutionStatus.tsx`, `ExperimentPipelineRuns.tsx`, `ArtifactDetailsTitle.tsx`, `ArtifactsTableRow.tsx` |
| **Distributed Workloads** | `WorkloadStatusLabel.tsx`, `utils.tsx` |
| **LM Eval** | `LMEvalStatusLabel.tsx` |
| **Model Serving** | `ModelStatusIcon.tsx`, `NodeStatusIcon.tsx` |
| **Eval Hub** | `EvaluationStatusLabel.tsx` |
| **AutoML / AutoRAG** | `AutomlRunsTableRow.tsx`, `AutoragRunsTableRow.tsx` |
| **Gen AI** | `AIModelTableRow.tsx`, `MCPServerStatus.tsx` |
| **MaaS** | `ApiKeysTableRow.tsx` |
| **Model Training** | `trainingJobList/utils.ts` |
| **Projects** | `ClusterStorageTableRow.tsx`, `StorageTableRow.tsx`, `ImageVersionSelector.tsx` |
| **Learning Center** | `DocCardBadges.tsx` |
| **Cypress tests** | Updated expected label text and test-id selectors across ~20 test files |
| **Unit tests** | Updated snapshots/assertions in spec files for affected components |

## How Has This Been Tested?

- ESLint and `lint-staged` pass on all commits (pre-commit hook ran successfully)
- Verified label rendering logic by reviewing each component's status-to-label mapping
- Checked that all unit test assertions were updated to match new label text and props
- Checked that all Cypress test selectors were updated to match new label text

## Test Impact

- Updated ~20 Cypress E2E/mock test files to reflect new label text (e.g., "Succeeded" → "Complete", "Running" → "Ready")
- Updated unit test specs for `AutomlRunsTableRow`, `EvaluationStatusLabel`, `NotebookStatusLabel`, `utils.spec.tsx` (pipelines), `distributedWorkloads/utils.spec.ts`, and `trainingJobList/utils.spec.ts`
- No new test files — all changes are assertion updates to match the updated label props and text

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Status text changes: "Running" → "Ready" and "Succeeded" → "Complete" across notebooks, models, workloads, and evaluations.
  * Labels now use outlined variants and explicit status props (success/warning/danger/grey) for clearer visuals.
  * Several status icons adjusted for consistent presentation (in‑progress, paused, skipped, completed, stopping).

* **Tests**
  * Unit and end‑to‑end tests updated to expect new status texts, icons, and label styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->