### PR TITLE
fix: allow custom OdhDocuments without matching OdhApplication (RHOAIENG-5317)

### DIFF
--- a/backend/src/utils/resourceUtils.ts
+++ b/backend/src/utils/resourceUtils.ts
@@ -359,9 +359,7 @@ const fetchDocs = async (fastify: KubeFastifyInstance): Promise<OdhDocument[]> =
             }
             return;
           }
-          if (appDefs.find((def) => def.metadata.name === doc.spec.appName)) {
-            docs.push(doc);
-          }
+          docs.push(doc);
         });
       }
     } catch (e) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-5317

## Description

Custom `OdhDocument` CRs created by users are silently dropped by the backend and never appear on the Learning Resources page.

The root cause is in `backend/src/utils/resourceUtils.ts` — `fetchDocs` requires every `OdhDocument`'s `spec.appName` to match an existing `OdhApplication` CR's `metadata.name`. When a user creates a custom document with a novel `appName` (e.g. `custom-odsci-app`), there is no corresponding `OdhApplication`, so the document is filtered out before it ever reaches the frontend.

The fix removes the `appName` allowlist check for documents that do **not** have a `spec.featureFlag`. Feature-flagged documents retain the existing gate (feature flag enabled + matching app required), since those are tied to platform features that can be explicitly disabled by admins.

The frontend already handles unmatched `appName` gracefully — `updateDocToComponent` in `docUtils.ts` simply sets `appEnabled: false` when no matching app is found, so no frontend changes are needed.

## How Has This Been Tested?

1. Created a custom `OdhDocument` CR on a live cluster with `spec.appName: custom-odsci-app` (no matching `OdhApplication` exists)
```
cat <<'EOF' | oc apply -n opendatahub -f -
apiVersion: dashboard.opendatahub.io/v1
kind: OdhDocument
metadata:
  name: custom-doc-howto-test
  labels:
    app: custom-odsci-app
  annotations:
    opendatahub.io/categories: "Package management,Notebook environments,Getting started,Testing"
spec:
  appName: custom-odsci-app
  description: "Custom How-To is a test item created to verify RHOAIENG-5317."
  displayName: "TEST - Custom How-To Documentation"
  durationMinutes: 15
  img: images/red-hat.svg
  provider: ods-ci
  type: how-to
  url: https://github.com/red-hat-data-services/ods-ci
EOF
```
2. Navigate to `http://localhost:4010/learning-resources` after running `npm run dev` and see the new resource appearing.

## Test Impact

No existing unit or Cypress tests cover `fetchDocs` backend filtering logic. This is a backend-only change with a narrow scope (3 lines removed). The feature-flag code path is unchanged.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`