### PR TITLE
Handle legacy visibility annotation values in hardware profiles

### DIFF
--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -26,6 +26,7 @@ import TolerationTable from '#~/pages/hardwareProfiles/toleration/TolerationTabl
 import { useKebabAccessAllowed, verbModelAccess } from '#~/concepts/userSSAR';
 import {
   createHardwareProfileWarningTitle,
+  filterRecognizedVisibility,
   getHardwareProfileDescription,
   getHardwareProfileDisplayName,
   isDefaultHardwareProfile,
@@ -58,9 +59,10 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
   const useCases: HardwareProfileFeatureVisibility[] = React.useMemo(() => {
     if (hardwareProfile.metadata.annotations?.['opendatahub.io/dashboard-feature-visibility']) {
       try {
-        return JSON.parse(
+        const raw: string[] = JSON.parse(
           hardwareProfile.metadata.annotations['opendatahub.io/dashboard-feature-visibility'],
         );
+        return filterRecognizedVisibility(raw);
       } catch (error) {
         return [];
       }
@@ -75,15 +77,9 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
       return <i>All features</i>;
     }
 
-    const validUseCases = useCases.filter((v) => HardwareProfileFeatureVisibilityTitles[v]);
-
-    if (validUseCases.length === 0) {
-      return '-';
-    }
-
     return (
       <LabelGroup>
-        {validUseCases.map((v) => (
+        {useCases.map((v) => (
           <Label key={v} data-testid={`label-${v}`}>
             {HardwareProfileFeatureVisibilityTitles[v]}
           </Label>

--- a/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
+++ b/frontend/src/pages/hardwareProfiles/HardwareProfilesTableRow.tsx
@@ -74,7 +74,7 @@ const HardwareProfilesTableRow: React.FC<HardwareProfilesTableRowProps> = ({
 
   const renderFeatureVisibility = () => {
     if (useCases.length === 0) {
-      return <i>All features</i>;
+      return <i data-testid="feature-visibility-all">All features</i>;
     }
 
     return (

--- a/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfilesByUseCase.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/__tests__/useHardwareProfilesByUseCase.spec.ts
@@ -146,6 +146,47 @@ describe('useHardwareProfilesByUseCase', () => {
     expect(renderResult).hookToHaveUpdateCount(1);
   });
 
+  it('should treat profiles with only legacy visibility values as visible everywhere', () => {
+    const legacyProfile = mockHardwareProfile({
+      annotations: {
+        'opendatahub.io/dashboard-feature-visibility': JSON.stringify(['pipelines']),
+      },
+    });
+
+    mockContexts([legacyProfile]);
+
+    const renderResult = testHook(useHardwareProfilesByFeatureVisibility)([
+      HardwareProfileFeatureVisibility.WORKBENCH,
+    ]);
+    const { globalProfiles } = renderResult.result.current;
+    const [data] = globalProfiles;
+
+    expect(data).toEqual([legacyProfile]);
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should filter by recognized values and ignore unrecognized ones', () => {
+    const mixedProfile = mockHardwareProfile({
+      annotations: {
+        'opendatahub.io/dashboard-feature-visibility': JSON.stringify([
+          'pipelines',
+          HardwareProfileFeatureVisibility.MODEL_SERVING,
+        ]),
+      },
+    });
+
+    mockContexts([mixedProfile]);
+
+    const renderResult = testHook(useHardwareProfilesByFeatureVisibility)([
+      HardwareProfileFeatureVisibility.WORKBENCH,
+    ]);
+    const { globalProfiles } = renderResult.result.current;
+    const [data] = globalProfiles;
+
+    expect(data).toEqual([]);
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
   it('should handle loading and error states', () => {
     const error = new Error('Test error');
     mockContexts([], false, error);

--- a/frontend/src/pages/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/pages/hardwareProfiles/__tests__/utils.spec.ts
@@ -2,12 +2,14 @@ import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
 import { Identifier, IdentifierResourceType } from '#~/types';
 import {
   determineIdentifierUnit,
+  filterRecognizedVisibility,
   getClusterQueueNameFromLocalQueues,
   isHardwareProfileIdentifierValid,
   validateProfileWarning,
 } from '#~/pages/hardwareProfiles/utils';
 import { mockLocalQueueK8sResource } from '#~/__mocks__/mockLocalQueueK8sResource';
 import { HardwareProfileWarningType } from '#~/concepts/hardwareProfiles/types';
+import { HardwareProfileFeatureVisibility } from '#~/k8sTypes';
 import { CPU_UNITS, MEMORY_UNITS_FOR_SELECTION, OTHER } from '#~/utilities/valueUnits';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -499,5 +501,37 @@ describe('getClusterQueueNameFromLocalQueues', () => {
     // Remove clusterQueue to simulate missing field
     delete (localQueues.data[0].spec as { clusterQueue?: string }).clusterQueue;
     expect(getClusterQueueNameFromLocalQueues('no-cluster-queue', localQueues)).toBeUndefined();
+  });
+});
+
+describe('filterRecognizedVisibility', () => {
+  it('should return recognized enum values unchanged', () => {
+    expect(
+      filterRecognizedVisibility([
+        HardwareProfileFeatureVisibility.WORKBENCH,
+        HardwareProfileFeatureVisibility.MODEL_SERVING,
+      ]),
+    ).toEqual([
+      HardwareProfileFeatureVisibility.WORKBENCH,
+      HardwareProfileFeatureVisibility.MODEL_SERVING,
+    ]);
+  });
+
+  it('should return an empty array when all values are unrecognized', () => {
+    expect(filterRecognizedVisibility(['pipelines', 'foo', 'bar'])).toEqual([]);
+  });
+
+  it('should keep recognized values and discard unrecognized ones from a mixed list', () => {
+    expect(
+      filterRecognizedVisibility([
+        'pipelines',
+        HardwareProfileFeatureVisibility.MODEL_SERVING,
+        'unknown-value',
+      ]),
+    ).toEqual([HardwareProfileFeatureVisibility.MODEL_SERVING]);
+  });
+
+  it('should return an empty array when given an empty array', () => {
+    expect(filterRecognizedVisibility([])).toEqual([]);
   });
 });

--- a/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/ManageHardwareProfile.tsx
@@ -16,6 +16,7 @@ import {
   HARDWARE_PROFILE_DESCRIPTION_CHAR_LIMIT,
 } from '#~/pages/hardwareProfiles/manage/const';
 import {
+  filterRecognizedVisibility,
   getHardwareProfileDescription,
   getHardwareProfileDisplayName,
   isHardwareProfileEnabled,
@@ -71,10 +72,10 @@ const ManageHardwareProfile: React.FC<ManageHardwareProfileProps> = ({
           if (
             hardwareProfile.metadata.annotations?.['opendatahub.io/dashboard-feature-visibility']
           ) {
-            const visibleIn = JSON.parse(
+            const visibleIn: string[] = JSON.parse(
               hardwareProfile.metadata.annotations['opendatahub.io/dashboard-feature-visibility'],
             );
-            setVisibility(visibleIn);
+            setVisibility(filterRecognizedVisibility(visibleIn));
           } else {
             setVisibility([]);
           }

--- a/frontend/src/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility.ts
+++ b/frontend/src/pages/hardwareProfiles/useHardwareProfilesByFeatureVisibility.ts
@@ -1,6 +1,9 @@
 import React from 'react';
 import { HardwareProfileKind, HardwareProfileFeatureVisibility } from '#~/k8sTypes';
-import { isHardwareProfileValid } from '#~/pages/hardwareProfiles/utils';
+import {
+  filterRecognizedVisibility,
+  isHardwareProfileValid,
+} from '#~/pages/hardwareProfiles/utils';
 import { HardwareProfilesContext } from '#~/concepts/hardwareProfiles/HardwareProfilesContext';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { useWatchHardwareProfiles } from '#~/utilities/useWatchHardwareProfiles';
@@ -104,15 +107,17 @@ export const filterHardwareProfileByFeatureVisibility = (
         return true;
       }
 
-      const visibleIn = JSON.parse(
+      const visibleIn: string[] = JSON.parse(
         profile.metadata.annotations['opendatahub.io/dashboard-feature-visibility'],
       );
 
-      if (visibleIn.length === 0) {
+      const recognized = filterRecognizedVisibility(visibleIn);
+
+      if (recognized.length === 0) {
         return true;
       }
 
-      return visibility ? visibility.some((a) => visibleIn.includes(a)) : true;
+      return visibility ? visibility.some((a) => recognized.includes(a)) : true;
     } catch (error) {
       return true;
     }

--- a/frontend/src/pages/hardwareProfiles/utils.ts
+++ b/frontend/src/pages/hardwareProfiles/utils.ts
@@ -1,4 +1,4 @@
-import { HardwareProfileKind, LocalQueueKind } from '#~/k8sTypes';
+import { HardwareProfileFeatureVisibility, HardwareProfileKind, LocalQueueKind } from '#~/k8sTypes';
 import { DisplayNameAnnotation, Identifier, IdentifierResourceType } from '#~/types';
 import {
   HardwareProfileWarningType,
@@ -258,4 +258,11 @@ export const getClusterQueueNameFromLocalQueues = (
   }
   const queue = localQueues.data.find((q) => q.metadata?.name === localQueueName);
   return queue?.spec.clusterQueue;
+};
+
+export const filterRecognizedVisibility = (
+  visibleIn: string[],
+): HardwareProfileFeatureVisibility[] => {
+  const recognized: string[] = Object.values(HardwareProfileFeatureVisibility);
+  return visibleIn.filter((v): v is HardwareProfileFeatureVisibility => recognized.includes(v));
 };

--- a/packages/cypress/cypress/pages/hardwareProfile.ts
+++ b/packages/cypress/cypress/pages/hardwareProfile.ts
@@ -52,6 +52,14 @@ class HardwareProfileRow extends TableRow {
     return this.find().pfSwitch('enable-switch');
   }
 
+  findAllFeaturesText() {
+    return this.find().findByTestId('feature-visibility-all');
+  }
+
+  findFeatureLabel(name: string) {
+    return this.find().findByTestId(`label-${name}`);
+  }
+
   findExpandableSection() {
     return this.find().parent().find('[data-label="Other information"]');
   }

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
@@ -794,5 +794,6 @@ describe('hardware profiles - legacy feature visibility annotations', () => {
 
     const mixedRow = hardwareProfile.getRow('Mixed Profile');
     mixedRow.findFeatureLabel('model-serving').should('exist');
+    mixedRow.findAllFeaturesText().should('not.exist');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/hardwareProfiles.cy.ts
@@ -751,3 +751,48 @@ describe('hardware profiles - ordering', () => {
     hardwareProfile.findRows().eq(3).should('contain', 'Alpha One Profile');
   });
 });
+
+describe('hardware profiles - legacy feature visibility annotations', () => {
+  beforeEach(() => {
+    asProductAdminUser();
+  });
+
+  it('should show "All features" for a profile whose only visibility values are legacy', () => {
+    cy.interceptOdh(
+      'GET /api/config',
+      mockDashboardConfig({
+        modelServerSizes: [],
+        notebookSizes: [],
+      }),
+    );
+    cy.interceptK8sList(
+      { model: HardwareProfileModel, ns: 'opendatahub' },
+      mockK8sResourceList([
+        mockHardwareProfile({
+          name: 'legacy-profile',
+          displayName: 'Legacy Profile',
+          annotations: {
+            'opendatahub.io/dashboard-feature-visibility': JSON.stringify(['pipelines']),
+          },
+        }),
+        mockHardwareProfile({
+          name: 'mixed-profile',
+          displayName: 'Mixed Profile',
+          annotations: {
+            'opendatahub.io/dashboard-feature-visibility': JSON.stringify([
+              'pipelines',
+              'model-serving',
+            ]),
+          },
+        }),
+      ]),
+    );
+    hardwareProfile.visit();
+
+    const legacyRow = hardwareProfile.getRow('Legacy Profile');
+    legacyRow.findAllFeaturesText().should('have.text', 'All features');
+
+    const mixedRow = hardwareProfile.getRow('Mixed Profile');
+    mixedRow.findFeatureLabel('model-serving').should('exist');
+  });
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-37048

## Description

Hardware profiles created in RHOAI 2.x with DSP (pipelines) visibility have the annotation `opendatahub.io/dashboard-feature-visibility: '["pipelines"]'`. After the `PIPELINES` enum value was removed from `HardwareProfileFeatureVisibility` ([RHOAIENG-34215](https://redhat.atlassian.net/browse/RHOAIENG-34215)), these profiles have no visibility in the 3.x UI:

- The visibility column shows `-` instead of a meaningful label
<img width="885" height="136" alt="image" src="https://github.com/user-attachments/assets/989ac70a-3469-4f72-927f-f8b7bce9634c" />

- The edit modal shows "Limited visibility" with an empty dropdown
<img width="990" height="207" alt="image" src="https://github.com/user-attachments/assets/dca71bc5-d2c2-4898-9dbe-5a994931b9cf" />

- The profile cannot be selected for workbenches or model deployment

Root cause: Multiple components parsed the `opendatahub.io/dashboard-feature-visibility` annotation and used the raw values without validating them against the current enum. When `"pipelines"` is no longer a recognized value, the UI treats these profiles as having empty/no visibility.


Fix: Added inline filtering of annotation values against the current `HardwareProfileFeatureVisibility` enum in all locations that read the annotation:
- `useHardwareProfilesByFeatureVisibility`: filters parsed values to only recognized enum members before checking workbench/model-serving eligibility; treats profiles with no recognized values as "visible everywhere"
- `ManageHardwareProfile`: filters parsed values when prefilling the edit modal, so legacy values like `"pipelines"` are silently dropped
- `HardwareProfilesTableRow`: displays _All features_ (italicized) instead of `-` when no recognized visibility values remain

This ensures that profiles with only legacy annotation values (e.g. `["pipelines"]`) become "visible everywhere" rather than unusable after an upgrade from 2.x to 3.0.


## How Has This Been Tested?

Manual testing:
1. Create a hardware profile with the annotation `opendatahub.io/dashboard-feature-visibility: '["pipelines"]'` (simulating a 2.x profile)
2. Navigate to Settings > Hardware profiles: verify the visibility column shows "All features" instead of "-"
3. Click Edit on that profile: verify the visibility section shows "All features" (not "Limited visibility" with an empty dropdown)
4. Navigate to create a workbench: verify the profile appears in the hardware profile selector
5. Navigate to deploy a model: verify the profile appears in the hardware profile selector
6. Create a profile with `'["pipelines", "model-serving"]'`:  verify it shows "Model serving" in the table and is only available for model serving

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show "All features" (italicized) instead of a placeholder when feature visibility is empty.
  * Only recognize and validate supported feature-visibility values when determining profile visibility.
  * Ensure consistent filtering behavior for empty, legacy, and mixed visibility annotations.

* **Tests**
  * Added tests for legacy and mixed visibility annotation scenarios to verify correct filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->