### PR TITLE
Add the relevant MLflow links in the Runs page

### DIFF
--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTable.tsx
@@ -5,7 +5,7 @@ import { Button, Skeleton, Tooltip } from '@patternfly/react-core';
 import { TableVariant, Td } from '@patternfly/react-table';
 import { ColumnsIcon } from '@patternfly/react-icons';
 
-import { TableBase, getTableColumnSort, useCheckboxTable } from '#~/components/table';
+import { getTableColumnSort, TableBase, useCheckboxTable } from '#~/components/table';
 import { ExperimentKF, PipelineRunKF, StorageStateKF } from '#~/concepts/pipelines/kfTypes';
 import { getPipelineRunColumns } from '#~/concepts/pipelines/content/tables/columns';
 import useIsMlflowPipelinesAvailable from '#~/concepts/mlflow/hooks/useIsMlflowPipelinesAvailable';
@@ -25,6 +25,7 @@ import SimpleMenuActions from '#~/components/SimpleMenuActions';
 import { ArchiveRunModal } from '#~/pages/pipelines/global/runs/ArchiveRunModal';
 import { RestoreRunModal } from '#~/pages/pipelines/global/runs/RestoreRunModal';
 import { compareRunsRoute, createRunRoute } from '#~/routes/pipelines/runs';
