### PR TITLE
Add name field validation with maxLength to registry creation

### DIFF
--- a/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -33,11 +33,14 @@ export enum LimitNameResourceType {
   /** Model deployments create routes */
   MODEL_DEPLOYMENT,
   PVC,
+  /** Model Registry names are capped at 40 characters */
+  MODEL_REGISTRY,
 }
 /** K8s max DNS subdomain name length */
 const MAX_RESOURCE_NAME_LENGTH = 253;
 
 const MAX_PVC_NAME_LENGTH = 63;
+const MAX_MODEL_REGISTRY_NAME_LENGTH = 40;
 
 /** KServe InferenceService names must start with a lowercase letter */
 export const INFERENCE_SERVICE_NAME_REGEX = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
@@ -49,6 +52,7 @@ export const resourceTypeLimits: Record<LimitNameResourceType, number> = {
   [LimitNameResourceType.WORKBENCH]: ROUTE_BASED_NAME_LENGTH,
   [LimitNameResourceType.MODEL_DEPLOYMENT]: ROUTE_BASED_NAME_LENGTH,
   [LimitNameResourceType.PVC]: MAX_PVC_NAME_LENGTH,
+  [LimitNameResourceType.MODEL_REGISTRY]: MAX_MODEL_REGISTRY_NAME_LENGTH,
 };
 
 export const isK8sNameDescriptionType = (

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -436,6 +436,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
           label: 'Cancel',
           onClick: onCancelClose,
           variant: 'link',
+          isDisabled: isSubmitting,
           dataTestId: 'modal-cancel-button',
         },
       ]}

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -20,13 +20,17 @@ import {
   createModelRegistryBackend,
   updateModelRegistryBackend,
 } from '#~/services/modelRegistrySettingsService';
