### PR TITLE
Fix dev proxy auth header forwarding in federated modules

### DIFF
--- a/packages/automl/frontend/config/webpack.dev.js
+++ b/packages/automl/frontend/config/webpack.dev.js
@@ -28,33 +28,54 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/automl/' : PUBLIC_PATH;
 
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -89,6 +110,7 @@ module.exports = smp.wrap(
             target: `${PROXY_PROTOCOL}://${PROXY_HOST}:${PROXY_PORT}`,
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/autorag/frontend/config/webpack.dev.js
+++ b/packages/autorag/frontend/config/webpack.dev.js
@@ -28,33 +28,54 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/autorag/' : PUBLIC_PATH;
 
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -93,6 +114,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/eval-hub/frontend/config/webpack.dev.js
+++ b/packages/eval-hub/frontend/config/webpack.dev.js
@@ -29,33 +29,54 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/eval-hub/' : PUBLIC_PATH;
 
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -94,6 +115,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
           {
             context: ['/mlflow'],
@@ -104,6 +126,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/gen-ai/frontend/config/webpack.dev.js
+++ b/packages/gen-ai/frontend/config/webpack.dev.js
@@ -18,24 +18,39 @@ const DIST_DIR = process.env._DIST_DIR;
 const PUBLIC_PATH = process.env._PUBLIC_PATH;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 
-const getProxyHeaders = () => {
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync('oc whoami --show-token').toString().trim();
-      const username = execSync('oc whoami').toString().trim();
-      // eslint-disable-next-line no-console
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
+// Get the oc token at startup as a fallback for standalone dev mode.
+const getOcToken = () => {
+  try {
+    const token = execSync('oc whoami --show-token').toString().trim();
+    const username = execSync('oc whoami').toString().trim();
+    // eslint-disable-next-line no-console
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
   }
-  return {};
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getOcToken() : '';
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the oc token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = merge(
@@ -82,7 +97,7 @@ module.exports = merge(
             protocol: PROXY_PROTOCOL,
           },
           changeOrigin: true,
-          headers: getProxyHeaders(),
+          onProxyReq,
         },
       ],
     },

--- a/packages/maas/frontend/config/webpack.dev.js
+++ b/packages/maas/frontend/config/webpack.dev.js
@@ -28,32 +28,54 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/mod-arch/' : PUBLIC_PATH;
 
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      console.info('Logged in as user:', username);
-      return {
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -92,6 +114,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/mlflow/frontend/config/webpack.dev.js
+++ b/packages/mlflow/frontend/config/webpack.dev.js
@@ -27,28 +27,43 @@ const ROOT_NODE_MODULES = path.resolve(RELATIVE_DIRNAME, '../../../node_modules'
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = PUBLIC_PATH;
 
-const getProxyHeaders = () => {
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
   }
-  return {};
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -87,7 +102,7 @@ module.exports = smp.wrap(
             },
             pathRewrite: { '^/_bff/mlflow/api': '/api' },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/notebooks/upstream/workspaces/frontend/config/webpack.dev.js
+++ b/packages/notebooks/upstream/workspaces/frontend/config/webpack.dev.js
@@ -27,56 +27,36 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
 
-// Get the kubeconfig token at startup as a fallback for standalone dev mode.
-const getKubeconfigToken = () => {
-  try {
-    const token = execSync(
-      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-    )
-      .toString()
-      .trim();
-    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-      .toString()
-      .trim();
-    // eslint-disable-next-line no-console
-    console.info('Logged in as user:', username);
-    return token;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to get Kubernetes token:', error.message);
-    return '';
-  }
-};
-
-const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
-
-// Build static proxy headers for auth methods that don't need dynamic forwarding.
+// Function to generate headers based on deployment mode
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  // For user_token, auth headers are set dynamically in onProxyReq below.
+  if (AUTH_METHOD === 'user_token') {
+    try {
+      const token = execSync(
+        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+      )
+        .toString()
+        .trim();
+      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+        .toString()
+        .trim();
+      // eslint-disable-next-line no-console
+      console.info('Logged in as user:', username);
+      return {
+        Authorization: `Bearer ${token}`,
+        'x-forwarded-access-token': token,
+      };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to get Kubernetes token:', error.message);
+      return {};
+    }
+  }
   return {};
-};
-
-// When using user_token auth, dynamically forward the authorization header from the
-// incoming request if present (e.g. from a host backend proxy with dev impersonation).
-// Fall back to the kubeconfig token captured at startup for standalone dev mode.
-const onProxyReq = (proxyReq, req) => {
-  if (AUTH_METHOD !== 'user_token') {
-    return;
-  }
-  const incomingAuth = req.headers.authorization;
-  if (incomingAuth) {
-    proxyReq.setHeader('Authorization', incomingAuth);
-    const token = incomingAuth.replace(/^Bearer\s+/i, '');
-    proxyReq.setHeader('x-forwarded-access-token', token);
-  } else if (fallbackToken) {
-    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
-    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
-  }
 };
 
 module.exports = smp.wrap(
@@ -118,7 +98,6 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
-            onProxyReq,
           },
         ],
         devMiddleware: {

--- a/packages/notebooks/upstream/workspaces/frontend/config/webpack.dev.js
+++ b/packages/notebooks/upstream/workspaces/frontend/config/webpack.dev.js
@@ -27,36 +27,56 @@ const DEPLOYMENT_MODE = process.env._DEPLOYMENT_MODE;
 const AUTH_METHOD = process.env._AUTH_METHOD;
 const BASE_PATH = DEPLOYMENT_MODE === 'kubeflow' ? '/workspaces' : PUBLIC_PATH;
 
-// Function to generate headers based on deployment mode
+// Get the kubeconfig token at startup as a fallback for standalone dev mode.
+const getKubeconfigToken = () => {
+  try {
+    const token = execSync(
+      "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
+    )
+      .toString()
+      .trim();
+    const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
+      .toString()
+      .trim();
+    // eslint-disable-next-line no-console
+    console.info('Logged in as user:', username);
+    return token;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to get Kubernetes token:', error.message);
+    return '';
+  }
+};
+
+const fallbackToken = AUTH_METHOD === 'user_token' ? getKubeconfigToken() : '';
+
+// Build static proxy headers for auth methods that don't need dynamic forwarding.
 const getProxyHeaders = () => {
   if (AUTH_METHOD === 'internal') {
     return {
       'kubeflow-userid': 'user@example.com',
     };
   }
-  if (AUTH_METHOD === 'user_token') {
-    try {
-      const token = execSync(
-        "kubectl config view --raw --minify --flatten -o jsonpath='{.users[].user.token}'",
-      )
-        .toString()
-        .trim();
-      const username = execSync("kubectl auth whoami -o jsonpath='{.status.userInfo.username}'")
-        .toString()
-        .trim();
-      // eslint-disable-next-line no-console
-      console.info('Logged in as user:', username);
-      return {
-        Authorization: `Bearer ${token}`,
-        'x-forwarded-access-token': token,
-      };
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to get Kubernetes token:', error.message);
-      return {};
-    }
-  }
+  // For user_token, auth headers are set dynamically in onProxyReq below.
   return {};
+};
+
+// When using user_token auth, dynamically forward the authorization header from the
+// incoming request if present (e.g. from a host backend proxy with dev impersonation).
+// Fall back to the kubeconfig token captured at startup for standalone dev mode.
+const onProxyReq = (proxyReq, req) => {
+  if (AUTH_METHOD !== 'user_token') {
+    return;
+  }
+  const incomingAuth = req.headers.authorization;
+  if (incomingAuth) {
+    proxyReq.setHeader('Authorization', incomingAuth);
+    const token = incomingAuth.replace(/^Bearer\s+/i, '');
+    proxyReq.setHeader('x-forwarded-access-token', token);
+  } else if (fallbackToken) {
+    proxyReq.setHeader('Authorization', `Bearer ${fallbackToken}`);
+    proxyReq.setHeader('x-forwarded-access-token', fallbackToken);
+  }
 };
 
 module.exports = smp.wrap(
@@ -98,6 +118,7 @@ module.exports = smp.wrap(
             },
             changeOrigin: true,
             headers: getProxyHeaders(),
+            onProxyReq,
           },
         ],
         devMiddleware: {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-56705

## Description

Each federated module's webpack dev server captures the kubeconfig/oc token at startup as static proxy headers. This overwrites any dynamically forwarded auth headers from the host backend proxy, breaking dev impersonation (`DEV_IMPERSONATE_USER`/`DEV_IMPERSONATE_PASSWORD`).

This PR replaces the static `headers` approach with an `onProxyReq` callback that dynamically forwards the `Authorization` header from each incoming request when present, falling back to the startup-captured token for standalone dev mode.

**Modules fixed:**
- gen-ai (uses `oc whoami`)
- maas
- automl
- autorag
- eval-hub (both proxy entries)
- mlflow

**Not included:**
- `packages/notebooks/upstream/` — mirrors upstream kubeflow/notebooks; fix submitted upstream in https://github.com/kubeflow/notebooks/pull/1013
- `packages/model-registry/upstream/` — already fixed upstream in https://github.com/kubeflow/model-registry/pull/2544

## How Has This Been Tested?

Tested manually in the model-registry module (upstream fix) against an ODH cluster:
1. Started the host backend with `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` set
2. Verified the bug: with static headers, the impersonated user's token was overwritten by the startup token
3. Verified the fix: with `onProxyReq`, the incoming auth header from the host proxy is forwarded correctly, and impersonation works as expected

The same pattern is applied consistently to all other modules.

## Test Impact

This is a dev-only webpack config change (not shipped in production builds). No automated tests are applicable — webpack dev server proxy configuration is validated through manual dev workflow testing.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`