### PR TITLE
fix(model-serving): preserve OCI storageUri and imagePullSecrets on edit (RHOAIENG-53682)

### DIFF
--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -327,18 +327,27 @@ export const applyConnectionData = (
       delete result.metadata.annotations['opendatahub.io/connection-path'];
     }
   }
-  if (
-    modelLocationData.additionalFields.modelUri &&
-    isModelServingCompatible(
-      modelLocationData.connectionTypeObject ?? [],
-      ModelServingCompatibleTypes.OCI,
-    )
-  ) {
+  const isOci = isModelServingCompatible(
+    modelLocationData.connectionTypeObject ?? [],
+    ModelServingCompatibleTypes.OCI,
+  );
+
+  if (modelLocationData.additionalFields.modelUri && isOci) {
     result.spec.predictor.model = {
       ...result.spec.predictor.model,
       storageUri: modelLocationData.additionalFields.modelUri,
     };
   }
+
+  // Update imagePullSecrets to reference the connection secret for OCI connections,
+  // or clear stale imagePullSecrets when switching away from OCI
+  const connectionSecretName = secretName ?? createConnectionData.nameDesc?.name;
+  if (isOci && connectionSecretName) {
+    result.spec.predictor.imagePullSecrets = [{ name: connectionSecretName }];
+  } else {
+    delete result.spec.predictor.imagePullSecrets;
+  }
+
   return result;
 };
 

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -327,10 +327,16 @@ export const applyConnectionData = (
       delete result.metadata.annotations['opendatahub.io/connection-path'];
     }
   }
