### PR TITLE
RHOAIENG-56174: Display package versions and support levels in the About modal for local development builds

### DIFF
--- a/frontend/config/discoverPluginPackages.js
+++ b/frontend/config/discoverPluginPackages.js
@@ -112,7 +112,36 @@ function getPluginPackageDetails() {
     }));
 }
 
+/**
+ * Filter workspace packages that are feature packages (extensions or module federation).
+ * Excludes tooling-only packages like eslint-config, jest-config, tsconfig, cypress, etc.
+ * @param {Array} workspaces - Array of workspace package objects
+ * @returns {Array} Array of feature packages
+ */
+function filterFeaturePackages(workspaces) {
+  return workspaces.filter((pkg) => pkg.exports?.['./extensions'] || pkg['module-federation']);
+}
+
+/**
+ * Get version and support level metadata for all feature packages
+ * (both static extension plugins and module federation remotes).
+ * Used by DefinePlugin to inject package metadata into the frontend bundle.
+ * @returns {{ name: string, version: string, supportLevel?: string }[]}
+ */
+function getPluginPackageVersions() {
+  const workspacePackages = getWorkspacePackages();
+  const featurePackages = filterFeaturePackages(workspacePackages);
+  return featurePackages
+    .filter((pkg) => pkg.name !== '@odh-dashboard/internal')
+    .map((pkg) => ({
+      name: pkg.name,
+      version: pkg.version || '0.0.0',
+      ...(pkg.supportLevel ? { supportLevel: pkg.supportLevel } : {}),
+    }));
+}
+
 module.exports = {
   discoverPluginPackages,
   getPluginPackageDetails,
+  getPluginPackageVersions,
 };

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -8,7 +8,7 @@ const webpack = require('webpack');
 const { setupWebpackDotenvFilesForEnv } = require('./dotenv');
 const GenerateExtensionsPlugin = require('./generateExtensionsPlugin');
 const { moduleFederationPlugins, moduleFederationConfig } = require('./moduleFederation');
-const { getPluginPackageDetails } = require('./discoverPluginPackages');
+const { getPluginPackageDetails, getPluginPackageVersions } = require('./discoverPluginPackages');
 const { getExtensionChunksFilter, getPluginChunkName } = require('./pluginChunking');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