+import { mlflowCompareRunsRoute } from '#~/routes/pipelines/mlflow';
 import {
   ExperimentContext,
   useContextExperimentArchivedOrDeleted,
@@ -37,7 +38,7 @@ import useMlflowExperiments from '#~/concepts/mlflow/hooks/useMlflowExperiments'
 import { CustomMetricsColumnsModal } from './CustomMetricsColumnsModal';
 import { UnavailableMetricValue } from './UnavailableMetricValue';
 import { useMetricColumns } from './useMetricColumns';
-import { filterByMlflowExperiment } from './utils';
+import { filterByMlflowExperiment, getMlflowExperimentId, getMlflowRunId } from './utils';
 
 type PipelineRunTableProps = {
   runs: PipelineRunKF[];
@@ -101,15 +102,17 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   const [isArchiveModalOpen, setIsArchiveModalOpen] = React.useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = React.useState(false);
   const [isCustomColModalOpen, setIsCustomColModalOpen] = React.useState(false);
-  const selectedRuns = selectedIds.reduce((acc: PipelineRunKF[], selectedId) => {
-    const selectedRun = runs.find((run) => run.run_id === selectedId);
-
-    if (selectedRun) {
-      acc.push(selectedRun);
-    }
-
-    return acc;
-  }, []);
+  const selectedRuns = React.useMemo(
+    () =>
+      selectedIds.reduce((acc: PipelineRunKF[], selectedId) => {
+        const selectedRun = runs.find((run) => run.run_id === selectedId);
+        if (selectedRun) {
+          acc.push(selectedRun);
+        }
+        return acc;
+      }, []),
+    [selectedIds, runs],
+  );
   const restoreButtonTooltipRef = React.useRef(null);
   const archivedExperiments = selectedRuns.reduce<ExperimentKF[]>((acc, selectedRun) => {
     const currentExperiment = allExperiments.find(
@@ -117,7 +120,6 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
     );
 
     if (currentExperiment && currentExperiment.storage_state === StorageStateKF.ARCHIVED) {
-      // Create a Set to track unique experiment_id
       if (
         !acc.some(
           (selectedExperiment) =>
@@ -134,8 +136,31 @@ const PipelineRunTable: React.FC<PipelineRunTableProps> = ({
   const { isExperimentArchived: isContextExperimentArchived } =
     useContextExperimentArchivedOrDeleted();
   const createRunHref = createRunRoute(namespace, experiment?.experiment_id);
-  const compareRunsHref = compareRunsRoute(namespace, selectedIds, experiment?.experiment_id);
-  const isCompareDisabled = selectedIds.length === 0 || selectedIds.length > 10;
+  const hasSelectedRuns = selectedIds.length > 0;
+
+  const { compareRunsHref, isCompareDisabled } = React.useMemo(() => {
+    const validRunIds = selectedRuns.map(getMlflowRunId).filter((id): id is string => !!id);
+    const validExpIds = selectedRuns.map(getMlflowExperimentId).filter((id): id is string => !!id);
+    const allHaveMlflow =
+      hasSelectedRuns &&
+      validRunIds.length === selectedIds.length &&
+      validExpIds.length === selectedIds.length;
+    const href =
+      isMlflowAvailable && allHaveMlflow
+        ? mlflowCompareRunsRoute(namespace, validRunIds, [...new Set(validExpIds)])
+        : compareRunsRoute(namespace, selectedIds, experiment?.experiment_id);
+    return {
+      compareRunsHref: href,
+      isCompareDisabled: !hasSelectedRuns || selectedIds.length > 10,
+    };
+  }, [
+    selectedRuns,
+    selectedIds,
+    hasSelectedRuns,
+    isMlflowAvailable,
+    namespace,
+    experiment?.experiment_id,
+  ]);
   const primaryToolbarAction = React.useMemo(() => {
     if (runType === PipelineRunType.ARCHIVED) {
       return (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -21,6 +21,7 @@ import {
   globalArchivedPipelineRunsRoute,
   globalPipelineRunsRoute,
 } from '#~/routes/pipelines/runs';
+import { mlflowCompareRunsRoute } from '#~/routes/pipelines/mlflow';
 import { ArchiveRunModal } from '#~/pages/pipelines/global/runs/ArchiveRunModal';
 import PipelineRunTableRowExperiment from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment';
 import PipelineRunTableRowMlflowExperiment from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowMlflowExperiment';
@@ -38,7 +39,7 @@ import {
   FilterOptions,
   LEGACY_EXPERIMENT_FILTER_PARAM,
 } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
-import { isPipelineRunRegistered } from './utils';
+import { getMlflowExperimentId, getMlflowRunId, isPipelineRunRegistered } from './utils';
 
 type PipelineRunTableRowProps = {
   checkboxProps: Omit<React.ComponentProps<typeof CheckboxTd>, 'id'>;
@@ -150,7 +151,13 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       {
         title: 'Compare runs',
         onClick: () => {
-          navigate(compareRunsRoute(namespace, [run.run_id], contextExperiment?.experiment_id));
+          const mlflowRunId = getMlflowRunId(run);
+          const mlflowExpId = getMlflowExperimentId(run);
+          if (mlflow?.isAvailable && mlflowRunId && mlflowExpId) {
+            navigate(mlflowCompareRunsRoute(namespace, [mlflowRunId], [mlflowExpId]));
+          } else {
+            navigate(compareRunsRoute(namespace, [run.run_id], contextExperiment?.experiment_id));
+          }
         },
       },
       ...(!version ? [] : [duplicateAction]),
@@ -162,10 +169,13 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
         onClick: () => setIsArchiveModalOpen(true),
       },
     ];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     runType,
-    run.state,
     run.run_id,
+    run.state,
+    run.plugins_output,
+    run.plugins_input,
     version,
     navigate,
     namespace,
@@ -176,6 +186,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
     api,
     refreshAllAPI,
     notification,
+    mlflow?.isAvailable,
   ]);
 
   return (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -169,6 +169,8 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
         onClick: () => setIsArchiveModalOpen(true),
       },
     ];
+    // `run` is used in closures but only specific fields affect the result;
+    // listing them individually avoids re-creating actions on unrelated run changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     runType,

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
@@ -213,6 +213,18 @@ describe('getMlflowExperimentId', () => {
     });
     expect(getMlflowExperimentId(run)).toBe('7');
   });
+
+  it('returns experiment_id from plugins_output even when plugin state is FAILED (current behavior)', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_id: { value: 'failed-exp' } },
+          state: PluginStateKF.PLUGIN_FAILED,
+        },
+      },
+    });
+    expect(getMlflowExperimentId(run)).toBe('failed-exp');
+  });
 });
 
 describe('getMlflowRunId', () => {
@@ -250,5 +262,17 @@ describe('getMlflowRunId', () => {
       plugins_input: { mlflow: { root_run_id: 'input-run-id' } },
     });
     expect(getMlflowRunId(run)).toBeUndefined();
+  });
+
+  it('returns root_run_id even when plugin state is FAILED (current behavior)', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { root_run_id: { value: 'partial-id' } },
+          state: PluginStateKF.PLUGIN_FAILED,
+        },
+      },
+    });
+    expect(getMlflowRunId(run)).toBe('partial-id');
   });
 });

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/__tests__/utils.spec.ts
@@ -4,7 +4,9 @@ import { buildMockRecurringRunKF } from '#~/__mocks__/mockRecurringRunKF';
 import { PluginStateKF } from '#~/concepts/pipelines/kfTypes';
 import {
   filterByMlflowExperiment,
+  getMlflowExperimentId,
   getMlflowExperimentNameFromRun,
+  getMlflowRunId,
 } from '#~/concepts/pipelines/content/tables/pipelineRun/utils';
 
 describe('getMlflowExperimentNameFromRun', () => {
@@ -159,5 +161,94 @@ describe('filterByMlflowExperiment', () => {
     const result = filterByMlflowExperiment(recurringRuns, 'scheduled-exp');
     expect(result).toHaveLength(1);
     expect(result[0].recurring_run_id).toBe('sa');
+  });
+});
+
+describe('getMlflowExperimentId', () => {
+  it('returns experiment_id from plugins_output', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_id: { value: '42' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowExperimentId(run)).toBe('42');
+  });
+
+  it('falls back to plugins_input when plugins_output is absent', () => {
+    const run = buildMockRunKF({
+      plugins_input: { mlflow: { experiment_id: 'input-exp' } },
+    });
+    expect(getMlflowExperimentId(run)).toBe('input-exp');
+  });
+
+  it('prefers plugins_output over plugins_input', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_id: { value: 'output-exp' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+      plugins_input: { mlflow: { experiment_id: 'input-exp' } },
+    });
+    expect(getMlflowExperimentId(run)).toBe('output-exp');
+  });
+
+  it('returns undefined when neither source has data', () => {
+    const run = buildMockRunKF({});
+    expect(getMlflowExperimentId(run)).toBeUndefined();
+  });
+
+  it('converts numeric values to string', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_id: { value: 7 } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowExperimentId(run)).toBe('7');
+  });
+});
+
+describe('getMlflowRunId', () => {
+  it('returns root_run_id from plugins_output', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { root_run_id: { value: 'abc-123' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowRunId(run)).toBe('abc-123');
+  });
+
+  it('returns undefined when plugins_output has no root_run_id', () => {
+    const run = buildMockRunKF({
+      plugins_output: {
+        mlflow: {
+          entries: { experiment_id: { value: '42' } },
+          state: PluginStateKF.PLUGIN_SUCCEEDED,
+        },
+      },
+    });
+    expect(getMlflowRunId(run)).toBeUndefined();
+  });
+
+  it('returns undefined when plugins_output is absent', () => {
+    const run = buildMockRunKF({});
+    expect(getMlflowRunId(run)).toBeUndefined();
+  });
+
+  it('does not fall back to plugins_input', () => {
+    const run = buildMockRunKF({
+      plugins_input: { mlflow: { root_run_id: 'input-run-id' } },
+    });
+    expect(getMlflowRunId(run)).toBeUndefined();
   });
 });

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
@@ -50,6 +50,8 @@ export const getMlflowExperimentId = (run: PipelineRunKF): string | undefined =>
   return undefined;
 };
 
