### PR TITLE
fix(model-serving): show user-friendly error for duplicate model deployment names

### DIFF
--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   isValueFromEnvVar,
   isPVCUri,
   getPVCNameFromURI,
+  translateModelServingError,
 } from '#~/pages/modelServing/screens/projects/utils';
 import { ServingPlatformStatuses } from '#~/pages/modelServing/screens/types';
 import { ServingRuntimePlatform } from '#~/types';
@@ -611,5 +612,30 @@ describe('getPVCNameFromURI', () => {
   it('should return an empty string if the URI is not a PVC URI', () => {
     const uri = 'http://pvc-1/model-path';
     expect(getPVCNameFromURI(uri)).toEqual('');
+  });
+});
+
+describe('translateModelServingError', () => {
+  it('should translate a kserve "already exists" error to a user-friendly message', () => {
+    const error = new Error('servingruntimes.serving.kserve.io "test-model" already exists');
+    const result = translateModelServingError(error);
+    expect(result.message).toBe(
+      'A model deployment with the name "test-model" already exists. Please choose a different model deployment name.',
+    );
+  });
+
+  it('should translate an inferenceservices "already exists" error', () => {
+    const error = new Error('inferenceservices.serving.kserve.io "my-model" already exists');
+    const result = translateModelServingError(error);
+    expect(result.message).toBe(
+      'A model deployment with the name "my-model" already exists. Please choose a different model deployment name.',
+    );
+  });
+
+  it('should return the original error if it does not match', () => {
+    const error = new Error('some other error');
+    const result = translateModelServingError(error);
+    expect(result).toBe(error);
+    expect(result.message).toBe('some other error');
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts
@@ -638,4 +638,18 @@ describe('translateModelServingError', () => {
     expect(result).toBe(error);
     expect(result.message).toBe('some other error');
   });
+
+  it('should not translate non-KServe "already exists" errors', () => {
+    const error = new Error('secrets "conn-a" already exists');
+    const result = translateModelServingError(error);
+    expect(result).toBe(error);
+    expect(result.message).toBe('secrets "conn-a" already exists');
+  });
+
+  it('should not translate generic "already exists" errors', () => {
+    const error = new Error('Something "my-thing" already exists');
+    const result = translateModelServingError(error);
+    expect(result).toBe(error);
+    expect(result.message).toBe('Something "my-thing" already exists');
+  });
 });

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -339,7 +339,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
             : new Error(typeof e === 'string' ? e : 'An unexpected error occurred.');
         const translatedError = translateModelServingError(normalizedError);
         props.success = false;
-        props.errorMessage = translatedError;
+        props.errorMessage = translatedError.message;
         setErrorModal(translatedError);
         fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
       });

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -333,7 +333,11 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         watchDeployment();
       })
       .catch((e) => {
-        const translatedError = e instanceof Error ? translateModelServingError(e) : e;
+        const normalizedError =
+          e instanceof Error
+            ? e
+            : new Error(typeof e === 'string' ? e : 'An unexpected error occurred.');
+        const translatedError = translateModelServingError(normalizedError);
         props.success = false;
         props.errorMessage = translatedError;
         setErrorModal(translatedError);

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -13,6 +13,7 @@ import {
   getCreateInferenceServiceLabels,
   getSubmitInferenceServiceResourceFn,
   getSubmitServingRuntimeResourcesFn,
+  translateModelServingError,
   useCreateInferenceServiceObject,
   useCreateServingRuntimeObject,
   validateEnvVarName,
@@ -332,9 +333,10 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
         watchDeployment();
       })
       .catch((e) => {
+        const translatedError = e instanceof Error ? translateModelServingError(e) : e;
         props.success = false;
-        props.errorMessage = e;
-        setErrorModal(e);
+        props.errorMessage = translatedError;
+        setErrorModal(translatedError);
         fireFormTrackingEvent(editInfo ? 'Model Updated' : 'Model Deployed', props);
       });
   };

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
@@ -15,6 +15,7 @@ import {
   createNIMSecret,
   getSubmitInferenceServiceResourceFn,
   getSubmitServingRuntimeResourcesFn,
+  translateModelServingError,
   useCreateInferenceServiceObject,
   useCreateServingRuntimeObject,
   validateEnvVarName,
@@ -375,7 +376,8 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
         watchDeployment();
       })
       .catch((e) => {
-        setErrorModal(e);
+        const translatedError = e instanceof Error ? translateModelServingError(e) : e;
+        setErrorModal(translatedError);
       });
   };
   const getProjectName = () => {

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
@@ -376,7 +376,11 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
         watchDeployment();
       })
       .catch((e) => {
-        const translatedError = e instanceof Error ? translateModelServingError(e) : e;
+        const normalizedError =
+          e instanceof Error
+            ? e
+            : new Error(typeof e === 'string' ? e : 'An unexpected error occurred.');
+        const translatedError = translateModelServingError(normalizedError);
         setErrorModal(translatedError);
       });
   };

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/__tests__/ManageNIMServingModal.spec.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/__tests__/ManageNIMServingModal.spec.tsx
@@ -18,6 +18,8 @@ jest.mock('#~/pages/modelServing/screens/projects/utils', () => ({
   createNIMSecret: jest.fn(),
   getSubmitInferenceServiceResourceFn: jest.fn(() => jest.fn()),
   getSubmitServingRuntimeResourcesFn: jest.fn(() => jest.fn()),
+  translateModelServingError: jest.requireActual('#~/pages/modelServing/screens/projects/utils')
+    .translateModelServingError,
   useCreateInferenceServiceObject: jest.fn(),
   useCreateServingRuntimeObject: jest.fn(),
 }));

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -61,9 +61,11 @@ export const isGpuDisabled = (servingRuntime: ServingRuntimeKind): boolean =>
 
 export const translateModelServingError = (error: Error): Error => {
   const message = error.message || String(error);
-  if (message.includes('already exists')) {
-    const nameMatch = message.match(/"([^"]+)"/);
-    const name = nameMatch ? nameMatch[1] : 'this name';
+  const kserveMatch = message.match(
+    /(?:servingruntimes|inferenceservices)\.serving\.kserve\.io\s+"([^"]+)"\s+already exists/i,
+  );
+  if (kserveMatch) {
+    const name = kserveMatch[1];
     return new Error(
       `A model deployment with the name "${name}" already exists. Please choose a different model deployment name.`,
     );

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -59,6 +59,18 @@ export const isInferenceServiceRouteEnabled = (inferenceService: InferenceServic
 export const isGpuDisabled = (servingRuntime: ServingRuntimeKind): boolean =>
   servingRuntime.metadata.annotations?.['opendatahub.io/disable-gpu'] === 'true';
 
+export const translateModelServingError = (error: Error): Error => {
+  const message = error.message || String(error);
+  if (message.includes('already exists')) {
+    const nameMatch = message.match(/"([^"]+)"/);
+    const name = nameMatch ? nameMatch[1] : 'this name';
+    return new Error(
+      `A model deployment with the name "${name}" already exists. Please choose a different model deployment name.`,
+    );
+  }
+  return error;
+};
+
 export const getInferenceServiceFromServingRuntime = (
   inferenceServices: InferenceServiceKind[],
   servingRuntime: ServingRuntimeKind,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-14563

## Description
When deploying a model with a name that already exists, the raw K8s error message (e.g. `servingruntimes.serving.kserve.io "test-model" already exists`) was displayed directly to the user. This is confusing because it references internal Kubernetes resource types rather than the UI field name.

This PR adds a `translateModelServingError` utility that detects "already exists" errors from the K8s API and replaces them with a user-friendly message referencing the **Model deployment name** field:

> A model deployment with the name "test-model" already exists. Please choose a different model deployment name.

**Files changed:**
- `frontend/src/pages/modelServing/screens/projects/utils.ts` — Added `translateModelServingError` utility
- `frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx` — Applied error translation in the catch handler
- `frontend/src/pages/modelServing/screens/projects/__tests__/utils.spec.ts` — Added unit tests

## How Has This Been Tested?
- Unit tests added for `translateModelServingError` covering:
  - KServe serving runtime "already exists" errors → translated
  - KServe inference service "already exists" errors → translated  
  - Non-matching errors → passed through unchanged
- Manual code review of the error flow from K8s API → catch handler → DashboardModalFooter → Alert display

## Test Impact
- Added 3 unit tests for the new `translateModelServingError` utility function
- Existing tests are unaffected as the change only adds error translation in the catch path

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for model serving: deployment name conflicts now display clearer, user-friendly messages that identify the specific resource causing the conflict.
  * More consistent error handling: non-standard or non-error failures are normalized so users see the same clear, translated error text.

* **Tests**
  * Added and expanded test coverage to verify error translation and consistent, user-facing error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->