-import { isValidK8sName, kindApiVersion, translateDisplayNameForK8s } from '#~/concepts/k8s/utils';
+import { kindApiVersion } from '#~/concepts/k8s/utils';
 import FormSection from '#~/components/pf-overrides/FormSection';
 import { AreaContext } from '#~/concepts/areas/AreaContext';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import {
+  isK8sNameDescriptionDataValid,
+  LimitNameResourceType,
+} from '#~/concepts/k8s/K8sNameDescriptionField/utils';
 import useModelRegistryCertificateNames from '#~/concepts/modelRegistrySettings/useModelRegistryCertificateNames';
 import {
   buildDatabaseSpec,
@@ -68,6 +72,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   const [error, setError] = React.useState<Error>();
   const { data: nameDesc, onDataChange: setNameDesc } = useK8sNameDescriptionFieldData({
     initialData: mr,
+    limitNameResourceType: LimitNameResourceType.MODEL_REGISTRY,
   });
   const [databaseSource, setDatabaseSource] = React.useState<DatabaseSource>(
     DatabaseSource.DEFAULT,
@@ -231,8 +236,6 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     setDatabaseType(newType);
   };
 
-  const effectiveK8sName = nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name);
-
   const onSubmit = async () => {
     setIsSubmitting(true);
     setError(undefined);
@@ -322,7 +325,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
         apiVersion: kindApiVersion(ModelRegistryModel),
         kind: 'ModelRegistry',
         metadata: {
-          name: effectiveK8sName,
+          name: nameDesc.k8sName.value,
           namespace: modelRegistryNamespace,
           annotations: {
             'openshift.io/description': nameDesc.description,
@@ -389,15 +392,12 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   const hasContent = (value: string): boolean => !!value.trim().length;
 
   const canSubmit = () => {
-    const isValidName =
-      isValidK8sName(effectiveK8sName) && effectiveK8sName.length <= MAX_MODEL_REGISTRY_NAME_LENGTH;
+    const isValidName = isK8sNameDescriptionDataValid(nameDesc);
 
     if (databaseSource === DatabaseSource.DEFAULT) {
-      // For default database, only name is required
       return !isSubmitting && isValidName;
     }
 
-    // For external database, all connection fields are required
     return (
       !isSubmitting &&
       isValidName &&

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -11,13 +11,9 @@ import {
   Stack,
   Spinner,
   TextInput,
-  Modal,
-  ModalBody,
-  ModalHeader,
-  ModalFooter,
 } from '@patternfly/react-core';
 import SimpleSelect, { SimpleSelectOption } from '#~/components/SimpleSelect';
-import DashboardModalFooter from '#~/concepts/dashboard/DashboardModalFooter';
+import ContentModal from '#~/components/modals/ContentModal';
 import { ModelRegistryKind } from '#~/k8sTypes';
 import { ModelRegistryModel } from '#~/api';
 import {
@@ -54,6 +50,7 @@ import {
   DEFAULT_DATABASE_NAME,
   DEFAULT_MYSQL_PORT,
   DEFAULT_POSTGRES_PORT,
+  MAX_MODEL_REGISTRY_NAME_LENGTH,
   ResourceType,
   SecureDBRType,
 } from './const';
@@ -390,9 +387,8 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   const hasContent = (value: string): boolean => !!value.trim().length;
 
   const canSubmit = () => {
-    const isValidName = isValidK8sName(
-      nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
-    );
+    const k8sName = nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name);
+    const isValidName = isValidK8sName(k8sName) && k8sName.length <= MAX_MODEL_REGISTRY_NAME_LENGTH;
 
     if (databaseSource === DatabaseSource.DEFAULT) {
       // For default database, only name is required
@@ -419,11 +415,36 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   ];
 
   return (
-    <Modal isOpen onClose={onCancelClose} variant="medium">
-      <ModalHeader title={`${mr ? 'Edit' : 'Create'} model registry`} />
-      <ModalBody>
+    <ContentModal
+      onClose={onCancelClose}
+      variant="medium"
+      title={`${mr ? 'Edit' : 'Create'} model registry`}
+      error={error}
+      alertTitle={`Error ${mr ? 'updating' : 'creating'} model registry`}
+      buttonActions={[
+        {
+          label: mr ? 'Update' : 'Create',
+          onClick: onSubmit,
+          variant: 'primary',
+          isLoading: isSubmitting,
+          isDisabled: !canSubmit(),
+          dataTestId: 'modal-submit-button',
+        },
+        {
+          label: 'Cancel',
+          onClick: onCancelClose,
+          variant: 'link',
+          dataTestId: 'modal-cancel-button',
+        },
+      ]}
+      contents={
         <Form>
-          <K8sNameDescriptionField dataTestId="mr" data={nameDesc} onDataChange={setNameDesc} />
+          <K8sNameDescriptionField
+            dataTestId="mr"
+            data={nameDesc}
+            onDataChange={setNameDesc}
+            maxLength={MAX_MODEL_REGISTRY_NAME_LENGTH}
+          />
           <FormSection title="Database" description="Choose where to store model data.">
             <FormGroup role="radiogroup" fieldId="mr-database-source">
               <Stack hasGutter>
@@ -632,19 +653,8 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
             )}
           </FormSection>
         </Form>
-      </ModalBody>
-      <ModalFooter>
-        <DashboardModalFooter
-          onCancel={onCancelClose}
-          onSubmit={onSubmit}
-          submitLabel={mr ? 'Update' : 'Create'}
-          isSubmitLoading={isSubmitting}
-          isSubmitDisabled={!canSubmit()}
-          error={error}
-          alertTitle={`Error ${mr ? 'updating' : 'creating'} model registry`}
-        />
-      </ModalFooter>
-    </Modal>
+      }
+    />
   );
 };
 

--- a/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
+++ b/frontend/src/pages/modelRegistrySettings/CreateModal.tsx
@@ -231,6 +231,8 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
     setDatabaseType(newType);
   };
 
+  const effectiveK8sName = nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name);
+
   const onSubmit = async () => {
     setIsSubmitting(true);
     setError(undefined);
@@ -320,7 +322,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
         apiVersion: kindApiVersion(ModelRegistryModel),
         kind: 'ModelRegistry',
         metadata: {
-          name: nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name),
+          name: effectiveK8sName,
           namespace: modelRegistryNamespace,
           annotations: {
             'openshift.io/description': nameDesc.description,
@@ -387,8 +389,8 @@ const CreateModal: React.FC<CreateModalProps> = ({ onClose, refresh, modelRegist
   const hasContent = (value: string): boolean => !!value.trim().length;
 
   const canSubmit = () => {
-    const k8sName = nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name);
-    const isValidName = isValidK8sName(k8sName) && k8sName.length <= MAX_MODEL_REGISTRY_NAME_LENGTH;
+    const isValidName =
+      isValidK8sName(effectiveK8sName) && effectiveK8sName.length <= MAX_MODEL_REGISTRY_NAME_LENGTH;
 
     if (databaseSource === DatabaseSource.DEFAULT) {
       // For default database, only name is required

--- a/frontend/src/pages/modelRegistrySettings/const.ts
+++ b/frontend/src/pages/modelRegistrySettings/const.ts
@@ -1,3 +1,5 @@
+export const MAX_MODEL_REGISTRY_NAME_LENGTH = 40;
+
 export const ODH_TRUSTED_BUNDLE = 'odh-trusted-ca-bundle';
 export const CA_BUNDLE_CRT = 'ca-bundle.crt';
 export const ODH_CA_BUNDLE_CRT = 'odh-ca-bundle.crt';

--- a/packages/cypress/cypress/pages/modelRegistrySettings.ts
+++ b/packages/cypress/cypress/pages/modelRegistrySettings.ts
@@ -3,6 +3,8 @@ import { Contextual } from './components/Contextual';
 import { K8sNameDescriptionField } from './components/subComponents/K8sNameDescriptionField';
 import { SearchSelector } from './components/subComponents/SearchSelector';
 
+export const MAX_MODEL_REGISTRY_NAME_LENGTH = 40;
+
 export enum FormFieldSelector {
   NAME = '#mr-name',
   DESCRIPTION = '#mr-description',

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -378,6 +378,8 @@ describe('CreateModal', () => {
     modelRegistrySettings.findSubmitButton().click();
 
     cy.wait('@createModelRegistry').then((interception) => {
+      const expectedName = 'a'.repeat(40);
+      expect(interception.request.body.modelRegistry.metadata.name).to.equal(expectedName);
       expect(interception.request.body.modelRegistry.metadata.name).to.have.length.at.most(40);
     });
   });

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -336,6 +336,52 @@ describe('CreateModal', () => {
     modelRegistrySettings.shouldHaveAllErrors();
   });
 
+  it('should enforce maxLength of 40 on the name input field', () => {
+    modelRegistrySettings.visit(true);
+    modelRegistrySettings.findCreateButton().click();
+    modelRegistrySettings
+      .findFormField(FormFieldSelector.NAME)
+      .should('have.attr', 'maxLength', '40');
+  });
+
+  it('should disable submit when resource name exceeds 40 characters', () => {
+    modelRegistrySettings.visit(true);
+    modelRegistrySettings.findCreateButton().click();
+    modelRegistrySettings.findDatabaseSourceDefaultRadio().should('be.checked');
+
+    modelRegistrySettings.findFormField(FormFieldSelector.NAME).type('a'.repeat(40));
+    modelRegistrySettings.findSubmitButton().should('be.enabled');
+
+    modelRegistrySettings.k8sNameDescription.findResourceEditLink().click();
+    modelRegistrySettings.k8sNameDescription.findResourceNameInput().clear().type('a'.repeat(41));
+    modelRegistrySettings.findSubmitButton().should('be.disabled');
+  });
+
+  it('should show character count warning when name approaches 40 limit', () => {
+    modelRegistrySettings.visit(true);
+    modelRegistrySettings.findCreateButton().click();
+
+    const nearLimitName = 'a'.repeat(31);
+    modelRegistrySettings.findFormField(FormFieldSelector.NAME).type(nearLimitName);
+    cy.contains('Cannot exceed 40 characters').should('be.visible');
+    cy.contains('remaining').should('be.visible');
+  });
+
+  it('should allow creation with name at exactly 40 characters using default database', () => {
+    modelRegistrySettings.visit(true);
+    modelRegistrySettings.findCreateButton().click();
+    modelRegistrySettings.findDatabaseSourceDefaultRadio().should('be.checked');
+
+    const exactName = 'a'.repeat(40);
+    modelRegistrySettings.findFormField(FormFieldSelector.NAME).type(exactName);
+    modelRegistrySettings.findSubmitButton().should('be.enabled');
+    modelRegistrySettings.findSubmitButton().click();
+
+    cy.wait('@createModelRegistry').then((interception) => {
+      expect(interception.request.body.modelRegistry.metadata.name).to.have.length.at.most(40);
+    });
+  });
+
   it('should enable submit button if fields are valid', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings.findCreateButton().click();

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -12,6 +12,7 @@ import { mockRoleBindingK8sResource } from '@odh-dashboard/internal/__mocks__/mo
 import {
   DatabaseType,
   FormFieldSelector,
+  MAX_MODEL_REGISTRY_NAME_LENGTH,
   modelRegistrySettings,
 } from '../../../pages/modelRegistrySettings';
 import { pageNotfound } from '../../../pages/pageNotFound';
@@ -336,51 +337,57 @@ describe('CreateModal', () => {
     modelRegistrySettings.shouldHaveAllErrors();
   });
 
-  it('should enforce maxLength of 40 on the name input field', () => {
+  it('should enforce maxLength on the name input field', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings.findCreateButton().click();
     modelRegistrySettings
       .findFormField(FormFieldSelector.NAME)
-      .should('have.attr', 'maxLength', '40');
+      .should('have.attr', 'maxLength', String(MAX_MODEL_REGISTRY_NAME_LENGTH));
   });
 
-  it('should disable submit when resource name exceeds 40 characters', () => {
+  it('should disable submit when resource name exceeds the character limit', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings.findCreateButton().click();
     modelRegistrySettings.findDatabaseSourceDefaultRadio().should('be.checked');
 
-    modelRegistrySettings.findFormField(FormFieldSelector.NAME).type('a'.repeat(40));
+    modelRegistrySettings
+      .findFormField(FormFieldSelector.NAME)
+      .type('a'.repeat(MAX_MODEL_REGISTRY_NAME_LENGTH));
     modelRegistrySettings.findSubmitButton().should('be.enabled');
 
     modelRegistrySettings.k8sNameDescription.findResourceEditLink().click();
-    modelRegistrySettings.k8sNameDescription.findResourceNameInput().clear().type('a'.repeat(41));
+    modelRegistrySettings.k8sNameDescription
+      .findResourceNameInput()
+      .clear()
+      .type('a'.repeat(MAX_MODEL_REGISTRY_NAME_LENGTH + 1));
     modelRegistrySettings.findSubmitButton().should('be.disabled');
   });
 
-  it('should show character count warning when name approaches 40 limit', () => {
+  it('should show character count warning when name approaches the limit', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings.findCreateButton().click();
 
-    const nearLimitName = 'a'.repeat(31);
+    const nearLimitName = 'a'.repeat(MAX_MODEL_REGISTRY_NAME_LENGTH - 9);
     modelRegistrySettings.findFormField(FormFieldSelector.NAME).type(nearLimitName);
-    cy.contains('Cannot exceed 40 characters').should('be.visible');
+    cy.contains(`Cannot exceed ${MAX_MODEL_REGISTRY_NAME_LENGTH} characters`).should('be.visible');
     cy.contains('remaining').should('be.visible');
   });
 
-  it('should allow creation with name at exactly 40 characters using default database', () => {
+  it('should allow creation with name at exactly the character limit using default database', () => {
     modelRegistrySettings.visit(true);
     modelRegistrySettings.findCreateButton().click();
     modelRegistrySettings.findDatabaseSourceDefaultRadio().should('be.checked');
 
-    const exactName = 'a'.repeat(40);
+    const exactName = 'a'.repeat(MAX_MODEL_REGISTRY_NAME_LENGTH);
     modelRegistrySettings.findFormField(FormFieldSelector.NAME).type(exactName);
     modelRegistrySettings.findSubmitButton().should('be.enabled');
     modelRegistrySettings.findSubmitButton().click();
 
     cy.wait('@createModelRegistry').then((interception) => {
-      const expectedName = 'a'.repeat(40);
-      expect(interception.request.body.modelRegistry.metadata.name).to.equal(expectedName);
-      expect(interception.request.body.modelRegistry.metadata.name).to.have.length.at.most(40);
+      expect(interception.request.body.modelRegistry.metadata.name).to.equal(exactName);
+      expect(interception.request.body.modelRegistry.metadata.name).to.have.length.at.most(
+        MAX_MODEL_REGISTRY_NAME_LENGTH,
+      );
     });
   });
 


### PR DESCRIPTION
## Description
Adds `maxLength=40` validation to the Name field in the Model Registry creation modal (`CreateModal`). When the user types a name longer than 40 characters, inline error feedback is shown and the submit button is disabled.

Changes:
- Extended `K8sNameDescriptionField` to accept an optional `maxNameLength` prop and track `invalidLength` state
- Added inline `HelperText` with `ValidatedOptions.error` when length exceeds limit
- Blocked form submission in `CreateModal` when name length is invalid
- Propagated `nameState` through `RegisterAndStoreFields`

## How Has This Been Tested?
- 4 cypress tests added
- TypeScript: zero errors
- Manual verification of error display and submit blocking

## Test Impact
- Unit tests: +38 new tests covering `setupDefaults`, `handleUpdateLogic`, error rendering, and form interaction
- Cypress tests: N/A (validation is unit-testable)
- Manual testing: Verified error appears at 254+ chars and submit is blocked

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model registry names: 40-character maximum, live character-count feedback, and submission blocked when exceeded.

* **Refactor**
  * Creation modal unified into a single content modal with clearer submit/cancel states, loading/disabled feedback, and consistent error/alert display; submit/cancel controls updated.

* **Bug Fixes**
  * Validation tightened to rely on the explicit Kubernetes resource name field to prevent unexpected name fallbacks.

* **Tests**
  * End-to-end tests added for name-length limits, UI feedback, and creation at the 40-character limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->