### PR TITLE
fix: use EvalHubHealthStatus type in mock options to fix TS2322

### DIFF
--- a/packages/eval-hub/frontend/src/__mocks__/mockEvalHubHealth.ts
+++ b/packages/eval-hub/frontend/src/__mocks__/mockEvalHubHealth.ts
@@ -1,12 +1,7 @@
-import { EvalHubHealthResponse, EvalHubHealthStatus } from '~/app/types';
-
-type MockEvalHubHealthOptions = Partial<{
-  status: EvalHubHealthStatus;
-  available: boolean;
-}>;
+import { EvalHubHealthResponse } from '~/app/types';
 
 export const mockEvalHubHealth = (
-  options: MockEvalHubHealthOptions = {},
+  options: Partial<EvalHubHealthResponse> = {},
 ): EvalHubHealthResponse => ({
   status: options.status ?? 'healthy',
   available: options.available ?? true,

--- a/packages/eval-hub/frontend/src/__mocks__/mockEvalHubHealth.ts
+++ b/packages/eval-hub/frontend/src/__mocks__/mockEvalHubHealth.ts
@@ -1,7 +1,7 @@
-import { EvalHubHealthResponse } from '~/app/types';
+import { EvalHubHealthResponse, EvalHubHealthStatus } from '~/app/types';
 
 type MockEvalHubHealthOptions = Partial<{
-  status: string;
+  status: EvalHubHealthStatus;
   available: boolean;
 }>;
 


### PR DESCRIPTION
## Description

The `MockEvalHubHealthOptions` type declared `status` as `string`, but `EvalHubHealthResponse.status` expects `EvalHubHealthStatus` (`'healthy' | 'service-unreachable' | 'cr-not-found'`). The `??` fallback widened the type to `string`, causing TS2322.

Fixed by importing `EvalHubHealthStatus` and using it in the mock options type so the nullish coalescing narrows correctly.

## How Has This Been Tested?

- Verified `npm run type-check` passes in `packages/eval-hub/frontend`
- No UI changes

## Test Impact

This is a type-only fix in a mock file. No additional tests needed — the TypeScript compiler now catches invalid status values at the call site.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in test mocks for health responses by aligning mock inputs with the actual response shape. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->