### PR TITLE
[WIP] fix(hardwareProfiles): omit resources when user has not customized them

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileFormSection.tsx
@@ -43,6 +43,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
   } = useHardwareProfilesByFeatureVisibility(visibleIn, project);
 
   const [isExpanded, setIsExpanded] = React.useState(false);
+  const existingResources = React.useRef<ContainerResources | undefined>(undefined);
 
   React.useEffect(() => {
     if (initialHardwareProfile && hasValidationErrors) {
@@ -50,20 +51,32 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
     }
   }, [initialHardwareProfile, hasValidationErrors]);
 
+  React.useEffect(() => {
+    if (formData.resources && !existingResources.current) {
+      existingResources.current = formData.resources;
+    }
+  }, [formData.resources]);
+
   const onProfileSelect = (profile?: HardwareProfileKind) => {
-    // if no profile provided, use existing settings
     if (!profile) {
       setFormData('selectedProfile', undefined);
       setFormData('useExistingSettings', true);
+      if (existingResources.current) {
+        setFormData('resources', existingResources.current);
+      }
       return;
     }
 
-    // Reset customization when changing profiles
-    const newResources = getContainerResourcesFromHardwareProfile(profile);
+    if (
+      formData.selectedProfile?.metadata.name === profile.metadata.name &&
+      formData.selectedProfile.metadata.namespace === profile.metadata.namespace
+    ) {
+      return;
+    }
 
     setFormData('selectedProfile', profile);
     setFormData('useExistingSettings', false);
-    setFormData('resources', newResources);
+    setFormData('resources', getContainerResourcesFromHardwareProfile(profile));
   };
 
   return (
@@ -98,7 +111,7 @@ const HardwareProfileFormSection: React.FC<HardwareProfileFormSectionProps<PodSp
               isHardwareProfileSupported={isHardwareProfileSupported}
               initialHardwareProfile={initialHardwareProfile}
               onChange={onProfileSelect}
-              allowExistingSettings={isEditing && !initialHardwareProfile}
+              allowExistingSettings={isEditing}
               project={project}
             />
             <ZodErrorHelperText zodIssue={validation.getAllValidationIssues()} showAllErrors />

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useAssignHardwareProfile.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useAssignHardwareProfile.spec.ts
@@ -57,7 +57,7 @@ const createSharedTests = <T extends K8sResourceCommon>(config: TestConfig<T>) =
     expect(state.podSpecOptionsState).toBeDefined();
     expect(state.podSpecOptionsState.hardwareProfile).toBeDefined();
     expect(state.podSpecOptionsState.podSpecOptions).toEqual({
-      resources: { requests: {}, limits: {} }, // Default empty resources from formData
+      resources: undefined, // skipped when useExistingSettings is false without a selected profile
       tolerations: undefined,
       nodeSelector: undefined,
       selectedHardwareProfile: undefined,
@@ -285,10 +285,7 @@ const createSharedTests = <T extends K8sResourceCommon>(config: TestConfig<T>) =
     const renderResult = testHook(useAssignHardwareProfile)(resource, mockOptions);
     const { applyToResource, podSpecOptionsState } = renderResult.result.current;
 
-    expect(podSpecOptionsState.podSpecOptions.resources).toEqual({
-      requests: { cpu: '10', memory: '20Gi' },
-      limits: { cpu: '10', memory: '20Gi' },
-    });
+    expect(podSpecOptionsState.podSpecOptions.resources).toBeUndefined();
 
     const updatedResource = applyToResource(resource);
     expect(

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useHardwareProfileConfig.spec.ts
@@ -102,8 +102,8 @@ describe('useHardwareProfileConfig', () => {
 
     expect(state).toEqual({
       formData: {
-        selectedProfile: hardwareProfile,
-        useExistingSettings: false,
+        selectedProfile: undefined,
+        useExistingSettings: true,
         resources,
       },
       initialHardwareProfile: hardwareProfile,
@@ -140,7 +140,8 @@ describe('useHardwareProfileConfig', () => {
     );
     const state = renderResult.result.current;
 
-    expect(state.formData.selectedProfile).toBe(hardwareProfile);
+    expect(state.formData.selectedProfile).toBeUndefined();
+    expect(state.formData.useExistingSettings).toBe(true);
     expect(state.initialHardwareProfile).toBe(hardwareProfile);
   });
 
@@ -247,11 +248,12 @@ describe('useHardwareProfileConfig', () => {
     );
     const state = renderResult.result.current;
 
-    expect(state.formData.selectedProfile).toBe(hardwareProfile);
+    expect(state.formData.selectedProfile).toBeUndefined();
     expect(state.initialHardwareProfile).toBe(hardwareProfile);
-    expect(state.formData.useExistingSettings).toBe(false);
+    expect(state.formData.useExistingSettings).toBe(true);
 
-    // Resources should be merged: existing CPU/Memory preserved, new GPU added with default value
+    // Resources should be merged: existing CPU/Memory preserved, new GPU added with defaults
+    // Limits use maxCount from the HWP identifier (matching platform webhook behavior)
     expect(state.formData.resources).toEqual({
       requests: {
         cpu: '2',
@@ -261,7 +263,7 @@ describe('useHardwareProfileConfig', () => {
       limits: {
         cpu: '2',
         memory: '4Gi',
-        'nvidia.com/gpu': 1,
+        'nvidia.com/gpu': 2,
       },
     });
   });
@@ -344,7 +346,8 @@ describe('useHardwareProfileConfig', () => {
     );
     const state = renderResult.result.current;
 
-    expect(state.formData.selectedProfile).toBe(profile);
+    expect(state.formData.selectedProfile).toBeUndefined();
+    expect(state.formData.useExistingSettings).toBe(true);
     expect(state.formData.resources).toEqual({
       requests: { cpu: '2', memory: '4Gi' },
       limits: { cpu: '2', memory: '4Gi' },
@@ -402,7 +405,7 @@ describe('useHardwareProfileConfig', () => {
 
     expect(state.formData.resources).toEqual({
       requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
-      limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 4 },
     });
   });
 
@@ -578,10 +581,10 @@ describe('useHardwareProfileConfig', () => {
     );
     const state = renderResult.result.current;
 
-    // Customizations preserved, GPU added with default
+    // Customizations preserved, GPU added with default request and max limit
     expect(state.formData.resources).toEqual({
       requests: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 1 },
-      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 4 },
     });
   });
 
@@ -707,5 +710,174 @@ describe('useHardwareProfileConfig', () => {
       requests: { cpu: '4', memory: '8Gi' },
       limits: { cpu: '4', memory: '8Gi' },
     });
+  });
+
+  it('should set limits to maxCount on auto-selected profile for new deployments', () => {
+    const hardwareProfile = mockHardwareProfile({
+      name: 'max-limit-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue({
+      projectProfiles: [[], true, undefined],
+      globalProfiles: [[hardwareProfile], true, undefined],
+    });
+
+    const renderResult = testHook(useHardwareProfileConfig)();
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBe(hardwareProfile);
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '8', memory: '16Gi' },
+    });
+  });
+
+  it('should set GPU limits to maxCount on auto-selected profile', () => {
+    const hardwareProfile = mockHardwareProfile({
+      name: 'gpu-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '8Gi',
+          defaultCount: '4Gi',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 0,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue({
+      projectProfiles: [[], true, undefined],
+      globalProfiles: [[hardwareProfile], true, undefined],
+    });
+
+    const renderResult = testHook(useHardwareProfileConfig)();
+    const state = renderResult.result.current;
+
+    expect(state.formData.resources).toEqual({
+      requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 4 },
+    });
+  });
+
+  it('should preserve customized resources that differ from profile defaults on edit', () => {
+    const hardwareProfile = mockHardwareProfile({
+      name: 'edit-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '8',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '16Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue({
+      projectProfiles: [[], true, undefined],
+      globalProfiles: [[hardwareProfile], true, undefined],
+    });
+
+    const customizedResources = {
+      requests: { cpu: '6', memory: '12Gi' },
+      limits: { cpu: '6', memory: '12Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)(
+      'edit-profile',
+      customizedResources,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      hardwareProfile.metadata.namespace,
+    );
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBeUndefined();
+    expect(state.formData.useExistingSettings).toBe(true);
+    expect(state.initialHardwareProfile).toBe(hardwareProfile);
+    expect(state.formData.resources).toEqual(customizedResources);
+  });
+
+  it('should select hardware profile when edit resources match profile defaults', () => {
+    const hardwareProfile = mockHardwareProfile({
+      name: 'default-match-profile',
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '8Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+    mockUseHardwareProfiles.mockReturnValue({
+      projectProfiles: [[], true, undefined],
+      globalProfiles: [[hardwareProfile], true, undefined],
+    });
+
+    // Resources exactly match profile defaults (requests=default, limits=max)
+    const defaultResources = {
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '4', memory: '8Gi' },
+    };
+
+    const renderResult = testHook(useHardwareProfileConfig)(
+      'default-match-profile',
+      defaultResources,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      hardwareProfile.metadata.namespace,
+    );
+    const state = renderResult.result.current;
+
+    expect(state.formData.selectedProfile).toBe(hardwareProfile);
+    expect(state.formData.resources).toEqual(defaultResources);
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/__tests__/useModelServingHardwareProfileState.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/useModelServingHardwareProfileState.spec.ts
@@ -92,10 +92,7 @@ describe('useModelServingHardwareProfileState', () => {
       },
       hardwareProfile: expect.any(Object),
       podSpecOptions: {
-        resources: {
-          requests: {},
-          limits: {},
-        },
+        resources: undefined,
         tolerations: undefined,
         nodeSelector: undefined,
         selectedHardwareProfile: undefined,

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getExistingHardwareProfileData,
   assemblePodSpecOptions,
   applyHardwareProfileConfig,
+  getContainerResourcesFromHardwareProfile,
 } from '#~/concepts/hardwareProfiles/utils';
 import { HardwareProfileKind } from '#~/k8sTypes';
 import {
@@ -457,6 +458,128 @@ describe('assemblePodSpecOptions', () => {
   });
 });
 
+describe('getContainerResourcesFromHardwareProfile', () => {
+  it('should set requests to defaultCount and limits to maxCount', () => {
+    const profile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '8Gi',
+          defaultCount: '4Gi',
+        },
+      ],
+    });
+
+    const result = getContainerResourcesFromHardwareProfile(profile);
+
+    expect(result).toEqual({
+      requests: { cpu: '2', memory: '4Gi' },
+      limits: { cpu: '4', memory: '8Gi' },
+    });
+  });
+
+  it('should fall back to defaultCount for limits when maxCount is not set', () => {
+    const profile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: undefined as unknown as string,
+          defaultCount: '2',
+        },
+      ],
+    });
+
+    const result = getContainerResourcesFromHardwareProfile(profile);
+
+    expect(result).toEqual({
+      requests: { cpu: '2' },
+      limits: { cpu: '2' },
+    });
+  });
+
+  it('should handle GPU identifiers', () => {
+    const profile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'Memory',
+          identifier: 'memory',
+          minCount: '2Gi',
+          maxCount: '8Gi',
+          defaultCount: '4Gi',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 0,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+
+    const result = getContainerResourcesFromHardwareProfile(profile);
+
+    expect(result).toEqual({
+      requests: { cpu: '2', memory: '4Gi', 'nvidia.com/gpu': 1 },
+      limits: { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': 4 },
+    });
+  });
+
+  it('should handle custom identifiers', () => {
+    const profile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '2',
+          defaultCount: '1',
+        },
+        {
+          displayName: 'FPGA',
+          identifier: 'xilinx.com/fpga',
+          minCount: 0,
+          maxCount: 2,
+          defaultCount: 1,
+        },
+      ],
+    });
+
+    const result = getContainerResourcesFromHardwareProfile(profile);
+
+    expect(result).toEqual({
+      requests: { cpu: '1', 'xilinx.com/fpga': 1 },
+      limits: { cpu: '2', 'xilinx.com/fpga': 2 },
+    });
+  });
+
+  it('should return empty records when profile has no identifiers', () => {
+    const profile = mockHardwareProfile({ identifiers: [] });
+
+    const result = getContainerResourcesFromHardwareProfile(profile);
+
+    expect(result).toEqual({ requests: {}, limits: {} });
+  });
+});
+
 describe('applyHardwareProfileConfig', () => {
   const paths = NOTEBOOK_HARDWARE_PROFILE_PATHS;
 
@@ -490,24 +613,52 @@ describe('applyHardwareProfileConfig', () => {
     );
   });
 
-  it('should apply resources to notebook at configured path', () => {
+  it('should apply resources when they differ from hardware profile defaults', () => {
     const hardwareProfile = mockHardwareProfile({});
     const notebook = mockNotebookK8sResource({});
 
-    const resources: ContainerResources = {
-      requests: { cpu: '4', memory: '16Gi', 'nvidia.com/gpu': '1' },
-      limits: { cpu: '4', memory: '16Gi', 'nvidia.com/gpu': '1' },
+    const customizedResources: ContainerResources = {
+      requests: { cpu: '4', memory: '16Gi' },
+      limits: { cpu: '4', memory: '16Gi' },
     };
 
     const config = {
       selectedProfile: hardwareProfile,
       useExistingSettings: false,
-      resources,
+      resources: customizedResources,
     };
 
     const result = applyHardwareProfileConfig(notebook, config, paths);
 
-    expect(result.spec.template.spec.containers[0].resources).toEqual(resources);
+    expect(result.spec.template.spec.containers[0].resources).toEqual(customizedResources);
+  });
+
+  it('should not apply resources when they match hardware profile defaults', () => {
+    const hardwareProfile = mockHardwareProfile({});
+    const notebook = mockNotebookK8sResource({
+      resources: {
+        requests: { cpu: '1', memory: '2Gi' },
+        limits: { cpu: '1', memory: '2Gi' },
+      },
+    });
+
+    const defaultResources: ContainerResources = {
+      requests: { memory: '2Gi', cpu: '1' },
+      limits: { memory: '5Gi', cpu: '2' },
+    };
+
+    const config = {
+      selectedProfile: hardwareProfile,
+      useExistingSettings: false,
+      resources: defaultResources,
+    };
+
+    const result = applyHardwareProfileConfig(notebook, config, paths);
+
+    expect(result.spec.template.spec.containers[0].resources).toEqual({
+      requests: { cpu: '1', memory: '2Gi' },
+      limits: { cpu: '1', memory: '2Gi' },
+    });
   });
 
   it('should not mutate original resource', () => {
@@ -570,7 +721,7 @@ describe('applyHardwareProfileConfig', () => {
     ).toBeUndefined();
   });
 
-  it('should not apply resources when useExistingSettings is true', () => {
+  it('should not modify CR when useExistingSettings is true', () => {
     const hardwareProfile = mockHardwareProfile({ name: 'test-profile' });
     const notebook = mockNotebookK8sResource({
       resources: {
@@ -590,12 +741,12 @@ describe('applyHardwareProfileConfig', () => {
 
     const result = applyHardwareProfileConfig(notebook, config, paths);
 
-    // Should still have annotations
+    // Annotations should remain unchanged (no HWP annotation added)
     expect(result.metadata.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
-      'test-profile',
+      notebook.metadata.annotations?.['opendatahub.io/hardware-profile-name'],
     );
 
-    // But resources should remain unchanged (existing settings)
+    // Resources should remain unchanged (existing settings)
     expect(result.spec.template.spec.containers[0].resources).toEqual({
       requests: { cpu: '1', memory: '2Gi' },
       limits: { cpu: '1', memory: '2Gi' },
@@ -665,7 +816,7 @@ describe('applyHardwareProfileConfig', () => {
 
     const result = applyHardwareProfileConfig(inferenceService, config, inferenceServicePaths);
 
-    // Verify resources applied at correct path
+    // Resources differ from profile defaults so they should be applied
     expect(result.spec.predictor.model.resources).toEqual({
       requests: { cpu: '4', memory: '16Gi' },
       limits: { cpu: '4', memory: '16Gi' },
@@ -676,5 +827,86 @@ describe('applyHardwareProfileConfig', () => {
     expect((result as any).metadata?.annotations?.['opendatahub.io/hardware-profile-name']).toBe(
       'custom-path-test',
     );
+  });
+
+  it('should apply customized GPU resources that differ from profile defaults', () => {
+    const hardwareProfile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 0,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+    const notebook = mockNotebookK8sResource({});
+
+    const config = {
+      selectedProfile: hardwareProfile,
+      useExistingSettings: false,
+      resources: {
+        requests: { cpu: '2', 'nvidia.com/gpu': 2 },
+        limits: { cpu: '4', 'nvidia.com/gpu': 3 },
+      },
+    };
+
+    const result = applyHardwareProfileConfig(notebook, config, paths);
+
+    expect(result.spec.template.spec.containers[0].resources).toEqual({
+      requests: { cpu: '2', 'nvidia.com/gpu': 2 },
+      limits: { cpu: '4', 'nvidia.com/gpu': 3 },
+    });
+  });
+
+  it('should skip GPU resources when they match profile defaults', () => {
+    const hardwareProfile = mockHardwareProfile({
+      identifiers: [
+        {
+          displayName: 'CPU',
+          identifier: 'cpu',
+          minCount: '1',
+          maxCount: '4',
+          defaultCount: '2',
+        },
+        {
+          displayName: 'GPU',
+          identifier: 'nvidia.com/gpu',
+          minCount: 0,
+          maxCount: 4,
+          defaultCount: 1,
+        },
+      ],
+    });
+    const notebook = mockNotebookK8sResource({
+      resources: {
+        requests: { cpu: '1', 'nvidia.com/gpu': 0 },
+        limits: { cpu: '1', 'nvidia.com/gpu': 0 },
+      },
+    });
+
+    const config = {
+      selectedProfile: hardwareProfile,
+      useExistingSettings: false,
+      resources: {
+        requests: { cpu: '2', 'nvidia.com/gpu': 1 },
+        limits: { cpu: '4', 'nvidia.com/gpu': 4 },
+      },
+    };
+
+    const result = applyHardwareProfileConfig(notebook, config, paths);
+
+    expect(result.spec.template.spec.containers[0].resources).toEqual({
+      requests: { cpu: '1', 'nvidia.com/gpu': 0 },
+      limits: { cpu: '1', 'nvidia.com/gpu': 0 },
+    });
   });
 });

--- a/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
+++ b/frontend/src/concepts/hardwareProfiles/useHardwareProfileConfig.ts
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { isEqual } from 'lodash-es';
 import { HardwareProfileFeatureVisibility, HardwareProfileKind } from '#~/k8sTypes';
 import { UpdateObjectAtPropAndValue } from '#~/pages/projects/types';
 import useGenericObjectState from '#~/utilities/useGenericObjectState';
@@ -126,6 +127,7 @@ export const useHardwareProfileConfig = (
   } = useHardwareProfilesByFeatureVisibility(visibleIn, resourceNamespace);
 
   const initialHardwareProfile = useRef<HardwareProfileKind | undefined>(undefined);
+  const initialized = useRef(false);
   const [formData, setFormData, resetFormData] = useGenericObjectState<HardwareProfileConfig>({
     selectedProfile: undefined,
     useExistingSettings: false,
@@ -142,52 +144,58 @@ export const useHardwareProfileConfig = (
   const { kueueFilteringState } = useKueueConfiguration(currentProject);
 
   React.useEffect(() => {
-    if (!profilesLoaded || formData.selectedProfile) {
+    if (!profilesLoaded || initialized.current) {
       return;
     }
-    // only set form state if not already set
-    if (!formData.resources) {
-      let selectedProfile: HardwareProfileKind | undefined;
+    initialized.current = true;
 
-      // if editing, try to select existing profile
-      if (resources) {
-        // try to match to existing profile
-        if (existingHardwareProfileName && hardwareProfileNamespace) {
-          if (hardwareProfileNamespace === dashboardNamespace) {
-            selectedProfile = dashboardProfiles.find(
-              (profile) => profile.metadata.name === existingHardwareProfileName,
-            );
-          } else {
-            selectedProfile = projectScopedProfiles.find(
-              (profile) =>
-                profile.metadata.name === existingHardwareProfileName &&
-                profile.metadata.namespace === hardwareProfileNamespace,
-            );
-          }
+    let selectedProfile: HardwareProfileKind | undefined;
+
+    // if editing, try to select existing profile
+    if (resources) {
+      if (existingHardwareProfileName && hardwareProfileNamespace) {
+        if (hardwareProfileNamespace === dashboardNamespace) {
+          selectedProfile = dashboardProfiles.find(
+            (profile) => profile.metadata.name === existingHardwareProfileName,
+          );
         } else {
-          selectedProfile = matchToHardwareProfile(profiles, resources, tolerations, nodeSelector);
+          selectedProfile = projectScopedProfiles.find(
+            (profile) =>
+              profile.metadata.name === existingHardwareProfileName &&
+              profile.metadata.namespace === hardwareProfileNamespace,
+          );
         }
+      } else {
+        selectedProfile = matchToHardwareProfile(profiles, resources, tolerations, nodeSelector);
+      }
 
-        initialHardwareProfile.current = selectedProfile;
-        const mergedResources = selectedProfile
-          ? mergeProfileIdentifiersIntoResources(resources, selectedProfile)
-          : resources;
-        setFormData('resources', mergedResources);
+      initialHardwareProfile.current = selectedProfile;
+      const mergedResources = selectedProfile
+        ? mergeProfileIdentifiersIntoResources(resources, selectedProfile)
+        : resources;
+      const profileDefaults = selectedProfile
+        ? getContainerResourcesFromHardwareProfile(selectedProfile)
+        : undefined;
+      const isCustomized = profileDefaults ? !isEqual(mergedResources, profileDefaults) : true;
+
+      setFormData('resources', mergedResources);
+      if (isCustomized) {
+        setFormData('useExistingSettings', true);
+        setFormData('selectedProfile', undefined);
+      } else {
         setFormData('useExistingSettings', !selectedProfile);
         setFormData('selectedProfile', selectedProfile);
       }
-
+    } else {
       // if not editing existing profile, select the first enabled profile
-      else {
-        const filteredProfiles = filterProfilesByKueue(
-          profiles.filter(isHardwareProfileEnabled),
-          kueueFilteringState,
-        );
-        selectedProfile = filteredProfiles.length > 0 ? filteredProfiles[0] : undefined;
-        if (selectedProfile) {
-          setFormData('resources', getContainerResourcesFromHardwareProfile(selectedProfile));
-          setFormData('selectedProfile', selectedProfile);
-        }
+      const filteredProfiles = filterProfilesByKueue(
+        profiles.filter(isHardwareProfileEnabled),
+        kueueFilteringState,
+      );
+      selectedProfile = filteredProfiles.length > 0 ? filteredProfiles[0] : undefined;
+      if (selectedProfile) {
+        setFormData('resources', getContainerResourcesFromHardwareProfile(selectedProfile));
+        setFormData('selectedProfile', selectedProfile);
       }
     }
   }, [
@@ -198,8 +206,6 @@ export const useHardwareProfileConfig = (
     resources,
     tolerations,
     nodeSelector,
-    formData.resources,
-    formData.selectedProfile,
     hardwareProfileNamespace,
     projectScopedProfiles,
     dashboardProfiles,

--- a/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
+++ b/frontend/src/concepts/hardwareProfiles/useModelServingPodSpecOptionsState.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isEqual } from 'lodash-es';
 import { InferenceServiceKind, ServingRuntimeKind } from '#~/k8sTypes';
 import { useAppContext } from '#~/app/AppContext';
 import { getModelServingSizes } from '#~/concepts/modelServing/modelServingSizesUtils';
@@ -7,6 +8,7 @@ import { ModelServingSize } from '#~/pages/modelServing/screens/types';
 import { getInferenceServiceSize } from '#~/pages/modelServing/utils';
 import useServingHardwareProfileConfig from './useServingHardwareProfileConfig';
 import { PodSpecOptions, HardwarePodSpecOptionsState } from './types';
+import { getContainerResourcesFromHardwareProfile } from './utils';
 
 /**
  * most of this file (everything that uses and descends from PodSpecOptions) is deprecated
@@ -76,8 +78,15 @@ export const useModelServingHardwareProfileState = (
       ...annotationData,
     };
   } else {
+    const profileDefaults = hardwareProfile.formData.selectedProfile
+      ? getContainerResourcesFromHardwareProfile(hardwareProfile.formData.selectedProfile)
+      : undefined;
+    const formResources = hardwareProfile.formData.resources;
     podSpecOptions = {
-      resources: hardwareProfile.formData.resources,
+      resources:
+        formResources && profileDefaults && !isEqual(formResources, profileDefaults)
+          ? formResources
+          : undefined,
       tolerations: hardwareProfile.formData.selectedProfile?.spec.scheduling?.node?.tolerations,
       nodeSelector: hardwareProfile.formData.selectedProfile?.spec.scheduling?.node?.nodeSelector,
       ...annotationData,

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ModelResourceType } from '@odh-dashboard/model-serving/extension-points';
 import { K8sResourceCommon, Patch } from '@openshift/dynamic-plugin-sdk-utils';
-import { get, set } from 'lodash-es';
+import { get, set, isEqual } from 'lodash-es';
 import { ImageStreamKind, HardwareProfileKind, NotebookKind } from '#~/k8sTypes';
 import { getCompatibleIdentifiers } from '#~/pages/projects/screens/spawner/spawnerUtils';
 import {
@@ -123,7 +123,7 @@ export const getContainerResourcesFromHardwareProfile = (
   const newLimits =
     hardwareProfile.spec.identifiers?.reduce(
       (acc: Record<string, string | number>, identifier) => {
-        acc[identifier.identifier] = identifier.defaultCount;
+        acc[identifier.identifier] = identifier.maxCount ?? identifier.defaultCount;
         return acc;
       },
       { ...emptyRecord },
@@ -279,8 +279,14 @@ export const assemblePodSpecOptions = (
       ...podSpecOptions,
     };
   } else {
+    const profileDefaults = selectedProfile
+      ? getContainerResourcesFromHardwareProfile(selectedProfile)
+      : undefined;
     podSpecOptions = {
-      resources,
+      resources:
+        resources && profileDefaults && !isEqual(resources, profileDefaults)
+          ? resources
+          : undefined,
       tolerations: selectedProfile?.spec.scheduling?.node?.tolerations,
       nodeSelector: selectedProfile?.spec.scheduling?.node?.nodeSelector,
       ...podSpecOptions,
@@ -300,6 +306,11 @@ export const applyHardwareProfileConfig = <T extends K8sResourceCommon>(
   if (!result.metadata) {
     result.metadata = {};
   }
+
+  if (useExistingSettings) {
+    return result;
+  }
+
   if (selectedProfile) {
     const annotations = result.metadata.annotations || {};
     annotations['opendatahub.io/hardware-profile-name'] = selectedProfile.metadata.name;
@@ -313,9 +324,12 @@ export const applyHardwareProfileConfig = <T extends K8sResourceCommon>(
     delete result.metadata.annotations['opendatahub.io/hardware-profile-resource-version'];
   }
 
-  if (!useExistingSettings && selectedProfile && paths) {
+  if (selectedProfile && paths) {
     if (resources && paths.containerResourcesPath) {
-      set(result, paths.containerResourcesPath, resources);
+      const profileDefaults = getContainerResourcesFromHardwareProfile(selectedProfile);
+      if (!isEqual(resources, profileDefaults)) {
+        set(result, paths.containerResourcesPath, resources);
+      }
     }
   }
   return result;

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/__tests__/ManageNIMServingModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/__tests__/ManageNIMServingModal.spec.tsx
@@ -298,6 +298,13 @@ describe('ManageNIMServingModal', () => {
       hardwareProfile: {
         isFormDataValid: true,
         resetFormData: jest.fn(),
+        formData: {
+          useExistingSettings: false,
+          resources: {
+            limits: { cpu: '16', memory: '64Gi' },
+            requests: { cpu: '8', memory: '32Gi' },
+          },
+        },
       },
     },
     validateHardwareProfileForm: jest.fn(() => true),
@@ -687,6 +694,13 @@ describe('ManageNIMServingModal - Storage Class Fallback Logic', () => {
       hardwareProfile: {
         isFormDataValid: true,
         resetFormData: jest.fn(),
+        formData: {
+          useExistingSettings: false,
+          resources: {
+            limits: { cpu: '16', memory: '64Gi' },
+            requests: { cpu: '8', memory: '32Gi' },
+          },
+        },
       },
     },
     validateHardwareProfileForm: jest.fn(() => true),

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -222,7 +222,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
               <HardwareProfileTableColumn
                 namespace={obj.notebook.metadata.namespace}
                 resource={obj.notebook}
-                containerResources={podSpecOptionsState.podSpecOptions.resources}
+                containerResources={podSpecOptionsState.hardwareProfile.formData.resources}
                 isActive={obj.isRunning || obj.isStarting}
                 bindingState={{
                   bindingStateInfo,
@@ -271,7 +271,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
         <Td dataLabel="Limits">
           <ExpandableRowContent>
             <NotebookSizeDetails
-              notebookContainerSize={podSpecOptionsState.podSpecOptions.resources}
+              notebookContainerSize={podSpecOptionsState.hardwareProfile.formData.resources}
             />
           </ExpandableRowContent>
         </Td>

--- a/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -105,18 +105,8 @@ describe('NotebookServer', () => {
       // Check podSpecOptions exists
       expect(requestBody).to.have.property('podSpecOptions');
 
-      // Check podSpecOptions.resources
-      expect(requestBody.podSpecOptions).to.have.property('resources');
-      expect(requestBody.podSpecOptions.resources).to.have.property('requests');
-      expect(requestBody.podSpecOptions.resources.requests).to.deep.equal({
-        cpu: '1',
-        memory: '2Gi',
-      });
-      expect(requestBody.podSpecOptions.resources).to.have.property('limits');
-      expect(requestBody.podSpecOptions.resources.limits).to.deep.equal({
-        cpu: '1',
-        memory: '2Gi',
-      });
+      // Resources should be omitted when user has not customized them (webhook handles defaults)
+      expect(requestBody.podSpecOptions.resources).to.equal(undefined);
 
       // Check podSpecOptions.tolerations
       expect(requestBody.podSpecOptions).to.have.property('tolerations');

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -420,7 +420,7 @@ describe('Workbench Hardware Profiles', () => {
   describe('Edit Workbench Hardware Profiles', () => {
     it('should auto-select hardware profile from annotations', () => {
       initIntercepts();
-      // Mock notebook with hardware profile annotation
+      // Mock notebook with hardware profile annotation and resources matching profile defaults
       cy.interceptK8sList(
         {
           model: NotebookModel,
@@ -431,6 +431,10 @@ describe('Workbench Hardware Profiles', () => {
             hardwareProfileName: 'small-profile',
             hardwareProfileNamespace: 'test-project',
             displayName: 'Test Notebook',
+            resources: {
+              requests: { cpu: '1', memory: '2Gi' },
+              limits: { cpu: '2', memory: '4Gi' },
+            },
           }),
         ]),
       );
@@ -449,7 +453,7 @@ describe('Workbench Hardware Profiles', () => {
         disableProjectScoped: false,
       });
 
-      // Mock notebook with hardware profile annotation
+      // Mock notebook with hardware profile annotation and resources matching profile defaults
       cy.interceptK8sList(
         {
           model: NotebookModel,
@@ -460,6 +464,10 @@ describe('Workbench Hardware Profiles', () => {
             hardwareProfileName: 'large-profile-1',
             displayName: 'Test Notebook',
             hardwareProfileNamespace: 'test-project',
+            resources: {
+              requests: { cpu: '4', memory: '8Gi' },
+              limits: { cpu: '8', memory: '16Gi' },
+            },
           }),
         ]),
       );
@@ -506,7 +514,7 @@ describe('Workbench Hardware Profiles', () => {
         ]),
       );
 
-      // Mock notebook with disabled hardware profile annotation
+      // Mock notebook with disabled hardware profile annotation and matching resources
       cy.interceptK8sList(
         NotebookModel,
         mockK8sResourceList([
@@ -514,6 +522,10 @@ describe('Workbench Hardware Profiles', () => {
             hardwareProfileName: 'small-profile',
             hardwareProfileNamespace: 'opendatahub',
             displayName: 'Test Notebook',
+            resources: {
+              requests: { cpu: '1', memory: '2Gi' },
+              limits: { cpu: '2', memory: '4Gi' },
+            },
           }),
         ]),
       );
@@ -530,7 +542,7 @@ describe('Workbench Hardware Profiles', () => {
 
     it('should auto-select matching hardware profile when resources match', () => {
       initIntercepts();
-      // Mock notebook with matching resources but no hardware profile annotation
+      // Mock notebook with matching resources (requests=defaultCount, limits=maxCount) but no hardware profile annotation
       cy.interceptK8sList(
         NotebookModel,
         mockK8sResourceList([
@@ -554,8 +566,8 @@ describe('Workbench Hardware Profiles', () => {
                             memory: '2Gi',
                           },
                           limits: {
-                            cpu: '1',
-                            memory: '2Gi',
+                            cpu: '2',
+                            memory: '4Gi',
                           },
                         },
                       },
@@ -578,8 +590,6 @@ describe('Workbench Hardware Profiles', () => {
       editSpawnerPage.visit('test-notebook');
       editSpawnerPage.findAlertMessage().should('not.exist');
       hardwareProfileSection.findSelect().should('contain.text', 'Small Profile');
-      hardwareProfileSection.findSelect().click();
-      cy.findByRole('option', { name: 'Use existing settings' }).should('not.exist');
     });
 
     it('should auto-select "Use existing settings" when resources do not match any profile', () => {

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -472,16 +472,6 @@ describe('Model Serving Deploy Wizard', () => {
             modelFormat: {
               name: 'vLLM',
             },
-            resources: {
-              requests: {
-                cpu: '4',
-                memory: '8Gi',
-              },
-              limits: {
-                cpu: '4',
-                memory: '8Gi',
-              },
-            },
           },
         },
       },
@@ -504,11 +494,15 @@ describe('Model Serving Deploy Wizard', () => {
 
       // Check model format exists
       expect(interception.request.body.spec.predictor.model.modelFormat.name).to.equal('vLLM');
+
+      // Resources should not be set (user did not customize — platform webhook applies defaults)
+      expect(interception.request.body.spec.predictor.model).to.not.have.property('resources');
     });
 
     // Actual request
     cy.wait('@createInferenceService').then((interception) => {
       expect(interception.request.url).not.to.include('?dryRun=All');
+      expect(interception.request.body.spec.predictor.model).to.not.have.property('resources');
     });
 
     cy.get('@createInferenceService.all').then((interceptions) => {
@@ -1541,38 +1535,40 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findSaveConnectionCheckbox().should('not.be.checked');
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
-    // Step 2: Model deployment
-    hardwareProfileSection.findSelect().should('contain.text', 'Large Profile');
+    // Step 2: Model deployment — resources differ from profile defaults, so "Use existing settings" is shown
+    hardwareProfileSection.findSelect().should('contain.text', 'Use existing settings');
+    // Switch to profile to test the customize section validation
+    hardwareProfileSection.findSelect().click();
+    cy.findByRole('option', { name: /Large Profile/ }).click();
     hardwareProfileSection.findCustomizeButton().should('exist').click();
-    modelServingWizardEdit.findCPURequestedInput().should('have.value', '6');
-    modelServingWizardEdit.findCPULimitInput().should('have.value', '6');
-    modelServingWizardEdit.findMemoryRequestedInput().should('have.value', '10');
-    modelServingWizardEdit.findMemoryLimitInput().should('have.value', '10');
+    modelServingWizardEdit.findCPURequestedInput().should('have.value', '4');
+    modelServingWizardEdit.findCPULimitInput().should('have.value', '8');
+    modelServingWizardEdit.findMemoryRequestedInput().should('have.value', '8');
+    modelServingWizardEdit.findMemoryLimitInput().should('have.value', '16');
     modelServingWizardEdit.findNextButton().should('be.enabled');
 
     // Test validation: CPU request cannot exceed CPU limit
-    modelServingWizardEdit.findCPURequestedButton('Plus').click(); // set request to 7
+    // CPU request starts at 4, limit at 8 — increase request 5x to 9 (> limit 8)
+    for (let i = 0; i < 5; i++) {
+      modelServingWizardEdit.findCPURequestedButton('Plus').click();
+    }
     modelServingWizardEdit.findNextButton().should('be.disabled');
     cy.findAllByText('Limit must be greater than or equal to request').first().should('be.visible');
-    modelServingWizardEdit.findCPURequestedButton('Minus').click();
+    for (let i = 0; i < 5; i++) {
+      modelServingWizardEdit.findCPURequestedButton('Minus').click();
+    }
     modelServingWizardEdit.findNextButton().should('be.enabled');
 
     // Test validation: Memory request cannot exceed memory limit
-    modelServingWizardEdit.findMemoryRequestedButton('Plus').click(); // set request to 11
+    // Memory request starts at 8GiB, limit at 16GiB — increase request 9x to 17 (> limit 16)
+    for (let i = 0; i < 9; i++) {
+      modelServingWizardEdit.findMemoryRequestedButton('Plus').click();
+    }
     modelServingWizardEdit.findNextButton().should('be.disabled');
     cy.findAllByText('Limit must be greater than or equal to request').first().should('be.visible');
-    modelServingWizardEdit.findMemoryRequestedButton('Minus').click();
-    modelServingWizardEdit.findNextButton().should('be.enabled');
-
-    // Test validation: CPU and memory limit cannot be less than CPU and memory request
-    modelServingWizardEdit.findCPULimitButton('Minus').click();
-    modelServingWizardEdit.findNextButton().should('be.disabled');
-    cy.findAllByText('Limit must be greater than or equal to request').first().should('be.visible');
-    modelServingWizardEdit.findCPULimitButton('Plus').click();
-    modelServingWizardEdit.findMemoryLimitButton('Minus').click();
-    modelServingWizardEdit.findNextButton().should('be.disabled');
-    cy.findAllByText('Limit must be greater than or equal to request').first().should('be.visible');
-    modelServingWizardEdit.findMemoryLimitButton('Plus').click();
+    for (let i = 0; i < 9; i++) {
+      modelServingWizardEdit.findMemoryRequestedButton('Minus').click();
+    }
     modelServingWizardEdit.findNextButton().should('be.enabled');
   });
 

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -429,6 +429,11 @@ describe('Model Serving LLMD', () => {
             ],
           },
         ]);
+
+        // Resources should not be set (user did not customize — platform webhook applies defaults)
+        expect(interception.request.body.spec.template.containers[0]).to.not.have.property(
+          'resources',
+        );
       });
 
       // Actual request
@@ -438,6 +443,9 @@ describe('Model Serving LLMD', () => {
           'opendatahub.io/connections': 'test-s3-secret', // Connection name is only added in the actual request to avoid dry run failures
           'opendatahub.io/connection-path': 'test-model/',
         });
+        expect(interception.request.body.spec.template.containers[0]).to.not.have.property(
+          'resources',
+        );
       });
 
       cy.get('@createLLMInferenceService.all').then((interceptions) => {
@@ -525,7 +533,7 @@ describe('Model Serving LLMD', () => {
       modelServingWizardEdit.findModelDeploymentDescriptionInput().type('test-llmd-description-2');
 
       hardwareProfileSection.findSelect().should('exist');
-      hardwareProfileSection.findSelect().should('contain.text', 'Small');
+      hardwareProfileSection.findSelect().should('contain.text', 'Use existing settings');
       hardwareProfileSection.selectProfile(
         'Large Profile Compatible CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
       );

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
@@ -113,9 +113,13 @@ describe('NIM Model Serving', () => {
       if (nimInferenceService.status) {
         delete nimInferenceService.status;
       }
+      // Resources should not be in the body — user did not customize, webhook handles defaults
       cy.wait('@createInferenceService').then((interception) => {
         expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body).to.eql(nimInferenceService);
+        expect(interception.request.body.spec.predictor.model).to.not.have.property('resources');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/hardware-profile-name',
+        );
       });
 
       // Actual request

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -734,6 +734,10 @@ describe('Workbench page', () => {
           namespace: 'test-project',
         },
       });
+
+      // Resources should not be set when the user did not customize them
+      const container = interception.request.body.spec?.template?.spec?.containers?.[0];
+      expect(container).to.not.have.property('resources');
     });
     verifyRelativeURL('/projects/test-project?section=workbenches');
   });
@@ -1614,7 +1618,7 @@ describe('Workbench page', () => {
           lastImageSelection: 'test-imagestream:1.2',
           resources: {
             requests: { cpu: '4', memory: '8Gi' },
-            limits: { cpu: '4', memory: '8Gi' },
+            limits: { cpu: '8', memory: '16Gi' },
           },
           opts: {
             metadata: {
@@ -1713,7 +1717,7 @@ describe('Workbench page', () => {
           lastImageSelection: 'test-imagestream:1.2',
           resources: {
             requests: { cpu: '1', memory: '2Gi' },
-            limits: { cpu: '1', memory: '2Gi' },
+            limits: { cpu: '2', memory: '4Gi' },
           },
           opts: {
             metadata: {

--- a/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
@@ -3,6 +3,7 @@ import { Td } from '@patternfly/react-table';
 import HardwareProfileTableColumn from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfileTableColumn';
 import { useHardwareProfileBindingState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState';
 import { useAssignHardwareProfile } from '@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile';
+import { getExistingResources } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
 import type { CrPathConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/types';
 import { type Deployment } from '../../../../extension-points';
@@ -19,8 +20,16 @@ export const DeploymentHardwareProfileCell: React.FC<DeploymentHardwareProfileCe
       paths: hardwareProfilePaths,
     });
 
-    const containerResources =
-      hardwareProfileOptions.podSpecOptionsState.hardwareProfile.formData.resources;
+    const containerResources = React.useMemo(() => {
+      const { existingContainerResources } = getExistingResources(
+        deployment.model,
+        hardwareProfilePaths,
+      );
+      return (
+        existingContainerResources ??
+        hardwareProfileOptions.podSpecOptionsState.hardwareProfile.formData.resources
+      );
+    }, [deployment.model, hardwareProfilePaths, hardwareProfileOptions]);
     const [bindingStateInfo, bindingStateLoaded, bindingStateLoadError] =
       useHardwareProfileBindingState(deployment.model, MODEL_SERVING_VISIBILITY);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-54386

## Description

When deploying a model or creating a workbench, the Dashboard always sends explicit resource requests/limits from the auto-selected hardware profile (defaulting to `defaultCount` for both requests and limits). This overrides the platform webhook defaults (which set requests=`defaultCount`, limits=`maxCount`), causing a behavioral difference between Dashboard and GitOps/CLI deployments.

### Root Cause

`applyHardwareProfileConfig` always wrote resources to the CR spec whenever a hardware profile was selected, even when the user never explicitly customized them. Additionally, `getContainerResourcesFromHardwareProfile` set limits to `defaultCount` instead of `maxCount`, diverging from the webhook behavior.

### Fix

Uses `isEqual` comparison against profile defaults (requests=`defaultCount`, limits=`maxCount`) at each decision point to determine whether resources should be written:

- **`getContainerResourcesFromHardwareProfile`**: limits now use `maxCount` (matching webhook behavior)
- **`applyHardwareProfileConfig`**: only writes resources to the CR when they differ from profile defaults; returns the CR unchanged when `useExistingSettings` is true
- **`assemblePodSpecOptions`**: only includes resources in `podSpecOptions` when they differ from profile defaults
- **`useHardwareProfileConfig` (edit path)**: detects whether existing CR resources match profile defaults to decide between showing the profile as selected vs "Use existing settings"

### Additional fixes

- **Broken `initialSelectGuard`**: replaced with a same-profile check that correctly prevents SimpleSelect auto-select from resetting customized resources
- **"Use existing settings" not shown on edit**: `allowExistingSettings` now uses `isEditing` so the option is always available when editing, allowing the user to switch between profiles and their existing settings freely
- **Edit with customized resources**: when existing CR resources differ from profile defaults, the form initializes with "Use existing settings" selected instead of the profile
- **Existing resources restored on switch-back**: an `existingResources` ref captures the initial CR resources so switching back to "Use existing settings" restores them
- **Table popover showing wrong values**: `NotebookTableRow` reads `formData.resources` (always populated with merged CR values); `DeploymentHardwareProfileCell` reads CR resources directly via `getExistingResources` for display

### Behavior summary

| Scenario | Resources on CR | Annotation on CR |
|----------|----------------|------------------|
| Create, no customization | Omitted (webhook sets defaults) | Written |
| Create, user customizes | Written | Written |
| Edit, resources match defaults | Omitted (webhook handles) | Written |
| Edit, resources customized | Written (preserved) | Written |
| Edit, "Use existing settings" | CR unchanged | CR unchanged |

### Files Changed

| File | Change |
|------|--------|
| `useHardwareProfileConfig.ts` | `initialized` ref for one-time init; `isEqual` for edit-path customization detection; branches `useExistingSettings`/`selectedProfile` |
| `HardwareProfileFormSection.tsx` | Same-profile check replaces broken guard; `existingResources` ref; `allowExistingSettings={isEditing}` |
| `utils.ts` | `getContainerResourcesFromHardwareProfile` limits use `maxCount`; `applyHardwareProfileConfig` early return for `useExistingSettings`, `isEqual` check; `assemblePodSpecOptions` conditional resources |
| `useModelServingPodSpecOptionsState.ts` | Mirrors `isEqual` resource omission (deprecated modelmesh path) |
| `NotebookTableRow.tsx` | Reads `formData.resources` for display |
| `DeploymentHardwareProfileCell.tsx` | Reads CR resources directly via `getExistingResources` for display |

## How Has This Been Tested?

- `npm run type-check` passes (all 17 packages)
- `npm run lint` passes (0 errors)
- Unit tests: 307 tests pass across 19 test suites covering `useHardwareProfileConfig`, `useAssignHardwareProfile`, `useModelServingHardwareProfileState`, `applyHardwareProfileConfig`, `assemblePodSpecOptions`, `HardwareProfileSelect`, `ManageNIMServingModal`, and `inferenceServices`
- Manually tested create/edit flows for model deployments and workbenches on a live cluster

## Test Impact

- **`useHardwareProfileConfig.spec.ts`**: Added tests for limits=maxCount on auto-selected profiles, edit path with customized vs default resources, "Use existing settings" behavior, GPU identifier merging with maxCount limits
- **`utils.spec.ts`**: Added tests for resource omission when matching defaults, GPU resource handling, `useExistingSettings` early return preserving CR state
- **`useAssignHardwareProfile.spec.ts`**: Updated expectations for `podSpecOptions.resources` being `undefined` when not customized
- **`useModelServingHardwareProfileState.spec.ts`**: Updated for conditional resource inclusion
- **`ManageNIMServingModal.spec.tsx`**: Updated mock formData
- **Cypress mocked tests**: Updated `notebookServer.cy.ts`, `modelServingDeploy.cy.ts`, `modelServingLlmd.cy.ts`, `workbench.cy.ts` to verify resources are omitted from request bodies when not customized

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`