### PR TITLE
fix(gen-ai): Fix flaky mcpTab test by re-querying server rows after modal closes

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -377,10 +377,12 @@ describe('Playground - MCP Servers', () => {
       cy.step('Verify tools button is enabled after closing modal');
       // Wait for MCP table to be visible after potential tab remount
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
-      serverRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
 
       cy.step('Click tools button to open tools modal');
-      serverRow.findToolsButton().click();
+      freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with tools');
       mcpToolsModal.find().should('be.visible');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -465,8 +465,9 @@ describe('Playground - MCP Servers', () => {
       mcpServerSuccessModal.find().should('not.exist');
       // Wait for MCP table to be visible after potential tab remount
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
-      serverRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
-      serverRow.findToolsButton().click();
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with all tools selected');
       mcpToolsModal.find().should('be.visible');
@@ -559,7 +560,8 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            playgroundPage.mcpTab.getServerRow(serverName, serverUrl).findToolsButton().click();
+            const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+            reopenedServerRow.findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -70,10 +70,15 @@ describe('Playground - MCP Servers', () => {
       mcpServerSuccessModal.find().should('not.exist');
 
       cy.step('Verify server is now authenticated and tools button is enabled');
-      serverRow.findToolsButton().should('exist').should('not.have.attr', 'aria-disabled');
+      // Re-query server row after modal closes to avoid stale reference
+      const authenticatedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      authenticatedServerRow
+        .findToolsButton()
+        .should('exist')
+        .should('not.have.attr', 'aria-disabled');
 
       cy.step('Open tools modal');
-      serverRow.findToolsButton().click();
+      authenticatedServerRow.findToolsButton().click();
 
       cy.step('Wait for tools API call');
       cy.wait('@toolsRequest', { timeout: 10000 });
@@ -419,7 +424,7 @@ describe('Playground - MCP Servers', () => {
           mcpToolsModal.find().should('not.exist');
 
           cy.step('Re-open tools modal to verify persistence');
-          serverRow.findToolsButton().click();
+          freshServerRow.findToolsButton().click();
           mcpToolsModal.find().should('be.visible');
 
           cy.step('Verify tool selection persisted (2 tools deselected)');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -472,6 +472,7 @@ describe('Playground - MCP Servers', () => {
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
       freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with all tools selected');
@@ -566,6 +567,10 @@ describe('Playground - MCP Servers', () => {
 
             cy.step('Re-open to verify all tools remain selected');
             const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+            reopenedServerRow
+              .findToolsButton()
+              .should('exist')
+              .and('not.have.attr', 'aria-disabled');
             reopenedServerRow.findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -566,18 +566,14 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible and force immediate row query
-            playgroundPage.mcpTab
-              .findMCPServersTable()
-              .should('be.visible')
-              .then(() => {
-                const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
-                reopenedServerRow
-                  .findToolsButton()
-                  .should('exist')
-                  .and('not.have.attr', 'aria-disabled')
-                  .click();
-              });
+            // Wait for MCP table to be visible
+            playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+
+            // Directly query for the tools button by its testID (bypassing page object to avoid stale references)
+            cy.findByTestId(`mcp-server-tools-button-${serverUrl}`)
+              .should('exist')
+              .and('not.have.attr', 'aria-disabled')
+              .click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -566,6 +566,8 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
+            // Wait for MCP table to be visible after potential tab remount
+            playgroundPage.mcpTab.verifyMCPTabVisible();
             const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
             reopenedServerRow
               .findToolsButton()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -566,14 +566,18 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible after potential tab remount
-            playgroundPage.mcpTab.verifyMCPTabVisible();
-            const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
-            reopenedServerRow
-              .findToolsButton()
-              .should('exist')
-              .and('not.have.attr', 'aria-disabled');
-            reopenedServerRow.findToolsButton().click();
+            // Wait for MCP table to be visible and force immediate row query
+            playgroundPage.mcpTab
+              .findMCPServersTable()
+              .should('be.visible')
+              .then(() => {
+                const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+                reopenedServerRow
+                  .findToolsButton()
+                  .should('exist')
+                  .and('not.have.attr', 'aria-disabled')
+                  .click();
+              });
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -557,7 +557,7 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            serverRow.findToolsButton().click();
+            playgroundPage.mcpTab.getServerRow(serverName, serverUrl).findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -381,7 +381,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify tools button is enabled after closing modal');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
       freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
@@ -469,7 +469,7 @@ describe('Playground - MCP Servers', () => {
       playgroundPage.mcpTab.closeSuccessModal();
       mcpServerSuccessModal.find().should('not.exist');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
       freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
@@ -621,7 +621,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify warning alert is shown in MCP tab');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       cy.get('[data-testid="mcp-tools-warning-alert"]')
         .should('be.visible')
         .and('contain.text', 'Performance may be degraded with more than 40 active tools');
@@ -665,7 +665,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify warning alert is NOT shown (40 tools is the threshold, not exceeding)');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       cy.get('[data-testid="mcp-tools-warning-alert"]').should('not.exist');
 
       cy.step('Verify tools count shows 40 active');


### PR DESCRIPTION
## Description

This PR fixes flaky Gen AI mock tests in the MCP Servers tab by addressing stale element references.

### Root Cause

When modals close in the MCP Servers test, the underlying DOM can be re-rendered, causing previously queried Cypress elements to become stale. Attempting to interact with these stale references causes intermittent test failures.

### Changes Made

**Test Reliability Fix**
- Re-query server rows after modals close instead of reusing stale element references
- Ensures tests interact with fresh, valid DOM elements after modal interactions

### How Has This Been Tested?

**Local Testing**
- Ran Gen AI mock tests: `cd packages/gen-ai/frontend && npm run test:cypress-ci`
- Verified tests pass consistently with fresh element queries after modal closes

**CI Testing**
- All tests passing after `/retest`

### Test Impact

**Tests Modified:**
- `packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts`
  - Re-query server row after closing success modal (3 locations)
  - Prevents stale element references in tools button interactions

**Test Coverage:**
- MCP server modal workflows
- Stale element reference prevention

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
