### PR TITLE
Refactor extension functions

### DIFF
--- a/.claude/rules/modular-architecture.md
+++ b/.claude/rules/modular-architecture.md
@@ -95,6 +95,8 @@ packages/<name>/
 | Extensions codegen | `frontend/config/generateExtensionsPlugin.js` |
 | Extensions loader | `frontend/src/plugins/useAppExtensions.ts` |
 | Plugin store | `packages/plugin-core/src/core/plugin-store.ts` |
+| App actions (types/context) | `packages/plugin-core/src/core/app-actions.ts` |
+| App actions (provider) | `frontend/src/plugins/AppActionsProvider.tsx` |
 | Extension points | `packages/plugin-core/src/extension-points/` |
 | Area flags | `frontend/src/concepts/areas/types.ts`, `const.ts` |
 | Backend MF proxy | `backend/src/routes/module-federation.ts` |

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -537,3 +537,123 @@ import(/* webpackChunkName: "kserve-deploy" */ './src/deploy')
 // Avoid: generic name may collide with other plugins
 import(/* webpackChunkName: "deploy" */ './src/deploy')
 ```
+
+## App Actions
+
+Extensions frequently need to perform app-level side effects — navigating to a page, showing a toast notification, or opening a modal — in response to user interactions such as kebab menu clicks. These operations normally require React context (router, Redux, etc.), which is not available inside plain extension callback functions.
+
+**`AppActions`** provides a framework-agnostic interface that the host application implements. Extension code can call these actions without importing React Router, Redux, or any host-internal module.
+
+### Available Actions
+
+| Action | Signature | Purpose |
+|--------|-----------|---------|
+| `navigate` | `(path: string) => void` | Navigate to an in-app route |
+| `notification.success` | `(title, message?, actions?) => void` | Show a success toast |
+| `notification.error` | `(title, message?, actions?) => void` | Show an error toast |
+| `notification.info` | `(title, message?, actions?) => void` | Show an info toast |
+| `notification.warning` | `(title, message?, actions?) => void` | Show a warning toast |
+| `openModal` | `(component, props?) => ModalRef` | Open a lazily loaded modal component |
+
+### Using in React Code (Extensions & Host)
+
+Inside any React component that renders within the host application tree, use the `useAppActions` hook:
+
+```tsx
+import { useAppActions } from '@odh-dashboard/plugin-core';
+
+const MyExtensionComponent: React.FC = () => {
+  const { navigate, notification } = useAppActions();
+
+  const handleDeploy = async () => {
+    try {
+      await deployModel(data);
+      notification.success('Model deployed', `${data.name} is now serving.`);
+      navigate(`/model-serving/${data.name}`);
+    } catch (e) {
+      notification.error('Deployment failed', e.message);
+    }
+  };
+
+  return <Button onClick={handleDeploy}>Deploy</Button>;
+};
+```
+
+### Using in Extension Functions (Non-React)
+
+Pass the `AppActions` instance as a parameter to extension callback functions. The host component that invokes the function obtains `AppActions` via `useAppActions()` and forwards it:
+
+```typescript
+// Extension point definition
+export type KebabActionExtension = Extension<
+  'my-plugin.resource/kebab-action',
+  {
+    label: string;
+    action: CodeRef<(resource: MyResource, actions: AppActions) => void | Promise<void>>;
+  }
+>;
+```
+
+```typescript
+// Extension implementation
+export const deleteAction = (resource: MyResource, actions: AppActions): void => {
+  actions.openModal(
+    () => import('./DeleteConfirmModal'),
+    { resourceName: resource.metadata.name },
+  );
+};
+```
+
+```tsx
+// Host component that executes the action
+const { notification, navigate, openModal } = useAppActions();
+const appActions = useAppActions();
+const [resolvedActions] = useResolvedExtensions(isKebabActionExtension);
+
+const menuItems = resolvedActions.map((ext) => ({
+  label: ext.properties.label,
+  onClick: () => ext.properties.action(resource, appActions),
+}));
+```
+
+### Opening Modals
+
+The `openModal` function lazily loads a React component and renders it. The component receives an `onClose` callback plus any additional props:
+
+```tsx
+// ConfirmDeleteModal.tsx (extension-owned component)
+type ConfirmDeleteModalProps = {
+  onClose: () => void;
+  resourceName: string;
+};
+
+const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({ onClose, resourceName }) => (
+  <Modal isOpen onClose={onClose} title="Confirm Delete">
+    <p>Delete {resourceName}?</p>
+    <Button onClick={onClose}>Cancel</Button>
+    <Button variant="danger" onClick={() => { /* delete logic */ onClose(); }}>
+      Delete
+    </Button>
+  </Modal>
+);
+
+export default ConfirmDeleteModal;
+```
+
+```typescript
+// Opening from an extension function
+const ref = actions.openModal(
+  () => import('./ConfirmDeleteModal'),
+  { resourceName: 'my-model' },
+);
+
+// Programmatic close (optional)
+ref.close();
+```
+
+### Design Guidelines
+
+1. **Keep actions simple** — `AppActions` is intentionally a thin interface. Complex workflows should still live in dedicated extension components.
+2. **Prefer `AppActions` over custom event bridges** — instead of dispatching custom DOM events for cross-boundary communication, pass `AppActions` through the extension function contract.
+3. **Type your modal props** — although `openModal` accepts `Record<string, unknown>` for props, the modal component itself should define a precise props type for safety.
+4. **Use `useAppActions` in React, pass explicitly in functions** — React code should use the hook; plain functions should receive `AppActions` as a parameter from the calling component.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -548,12 +548,12 @@ Extensions frequently need to perform app-level side effects — navigating to a
 
 | Action | Signature | Purpose |
 |--------|-----------|---------|
-| `navigate` | `(path: string) => void` | Navigate to an in-app route |
+| `navigate` | `(path, options?) => void` | Navigate to an in-app route (options: `{ state?, replace? }`) |
 | `notification.success` | `(title, message?, actions?) => void` | Show a success toast |
 | `notification.error` | `(title, message?, actions?) => void` | Show an error toast |
 | `notification.info` | `(title, message?, actions?) => void` | Show an info toast |
 | `notification.warning` | `(title, message?, actions?) => void` | Show a warning toast |
-| `openModal` | `(component, props?) => ModalRef` | Open a lazily loaded modal component |
+| `openModal` | `(component, props?) => ModalRef` | Open a modal component |
 
 ### Using in React Code (Extensions & Host)
 
@@ -581,44 +581,76 @@ const MyExtensionComponent: React.FC = () => {
 
 ### Using in Extension Functions (Non-React)
 
-Pass the `AppActions` instance as a parameter to extension callback functions. The host component that invokes the function obtains `AppActions` via `useAppActions()` and forwards it:
+Pass the `AppActions` instance as a parameter to extension callback functions. The host
+component obtains `AppActions` via `useAppActions()` and forwards it when calling the
+extension's `CodeRef` function. The extension registers a lazy import in its extensions
+array, and the implementation is a plain function in a separate file.
+
+#### Example: extension-contributed row actions
+
+> **Note**: The `ModelRegistryRowAction` extension point below is a **hypothetical future example**
+> shown to illustrate the pattern. It is not implemented in the codebase today.
+
+A model registry table row could define an extension point that lets other packages contribute row actions. The extension function is plain — no hooks, no context — and receives `AppActions` from the host:
 
 ```typescript
