### PR TITLE
feat(build): add single-chunk-per-plugin webpack grouping strategy

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -431,11 +431,15 @@ const ModelCard: React.FC<{ extension: ModelExtension }> = ({ extension }) => {
 
 ## Chunk Naming Strategy
 
-The build system uses a **single-chunk-per-plugin** strategy for code references. This section applies to extension packages that are bundled into the host application (i.e., workspace packages with a `./extensions` export). For Module Federation remotes, chunking is handled by each remote's own webpack build.
+The build system uses a **single-chunk-per-plugin** strategy for extension code references. This section applies to extension packages that are bundled into the host application (i.e., workspace packages with a `./extensions` export). For Module Federation remotes, chunking is handled by each remote's own webpack build.
+
+### Scope
+
+The chunk grouping strategy **only affects dynamic imports originating from extension definition files** (files matching `extensions.ts` or files in an `extensions/` directory). Any other code-splitting within a plugin — such as `React.lazy()` route splitting inside components — retains normal webpack behavior and is not merged into the plugin chunk.
 
 ### Default Behavior
 
-When a plugin defines code references with dynamic imports, the build system automatically groups all modules from the same plugin package into a **single async chunk**. The chunk is named `plugin-<package-short-name>`.
+When a plugin defines code references with dynamic imports in its extension files, the build system automatically groups all modules from the same plugin package into a **single async chunk**. The chunk is named `plugin-<package-short-name>`.
 
 For example, a plugin at `@odh-dashboard/kserve` with multiple code references:
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -428,3 +428,108 @@ const ModelCard: React.FC<{ extension: ModelExtension }> = ({ extension }) => {
 - **Bundle Analysis**: Monitor plugin bundle sizes and optimize imports
 - **Feature Flag Filtering**: Use flags to prevent loading unused extensions entirely
 - **Memory Management**: Properly clean up resources in `HookNotify` components
+
+## Chunk Naming Strategy
+
+The build system uses a **single-chunk-per-plugin** strategy for code references. This section applies to extension packages that are bundled into the host application (i.e., workspace packages with a `./extensions` export). For Module Federation remotes, chunking is handled by each remote's own webpack build.
+
+### Default Behavior
+
+When a plugin defines code references with dynamic imports, the build system automatically groups all modules from the same plugin package into a **single async chunk**. The chunk is named `plugin-<package-short-name>`.
+
+For example, a plugin at `@odh-dashboard/kserve` with multiple code references:
+
+```typescript
+const extensions = [
+  {
+    type: 'model-serving.platform/watch-deployments',
+    properties: {
+      watch: () => import('./src/deployments').then((m) => m.useWatchDeployments),
+    },
+  },
+  {
+    type: 'model-serving.deployment/deploy',
+    properties: {
+      deploy: () => import('./src/deploy').then((m) => m.deployKServeDeployment),
+    },
+  },
+  {
+    type: 'model-serving.deployment/form-data',
+    properties: {
+      extractHardwareProfileConfig: () =>
+        import('./src/hardware').then((m) => m.extractHardwareProfileConfig),
+    },
+  },
+];
+```
+
+All three imports (`./src/deployments`, `./src/deploy`, `./src/hardware`) are bundled into one chunk named `plugin-kserve`. This reduces the number of network requests when a plugin's functionality is loaded.
+
+### Custom Chunk Names with `webpackChunkName`
+
+Extension authors can override the default grouping using webpack's [`webpackChunkName`](https://webpack.js.org/api/module-methods/#webpackchunkname) magic comment. This is useful when a plugin is large enough to benefit from logical separation into multiple chunks.
+
+```typescript
+const extensions = [
+  {
+    type: 'model-serving.deployment/deploy',
+    properties: {
+      // Placed in its own chunk named "kserve-deploy"
+      deploy: () =>
+        import(/* webpackChunkName: "kserve-deploy" */ './src/deploy').then(
+          (m) => m.deployKServeDeployment,
+        ),
+    },
+  },
+  {
+    type: 'model-serving.platform/watch-deployments',
+    properties: {
+      // Remains in the default "plugin-kserve" chunk
+      watch: () => import('./src/deployments').then((m) => m.useWatchDeployments),
+    },
+  },
+];
+```
+
+In this example, `./src/deploy` gets its own chunk (`kserve-deploy`) while `./src/deployments` stays in the default plugin chunk (`plugin-kserve`).
+
+**Grouping related imports:** Multiple imports from different files can share a `webpackChunkName` to be grouped into the same chunk:
+
+```typescript
+// Both imports land in a chunk named "kserve-hardware"
+extractHardwareProfileConfig: () =>
+  import(/* webpackChunkName: "kserve-hardware" */ './src/hardwareProfiles').then(
+    (m) => m.extractHardwareProfileConfig,
+  ),
+extractReplicas: () =>
+  import(/* webpackChunkName: "kserve-hardware" */ './src/replicas').then(
+    (m) => m.extractReplicas,
+  ),
+```
+
+### Shared Modules
+
+When a module is imported by both a named chunk and the default plugin chunk (or by two differently named chunks), the build system places it in the **default plugin chunk** rather than in any named chunk. This prevents a named chunk from becoming a hidden dependency of other chunks.
+
+For example, if `./src/deploy` (in chunk `kserve-deploy`) and `./src/deployments` (in the default chunk) both import `./src/utils`, then `./src/utils` is placed in `plugin-kserve`. This keeps the named `kserve-deploy` chunk genuinely optional — loading the default plugin chunk does not force the browser to also fetch the named chunk.
+
+### When to Use Custom Chunk Names
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Small plugin (< 50 KB) | Use default single-chunk grouping |
+| Large plugin with distinct features | Split into logical chunks (e.g., deploy vs. monitoring) |
+| Rarely used code paths | Separate into dedicated chunks to defer loading |
+| Multiple imports from the same file | No need for `webpackChunkName` — they share the same module |
+
+### Naming Convention
+
+When using `webpackChunkName`, prefix the chunk name with the plugin name:
+
+```typescript
+// Good: prefixed with plugin name
+import(/* webpackChunkName: "kserve-deploy" */ './src/deploy')
+
+// Avoid: generic name may collide with other plugins
+import(/* webpackChunkName: "deploy" */ './src/deploy')
+```

--- a/frontend/config/__tests__/discoverPluginPackages.spec.js
+++ b/frontend/config/__tests__/discoverPluginPackages.spec.js
@@ -25,6 +25,10 @@ beforeEach(() => {
   jest.resetModules();
 });
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('getPluginPackageDetails', () => {
   it('should return plugin packages with short names and locations, excluding internal', () => {
     jest.doMock('child_process', () => ({
@@ -72,7 +76,6 @@ describe('getPluginPackageDetails', () => {
       'Error querying workspaces with npm query:',
       'npm query failed',
     );
-    warnSpy.mockRestore();
   });
 
   it('should strip the org scope to produce shortName', () => {
@@ -129,7 +132,6 @@ describe('getPluginPackageDetails', () => {
       },
     ]);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('@odh-dashboard/no-path-plugin'));
-    warnSpy.mockRestore();
   });
 
   it('should cache the failure so subsequent calls do not re-run execSync', () => {
@@ -137,7 +139,7 @@ describe('getPluginPackageDetails', () => {
       throw new Error('npm query failed');
     });
     jest.doMock('child_process', () => ({ execSync: mockExecSync }));
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const {
       getPluginPackageDetails,
@@ -148,7 +150,6 @@ describe('getPluginPackageDetails', () => {
     discoverPluginPackages();
 
     expect(mockExecSync).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
   });
 
   it('should memoize the npm query call across multiple invocations', () => {

--- a/frontend/config/__tests__/discoverPluginPackages.spec.js
+++ b/frontend/config/__tests__/discoverPluginPackages.spec.js
@@ -100,6 +100,57 @@ describe('getPluginPackageDetails', () => {
     ]);
   });
 
+  it('should skip packages with missing path and warn', () => {
+    const packages = [
+      {
+        name: '@odh-dashboard/no-path-plugin',
+        exports: { './extensions': './extensions.ts' },
+      },
+      {
+        name: '@odh-dashboard/has-path-plugin',
+        path: '/workspace/packages/has-path-plugin',
+        exports: { './extensions': './extensions.ts' },
+      },
+    ];
+
+    jest.doMock('child_process', () => ({
+      execSync: jest.fn().mockReturnValue(JSON.stringify(packages)),
+    }));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { getPluginPackageDetails } = require('../discoverPluginPackages');
+    const result = getPluginPackageDetails();
+
+    expect(result).toEqual([
+      {
+        name: '@odh-dashboard/has-path-plugin',
+        shortName: 'has-path-plugin',
+        location: '/workspace/packages/has-path-plugin',
+      },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('@odh-dashboard/no-path-plugin'));
+    warnSpy.mockRestore();
+  });
+
+  it('should cache the failure so subsequent calls do not re-run execSync', () => {
+    const mockExecSync = jest.fn().mockImplementation(() => {
+      throw new Error('npm query failed');
+    });
+    jest.doMock('child_process', () => ({ execSync: mockExecSync }));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const {
+      getPluginPackageDetails,
+      discoverPluginPackages,
+    } = require('../discoverPluginPackages');
+
+    getPluginPackageDetails();
+    discoverPluginPackages();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
   it('should memoize the npm query call across multiple invocations', () => {
     const mockExecSync = jest.fn().mockReturnValue(JSON.stringify(mockWorkspacePackages));
     jest.doMock('child_process', () => ({ execSync: mockExecSync }));

--- a/frontend/config/__tests__/discoverPluginPackages.spec.js
+++ b/frontend/config/__tests__/discoverPluginPackages.spec.js
@@ -1,0 +1,117 @@
+const mockWorkspacePackages = [
+  {
+    name: '@odh-dashboard/kserve',
+    path: '/workspace/packages/kserve',
+    exports: { './extensions': './extensions.ts' },
+  },
+  {
+    name: '@odh-dashboard/model-serving',
+    path: '/workspace/packages/model-serving',
+    exports: { './extensions': './extensions.ts' },
+  },
+  {
+    name: '@odh-dashboard/internal',
+    path: '/workspace/frontend/src/__mocks__',
+    exports: { './extensions': './extensions.ts' },
+  },
+  {
+    name: '@odh-dashboard/tsconfig',
+    path: '/workspace/packages/tsconfig',
+    exports: {},
+  },
+];
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+describe('getPluginPackageDetails', () => {
+  it('should return plugin packages with short names and locations, excluding internal', () => {
+    jest.doMock('child_process', () => ({
+      execSync: jest.fn().mockReturnValue(JSON.stringify(mockWorkspacePackages)),
+    }));
+
+    const { getPluginPackageDetails } = require('../discoverPluginPackages');
+    const result = getPluginPackageDetails();
+
+    expect(result).toEqual([
+      {
+        name: '@odh-dashboard/kserve',
+        shortName: 'kserve',
+        location: '/workspace/packages/kserve',
+      },
+      {
+        name: '@odh-dashboard/model-serving',
+        shortName: 'model-serving',
+        location: '/workspace/packages/model-serving',
+      },
+    ]);
+  });
+
+  it('should return empty array when no workspace packages exist', () => {
+    jest.doMock('child_process', () => ({
+      execSync: jest.fn().mockReturnValue(JSON.stringify([])),
+    }));
+
+    const { getPluginPackageDetails } = require('../discoverPluginPackages');
+    expect(getPluginPackageDetails()).toEqual([]);
+  });
+
+  it('should return empty array when npm query fails', () => {
+    jest.doMock('child_process', () => ({
+      execSync: jest.fn().mockImplementation(() => {
+        throw new Error('npm query failed');
+      }),
+    }));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { getPluginPackageDetails } = require('../discoverPluginPackages');
+    expect(getPluginPackageDetails()).toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Error querying workspaces with npm query:',
+      'npm query failed',
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should strip the org scope to produce shortName', () => {
+    const packages = [
+      {
+        name: '@custom-org/my-plugin',
+        path: '/workspace/packages/my-plugin',
+        exports: { './extensions': './extensions.ts' },
+      },
+    ];
+
+    jest.doMock('child_process', () => ({
+      execSync: jest.fn().mockReturnValue(JSON.stringify(packages)),
+    }));
+
+    const { getPluginPackageDetails } = require('../discoverPluginPackages');
+    const result = getPluginPackageDetails();
+
+    expect(result).toEqual([
+      {
+        name: '@custom-org/my-plugin',
+        shortName: 'my-plugin',
+        location: '/workspace/packages/my-plugin',
+      },
+    ]);
+  });
+
+  it('should memoize the npm query call across multiple invocations', () => {
+    const mockExecSync = jest.fn().mockReturnValue(JSON.stringify(mockWorkspacePackages));
+    jest.doMock('child_process', () => ({ execSync: mockExecSync }));
+
+    const {
+      getPluginPackageDetails,
+      discoverPluginPackages,
+    } = require('../discoverPluginPackages');
+
+    getPluginPackageDetails();
+    discoverPluginPackages();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/config/__tests__/pluginChunking.spec.js
+++ b/frontend/config/__tests__/pluginChunking.spec.js
@@ -1,0 +1,81 @@
+const { getPluginChunkName } = require('../pluginChunking');
+
+const pluginPackageDetails = [
+  { shortName: 'kserve', location: '/workspace/packages/kserve' },
+  { shortName: 'model-serving', location: '/workspace/packages/model-serving' },
+];
+
+const mockModule = (resource) => ({ resource });
+
+const mockChunk = (name, isInitial = false) => ({
+  name,
+  canBeInitial: () => isInitial,
+});
+
+describe('getPluginChunkName', () => {
+  const getName = getPluginChunkName(pluginPackageDetails);
+
+  describe('default plugin chunk naming', () => {
+    it('should return plugin-<shortName> when all async chunks are unnamed', () => {
+      const module = mockModule('/workspace/packages/kserve/src/index.ts');
+      const chunks = [mockChunk(undefined)];
+      expect(getName(module, chunks)).toBe('plugin-kserve');
+    });
+  });
+
+  describe('explicit webpackChunkName', () => {
+    it('should preserve the name when all async chunks share the same webpackChunkName', () => {
+      const module = mockModule('/workspace/packages/kserve/src/deploy.ts');
+      const chunks = [mockChunk('kserve-deploy'), mockChunk('kserve-deploy')];
+      expect(getName(module, chunks)).toBe('kserve-deploy');
+    });
+
+    it('should fall back to default when async chunks have different names', () => {
+      const module = mockModule('/workspace/packages/kserve/src/utils.ts');
+      const chunks = [mockChunk('kserve-deploy'), mockChunk('kserve-monitoring')];
+      expect(getName(module, chunks)).toBe('plugin-kserve');
+    });
+
+    it('should fall back to default when some chunks are named and some are not', () => {
+      const module = mockModule('/workspace/packages/kserve/src/shared.ts');
+      const chunks = [mockChunk('kserve-deploy'), mockChunk(undefined)];
+      expect(getName(module, chunks)).toBe('plugin-kserve');
+    });
+  });
+
+  describe('initial chunk filtering', () => {
+    it('should ignore initial chunks and use the async chunk name', () => {
+      const module = mockModule('/workspace/packages/kserve/src/deploy.ts');
+      const chunks = [mockChunk('main', true), mockChunk('kserve-deploy')];
+      expect(getName(module, chunks)).toBe('kserve-deploy');
+    });
+
+    it('should fall back to default when only initial chunks exist', () => {
+      const module = mockModule('/workspace/packages/kserve/src/index.ts');
+      const chunks = [mockChunk('main', true)];
+      expect(getName(module, chunks)).toBe('plugin-kserve');
+    });
+  });
+
+  describe('unknown modules', () => {
+    it('should return false for a module outside all plugin packages', () => {
+      const module = mockModule('/workspace/node_modules/lodash/index.js');
+      const chunks = [mockChunk(undefined)];
+      expect(getName(module, chunks)).toBe(false);
+    });
+
+    it('should return false when module.resource is undefined', () => {
+      const module = mockModule(undefined);
+      const chunks = [mockChunk(undefined)];
+      expect(getName(module, chunks)).toBe(false);
+    });
+  });
+
+  describe('path matching precision', () => {
+    it('should not match a directory whose name is a prefix of a plugin path', () => {
+      const module = mockModule('/workspace/packages/kserve-extra/src/index.ts');
+      const chunks = [mockChunk(undefined)];
+      expect(getName(module, chunks)).toBe(false);
+    });
+  });
+});

--- a/frontend/config/__tests__/pluginChunking.spec.js
+++ b/frontend/config/__tests__/pluginChunking.spec.js
@@ -58,16 +58,16 @@ describe('getPluginChunkName', () => {
   });
 
   describe('unknown modules', () => {
-    it('should return false for a module outside all plugin packages', () => {
+    it('should return undefined for a module outside all plugin packages', () => {
       const module = mockModule('/workspace/node_modules/lodash/index.js');
       const chunks = [mockChunk(undefined)];
-      expect(getName(module, chunks)).toBe(false);
+      expect(getName(module, chunks)).toBeUndefined();
     });
 
-    it('should return false when module.resource is undefined', () => {
+    it('should return undefined when module.resource is undefined', () => {
       const module = mockModule(undefined);
       const chunks = [mockChunk(undefined)];
-      expect(getName(module, chunks)).toBe(false);
+      expect(getName(module, chunks)).toBeUndefined();
     });
   });
 
@@ -75,7 +75,7 @@ describe('getPluginChunkName', () => {
     it('should not match a directory whose name is a prefix of a plugin path', () => {
       const module = mockModule('/workspace/packages/kserve-extra/src/index.ts');
       const chunks = [mockChunk(undefined)];
-      expect(getName(module, chunks)).toBe(false);
+      expect(getName(module, chunks)).toBeUndefined();
     });
   });
 });

--- a/frontend/config/__tests__/pluginChunking.spec.js
+++ b/frontend/config/__tests__/pluginChunking.spec.js
@@ -1,4 +1,8 @@
-const { getPluginChunkName } = require('../pluginChunking');
+const {
+  isExtensionFile,
+  getExtensionChunksFilter,
+  getPluginChunkName,
+} = require('../pluginChunking');
 
 const pluginPackageDetails = [
   { shortName: 'kserve', location: '/workspace/packages/kserve' },
@@ -10,6 +14,112 @@ const mockModule = (resource) => ({ resource });
 const mockChunk = (name, isInitial = false) => ({
   name,
   canBeInitial: () => isInitial,
+});
+
+const mockChunkWithOrigin = (originResource, isInitial = false) => ({
+  canBeInitial: () => isInitial,
+  groupsIterable: [
+    {
+      origins: [{ module: { resource: originResource } }],
+    },
+  ],
+});
+
+describe('isExtensionFile', () => {
+  it('should match extensions.ts at the package root', () => {
+    expect(isExtensionFile('/workspace/packages/kserve/extensions.ts', pluginPackageDetails)).toBe(
+      true,
+    );
+  });
+
+  it('should match files in an extensions/ directory', () => {
+    expect(
+      isExtensionFile('/workspace/packages/model-serving/extensions/odh.ts', pluginPackageDetails),
+    ).toBe(true);
+  });
+
+  it('should match nested extension files', () => {
+    expect(
+      isExtensionFile(
+        '/workspace/packages/kserve/upstream/odh/extensions.ts',
+        pluginPackageDetails,
+      ),
+    ).toBe(true);
+  });
+
+  it('should not match regular source files', () => {
+    expect(isExtensionFile('/workspace/packages/kserve/src/deploy.ts', pluginPackageDetails)).toBe(
+      false,
+    );
+  });
+
+  it('should not match files from unknown packages', () => {
+    expect(
+      isExtensionFile('/workspace/node_modules/lodash/extensions.ts', pluginPackageDetails),
+    ).toBe(false);
+  });
+
+  it('should not match files with "extensions" as a substring in the name', () => {
+    expect(
+      isExtensionFile('/workspace/packages/kserve/src/extensionsHelper.ts', pluginPackageDetails),
+    ).toBe(false);
+  });
+});
+
+describe('getExtensionChunksFilter', () => {
+  const filter = getExtensionChunksFilter(pluginPackageDetails);
+
+  it('should include async chunks originating from an extensions.ts file', () => {
+    const chunk = mockChunkWithOrigin('/workspace/packages/kserve/extensions.ts');
+    expect(filter(chunk)).toBe(true);
+  });
+
+  it('should include async chunks originating from an extensions/ directory', () => {
+    const chunk = mockChunkWithOrigin('/workspace/packages/model-serving/extensions/odh.ts');
+    expect(filter(chunk)).toBe(true);
+  });
+
+  it('should exclude initial chunks even if originating from extension files', () => {
+    const chunk = mockChunkWithOrigin('/workspace/packages/kserve/extensions.ts', true);
+    expect(filter(chunk)).toBe(false);
+  });
+
+  it('should exclude async chunks originating from non-extension source files', () => {
+    const chunk = mockChunkWithOrigin('/workspace/packages/kserve/src/SomeLazyPage.tsx');
+    expect(filter(chunk)).toBe(false);
+  });
+
+  it('should exclude chunks from unrelated directories', () => {
+    const chunk = mockChunkWithOrigin('/workspace/node_modules/lodash/index.js');
+    expect(filter(chunk)).toBe(false);
+  });
+
+  it('should include chunks when any origin matches an extension file', () => {
+    const chunk = {
+      canBeInitial: () => false,
+      groupsIterable: [
+        {
+          origins: [{ module: { resource: '/workspace/packages/kserve/src/utils.ts' } }],
+        },
+        {
+          origins: [{ module: { resource: '/workspace/packages/kserve/extensions.ts' } }],
+        },
+      ],
+    };
+    expect(filter(chunk)).toBe(true);
+  });
+
+  it('should handle origins with missing module gracefully', () => {
+    const chunk = {
+      canBeInitial: () => false,
+      groupsIterable: [
+        {
+          origins: [{ module: null }],
+        },
+      ],
+    };
+    expect(filter(chunk)).toBe(false);
+  });
 });
 
 describe('getPluginChunkName', () => {

--- a/frontend/config/discoverPluginPackages.js
+++ b/frontend/config/discoverPluginPackages.js
@@ -20,7 +20,8 @@ function getWorkspacePackages() {
     return cachedWorkspacePackages;
   } catch (error) {
     console.warn('Error querying workspaces with npm query:', error.message);
-    return [];
+    cachedWorkspacePackages = [];
+    return cachedWorkspacePackages;
   }
 }
 
@@ -92,7 +93,18 @@ function getPluginPackageDetails() {
   const workspacePackages = getWorkspacePackages();
   const pluginPackages = filterPluginPackages(workspacePackages);
   return pluginPackages
-    .filter((pkg) => pkg.name !== '@odh-dashboard/internal')
+    .filter((pkg) => {
+      if (pkg.name === '@odh-dashboard/internal') {
+        return false;
+      }
+      if (!pkg.path) {
+        console.warn(
+          `Plugin package ${pkg.name} has no path from npm query, skipping chunk grouping`,
+        );
+        return false;
+      }
+      return true;
+    })
     .map((pkg) => ({
       name: pkg.name,
       shortName: pkg.name.replace(/^@[^/]+\//, ''),

--- a/frontend/config/discoverPluginPackages.js
+++ b/frontend/config/discoverPluginPackages.js
@@ -1,15 +1,23 @@
 const { execSync } = require('child_process');
 
+// Avoids running `npm query` multiple times within the same webpack build process,
+// since both discoverPluginPackages() and getPluginPackageDetails() need this data.
+let cachedWorkspacePackages = null;
+
 /**
- * Get all workspace packages using npm query
+ * Get all workspace packages using npm query (memoized).
  * @returns {Array} Array of workspace package objects
  */
 function getWorkspacePackages() {
+  if (cachedWorkspacePackages) {
+    return cachedWorkspacePackages;
+  }
   try {
     const stdout = execSync('npm query .workspace --json', {
       encoding: 'utf8',
     });
-    return JSON.parse(stdout);
+    cachedWorkspacePackages = JSON.parse(stdout);
+    return cachedWorkspacePackages;
   } catch (error) {
     console.warn('Error querying workspaces with npm query:', error.message);
     return [];
@@ -74,6 +82,25 @@ function discoverPluginPackages() {
   return availablePluginNames;
 }
 
+/**
+ * Get details of plugin packages for webpack chunk grouping.
+ * Returns the short name and filesystem location for each plugin package,
+ * excluding the host internal package.
+ * @returns {{ name: string, shortName: string, location: string }[]}
+ */
+function getPluginPackageDetails() {
+  const workspacePackages = getWorkspacePackages();
+  const pluginPackages = filterPluginPackages(workspacePackages);
+  return pluginPackages
+    .filter((pkg) => pkg.name !== '@odh-dashboard/internal')
+    .map((pkg) => ({
+      name: pkg.name,
+      shortName: pkg.name.replace(/^@[^/]+\//, ''),
+      location: pkg.path,
+    }));
+}
+
 module.exports = {
   discoverPluginPackages,
+  getPluginPackageDetails,
 };

--- a/frontend/config/pluginChunking.js
+++ b/frontend/config/pluginChunking.js
@@ -1,0 +1,33 @@
+/**
+ * Returns a webpack splitChunks `name` function that groups plugin modules
+ * into a single chunk per plugin package.
+ *
+ * - If all async chunks containing the module have the same explicit
+ *   webpackChunkName, that name is preserved.
+ * - If chunks have mixed or no names, the module falls into the default
+ *   plugin chunk (`plugin-<shortName>`), avoiding shared-module
+ *   mis-attribution across differently named chunks.
+ *
+ * @param {Array<{ shortName: string, location: string }>} pluginPackageDetails
+ * @returns {function} A name function for use in splitChunks.cacheGroups
+ */
+function getPluginChunkName(pluginPackageDetails) {
+  return (module, chunks) => {
+    const asyncChunks = chunks.filter((c) => !c.canBeInitial());
+    const namedChunks = asyncChunks.filter((c) => c.name);
+
+    if (namedChunks.length > 0 && namedChunks.length === asyncChunks.length) {
+      const names = new Set(namedChunks.map((c) => c.name));
+      if (names.size === 1) {
+        return namedChunks[0].name;
+      }
+    }
+
+    const plugin = pluginPackageDetails.find((pkg) =>
+      module.resource?.startsWith(`${pkg.location}/`),
+    );
+    return plugin ? `plugin-${plugin.shortName}` : false;
+  };
+}
+
+module.exports = { getPluginChunkName };

--- a/frontend/config/pluginChunking.js
+++ b/frontend/config/pluginChunking.js
@@ -1,4 +1,55 @@
 /**
+ * Checks whether a file path is an extension definition file within any
+ * of the known plugin packages.
+ *
+ * Extension files follow naming patterns such as:
+ *   extensions.ts, extensions/foo.ts, path/to/odh/extensions.ts
+ *
+ * @param {string} resource - Absolute path to the module file
+ * @param {Array<{ location: string }>} pluginPackageDetails
+ * @returns {boolean}
+ */
+function isExtensionFile(resource, pluginPackageDetails) {
+  return pluginPackageDetails.some((pkg) => {
+    if (!resource.startsWith(`${pkg.location}/`)) {
+      return false;
+    }
+    const relativePath = resource.slice(pkg.location.length + 1);
+    return /(^|\/)extensions(\/|\.)/i.test(relativePath);
+  });
+}
+
+/**
+ * Returns a webpack splitChunks `chunks` function that only includes
+ * async chunks originating from dynamic imports in extension files.
+ *
+ * This prevents route-level or other code-splitting chunks within a plugin
+ * from being merged into the single plugin chunk — only extension code
+ * references are grouped together.
+ *
+ * @param {Array<{ shortName: string, location: string }>} pluginPackageDetails
+ * @returns {function} A chunks filter function for use in splitChunks.cacheGroups
+ */
+function getExtensionChunksFilter(pluginPackageDetails) {
+  return (chunk) => {
+    if (chunk.canBeInitial()) {
+      return false;
+    }
+    for (const group of chunk.groupsIterable) {
+      for (const origin of group.origins) {
+        if (
+          origin.module?.resource &&
+          isExtensionFile(origin.module.resource, pluginPackageDetails)
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+}
+
+/**
  * Returns a webpack splitChunks `name` function that groups plugin modules
  * into a single chunk per plugin package.
  *
@@ -30,4 +81,4 @@ function getPluginChunkName(pluginPackageDetails) {
   };
 }
 
-module.exports = { getPluginChunkName };
+module.exports = { isExtensionFile, getExtensionChunksFilter, getPluginChunkName };

--- a/frontend/config/pluginChunking.js
+++ b/frontend/config/pluginChunking.js
@@ -26,7 +26,7 @@ function getPluginChunkName(pluginPackageDetails) {
     const plugin = pluginPackageDetails.find((pkg) =>
       module.resource?.startsWith(`${pkg.location}/`),
     );
-    return plugin ? `plugin-${plugin.shortName}` : false;
+    return plugin ? `plugin-${plugin.shortName}` : undefined;
   };
 }
 

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -8,6 +8,8 @@ const webpack = require('webpack');
 const { setupWebpackDotenvFilesForEnv } = require('./dotenv');
 const GenerateExtensionsPlugin = require('./generateExtensionsPlugin');
 const { moduleFederationPlugins, moduleFederationConfig } = require('./moduleFederation');
+const { getPluginPackageDetails } = require('./discoverPluginPackages');
+const { getPluginChunkName } = require('./pluginChunking');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -31,9 +33,15 @@ try {
   COMMIT_HASH_DIRECT = 'unknown';
 }
 
+const pluginPackageDetails = getPluginPackageDetails();
+
 if (OUTPUT_ONLY !== 'true') {
   console.info(
     `\nPrepping files...\n  SRC DIR: ${SRC_DIR}\n  OUTPUT DIR: ${DIST_DIR}\n  PUBLIC PATH: ${PUBLIC_PATH}\n`,
+  );
+  console.info(
+    'Plugin chunk groups:',
+    pluginPackageDetails.map((p) => p.shortName),
   );
   if (COVERAGE === 'true') {
     console.info('\nAdding code coverage instrumentation.\n');
@@ -207,6 +215,23 @@ module.exports = (env) => ({
     path: DIST_DIR,
     publicPath: PUBLIC_PATH,
     chunkFilename: '[name]-[chunkhash].js',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        pluginChunks: {
+          test(module) {
+            return pluginPackageDetails.some(
+              (pkg) => module.resource && module.resource.startsWith(`${pkg.location}/`),
+            );
+          },
+          name: getPluginChunkName(pluginPackageDetails),
+          chunks: 'async',
+          enforce: true,
+          priority: 10,
+        },
+      },
+    },
   },
   plugins: [
     // Generate extensions file before compilation

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -9,7 +9,7 @@ const { setupWebpackDotenvFilesForEnv } = require('./dotenv');
 const GenerateExtensionsPlugin = require('./generateExtensionsPlugin');
 const { moduleFederationPlugins, moduleFederationConfig } = require('./moduleFederation');
 const { getPluginPackageDetails } = require('./discoverPluginPackages');
-const { getPluginChunkName } = require('./pluginChunking');
+const { getExtensionChunksFilter, getPluginChunkName } = require('./pluginChunking');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -233,7 +233,7 @@ module.exports = (env) => ({
             );
           },
           name: getPluginChunkName(pluginPackageDetails),
-          chunks: 'async',
+          chunks: getExtensionChunksFilter(pluginPackageDetails),
           enforce: true,
           priority: 10,
         },

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -35,6 +35,13 @@ try {
 
 const pluginPackageDetails = getPluginPackageDetails();
 
+if (pluginPackageDetails.length === 0) {
+  console.warn(
+    'Warning: No plugin packages discovered. The pluginChunks splitChunks group will have no effect. ' +
+      'Check that workspace packages have ./extensions exports and that npm query is working.',
+  );
+}
+
 if (OUTPUT_ONLY !== 'true') {
   console.info(
     `\nPrepping files...\n  SRC DIR: ${SRC_DIR}\n  OUTPUT DIR: ${DIST_DIR}\n  PUBLIC PATH: ${PUBLIC_PATH}\n`,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "test:type-check": "tsc --noEmit",
     "test:jest": "jest",
     "test:jest:coverage": "rimraf jest-coverage && jest --silent --coverage --coverageReporters=json --coverageReporters=lcov",
+    "test-unit": "jest config/__tests__ --silent",
     "test:unit": "npm run test:jest -- --silent",
     "test:unit-coverage": "npm run test:jest:coverage",
     "test:cypress-ci": "npx concurrently -P -k -s first \"turbo run cypress:server:build --cwd=.. && turbo run cypress:server --cwd=..\" \"turbo run cypress:server:wait --cwd=.. && npm run cypress:run:mock -- {@}\" -- ",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-30122

## Description

Adds a webpack `splitChunks` strategy that consolidates dynamically imported modules from each plugin package's **extension files** into a single async chunk named `plugin-<shortName>`. This gives human-readable chunk names, reduces the number of network requests when plugin functionality is loaded, and provides extension authors with control over chunk splitting via `webpackChunkName` magic comments.

The strategy is scoped to only affect chunks originating from extension definition files (`extensions.ts` or files in an `extensions/` directory). Any other code-splitting within a plugin — such as `React.lazy()` route splitting inside components — retains normal webpack behavior and is not merged into the plugin chunk.

### What changed

* **`frontend/config/pluginChunking.js`** (new): Three exported functions:
  - `isExtensionFile()` — checks whether a file path is an extension definition file within a known plugin package, using the pattern `/(^|\/)extensions(\/|\.)/i`.
  - `getExtensionChunksFilter()` — returns a webpack `splitChunks.chunks` filter function that inspects each chunk's group origins and only includes async chunks whose `import()` call lives in an extension file. This prevents route-level or other code-splitting chunks from being merged into the plugin chunk.
  - `getPluginChunkName()` — returns a `splitChunks.name` function that groups modules into `plugin-<shortName>` by default, preserving explicit `webpackChunkName` when all async chunks agree on the same name, and falling back to the default plugin chunk for shared modules.
* **`frontend/config/discoverPluginPackages.js`**: Added `getPluginPackageDetails()` to expose each plugin's short name and filesystem location for chunk grouping. Memoized `getWorkspacePackages()` to avoid redundant `npm query` calls during a single build. Failure results are also cached.
* **`frontend/config/webpack.common.js`**: Integrated the new `optimization.splitChunks.cacheGroups.pluginChunks` config using the above utilities. Logs discovered plugin chunk groups at build time and warns when none are found.
* **`docs/extensibility.md`**: Documented the chunk naming strategy including scope, default behavior, custom `webpackChunkName` overrides, shared module handling, a decision table for when to split, and naming conventions.

### Build comparison

| Metric              | Before                                      | After                                        |
| ------------------- | ------------------------------------------- | -------------------------------------------- |
| Total JS chunks     | 233                                         | 219                                          |
| Named plugin chunks | 0                                           | 8                                            |
| Plugin chunk naming | Auto-generated numeric (e.g., 1611-016f...) | Human-readable (e.g., plugin-kserve-bbaa...) |

Plugin chunks produced:

```
plugin-feature-store
plugin-kserve
plugin-llmd-serving
plugin-mlflow-embedded
plugin-model-registry
plugin-model-serving
plugin-model-training
plugin-observability
```

Note: `model-serving-backport` does not produce a named chunk because its extension code references only import from `@odh-dashboard/internal` (the host package, excluded from chunk grouping), so no modules match the `test` function.

### Merge behavior

Verified that `webpack-merge` deep-merges `optimization.splitChunks` from `webpack.common.js` alongside:

* `optimization.runtimeChunk` / `removeEmptyChunks` in dev
* `optimization.minimize` / `minimizer` in prod

All keys coexist without conflicts.

## How Has This Been Tested?

1. **Production build** — `npm run build` in `frontend/` completed successfully; verified 8 `plugin-*` chunk files in output.
2. **webpack-merge verification** — Confirmed `splitChunks.cacheGroups` survives merge with both `webpack.dev.js` and `webpack.prod.js` optimization keys.
3. **Unit tests** — 29 tests across two spec files covering chunk naming logic, extension file detection, chunk origin filtering, and plugin package discovery.
4. **Turbo pipeline** — Verified `npm run test-unit` from root picks up the new tests via the `odh-dashboard-frontend` workspace.

## Test Impact

Added two new test files:

* **`frontend/config/__tests__/pluginChunking.spec.js`** (22 tests): `isExtensionFile` matching (6 tests), `getExtensionChunksFilter` chunk origin filtering (7 tests), `getPluginChunkName` default naming, explicit `webpackChunkName` preservation, mixed/partial name fallback, initial chunk filtering, unknown module handling, path prefix precision (9 tests).
* **`frontend/config/__tests__/discoverPluginPackages.spec.js`** (7 tests): correct filtering and mapping, `@odh-dashboard/internal` exclusion, empty workspace handling, `npm query` failure graceful degradation, org-scope stripping, failure caching, memoization.

Added `"test-unit"` script to `frontend/package.json` scoped to `config/__tests__` so these tests run in the turbo `test-unit` pipeline without overlapping with `@odh-dashboard/internal` tests.

## Request review criteria:

Self checklist (all need to be checked):

* The developer has manually tested the changes and verified that the changes work
* Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
* The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
* The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:

* Included any necessary screenshots or gifs if it was a UI change.
* Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:

* The developer has tested their solution on a cluster by using the image produced by the PR to `main`