+// root_run_id is only populated in plugins_output after the backend creates the MLflow run.
+// Unlike experiment_id, there is no plugins_input equivalent to fall back to.
 export const getMlflowRunId = (run: PipelineRunKF): string | undefined => {
   const outputEntry = run.plugins_output?.mlflow?.entries;
   const outputId = outputEntry?.root_run_id?.value;

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/utils.ts
@@ -36,3 +36,25 @@ export const isPipelineRunRegistered = (artifact: Artifact[]): boolean => {
   const artifactModelData = artifact.map((a) => getArtifactModelData(a));
   return artifactModelData.some((data) => data.registeredModelName);
 };
+
+export const getMlflowExperimentId = (run: PipelineRunKF): string | undefined => {
+  const outputEntry = run.plugins_output?.mlflow?.entries;
+  const outputId = outputEntry?.experiment_id?.value;
+  if (outputId != null) {
+    return String(outputId);
+  }
+  const inputId = run.plugins_input?.mlflow?.experiment_id;
+  if (inputId != null) {
+    return String(inputId);
+  }
+  return undefined;
+};
+
+export const getMlflowRunId = (run: PipelineRunKF): string | undefined => {
+  const outputEntry = run.plugins_output?.mlflow?.entries;
+  const outputId = outputEntry?.root_run_id?.value;
+  if (outputId != null) {
+    return String(outputId);
+  }
+  return undefined;
+};

--- a/frontend/src/routes/pipelines/__tests__/mlflow.spec.ts
+++ b/frontend/src/routes/pipelines/__tests__/mlflow.spec.ts
@@ -1,0 +1,30 @@
+import { mlflowCompareRunsRoute } from '#~/routes/pipelines/mlflow';
+
+describe('mlflowCompareRunsRoute', () => {
+  it('builds a compare URL with runs, experiments, and workspace', () => {
+    const params = new URLSearchParams();
+    params.set('runs', JSON.stringify(['r1', 'r2']));
+    params.set('experiments', JSON.stringify(['e1']));
+    params.set('workspace', 'my-ns');
+    expect(mlflowCompareRunsRoute('my-ns', ['r1', 'r2'], ['e1'])).toBe(
+      `/develop-train/mlflow/experiments/compare-runs?${params.toString()}`,
+    );
+  });
+
+  it('omits runs param when array is empty', () => {
+    const url = mlflowCompareRunsRoute('ns', [], ['e1']);
+    expect(url).not.toContain('runs=');
+    expect(url).toContain('experiments=');
+  });
+
+  it('omits experiments param when array is empty', () => {
+    const url = mlflowCompareRunsRoute('ns', ['r1'], []);
+    expect(url).toContain('runs=');
+    expect(url).not.toContain('experiments=');
+  });
+
+  it('encodes experiment IDs in the URL', () => {
+    const url = mlflowCompareRunsRoute('ns', ['r1', 'r2'], ['e1']);
+    expect(url).toContain(`experiments=${encodeURIComponent(JSON.stringify(['e1']))}`);
+  });
+});

--- a/frontend/src/routes/pipelines/mlflow.ts
+++ b/frontend/src/routes/pipelines/mlflow.ts
@@ -18,7 +18,8 @@ const withWorkspace = (basePath: string, namespace?: string): string => {
   if (!namespace) {
     return basePath;
   }
-  return `${basePath}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
+  const separator = basePath.includes('?') ? '&' : '?';
+  return `${basePath}${separator}${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
 };
 
 export const mlflowExperimentsBaseRoute = (namespace?: string): string =>
@@ -32,6 +33,23 @@ export const globPromptManagementAll = `${promptManagementPath}/*`;
 
 export const mlflowPromptManagementBaseRoute = (namespace?: string): string =>
   withWorkspace(promptManagementPath, namespace);
+
+export const mlflowCompareRunsRoute = (
+  namespace: string,
+  runIds: string[],
+  experimentIds: string[],
+): string => {
+  const params = new URLSearchParams();
+  if (runIds.length > 0) {
+    params.set('runs', JSON.stringify(runIds));
+  }
+  if (experimentIds.length > 0) {
+    params.set('experiments', JSON.stringify(experimentIds));
+  }
+  const queryString = params.toString();
+  const basePath = `${mlflowExperimentsPath}/compare-runs${queryString ? `?${queryString}` : ''}`;
+  return withWorkspace(basePath, namespace);
+};
 
 export const mlflowLaunchRoute = (namespace?: string): string => {
   if (!namespace) {

--- a/packages/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineRunsGlobal.ts
@@ -63,6 +63,10 @@ class PipelineRunsGlobal {
     return cy.findByTestId('restore-button');
   }
 
+  findCompareRunsButton() {
+    return cy.findByTestId('compare-runs-button');
+  }
+
   findActiveRunsToolbar() {
     return cy.findByTestId('active-runs-table-toolbar');
   }

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -64,6 +64,16 @@ const mockActiveRuns = [
     experiment_id: 'test-experiment-1',
     created_at: '2024-02-01T00:00:00Z',
     state: RuntimeStateKF.RUNNING,
+    plugins_output: {
+      mlflow: {
+        entries: {
+          experiment_id: { value: '6' },
+          experiment_name: { value: 'mlflow-exp-1' },
+          root_run_id: { value: 'mlflow-run-aaa' },
+        },
+        state: PluginStateKF.PLUGIN_SUCCEEDED,
+      },
+    },
   }),
   buildMockRunKF({
     display_name: 'Test active run 2',
@@ -75,6 +85,16 @@ const mockActiveRuns = [
     experiment_id: 'test-experiment-3',
     created_at: '2024-02-05T00:00:00Z',
     state: RuntimeStateKF.SUCCEEDED,
+    plugins_output: {
+      mlflow: {
+        entries: {
+          experiment_id: { value: '14' },
+          experiment_name: { value: 'mlflow-exp-2' },
+          root_run_id: { value: 'mlflow-run-bbb' },
+        },
+        state: PluginStateKF.PLUGIN_SUCCEEDED,
+      },
+    },
   }),
   buildMockRunKF({
     display_name: 'Test active run 3',
@@ -86,6 +106,16 @@ const mockActiveRuns = [
     experiment_id: 'test-experiment-1',
     created_at: '2024-02-10T00:00:00Z',
     state: RuntimeStateKF.PENDING,
+    plugins_output: {
+      mlflow: {
+        entries: {
+          experiment_id: { value: '6' },
+          experiment_name: { value: 'mlflow-exp-1' },
+          root_run_id: { value: 'mlflow-run-ccc' },
+        },
+        state: PluginStateKF.PLUGIN_SUCCEEDED,
+      },
+    },
   }),
 ];
 
@@ -446,6 +476,88 @@ describe('Pipeline runs', () => {
 
           verifyRelativeURL(
             `/develop-train/pipelines/runs/${projectName}/runs/${mockActiveRuns[0].run_id}`,
+          );
+        });
+
+        it('compare runs button navigates to MLflow when dev flag is enabled', () => {
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          interceptMlflowStatus();
+          interceptDSPAMlflowIntegration(projectName);
+          pipelineRunsGlobal.visit(projectName, 'active');
+
+          activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
+          activeRunsTable.getRowByName(mockActiveRuns[1].display_name).findCheckbox().click();
+
+          pipelineRunsGlobal.findCompareRunsButton().click();
+
+          const params = new URLSearchParams();
+          params.set('runs', JSON.stringify(['mlflow-run-aaa', 'mlflow-run-bbb']));
+          params.set('experiments', JSON.stringify(['6', '14']));
+          params.set('workspace', projectName);
+          verifyRelativeURL(`/develop-train/mlflow/experiments/compare-runs?${params.toString()}`);
+        });
+
+        it('compare runs button navigates to KFP when MLflow dev flag is disabled', () => {
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
+          pipelineRunsGlobal.visit(projectName, 'active');
+
+          activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
+          activeRunsTable.getRowByName(mockActiveRuns[1].display_name).findCheckbox().click();
+
+          pipelineRunsGlobal.findCompareRunsButton().click();
+
+          verifyRelativeURL(
+            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${mockActiveRuns[0].run_id},${mockActiveRuns[1].run_id}`,
+          );
+        });
+
+        it('compare runs falls back to KFP for mixed MLflow metadata when MLflow is enabled', () => {
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          interceptMlflowStatus();
+          interceptDSPAMlflowIntegration(projectName);
+          const runWithoutMlflow = buildMockRunKF({
+            display_name: 'Run without mlflow',
+            run_id: 'run-no-mlflow',
+            experiment_id: 'test-experiment-1',
+            state: RuntimeStateKF.SUCCEEDED,
+          });
+          cy.interceptOdh(
+            'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+            {
+              path: {
+                namespace: projectName,
+                serviceName: 'dspa',
+                runId: mockActiveRuns[0].run_id,
+              },
+            },
+            mockActiveRuns[0],
+          );
+          cy.interceptOdh(
+            'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/runs/:runId',
+            {
+              path: {
+                namespace: projectName,
+                serviceName: 'dspa',
+                runId: runWithoutMlflow.run_id,
+              },
+            },
+            runWithoutMlflow,
+          );
+          activeRunsTable.mockGetActiveRuns([mockActiveRuns[0], runWithoutMlflow], projectName);
+          pipelineRunsGlobal.visit(projectName, 'active');
+          cy.wait('@mlflowStatus');
+
+          activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
+          activeRunsTable.getRowByName(runWithoutMlflow.display_name).findCheckbox().click();
+
+          pipelineRunsGlobal
+            .findCompareRunsButton()
+            .should('have.attr', 'href')
+            .and('include', `compareRuns=${mockActiveRuns[0].run_id},${runWithoutMlflow.run_id}`);
+          pipelineRunsGlobal.findCompareRunsButton().click();
+
+          verifyRelativeURL(
+            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${mockActiveRuns[0].run_id},${runWithoutMlflow.run_id}`,
           );
         });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -561,6 +561,47 @@ describe('Pipeline runs', () => {
           );
         });
 
+        it('per-row kebab Compare runs navigates to MLflow when MLflow metadata is present', () => {
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          interceptMlflowStatus();
+          interceptDSPAMlflowIntegration(projectName);
+          pipelineRunsGlobal.visit(projectName, 'active');
+          cy.wait('@mlflowStatus');
+
+          activeRunsTable
+            .getRowByName(mockActiveRuns[0].display_name)
+            .findKebabAction('Compare runs')
+            .click();
+
+          verifyRelativeURL(
+            `/develop-train/mlflow/experiments/compare-runs?runs=%5B%22mlflow-run-aaa%22%5D&experiments=%5B%226%22%5D&workspace=${projectName}`,
+          );
+        });
+
+        it('per-row kebab Compare runs falls back to KFP when MLflow metadata is absent', () => {
+          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
+          interceptMlflowStatus();
+          interceptDSPAMlflowIntegration(projectName);
+          const runWithoutMlflow = buildMockRunKF({
+            display_name: 'Run without mlflow kebab',
+            run_id: 'run-no-mlflow-kebab',
+            experiment_id: 'test-experiment-1',
+            state: RuntimeStateKF.SUCCEEDED,
+          });
+          activeRunsTable.mockGetActiveRuns([runWithoutMlflow], projectName);
+          pipelineRunsGlobal.visit(projectName, 'active');
+          cy.wait('@mlflowStatus');
+
+          activeRunsTable
+            .getRowByName(runWithoutMlflow.display_name)
+            .findKebabAction('Compare runs')
+            .click();
+
+          verifyRelativeURL(
+            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${runWithoutMlflow.run_id}`,
+          );
+        });
+
         it('navigate to MLflow experiment details from active run row', () => {
           cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
           interceptMlflowStatus();

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -484,6 +484,7 @@ describe('Pipeline runs', () => {
           interceptMlflowStatus();
           interceptDSPAMlflowIntegration(projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
+          cy.wait('@mlflowStatus');
 
           activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
           activeRunsTable.getRowByName(mockActiveRuns[1].display_name).findCheckbox().click();
@@ -499,15 +500,20 @@ describe('Pipeline runs', () => {
 
         it('compare runs button navigates to KFP when MLflow dev flag is disabled', () => {
           cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: false }));
+          interceptMlflowStatus(false);
+          interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
           pipelineRunsGlobal.visit(projectName, 'active');
+          cy.wait('@mlflowStatus');
 
           activeRunsTable.getRowByName(mockActiveRuns[0].display_name).findCheckbox().click();
           activeRunsTable.getRowByName(mockActiveRuns[1].display_name).findCheckbox().click();
 
+          pipelineRunsGlobal.findCompareRunsButton().should('not.be.disabled');
           pipelineRunsGlobal.findCompareRunsButton().click();
 
-          verifyRelativeURL(
-            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${mockActiveRuns[0].run_id},${mockActiveRuns[1].run_id}`,
+          cy.url().should(
+            'include',
+            `compare-runs?compareRuns=${mockActiveRuns[0].run_id},${mockActiveRuns[1].run_id}`,
           );
         });
 
@@ -579,27 +585,27 @@ describe('Pipeline runs', () => {
         });
 
         it('per-row kebab Compare runs falls back to KFP when MLflow metadata is absent', () => {
-          cy.interceptOdh('GET /api/config', mockDashboardConfig({ mlflowPipelines: true }));
-          interceptMlflowStatus();
-          interceptDSPAMlflowIntegration(projectName);
+          interceptMlflowStatus(false);
+          interceptDSPAMlflowIntegration(projectName, DSPAMlflowIntegrationMode.DISABLED);
           const runWithoutMlflow = buildMockRunKF({
             display_name: 'Run without mlflow kebab',
             run_id: 'run-no-mlflow-kebab',
+            pipeline_version_reference: {
+              pipeline_id: pipelineId,
+              pipeline_version_id: 'test-version-1',
+            },
             experiment_id: 'test-experiment-1',
             state: RuntimeStateKF.SUCCEEDED,
           });
           activeRunsTable.mockGetActiveRuns([runWithoutMlflow], projectName);
           pipelineRunsGlobal.visit(projectName, 'active');
-          cy.wait('@mlflowStatus');
 
           activeRunsTable
             .getRowByName(runWithoutMlflow.display_name)
             .findKebabAction('Compare runs')
             .click();
 
-          verifyRelativeURL(
-            `/develop-train/pipelines/runs/${projectName}/compare-runs?compareRuns=${runWithoutMlflow.run_id}`,
-          );
+          cy.url().should('include', `compareRuns=${runWithoutMlflow.run_id}`);
         });
 
         it('navigate to MLflow experiment details from active run row', () => {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-37533
## Description
https://github.com/user-attachments/assets/e1a01a92-2e97-480c-b9d2-d7422eafdcdc
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- When the MLflow feature flag is enabled and pipeline runs have MLflow metadata (plugins_output), the Compare runs button on the pipeline runs page navigates to the MLflow compare runs page instead of the KFP compare runs page.
- When the MLflow feature flag is disabled, both links fall back to the existing KFP routes (no behavioral change)

Note: Currently behind the `mlflowPipelines` dev flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This needs to be verified with a cluster with a KFP API server image that supports `plugins_input`/`plugins_output`
- Enable the `mlflow` feature flag (will later be `mlflowPipelines`)
- Navigate to the Runs page, and select some runs
- Click on the compare runs button, and verify it redirects to mlflow compare runs page
- Click on an experiment in the experiments column in the runs page

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added mock tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Compare runs" now routes to MLflow's comparison view when MLflow is enabled and selected runs include MLflow identifiers.

* **Improvements**
  * Workspace query handling for comparison routes improved to append parameters correctly.

* **Tests**
  * Added end-to-end tests covering navigation for both MLflow-enabled and MLflow-disabled scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->