-// Extension point definition
-export type KebabActionExtension = Extension<
-  'my-plugin.resource/kebab-action',
+// 1. Extension point definition (model-registry)
+type ModelRegistryRowAction = Extension<
+  'model-registry.registered-model/row-action',
   {
-    label: string;
-    action: CodeRef<(resource: MyResource, actions: AppActions) => void | Promise<void>>;
+    platform: string;
+    title: string;
+    onClick: CodeRef<(model: RegisteredModel, actions: AppActions) => void>;
+    isDisabled?: CodeRef<(model: RegisteredModel) => boolean>;
   }
 >;
 ```
 
 ```typescript
-// Extension implementation
-export const deleteAction = (resource: MyResource, actions: AppActions): void => {
-  actions.openModal(
-    () => import('./DeleteConfirmModal'),
-    { resourceName: resource.metadata.name },
-  );
+// 2. Extension registration (another-package/extensions.ts) — CodeRef lazy import
+const extensions: Extension[] = [
+  {
+    type: 'model-registry.registered-model/row-action',
+    properties: {
+      platform: 'my-platform',
+      title: 'Export to catalog',
+      onClick: () => import('./src/actions').then((m) => m.exportAction),
+    },
+  },
+];
+```
+
+```typescript
+// 3. Extension implementation (another-package/src/actions.ts) — plain function, no React
+export const exportAction = async (
+  model: RegisteredModel,
+  actions: AppActions,
+): Promise<void> => {
+  await exportModel(model);
+  actions.notification.success('Model exported', `${model.name} was exported to the catalog.`);
+  actions.navigate('/catalog');
 };
 ```
 
 ```tsx
-// Host component that executes the action
-const { notification, navigate, openModal } = useAppActions();
-const appActions = useAppActions();
-const [resolvedActions] = useResolvedExtensions(isKebabActionExtension);
+// 4. Host wiring (RegisteredModelTableRow.tsx)
+const actions = useAppActions();
+const [rowActionExtensions] = useResolvedExtensions(isModelRegistryRowAction);
 
-const menuItems = resolvedActions.map((ext) => ({
-  label: ext.properties.label,
-  onClick: () => ext.properties.action(resource, appActions),
+const extensionActions: IAction[] = rowActionExtensions.map((ext) => ({
+  title: ext.properties.title,
+  onClick: () => ext.properties.onClick(rm, actions),
 }));
+
+// Merge with hardcoded actions
+<ActionsColumn items={[...baseActions, ...extensionActions]} />
 ```
+
+Without `AppActions`, the extension's `onClick` function could not navigate or show a toast — it has no access to React Router or Redux. The host bridges this gap by passing `AppActions` as a parameter.
 
 ### Opening Modals
 
-The `openModal` function lazily loads a React component and renders it. The component receives an `onClose` callback plus any additional props:
+`openModal` accepts a React component and renders it. The host injects `onClose` (which unmounts the modal); if the caller also passes `onClose`, both run when the modal closes:
 
 ```tsx
 // ConfirmDeleteModal.tsx (extension-owned component)
@@ -641,19 +673,35 @@ export default ConfirmDeleteModal;
 ```
 
 ```typescript
-// Opening from an extension function
-const ref = actions.openModal(
-  () => import('./ConfirmDeleteModal'),
-  { resourceName: 'my-model' },
-);
+import ConfirmDeleteModal from './ConfirmDeleteModal';
 
-// Programmatic close (optional)
-ref.close();
+// Opening from an extension function
+actions.openModal(ConfirmDeleteModal, { resourceName: 'my-model' });
+```
+
+#### Closing modals
+
+When the modal component calls `onClose`, the provider automatically unmounts it. If the
+caller also passes `onClose` in props, both run — the provider cleans up first, then the
+caller's callback fires with any arguments the modal passed (e.g. a confirmation boolean).
+
+Some modals have actions (like `onSubmit` or `buttonActions`) that don't call `onClose`
+internally. In these cases, use the `ModalRef` returned by `openModal` to close
+programmatically:
+
+```typescript
+const ref = actions.openModal(ConnectionModal, {
+  type: locationType,
+  onSubmit: (connection) => {
+    fillForm(connection);
+    ref.close();
+  },
+});
 ```
 
 ### Design Guidelines
 
 1. **Keep actions simple** — `AppActions` is intentionally a thin interface. Complex workflows should still live in dedicated extension components.
 2. **Prefer `AppActions` over custom event bridges** — instead of dispatching custom DOM events for cross-boundary communication, pass `AppActions` through the extension function contract.
-3. **Type your modal props** — although `openModal` accepts `Record<string, unknown>` for props, the modal component itself should define a precise props type for safety.
+3. **Type your modal props** — `openModal` infers required props from the component type, so define a precise props interface on the modal component.
 4. **Use `useAppActions` in React, pass explicitly in functions** — React code should use the hook; plain functions should receive `AppActions` as a parameter from the calling component.

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -28,6 +28,7 @@ import { IntegrationsStatusProvider } from '#~/concepts/integrations/Integration
 import { NotificationWatcherContextProvider } from '#~/concepts/notificationWatcher/NotificationWatcherContext';
 import { AccessReviewProvider } from '#~/concepts/userSSAR';
 import { ExtensibilityContextProvider } from '#~/plugins/ExtensibilityContext';
+import AppActionsProvider from '#~/plugins/AppActionsProvider';
 import useFetchDscStatus from '#~/concepts/areas/useFetchDscStatus';
 import { PluginStoreAreaFlagsProvider } from '#~/plugins/PluginStoreAreaFlagsProvider';
 import { OdhPlatformType } from '#~/types';
@@ -147,58 +148,60 @@ const App: React.FC = () => {
   }
 
   return (
-    <DashboardConfigContext.Provider value={dashboardConfig.spec}>
-      <AppContext.Provider value={contextValue}>
-        <AreaContextProvider flags={devFeatureFlagsProps.devFeatureFlags}>
-          <PluginStoreAreaFlagsProvider />
-          <AccessReviewProvider>
-            <Page
-              className="odh-dashboard"
-              isManagedSidebar
-              isContentFilled
-              masthead={
-                <Header
-                  dashboardConfig={dashboardConfig.spec.dashboardConfig}
-                  {...devFeatureFlagsProps}
-                  onNotificationsClick={() => setNotificationsOpen(!notificationsOpen)}
-                />
-              }
-              sidebar={isAllowed ? <NavSidebar /> : undefined}
-              notificationDrawer={
-                <AppNotificationDrawer onClose={() => setNotificationsOpen(false)} />
-              }
-              isNotificationDrawerExpanded={notificationsOpen}
-              mainContainerId={DASHBOARD_MAIN_CONTAINER_ID}
-              data-testid={DASHBOARD_MAIN_CONTAINER_ID}
-              banner={
-                <DevFeatureFlagsBanner
-                  dashboardConfig={dashboardConfig.spec.dashboardConfig}
-                  {...devFeatureFlagsProps}
-                />
-              }
-            >
-              <ErrorBoundary>
-                <IntegrationsStatusProvider>
-                  <ProjectsContextProvider>
-                    <HardwareProfilesContextProvider>
-                      <ModelRegistriesContextProvider>
-                        <QuickStarts>
-                          <NotificationWatcherContextProvider>
-                            <AppRoutes />
-                          </NotificationWatcherContextProvider>
-                        </QuickStarts>
-                      </ModelRegistriesContextProvider>
-                    </HardwareProfilesContextProvider>
-                  </ProjectsContextProvider>
-                </IntegrationsStatusProvider>
-                <ToastNotifications />
-                <TelemetrySetup />
-              </ErrorBoundary>
-            </Page>
-          </AccessReviewProvider>
-        </AreaContextProvider>
-      </AppContext.Provider>
-    </DashboardConfigContext.Provider>
+    <AppActionsProvider>
+      <DashboardConfigContext.Provider value={dashboardConfig.spec}>
+        <AppContext.Provider value={contextValue}>
+          <AreaContextProvider flags={devFeatureFlagsProps.devFeatureFlags}>
+            <PluginStoreAreaFlagsProvider />
+            <AccessReviewProvider>
+              <Page
+                className="odh-dashboard"
+                isManagedSidebar
+                isContentFilled
+                masthead={
+                  <Header
+                    dashboardConfig={dashboardConfig.spec.dashboardConfig}
+                    {...devFeatureFlagsProps}
+                    onNotificationsClick={() => setNotificationsOpen(!notificationsOpen)}
+                  />
+                }
+                sidebar={isAllowed ? <NavSidebar /> : undefined}
+                notificationDrawer={
+                  <AppNotificationDrawer onClose={() => setNotificationsOpen(false)} />
+                }
+                isNotificationDrawerExpanded={notificationsOpen}
+                mainContainerId={DASHBOARD_MAIN_CONTAINER_ID}
+                data-testid={DASHBOARD_MAIN_CONTAINER_ID}
+                banner={
+                  <DevFeatureFlagsBanner
+                    dashboardConfig={dashboardConfig.spec.dashboardConfig}
+                    {...devFeatureFlagsProps}
+                  />
+                }
+              >
+                <ErrorBoundary>
+                  <IntegrationsStatusProvider>
+                    <ProjectsContextProvider>
+                      <HardwareProfilesContextProvider>
+                        <ModelRegistriesContextProvider>
+                          <QuickStarts>
+                            <NotificationWatcherContextProvider>
+                              <AppRoutes />
+                            </NotificationWatcherContextProvider>
+                          </QuickStarts>
+                        </ModelRegistriesContextProvider>
+                      </HardwareProfilesContextProvider>
+                    </ProjectsContextProvider>
+                  </IntegrationsStatusProvider>
+                  <ToastNotifications />
+                  <TelemetrySetup />
+                </ErrorBoundary>
+              </Page>
+            </AccessReviewProvider>
+          </AreaContextProvider>
+        </AppContext.Provider>
+      </DashboardConfigContext.Provider>
+    </AppActionsProvider>
   );
 };
 

--- a/frontend/src/plugins/AppActionsProvider.tsx
+++ b/frontend/src/plugins/AppActionsProvider.tsx
@@ -20,11 +20,10 @@ type ModalEntry = {
   props: Record<string, unknown>;
 };
 
-let modalIdCounter = 0;
-
 const AppActionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const modalIdCounter = React.useRef(0);
   const [modals, setModals] = React.useState<ModalEntry[]>([]);
 
   const removeModal = React.useCallback((id: string) => {
@@ -83,7 +82,7 @@ const AppActionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => 
 
   const openModal: AppActions['openModal'] = React.useCallback(
     (Component, props) => {
-      const id = String(++modalIdCounter);
+      const id = String(++modalIdCounter.current);
       const entry: ModalEntry = { id, Component, props: props ?? {} };
       setModals((prev) => [...prev, entry]);
       return {
@@ -95,7 +94,7 @@ const AppActionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => 
 
   const appActions: AppActions = React.useMemo(
     () => ({
-      navigate,
+      navigate: (path, options) => navigate(path, options),
       notification,
       openModal,
     }),

--- a/frontend/src/plugins/AppActionsProvider.tsx
+++ b/frontend/src/plugins/AppActionsProvider.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AlertVariant } from '@patternfly/react-core';
+import {
+  AppActionsContext,
+  type AppActions,
+  type AppNotificationAction,
+  type AppNotificationActions,
+} from '@odh-dashboard/plugin-core';
+import { addNotification } from '#~/redux/actions/actions';
+import { useAppDispatch } from '#~/redux/hooks';
+
+type ModalEntry = {
+  id: string;
+  // `any` is required because the generic prop type from openModal<P> is erased when
+  // stored in state — we can't parameterize ModalEntry over P. Type safety is enforced
+  // at the call site via the generic signature on AppActions['openModal'].
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Component: React.ComponentType<any>;
+  props: Record<string, unknown>;
+};
+
+let modalIdCounter = 0;
+
+const AppActionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const [modals, setModals] = React.useState<ModalEntry[]>([]);
+
+  const removeModal = React.useCallback((id: string) => {
+    setModals((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const notification: AppNotificationActions = React.useMemo(
+    () => ({
+      success: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.success,
+            title,
+            message,
+            actions,
+            timestamp: new Date(),
+          }),
+        );
+      },
+      error: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.danger,
+            title,
+            message,
+            actions,
+            timestamp: new Date(),
+          }),
+        );
+      },
+      info: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.info,
+            title,
+            message,
+            actions,
+            timestamp: new Date(),
+          }),
+        );
+      },
+      warning: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => {
+        dispatch(
+          addNotification({
+            status: AlertVariant.warning,
+            title,
+            message,
+            actions,
+            timestamp: new Date(),
+          }),
+        );
+      },
+    }),
+    [dispatch],
+  );
+
+  const openModal: AppActions['openModal'] = React.useCallback(
+    (Component, props) => {
+      const id = String(++modalIdCounter);
+      const entry: ModalEntry = { id, Component, props: props ?? {} };
+      setModals((prev) => [...prev, entry]);
+      return {
+        close: () => removeModal(id),
+      };
+    },
+    [removeModal],
+  );
+
+  const appActions: AppActions = React.useMemo(
+    () => ({
+      navigate,
+      notification,
+      openModal,
+    }),
+    [navigate, notification, openModal],
+  );
+
+  return (
+    <AppActionsContext.Provider value={appActions}>
+      {children}
+      {modals.map((modal) => (
+        <ModalRenderer key={modal.id} modal={modal} onRemove={() => removeModal(modal.id)} />
+      ))}
+    </AppActionsContext.Provider>
+  );
+};
+
+type ModalRendererProps = {
+  modal: ModalEntry;
+  onRemove: () => void;
+};
+
+const ModalRenderer: React.FC<ModalRendererProps> = ({ modal, onRemove }) => {
+  const { onClose: callerOnClose, ...rest } = modal.props;
+  const onClose = (...args: unknown[]) => {
+    onRemove();
+    if (typeof callerOnClose === 'function') {
+      callerOnClose(...args);
+    }
+  };
+  return <modal.Component {...rest} onClose={onClose} />;
+};
+
+export default AppActionsProvider;

--- a/frontend/src/plugins/__tests__/AppActionsProvider.spec.tsx
+++ b/frontend/src/plugins/__tests__/AppActionsProvider.spec.tsx
@@ -25,6 +25,12 @@ const TestConsumer: React.FC = () => {
       <button data-testid="navigate" onClick={() => actions.navigate('/test-path')}>
         Navigate
       </button>
+      <button
+        data-testid="navigate-options"
+        onClick={() => actions.navigate('/other', { state: { from: 'test' }, replace: true })}
+      >
+        Navigate with options
+      </button>
       <button data-testid="notify-success" onClick={() => actions.notification.success('Done')}>
         Success
       </button>
@@ -42,9 +48,7 @@ const TestConsumer: React.FC = () => {
       </button>
       <button
         data-testid="open-modal"
-        onClick={() =>
-          actions.openModal(MockModal, { title: 'Test Modal' })
-        }
+        onClick={() => actions.openModal(MockModal, { title: 'Test Modal' })}
       >
         Open Modal
       </button>
@@ -74,10 +78,25 @@ describe('AppActionsProvider', () => {
     );
 
     fireEvent.click(screen.getByTestId('navigate'));
-    expect(mockNavigate).toHaveBeenCalledWith('/test-path');
+    expect(mockNavigate).toHaveBeenCalledWith('/test-path', undefined);
   });
 
-  it('should provide notification actions', () => {
+  it('should pass options to navigate', () => {
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('navigate-options'));
+    expect(mockNavigate).toHaveBeenCalledWith('/other', {
+      state: { from: 'test' },
+      replace: true,
+    });
+  });
+
+  it('should dispatch success notification with correct payload', () => {
+    const { addNotification } = jest.requireMock('#~/redux/actions/actions');
     render(
       <AppActionsProvider>
         <TestConsumer />
@@ -85,19 +104,43 @@ describe('AppActionsProvider', () => {
     );
 
     fireEvent.click(screen.getByTestId('notify-success'));
-    expect(mockDispatch).toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', title: 'Done' }),
+    );
+  });
 
-    mockDispatch.mockClear();
+  it('should dispatch error notification with message', () => {
+    const { addNotification } = jest.requireMock('#~/redux/actions/actions');
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
     fireEvent.click(screen.getByTestId('notify-error'));
-    expect(mockDispatch).toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'danger', title: 'Failed', message: 'Details' }),
+    );
+  });
 
-    mockDispatch.mockClear();
+  it('should dispatch info and warning notifications', () => {
+    const { addNotification } = jest.requireMock('#~/redux/actions/actions');
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
     fireEvent.click(screen.getByTestId('notify-info'));
-    expect(mockDispatch).toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'info', title: 'Info' }),
+    );
 
-    mockDispatch.mockClear();
+    addNotification.mockClear();
     fireEvent.click(screen.getByTestId('notify-warning'));
-    expect(mockDispatch).toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'warning', title: 'Warn' }),
+    );
   });
 
   it('should open and close a modal', async () => {

--- a/frontend/src/plugins/__tests__/AppActionsProvider.spec.tsx
+++ b/frontend/src/plugins/__tests__/AppActionsProvider.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useAppActions } from '@odh-dashboard/plugin-core';
+import AppActionsProvider from '#~/plugins/AppActionsProvider';
+
+const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(() => mockNavigate),
+}));
+
+jest.mock('#~/redux/hooks', () => ({
+  useAppDispatch: jest.fn(() => mockDispatch),
+}));
+
+jest.mock('#~/redux/actions/actions', () => ({
+  addNotification: jest.fn((payload) => ({ type: 'ADD_NOTIFICATION', payload })),
+}));
+
+const TestConsumer: React.FC = () => {
+  const actions = useAppActions();
+  return (
+    <div>
+      <button data-testid="navigate" onClick={() => actions.navigate('/test-path')}>
+        Navigate
+      </button>
+      <button data-testid="notify-success" onClick={() => actions.notification.success('Done')}>
+        Success
+      </button>
+      <button
+        data-testid="notify-error"
+        onClick={() => actions.notification.error('Failed', 'Details')}
+      >
+        Error
+      </button>
+      <button data-testid="notify-info" onClick={() => actions.notification.info('Info')}>
+        Info
+      </button>
+      <button data-testid="notify-warning" onClick={() => actions.notification.warning('Warn')}>
+        Warning
+      </button>
+      <button
+        data-testid="open-modal"
+        onClick={() =>
+          actions.openModal(MockModal, { title: 'Test Modal' })
+        }
+      >
+        Open Modal
+      </button>
+    </div>
+  );
+};
+
+const MockModal: React.FC<{ onClose: () => void; title?: string }> = ({ onClose, title }) => (
+  <div data-testid="mock-modal">
+    <span data-testid="modal-title">{title}</span>
+    <button data-testid="close-modal" onClick={onClose}>
+      Close
+    </button>
+  </div>
+);
+
+describe('AppActionsProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should provide navigate action', () => {
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('navigate'));
+    expect(mockNavigate).toHaveBeenCalledWith('/test-path');
+  });
+
+  it('should provide notification actions', () => {
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('notify-success'));
+    expect(mockDispatch).toHaveBeenCalled();
+
+    mockDispatch.mockClear();
+    fireEvent.click(screen.getByTestId('notify-error'));
+    expect(mockDispatch).toHaveBeenCalled();
+
+    mockDispatch.mockClear();
+    fireEvent.click(screen.getByTestId('notify-info'));
+    expect(mockDispatch).toHaveBeenCalled();
+
+    mockDispatch.mockClear();
+    fireEvent.click(screen.getByTestId('notify-warning'));
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should open and close a modal', async () => {
+    render(
+      <AppActionsProvider>
+        <TestConsumer />
+      </AppActionsProvider>,
+    );
+
+    expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('open-modal'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('modal-title')).toHaveTextContent('Test Modal');
+
+    fireEvent.click(screen.getByTestId('close-modal'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should support closing modal via returned ref', async () => {
+    let modalRef: { close: () => void } | null = null;
+
+    const RefConsumer: React.FC = () => {
+      const actions = useAppActions();
+      return (
+        <div>
+          <button
+            data-testid="open"
+            onClick={() => {
+              modalRef = actions.openModal(MockModal);
+            }}
+          >
+            Open
+          </button>
+          <button data-testid="close-via-ref" onClick={() => modalRef?.close()}>
+            Close via ref
+          </button>
+        </div>
+      );
+    };
+
+    render(
+      <AppActionsProvider>
+        <RefConsumer />
+      </AppActionsProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('open'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('close-via-ref'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugin-core/src/core/__tests__/appActions.spec.tsx
+++ b/packages/plugin-core/src/core/__tests__/appActions.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { AppActionsContext, useAppActions, type AppActions } from '../app-actions';
+
+const mockAppActions: AppActions = {
+  navigate: jest.fn(),
+  notification: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+  },
+  openModal: jest.fn(() => ({ close: jest.fn() })),
+};
+
+describe('useAppActions', () => {
+  it('should throw when used outside of a provider', () => {
+    expect(() => renderHook(() => useAppActions())).toThrow(
+      'useAppActions must be used within an AppActionsProvider',
+    );
+  });
+
+  it('should return app actions when used within a provider', () => {
+    const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+      <AppActionsContext.Provider value={mockAppActions}>{children}</AppActionsContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAppActions(), { wrapper });
+
+    expect(result.current).toBe(mockAppActions);
+    expect(typeof result.current.navigate).toBe('function');
+    expect(typeof result.current.notification.success).toBe('function');
+    expect(typeof result.current.notification.error).toBe('function');
+    expect(typeof result.current.notification.info).toBe('function');
+    expect(typeof result.current.notification.warning).toBe('function');
+    expect(typeof result.current.openModal).toBe('function');
+  });
+});

--- a/packages/plugin-core/src/core/app-actions.ts
+++ b/packages/plugin-core/src/core/app-actions.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 
 /**
- * Notification severity levels for toast notifications.
- */
-export type AppNotificationStatus = 'success' | 'error' | 'info' | 'warning';
-
-/**
  * A clickable action rendered within a toast notification.
  */
 export type AppNotificationAction = {
@@ -44,7 +39,10 @@ export type ModalRef = {
  */
 export type AppActions = {
   /** Navigate to an in-app route. */
-  navigate: (path: string) => void;
+  navigate: (
+    path: string,
+    options?: { state?: Record<string, unknown>; replace?: boolean },
+  ) => void;
 
   /** Dispatch a toast notification. */
   notification: AppNotificationActions;

--- a/packages/plugin-core/src/core/app-actions.ts
+++ b/packages/plugin-core/src/core/app-actions.ts
@@ -1,0 +1,106 @@
+import * as React from 'react';
+
+/**
+ * Notification severity levels for toast notifications.
+ */
+export type AppNotificationStatus = 'success' | 'error' | 'info' | 'warning';
+
+/**
+ * A clickable action rendered within a toast notification.
+ */
+export type AppNotificationAction = {
+  title: string;
+  onClick: () => void;
+};
+
+/**
+ * Functions for dispatching toast notifications by severity.
+ *
+ * Each function accepts:
+ * - `title` — the notification headline
+ * - `message` — optional body content (supports React nodes for links, bold text, etc.)
+ * - `actions` — optional clickable actions rendered as buttons within the notification
+ */
+export type AppNotificationActions = {
+  success: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => void;
+  error: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => void;
+  info: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => void;
+  warning: (title: string, message?: React.ReactNode, actions?: AppNotificationAction[]) => void;
+};
+
+/**
+ * Handle returned by `openModal` that allows programmatic control of the modal.
+ */
+export type ModalRef = {
+  close: () => void;
+};
+
+/**
+ * App-level actions that extension functions can invoke without needing
+ * direct access to React context, hooks, or Redux.
+ *
+ * Obtain an instance via the `useAppActions()` hook in React code, or
+ * receive one as a parameter in extension callback functions.
+ */
+export type AppActions = {
+  /** Navigate to an in-app route. */
+  navigate: (path: string) => void;
+
+  /** Dispatch a toast notification. */
+  notification: AppNotificationActions;
+
+  /**
+   * Open a modal component.
+   *
+   * TypeScript infers the required props from the component type and enforces
+   * them on the `props` argument. The host always handles unmounting the modal;
+   * if the caller passes `onClose` in `props`, it is composed with the internal
+   * cleanup so both run when the modal closes. Arguments passed to `onClose` by
+   * the modal component (e.g. a confirmation boolean) are forwarded to the
+   * caller's `onClose`.
+   *
+   * Returns a `ModalRef` that can programmatically close the modal.
+   *
+   * @example
+   * ```ts
+   * // Simple — host provides onClose automatically
+   * actions.openModal(ConfirmDeleteModal, { resourceName: 'my-model' });
+   *
+   * // With close callback that receives modal arguments
+   * actions.openModal(StopModal, {
+   *   modelName: 'my-model',
+   *   onClose: (confirmed: boolean) => { if (confirmed) stopDeployment(); },
+   * });
+   *
+   * // Lazy loaded via React.lazy
+   * const LazyModal = React.lazy(() => import('./HeavyModal'));
+   * actions.openModal(LazyModal, { data });
+   * ```
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  openModal: <P extends { onClose: (...args: any[]) => void }>(
+    component: React.ComponentType<P>,
+    props?: Partial<Pick<P, 'onClose'>> & Omit<P, 'onClose'>,
+  ) => ModalRef;
+};
+
+/**
+ * React context that carries the current `AppActions` instance.
+ *
+ * The host application provides this via `AppActionsProvider`.
+ * Extensions consume it via `useAppActions()`.
+ */
+export const AppActionsContext = React.createContext<AppActions | null>(null);
+
+/**
+ * Returns the current `AppActions` instance.
+ *
+ * Must be called within an `AppActionsProvider`.
+ */
+export const useAppActions = (): AppActions => {
+  const ctx = React.useContext(AppActionsContext);
+  if (!ctx) {
+    throw new Error('useAppActions must be used within an AppActionsProvider');
+  }
+  return ctx;
+};

--- a/packages/plugin-core/src/core/index.ts
+++ b/packages/plugin-core/src/core/index.ts
@@ -1,3 +1,4 @@
+export * from './app-actions';
 export * from './DashboardConfigContext';
 export * from './helpers';
 export * from './plugin-store';


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-30947

## Description

Introduces the `AppActions` API — a framework-agnostic interface that lets extension functions perform common app-level side effects (navigation, toast notifications, opening modals) without directly depending on React context, hooks, or Redux.

**What's included:**

- **`AppActions` type and `useAppActions` hook** (`plugin-core`) — defines `navigate`, `notification` (success/error/info/warning), and `openModal` with `ModalRef` for programmatic close.
- **`AppActionsProvider`** (`frontend`) — concrete implementation wired into `App.tsx`, backed by React Router, Redux dispatch, and a local modal render list.
- **Documentation** (`docs/extensibility.md`) — new "App Actions" section covering React usage, the non-React `CodeRef` pattern (extension point → lazy registration → plain function implementation → host wiring), modal lifecycle, and design guidelines.
- **Unit tests** (`AppActionsProvider.spec.tsx`) — covers navigate (with options), all four notification variants with payload assertions, modal open/close, and `ModalRef.close()`.

**Why:**

Extension callback functions (e.g. kebab menu `onClick` handlers registered via `CodeRef`) execute outside React component trees and have no access to router or Redux context. `AppActions` bridges this gap — the host component calls `useAppActions()` and passes the instance into the extension's plain function, enabling navigation, toasts, and modals without any React imports in the extension code.

## How Has This Been Tested?

- Unit tests for `AppActionsProvider` (7 tests passing): navigate, navigate with options, notification payloads (success/error/info/warning), modal open/close via `onClose`, modal close via `ModalRef.close()`.
- Type-check passes for both `frontend` and `plugin-core`.
- Lint passes on all changed files (pre-existing markdown lint false positives in `docs/extensibility.md` are unchanged).

## Test Impact

- Added `frontend/src/plugins/__tests__/AppActionsProvider.spec.tsx` (7 tests) covering all `AppActions` APIs.
- Added `packages/plugin-core/src/core/__tests__/appActions.spec.tsx` for the `useAppActions` hook and context.
- No existing tests were modified or removed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] N/A — no UI/visual changes; this is an internal API and infrastructure addition.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensions can now perform app-level actions including route navigation, toast notifications with multiple severity levels, and modal management without requiring React or Redux dependencies.

* **Documentation**
  * Added extensibility guide documenting the app actions framework for plugins performing app-level side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->