### PR TITLE
ci: add report-only Semgrep workflow with SARIF upload

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,87 @@
+# Semgrep static analysis using the repository root semgrep.yaml (report-only).
+#
+# Report-only: the scan step uses continue-on-error so findings do not fail the check.
+# To enforce: remove continue-on-error from the "Run Semgrep" step.
+#
+# Follow-ups when tightening:
+# - Add # nosemgrep: k8s-rbac-cluster-admin-binding to intentional fixtures (e.g.
+#   packages/cypress/cypress/fixtures/resources/yaml/cluster_role_binding.yaml), or
+#   agree on path excludes.
+# - Optionally set k8s-rbac-cluster-admin-binding severity to ERROR in semgrep.yaml.
+#
+# SARIF upload to the Security tab is skipped on forked repositories (permission limits).
+
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep (report-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      SEMGREP_SEND_METRICS: off
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: |
+          python -m pip install --upgrade pip
+          pip install "semgrep==1.156.0"
+
+      - name: Run Semgrep
+        id: semgrep
+        continue-on-error: true
+        run: |
+          semgrep scan \
+            --config semgrep.yaml \
+            --sarif \
+            --output semgrep.sarif \
+            .
+
+      - name: Semgrep findings summary
+        if: always()
+        run: |
+          if [ -f semgrep.sarif ] && command -v jq >/dev/null; then
+            count=$(jq '[.runs[]?.results[]?] | length' semgrep.sarif)
+            echo "### Semgrep findings: ${count}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Scan step outcome: ${{ steps.semgrep.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Semgrep" >> "$GITHUB_STEP_SUMMARY"
+            echo "No semgrep.sarif produced or jq unavailable; scan step outcome: ${{ steps.semgrep.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Semgrep SARIF to GitHub Security
+        if: always() && hashFiles('semgrep.sarif') != '' && github.event.repository.fork == false
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      - name: Upload Semgrep artifacts
+        if: always() && hashFiles('semgrep.sarif') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-sarif
+          path: semgrep.sarif
+          retention-days: 30


### PR DESCRIPTION
## Semgrep GitHub Action (report-only)

> **This is Step 1 of a phased rollout.** This PR adds Semgrep as a report-only CI check. It will not block any PRs. The goal is to give the team visibility into security findings before we turn enforcement on in a future step.

### Why are we doing this?

Our repository already ships a comprehensive `semgrep.yaml` ruleset (64 rules covering Go, TypeScript, YAML manifests, and generic secrets detection), but nothing in CI actually runs it today. That means a new contributor could accidentally introduce a `cluster-admin` binding in a Kubernetes manifest, and no automated check would catch it before merge.

This workflow closes that gap. It runs Semgrep on every PR and push to `main`, surfaces findings in the GitHub Security tab and as downloadable artifacts, and does **not** fail the build yet. Think of it as turning on the security camera before you wire it to the alarm.

### What problem does this solve?

- **Accidental privilege escalation:** The `k8s-rbac-cluster-admin-binding` rule flags any YAML manifest that binds `cluster-admin`. A single overlooked `roleRef: name: cluster-admin` in a new manifest could grant unrestricted cluster access to a workload that doesn't need it.
- **Secrets in code:** Generic rules catch hardcoded passwords, AWS keys, private keys, and GitHub tokens across all file types.
- **Broad coverage at zero risk:** By running report-only first, we get a full picture of existing findings (270 on the initial run) without disrupting any contributor's workflow.

### Phased rollout

| Phase | What happens | Impact on contributors |
|-------|-------------|----------------------|
| **Step 1** (this PR) | Semgrep runs on every PR; results appear in Security tab and artifacts. Job always passes. | None. Green check regardless of findings. |
| **Step 2** (follow-up) | Team reviews the 270 existing findings. Suppress known-good items with `# nosemgrep` comments or path excludes (e.g. the Cypress `cluster_role_binding.yaml` fixture). | Minimal. Small cleanup commits. |
| **Step 3** (follow-up) | Remove `continue-on-error: true` so new findings fail CI. Optionally promote `k8s-rbac-cluster-admin-binding` from WARNING to ERROR. | PRs that introduce flagged patterns must fix them before merge. |

### What the workflow does

- **Triggers:** `pull_request`, `push` to `main`, and `workflow_dispatch` for manual runs.
- **Concurrency:** Matches the pattern in `test.yml` so rapid pushes cancel stale runs instead of stacking them.
- **Permissions:** `contents: read` + `security-events: write` (the latter is required for SARIF upload to the Security tab).
- **Semgrep version:** Pinned to `1.156.0` for reproducible builds.
- **Report-only:** `continue-on-error: true` on the scan step means findings do not fail the workflow.
- **SARIF upload:** Populates the GitHub Security tab. Skipped on forked repos (`github.event.repository.fork == false`) because forks lack `security-events: write` permissions.
- **Artifact upload:** `semgrep-sarif` artifact with 30-day retention for reviewers who do not have Security tab access.

### Initial scan results (Step 1 baseline)

The first run on the `toil` branch completed in ~66 seconds:

- **6,647 files** scanned across Go, TypeScript, YAML, and JavaScript
- **64 rules** evaluated
- **270 findings** reported (all report-only, no PR blocked)
- SARIF uploaded to Security tab and as artifact

These 270 findings are the **existing baseline** that will be triaged in Step 2. They include known-good patterns like the Cypress `cluster-admin` fixture and informational-level rules that may not need action.

### For reviewers

**What to look at:**

1. `.github/workflows/semgrep.yml` -- the only file changed. 87 lines, single job, six steps.
2. Confirm the workflow ran green on the PR: [PR #6956 checks](https://github.com/opendatahub-io/odh-dashboard/pull/6956/checks).
3. No existing tests, builds, or workflows are affected. This is purely additive.

**What you do not need to worry about:**

- This PR does not block any PRs. It is report-only.
- This PR does not modify `semgrep.yaml` or any application code.
- This PR does not require any secrets or org-level configuration changes (SARIF upload works with the default `GITHUB_TOKEN`).

**Known follow-ups (not in scope for this PR):**

- Triage the 270 baseline findings and add suppressions where appropriate.
- Enable the blocking gate (remove `continue-on-error`).
- Consider bumping `k8s-rbac-cluster-admin-binding` severity from WARNING to ERROR once blocking is enabled.
- GitHub Actions Node.js 20 deprecation warnings on `checkout@v4`, `setup-python@v5`, `upload-artifact@v4` -- these should be bumped to Node.js 24-compatible versions across all workflows, not just this one.