### PR TITLE
check for module federation port conflict

### DIFF
--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -86,12 +86,13 @@ Each package needs a unique port. See [docs/onboard-modular-architecture.md § C
 To see current port assignments and detect conflicts, run:
 
 ```bash
-node scripts/validate-module-ports.js
+npm run validate:ports
 ```
 
 The source of truth for each package is:
 - **Frontend port**: `module-federation.local.port` in the package's `package.json`
-- **BFF port**: `PORT=` values in the package's `Makefile`
+- **BFF port (local dev/E2E)**: `bffConfig.port` in the package's `package.json` (used by CI E2E workflow and Cypress scripts; not currently conflict-checked by the validator)
+- **Production service port**: `service.port` in `federation-configmap.yaml` (validated by the conflict-check script)
 
 ### 4. Directory structure
 

--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -83,20 +83,15 @@ Add `install:module` script if the package has its own `node_modules`:
 
 Each package needs a unique port. See [docs/onboard-modular-architecture.md § Configure the Port](../../docs/onboard-modular-architecture.md#3-configure-the-port) for where to update it (both `Makefile` and `package.json`).
 
-Current port assignments:
+To see current port assignments and detect conflicts, run:
 
-| Package | Frontend Port | BFF Port |
-|---|---|---|
-| model-registry | 9100 | 4000 |
-| gen-ai | 9102 | 8080 |
-| eval-hub | 9105 | 4002 |
-| maas | 9104 | 8081 |
-| notebooks | 9105 | — |
-| autorag | 9107 | 4001 |
-| automl | 9108 | 4003 |
-| mlflow | 9110 | 4020 |
+```bash
+node scripts/validate-module-ports.js
+```
 
-Note: eval-hub and notebooks both use frontend port 9105 (conflict).
+The source of truth for each package is:
+- **Frontend port**: `module-federation.local.port` in the package's `package.json`
+- **BFF port**: `PORT=` values in the package's `Makefile`
 
 ### 4. Directory structure
 

--- a/.claude/skills/dev-workflow/reference.md
+++ b/.claude/skills/dev-workflow/reference.md
@@ -92,18 +92,17 @@ The `local` field in `module-federation` config tells the backend where to proxy
 | Backend | 4000 | Node.js/Fastify reverse proxy | Yes |
 | Host frontend | 4010 | Webpack dev server (host) | Yes |
 
-| Package | Frontend Port | BFF Port (federated) | Has `start:dev`? |
-|---|---|---|---|
-| model-registry | 9100 | **4000** | Yes |
-| gen-ai | 9102 | 8080 (no federated target) | No (use Makefile) |
-| eval-hub | 9105 | 4002 | No (use Makefile) |
-| maas | 9104 | 8081 | No (use Makefile) |
-| notebooks | 9105 | — | Yes |
-| autorag | 9107 | 4001 | No (use Makefile) |
-| automl | 9108 | 4003 | No (use Makefile) |
-| mlflow | 9110 | 4020 | No (use Makefile) |
+To see all current port assignments and detect conflicts:
 
-**Known port conflicts:**
+```bash
+node scripts/validate-module-ports.js
+```
+
+The source of truth for each package is:
+- **Frontend port**: `module-federation.local.port` in the package's `package.json`
+- **BFF port**: `PORT=` values in the package's `Makefile`
+
+**Known port conflict:**
 
 - **model-registry BFF (4000) vs dashboard backend (4000).** Both default to port 4000. To run them together, change the dashboard backend port via `.env.development.local`:
 
@@ -113,10 +112,6 @@ The `local` field in `module-federation` config tells the backend where to proxy
   ```
 
   The frontend's webpack proxy target (`_BACKEND_PORT`) and the backend itself both pick up this override. The model-registry BFF keeps port 4000 (hardcoded in its Makefile). Avoid using 4020 — mlflow's BFF uses that port.
-
-- **eval-hub (9105) vs notebooks (9105).** Both declare `module-federation.local.port: 9105`. Cannot run both simultaneously without changing one.
-
-- **mlflow BFF (4020).** Conflicts with `BACKEND_PORT=4020` if used as a workaround. Use 4050 or another unused port for the dashboard backend instead.
 
 ### Running multi-component dev
 

--- a/.claude/skills/dev-workflow/reference.md
+++ b/.claude/skills/dev-workflow/reference.md
@@ -95,12 +95,13 @@ The `local` field in `module-federation` config tells the backend where to proxy
 To see all current port assignments and detect conflicts:
 
 ```bash
-node scripts/validate-module-ports.js
+npm run validate:ports
 ```
 
 The source of truth for each package is:
 - **Frontend port**: `module-federation.local.port` in the package's `package.json`
-- **BFF port**: `PORT=` values in the package's `Makefile`
+- **BFF port (local dev/E2E)**: `bffConfig.port` in the package's `package.json` (used by CI E2E workflow and Cypress scripts; not currently conflict-checked by the validator)
+- **Production service port**: `service.port` in `federation-configmap.yaml` (validated by CI via `npm run validate:ports`)
 
 **Known port conflict:**
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Validate module federation ports
+        run: npm run validate:ports
+
       - name: Check for uncommitted changes
         run: git diff --exit-code
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,7 +12,7 @@ fi
 echo "🔍 Running lint-staged to check staged files..."
 
 # If any package.json or federation manifest is staged, validate port uniqueness
-if git diff --cached --name-only | grep -qE 'package\.json$|manifests/modular-architecture/'; then
+if git diff --cached --name-only | grep -qE 'package\.json$|federation-configmap\.yaml$'; then
     echo "📦 Port-related file changed — validating module federation ports..."
     if ! node scripts/validate-module-ports.js; then
         echo ""

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,6 +11,18 @@ fi
 
 echo "🔍 Running lint-staged to check staged files..."
 
+# If any package.json or federation manifest is staged, validate port uniqueness
+if git diff --cached --name-only | grep -qE 'package\.json$|manifests/modular-architecture/'; then
+    echo "📦 Port-related file changed — validating module federation ports..."
+    if ! node scripts/validate-module-ports.js; then
+        echo ""
+        echo "💥 Module federation port conflict detected!"
+        echo "   See docs/onboard-modular-architecture.md for the port registry."
+        echo ""
+        exit 1
+    fi
+fi
+
 # Run lint-staged and if it fails, show helpful instructions
 if ! npx lint-staged; then
     echo ""

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ if git diff --cached --name-only | grep -qE 'package\.json$|manifests/modular-ar
     if ! node scripts/validate-module-ports.js; then
         echo ""
         echo "💥 Module federation port conflict detected!"
-        echo "   See docs/onboard-modular-architecture.md for the port registry."
+        echo "   Run 'npm run validate:ports' to see current assignments."
         echo ""
         exit 1
     fi

--- a/docs/bff-e2e-testing.md
+++ b/docs/bff-e2e-testing.md
@@ -138,17 +138,9 @@ npm run cypress:run -- --env grepTags="@YourPackageCI"
 
 ## Supported Packages
 
-Currently, the following packages have BFF E2E support:
+Currently, the following packages have BFF E2E support: automl, autorag, eval-hub, gen-ai, maas, mlflow, model-registry.
 
-| Package | Frontend Port | BFF Port | CI Tag |
-|---------|---------------|----------|--------|
-| automl | 9108 | 4003 | @AutoMLCI |
-| autorag | 9107 | 4001 | @AutoRAGCI |
-| eval-hub | 9105 | 4002 | @EvalHubCI |
-| gen-ai | 9102 | 8080 | @GenAICI |
-| maas | 9104 | 8081 | @MaaSCI |
-| mlflow | 9110 | 4020 | @MLflowCI |
-| model-registry | 9100 | 4000 | @ModelRegistryCI |
+To see current port assignments, run `node scripts/validate-module-ports.js`. The source of truth for each package is `module-federation.local.port` in its `package.json` (frontend port) and `PORT=` in its `Makefile` (BFF port). CI tags are in the `e2eCiTags` field of each package's `package.json`.
 
 ## Troubleshooting
 

--- a/docs/onboard-modular-architecture.md
+++ b/docs/onboard-modular-architecture.md
@@ -27,7 +27,28 @@ npx mod-arch-installer -n <your-module-name>
 
 ### 3. Configure the Port
 
-By default, the modular architecture component runs on port `9103`. If you need to use a different port or want to ensure it doesn't conflict with other modules:
+Each module needs a **unique** local dev port so that multiple federated modules can run simultaneously. Pick an unused port from the registry below and update both `Makefile` and `package.json`.
+
+#### Port Registry
+
+| Port | Module | Package |
+| ---- | ----------------- | -------------------------------- |
+| 4000 | Dashboard Backend | `backend` |
+| 4010 | Dashboard Frontend| `frontend` |
+| 9005 | Observability | `@odh-dashboard/observability` |
+| 9100 | Model Registry | `@odh-dashboard/model-registry` |
+| 9102 | Gen AI | `@odh-dashboard/gen-ai` |
+| 9104 | MaaS | `@odh-dashboard/maas` |
+| 9105 | Notebooks | `@odh-dashboard/notebooks` |
+| 9106 | Eval Hub | `@odh-dashboard/eval-hub` |
+| 9107 | AutoRAG | `@odh-dashboard/autorag` |
+| 9108 | AutoML | `@odh-dashboard/automl` |
+| 9110 | MLflow | `@odh-dashboard/mlflow` |
+| 9300 | MLflow Embedded | `@odh-dashboard/mlflow-embedded` |
+
+> **Convention**: Frontend federation ports use the 9100–9399 range. BFF ports use the 4000–4099 range. Pick the next available number in the appropriate range.
+
+#### Steps
 
 1. **Update `Makefile`**:
    Open `packages/<your-module-name>/Makefile` and find the `dev-frontend-federated` target. Update the `PORT` variable:
@@ -47,6 +68,15 @@ By default, the modular architecture component runs on port `9103`. If you need 
      }
    }
    ```
+
+3. **Validate uniqueness**:
+   Run the port validation script to confirm there are no conflicts:
+
+   ```bash
+   node scripts/validate-module-ports.js
+   ```
+
+   This check also runs automatically in CI and the pre-commit hook.
 
 ### 4. Add Feature Flag
 

--- a/docs/onboard-modular-architecture.md
+++ b/docs/onboard-modular-architecture.md
@@ -27,28 +27,17 @@ npx mod-arch-installer -n <your-module-name>
 
 ### 3. Configure the Port
 
-Each module needs a **unique** local dev port so that multiple federated modules can run simultaneously. Pick an unused port from the registry below and update both `Makefile` and `package.json`.
+Each module needs a **unique** local dev port so that multiple federated modules can run simultaneously. To see which ports are already in use, run the validation script:
 
-#### Port Registry
+```bash
+npm run validate:ports
+```
 
-| Port | Module | Package |
-| ---- | ----------------- | -------------------------------- |
-| 4000 | Dashboard Backend | `backend` |
-| 4010 | Dashboard Frontend| `frontend` |
-| 9005 | Observability | `@odh-dashboard/observability` |
-| 9100 | Model Registry | `@odh-dashboard/model-registry` |
-| 9102 | Gen AI | `@odh-dashboard/gen-ai` |
-| 9104 | MaaS | `@odh-dashboard/maas` |
-| 9105 | Notebooks | `@odh-dashboard/notebooks` |
-| 9106 | Eval Hub | `@odh-dashboard/eval-hub` |
-| 9107 | AutoRAG | `@odh-dashboard/autorag` |
-| 9108 | AutoML | `@odh-dashboard/automl` |
-| 9110 | MLflow | `@odh-dashboard/mlflow` |
-| 9300 | MLflow Embedded | `@odh-dashboard/mlflow-embedded` |
+This prints a complete list of all current port assignments, sourced directly from the workspace `package.json` files and `federation-configmap.yaml`.
 
 > **Convention**: Frontend federation ports use the 9100–9399 range. BFF ports use the 4000–4099 range. Pick the next available number in the appropriate range.
 
-#### Steps
+Pick an unused port and update both `Makefile` and `package.json`:
 
 1. **Update `Makefile`**:
    Open `packages/<your-module-name>/Makefile` and find the `dev-frontend-federated` target. Update the `PORT` variable:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "commit:skip-lint-hook": "SKIP_LINT_HOOK=true git commit",
     "commit:force-lint-hook": "FORCE_LINT_HOOK=true git commit",
     "prepare": "husky",
+    "validate:ports": "node scripts/validate-module-ports.js",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "test-unit": "turbo run test-unit",

--- a/packages/eval-hub/Makefile
+++ b/packages/eval-hub/Makefile
@@ -37,7 +37,7 @@ dev-bff:
 
 .PHONY: dev-frontend
 dev-frontend:
-	cd frontend && DEPLOYMENT_MODE=standalone PORT=9105 PROXY_PORT=4002 STYLE_THEME=mui-theme npm run start:dev
+	cd frontend && DEPLOYMENT_MODE=standalone PORT=9106 PROXY_PORT=4002 STYLE_THEME=mui-theme npm run start:dev
 
 .PHONY: dev-start
 dev-start:
@@ -77,7 +77,7 @@ dev-start-federated-no-portforward: ## Start frontend and bff without port-forwa
 
 .PHONY: dev-frontend-federated
 dev-frontend-federated:
-	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=9105 PROXY_PORT=4002 npm run start:dev
+	cd frontend && AUTH_METHOD=user_token DEPLOYMENT_MODE=federated STYLE_THEME=patternfly PORT=9106 PROXY_PORT=4002 npm run start:dev
 
 .PHONY: dev-bff-federated
 dev-bff-federated:

--- a/packages/eval-hub/package.json
+++ b/packages/eval-hub/package.json
@@ -16,7 +16,7 @@
     ],
     "local": {
       "host": "localhost",
-      "port": 9105
+      "port": 9106
     },
     "service": {
       "name": "odh-dashboard",
@@ -36,9 +36,9 @@
     "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --mock-evalhub-client' odh-ct-bff-consumer --bff-dir bff",
     "cypress:server:build": "cd frontend && DIST_DIR=./public-cypress DEPLOYMENT_MODE=federated npm run build",
     "cypress:server:build:coverage": "COVERAGE=true npm run cypress:server:build",
-    "cypress:server": "cd frontend && serve ./public-cypress -p 9105 -s -L",
-    "cypress:server:dev": "cd frontend && DEPLOYMENT_MODE=federated PORT=9105 PROXY_PORT=4002 npm run start:dev",
-    "cypress:server:wait": "npx wait-on -i 1000 http://localhost:9105"
+    "cypress:server": "cd frontend && serve ./public-cypress -p 9106 -s -L",
+    "cypress:server:dev": "cd frontend && DEPLOYMENT_MODE=federated PORT=9106 PROXY_PORT=4002 npm run start:dev",
+    "cypress:server:wait": "npx wait-on -i 1000 http://localhost:9106"
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",

--- a/scripts/validate-module-ports.js
+++ b/scripts/validate-module-ports.js
@@ -169,7 +169,7 @@ function validate() {
     console.error(
       `\nEach module must have a unique "module-federation.local.port" in its package.json.`,
     );
-    console.error(`See docs/onboard-modular-architecture.md for the port registry.\n`);
+    console.error(`See docs/onboard-modular-architecture.md for port conventions.\n`);
   }
 
   // --- 2. Validate production service ports from federation-configmap.yaml ---

--- a/scripts/validate-module-ports.js
+++ b/scripts/validate-module-ports.js
@@ -1,0 +1,231 @@
+/**
+ * Validates that module-federation ports are unique across workspace packages.
+ *
+ * Two categories of ports are checked:
+ *
+ * 1. Local dev ports (package.json "module-federation.local.port")
+ *    Must be unique so multiple federated modules can run simultaneously.
+ *
+ * 2. Production service ports (federation-configmap.yaml "service.port")
+ *    Must be unique because all BFF sidecars run in the same pod.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+};
+
+function getWorkspacePackages() {
+  try {
+    const stdout = execSync('npm query .workspace --json', { encoding: 'utf8' });
+    return JSON.parse(stdout);
+  } catch (error) {
+    console.error(`${colors.red}Error querying workspaces:${colors.reset}`, error.message);
+    throw new Error('Failed to query workspace packages');
+  }
+}
+
+/**
+ * Extracts the local dev port from a module-federation config, handling both
+ * the old format (local.port) and the new format (backend.localService.port).
+ * Also checks proxyService entries for packages that only define proxy ports.
+ */
+function extractLocalPort(mfConfig) {
+  if (mfConfig.local?.port != null) {
+    return mfConfig.local.port;
+  }
+  if (mfConfig.backend?.localService?.port != null) {
+    return mfConfig.backend.localService.port;
+  }
+  if (Array.isArray(mfConfig.proxyService)) {
+    for (const proxy of mfConfig.proxyService) {
+      if (proxy.localService?.port != null) {
+        return proxy.localService.port;
+      }
+    }
+  }
+  return null;
+}
+
+function extractName(mfConfig) {
+  return mfConfig.name ?? 'unknown';
+}
+
+/**
+ * Parses the federation-configmap.yaml to extract production service ports.
+ * The configmap contains a JSON array embedded in YAML under
+ * data."module-federation-config.json".
+ */
+function parseFederationConfigMap() {
+  const configMapPath = path.resolve(
+    __dirname,
+    '../manifests/modular-architecture/federation-configmap.yaml',
+  );
+
+  if (!fs.existsSync(configMapPath)) {
+    return null;
+  }
+
+  const content = fs.readFileSync(configMapPath, 'utf8');
+
+  // Extract the JSON array from the YAML. It starts after the
+  // "module-federation-config.json: |" line and is indented.
+  const jsonMatch = content.match(/module-federation-config\.json:\s*\|\s*\n([\s\S]+)/);
+  if (!jsonMatch) {
+    return null;
+  }
+
+  const lines = jsonMatch[1].split('\n');
+  const indent = lines.find((l) => l.trim())?.match(/^(\s*)/)?.[1].length ?? 0;
+  const rawJson = lines
+    .map((line) => (indent > 0 ? line.slice(indent) : line))
+    .join('\n')
+    .trim();
+
+  try {
+    return JSON.parse(rawJson);
+  } catch {
+    console.warn(`${colors.yellow}⚠ Could not parse federation-configmap.yaml JSON${colors.reset}`);
+    return null;
+  }
+}
+
+/**
+ * Checks a port map for conflicts. Returns an array of conflict objects.
+ */
+function checkPortMap(portMap) {
+  const conflicts = [];
+  const sorted = [...portMap.entries()].toSorted(([a], [b]) => a - b);
+
+  for (const [port, owners] of sorted) {
+    const hasConflict = owners.length > 1;
+    const color = hasConflict ? colors.red : colors.green;
+    const marker = hasConflict ? '✗ CONFLICT' : '✓';
+
+    for (const { name } of owners) {
+      console.log(`  ${color}${marker}${colors.reset}  port ${port}  →  ${name}`);
+    }
+
+    if (hasConflict) {
+      conflicts.push({ port, owners });
+    }
+  }
+
+  return conflicts;
+}
+
+function validate() {
+  let hasErrors = false;
+
+  // --- 1. Validate local dev ports from package.json ---
+  const packages = getWorkspacePackages();
+  const localPortMap = new Map();
+  let totalModules = 0;
+
+  for (const pkg of packages) {
+    const mfConfig = pkg['module-federation'];
+    if (!mfConfig) {
+      continue;
+    }
+
+    totalModules++;
+    const port = extractLocalPort(mfConfig);
+    const mfName = extractName(mfConfig);
+    const packageName = pkg.name || pkg.path;
+
+    if (port == null) {
+      console.warn(
+        `${colors.yellow}⚠ ${packageName} (${mfName}): no local dev port configured${colors.reset}`,
+      );
+      continue;
+    }
+
+    if (!localPortMap.has(port)) {
+      localPortMap.set(port, []);
+    }
+    localPortMap.get(port).push({ name: `${mfName} (${packageName})` });
+  }
+
+  console.log(`\n${colors.cyan}Local Dev Ports (package.json)${colors.reset}`);
+  console.log('─'.repeat(60));
+  const localConflicts = checkPortMap(localPortMap);
+  console.log('─'.repeat(60));
+  console.log(`  ${totalModules} federated module(s), ${localPortMap.size} unique port(s)\n`);
+
+  if (localConflicts.length > 0) {
+    hasErrors = true;
+    console.error(`${colors.red}✗ Local dev port conflicts detected:${colors.reset}\n`);
+    for (const { port, owners } of localConflicts) {
+      const names = owners.map((o) => o.name).join(', ');
+      console.error(`  Port ${port} is used by: ${names}`);
+    }
+    console.error(
+      `\nEach module must have a unique "module-federation.local.port" in its package.json.`,
+    );
+    console.error(`See docs/onboard-modular-architecture.md for the port registry.\n`);
+  }
+
+  // --- 2. Validate production service ports from federation-configmap.yaml ---
+  const configMapEntries = parseFederationConfigMap();
+
+  if (configMapEntries) {
+    const servicePortMap = new Map();
+
+    for (const entry of configMapEntries) {
+      const name = entry.name ?? 'unknown';
+      const servicePort = entry.service?.port;
+
+      if (servicePort == null) {
+        continue;
+      }
+
+      if (!servicePortMap.has(servicePort)) {
+        servicePortMap.set(servicePort, []);
+      }
+      servicePortMap.get(servicePort).push({ name });
+    }
+
+    if (servicePortMap.size > 0) {
+      console.log(
+        `${colors.cyan}Production Service Ports (federation-configmap.yaml)${colors.reset}`,
+      );
+      console.log('─'.repeat(60));
+      const serviceConflicts = checkPortMap(servicePortMap);
+      console.log('─'.repeat(60));
+      console.log(
+        `  ${configMapEntries.length} module(s), ${servicePortMap.size} unique port(s)\n`,
+      );
+
+      if (serviceConflicts.length > 0) {
+        hasErrors = true;
+        console.error(
+          `${colors.red}✗ Production service port conflicts detected:${colors.reset}\n`,
+        );
+        for (const { port, owners } of serviceConflicts) {
+          const names = owners.map((o) => o.name).join(', ');
+          console.error(`  Port ${port} is used by: ${names}`);
+        }
+        console.error(
+          `\nEach module must have a unique "service.port" in federation-configmap.yaml.`,
+        );
+        console.error(
+          `Ports must also match in deployment.yaml, service.yaml, and networkpolicy.yaml.\n`,
+        );
+      }
+    }
+  }
+
+  if (!hasErrors) {
+    console.log(`${colors.green}✓ All module federation ports are unique.${colors.reset}\n`);
+  }
+  process.exitCode = hasErrors ? 1 : 0;
+}
+
+validate();

--- a/scripts/validate-module-ports.js
+++ b/scripts/validate-module-ports.js
@@ -33,41 +33,44 @@ function getWorkspacePackages() {
 }
 
 /**
- * Extracts the local dev port from a module-federation config, handling both
- * the old format (local.port) and the new format (backend.localService.port).
- * Also checks proxyService entries for packages that only define proxy ports.
+ * Extracts all local dev ports from a module-federation config.
+ * A single package may define multiple ports (e.g. webpack dev server + proxy target).
+ * Returns an array of { port, source } objects.
  */
-function extractLocalPort(mfConfig) {
+function extractLocalPorts(mfConfig) {
+  const ports = [];
   if (mfConfig.local?.port != null) {
-    return mfConfig.local.port;
+    ports.push({ port: mfConfig.local.port, source: 'local.port' });
   }
   if (mfConfig.backend?.localService?.port != null) {
-    return mfConfig.backend.localService.port;
+    ports.push({ port: mfConfig.backend.localService.port, source: 'backend.localService.port' });
   }
   if (Array.isArray(mfConfig.proxyService)) {
     for (const proxy of mfConfig.proxyService) {
       if (proxy.localService?.port != null) {
-        return proxy.localService.port;
+        ports.push({ port: proxy.localService.port, source: 'proxyService.localService.port' });
       }
     }
   }
-  return null;
+  return ports;
 }
 
 function extractName(mfConfig) {
   return mfConfig.name ?? 'unknown';
 }
 
+const CONFIGMAP_PATHS = [
+  '../manifests/modular-architecture/federation-configmap.yaml',
+  '../manifests/rhoai/shared/base/federation-configmap.yaml',
+];
+
 /**
- * Parses the federation-configmap.yaml to extract production service ports.
+ * Parses a federation-configmap.yaml to extract production service ports.
  * The configmap contains a JSON array embedded in YAML under
  * data."module-federation-config.json".
  */
-function parseFederationConfigMap() {
-  const configMapPath = path.resolve(
-    __dirname,
-    '../manifests/modular-architecture/federation-configmap.yaml',
-  );
+function parseFederationConfigMap(relativePath) {
+  const configMapPath = path.resolve(__dirname, relativePath);
 
   if (!fs.existsSync(configMapPath)) {
     return null;
@@ -75,8 +78,6 @@ function parseFederationConfigMap() {
 
   const content = fs.readFileSync(configMapPath, 'utf8');
 
-  // Extract the JSON array from the YAML. It starts after the
-  // "module-federation-config.json: |" line and is indented.
   const jsonMatch = content.match(/module-federation-config\.json:\s*\|\s*\n([\s\S]+)/);
   if (!jsonMatch) {
     return null;
@@ -84,15 +85,29 @@ function parseFederationConfigMap() {
 
   const lines = jsonMatch[1].split('\n');
   const indent = lines.find((l) => l.trim())?.match(/^(\s*)/)?.[1].length ?? 0;
-  const rawJson = lines
-    .map((line) => (indent > 0 ? line.slice(indent) : line))
-    .join('\n')
-    .trim();
+
+  // Stop capturing when indentation drops back to or below the data key level,
+  // so we don't accidentally include subsequent YAML keys.
+  const jsonLines = [];
+  for (const line of lines) {
+    if (line.trim() === '') {
+      jsonLines.push('');
+      continue;
+    }
+    const lineIndent = line.match(/^(\s*)/)?.[1].length ?? 0;
+    if (lineIndent < indent) {
+      break;
+    }
+    jsonLines.push(indent > 0 ? line.slice(indent) : line);
+  }
+  const rawJson = jsonLines.join('\n').trim();
 
   try {
     return JSON.parse(rawJson);
   } catch {
-    console.warn(`${colors.yellow}⚠ Could not parse federation-configmap.yaml JSON${colors.reset}`);
+    console.warn(
+      `${colors.yellow}⚠ Could not parse JSON from ${path.basename(configMapPath)}${colors.reset}`,
+    );
     return null;
   }
 }
@@ -136,21 +151,23 @@ function validate() {
     }
 
     totalModules++;
-    const port = extractLocalPort(mfConfig);
+    const ports = extractLocalPorts(mfConfig);
     const mfName = extractName(mfConfig);
     const packageName = pkg.name || pkg.path;
 
-    if (port == null) {
+    if (ports.length === 0) {
       console.warn(
         `${colors.yellow}⚠ ${packageName} (${mfName}): no local dev port configured${colors.reset}`,
       );
       continue;
     }
 
-    if (!localPortMap.has(port)) {
-      localPortMap.set(port, []);
+    for (const { port, source } of ports) {
+      if (!localPortMap.has(port)) {
+        localPortMap.set(port, []);
+      }
+      localPortMap.get(port).push({ name: `${mfName} [${source}] (${packageName})` });
     }
-    localPortMap.get(port).push({ name: `${mfName} (${packageName})` });
   }
 
   console.log(`\n${colors.cyan}Local Dev Ports (package.json)${colors.reset}`);
@@ -172,30 +189,43 @@ function validate() {
     console.error(`See docs/onboard-modular-architecture.md for port conventions.\n`);
   }
 
-  // --- 2. Validate production service ports from federation-configmap.yaml ---
-  const configMapEntries = parseFederationConfigMap();
+  // --- 2. Validate production service ports from federation-configmap.yaml files ---
+  for (const configMapRelPath of CONFIGMAP_PATHS) {
+    const configMapEntries = parseFederationConfigMap(configMapRelPath);
+    const configMapLabel = `${path.basename(
+      path.dirname(configMapRelPath),
+    )}/federation-configmap.yaml`;
 
-  if (configMapEntries) {
+    if (!configMapEntries) {
+      continue;
+    }
+
     const servicePortMap = new Map();
 
     for (const entry of configMapEntries) {
       const name = entry.name ?? 'unknown';
-      const servicePort = entry.service?.port;
 
-      if (servicePort == null) {
-        continue;
+      if (entry.service?.port != null) {
+        if (!servicePortMap.has(entry.service.port)) {
+          servicePortMap.set(entry.service.port, []);
+        }
+        servicePortMap.get(entry.service.port).push({ name: `${name} [service]` });
       }
 
-      if (!servicePortMap.has(servicePort)) {
-        servicePortMap.set(servicePort, []);
+      if (Array.isArray(entry.proxyService)) {
+        for (const proxy of entry.proxyService) {
+          if (proxy.service?.port != null) {
+            if (!servicePortMap.has(proxy.service.port)) {
+              servicePortMap.set(proxy.service.port, []);
+            }
+            servicePortMap.get(proxy.service.port).push({ name: `${name} [proxyService]` });
+          }
+        }
       }
-      servicePortMap.get(servicePort).push({ name });
     }
 
     if (servicePortMap.size > 0) {
-      console.log(
-        `${colors.cyan}Production Service Ports (federation-configmap.yaml)${colors.reset}`,
-      );
+      console.log(`${colors.cyan}Production Service Ports (${configMapLabel})${colors.reset}`);
       console.log('─'.repeat(60));
       const serviceConflicts = checkPortMap(servicePortMap);
       console.log('─'.repeat(60));
@@ -206,7 +236,7 @@ function validate() {
       if (serviceConflicts.length > 0) {
         hasErrors = true;
         console.error(
-          `${colors.red}✗ Production service port conflicts detected:${colors.reset}\n`,
+          `${colors.red}✗ Production service port conflicts in ${configMapLabel}:${colors.reset}\n`,
         );
         for (const { port, owners } of serviceConflicts) {
           const names = owners.map((o) => o.name).join(', ');


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-30635

## Description

As we onboard more federated modules, the risk of local dev port collisions grows. Ports are scattered across 10+ separate `package.json` files, making conflicts hard to spot during review.

This PR adds automated validation to catch module federation port conflicts early:

- **New script** (`scripts/validate-module-ports.js`) reads `module-federation.local.port` from every workspace `package.json` and `service.port` from `federation-configmap.yaml`, then checks for duplicates.
- **CI integration** — runs as a step in `.github/workflows/test.yml` so conflicts block merge.
- **Pre-commit hook** — conditionally runs when any `package.json` or federation manifest file is staged.
- **`npm run validate:ports`** — available for manual invocation.

Also fixes a pre-existing port conflict:
- **eval-hub** was using port `9105` for its `module-federation.local.port`, which collided with **notebooks** (`9105` is synced from upstream and hard to change). Reassigned eval-hub to `9106` across `package.json`, `Makefile`, and cypress scripts.

Updated `docs/onboard-modular-architecture.md` with a port registry table and validation instructions to help future module authors pick conflict-free ports.

## How Has This Been Tested?

- Ran `node scripts/validate-module-ports.js` — all 10 modules pass with 10 unique local dev ports and 8 unique production service ports.
- Verified the script exits non-zero when a conflict is introduced (tested by temporarily duplicating a port).
- Confirmed the pre-commit hook triggers correctly when a `package.json` is staged.
- Verified `npm run validate:ports` alias works from the root.

## Test Impact

This is a tooling/infra change — no UI or runtime behavior is affected. The validation script is a standalone Node.js script with no dependencies beyond `child_process`, `fs`, and `path`. No unit tests are added because:
- The script is exercised in CI on every PR (functional test via `test.yml`).
- The pre-commit hook provides local coverage.
- The script is intentionally simple (~230 lines, no external deps) to minimize maintenance burden.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- N/A — no UI changes.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated validator to detect duplicate module-federation and production service ports and fail on conflicts.

* **Documentation**
  * Updated onboarding and workflow docs with uniqueness requirements, port-range conventions, and instructions to list/choose available ports using the validator.

* **Chores**
  * Added an npm script to run the validator and integrated it into CI and the pre-commit hook (commits blocked on conflicts).

* **Bug Fixes**
  * Adjusted a module’s local dev port to avoid a detected conflict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->