### PR TITLE
add event tracking for evalhub

### DIFF
--- a/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
+++ b/packages/eval-hub/bff/internal/integrations/evalhub/evalhub_client.go
@@ -249,6 +249,7 @@ type ProviderResource struct {
 // Fields match the official eval-hub API spec exactly.
 type ProviderBenchmark struct {
 	ID           string                         `json:"id"`
+	URL          string                         `json:"url,omitempty"`
 	Name         string                         `json:"name"`
 	Description  string                         `json:"description,omitempty"`
 	Category     string                         `json:"category,omitempty"`
@@ -296,6 +297,7 @@ type CollectionResource struct {
 // CollectionBenchmark represents a BenchmarkConfig entry within a collection.
 type CollectionBenchmark struct {
 	ID           string                  `json:"id"`
+	URL          string                  `json:"url,omitempty"`
 	ProviderID   string                  `json:"provider_id,omitempty"`
 	Weight       float64                 `json:"weight,omitempty"`
 	PrimaryScore *CollectionPrimaryScore `json:"primary_score,omitempty"`

--- a/packages/eval-hub/frontend/jest.config.js
+++ b/packages/eval-hub/frontend/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/config/transform.style.js',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/config/transform.file.js',
+    '#~/(.*)': '<rootDir>/../../../frontend/src/$1',
     '~/(.*)': '<rootDir>/src/$1',
   },
   testEnvironment: 'jest-environment-jsdom',

--- a/packages/eval-hub/frontend/src/__tests__/unit/testUtils/mocks.tsx
+++ b/packages/eval-hub/frontend/src/__tests__/unit/testUtils/mocks.tsx
@@ -39,5 +39,6 @@ export const mockProjectIconWithSizeModule = () => ({
 });
 
 export const mockIconSizeModule = () => ({
+  ...jest.requireActual('@odh-dashboard/internal/types'),
   IconSize: { LG: 'lg' },
 });

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkCard.tsx
@@ -10,8 +10,11 @@ import {
   Label,
   LabelGroup,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { FlatBenchmark } from '~/app/types';
-import { getCategoryColor, VISIBLE_METRICS_COUNT } from './benchmarkUtils';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
+import { getCategoryColor, toSafeExternalUrl, VISIBLE_METRICS_COUNT } from './benchmarkUtils';
 
 type BenchmarkCardProps = {
   benchmark: FlatBenchmark;
@@ -27,6 +30,7 @@ const BenchmarkCard: React.FC<BenchmarkCardProps> = ({
   onRunBenchmark,
 }) => {
   const color = getCategoryColor(benchmark.category);
+  const safeBenchmarkUrl = toSafeExternalUrl(benchmark.url);
 
   return (
     <Card
@@ -59,7 +63,29 @@ const BenchmarkCard: React.FC<BenchmarkCardProps> = ({
             marginTop: 'var(--pf-t--global--spacer--xs)',
           }}
         >
-          {benchmark.id}
+          {safeBenchmarkUrl ? (
+            <Button
+              variant="link"
+              isInline
+              component="a"
+              href={safeBenchmarkUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="end"
+              onClick={() =>
+                fireMiscTrackingEvent(EVAL_HUB_EVENTS.EXTERNAL_LINK_CLICKED, {
+                  url: safeBenchmarkUrl,
+                  benchmarkId: benchmark.id,
+                  surface: 'benchmark_card',
+                })
+              }
+            >
+              {benchmark.id}
+            </Button>
+          ) : (
+            benchmark.id
+          )}
         </Content>
       </CardTitle>
 

--- a/packages/eval-hub/frontend/src/app/components/BenchmarkDrawerPanel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/BenchmarkDrawerPanel.tsx
@@ -13,8 +13,11 @@ import {
   StackItem,
   Title,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { FlatBenchmark } from '~/app/types';
-import { getCategoryColor } from './benchmarkUtils';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
+import { getCategoryColor, toSafeExternalUrl } from './benchmarkUtils';
 
 type BenchmarkDrawerPanelProps = {
   benchmark: FlatBenchmark | undefined;
@@ -32,6 +35,7 @@ const BenchmarkDrawerPanel: React.FC<BenchmarkDrawerPanelProps> = ({
   }
 
   const color = getCategoryColor(benchmark.category);
+  const safeBenchmarkUrl = toSafeExternalUrl(benchmark.url);
 
   return (
     <DrawerPanelContent isResizable minSize="400px" data-testid="benchmark-drawer-panel">
@@ -55,7 +59,29 @@ const BenchmarkDrawerPanel: React.FC<BenchmarkDrawerPanelProps> = ({
                 color: 'var(--pf-t--global--text--color--subtle)',
               }}
             >
-              {benchmark.id}
+              {safeBenchmarkUrl ? (
+                <Button
+                  variant="link"
+                  isInline
+                  component="a"
+                  href={safeBenchmarkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  icon={<ExternalLinkAltIcon />}
+                  iconPosition="end"
+                  onClick={() =>
+                    fireMiscTrackingEvent(EVAL_HUB_EVENTS.EXTERNAL_LINK_CLICKED, {
+                      url: safeBenchmarkUrl,
+                      benchmarkId: benchmark.id,
+                      surface: 'benchmark_drawer',
+                    })
+                  }
+                >
+                  {benchmark.id}
+                </Button>
+              ) : (
+                benchmark.id
+              )}
             </Content>
           </StackItem>
         </Stack>

--- a/packages/eval-hub/frontend/src/app/components/CollectionDrawerPanel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/CollectionDrawerPanel.tsx
@@ -14,7 +14,11 @@ import {
   StackItem,
   Title,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { Collection } from '~/app/types';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
+import { toSafeExternalUrl } from './benchmarkUtils';
 
 type CollectionDrawerPanelProps = {
   collection: Collection | undefined;
@@ -77,17 +81,44 @@ const CollectionDrawerPanel: React.FC<CollectionDrawerPanelProps> = ({
                 <StackItem>
                   <Content component="h4">Benchmarks</Content>
                 </StackItem>
-                {collection.benchmarks.map((b) => (
-                  <StackItem key={`${b.provider_id ?? 'unknown'}-${b.id}`}>
-                    <Panel variant="bordered">
-                      <PanelMain>
-                        <PanelMainBody>
-                          <Content component="p">{b.id}</Content>
-                        </PanelMainBody>
-                      </PanelMain>
-                    </Panel>
-                  </StackItem>
-                ))}
+                {collection.benchmarks.map((b) => {
+                  const safeUrl = toSafeExternalUrl(b.url);
+                  return (
+                    <StackItem key={`${b.provider_id ?? 'unknown'}-${b.id}`}>
+                      <Panel variant="bordered">
+                        <PanelMain>
+                          <PanelMainBody>
+                            <Content component="p">
+                              {safeUrl ? (
+                                <Button
+                                  variant="link"
+                                  isInline
+                                  component="a"
+                                  href={safeUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  icon={<ExternalLinkAltIcon />}
+                                  iconPosition="end"
+                                  onClick={() =>
+                                    fireMiscTrackingEvent(EVAL_HUB_EVENTS.EXTERNAL_LINK_CLICKED, {
+                                      url: safeUrl,
+                                      benchmarkId: b.id,
+                                      surface: 'collection_drawer',
+                                    })
+                                  }
+                                >
+                                  {b.id}
+                                </Button>
+                              ) : (
+                                b.id
+                              )}
+                            </Content>
+                          </PanelMainBody>
+                        </PanelMain>
+                      </Panel>
+                    </StackItem>
+                  );
+                })}
               </Stack>
             </StackItem>
           )}

--- a/packages/eval-hub/frontend/src/app/components/EvalHubEmptyState.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvalHubEmptyState.tsx
@@ -9,6 +9,8 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
+import { fireSimpleTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 
 const EvalHubEmptyState: React.FC = () => {
   const navigate = useNavigate();
@@ -30,7 +32,10 @@ const EvalHubEmptyState: React.FC = () => {
           <Button
             variant="primary"
             data-testid="create-evaluation-button"
-            onClick={() => navigate('create')}
+            onClick={() => {
+              fireSimpleTrackingEvent(EVAL_HUB_EVENTS.START_EVALUATION_SELECTED);
+              navigate('create');
+            }}
           >
             Create new evaluation
           </Button>

--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
@@ -22,7 +22,9 @@ import {
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, ThProps } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
+import { fireSimpleTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { EvaluationJob } from '~/app/types';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import { getEvaluationName, getBenchmarkName } from '~/app/utilities/evaluationUtils';
 import { CollectionNameMap } from '~/app/hooks/useCollectionNameMap';
 import EvaluationsTableRow from './EvaluationsTableRow';
@@ -234,7 +236,10 @@ const EvaluationsTable: React.FC<EvaluationsTableProps> = ({
               <Button
                 variant="primary"
                 data-testid="create-evaluation-button"
-                onClick={() => navigate('create')}
+                onClick={() => {
+                  fireSimpleTrackingEvent(EVAL_HUB_EVENTS.START_EVALUATION_SELECTED);
+                  navigate('create');
+                }}
               >
                 New evaluation
               </Button>

--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
@@ -10,7 +10,9 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { EvaluationJob } from '~/app/types';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { EvaluationJob, EvaluationJobState } from '~/app/types';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import {
   formatDate,
   getAllBenchmarkNames,
@@ -31,7 +33,7 @@ type EvaluationsTableRowProps = {
   onActionComplete: () => void;
 };
 
-const IN_PROGRESS_STATES = new Set(['running', 'pending']);
+const IN_PROGRESS_STATES = new Set(['running', 'pending', 'stopping']);
 
 type ConfirmAction = 'stop' | 'delete' | null;
 
@@ -59,6 +61,61 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
     }
   }, [isInProgress]);
 
+  // Snapshot latest job data in a ref so the completion-tracking effect can
+  // read current values without being re-triggered by them.
+  const completionTrackingDataRef = React.useRef({
+    evaluationName,
+    benchmarkTypes: JSON.stringify(allBenchmarkNames),
+    createdAt: job.resource.created_at,
+    updatedAt: job.resource.updated_at,
+    errorMessage: job.status.message?.message,
+  });
+  completionTrackingDataRef.current = {
+    evaluationName,
+    benchmarkTypes: JSON.stringify(allBenchmarkNames),
+    createdAt: job.resource.created_at,
+    updatedAt: job.resource.updated_at,
+    errorMessage: job.status.message?.message,
+  };
+
+  const prevStateRef = React.useRef<EvaluationJobState>(job.status.state);
+
+  React.useEffect(() => {
+    const prevState = prevStateRef.current;
+    const currentState = job.status.state;
+    prevStateRef.current = currentState;
+
+    if (IN_PROGRESS_STATES.has(prevState) && !IN_PROGRESS_STATES.has(currentState)) {
+      const {
+        evaluationName: evalName,
+        benchmarkTypes,
+        createdAt,
+        updatedAt,
+        errorMessage,
+      } = completionTrackingDataRef.current;
+
+      const durationMs =
+        createdAt && updatedAt
+          ? new Date(updatedAt).getTime() - new Date(createdAt).getTime()
+          : undefined;
+
+      const runOutcome: 'completed' | 'failed' | 'cancelled' =
+        currentState === 'completed'
+          ? 'completed'
+          : currentState === 'cancelled' || currentState === 'stopped'
+            ? 'cancelled'
+            : 'failed';
+
+      fireMiscTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_COMPLETED, {
+        evaluationName: evalName,
+        runOutcome,
+        durationMs,
+        benchmarkTypes,
+        error: errorMessage,
+      });
+    }
+  }, [job.status.state]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleConfirm = async () => {
     if (!namespace) {
       setActionError('Namespace is required to perform this action');
@@ -76,6 +133,12 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
         setIsStopping(true);
       }
       await apiCall({});
+      if (!isStop) {
+        fireMiscTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_DELETED, {
+          evaluationName,
+          previousState: job.status.state,
+        });
+      }
       setConfirmAction(null);
       onActionComplete();
     } catch (e) {

--- a/packages/eval-hub/frontend/src/app/components/benchmarkUtils.ts
+++ b/packages/eval-hub/frontend/src/app/components/benchmarkUtils.ts
@@ -22,3 +22,15 @@ export const getCategoryColor = (category?: string): CategoryColor => {
 };
 
 export const VISIBLE_METRICS_COUNT = 3;
+
+export const toSafeExternalUrl = (raw?: string): string | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/eval-hub/frontend/src/app/pages/ChooseBenchmarkCollectionPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/ChooseBenchmarkCollectionPage.tsx
@@ -30,9 +30,11 @@ import {
 } from '@patternfly/react-core';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useCollections } from '~/app/hooks/useCollections';
 import { Collection } from '~/app/types';
 import { evaluationCreateRoute, evaluationStartRoute, evaluationsBaseRoute } from '~/app/routes';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import CollectionDrawerPanel from '~/app/components/CollectionDrawerPanel';
 import { getCategoryColor } from '~/app/components/benchmarkUtils';
 
@@ -63,6 +65,12 @@ const ChooseBenchmarkCollectionPage: React.FC = () => {
 
   const handleRunCollection = React.useCallback(
     (c: Collection) => {
+      fireMiscTrackingEvent(EVAL_HUB_EVENTS.BENCHMARK_RUN_SELECTED, {
+        runType: 'collection',
+        collectionName: c.name,
+        benchmarkTypes: JSON.stringify((c.benchmarks ?? []).map((b) => b.id)),
+        countOfBenchmarks: c.benchmarks?.length ?? 0,
+      });
       const params = new URLSearchParams({
         type: 'collection',
         collectionId: c.resource.id,

--- a/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/ChooseStandardisedBenchmarksPage.tsx
@@ -25,9 +25,11 @@ import {
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { useProviders } from '~/app/hooks/useProviders';
 import { FlatBenchmark } from '~/app/types';
 import { evaluationCreateRoute, evaluationStartRoute, evaluationsBaseRoute } from '~/app/routes';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import BenchmarkDrawerPanel from '~/app/components/BenchmarkDrawerPanel';
 import BenchmarkCard from '~/app/components/BenchmarkCard';
 import {
@@ -44,6 +46,11 @@ const ChooseStandardisedBenchmarksPage: React.FC = () => {
 
   const handleRunBenchmark = React.useCallback(
     (b: FlatBenchmark) => {
+      fireMiscTrackingEvent(EVAL_HUB_EVENTS.BENCHMARK_RUN_SELECTED, {
+        runType: 'single',
+        benchmarkTypes: JSON.stringify([b.id]),
+        countOfBenchmarks: 1,
+      });
       const params = new URLSearchParams({
         type: 'benchmark',
         providerId: b.providerId,

--- a/packages/eval-hub/frontend/src/app/pages/EvaluationResultsPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/EvaluationResultsPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@patternfly/react-icons';
 import { Link, useParams } from 'react-router-dom';
 import { loadRemote } from '@module-federation/runtime';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { DeploymentMode, useModularArchContext } from 'mod-arch-core';
 import { evaluationsBaseRoute } from '~/app/routes';
@@ -36,6 +37,7 @@ import {
 import BenchmarkResultCard from '~/app/components/BenchmarkResultCard';
 import BenchmarkResultDetails from '~/app/components/BenchmarkResultDetails';
 import InlineHelpIcon from '~/app/components/InlineHelpIcon';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 
 interface MlflowRunTabsProps {
   experimentId: string;
@@ -230,7 +232,14 @@ const EvaluationResultsPage: React.FC = () => {
                     benchmarkId={id}
                     job={job}
                     isSelected={selectedBenchmarkId === id}
-                    onClick={() => setSelectedBenchmarkId(id)}
+                    onClick={() => {
+                      setSelectedBenchmarkId(id);
+                      fireMiscTrackingEvent(EVAL_HUB_EVENTS.RESULT_BENCHMARK_CARD_SELECTED, {
+                        benchmarkId: id,
+                        evaluationName,
+                        collectionName: job.collection?.id,
+                      });
+                    }}
                   />
                 ))}
               </Gallery>

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -34,7 +34,13 @@ import {
   useMlflowExperiments,
   type MlflowExperiment,
 } from '@odh-dashboard/internal/concepts/mlflow';
+import {
+  fireFormTrackingEvent,
+  fireMiscTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { TrackingOutcome } from '@odh-dashboard/internal/concepts/analyticsTracking/trackingProperties';
 import { createEvaluationJob } from '~/app/api/k8s';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import buildEvaluationRequest from '~/app/utils/buildEvaluationRequest';
 import getErrorTitle from '~/app/utils/getErrorTitle';
 import {
@@ -117,6 +123,7 @@ const StartEvaluationRunPage: React.FC = () => {
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const abortControllerRef = React.useRef<AbortController | null>(null);
+  const experimentManuallyChangedRef = React.useRef(false);
 
   React.useEffect(
     () => () => {
@@ -245,11 +252,53 @@ const StartEvaluationRunPage: React.FC = () => {
       experimentTags: undefined,
     });
 
+    fireMiscTrackingEvent(EVAL_HUB_EVENTS.MLFLOW_EXPERIMENT_SELECTED, {
+      experimentSelection: isNewExperiment
+        ? 'new'
+        : !experimentManuallyChangedRef.current &&
+            selectedExperiment?.name === DEFAULT_EXPERIMENT_NAME
+          ? 'default'
+          : 'existing',
+      experimentName,
+    });
+
+    // Snapshot form state now so both success and error paths share the same properties.
+    const runTrackingProps = {
+      source: 'evaluations_page',
+      evaluationName: evaluationName.trim(),
+      sourceType:
+        inputMode === 'inference'
+          ? ('inference_endpoint' as const)
+          : ('pre_recorded_responses' as const),
+      modelName: inputMode === 'inference' ? modelName.trim() : undefined,
+      endpointOrigin: (() => {
+        if (inputMode !== 'inference') {
+          return undefined;
+        }
+        try {
+          return new URL(endpointUrl.trim()).origin;
+        } catch {
+          return undefined;
+        }
+      })(),
+      hasAPIKey: inputMode === 'inference' ? apiKeySecretRef.trim() !== '' : false,
+      sourceName: inputMode === 'prerecorded' ? sourceName.trim() : undefined,
+      hasDatasetURL: inputMode === 'prerecorded' ? datasetUrl.trim() !== '' : false,
+      hasAccessToken: inputMode === 'prerecorded' ? accessToken.trim() !== '' : false,
+      hasAdditionalArguments: showAdditionalArgs && additionalArgs.trim() !== '',
+      countOfAdditionalArguments: Object.keys(parsedArgs).length,
+    };
+
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
     try {
       await createEvaluationJob('', namespace ?? '', request)({ signal: controller.signal });
+      fireFormTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_RUN_STARTED, {
+        ...runTrackingProps,
+        outcome: TrackingOutcome.submit,
+        success: true,
+      });
       notification.success(
         'Evaluation started',
         `Evaluation "${evaluationName}" has been started.`,
@@ -260,6 +309,12 @@ const StartEvaluationRunPage: React.FC = () => {
         return;
       }
       const message = e instanceof Error ? e.message : 'An unknown error occurred.';
+      fireFormTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_RUN_STARTED, {
+        ...runTrackingProps,
+        outcome: TrackingOutcome.submit,
+        success: false,
+        errorName: e instanceof Error ? e.name : 'UnknownError',
+      });
       notification.error(getErrorTitle(e, 'Failed to start evaluation'), message);
     } finally {
       setIsSubmitting(false);
@@ -368,6 +423,7 @@ const StartEvaluationRunPage: React.FC = () => {
               onChange={() => {
                 setExperimentMode('existing');
                 setNewExperimentName('');
+                experimentManuallyChangedRef.current = true;
               }}
             />
 
@@ -377,7 +433,10 @@ const StartEvaluationRunPage: React.FC = () => {
                   workspace={namespace}
                   filter={EXPERIMENT_FILTER}
                   selection={selectedExperiment?.name}
-                  onSelect={setSelectedExperiment}
+                  onSelect={(exp) => {
+                    setSelectedExperiment(exp);
+                    experimentManuallyChangedRef.current = true;
+                  }}
                 />
               </div>
             )}
@@ -392,6 +451,7 @@ const StartEvaluationRunPage: React.FC = () => {
                 onChange={() => {
                   setExperimentMode('new');
                   setSelectedExperiment(undefined);
+                  experimentManuallyChangedRef.current = true;
                 }}
               />
             </div>
@@ -601,7 +661,20 @@ const StartEvaluationRunPage: React.FC = () => {
             <Button
               variant="link"
               data-testid="start-evaluation-cancel"
-              onClick={() => navigate(evaluationsBaseRoute(namespace))}
+              onClick={() => {
+                fireFormTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_RUN_STARTED, {
+                  source: 'evaluations_page',
+                  evaluationName: evaluationName.trim(),
+                  sourceType:
+                    inputMode === 'inference'
+                      ? ('inference_endpoint' as const)
+                      : ('pre_recorded_responses' as const),
+                  hasAPIKey: inputMode === 'inference' ? apiKeySecretRef.trim() !== '' : false,
+                  hasAdditionalArguments: showAdditionalArgs && additionalArgs.trim() !== '',
+                  outcome: TrackingOutcome.cancel,
+                });
+                navigate(evaluationsBaseRoute(namespace));
+              }}
             >
               Cancel
             </Button>

--- a/packages/eval-hub/frontend/src/app/tracking/evalhubTrackingConstants.ts
+++ b/packages/eval-hub/frontend/src/app/tracking/evalhubTrackingConstants.ts
@@ -1,0 +1,72 @@
+export const EVAL_HUB_EVENTS = {
+  PAGE_VIEWED: 'Evaluations Page Viewed',
+  START_EVALUATION_SELECTED: 'Evaluations Start Evaluation Selected',
+  EVALUATION_RUN_STARTED: 'Evaluations Evaluation Run Started',
+  EVALUATION_COMPLETED: 'Evaluations Evaluation Completed',
+  EVALUATION_DELETED: 'Evaluations Evaluation Deleted',
+  EXTERNAL_LINK_CLICKED: 'Evaluations External Link Clicked',
+  MLFLOW_EXPERIMENT_SELECTED: 'Evaluations MLFlow Experiment Selected',
+  RESULT_BENCHMARK_CARD_SELECTED: 'Evaluations Result Benchmark Card Selected',
+  BENCHMARK_RUN_SELECTED: 'Evaluations Benchmark Run Selected',
+} as const;
+
+/**
+ * `source` identifies which page/surface the user initiated the evaluation flow from.
+ * Currently always 'evaluations_page', but future entry points (e.g. a model detail
+ * page shortcut) would pass a different value so analysts can segment by origin.
+ */
+export type EvaluationRunStartedProperties = {
+  source: string;
+  evaluationName?: string;
+  sourceType?: 'inference_endpoint' | 'pre_recorded_responses';
+  modelName?: string;
+  endpointOrigin?: string;
+  hasAPIKey?: boolean;
+  sourceName?: string;
+  hasDatasetURL?: boolean;
+  hasAccessToken?: boolean;
+  hasAdditionalArguments?: boolean;
+  countOfAdditionalArguments?: number;
+  outcome?: string;
+  success?: boolean;
+  errorName?: string;
+};
+
+export type EvaluationCompletedProperties = {
+  evaluationName: string;
+  runOutcome: 'completed' | 'failed' | 'cancelled';
+  durationMs?: number;
+  /** JSON-serialised array of benchmark type IDs. */
+  benchmarkTypes?: string;
+  error?: string;
+};
+
+export type EvaluationDeletedProperties = {
+  evaluationName: string;
+  /** State the evaluation was in at the time of deletion (e.g. 'completed', 'failed', 'running'). */
+  previousState: string;
+};
+
+export type ExternalLinkClickedProperties = {
+  href: string;
+  section?: string;
+};
+
+export type MlflowExperimentSelectedProperties = {
+  experimentSelection: 'default' | 'existing' | 'new';
+  experimentName?: string;
+};
+
+export type ResultBenchmarkCardSelectedProperties = {
+  benchmarkId: string;
+  evaluationName?: string;
+  collectionName?: string;
+};
+
+export type BenchmarkRunSelectedProperties = {
+  collectionName?: string;
+  /** Array of benchmark type IDs. Serialised as a JSON string when sent to Segment. */
+  benchmarkTypes: string[];
+  runType: 'single' | 'collection';
+  countOfBenchmarks: number;
+};

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -283,6 +283,7 @@ export type CollectionPassCriteria = {
 
 export type CollectionBenchmark = {
   id: string;
+  url?: string;
   provider_id?: string;
   weight?: number;
   primary_score?: CollectionPrimaryScore;
@@ -341,6 +342,7 @@ export type ProviderBenchmarkPassCriteria = {
 
 export type ProviderBenchmark = {
   id: string;
+  url?: string;
   name: string;
   description?: string;
   category?: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
closes: https://redhat.atlassian.net/browse/RHOAIENG-55891
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
<section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-4" class="markdown-section chat-fade-in" data-markdown-raw="

## Description
Adds Segment.io analytics event tracking across the EvalHub package to capture user interactions and evaluation lifecycle events for product telemetry." data-section-index="6" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Adds Segment.io analytics</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>event tracking across the EvalHub package to capture user interactions and</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>evaluation lifecycle events for product telemetry.</span></section><section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-8" class="markdown-section chat-fade-in" data-markdown-raw="
**Events instrumented:**" data-section-index="8" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="markdown-bold-text" style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Events instru</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">mented:</span></span></section><div class="monaco-scrollable-element mac markdown-table-container is-scrollable-right" role="presentation" style="scrollbar-width: none; overflow: hidden; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; margin: 1em 0px; width: fit-content; max-width: 100%; border-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px;"><div class="markdown-table-wrapper" style="--fade-start: rgba(0,0,0,.25); --fade-end: #000; --markdown-table-fade-width: 10px; mask-image: linear-gradient(to right, rgb(0, 0, 0) calc(100% - 10px), rgba(0, 0, 0, 0.25) 100%); --mask: linear-gradient(to right,#000 calc(100% - 10px),rgba(0,0,0,.25) 100%); overflow: hidden;">
Event | Surface | Details captured
-- | -- | --
EVALUATION_RUN_STARTED | Start Evaluation Run page | Source type, model name, endpoint URL, key presence, additional args count, outcome (submit/cancel/error)
EVALUATION_COMPLETED | Evaluations table row | Run outcome (completed/failed/cancelled), duration (ms), benchmark types, error message
EVALUATION_DELETED | Evaluations table row | Evaluation name, previous state
MLFLOW_EXPERIMENT_SELECTED | Start Evaluation Run page | Selection type (default/new/existing), experiment name
START_EVALUATION_SELECTED | Empty state CTA, table toolbar | —
BENCHMARK_RUN_SELECTED | Choose Benchmark Collection page, Choose Standardised Benchmarks page | Run type, collection/benchmark name, benchmark types, count
RESULT_BENCHMARK_CARD_SELECTED | Evaluation Results page | Benchmark ID, evaluation name
EXTERNAL_LINK_CLICKED | Benchmark Card, Benchmark Drawer Panel, Collection Drawer Panel | URL, benchmark ID, surface

</div><div role="presentation" aria-hidden="true" class="invisible scrollbar horizontal fade" style="opacity: 0; pointer-events: none; transition: opacity 0.8s linear; position: absolute; width: 802px; height: 10px; left: 0px; bottom: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(228, 228, 228, 0.07); position: absolute; top: 0px; left: 0px; height: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; width: 454px;"></div></div><div role="presentation" aria-hidden="true" class="invisible scrollbar vertical" style="opacity: 0; pointer-events: none; position: absolute; width: 0px; height: 274px; right: 0px; top: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(228, 228, 228, 0.07); position: absolute; top: 0px; left: 0px; width: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; height: 274px;"></div></div></div><section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-11" class="markdown-section chat-fade-in" data-markdown-raw="
All tracking constants are centralised in `~/app/tracking/evalhubTrackingConstants.ts` using the existing `fireMiscTrackingEvent`, `fireFormTrackingEvent`, and `fireSimpleTrackingEvent` utilities from `@odh-dashboard/internal`." data-section-index="11" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">All tracking</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>constants are centralised in<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">~/app/tracking/evalhubTrackingConstants.ts</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>using the existing<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">fireMiscTrackingEvent</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">,<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">fireFormTrackingEvent</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">, and<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">fireSimpleTrackingEvent</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>utilities from<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">@odh-dashboard/internal</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">.</span></section><section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-13" class="markdown-section chat-fade-in" data-markdown-raw="
Also adds an optional `url` field to the `CollectionBenchmark` and `ProviderBenchmark` TypeScript types to support rendering external benchmark links within the UI, and a minor update to `evalhub_client.go` in the BFF." data-section-index="13" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Also adds an optional<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">url</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>field to the<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">CollectionBenchmark</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>and<span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">ProviderBenchmark</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>TypeScript types to support rendering external</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>benchmark links within the UI, and a minor update to</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span></span><span class="markdown-inline-code leading-[1.4]" style="--tw-leading: 1.4; line-height: 1.4; animation: 0.25s ease 0s 1 normal none running fade-in; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">evalhub_client.go</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>in the BFF</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">.</span></section><section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-14" class="markdown-section chat-fade-in" data-markdown-raw="

## How Has This Been Tested?" data-section-index="14" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600 !important; font-size: 1.3em; line-height: 1.25; margin-bottom: 10px; margin-top: 20px;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">How Has This Been Tested?</span></h2></section><section id="markdown-section-b353920c-56cf-4deb-ad4f-baebc8a884bd-15" class="markdown-section chat-fade-in" data-markdown-raw="

- Manually verified each tracking event fires correctly using the Segment debugger / network tab in a local dev environment
- Tested the Start Evaluation Run form submit (success + error), cancel, and CTA click paths
- Verified evaluation completion, failure, and cancellation tracking by running evaluations through each terminal state
- Tested external link clicks from Benchmark Cards, Benchmark Drawer, and Collection Drawer panels
- Confirmed no regressions on the EvalHub Evaluations page, Results page, and benchmark selection flows" data-section-


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark IDs now become clickable external links (open in new tab, show external-link icon) when a safe URL is available; link clicks are tracked.
  * Benchmarks and providers can include optional external URLs.

* **Bug Fixes**
  * Evaluations transitioning to "stopping" are treated as in-progress for more accurate status and actions.

* **Chores**
  * App-wide analytics/telemetry added for runs, starts, cancels, completions, deletions, benchmark selections, and experiment choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->