### PR TITLE
fix(model-serving): add optional chaining for ServingRuntime spec access

### DIFF
--- a/frontend/src/pages/modelServing/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/__tests__/utils.spec.ts
@@ -1,12 +1,16 @@
 import {
   getInferenceServiceSizeOrReturnEmpty,
   getServingRuntimeOrReturnEmpty,
+  getKServeContainer,
+  getKServeContainerArgs,
+  getKServeContainerEnvVarStrs,
   resourcesArePositive,
   setUpTokenAuth,
   isOciModelUri,
   getInferenceServiceStoppedStatus,
   getServingRuntimeVersionStatus,
   getModelServingPVCAnnotations,
+  isModelServerEditInfoChanged,
 } from '#~/pages/modelServing/utils';
 import { mockServingRuntimeK8sResource } from '#~/__mocks__/mockServingRuntimeK8sResource';
 import { mockPVCK8sResource } from '#~/__mocks__/mockPVCK8sResource';
@@ -26,6 +30,12 @@ import { mock404Error } from '#~/__mocks__/mockK8sStatus';
 import { mockInferenceServiceK8sResource } from '#~/__mocks__/mockInferenceServiceK8sResource';
 import { mockRoleK8sResource } from '#~/__mocks__/mockRoleK8sResource';
 import { ServingRuntimeVersionStatusLabel } from '#~/pages/modelServing/screens/const';
+import { ServingRuntimeKind } from '#~/k8sTypes';
+import {
+  CreatingServingRuntimeObject,
+  ServingRuntimeEditInfo,
+} from '#~/pages/modelServing/screens/types';
+import { ModelServingPodSpecOptionsState } from '#~/concepts/hardwareProfiles/deprecated/useModelServingAcceleratorDeprecatedPodSpecOptionsState';
 
 jest.mock('#~/api', () => ({
   ...jest.requireActual('#~/api'),
@@ -322,6 +332,92 @@ describe('getModelServingPVCAnnotations', () => {
     expect(getModelServingPVCAnnotations(pvc)).toEqual({
       modelName: null,
       modelPath: null,
+    });
+  });
+});
+
+describe('spec-less ServingRuntime handling', () => {
+  const speclessRuntime = {
+    apiVersion: 'serving.kserve.io/v1alpha1',
+    kind: 'ServingRuntime',
+    metadata: { name: 'no-spec', namespace: 'test' },
+  } as unknown as ServingRuntimeKind;
+
+  const emptyContainersRuntime = {
+    apiVersion: 'serving.kserve.io/v1alpha1',
+    kind: 'ServingRuntime',
+    metadata: { name: 'empty-containers', namespace: 'test' },
+    spec: { containers: [] },
+  } as unknown as ServingRuntimeKind;
+
+  describe('getServingRuntimeOrReturnEmpty', () => {
+    it('should return undefined for a spec-less serving runtime', () => {
+      expect(getServingRuntimeOrReturnEmpty(speclessRuntime)).toBeUndefined();
+    });
+
+    it('should return undefined for a serving runtime with empty containers', () => {
+      expect(getServingRuntimeOrReturnEmpty(emptyContainersRuntime)).toBeUndefined();
+    });
+  });
+
+  describe('getKServeContainer', () => {
+    it('should return undefined for a spec-less serving runtime', () => {
+      expect(getKServeContainer(speclessRuntime)).toBeUndefined();
+    });
+
+    it('should return undefined for a serving runtime with empty containers', () => {
+      expect(getKServeContainer(emptyContainersRuntime)).toBeUndefined();
+    });
+  });
+
+  describe('getKServeContainerArgs', () => {
+    it('should return undefined for a spec-less serving runtime', () => {
+      expect(getKServeContainerArgs(speclessRuntime)).toBeUndefined();
+    });
+  });
+
+  describe('getKServeContainerEnvVarStrs', () => {
+    it('should return undefined for a spec-less serving runtime', () => {
+      expect(getKServeContainerEnvVarStrs(speclessRuntime)).toBeUndefined();
+    });
+  });
+
+  describe('isModelServerEditInfoChanged', () => {
+    const createData: CreatingServingRuntimeObject = {
+      name: 'test',
+      k8sName: 'test',
+      servingRuntimeTemplateName: 'ovms',
+      numReplicas: 1,
+      externalRoute: false,
+      tokenAuth: false,
+      tokens: [],
+    };
+
+    const podSpecOptionsState = {
+      podSpecOptions: {
+        resources: undefined,
+        tolerations: undefined,
+        nodeSelector: undefined,
+      },
+      modelSize: { size: undefined, sizes: [] },
+    } as unknown as ModelServingPodSpecOptionsState;
+
+    it('should not crash when editInfo contains a spec-less serving runtime', () => {
+      const editInfo: ServingRuntimeEditInfo = {
+        servingRuntime: speclessRuntime,
+        secrets: [],
+      };
+      expect(() =>
+        isModelServerEditInfoChanged(createData, podSpecOptionsState, editInfo),
+      ).not.toThrow();
+    });
+
+    it('should return true when editInfo contains a spec-less serving runtime', () => {
+      const editInfo: ServingRuntimeEditInfo = {
+        servingRuntime: speclessRuntime,
+        secrets: [],
+      };
+      expect(isModelServerEditInfoChanged(createData, podSpecOptionsState, editInfo)).toBe(true);
     });
   });
 });

--- a/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/__tests__/utils.spec.ts
@@ -44,6 +44,30 @@ describe('getDisplayNameFromServingRuntimeTemplate', () => {
     );
     expect(servingRuntime).toBe('OpenVINO Model Server');
   });