@@ -298,6 +298,7 @@ module.exports = (env) => ({
     }),
     new webpack.DefinePlugin({
       __COMMIT_HASH__: JSON.stringify(COMMIT_HASH_DIRECT),
+      __PACKAGE_VERSIONS__: JSON.stringify(getPluginPackageVersions()),
     }),
     env === 'development' || MF_DEV
       ? new webpack.EnvironmentPlugin({

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -298,7 +298,7 @@ module.exports = (env) => ({
     }),
     new webpack.DefinePlugin({
       __COMMIT_HASH__: JSON.stringify(COMMIT_HASH_DIRECT),
-      __PACKAGE_VERSIONS__: JSON.stringify(getPluginPackageVersions()),
+      __PACKAGE_VERSIONS__: JSON.stringify(env === 'development' ? getPluginPackageVersions() : []),
     }),
     env === 'development' || MF_DEV
       ? new webpack.EnvironmentPlugin({

--- a/frontend/src/app/AboutDialog.tsx
+++ b/frontend/src/app/AboutDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { AboutModal, Alert, Bullseye, Spinner, Content } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { ODH_LOGO, ODH_LOGO_DARK, ODH_PRODUCT_NAME } from '#~/utilities/const';
 import { DataScienceStackComponentMap } from '#~/concepts/areas/const';
 import { DataScienceClusterComponentStatus } from '#~/k8sTypes';
@@ -10,7 +10,14 @@ import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
 import useFetchDsciStatus from '#~/concepts/areas/useFetchDsciStatus';
 import { useWatchOperatorSubscriptionStatus } from '#~/utilities/useWatchOperatorSubscriptionStatus';
 import ExternalLink from '#~/components/ExternalLink';
+import { PackageVersionInfo } from '#~/types';
 import { useThemeContext } from './ThemeContext';
+
+const supportLevelLabels: Record<string, string> = {
+  GA: 'Generally Available',
+  TP: 'Technology Preview',
+  DP: 'Developer Preview',
+};
 
 const RhoaiAboutText = `Red Hat® OpenShift® AI (formerly Red Hat OpenShift Data Science) is a flexible, scalable MLOps platform for data scientists and developers of artificial intelligence and machine learning (AI/ML) applications. Built using open source technologies, OpenShift AI supports the full lifecycle of AI/ML experiments and models, on premise and in the public cloud.`;
 const RhoaiDefaultReleaseName = `OpenShift AI`;
@@ -38,6 +45,13 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
   const error = errorDsci || errorSubStatus;
   const loading =
     (!errorDsci && !loadedDsci && !loadedDsc) || (!errorSubStatus && !loadedSubStatus && !errorDsc);
+
+  const [isDashboardExpanded, setIsDashboardExpanded] = React.useState(true);
+
+  const packageVersions: PackageVersionInfo[] = useMemo(
+    () => (__PACKAGE_VERSIONS__ ?? []).toSorted((a, b) => a.name.localeCompare(b.name)),
+    [],
+  );
 
   // Group components by display name while merging releases
   const groupedComponents = useMemo(() => {
@@ -149,6 +163,7 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
               <Table aria-label="Component Releases Table" data-testid="component-releases-table">
                 <Thead>
                   <Tr data-testid="table-row-title">
+                    <Th screenReaderText="Row expansion" />
                     <Th modifier="wrap">
                       {isRHOAI ? RhoaiDefaultComponentReleaseName : OdhDefaultComponentReleaseName}{' '}
                       component
@@ -158,35 +173,132 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ onClose }) => {
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {groupedComponents.map(([displayName, details]) =>
-                    details?.releases && details.releases.length > 0 ? (
-                      details.releases.map((release, index) => (
-                        <Tr key={`${displayName}-${index}`} data-testid="table-row-data">
-                          {index === 0 ? (
-                            <Td rowSpan={details.releases.length}>{displayName}</Td>
-                          ) : null}
-                          <Td
-                            style={{
-                              paddingInlineStart: 'var(--pf-v6-c-table--cell--Padding--base)',
-                            }}
-                          >
-                            {release.repoUrl ? (
-                              <ExternalLink text={release.name} to={release.repoUrl} />
+                  {groupedComponents.map(([displayName, details], componentIndex) => {
+                    const isDashboard = displayName === 'Dashboard';
+                    const hasPackages = isDashboard && packageVersions.length > 0;
+
+                    return (
+                      <React.Fragment key={displayName}>
+                        {details?.releases && details.releases.length > 0 ? (
+                          details.releases.map((release, index) => (
+                            <Tr key={`${displayName}-${index}`} data-testid="table-row-data">
+                              {index === 0 ? (
+                                <>
+                                  {hasPackages ? (
+                                    <Td
+                                      rowSpan={details.releases.length}
+                                      expand={{
+                                        rowIndex: componentIndex,
+                                        isExpanded: isDashboardExpanded,
+                                        onToggle: () => setIsDashboardExpanded((prev) => !prev),
+                                      }}
+                                    />
+                                  ) : (
+                                    <Td rowSpan={details.releases.length} />
+                                  )}
+                                  <Td rowSpan={details.releases.length}>
+                                    {displayName}
+                                    {hasPackages && !isDashboardExpanded ? (
+                                      <Content
+                                        component="small"
+                                        style={{
+                                          display: 'block',
+                                          color: 'var(--pf-t--global--text--color--subtle)',
+                                        }}
+                                        data-testid="dashboard-packages-hint"
+                                      >
+                                        Includes {packageVersions.length} packages. Expand for more
+                                        details.
+                                      </Content>
+                                    ) : null}
+                                  </Td>
+                                </>
+                              ) : null}
+                              <Td
+                                style={{
+                                  paddingInlineStart: 'var(--pf-v6-c-table--cell--Padding--base)',
+                                }}
+                              >
+                                {release.repoUrl ? (
+                                  <ExternalLink text={release.name} to={release.repoUrl} />
+                                ) : (
+                                  release.name
+                                )}
+                              </Td>
+                              <Td>{release.version}</Td>
+                            </Tr>
+                          ))
+                        ) : (
+                          <Tr data-testid={isDashboard ? 'dashboard-component-row' : undefined}>
+                            {hasPackages ? (
+                              <Td
+                                expand={{
+                                  rowIndex: componentIndex,
+                                  isExpanded: isDashboardExpanded,
+                                  onToggle: () => setIsDashboardExpanded((prev) => !prev),
+                                }}
+                              />
                             ) : (
-                              release.name
+                              <Td />
                             )}
-                          </Td>
-                          <Td>{release.version}</Td>
-                        </Tr>
-                      ))
-                    ) : (
-                      <Tr key={displayName}>
-                        <Td>{displayName}</Td>
-                        <Td>-</Td>
-                        <Td>-</Td>
-                      </Tr>
-                    ),
-                  )}
+                            <Td>
+                              {displayName}
+                              {hasPackages && !isDashboardExpanded ? (
+                                <Content
+                                  component="small"
+                                  style={{
+                                    display: 'block',
+                                    color: 'var(--pf-t--global--text--color--subtle)',
+                                  }}
+                                  data-testid="dashboard-packages-hint"
+                                >
+                                  Includes {packageVersions.length} packages. Expand for more
+                                  details.
+                                </Content>
+                              ) : null}
+                            </Td>
+                            <Td>-</Td>
+                            <Td>-</Td>
+                          </Tr>
+                        )}
+                        {hasPackages && isDashboardExpanded ? (
+                          <Tr isExpanded data-testid="dashboard-packages-expanded-row">
+                            <Td colSpan={4}>
+                              <ExpandableRowContent>
+                                <Table
+                                  aria-label="Package Versions Table"
+                                  data-testid="package-versions-table"
+                                >
+                                  <Thead>
+                                    <Tr data-testid="package-table-row-title">
+                                      <Th modifier="wrap">Package</Th>
+                                      <Th modifier="wrap">Version</Th>
+                                      <Th modifier="wrap">Support level</Th>
+                                    </Tr>
+                                  </Thead>
+                                  <Tbody>
+                                    {packageVersions.map((pkg) => (
+                                      <Tr key={pkg.name} data-testid="package-table-row-data">
+                                        <Td data-testid="package-name">
+                                          {pkg.name.replace(/^@[^/]+\//, '')}
+                                        </Td>
+                                        <Td data-testid="package-version">{pkg.version}</Td>
+                                        <Td data-testid="package-support-level">
+                                          {pkg.supportLevel
+                                            ? supportLevelLabels[pkg.supportLevel]
+                                            : '--'}
+                                        </Td>
+                                      </Tr>
+                                    ))}
+                                  </Tbody>
+                                </Table>
+                              </ExpandableRowContent>
+                            </Td>
+                          </Tr>
+                        ) : null}
+                      </React.Fragment>
+                    );
+                  })}
                 </Tbody>
               </Table>
             ) : (

--- a/frontend/src/app/__tests__/AboutDialog.spec.tsx
+++ b/frontend/src/app/__tests__/AboutDialog.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ClusterState, UserState } from '#~/redux/selectors/types';
@@ -53,6 +53,8 @@ const useFetchDsciStatusMock = jest.mocked(useFetchDsciStatus);
 const useFetchDscStatusMock = jest.mocked(useFetchDscStatus);
 const useWatchOperatorSubscriptionStatusMock = jest.mocked(useWatchOperatorSubscriptionStatus);
 
+const originalPackageVersions = globalThis.__PACKAGE_VERSIONS__;
+
 describe('AboutDialog', () => {
   const lastUpdated = new Date('2024-06-25T00:00:00Z');
   let dashboardConfig: DashboardConfigKind;
@@ -72,7 +74,12 @@ describe('AboutDialog', () => {
   let operatorSubscriptionStatus: SubscriptionStatusData;
   let operatorSubscriptionFetchStatus: FetchState<SubscriptionStatusData>;
 
+  afterEach(() => {
+    globalThis.__PACKAGE_VERSIONS__ = originalPackageVersions;
+  });
+
   beforeEach(() => {
+    globalThis.__PACKAGE_VERSIONS__ = [];
     dashboardConfig = mockDashboardConfig({});
     if (dashboardConfig.metadata) {
       dashboardConfig.metadata.namespace = 'odh-dashboard';
@@ -213,5 +220,99 @@ describe('AboutDialog', () => {
       (row) => row.textContent.includes('KServe') && row.textContent.includes('1.12.0'),
     );
     expect(hasComponentReleasesMetadata).toBe(true);
+  });
+
+  it('should not show packages table when __PACKAGE_VERSIONS__ is empty', async () => {
+    globalThis.__PACKAGE_VERSIONS__ = [];
+    useAppContextMock.mockReturnValue(appContext);
+    useUserMock.mockReturnValue(userInfo);
+    useClusterInfoMock.mockReturnValue(clusterInfo);
+    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
+    useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
+    useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
+
+    // eslint-disable-next-line no-restricted-syntax
+    render(<AboutDialog onClose={jest.fn()} />);
+
+    expect(screen.queryByTestId('package-versions-table')).not.toBeInTheDocument();
+  });
+
+  it('should show packages table with versions and support levels when Dashboard row is expanded', async () => {
+    globalThis.__PACKAGE_VERSIONS__ = [
+      { name: '@odh-dashboard/model-serving', version: '0.0.0', supportLevel: 'GA' },
+      { name: '@odh-dashboard/feature-store', version: '0.0.0', supportLevel: 'DP' },
+      { name: '@odh-dashboard/model-training', version: '0.0.0', supportLevel: 'TP' },
+    ];
+    if (dscStatus.components) {
+      dscStatus.components[DataScienceStackComponent.DASHBOARD] = {};
+    }
+    useAppContextMock.mockReturnValue(appContext);
+    useUserMock.mockReturnValue(userInfo);
+    useClusterInfoMock.mockReturnValue(clusterInfo);
+    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
+    useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
+    useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
+
+    // eslint-disable-next-line no-restricted-syntax
+    render(<AboutDialog onClose={jest.fn()} />);
+
+    const packageTable = await screen.findByTestId('package-versions-table');
+    expect(packageTable).toBeInTheDocument();
+
+    const packageRows = await screen.findAllByTestId('package-table-row-data');
+    expect(packageRows).toHaveLength(3);
+
+    const packageNames = screen.getAllByTestId('package-name').map((el) => el.textContent);
+    expect(packageNames).toEqual(['feature-store', 'model-serving', 'model-training']);
+
+    const versions = screen.getAllByTestId('package-version').map((el) => el.textContent);
+    expect(versions).toEqual(['0.0.0', '0.0.0', '0.0.0']);
+
+    const supportLevels = screen
+      .getAllByTestId('package-support-level')
+      .map((el) => el.textContent);
+    expect(supportLevels).toEqual([
+      'Developer Preview',
+      'Generally Available',
+      'Technology Preview',
+    ]);
+
+    expect(screen.queryByTestId('dashboard-packages-hint')).not.toBeInTheDocument();
+
+    const dashboardRow = screen.getByTestId('dashboard-component-row');
+    const expandToggle = within(dashboardRow).getByRole('button');
+    fireEvent.click(expandToggle);
+
+    expect(screen.queryByTestId('package-versions-table')).not.toBeInTheDocument();
+    expect(screen.getByTestId('dashboard-packages-hint')).toHaveTextContent(
+      'Includes 3 packages. Expand for more details.',
+    );
+  });
+
+  it('should show -- for packages without a support level', async () => {
+    globalThis.__PACKAGE_VERSIONS__ = [
+      { name: '@odh-dashboard/model-serving-backport', version: '0.0.0' },
+    ];
+    if (dscStatus.components) {
+      dscStatus.components[DataScienceStackComponent.DASHBOARD] = {};
+    }
+    useAppContextMock.mockReturnValue(appContext);
+    useUserMock.mockReturnValue(userInfo);
+    useClusterInfoMock.mockReturnValue(clusterInfo);
+    useFetchDsciStatusMock.mockReturnValue(dsciFetchStatus);
+    useFetchDscStatusMock.mockReturnValue(dscFetchStatus);
+    useWatchOperatorSubscriptionStatusMock.mockReturnValue(operatorSubscriptionFetchStatus);
+
+    // eslint-disable-next-line no-restricted-syntax
+    render(<AboutDialog onClose={jest.fn()} />);
+
+    const packageTable = await screen.findByTestId('package-versions-table');
+    expect(packageTable).toBeInTheDocument();
+
+    const supportLevel = screen.getByTestId('package-support-level');
+    expect(supportLevel.textContent).toBe('--');
+
+    const packageName = screen.getByTestId('package-name');
+    expect(packageName.textContent).toBe('model-serving-backport');
   });
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -280,7 +280,15 @@ declare global {
   // Webpack injected global variables
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const __COMMIT_HASH__: string | undefined;
+  // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
+  var __PACKAGE_VERSIONS__: PackageVersionInfo[] | undefined;
 }
+
+export type PackageVersionInfo = {
+  name: string;
+  version: string;
+  supportLevel?: 'TP' | 'DP' | 'GA';
+};
 
 export type ApplicationAction = {
   label: string;

--- a/packages/automl/package.json
+++ b/packages/automl/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/automl",
   "description": "AutoML plugin.",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "module-federation": {
     "name": "automl",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/autorag/package.json
+++ b/packages/autorag/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/autorag",
   "description": "AutoRAG plugin.",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "module-federation": {
     "name": "autorag",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/cypress/cypress/pages/aboutDialog.ts
+++ b/packages/cypress/cypress/pages/aboutDialog.ts
@@ -81,6 +81,23 @@ export class AboutDialog {
     });
   }
 
+  expandDashboardRow(): void {
+    cy.findByTestId('dashboard-component-row').find('button').click();
+  }
+
+  findPackageVersionsTable(): Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('package-versions-table');
+  }
+
+  getPackageRow(name: string): TableRow {
+    return new TableRow(() =>
+      this.findPackageVersionsTable()
+        .findAllByTestId('package-table-row-data')
+        .contains(name)
+        .parents('tr'),
+    );
+  }
+
   isAdminAccessLevel(): Chainable<JQuery<HTMLElement>> {
     return this.findAccessLevel().should('contain.text', 'Administrator');
   }

--- a/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/application.cy.ts
@@ -196,6 +196,32 @@ describe('Application', () => {
     aboutDialog.findProductName().should('contain.text', 'OpenShift AI');
   });
 
+  it('should show package versions table expanded by default under Dashboard', () => {
+    appChrome.visit();
+    aboutDialog.show();
+
+    aboutDialog.findPackageVersionsTable().should('exist');
+    aboutDialog
+      .findPackageVersionsTable()
+      .findAllByTestId('package-table-row-data')
+      .should('have.length.greaterThan', 0);
+
+    aboutDialog
+      .findPackageVersionsTable()
+      .findByTestId('package-table-row-title')
+      .should('contain.text', 'Package')
+      .and('contain.text', 'Version')
+      .and('contain.text', 'Support level');
+
+    const row = aboutDialog.getPackageRow('model-serving');
+    row.find().findByTestId('package-version').should('contain.text', '0.0.0');
+    row.find().findByTestId('package-support-level').should('contain.text', 'Generally Available');
+
+    aboutDialog.expandDashboardRow();
+    aboutDialog.findPackageVersionsTable().should('not.exist');
+    cy.findByTestId('dashboard-packages-hint').should('contain.text', 'packages');
+  });
+
   it('should show the login modal when receiving a 403 status code', () => {
     // Mock the intercept to return a 403 status code
     cy.interceptOdh('GET /api/config', {

--- a/packages/eval-hub/package.json
+++ b/packages/eval-hub/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/eval-hub",
   "description": "Eval Hub plugin.",
   "version": "0.0.0",
+  "supportLevel": "DP",
   "module-federation": {
     "name": "evalHub",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/feature-store/package.json
+++ b/packages/feature-store/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/feature-store",
   "description": "Feature store plugin for managing feature engineering and data pipelines.",
   "version": "0.0.0",
+  "supportLevel": "DP",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/gen-ai/package.json
+++ b/packages/gen-ai/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/gen-ai",
   "description": "Gen AI plugin.",
   "version": "0.0.0",
+  "supportLevel": "GA",
   "module-federation": {
     "name": "genAi",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/jest-config/config/jest.setup.ts
+++ b/packages/jest-config/config/jest.setup.ts
@@ -22,8 +22,11 @@ if (typeof global.structuredClone === 'undefined') {
 declare global {
   // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
   var __COMMIT_HASH__: string;
+  // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
+  var __PACKAGE_VERSIONS__: { name: string; version: string; supportLevel?: string }[];
 }
 globalThis.__COMMIT_HASH__ = 'test-commit-hash';
+globalThis.__PACKAGE_VERSIONS__ = [];
 
 const tryExpect = (expectFn: () => void) => {
   try {

--- a/packages/kserve/package.json
+++ b/packages/kserve/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/kserve",
   "description": "KServe model serving platform extension",
   "version": "0.0.0",
+  "supportLevel": "GA",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/llmd-serving/package.json
+++ b/packages/llmd-serving/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/llmd-serving",
   "description": "Support for LLM-d model serving deployments via kserve",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/maas/package.json
+++ b/packages/maas/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/maas",
   "description": "Models-as-a-Service plugin",
   "version": "0.0.1",
+  "supportLevel": "GA",
   "module-federation": {
     "name": "maas",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/mlflow-embedded/package.json
+++ b/packages/mlflow-embedded/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/mlflow-embedded",
   "description": "Embeds selected pages from the external MLflow frontend into the dashboard.",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/mlflow/package.json
+++ b/packages/mlflow/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/mlflow",
   "description": "MLflow plugin.",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "module-federation": {
     "name": "mlflow",
     "remoteEntry": "/remoteEntry.js",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/model-registry",
   "description": "Model registry plugin.",
   "version": "0.0.0",
+  "supportLevel": "GA",
   "scripts": {
     "install:module": "npm install --prefix upstream/frontend",
     "lint": "eslint .",

--- a/packages/model-serving/package.json
+++ b/packages/model-serving/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/model-serving",
   "description": "Plugin to display model deployments. Used in combination with specific model serving platform extensions.",
   "version": "0.0.0",
+  "supportLevel": "GA",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/model-training/package.json
+++ b/packages/model-training/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/model-training",
   "description": "Model training plugin for managing training jobs and experiments.",
   "version": "0.0.0",
+  "supportLevel": "TP",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/notebooks",
   "description": "Notebooks plugin.",
   "version": "0.0.0",
+  "supportLevel": "GA",
   "scripts": {
     "lint": "eslint .",
     "type-check": "tsc --noEmit",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -3,6 +3,7 @@
   "name": "@odh-dashboard/observability",
   "description": "Observability plugin for monitoring AI workloads and infrastructure using Perses dashboards.",
   "version": "0.0.0",
+  "supportLevel": "DP",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-56174

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Enhances the Dashboard About modal to display package versions and support levels for feature packages in local development builds.

**What was done:**
- Added `supportLevel` metadata (`GA`, `TP`, or `DP`) to all feature `package.json` files.
- Added a build-time discovery script (`getPluginPackageVersions`) that filters workspace packages to feature packages (those with `./extensions` exports or `module-federation` config) and collects their `name`, `version`, and optional `supportLevel`.
- Injected the collected metadata into the frontend bundle via webpack `DefinePlugin` as `__PACKAGE_VERSIONS__`, gated to development builds only — production builds receive an empty array since there is no automatic versioning infrastructure in place yet.
- Updated the About modal to render an expandable sub-table under the Dashboard component row showing each package's name, version, and human-readable support level (GA → "Generally Available", TP → "Technology Preview", DP → "Developer Preview", or `--` if unset).
- The sub-table is expanded by default. When collapsed, a hint ("Includes N packages. Expand for more details.") is shown. Non-Dashboard component rows are unaffected.
- 
**Why:** In a local development build, the DSC status that normally populates component release versions is not available. This change lets developers see which feature packages are included, their versions, and their support classification directly in the About modal.

https://github.com/user-attachments/assets/3b343c5b-3e90-443a-a664-59a575d6b119

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- **Unit tests**: Ran `AboutDialog.spec.tsx` — all 5 tests pass, covering: ODH values, RHOAI values, empty package list, full rendering with sorting/expand/collapse, and fallback `--` for missing support levels.
- **TypeScript check**: `tsc --noEmit` passes with no errors.
- **Production build verification**: Ran `npm run build` and confirmed via bundle analysis that no package version data is present in the production output — `__PACKAGE_VERSIONS__` is replaced with `[]` at compile time.
- **Lint**: Pre-commit hooks (eslint + prettier) pass on all changed files.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- **Unit tests added** (`frontend/src/app/__tests__/AboutDialog.spec.tsx`):
  - `should not show packages table when __PACKAGE_VERSIONS__ is empty`
  - `should show packages table with versions and support levels when Dashboard row is expanded`
  - `should show -- for packages without a support level`
- **Cypress mocked tests added** (`packages/cypress/cypress/tests/mocked/applications/application.cy.ts`):
  - `should show package versions table expanded by default under Dashboard` — validates table presence, column headers, row data (version + support level), and expand/collapse behavior.
- **Cypress page object extended** (`packages/cypress/cypress/pages/aboutDialog.ts`):
  - Added `expandDashboardRow()`, `findPackageVersionsTable()`, `getPackageRow()` helpers.
- **Jest setup updated** (`packages/jest-config/config/jest.setup.ts`):
  - Added `__PACKAGE_VERSIONS__` global declaration and default empty value for test environments.
 
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Installed Packages" table in the About dialog displaying package names, versions, and support levels (Technical Preview, Developer Preview, Generally Available).
  * Made the Dashboard row expandable to show/hide the packages table.

* **Tests**
  * Added unit and end-to-end tests for the new packages feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->