-  const isOci = isModelServingCompatible(
-    modelLocationData.connectionTypeObject ?? [],
-    ModelServingCompatibleTypes.OCI,
-  );
+  // Determine OCI status from connectionTypeObject when available, falling back to
+  // the modelUri prefix when connectionTypeObject hasn't been resolved yet (e.g.
+  // during edit before connection types finish loading).
+  const isOci =
+    isModelServingCompatible(
+      modelLocationData.connectionTypeObject ?? [],
+      ModelServingCompatibleTypes.OCI,
+    ) ||
+    (!modelLocationData.connectionTypeObject &&
+      !!modelLocationData.additionalFields.modelUri?.startsWith('oci://'));
 
   if (modelLocationData.additionalFields.modelUri && isOci) {
     result.spec.predictor.model = {
@@ -344,7 +350,7 @@ export const applyConnectionData = (
   const connectionSecretName = secretName ?? createConnectionData.nameDesc?.name;
   if (isOci && connectionSecretName) {
     result.spec.predictor.imagePullSecrets = [{ name: connectionSecretName }];
-  } else {
+  } else if (!isOci) {
     delete result.spec.predictor.imagePullSecrets;
   }
 

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -327,16 +327,10 @@ export const applyConnectionData = (
       delete result.metadata.annotations['opendatahub.io/connection-path'];
     }
   }
-  // Determine OCI status from connectionTypeObject when available, falling back to
-  // the modelUri prefix when connectionTypeObject hasn't been resolved yet (e.g.
-  // during edit before connection types finish loading).
-  const isOci =
-    isModelServingCompatible(
-      modelLocationData.connectionTypeObject ?? [],
-      ModelServingCompatibleTypes.OCI,
-    ) ||
-    (!modelLocationData.connectionTypeObject &&
-      !!modelLocationData.additionalFields.modelUri?.startsWith('oci://'));
+  const isOci = isModelServingCompatible(
+    modelLocationData.connectionTypeObject ?? [],
+    ModelServingCompatibleTypes.OCI,
+  );
 
   if (modelLocationData.additionalFields.modelUri && isOci) {
     result.spec.predictor.model = {

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -327,27 +327,18 @@ export const applyConnectionData = (
       delete result.metadata.annotations['opendatahub.io/connection-path'];
     }
   }
-  const isOci = isModelServingCompatible(
-    modelLocationData.connectionTypeObject ?? [],
-    ModelServingCompatibleTypes.OCI,
-  );
-
-  if (modelLocationData.additionalFields.modelUri && isOci) {
+  if (
+    modelLocationData.additionalFields.modelUri &&
+    isModelServingCompatible(
+      modelLocationData.connectionTypeObject ?? [],
+      ModelServingCompatibleTypes.OCI,
+    )
+  ) {
     result.spec.predictor.model = {
       ...result.spec.predictor.model,
       storageUri: modelLocationData.additionalFields.modelUri,
     };
   }
-
-  // Update imagePullSecrets to reference the connection secret for OCI connections,
-  // or clear stale imagePullSecrets when switching away from OCI
-  const connectionSecretName = secretName ?? createConnectionData.nameDesc?.name;
-  if (isOci && connectionSecretName) {
-    result.spec.predictor.imagePullSecrets = [{ name: connectionSecretName }];
-  } else {
-    delete result.spec.predictor.imagePullSecrets;
-  }
-
   return result;
 };
 

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -344,7 +344,7 @@ export const applyConnectionData = (
   const connectionSecretName = secretName ?? createConnectionData.nameDesc?.name;
   if (isOci && connectionSecretName) {
     result.spec.predictor.imagePullSecrets = [{ name: connectionSecretName }];
-  } else if (!isOci) {
+  } else {
     delete result.spec.predictor.imagePullSecrets;
   }
 

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -1,5 +1,10 @@
 import { MetadataAnnotation, type SecretKind } from '@odh-dashboard/internal/k8sTypes';
-import { getGeneratedSecretName } from '@odh-dashboard/internal/api/index';
+import {
+  getGeneratedSecretName,
+  isGeneratedSecretName,
+  deleteSecret,
+  getSecret,
+} from '@odh-dashboard/internal/api/index';
 import {
   getDisplayNameFromK8sResource,
   getResourceNameFromK8sResource,
@@ -186,6 +191,25 @@ export const deployModel = async (
       false,
     );
   }
+
+  // Clean up the old generated secret now that the IS references the new one.
+  // This must happen AFTER the IS update — deleting the old secret before the
+  // update triggers a KServe mutating webhook bug that strips storageUri when
+  // the currently-referenced imagePullSecrets secret is missing.
+  const oldConnectionSecretName = wizardState.modelLocationData.selectedConnection?.metadata.name;
+  if (
+    oldConnectionSecretName &&
+    createdSecretName !== oldConnectionSecretName &&
+    isGeneratedSecretName(oldConnectionSecretName)
+  ) {
+    try {
+      await getSecret(projectName, oldConnectionSecretName);
+      await deleteSecret(projectName, oldConnectionSecretName);
+    } catch {
+      // Old secret already gone or inaccessible — nothing to clean up
+    }
+  }
+
   if (runPostDeploy) {
     await runPostDeploy(deploymentResult.model, existingDeployment);
   }

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -1,10 +1,5 @@
 import { MetadataAnnotation, type SecretKind } from '@odh-dashboard/internal/k8sTypes';
-import {
-  getGeneratedSecretName,
-  isGeneratedSecretName,
-  deleteSecret,
-  getSecret,
-} from '@odh-dashboard/internal/api/index';
+import { getGeneratedSecretName } from '@odh-dashboard/internal/api/index';
 import {
   getDisplayNameFromK8sResource,
   getResourceNameFromK8sResource,
@@ -148,7 +143,7 @@ export const deployModel = async (
   }
 
   // Create secret
-  const newSecret = await handleConnectionCreation(
+  const { secret: newSecret, cleanup: cleanupOldSecret } = await handleConnectionCreation(
     wizardState.createConnectionData.data,
     projectName,
     wizardState.modelLocationData.data,
@@ -193,22 +188,7 @@ export const deployModel = async (
   }
 
   // Clean up the old generated secret now that the IS references the new one.
-  // This must happen AFTER the IS update — deleting the old secret before the
-  // update triggers a KServe mutating webhook bug that strips storageUri when
-  // the currently-referenced imagePullSecrets secret is missing.
-  const oldConnectionSecretName = wizardState.modelLocationData.selectedConnection?.metadata.name;
-  if (
-    oldConnectionSecretName &&
-    createdSecretName !== oldConnectionSecretName &&
-    isGeneratedSecretName(oldConnectionSecretName)
-  ) {
-    try {
-      await getSecret(projectName, oldConnectionSecretName);
-      await deleteSecret(projectName, oldConnectionSecretName);
-    } catch {
-      // Old secret already gone or inaccessible — nothing to clean up
-    }
-  }
+  await cleanupOldSecret?.();
 
   if (runPostDeploy) {
     await runPostDeploy(deploymentResult.model, existingDeployment);

--- a/packages/model-serving/src/concepts/__tests__/connectionUtils.spec.ts
+++ b/packages/model-serving/src/concepts/__tests__/connectionUtils.spec.ts
@@ -50,12 +50,19 @@ describe('handleConnectionCreation', () => {
     jest.clearAllMocks();
     isGeneratedSecretNameMock.mockImplementation((name: string) => name.startsWith('secret-'));
     getGeneratedSecretNameMock.mockReturnValue('secret-new123');
-    assembleConnectionSecretMock.mockReturnValue(mockSecret('placeholder'));
+    assembleConnectionSecretMock.mockReturnValue(mockConnection('placeholder'));
     createSecretMock.mockImplementation(async (secret) =>
       mockSecret((secret as SecretKind).metadata.name),
     );
     getSecretMock.mockImplementation(async (_ns, name) => mockSecret(name));
-    deleteSecretMock.mockResolvedValue({ apiVersion: 'v1', kind: 'Status', status: 'Success' });
+    deleteSecretMock.mockResolvedValue({
+      apiVersion: 'v1',
+      kind: 'Status',
+      status: 'Success',
+      code: 200,
+      message: '',
+      reason: '',
+    });
   });
 
   it('should return a cleanup function when the old secret name differs from the new one', async () => {

--- a/packages/model-serving/src/concepts/__tests__/connectionUtils.spec.ts
+++ b/packages/model-serving/src/concepts/__tests__/connectionUtils.spec.ts
@@ -1,0 +1,180 @@
+import {
+  createSecret,
+  getSecret,
+  deleteSecret,
+  isGeneratedSecretName,
+  getGeneratedSecretName,
+} from '@odh-dashboard/internal/api/index';
+import { assembleConnectionSecret } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
+import { SecretKind } from '@odh-dashboard/internal/k8sTypes';
+import { Connection } from '@odh-dashboard/internal/concepts/connectionTypes/types';
+import { ModelLocationType } from '../../components/deploymentWizard/types';
+import { handleConnectionCreation } from '../connectionUtils';
+
+jest.mock('@odh-dashboard/internal/api/index');
+jest.mock('@odh-dashboard/internal/concepts/connectionTypes/utils', () => ({
+  ...jest.requireActual('@odh-dashboard/internal/concepts/connectionTypes/utils'),
+  assembleConnectionSecret: jest.fn(),
+  getConnectionProtocolType: jest.fn().mockReturnValue('oci'),
+}));
+
+const createSecretMock = jest.mocked(createSecret);
+const getSecretMock = jest.mocked(getSecret);
+const deleteSecretMock = jest.mocked(deleteSecret);
+const isGeneratedSecretNameMock = jest.mocked(isGeneratedSecretName);
+const getGeneratedSecretNameMock = jest.mocked(getGeneratedSecretName);
+const assembleConnectionSecretMock = jest.mocked(assembleConnectionSecret);
+
+const mockSecret = (name: string): SecretKind => ({
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: { name, namespace: 'test-ns' },
+  data: {},
+});
+
+const mockConnection = (name: string): Connection =>
+  ({
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: {
+      name,
+      namespace: 'test-ns',
+      labels: { 'opendatahub.io/dashboard': 'true' },
+      annotations: { 'opendatahub.io/connection-type-ref': 'oci-v1' },
+    },
+    data: {},
+  } as unknown as Connection);
+
+describe('handleConnectionCreation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isGeneratedSecretNameMock.mockImplementation((name: string) => name.startsWith('secret-'));
+    getGeneratedSecretNameMock.mockReturnValue('secret-new123');
+    assembleConnectionSecretMock.mockReturnValue(mockSecret('placeholder'));
+    createSecretMock.mockImplementation(async (secret) =>
+      mockSecret((secret as SecretKind).metadata.name),
+    );
+    getSecretMock.mockImplementation(async (_ns, name) => mockSecret(name));
+    deleteSecretMock.mockResolvedValue({ apiVersion: 'v1', kind: 'Status', status: 'Success' });
+  });
+
+  it('should return a cleanup function when the old secret name differs from the new one', async () => {
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      'secret-old456',
+      false,
+      mockConnection('secret-old456'),
+    );
+
+    expect(result.secret).toBeDefined();
+    expect(result.cleanup).toBeDefined();
+
+    // Secret should be created but old secret should NOT be deleted yet
+    expect(createSecretMock).toHaveBeenCalled();
+    expect(deleteSecretMock).not.toHaveBeenCalled();
+  });
+
+  it('should delete the old generated secret when cleanup is called', async () => {
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      'secret-old456',
+      false,
+      mockConnection('secret-old456'),
+    );
+
+    await result.cleanup?.();
+
+    expect(getSecretMock).toHaveBeenCalledWith('test-ns', 'secret-old456');
+    expect(deleteSecretMock).toHaveBeenCalledWith('test-ns', 'secret-old456');
+  });
+
+  it('should not delete a non-generated secret when cleanup is called', async () => {
+    isGeneratedSecretNameMock.mockImplementation((name: string) => name.startsWith('secret-'));
+
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      'my-saved-connection',
+      false,
+      mockConnection('my-saved-connection'),
+    );
+
+    // The old secret name is not generated, so no cleanup needed
+    // (actualSecretName will be 'my-saved-connection' since it's not generated)
+    expect(result.cleanup).toBeUndefined();
+  });
+
+  it('should not return a cleanup function when there is no old connection', async () => {
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      undefined,
+      false,
+      undefined,
+    );
+
+    expect(result.secret).toBeDefined();
+    expect(result.cleanup).toBeUndefined();
+  });
+
+  it('should not return a cleanup function for dry run when names match', async () => {
+    // When the old and new names are the same, no cleanup is needed
+    getGeneratedSecretNameMock.mockReturnValue('secret-old456');
+
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      'secret-old456',
+      true,
+      mockConnection('secret-old456'),
+    );
+
+    expect(result.cleanup).toBeUndefined();
+  });
+
+  it('should return cleanup function for dry run when names differ', async () => {
+    const result = await handleConnectionCreation(
+      {},
+      'test-ns',
+      {
+        type: ModelLocationType.NEW,
+        fieldValues: {},
+        additionalFields: {},
+      },
+      'secret-old456',
+      true,
+      mockConnection('secret-old456'),
+    );
+
+    expect(result.cleanup).toBeDefined();
+    // Cleanup should not have been called automatically
+    expect(deleteSecretMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -121,6 +121,7 @@ export const handleConnectionCreation = async (
   // has been updated to reference the new secret. Deleting the old secret before
   // the IS update triggers a KServe mutating webhook bug that strips storageUri
   // when the currently-referenced imagePullSecrets secret is missing.
+  // See https://redhat.atlassian.net/browse/RHOAIENG-61105
   const oldSecretName = selectedConnection?.metadata.name;
   const cleanup =
     oldSecretName && oldSecretName !== actualSecretName

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -1,6 +1,7 @@
 import {
   createSecret,
   getSecret,
+  deleteSecret,
   patchSecretWithOwnerReference,
   patchSecretWithProtocolAnnotation,
   hasProtocolAnnotation,
@@ -19,17 +20,22 @@ import { K8sNameDescriptionType } from '@odh-dashboard/internal/concepts/k8s/K8s
 import { CreateConnectionData } from '../components/deploymentWizard/fields/CreateConnectionInputFields';
 import { ModelLocationData, ModelLocationType } from '../components/deploymentWizard/types';
 
+export type ConnectionCreationResult = {
+  secret: SecretKind | undefined;
+  cleanup?: () => Promise<void>;
+};
+
 export const handleConnectionCreation = async (
   createConnectionData: CreateConnectionData,
   project: string,
   modelLocationData?: ModelLocationData,
   secretName?: string,
   dryRun?: boolean,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   selectedConnection?: Connection,
-): Promise<SecretKind | undefined> => {
+): Promise<ConnectionCreationResult> => {
+  const noResult: ConnectionCreationResult = { secret: undefined };
   if (!modelLocationData) {
-    return Promise.resolve(undefined);
+    return noResult;
   }
   const protocolType =
     (modelLocationData.connectionTypeObject
@@ -51,7 +57,7 @@ export const handleConnectionCreation = async (
           console.warn('Failed to get secret for protocol annotation:', err);
         });
     }
-    return Promise.resolve(undefined);
+    return noResult;
   }
 
   const connectionTypeName = modelLocationData.connectionTypeObject?.metadata.name ?? 'uri-v1';
@@ -110,19 +116,33 @@ export const handleConnectionCreation = async (
     delete annotatedConnection.metadata.annotations['openshift.io/description'];
   }
 
-  if (dryRun) {
-    const dryRunCreatedSecret = await createSecret(annotatedConnection, { dryRun: true });
+  // Build a cleanup function that deletes the old generated secret if it was
+  // replaced by a new one. The caller must run this AFTER the InferenceService
+  // has been updated to reference the new secret. Deleting the old secret before
+  // the IS update triggers a KServe mutating webhook bug that strips storageUri
+  // when the currently-referenced imagePullSecrets secret is missing.
+  const oldSecretName = selectedConnection?.metadata.name;
+  const cleanup =
+    oldSecretName && oldSecretName !== actualSecretName
+      ? async (): Promise<void> => {
+          try {
+            const existingSecret = await getSecret(project, oldSecretName);
+            if (isGeneratedSecretName(existingSecret.metadata.name)) {
+              await deleteSecret(project, existingSecret.metadata.name);
+            }
+          } catch {
+            // Old secret already gone or inaccessible — nothing to clean up
+          }
+        }
+      : undefined;
 
-    return dryRunCreatedSecret;
+  if (dryRun) {
+    return { secret: await createSecret(annotatedConnection, { dryRun: true }), cleanup };
   }
 
-  // Note: the old generated secret is NOT deleted here. The caller (deployModel)
-  // deletes it after the InferenceService has been updated to reference the new
-  // secret. Deleting it before the IS update triggers a KServe mutating webhook
-  // bug that strips storageUri when the currently-referenced secret is missing.
   const createdSecret = await createSecret(annotatedConnection);
   const finalSecret = await getSecret(project, createdSecret.metadata.name);
-  return finalSecret;
+  return { secret: finalSecret, cleanup };
 };
 
 export const handleSecretOwnerReferencePatch = async (

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -1,11 +1,9 @@
 import {
   createSecret,
-  replaceSecret,
   getSecret,
   patchSecretWithOwnerReference,
   patchSecretWithProtocolAnnotation,
   hasProtocolAnnotation,
-  deleteSecret,
   isGeneratedSecretName,
   getGeneratedSecretName,
 } from '@odh-dashboard/internal/api/index';
@@ -27,6 +25,7 @@ export const handleConnectionCreation = async (
   modelLocationData?: ModelLocationData,
   secretName?: string,
   dryRun?: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   selectedConnection?: Connection,
 ): Promise<SecretKind | undefined> => {
   if (!modelLocationData) {
@@ -57,18 +56,12 @@ export const handleConnectionCreation = async (
 
   const connectionTypeName = modelLocationData.connectionTypeObject?.metadata.name ?? 'uri-v1';
   const formSecretName = createConnectionData.nameDesc?.k8sName.value;
-  const oldSecretName = selectedConnection?.metadata.name;
   const actualSecretName = (() => {
     if (createConnectionData.saveConnection && formSecretName) {
       return formSecretName;
     }
     const candidate = secretName ?? formSecretName;
-    // Reuse an existing generated secret name to avoid changing the IS's
-    // imagePullSecrets reference, which triggers the KServe webhook to strip storageUri.
-    if (candidate && isGeneratedSecretName(candidate)) {
-      return candidate;
-    }
-    if (!candidate) {
+    if (!candidate || isGeneratedSecretName(candidate)) {
       return getGeneratedSecretName();
     }
     return candidate;
@@ -117,46 +110,19 @@ export const handleConnectionCreation = async (
     delete annotatedConnection.metadata.annotations['openshift.io/description'];
   }
 
-  const newSecretName = actualSecretName;
-  const isReusing = oldSecretName && oldSecretName === newSecretName;
-
-  if (isReusing) {
-    // Reusing the same secret name — replace it to avoid changing imagePullSecrets
-    // on the InferenceService, which triggers a KServe webhook that strips storageUri.
-    const existingSecret = await getSecret(project, oldSecretName);
-    const replacedSecret = await replaceSecret(
-      {
-        ...annotatedConnection,
-        metadata: {
-          ...annotatedConnection.metadata,
-          resourceVersion: existingSecret.metadata.resourceVersion,
-        },
-      },
-      dryRun ? { dryRun: true } : undefined,
-    );
-    if (dryRun) {
-      return replacedSecret;
-    }
-    return getSecret(project, replacedSecret.metadata.name);
-  }
-
   if (dryRun) {
-    return createSecret(annotatedConnection, { dryRun: true });
+    const dryRunCreatedSecret = await createSecret(annotatedConnection, { dryRun: true });
+
+    return dryRunCreatedSecret;
   }
 
-  if (oldSecretName && oldSecretName !== newSecretName) {
-    try {
-      const existingSecret = await getSecret(project, oldSecretName);
-      if (isGeneratedSecretName(existingSecret.metadata.name)) {
-        await deleteSecret(project, existingSecret.metadata.name);
-      }
-    } catch {
-      console.error('Old secret not found, skipping delete');
-    }
-  }
-
+  // Note: the old generated secret is NOT deleted here. The caller (deployModel)
+  // deletes it after the InferenceService has been updated to reference the new
+  // secret. Deleting it before the IS update triggers a KServe mutating webhook
+  // bug that strips storageUri when the currently-referenced secret is missing.
   const createdSecret = await createSecret(annotatedConnection);
-  return getSecret(project, createdSecret.metadata.name);
+  const finalSecret = await getSecret(project, createdSecret.metadata.name);
+  return finalSecret;
 };
 
 export const handleSecretOwnerReferencePatch = async (

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -122,6 +122,7 @@ export const handleConnectionCreation = async (
   // the IS update triggers a KServe mutating webhook bug that strips storageUri
   // when the currently-referenced imagePullSecrets secret is missing.
   // See https://redhat.atlassian.net/browse/RHOAIENG-61105
+  // TODO: Revert this workaround when the KServe bug is fixed (RHOAIENG-61106)
   const oldSecretName = selectedConnection?.metadata.name;
   const cleanup =
     oldSecretName && oldSecretName !== actualSecretName

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -1,5 +1,6 @@
 import {
   createSecret,
+  replaceSecret,
   getSecret,
   patchSecretWithOwnerReference,
   patchSecretWithProtocolAnnotation,
@@ -56,12 +57,18 @@ export const handleConnectionCreation = async (
 
   const connectionTypeName = modelLocationData.connectionTypeObject?.metadata.name ?? 'uri-v1';
   const formSecretName = createConnectionData.nameDesc?.k8sName.value;
+  const oldSecretName = selectedConnection?.metadata.name;
   const actualSecretName = (() => {
     if (createConnectionData.saveConnection && formSecretName) {
       return formSecretName;
     }
     const candidate = secretName ?? formSecretName;
-    if (!candidate || isGeneratedSecretName(candidate)) {
+    // Reuse an existing generated secret name to avoid changing the IS's
+    // imagePullSecrets reference, which triggers the KServe webhook to strip storageUri.
+    if (candidate && isGeneratedSecretName(candidate)) {
+      return candidate;
+    }
+    if (!candidate) {
       return getGeneratedSecretName();
     }
     return candidate;
@@ -110,19 +117,36 @@ export const handleConnectionCreation = async (
     delete annotatedConnection.metadata.annotations['openshift.io/description'];
   }
 
-  if (dryRun) {
-    const dryRunCreatedSecret = await createSecret(annotatedConnection, { dryRun: true });
+  const newSecretName = actualSecretName;
+  const isReusing = oldSecretName && oldSecretName === newSecretName;
 
-    return dryRunCreatedSecret;
+  if (isReusing) {
+    // Reusing the same secret name — replace it to avoid changing imagePullSecrets
+    // on the InferenceService, which triggers a KServe webhook that strips storageUri.
+    const existingSecret = await getSecret(project, oldSecretName);
+    const replacedSecret = await replaceSecret(
+      {
+        ...annotatedConnection,
+        metadata: {
+          ...annotatedConnection.metadata,
+          resourceVersion: existingSecret.metadata.resourceVersion,
+        },
+      },
+      dryRun ? { dryRun: true } : undefined,
+    );
+    if (dryRun) {
+      return replacedSecret;
+    }
+    return getSecret(project, replacedSecret.metadata.name);
   }
 
-  const oldSecretName = selectedConnection?.metadata.name;
-  const newSecretName = actualSecretName;
+  if (dryRun) {
+    return createSecret(annotatedConnection, { dryRun: true });
+  }
+
   if (oldSecretName && oldSecretName !== newSecretName) {
     try {
       const existingSecret = await getSecret(project, oldSecretName);
-
-      // Only delete if it was a generated secret
       if (isGeneratedSecretName(existingSecret.metadata.name)) {
         await deleteSecret(project, existingSecret.metadata.name);
       }
@@ -132,8 +156,7 @@ export const handleConnectionCreation = async (
   }
 
   const createdSecret = await createSecret(annotatedConnection);
-  const finalSecret = await getSecret(project, createdSecret.metadata.name);
-  return finalSecret;
+  return getSecret(project, createdSecret.metadata.name);
 };
 
 export const handleSecretOwnerReferencePatch = async (

--- a/packages/model-serving/src/concepts/connectionUtils.ts
+++ b/packages/model-serving/src/concepts/connectionUtils.ts
@@ -127,11 +127,12 @@ export const handleConnectionCreation = async (
       ? async (): Promise<void> => {
           try {
             const existingSecret = await getSecret(project, oldSecretName);
+            // Only delete if it was a generated secret
             if (isGeneratedSecretName(existingSecret.metadata.name)) {
               await deleteSecret(project, existingSecret.metadata.name);
             }
           } catch {
-            // Old secret already gone or inaccessible — nothing to clean up
+            console.error('Old secret not found, skipping delete');
           }
         }
       : undefined;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-53682

## Description

When editing a KServe deployment that uses an unsaved OCI connection, the `storageUri` and `imagePullSecrets` fields were being dropped from the InferenceService after save.

### Root cause: KServe mutating webhook

The **KServe mutating admission webhook** (`inferenceservice.kserve-webhook-server.defaulter`) strips `storageUri` from `spec.predictor.model` when the secret currently referenced by the InferenceService's `imagePullSecrets` has been deleted — even if the PUT payload includes a valid `storageUri` and references a new, existing secret. This is a KServe bug tracked as [RHOAIENG-61105](https://redhat.atlassian.net/browse/RHOAIENG-61105); `storageUri` is independent of `imagePullSecrets` and should not be stripped. Workaround revert tracked as [RHOAIENG-61106](https://redhat.atlassian.net/browse/RHOAIENG-61106).

The dashboard triggered this by performing the following sequence on every edit of an unsaved OCI connection:
1. **Delete** the old generated secret (e.g. `secret-abc`)
2. **Create** a new secret with a new generated name (e.g. `secret-xyz`)
3. **PUT** the InferenceService with `imagePullSecrets` updated to `[{name: "secret-xyz"}]`

At step 3, the webhook checks the IS's *current* `imagePullSecrets` reference (`secret-abc`), finds it deleted, and strips `storageUri` from the spec.

### CLI reproduction of the KServe webhook bug

These steps reproduce the bug entirely from the CLI, independent of the dashboard. Replace `$NAMESPACE` with your target namespace.

```bash
# 1. Create an OCI pull secret with dashboard labels (required by the ODH admission webhook)
cat <<EOF | oc apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: repro-oci-secret
  namespace: $NAMESPACE
  labels:
    opendatahub.io/dashboard: "true"
  annotations:
    opendatahub.io/connection-type-ref: oci-v1
    opendatahub.io/connection-type-protocol: oci
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7InVzZXJuYW1lIjoiZmFrZSIsInBhc3N3b3JkIjoiZmFrZSJ9fX0=
EOF

# 2. Create an InferenceService with storageUri + imagePullSecrets (OCI pattern)
cat <<EOF | oc create -f -
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: repro-oci-bug
  namespace: $NAMESPACE
  annotations:
    openshift.io/display-name: repro-oci-bug
    opendatahub.io/connections: repro-oci-secret
  labels:
    opendatahub.io/dashboard: "true"
spec:
  predictor:
    imagePullSecrets:
    - name: repro-oci-secret
    model:
      modelFormat:
        name: vLLM
      runtime: repro-oci-bug
      storageUri: oci://quay.io/example/model:latest
EOF

# 3. Verify storageUri is present
oc get inferenceservice repro-oci-bug -n $NAMESPACE \
  -o jsonpath='{.spec.predictor.model.storageUri}'
# Expected output: oci://quay.io/example/model:latest

# 4. Create a second secret (simulating what the dashboard does on edit)
cat <<EOF | oc apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: repro-oci-secret-2
  namespace: $NAMESPACE
  labels:
    opendatahub.io/dashboard: "true"
  annotations:
    opendatahub.io/connection-type-ref: oci-v1
    opendatahub.io/connection-type-protocol: oci
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7InVzZXJuYW1lIjoiZmFrZSIsInBhc3N3b3JkIjoiZmFrZSJ9fX0=
EOF

# 5. DELETE the old secret (this is what the dashboard did before the fix)
oc delete secret repro-oci-secret -n $NAMESPACE

# 6. PUT the IS with imagePullSecrets changed to the new secret
oc get inferenceservice repro-oci-bug -n $NAMESPACE -o json | \
  python3 -c "
import json, sys
obj = json.load(sys.stdin)
obj['spec']['predictor']['imagePullSecrets'] = [{'name': 'repro-oci-secret-2'}]
obj['metadata']['annotations']['opendatahub.io/connections'] = 'repro-oci-secret-2'
json.dump(obj, open('/tmp/repro.json', 'w'))
" && oc replace -f /tmp/repro.json

# 7. Verify storageUri is stripped
oc get inferenceservice repro-oci-bug -n $NAMESPACE \
  -o jsonpath='{.spec.predictor.model.storageUri}'
# Expected output: (empty) ← BUG: webhook stripped storageUri

# Cleanup
oc delete inferenceservice repro-oci-bug -n $NAMESPACE
oc delete secret repro-oci-secret-2 -n $NAMESPACE
```

### Fix (workaround for [RHOAIENG-61105](https://redhat.atlassian.net/browse/RHOAIENG-61105))

**`connectionUtils.ts` (handleConnectionCreation)** — Instead of deleting the old generated secret inline before creating the new one, return a `cleanup` function alongside the created secret. The cleanup function encapsulates the old secret deletion logic but lets the caller control when it runs.

**`utils.ts` (deployModel)** — Call the returned `cleanup` function **after** the InferenceService has been updated to reference the new secret. This ensures the old secret still exists when the webhook processes the IS update, avoiding the bug.

This workaround should be reverted when [RHOAIENG-61105](https://redhat.atlassian.net/browse/RHOAIENG-61105) is fixed upstream (tech debt issue for revert: [RHOAIENG-61106](https://redhat.atlassian.net/browse/RHOAIENG-61106)).

## How Has This Been Tested?
- Reproduced the root cause via CLI (see reproduction steps above)
- Manually tested the fix on a live cluster: created OCI deployments, stopped them, edited them, and verified `storageUri` and `imagePullSecrets` persist after save
- Verified with `oc get` that the InferenceService spec is correct after each edit
- Lint and type-check pass cleanly

## Test Impact
- Added unit tests for `handleConnectionCreation` in `connectionUtils.spec.ts` covering:
  - Cleanup function is returned when old and new secret names differ
  - Old secret is not deleted until cleanup is explicitly called
  - Cleanup deletes the old generated secret
  - Non-generated secrets are not cleaned up
  - No cleanup function when there is no old connection
  - Cleanup function behavior during dry run

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`