### PR TITLE
fetch all perses dashboards across namespaces

### DIFF
--- a/backend/src/utils/dsci.ts
+++ b/backend/src/utils/dsci.ts
@@ -21,10 +21,5 @@ export const getClusterInitialization = async (
     throw createCustomError('DSCI Unavailable', 'Unable to get status', 404);
   }
 
-  const monitoringNamespace = result.spec.monitoring?.namespace;
-
-  return {
-    ...result.status,
-    ...(monitoringNamespace != null && { monitoring: { namespace: monitoringNamespace } }),
-  };
+  return result.status;
 };

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,9 +10,7 @@ The ODH Dashboard uses [Perses](https://perses.dev/) dashboards for observabilit
 
 ### Resource Location
 
-Dashboard resources **must** be created in the product namespace (e.g., `opendatahub`).
-
-The UI fetches dashboards via the Perses API provided by the Perses service and automatically loads them.
+Dashboard resources can be created in any Perses project. The UI fetches all dashboards via the global Perses API (`/api/v1/dashboards`) and automatically loads them. Dashboards are filtered by name prefix and admin status regardless of which project they belong to.
 
 ### File Location
 

--- a/frontend/src/__mocks__/mockDsciStatus.ts
+++ b/frontend/src/__mocks__/mockDsciStatus.ts
@@ -12,11 +12,7 @@ export const mockDsciStatus = ({
   conditions = [],
   requiredCapabilities = [],
   phase = 'Ready',
-  monitoringNamespace = 'opendatahub',
 }: MockDsciStatus): DataScienceClusterInitializationKindStatus => ({
-  monitoring: {
-    namespace: monitoringNamespace,
-  },
   conditions: [
     ...[
       {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1543,10 +1543,6 @@ export type DataScienceClusterInitializationKindStatus = {
   };
   components?: Record<string, never>;
   phase?: string;
-  // Added by the backend to identify the monitoring namespace
-  monitoring?: {
-    namespace?: string;
-  };
 };
 
 export type ModelRegistryKind = K8sResourceCommon & {

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -1,6 +1,5 @@
 import type { DashboardResource } from '@perses-dev/core';
 import { mockDashboardConfig, mockStatus } from '@odh-dashboard/internal/__mocks__';
-import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
 import { observabilityDashboardPage } from '../../pages/observabilityDashboard';
 
 // Minimal test fixtures following the naming pattern from packages/observability/setup
@@ -26,44 +25,27 @@ const mockNonAdminDashboard = createMockPersesDashboard('dashboard-1-model', 'Mo
 type InitInterceptsOptions = {
   dashboards?: DashboardResource[];
   isAdmin?: boolean;
-  monitoringNamespace?: string;
 };
 
-const initIntercepts = ({
-  dashboards = [],
-  isAdmin = false,
-  monitoringNamespace,
-}: InitInterceptsOptions = {}) => {
-  // Mock dashboard config with observability feature enabled
+const initIntercepts = ({ dashboards = [], isAdmin = false }: InitInterceptsOptions = {}) => {
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ observabilityDashboard: true }));
 
   cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin }));
 
-  if (monitoringNamespace) {
-    cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({ monitoringNamespace }));
-  }
-
-  // Mock the Perses dashboards API endpoint
-  // The actual endpoint is: /perses/api/api/v1/projects/{namespace}/dashboards
-  cy.intercept('GET', '/perses/api/api/v1/projects/*/dashboards', {
+  // Mock the global Perses dashboards API endpoint
+  cy.intercept('GET', '/perses/api/api/v1/dashboards', {
     statusCode: 200,
     body: dashboards,
   }).as('getPersesDashboards');
 };
 
 describe('Observability Dashboard', () => {
-  it('should show empty state and use the monitoringNamespace from DSCI', () => {
-    const customNamespace = 'custom-monitoring-ns';
-
-    initIntercepts({ dashboards: [], isAdmin: true, monitoringNamespace: customNamespace });
+  it('should show empty state when no dashboards exist', () => {
+    initIntercepts({ dashboards: [], isAdmin: true });
 
     observabilityDashboardPage.visit();
 
-    cy.wait('@getPersesDashboards').then((interception) => {
-      expect(interception.request.url).to.include(
-        `/perses/api/api/v1/projects/${customNamespace}/dashboards`,
-      );
-    });
+    cy.wait('@getPersesDashboards');
 
     observabilityDashboardPage.shouldHaveEmptyState();
   });

--- a/packages/observability/src/api/usePersesDashboards.ts
+++ b/packages/observability/src/api/usePersesDashboards.ts
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { DashboardResource } from '@perses-dev/core';
 import { useAccessReview } from '@odh-dashboard/internal/api/useAccessReview';
-import useFetchDsciStatus from '@odh-dashboard/internal/concepts/areas/useFetchDsciStatus';
 import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import useFetch, { type FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
-import { fetchProjectDashboards } from '../perses/perses-client/perses-client';
 import {
   filterDashboards,
   filterDashboardsByThanosNonTenancyAccess,
   THANOS_QUERIER_NON_TENANCY_ACCESS,
 } from '../utils/dashboardUtils';
+import { fetchPersesDashboardsMetadata } from '../perses/perses-client';
 
 type UsePersesDashboardsResult = Omit<FetchStateObject<DashboardResource[]>, 'data'> & {
   dashboards: DashboardResource[];
@@ -19,16 +18,9 @@ type UsePersesDashboardsResult = Omit<FetchStateObject<DashboardResource[]>, 'da
  * Hook to fetch observability dashboards from Perses API
  */
 export const usePersesDashboards = (): UsePersesDashboardsResult => {
-  const [dsciStatus, dsciLoaded] = useFetchDsciStatus();
-  const monitoringNamespace = dsciStatus?.monitoring?.namespace;
   const { isAdmin } = useUser();
   const [canAccessThanosNonTenancy, thanosNonTenancyAccessLoaded] = useAccessReview(
     THANOS_QUERIER_NON_TENANCY_ACCESS,
-  );
-
-  const fetchDashboards = React.useCallback(
-    () => (monitoringNamespace ? fetchProjectDashboards(monitoringNamespace) : Promise.resolve([])),
-    [monitoringNamespace],
   );
 
   const {
@@ -36,7 +28,7 @@ export const usePersesDashboards = (): UsePersesDashboardsResult => {
     loaded,
     error,
     refresh,
-  } = useFetch(fetchDashboards, [], { initialPromisePurity: true });
+  } = useFetch(fetchPersesDashboardsMetadata, [], { initialPromisePurity: true });
 
   const dashboards = React.useMemo(() => {
     const afterAdminFilter = filterDashboards(allDashboards, isAdmin);
@@ -45,7 +37,7 @@ export const usePersesDashboards = (): UsePersesDashboardsResult => {
 
   return {
     dashboards,
-    loaded: loaded && dsciLoaded && thanosNonTenancyAccessLoaded,
+    loaded: loaded && thanosNonTenancyAccessLoaded,
     error,
     refresh,
   };

--- a/packages/observability/src/perses/perses-client/README.md
+++ b/packages/observability/src/perses/perses-client/README.md
@@ -38,7 +38,7 @@ configurations from a Perses server, you need this client code.
   - Build proxy URLs for datasource queries (`/perses/api/proxy/...`)
   - Fetch datasources and global datasources through the ODH backend proxy
 - **`odhPersesFetchJson` function** (`perses-client.ts`): Wrapper around Perses `fetchJson` for ODH-specific fetch handling
-- **`fetchProjectDashboards` function** (`perses-client.ts`): Helper to fetch all dashboards for a specific project
+- **`fetchPersesDashboardsMetadata` function** (`perses-client.ts`): Helper to fetch all dashboards
 
 ## Future
 

--- a/packages/observability/src/perses/perses-client/perses-client.ts
+++ b/packages/observability/src/perses/perses-client/perses-client.ts
@@ -55,14 +55,3 @@ export const fetchPersesDashboard = async (
 
   return odhPersesFetchJson<DashboardResource>(persesURL);
 };
-
-/**
- * Fetch all dashboards for a specific project
- * URL: /api/v1/projects/{project}/dashboards
- */
-export const fetchProjectDashboards = async (project: string): Promise<DashboardResource[]> => {
-  const listDashboardsURL = `/api/v1/projects/${encodeURIComponent(project)}/dashboards`;
-  const persesURL = `${PERSES_PROXY_BASE_PATH}${listDashboardsURL}`;
-
-  return odhPersesFetchJson<DashboardResource[]>(persesURL);
-};


### PR DESCRIPTION
## Description

Fetches all Perses dashboards across all projects in a single API call instead of requiring the monitoring namespace from DSCI status. This removes an unnecessary dependency on the DSCI `spec.monitoring.namespace` field and simplifies the data flow. Also adds a defensive null check for dashboards that don't define any variables.

## How Has This Been Tested?

- Verified dashboards load correctly from all Perses projects
- Confirmed non-admin filtering still works
- Tested with dashboards that have no variables defined

Pre-reqs:
- install COO operator
- install open telemetry operator
- enable monitoring stack in DSCI
- enable the `observabilityDashboard` feature flag

Navigate to `Observe & monitor => Dashboard`

## Test Impact

- Existing mocks updated to match simplified types
- No new tests needed — this is a simplification of existing behavior

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboards can be listed via the global Perses API (across projects).

* **Bug Fixes**
  * Safer handling of missing/undefined dashboard variables to prevent empty-state errors.

* **Refactor**
  * Dashboard loading no longer depends on a cluster monitoring namespace; UI fetch logic simplified and more reliable.
  * Removed legacy project-scoped dashboard helper in favor of global metadata fetching.

* **Documentation**
  * Updated observability docs and added a Perses observability status/tech-preview page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->