### PR TITLE
fix: show feature store warning only when multiple CRDs have UI enabled

### DIFF
--- a/backend/src/routes/api/featurestores/featureStores.ts
+++ b/backend/src/routes/api/featurestores/featureStores.ts
@@ -21,6 +21,7 @@ import {
 
 interface FeatureStoreResponse {
   featureStores: FeatureStore[];
+  enabledCRDCount: number;
 }
 
 interface FeatureStore {
@@ -45,8 +46,11 @@ interface CustomObjectResponse {
   };
 }
 
-function buildFeatureStoreResponse(featureStores: FeatureStore[]): FeatureStoreResponse {
-  return { featureStores };
+function buildFeatureStoreResponse(
+  featureStores: FeatureStore[],
+  enabledCRDCount: number,
+): FeatureStoreResponse {
+  return { featureStores, enabledCRDCount };
 }
 
 async function fetchFeatureStoreCRDs(
@@ -67,16 +71,6 @@ async function fetchFeatureStoreCRDs(
     handleError(fastify, error, `Error fetching FeatureStore CRDs from namespace ${namespace}`);
     return [];
   }
-}
-
-async function getEnabledProjectNames(
-  fastify: KubeFastifyInstance,
-  namespace: string,
-): Promise<string[]> {
-  const allCrds = await fetchFeatureStoreCRDs(fastify, namespace);
-  const enabledCrds = filterEnabledCRDs(allCrds as FeatureStoreCRD[]);
-
-  return enabledCrds.map((crd) => crd.spec?.feastProject).filter(Boolean);
 }
 
 async function processFeatureStoreConfigs(
@@ -223,13 +217,13 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       );
 
       if (!feastConfig) {
-        reply.send({ featureStores: [] });
+        reply.send(buildFeatureStoreResponse([], 0));
         return;
       }
 
       if (!feastConfig.data?.namespaces) {
         fastify.log.warn(`No namespaces data found in ConfigMap ${feastConfig.metadata?.name}`);
-        reply.send({ featureStores: [] });
+        reply.send(buildFeatureStoreResponse([], 0));
         return;
       }
 
@@ -241,14 +235,26 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       const namespacePromises = Object.entries(namespaces)
         .filter(([, clientConfigs]) => Array.isArray(clientConfigs))
         .map(async ([ns, clientConfigs]) => {
-          const enabledProjectNames = await getEnabledProjectNames(fastify, ns);
-          return processFeatureStoreConfigs(fastify, ns, clientConfigs, enabledProjectNames, token);
+          const allCrds = await fetchFeatureStoreCRDs(fastify, ns);
+          const enabledCrds = filterEnabledCRDs(allCrds as FeatureStoreCRD[]);
+          const enabledProjectNames = enabledCrds
+            .map((crd) => crd.spec?.feastProject)
+            .filter(Boolean);
+          const featureStores = await processFeatureStoreConfigs(
+            fastify,
+            ns,
+            clientConfigs,
+            enabledProjectNames,
+            token,
+          );
+          return { featureStores, enabledCRDCount: enabledCrds.length };
         });
 
       const namespaceResults = await Promise.all(namespacePromises);
-      const allFeatureStores = namespaceResults.flat();
+      const allFeatureStores = namespaceResults.flatMap((r) => r.featureStores);
+      const totalEnabledCRDCount = namespaceResults.reduce((sum, r) => sum + r.enabledCRDCount, 0);
 
-      reply.send(buildFeatureStoreResponse(allFeatureStores));
+      reply.send(buildFeatureStoreResponse(allFeatureStores, totalEnabledCRDCount));
     } catch (error) {
       const errorMessage = handleError(
         fastify,

--- a/packages/feature-store/src/FeatureStoreContext.tsx
+++ b/packages/feature-store/src/FeatureStoreContext.tsx
@@ -18,6 +18,7 @@ type FeatureStoreFetchState = {
 export type FeatureStoreContextType = {
   // Registry-based discovery
   featureStores: RegistryFeatureStore[];
+  enabledCRDCount: number;
   activeFeatureStore: RegistryFeatureStore | null;
   loaded: FeatureStoreFetchState['loaded'];
   loadError: FeatureStoreFetchState['error'];
@@ -39,6 +40,7 @@ export type FeatureStoreContextType = {
 export const FeatureStoreContext = React.createContext<FeatureStoreContextType>({
   // Registry-based discovery defaults
   featureStores: [],
+  enabledCRDCount: 0,
   activeFeatureStore: null,
   loaded: false,
   loadError: new Error('Not in FeatureStore provider'),
@@ -68,6 +70,7 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
 }) => {
   const {
     featureStores: registryFeatureStores,
+    enabledCRDCount,
     loaded: registryLoaded,
     error: registryError,
     refresh: refreshRegistry,
@@ -150,6 +153,7 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
     () => ({
       // Registry-based discovery
       featureStores: filteredFeatureStores,
+      enabledCRDCount,
       activeFeatureStore,
       loaded: registryLoaded && featureStoreProjectsLoaded,
       loadError: registryError || featureStoreProjectsError,
@@ -169,6 +173,7 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
     }),
     [
       filteredFeatureStores,
+      enabledCRDCount,
       activeFeatureStore,
       registryLoaded,
       registryError,

--- a/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreCR.spec.tsx
+++ b/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreCR.spec.tsx
@@ -37,6 +37,7 @@ describe('useFeatureStoreCR', () => {
     overrides: Partial<React.ComponentProps<typeof FeatureStoreContext.Provider>['value']> = {},
   ) => ({
     featureStores: [],
+    enabledCRDCount: 0,
     activeFeatureStore: null,
     loaded: false,
     loadError: undefined,

--- a/packages/feature-store/src/components/FeatureStoreWarningAlert.tsx
+++ b/packages/feature-store/src/components/FeatureStoreWarningAlert.tsx
@@ -12,12 +12,12 @@ import { ODH_PRODUCT_NAME } from '@odh-dashboard/internal/utilities/const';
 import { FeatureStoreContext } from '../FeatureStoreContext';
 
 const FeatureStoreWarningAlert: React.FC = () => {
-  const { featureStores, loaded } = React.useContext(FeatureStoreContext);
+  const { enabledCRDCount, loaded } = React.useContext(FeatureStoreContext);
   const [isAdmin, isAdminLoaded] = useAccessAllowed(verbModelAccess('create', FeatureStoreModel));
   const { serverURL } = useClusterInfo();
   const osConsoleAction = getOpenShiftConsoleAction(serverURL);
 
-  if (!loaded || featureStores.length <= 1 || !isAdminLoaded) {
+  if (!loaded || enabledCRDCount <= 1 || !isAdminLoaded) {
     return null;
   }
 

--- a/packages/feature-store/src/hooks/useRegistryFeatureStores.ts
+++ b/packages/feature-store/src/hooks/useRegistryFeatureStores.ts
@@ -20,38 +20,48 @@ export type RegistryFeatureStore = {
 
 type RegistryFeatureStoresResponse = {
   featureStores: RegistryFeatureStore[];
+  enabledCRDCount?: number;
 };
 
 type UseRegistryFeatureStoresReturn = {
   featureStores: RegistryFeatureStore[];
+  enabledCRDCount: number;
   loaded: boolean;
   error: Error | undefined;
   refresh: () => Promise<void>;
 };
 
+type FeatureStoresData = {
+  featureStores: RegistryFeatureStore[];
+  enabledCRDCount: number;
+};
+
 export const useRegistryFeatureStores = (): UseRegistryFeatureStoresReturn => {
-  const callback = React.useCallback<
-    FetchStateCallbackPromise<RegistryFeatureStore[]>
-  >(async () => {
+  const callback = React.useCallback<FetchStateCallbackPromise<FeatureStoresData>>(async () => {
     const data: RegistryFeatureStoresResponse = await proxyGET('', `/api/featurestores`);
-    return data.featureStores;
+    return { featureStores: data.featureStores, enabledCRDCount: data.enabledCRDCount ?? 0 };
   }, []);
 
   const {
-    data: featureStores,
+    data,
     loaded,
     error,
     refresh: refreshData,
-  } = useFetch(callback, [], {
-    initialPromisePurity: true,
-  });
+  } = useFetch(
+    callback,
+    { featureStores: [], enabledCRDCount: 0 },
+    {
+      initialPromisePurity: true,
+    },
+  );
 
   const refresh = React.useCallback(async () => {
     await refreshData();
   }, [refreshData]);
 
   return {
-    featureStores,
+    featureStores: data.featureStores,
+    enabledCRDCount: data.enabledCRDCount,
     loaded,
     error,
     refresh,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-42596

## Description

The "Missing feature stores detected" warning alert was being displayed whenever `featureStores.length > 1`, but `featureStores` contains **registry projects**, not **CRDs**. A single CRD with a shared remote registry can return multiple projects, causing the warning to appear even when only one CRD has `feature-store-ui: enabled`.

**Root cause:** The alert condition checked the count of feature store projects (from the registry API) instead of the count of CRDs with `feature-store-ui: enabled`.

**Fix:** The backend now returns `enabledCRDCount` alongside the `featureStores` array. This count reflects how many CRDs across all namespaces have the `feature-store-ui: enabled` label. The `FeatureStoreWarningAlert` component now checks `enabledCRDCount > 1` instead of `featureStores.length > 1`.

Changes:
- **`backend/src/routes/api/featurestores/featureStores.ts`**: Count enabled CRDs per namespace and include `enabledCRDCount` in the response. Removed the now-unused `getEnabledProjectNames` helper (logic inlined).
- **`packages/feature-store/src/hooks/useRegistryFeatureStores.ts`**: Extract and return `enabledCRDCount` from the API response.
- **`packages/feature-store/src/FeatureStoreContext.tsx`**: Propagate `enabledCRDCount` through the context.
- **`packages/feature-store/src/components/FeatureStoreWarningAlert.tsx`**: Use `enabledCRDCount <= 1` instead of `featureStores.length <= 1`.

## How Has This Been Tested?

In-session validation skipped due to resource limits; rely on CI/local verification.

**Manual test steps:**
1. Configure 2+ feature store projects with shared remote registry, only 1 CR with `feature-store-ui: enabled` — verify **no warning** is shown
2. Enable `feature-store-ui: enabled` on a second CR — verify the **warning appears**
3. Disable the label on the second CR — verify the **warning disappears**

## Test Impact

No existing tests cover the `FeatureStoreWarningAlert` component. The backend API response change is backward-compatible (new field added).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- N/A — Logic-only change, no visual UI changes.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System now exposes and returns the count of enabled custom resources in the feature store registry.

* **Improvements**
  * UI context and warning alert now use the enabled-resource count for more accurate behavior and visibility.

* **Tests**
  * Test fixtures updated to include the enabled-resource count for more representative coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->