### PR TITLE
Fix legacy HWP tolerations not injected into ISVCs

### DIFF
--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -602,6 +602,8 @@ describe('assembleInferenceService', () => {
         },
       ],
     });
+    // mockHardwareProfile uses a destructuring default for uid, so passing
+    // undefined doesn't clear it. We must delete it explicitly.
     delete (legacyHardwareProfile.metadata as Record<string, unknown>).uid;
 
     const podSpecOptions = mockModelServingPodSpecOptions({

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -590,6 +590,45 @@ describe('assembleInferenceService', () => {
     expect(resultKServe.spec.predictor.nodeSelector).toBeUndefined();
   });
 
+  it('should inject tolerations for legacy hardware profiles', () => {
+    const legacyHardwareProfile = mockHardwareProfile({
+      name: 'legacy-hwp',
+      uid: undefined,
+      tolerations: [
+        {
+          key: 'nvidia.com/gpu',
+          operator: TolerationOperator.EXISTS,
+          effect: TolerationEffect.NO_SCHEDULE,
+        },
+      ],
+    });
+    delete (legacyHardwareProfile.metadata as Record<string, unknown>).uid;
+
+    const podSpecOptions = mockModelServingPodSpecOptions({
+      selectedHardwareProfile: legacyHardwareProfile,
+      tolerations: legacyHardwareProfile.spec.scheduling?.node?.tolerations,
+      nodeSelector: undefined,
+      resources: {
+        requests: { cpu: '1', memory: '2Gi' },
+        limits: { cpu: '2', memory: '4Gi' },
+      },
+    });
+
+    const result = assembleInferenceService(
+      mockInferenceServiceModalData({}),
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      podSpecOptions,
+    );
+
+    expect(result.spec.predictor.tolerations).toEqual(
+      legacyHardwareProfile.spec.scheduling?.node?.tolerations,
+    );
+  });
+
   it('should set pod specs for accelerator profiles', () => {
     const gpuTolerations = [
       {

--- a/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
+++ b/frontend/src/api/k8s/__tests__/inferenceServices.spec.ts
@@ -607,7 +607,7 @@ describe('assembleInferenceService', () => {
     const podSpecOptions = mockModelServingPodSpecOptions({
       selectedHardwareProfile: legacyHardwareProfile,
       tolerations: legacyHardwareProfile.spec.scheduling?.node?.tolerations,
-      nodeSelector: undefined,
+      nodeSelector: { 'nvidia.com/gpu.present': 'true' },
       resources: {
         requests: { cpu: '1', memory: '2Gi' },
         limits: { cpu: '2', memory: '4Gi' },
@@ -626,6 +626,10 @@ describe('assembleInferenceService', () => {
 
     expect(result.spec.predictor.tolerations).toEqual(
       legacyHardwareProfile.spec.scheduling?.node?.tolerations,
+    );
+    expect(result.spec.predictor.nodeSelector).toEqual({ 'nvidia.com/gpu.present': 'true' });
+    expect(result.metadata.annotations?.['opendatahub.io/legacy-hardware-profile-name']).toBe(
+      'legacy-hwp',
     );
   });
 

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -230,7 +230,10 @@ export const assembleInferenceService = (
 
   if (!isModelMesh && podSpecOptions) {
     const { tolerations, resources, nodeSelector } = podSpecOptions;
-    if (!podSpecOptions.selectedHardwareProfile) {
+    const isLegacyHardwareProfile =
+      podSpecOptions.selectedHardwareProfile &&
+      !podSpecOptions.selectedHardwareProfile.metadata.uid;
+    if (!podSpecOptions.selectedHardwareProfile || isLegacyHardwareProfile) {
       if (tolerations) {
         updatedInferenceService.spec.predictor.tolerations = tolerations;
       }

--- a/frontend/src/api/k8s/inferenceServices.ts
+++ b/frontend/src/api/k8s/inferenceServices.ts
@@ -15,6 +15,7 @@ import { applyK8sAPIOptions } from '#~/api/apiMergeUtils';
 import { getInferenceServiceDeploymentMode } from '#~/pages/modelServing/screens/projects/utils';
 import { parseCommandLine } from '#~/api/k8s/utils';
 import { ModelServingPodSpecOptions } from '#~/concepts/hardwareProfiles/useModelServingPodSpecOptionsState';
+import { isLegacyHardwareProfileSelected } from '#~/concepts/hardwareProfiles/utils';
 import { getModelServingProjects } from './projects';
 
 const applyAuthToInferenceService = (
@@ -148,10 +149,7 @@ export const assembleInferenceService = (
 
   const dashboardNamespace = data.dashboardNamespace ?? '';
   if (!isModelMesh && podSpecOptions && podSpecOptions.selectedHardwareProfile) {
-    const isLegacyHardwareProfile =
-      !!podSpecOptions.selectedAcceleratorProfile ||
-      !podSpecOptions.selectedHardwareProfile.metadata.uid;
-    if (!isLegacyHardwareProfile) {
+    if (!isLegacyHardwareProfileSelected(podSpecOptions)) {
       annotations['opendatahub.io/hardware-profile-name'] =
         podSpecOptions.selectedHardwareProfile.metadata.name;
     } else {
@@ -230,10 +228,10 @@ export const assembleInferenceService = (
 
   if (!isModelMesh && podSpecOptions) {
     const { tolerations, resources, nodeSelector } = podSpecOptions;
-    const isLegacyHardwareProfile =
-      podSpecOptions.selectedHardwareProfile &&
-      !podSpecOptions.selectedHardwareProfile.metadata.uid;
-    if (!podSpecOptions.selectedHardwareProfile || isLegacyHardwareProfile) {
+    if (
+      !podSpecOptions.selectedHardwareProfile ||
+      isLegacyHardwareProfileSelected(podSpecOptions)
+    ) {
       if (tolerations) {
         updatedInferenceService.spec.predictor.tolerations = tolerations;
       }

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -10,6 +10,7 @@ import {
 } from '#~/types';
 import { useIsAreaAvailable, SupportedArea } from '#~/concepts/areas';
 import { splitValueUnit, CPU_UNITS, MEMORY_UNITS_FOR_PARSING } from '#~/utilities/valueUnits';
+import { PodSpecOptions } from './types';
 
 export const formatToleration = (toleration: Toleration): string => {
   const parts = [`Key = ${toleration.key}`];
@@ -174,3 +175,8 @@ export const getProfileScore = (profile: HardwareProfileKind): number => {
 
   return score;
 };
+
+export const isLegacyHardwareProfileSelected = (podSpecOptions: PodSpecOptions): boolean =>
+  !!podSpecOptions.selectedHardwareProfile &&
+  (!!podSpecOptions.selectedAcceleratorProfile ||
+    !podSpecOptions.selectedHardwareProfile.metadata.uid);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-50153

## Description

The dashboard controller isn't injecting tolerations from legacy Hardware Profiles (HWPs) into ISVCs in RHOAI 2.25. When creating an ISVC using a legacy HWP, the tolerations are not applied to the ISVC predictor spec.

Root cause: In `assembleInferenceService()`, the condition `if (!podSpecOptions.selectedHardwareProfile)` skips injecting tolerations whenever any hardware profile is selected. This is correct for native HWPs (where the backend controller handles injection via the `opendatahub.io/hardware-profile-name` annotation), but wrong for legacy HWPs; there is no backend controller that injects tolerations for legacy profiles.

Fix: Added a legacy HWP detection check based on the absence of `metadata.uid`. Legacy HWPs are always in-memory objects (created by `useMigratedHardwareProfiles`), never persisted to the K8s API server, so they never have a `uid`. When a legacy HWP is detected, tolerations are injected directly into the ISVC predictor spec.

## How Has This Been Tested?

Manual testing:
1. Ensure an AcceleratorProfile exists on the cluster (this will appear as a legacy HWP in the dashboard)
2. Go to Model Serving and deploy a model using KServe single-model serving
3. Select the legacy hardware profile
4. Deploy the model
5. Verify the resulting ISVC has the expected tolerations in `spec.predictor.tolerations` by running:
   ```
   oc get inferenceservice <name> -n <namespace> -o jsonpath='{.spec.predictor.tolerations}'
   ```


## Test Impact

- 1 new unit test added covering the legacy HWP toleration injection scenario

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`