+
+  it('should return default name for a spec-less serving runtime', () => {
+    const speclessRuntime = {
+      metadata: { name: 'no-spec', namespace: 'test' },
+    } as unknown as ServingRuntimeKind;
+    expect(getDisplayNameFromServingRuntimeTemplate(speclessRuntime)).toBe(
+      'Unknown Serving Runtime',
+    );
+  });
+
+  it('should return template display name for a spec-less serving runtime with annotations', () => {
+    const speclessWithAnnotations = {
+      metadata: {
+        name: 'no-spec',
+        namespace: 'test',
+        annotations: {
+          'opendatahub.io/template-display-name': 'My Custom Runtime',
+        },
+      },
+    } as unknown as ServingRuntimeKind;
+    expect(getDisplayNameFromServingRuntimeTemplate(speclessWithAnnotations)).toBe(
+      'My Custom Runtime',
+    );
+  });
 });
 
 describe('getTemplateEnabledForPlatform', () => {

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -127,7 +127,7 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
     resource.metadata.annotations?.['opendatahub.io/template-display-name'] ||
     resource.metadata.annotations?.['opendatahub.io/template-name'];
   const legacyTemplateName =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- K8s resources can arrive without spec at runtime (RHOAIENG-32511)
     resource.spec?.builtInAdapter?.serverType === 'ovms' ? 'OpenVINO Model Server' : undefined;
 
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';

--- a/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
+++ b/frontend/src/pages/modelServing/customServingRuntimes/utils.ts
@@ -127,7 +127,8 @@ export const getDisplayNameFromServingRuntimeTemplate = (resource: ServingRuntim
     resource.metadata.annotations?.['opendatahub.io/template-display-name'] ||
     resource.metadata.annotations?.['opendatahub.io/template-name'];
   const legacyTemplateName =
-    resource.spec.builtInAdapter?.serverType === 'ovms' ? 'OpenVINO Model Server' : undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    resource.spec?.builtInAdapter?.serverType === 'ovms' ? 'OpenVINO Model Server' : undefined;
 
   return templateName || legacyTemplateName || 'Unknown Serving Runtime';
 };

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
@@ -20,6 +20,7 @@ const useModelFramework = (
     setLoadedFrameworksForRuntimeName(null);
     getServingRuntime(name, namespace)
       .then((servingRuntime) => {
+        // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         setModels(servingRuntime.spec?.supportedModelFormats || []);
         setLoadedFrameworksForRuntimeName(name);

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
@@ -20,7 +20,7 @@ const useModelFramework = (
     setLoadedFrameworksForRuntimeName(null);
     getServingRuntime(name, namespace)
       .then((servingRuntime) => {
-        setModels(servingRuntime.spec.supportedModelFormats || []);
+        setModels(servingRuntime.spec?.supportedModelFormats || []);
         setLoadedFrameworksForRuntimeName(name);
       })
       .catch((e) => {

--- a/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
+++ b/frontend/src/pages/modelServing/screens/projects/InferenceServiceModal/useModelFramework.ts
@@ -20,6 +20,7 @@ const useModelFramework = (
     setLoadedFrameworksForRuntimeName(null);
     getServingRuntime(name, namespace)
       .then((servingRuntime) => {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         setModels(servingRuntime.spec?.supportedModelFormats || []);
         setLoadedFrameworksForRuntimeName(name);
       })

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
@@ -36,7 +36,8 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
   // todo: deal with the accelProfile below...
   const { hardwareProfile } = useModelServingPodSpecOptionsState(obj, isvc);
 
-  const resources = isvc?.spec.predictor.model?.resources || obj.spec.containers[0].resources;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const resources = isvc?.spec.predictor.model?.resources || obj.spec?.containers?.[0]?.resources;
   const sizes = getModelServingSizes(dashboardConfig);
   const size = sizes.find(
     (currentSize) => getResourceSize(sizes, resources || {}).name === currentSize.name,
@@ -48,7 +49,8 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
       <DescriptionListGroup>
         <DescriptionListTerm>Model server replicas</DescriptionListTerm>
         <DescriptionListDescription>
-          {isvc?.spec.predictor.minReplicas ?? obj.spec.replicas ?? 'Unknown'}
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
+          {isvc?.spec.predictor.minReplicas ?? obj.spec?.replicas ?? 'Unknown'}
         </DescriptionListDescription>
       </DescriptionListGroup>
       {resources && (

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
@@ -36,6 +36,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
   // todo: deal with the accelProfile below...
   const { hardwareProfile } = useModelServingPodSpecOptionsState(obj, isvc);
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const resources = isvc?.spec?.predictor?.model?.resources || obj.spec?.containers?.[0]?.resources;
   const sizes = getModelServingSizes(dashboardConfig);
@@ -49,6 +50,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
       <DescriptionListGroup>
         <DescriptionListTerm>Model server replicas</DescriptionListTerm>
         <DescriptionListDescription>
+          {/* K8s resources can arrive without spec at runtime (RHOAIENG-32511) */}
           {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
           {isvc?.spec?.predictor?.minReplicas ?? obj.spec?.replicas ?? 'Unknown'}
         </DescriptionListDescription>

--- a/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/ServingRuntimeDetails.tsx
@@ -37,7 +37,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
   const { hardwareProfile } = useModelServingPodSpecOptionsState(obj, isvc);
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const resources = isvc?.spec.predictor.model?.resources || obj.spec?.containers?.[0]?.resources;
+  const resources = isvc?.spec?.predictor?.model?.resources || obj.spec?.containers?.[0]?.resources;
   const sizes = getModelServingSizes(dashboardConfig);
   const size = sizes.find(
     (currentSize) => getResourceSize(sizes, resources || {}).name === currentSize.name,
@@ -50,7 +50,7 @@ const ServingRuntimeDetails: React.FC<ServingRuntimeDetailsProps> = ({ project, 
         <DescriptionListTerm>Model server replicas</DescriptionListTerm>
         <DescriptionListDescription>
           {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-          {isvc?.spec.predictor.minReplicas ?? obj.spec?.replicas ?? 'Unknown'}
+          {isvc?.spec?.predictor?.minReplicas ?? obj.spec?.replicas ?? 'Unknown'}
         </DescriptionListDescription>
       </DescriptionListGroup>
       {resources && (

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -400,6 +400,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                   servingRuntimeName={servingRuntimeSelected?.metadata.name}
+                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                   modelContext={servingRuntimeSelected?.spec?.supportedModelFormats}
                   registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
                 />

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -400,6 +400,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                   servingRuntimeName={servingRuntimeSelected?.metadata.name}
+                  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
                   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                   modelContext={servingRuntimeSelected?.spec?.supportedModelFormats}
                   registeredModelFormat={modelDeployPrefillInfo?.modelFormat}

--- a/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/kServeModal/ManageKServeModal.tsx
@@ -400,7 +400,7 @@ const ManageKServeModal: React.FC<ManageKServeModalProps> = ({
                   data={createDataInferenceService}
                   setData={setCreateDataInferenceService}
                   servingRuntimeName={servingRuntimeSelected?.metadata.name}
-                  modelContext={servingRuntimeSelected?.spec.supportedModelFormats}
+                  modelContext={servingRuntimeSelected?.spec?.supportedModelFormats}
                   registeredModelFormat={modelDeployPrefillInfo?.modelFormat}
                 />
                 <KServeAutoscalerReplicaSection

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
@@ -235,6 +235,7 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     const { servingRuntime } = editInfo?.servingRuntimeEditInfo || {};
     if (servingRuntime) {
       // Find the volumeMount with mountPath '/mnt/models/cache' and extract its subPath
+      // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const containers = servingRuntime.spec?.containers ?? [];
       for (const container of containers) {

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/ManageNIMServingModal.tsx
@@ -235,7 +235,8 @@ const ManageNIMServingModal: React.FC<ManageNIMServingModalProps> = ({
     const { servingRuntime } = editInfo?.servingRuntimeEditInfo || {};
     if (servingRuntime) {
       // Find the volumeMount with mountPath '/mnt/models/cache' and extract its subPath
-      const { containers } = servingRuntime.spec;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const containers = servingRuntime.spec?.containers ?? [];
       for (const container of containers) {
         const volumeMounts = container.volumeMounts || [];
         for (const volumeMount of volumeMounts) {

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -16,6 +16,13 @@ type UseNIMCompatiblePVCsState = {
 };
 
 const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
+  if (
+    servingRuntime.metadata.annotations?.['opendatahub.io/template-name'] ===
+    'nvidia-nim-runtime'
+  ) {
+    return true;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const containers = servingRuntime.spec?.containers;
 
@@ -23,9 +30,7 @@ const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
   return !!containers?.some(
     (container) =>
       container.image?.includes('nvcr.io/nim/') ||
-      container.image?.includes('nvidia/nim/') ||
-      servingRuntime.metadata.annotations?.['opendatahub.io/template-name'] ===
-        'nvidia-nim-runtime',
+      container.image?.includes('nvidia/nim/'),
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -33,7 +33,8 @@ const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
 };
 
 const extractPVCFromServingRuntime = (servingRuntime: ServingRuntimeKind): string | null => {
-  const { volumes } = servingRuntime.spec;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const volumes = servingRuntime.spec?.volumes;
   if (!volumes) {
     return null;
   }

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -17,8 +17,7 @@ type UseNIMCompatiblePVCsState = {
 
 const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
   if (
-    servingRuntime.metadata.annotations?.['opendatahub.io/template-name'] ===
-    'nvidia-nim-runtime'
+    servingRuntime.metadata.annotations?.['opendatahub.io/template-name'] === 'nvidia-nim-runtime'
   ) {
     return true;
   }
@@ -29,8 +28,7 @@ const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return !!containers?.some(
     (container) =>
-      container.image?.includes('nvcr.io/nim/') ||
-      container.image?.includes('nvidia/nim/'),
+      container.image?.includes('nvcr.io/nim/') || container.image?.includes('nvidia/nim/'),
   );
 };
 

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -16,8 +16,10 @@ type UseNIMCompatiblePVCsState = {
 };
 
 const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const containers = servingRuntime.spec?.containers;
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return !!containers?.some(
     (container) =>
       container.image?.includes('nvcr.io/nim/') ||
@@ -48,12 +50,15 @@ const parseNimModelFromImage = (image: string): string | null => {
 };
 
 const extractModelFromServingRuntime = (servingRuntime: ServingRuntimeKind): string | null => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const supportedFormats = servingRuntime.spec?.supportedModelFormats;
   if (supportedFormats?.length && supportedFormats[0]?.name) {
     return supportedFormats[0].name;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const containers = servingRuntime.spec?.containers;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   for (const container of containers ?? []) {
     const parsed = parseNimModelFromImage(container.image ?? '');
     if (parsed) {

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -16,9 +16,9 @@ type UseNIMCompatiblePVCsState = {
 };
 
 const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
-  const { containers } = servingRuntime.spec;
+  const containers = servingRuntime.spec?.containers;
 
-  return containers.some(
+  return !!containers?.some(
     (container) =>
       container.image?.includes('nvcr.io/nim/') ||
       container.image?.includes('nvidia/nim/') ||
@@ -48,13 +48,13 @@ const parseNimModelFromImage = (image: string): string | null => {
 };
 
 const extractModelFromServingRuntime = (servingRuntime: ServingRuntimeKind): string | null => {
-  const supportedFormats = servingRuntime.spec.supportedModelFormats;
+  const supportedFormats = servingRuntime.spec?.supportedModelFormats;
   if (supportedFormats?.length && supportedFormats[0]?.name) {
     return supportedFormats[0].name;
   }
 
-  const { containers } = servingRuntime.spec;
-  for (const container of containers) {
+  const containers = servingRuntime.spec?.containers;
+  for (const container of containers ?? []) {
     const parsed = parseNimModelFromImage(container.image ?? '');
     if (parsed) {
       return parsed;

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMCompatiblePVCs.ts
@@ -22,6 +22,7 @@ const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
     return true;
   }
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const containers = servingRuntime.spec?.containers;
 
@@ -33,6 +34,7 @@ const isNIMServingRuntime = (servingRuntime: ServingRuntimeKind): boolean => {
 };
 
 const extractPVCFromServingRuntime = (servingRuntime: ServingRuntimeKind): string | null => {
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const volumes = servingRuntime.spec?.volumes;
   if (!volumes) {
@@ -54,6 +56,7 @@ const parseNimModelFromImage = (image: string): string | null => {
 };
 
 const extractModelFromServingRuntime = (servingRuntime: ServingRuntimeKind): string | null => {
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const supportedFormats = servingRuntime.spec?.supportedModelFormats;
   if (supportedFormats?.length && supportedFormats[0]?.name) {

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
@@ -18,6 +18,7 @@ export const useNIMPVC = (
   React.useEffect(() => {
     const fetchPVC = async () => {
       if (namespace && servingRuntimeEditInfo) {
+        // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         const pvcName = servingRuntimeEditInfo.spec?.volumes?.find(
           (vol) => vol.persistentVolumeClaim?.claimName,

--- a/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/NIMServiceModal/useNIMPVC.ts
@@ -18,7 +18,8 @@ export const useNIMPVC = (
   React.useEffect(() => {
     const fetchPVC = async () => {
       if (namespace && servingRuntimeEditInfo) {
-        const pvcName = servingRuntimeEditInfo.spec.volumes?.find(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const pvcName = servingRuntimeEditInfo.spec?.volumes?.find(
           (vol) => vol.persistentVolumeClaim?.claimName,
         )?.persistentVolumeClaim?.claimName;
         if (pvcName) {

--- a/frontend/src/pages/modelServing/screens/projects/nim/__tests__/nimUtils.spec.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/__tests__/nimUtils.spec.ts
@@ -2,8 +2,10 @@ import { ServingRuntimeKind } from '#~/k8sTypes';
 import { fetchInferenceServiceCount } from '#~/pages/modelServing/screens/projects/utils';
 import { deletePvc, deleteSecret, listNIMAccounts, listServingRuntimes, getPvc } from '#~/api';
 import {
+  checkPVCUsage,
   fetchNIMAccountTemplateName,
   getNIMResourcesToDelete,
+  updateServingRuntimeTemplate,
 } from '#~/pages/modelServing/screens/projects/nim/nimUtils';
 import { mockNimAccount } from '#~/__mocks__/mockNimAccount';
 import { mockServingRuntimeK8sResource } from '#~/__mocks__';
@@ -198,5 +200,51 @@ describe('fetchNIMAccountTemplateName', () => {
     );
 
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('spec-less ServingRuntime handling', () => {
+  const speclessRuntime = {
+    apiVersion: 'serving.kserve.io/v1alpha1',
+    kind: 'ServingRuntime',
+    metadata: { name: 'no-spec', namespace: 'test-project' },
+  } as unknown as ServingRuntimeKind;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getNIMResourcesToDelete', () => {
+    it('should return empty array for a spec-less serving runtime', async () => {
+      jest.mocked(fetchInferenceServiceCount).mockResolvedValue(0);
+
+      const result = await getNIMResourcesToDelete('test-project', speclessRuntime);
+
+      expect(result).toEqual([]);
+      expect(deletePvc).not.toHaveBeenCalled();
+      expect(deleteSecret).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkPVCUsage', () => {
+    it('should not crash when serving runtimes have no spec', async () => {
+      (listServingRuntimes as jest.Mock).mockResolvedValue([speclessRuntime]);
+
+      const result = await checkPVCUsage('nim-pvc-abc12', 'test-project');
+
+      expect(result).toEqual({ count: 0, servingRuntimes: [] });
+    });
+  });
+
+  describe('updateServingRuntimeTemplate', () => {
+    it('should not crash for a spec-less serving runtime', () => {
+      expect(() => updateServingRuntimeTemplate(speclessRuntime, 'new-pvc')).not.toThrow();
+    });
+
+    it('should return the runtime unchanged for a spec-less runtime', () => {
+      const result = updateServingRuntimeTemplate(speclessRuntime, 'new-pvc');
+      expect(result.metadata.name).toBe('no-spec');
+      expect((result as unknown as Record<string, unknown>).spec).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -95,10 +95,13 @@ export const getNIMServingRuntimeTemplate = async (
 export const updateServingRuntimeTemplate = (
   servingRuntime: ServingRuntimeKind,
   pvcName: string,
-  pvcSubPath?: string, // ← NEW: Optional subPath parameter
+  pvcSubPath?: string,
 ): ServingRuntimeKind => {
+  // TODO(RHOAIENG-32511): shallow copy — spec is still the same reference. Deep-copy spec
+  // in a follow-up to avoid mutating the caller's original.
   const updatedServingRuntime = { ...servingRuntime };
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!updatedServingRuntime.spec) {
     return updatedServingRuntime;
@@ -153,6 +156,7 @@ export const checkPVCUsage = async (
     const servingRuntimes = await listServingRuntimes(namespace);
 
     const usingPVC = servingRuntimes.filter((sr) => {
+      // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const volumes = sr.spec?.volumes || [];
       return volumes.some((volume) => volume.persistentVolumeClaim?.claimName === pvcName);
@@ -200,6 +204,7 @@ export const getNIMResourcesToDelete = async (
   // Handle PVC deletion with reference counting
   // IMPORTANT: With subPath support, multiple deployments may share the same PVC
   // We only delete the PVC when NO deployments are using it anymore
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const pvcName = servingRuntime.spec?.volumes?.find(
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -273,12 +278,14 @@ export const getNIMResourcesToDelete = async (
   let nimSecretName: string | undefined;
   let imagePullSecretName: string | undefined;
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const pullNGCSecret = servingRuntime.spec?.imagePullSecrets?.[0]?.name ?? '';
   if (pullNGCSecret === 'ngc-secret') {
     imagePullSecretName = pullNGCSecret;
   }
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   servingRuntime.spec?.containers?.forEach((container) => {
     container.env?.forEach((env) => {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -99,7 +99,9 @@ export const updateServingRuntimeTemplate = (
 ): ServingRuntimeKind => {
   const updatedServingRuntime = { ...servingRuntime };
 
-  updatedServingRuntime.spec.containers = updatedServingRuntime.spec.containers.map((container) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const containers = updatedServingRuntime.spec?.containers ?? [];
+  updatedServingRuntime.spec.containers = containers.map((container) => {
     if (container.volumeMounts) {
       const updatedVolumeMounts = container.volumeMounts.map((volumeMount) => {
         if (volumeMount.mountPath === '/mnt/models/cache') {
@@ -123,7 +125,8 @@ export const updateServingRuntimeTemplate = (
     return container;
   });
 
-  if (updatedServingRuntime.spec.volumes) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (updatedServingRuntime.spec?.volumes) {
     const updatedVolumes = updatedServingRuntime.spec.volumes.map((volume) => {
       if (volume.name.startsWith('nim-pvc')) {
         return {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -150,7 +150,7 @@ export const checkPVCUsage = async (
     const servingRuntimes = await listServingRuntimes(namespace);
 
     const usingPVC = servingRuntimes.filter((sr) => {
-      const volumes = sr.spec.volumes || [];
+      const volumes = sr.spec?.volumes || [];
       return volumes.some((volume) => volume.persistentVolumeClaim?.claimName === pvcName);
     });
 
@@ -196,7 +196,7 @@ export const getNIMResourcesToDelete = async (
   // Handle PVC deletion with reference counting
   // IMPORTANT: With subPath support, multiple deployments may share the same PVC
   // We only delete the PVC when NO deployments are using it anymore
-  const pvcName = servingRuntime.spec.volumes?.find((vol) =>
+  const pvcName = servingRuntime.spec?.volumes?.find((vol) =>
     vol.persistentVolumeClaim?.claimName.startsWith('nim-pvc'),
   )?.persistentVolumeClaim?.claimName;
 
@@ -267,12 +267,12 @@ export const getNIMResourcesToDelete = async (
   let nimSecretName: string | undefined;
   let imagePullSecretName: string | undefined;
 
-  const pullNGCSecret = servingRuntime.spec.imagePullSecrets?.[0]?.name ?? '';
+  const pullNGCSecret = servingRuntime.spec?.imagePullSecrets?.[0]?.name ?? '';
   if (pullNGCSecret === 'ngc-secret') {
     imagePullSecretName = pullNGCSecret;
   }
 
-  servingRuntime.spec.containers.forEach((container) => {
+  servingRuntime.spec?.containers?.forEach((container) => {
     container.env?.forEach((env) => {
       const secretName = env.valueFrom?.secretKeyRef?.name;
       if (secretName === 'nvidia-nim-secrets') {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -197,10 +197,11 @@ export const getNIMResourcesToDelete = async (
   // Handle PVC deletion with reference counting
   // IMPORTANT: With subPath support, multiple deployments may share the same PVC
   // We only delete the PVC when NO deployments are using it anymore
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   const pvcName = servingRuntime.spec?.volumes?.find((vol) =>
     vol.persistentVolumeClaim?.claimName?.startsWith('nim-pvc'),
   )?.persistentVolumeClaim?.claimName;
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 
   if (pvcName) {
     try {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -100,17 +100,17 @@ export const updateServingRuntimeTemplate = (
   const updatedServingRuntime = { ...servingRuntime };
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const containers = updatedServingRuntime.spec?.containers ?? [];
-  updatedServingRuntime.spec.containers = containers.map((container) => {
+  if (!updatedServingRuntime.spec) {
+    return updatedServingRuntime;
+  }
+
+  updatedServingRuntime.spec.containers = updatedServingRuntime.spec.containers.map((container) => {
     if (container.volumeMounts) {
       const updatedVolumeMounts = container.volumeMounts.map((volumeMount) => {
         if (volumeMount.mountPath === '/mnt/models/cache') {
           return {
             ...volumeMount,
             name: pvcName,
-            // ← NEW: Add subPath if provided
-            // SubPath allows mounting a subdirectory of the PVC
-            // Example: subPath: "/llama-3.1-8b-instruct"
             ...(pvcSubPath ? { subPath: pvcSubPath } : {}),
           };
         }
@@ -125,8 +125,7 @@ export const updateServingRuntimeTemplate = (
     return container;
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (updatedServingRuntime.spec?.volumes) {
+  if (updatedServingRuntime.spec.volumes) {
     const updatedVolumes = updatedServingRuntime.spec.volumes.map((volume) => {
       if (volume.name.startsWith('nim-pvc')) {
         return {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -111,6 +111,7 @@ export const updateServingRuntimeTemplate = (
           return {
             ...volumeMount,
             name: pvcName,
+            // SubPath allows mounting a subdirectory of the PVC
             ...(pvcSubPath ? { subPath: pvcSubPath } : {}),
           };
         }
@@ -199,11 +200,11 @@ export const getNIMResourcesToDelete = async (
   // Handle PVC deletion with reference counting
   // IMPORTANT: With subPath support, multiple deployments may share the same PVC
   // We only delete the PVC when NO deployments are using it anymore
-  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-  const pvcName = servingRuntime.spec?.volumes?.find((vol) =>
-    vol.persistentVolumeClaim?.claimName?.startsWith('nim-pvc'),
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const pvcName = servingRuntime.spec?.volumes?.find(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    (vol) => vol.persistentVolumeClaim?.claimName?.startsWith('nim-pvc'),
   )?.persistentVolumeClaim?.claimName;
-  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 
   if (pvcName) {
     try {

--- a/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/nim/nimUtils.ts
@@ -150,6 +150,7 @@ export const checkPVCUsage = async (
     const servingRuntimes = await listServingRuntimes(namespace);
 
     const usingPVC = servingRuntimes.filter((sr) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const volumes = sr.spec?.volumes || [];
       return volumes.some((volume) => volume.persistentVolumeClaim?.claimName === pvcName);
     });
@@ -196,8 +197,9 @@ export const getNIMResourcesToDelete = async (
   // Handle PVC deletion with reference counting
   // IMPORTANT: With subPath support, multiple deployments may share the same PVC
   // We only delete the PVC when NO deployments are using it anymore
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const pvcName = servingRuntime.spec?.volumes?.find((vol) =>
-    vol.persistentVolumeClaim?.claimName.startsWith('nim-pvc'),
+    vol.persistentVolumeClaim?.claimName?.startsWith('nim-pvc'),
   )?.persistentVolumeClaim?.claimName;
 
   if (pvcName) {
@@ -267,11 +269,13 @@ export const getNIMResourcesToDelete = async (
   let nimSecretName: string | undefined;
   let imagePullSecretName: string | undefined;
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const pullNGCSecret = servingRuntime.spec?.imagePullSecrets?.[0]?.name ?? '';
   if (pullNGCSecret === 'ngc-secret') {
     imagePullSecretName = pullNGCSecret;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   servingRuntime.spec?.containers?.forEach((container) => {
     container.env?.forEach((env) => {
       const secretName = env.valueFrom?.secretKeyRef?.name;

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
@@ -16,8 +16,10 @@ const useServingAcceleratorProfileFormState = (
     servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
   const resources =
     inferenceService?.spec.predictor.model?.resources ||
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     servingRuntime?.spec?.containers?.[0]?.resources;
   const tolerations =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     inferenceService?.spec.predictor.tolerations || servingRuntime?.spec?.tolerations;
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const namespace = servingRuntime?.metadata.namespace;

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
@@ -14,13 +14,14 @@ const useServingAcceleratorProfileFormState = (
 ): UseAcceleratorProfileFormResult => {
   const acceleratorProfileName =
     servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   const resources =
-    inferenceService?.spec.predictor.model?.resources ||
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    inferenceService?.spec?.predictor?.model?.resources ||
     servingRuntime?.spec?.containers?.[0]?.resources;
   const tolerations =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    inferenceService?.spec.predictor.tolerations || servingRuntime?.spec?.tolerations;
+    inferenceService?.spec?.predictor?.tolerations || servingRuntime?.spec?.tolerations;
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const namespace = servingRuntime?.metadata.namespace;
   const acceleratorProfileNamespace =

--- a/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
+++ b/frontend/src/pages/modelServing/screens/projects/useServingAcceleratorProfileFormState.ts
@@ -16,9 +16,9 @@ const useServingAcceleratorProfileFormState = (
     servingRuntime?.metadata.annotations?.['opendatahub.io/accelerator-name'];
   const resources =
     inferenceService?.spec.predictor.model?.resources ||
-    servingRuntime?.spec.containers[0].resources;
+    servingRuntime?.spec?.containers?.[0]?.resources;
   const tolerations =
-    inferenceService?.spec.predictor.tolerations || servingRuntime?.spec.tolerations;
+    inferenceService?.spec.predictor.tolerations || servingRuntime?.spec?.tolerations;
   const isProjectScopedAvailable = useIsAreaAvailable(SupportedArea.DS_PROJECT_SCOPED).status;
   const namespace = servingRuntime?.metadata.namespace;
   const acceleratorProfileNamespace =

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -96,7 +96,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
     ? getDisplayNameFromServingRuntimeTemplate(existingData.servingRuntime)
     : '';
 
-  const existingNumReplicas = existingData?.servingRuntime?.spec.replicas ?? 1;
+  const existingNumReplicas = existingData?.servingRuntime?.spec?.replicas ?? 1;
 
   const existingExternalRoute =
     existingData?.servingRuntime?.metadata.annotations?.['enable-route'] === 'true';
@@ -105,7 +105,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
 
   const existingTokens = useDeepCompareMemoize(getServingRuntimeTokens(existingData?.secrets));
 
-  const existingImageName = existingData?.servingRuntime?.spec.containers[0].image;
+  const existingImageName = existingData?.servingRuntime?.spec?.containers?.[0]?.image;
   const servingRuntimeScope =
     existingData?.servingRuntime?.metadata.annotations?.['opendatahub.io/serving-runtime-scope'];
 
@@ -450,7 +450,7 @@ export const getSubmitServingRuntimeResourcesFn = (
   }
   const servingRuntimeData = {
     ...createData,
-    existingTolerations: servingRuntimeSelected.spec.tolerations || [],
+    existingTolerations: servingRuntimeSelected?.spec?.tolerations || [],
     ...(name !== undefined && { name }),
   };
 

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -96,6 +96,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
     ? getDisplayNameFromServingRuntimeTemplate(existingData.servingRuntime)
     : '';
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const existingNumReplicas = existingData?.servingRuntime?.spec?.replicas ?? 1;
 
@@ -106,6 +107,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
 
   const existingTokens = useDeepCompareMemoize(getServingRuntimeTokens(existingData?.secrets));
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const existingImageName = existingData?.servingRuntime?.spec?.containers?.[0]?.image;
   const servingRuntimeScope =
@@ -452,6 +454,7 @@ export const getSubmitServingRuntimeResourcesFn = (
   }
   const servingRuntimeData = {
     ...createData,
+    // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     existingTolerations: servingRuntimeSelected?.spec?.tolerations || [],
     ...(name !== undefined && { name }),

--- a/frontend/src/pages/modelServing/screens/projects/utils.ts
+++ b/frontend/src/pages/modelServing/screens/projects/utils.ts
@@ -96,6 +96,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
     ? getDisplayNameFromServingRuntimeTemplate(existingData.servingRuntime)
     : '';
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const existingNumReplicas = existingData?.servingRuntime?.spec?.replicas ?? 1;
 
   const existingExternalRoute =
@@ -105,6 +106,7 @@ export const useCreateServingRuntimeObject = (existingData?: {
 
   const existingTokens = useDeepCompareMemoize(getServingRuntimeTokens(existingData?.secrets));
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const existingImageName = existingData?.servingRuntime?.spec?.containers?.[0]?.image;
   const servingRuntimeScope =
     existingData?.servingRuntime?.metadata.annotations?.['opendatahub.io/serving-runtime-scope'];
@@ -450,6 +452,7 @@ export const getSubmitServingRuntimeResourcesFn = (
   }
   const servingRuntimeData = {
     ...createData,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     existingTolerations: servingRuntimeSelected?.spec?.tolerations || [],
     ...(name !== undefined && { name }),
   };

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -344,7 +344,8 @@ export const isModelServerEditInfoChanged = (
       editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==
         String(createData.externalRoute) ||
-      editInfo.servingRuntime.metadata.annotations['enable-auth'] !==
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      editInfo.servingRuntime.metadata.annotations?.['enable-auth'] !==
         String(createData.tokenAuth) ||
       isPodSpecOptionsChanged(podSpecOptionsState, editInfo.servingRuntime) ||
       (createData.tokenAuth &&

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -250,6 +250,7 @@ export const getInferenceServiceSizeOrReturnEmpty = (
 export const getServingRuntimeOrReturnEmpty = (
   servingRuntime?: ServingRuntimeKind,
 ): ContainerResources | undefined => {
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const resources = servingRuntime?.spec?.containers?.[0]?.resources;
   if (resources && Object.keys(resources).length === 0) {
@@ -261,6 +262,7 @@ export const getServingRuntimeOrReturnEmpty = (
 export const getKServeContainer = (
   servingRuntime?: ServingRuntimeKind,
 ): ServingContainer | undefined =>
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   servingRuntime?.spec?.containers?.find((container) => container.name === 'kserve-container');
 
@@ -319,9 +321,11 @@ const isPodSpecOptionsChanged = (
   const currentSize = getServingRuntimeOrReturnEmpty(existingServingRuntime);
 
   const initialTolerations = currentPodSpecOptionsState.podSpecOptions.tolerations;
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const currentTolerations = existingServingRuntime?.spec?.tolerations;
 
+  // K8s resources can arrive without spec at runtime (RHOAIENG-32511)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const currentNodeSelector = existingServingRuntime?.spec?.nodeSelector;
   const initialNodeSelector = currentPodSpecOptionsState.podSpecOptions.nodeSelector;
@@ -340,6 +344,7 @@ export const isModelServerEditInfoChanged = (
 ): boolean =>
   editInfo?.servingRuntime
     ? getDisplayNameFromK8sResource(editInfo.servingRuntime) !== createData.name ||
+      // K8s resources can arrive without spec/annotations at runtime (RHOAIENG-32511)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -319,9 +319,11 @@ const isPodSpecOptionsChanged = (
   const currentSize = getServingRuntimeOrReturnEmpty(existingServingRuntime);
 
   const initialTolerations = currentPodSpecOptionsState.podSpecOptions.tolerations;
-  const currentTolerations = existingServingRuntime?.spec.tolerations;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const currentTolerations = existingServingRuntime?.spec?.tolerations;
 
-  const currentNodeSelector = existingServingRuntime?.spec.nodeSelector;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const currentNodeSelector = existingServingRuntime?.spec?.nodeSelector;
   const initialNodeSelector = currentPodSpecOptionsState.podSpecOptions.nodeSelector;
 
   return (
@@ -342,7 +344,7 @@ export const isModelServerEditInfoChanged = (
       editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==
         String(createData.externalRoute) ||
-      editInfo.servingRuntime.metadata.annotations['enable-auth'] !==
+      editInfo.servingRuntime.metadata.annotations?.['enable-auth'] !==
         String(createData.tokenAuth) ||
       isPodSpecOptionsChanged(podSpecOptionsState, editInfo.servingRuntime) ||
       (createData.tokenAuth &&

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -250,20 +250,17 @@ export const getInferenceServiceSizeOrReturnEmpty = (
 export const getServingRuntimeOrReturnEmpty = (
   servingRuntime?: ServingRuntimeKind,
 ): ContainerResources | undefined => {
-  if (
-    servingRuntime?.spec.containers[0]?.resources &&
-    Object.keys(servingRuntime.spec.containers[0]?.resources).length === 0
-  ) {
+  const resources = servingRuntime?.spec?.containers?.[0]?.resources;
+  if (resources && Object.keys(resources).length === 0) {
     return undefined;
   }
-
-  return servingRuntime?.spec.containers[0]?.resources;
+  return resources;
 };
 
 export const getKServeContainer = (
   servingRuntime?: ServingRuntimeKind,
 ): ServingContainer | undefined =>
-  servingRuntime?.spec.containers.find((container) => container.name === 'kserve-container');
+  servingRuntime?.spec?.containers?.find((container) => container.name === 'kserve-container');
 
 // will return `undefined` if no kserve container, force empty array if there is kserve with no args
 export const getKServeContainerArgs = (
@@ -339,7 +336,7 @@ export const isModelServerEditInfoChanged = (
 ): boolean =>
   editInfo?.servingRuntime
     ? getDisplayNameFromK8sResource(editInfo.servingRuntime) !== createData.name ||
-      editInfo.servingRuntime.spec.replicas !== createData.numReplicas ||
+      editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==
         String(createData.externalRoute) ||
       editInfo.servingRuntime.metadata.annotations['enable-auth'] !==

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -250,6 +250,7 @@ export const getInferenceServiceSizeOrReturnEmpty = (
 export const getServingRuntimeOrReturnEmpty = (
   servingRuntime?: ServingRuntimeKind,
 ): ContainerResources | undefined => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const resources = servingRuntime?.spec?.containers?.[0]?.resources;
   if (resources && Object.keys(resources).length === 0) {
     return undefined;
@@ -260,6 +261,7 @@ export const getServingRuntimeOrReturnEmpty = (
 export const getKServeContainer = (
   servingRuntime?: ServingRuntimeKind,
 ): ServingContainer | undefined =>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   servingRuntime?.spec?.containers?.find((container) => container.name === 'kserve-container');
 
 // will return `undefined` if no kserve container, force empty array if there is kserve with no args
@@ -336,6 +338,7 @@ export const isModelServerEditInfoChanged = (
 ): boolean =>
   editInfo?.servingRuntime
     ? getDisplayNameFromK8sResource(editInfo.servingRuntime) !== createData.name ||
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==
         String(createData.externalRoute) ||

--- a/frontend/src/pages/modelServing/utils.ts
+++ b/frontend/src/pages/modelServing/utils.ts
@@ -344,7 +344,7 @@ export const isModelServerEditInfoChanged = (
       editInfo.servingRuntime.spec?.replicas !== createData.numReplicas ||
       editInfo.servingRuntime.metadata.annotations?.['enable-route'] !==
         String(createData.externalRoute) ||
-      editInfo.servingRuntime.metadata.annotations?.['enable-auth'] !==
+      editInfo.servingRuntime.metadata.annotations['enable-auth'] !==
         String(createData.tokenAuth) ||
       isPodSpecOptionsChanged(podSpecOptionsState, editInfo.servingRuntime) ||
       (createData.tokenAuth &&


### PR DESCRIPTION
When a ServingRuntime is deployed without a spec property, accessing spec.tolerations, spec.containers, etc. throws a TypeError that crashes the page. This adds optional chaining (`?.spec?.`) across all unsafe access points to prevent the crash and allow graceful rendering.

Fixes https://issues.redhat.com/browse/RHOAIENG-32511

## Description

When a `ServingRuntime` custom resource exists in the cluster without a `spec` property (or with a `spec` that's missing expected sub-fields like `containers`, `tolerations`, `volumes`), the Model Serving UI crashes with an unhandled `TypeError`. This can happen when a ServingRuntime is partially created, corrupted, or managed by an external controller that doesn't populate all fields.

This PR adds optional chaining (`?.`) to all unsafe `spec` property accesses across model serving code:

- **`customServingRuntimes/utils.ts`** — `spec?.builtInAdapter` for display name fallback
- **`useModelFramework.ts`** — `spec?.supportedModelFormats`
- **`ManageKServeModal.tsx`** — `spec?.supportedModelFormats` for model context
- **`ServingRuntimeDetails.tsx`** — obj.spec?.containers?.[0]?.resources and obj.spec?.replicas; also added isvc?.spec?.predictor? guards for defensive consistency
- **`ManageNIMServingModal.tsx`** — spec?.containers for subPath extraction in edit mode
- **`useNIMCompatiblePVCs.ts`** — `spec?.containers` for NIM runtime detection, `spec?.volumes` for PVC extraction, `spec?.supportedModelFormats` for model extraction
- **`useNIMPVC.ts`** — `spec?.volumes` for PVC lookup in edit mode
- **`nimUtils.ts`** — `spec?.volumes`, `spec?.imagePullSecrets`, `spec?.containers` for PVC usage checks and resource cleanup; early return in `updateServingRuntimeTemplate` when spec is missing
- **`useServingAcceleratorProfileFormState.ts`** — `spec?.containers?.[0]?.resources` and `spec?.tolerations` for accelerator profiles
- **`screens/projects/utils.ts`** — `spec?.replicas`, `spec?.containers?.[0]?.image`, `spec?.tolerations` for serving runtime form state
- **`modelServing/utils.ts`** — `spec?.containers?.[0]?.resources`, `spec?.containers?.find(...)`, `spec?.tolerations`, `spec?.nodeSelector`, `spec?.replicas` for container resource extraction and edit detection

**14 files changed** (11 source files + 3 test files), all within `frontend/src/pages/modelServing/`.

### The `Models` page doesn't crash now.

<img width="1506" height="907" alt="Screenshot 2026-04-14 at 8 07 44 PM" src="https://github.com/user-attachments/assets/c2395692-f3ff-42c1-b092-d0ff524596ca" />

### Why `eslint-disable` comments?

The `ServingRuntimeKind` TypeScript type defines `spec` as a required property, so TypeScript considers `spec?.` to be unnecessary. However, at runtime, Kubernetes resources can arrive without a `spec`. Each optional chain is annotated with `// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition` to suppress this false positive. A cleaner long-term solution would be introducing a safe accessor helper or a `RawServingRuntimeKind` type alias that marks `spec` as optional at the function boundary, avoiding the need for lint suppression entirely — this can be tracked as a follow-up improvement.

## How Has This Been Tested?

### Manual testing
1. Deployed a ServingRuntime with no `spec` property and verified the dashboard renders without crashing on both the global model serving page and the project model server tab.
2. Deployed a ServingRuntime with `containers: []` (empty containers) and verified graceful degradation.
3. Deployed a NIM-annotated ServingRuntime with no `spec` and verified NIM-specific code paths don't crash.
4. Confirmed that model serving pages (inference services, KServe modals, NIM modals) continue to render correctly with well-formed ServingRuntimes.

### Unit tests added (12 new test cases)
- **`customServingRuntimes/__tests__/utils.spec.ts`** — `getDisplayNameFromServingRuntimeTemplate` returns "Unknown Serving Runtime" for spec-less runtimes; returns annotation display name when spec is missing but annotations exist.
- **`modelServing/__tests__/utils.spec.ts`** — `getServingRuntimeOrReturnEmpty`, `getKServeContainer`, `getKServeContainerArgs`, `getKServeContainerEnvVarStrs` all return `undefined` for spec-less runtimes; `isModelServerEditInfoChanged` doesn't crash with spec-less runtime in editInfo.
- **`nim/__tests__/nimUtils.spec.ts`** — `getNIMResourcesToDelete` returns empty array for spec-less runtime; `checkPVCUsage` handles spec-less runtimes in the list; `updateServingRuntimeTemplate` returns unchanged runtime when spec is missing.

## Test Impact

12 new unit tests were added across 3 test files to validate that all modified utility functions gracefully handle a `ServingRuntime` with no `spec` property. The new tests caught and confirmed a fix for an additional crash in `updateServingRuntimeTemplate` where reading `spec?.containers` was safe but writing back to `spec.containers =` still failed. All 103 tests across the 4 affected test files pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability across model serving screens by defensively handling missing runtime configuration fields (spec, containers, volumes, tolerations, image pull secrets, etc.). Prevents crashes and incorrect behavior when runtime data is partial or absent, improving inference service creation, runtime selection, PVC checks, resource population, and form submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->