### PR TITLE
jira triage skills

### DIFF
--- a/.claude/rules/jira-creation.md
+++ b/.claude/rules/jira-creation.md
@@ -16,12 +16,12 @@ User requests Jira creation (e.g., "create jira", "make jira tickets", "log a bu
 
 * **Project Key**: `RHOAIENG` (This is the primary project for Dashboard-related issues).
 * **Team Field**:
-  * ID: `customfield_12313240`
-  * Value: `'4158'` (This string value represents the "RHOAI Dashboard" team).
+  * ID: `customfield_10001` (Jira Teams / `atlassian-team`)
+  * Value: `"ec74d716-af36-4b3c-950f-f79213d08f71-1809"` (RHOAI Dashboard team)
 * **Component**: `'AI Core Dashboard'` (This string value should be used for the components field).
 * **Epic Link Custom Field ID** (for Stories/Tasks under an Epic): `customfield_12311140`.
 * **Verify Information**: Always confirm specific details like summaries, descriptions, parent epic keys, and any ambiguous fields with the user.
-* **Team Value is a STRING**: The team field value (`'4158'`) must be passed as a string.
+* **Team Value is a plain string**: Pass `{"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809"}` in `additional_fields`. Do NOT wrap in `{"id": "..."}` — the mcp-atlassian server expects the bare team ID string.
 * **Component is a STRING argument**: The `components` parameter is a direct top-level argument in the tool call.
 * **Iterative Creation**: If multiple issues are requested, create them one by one, confirming success or handling errors for each before proceeding.
 * **Error Handling**: If a tool call fails, analyze the error message. It often provides clues about field formats or missing required fields.
@@ -121,7 +121,7 @@ A defect in the product — e.g., something should be working but it is not. Thi
 * **Bugs are NOT**:
   * New functionality that is unlike existing functionality.
   * A way to "improve" things outside of "expected functionality" - e.g., "A form should submit cleanly and report k8s errors on the form" (expected) vs "A form should scroll to where the error is in the form" (new functionality).
-  * Tests that are broken (these should be Tasks).
+  * Tests that are broken, **including intermittent Cypress/CI flakes** (file as **Task**). A failing or flaky test does not by itself prove a user-facing product defect — use Task for spec/CI stability work unless the report documents reproducible broken **product** behavior.
 
 ### Information Gathering
 
@@ -163,7 +163,7 @@ summary="BUG: [User-provided summary]",
 description="[Formatted markdown string including Description, Steps, Actual, Expected, Reproducibility, and Acceptance Criteria]",
 components="AI Core Dashboard",
 additional_fields={
-	"customfield_12313240": "4158",  # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},     # e.g., "Critical", "Major", "Normal", "Minor" (See Appendix A)
 	"labels": ["..."]                # e.g., ["needs-info"] (See Appendix B for other general labels)
 }
@@ -179,6 +179,7 @@ A user-impact addition/change to the product — e.g., feature work to add parti
 
 * **Stories are NOT**:
   * Test additions (outside of expected tests accompanying new work - these are Tasks).
+  * Cypress/CI **flake** or spec-stability work (these are **Tasks**, not Stories or Bugs).
   * Fixes to defects in the product (these are Bugs).
 
 ### Information Gathering
@@ -212,7 +213,7 @@ summary="STORY: [User-provided summary]",
 description="[Formatted markdown string including Description of enhancement, Acceptance Criteria, and Additional info]",
 components="AI Core Dashboard",
 additional_fields={
-	"customfield_12313240": "4158",  # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},     # e.g., "Major", "Normal" (See Appendix A)
 	"labels": ["enhancement", "..."] # e.g., ["enhancement", "needs-ux"] (See Appendix B for other general labels)
 }
@@ -225,6 +226,8 @@ additional_fields={
 ### Definition
 
 A non-user facing change to the product — e.g., add a test, fix a test, or a refactor of code that does not impact the user (code cleanness / DRY / etc).
+
+* **Use Task for:** Cypress or CI **flakes** (intermittent failures, timing, unstable specs), E2E test stabilization, and similar work — consistent with triage rules that keep these as **Task**, not Bug.
 
 * **Tasks are NOT**:
   * New product functionality visible to the user.
@@ -259,7 +262,7 @@ summary="TASK: [User-provided summary]",
 description="[Formatted markdown string including Description of task, Acceptance Criteria, and Additional info]",
 components="AI Core Dashboard",
 additional_fields={
-	"customfield_12313240": "4158",  # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},     # e.g., "Normal", "Minor" (See Appendix A)
 	"labels": ["tech-debt", "..."]   # e.g., ["tech-debt", "needs-info"] (See Appendix B for other general labels)
 }
@@ -295,7 +298,7 @@ description="[Formatted markdown string for Story description, AC, and Additiona
 components="AI Core Dashboard",
 additional_fields={
 	"customfield_12311140": PARENT_EPIC_KEY,  # Epic Link field
-	"customfield_12313240": "4158",           # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},
 	"labels": ["enhancement", "..."]
 }
@@ -333,7 +336,7 @@ description="[Formatted markdown string for Task description, AC, and Additional
 components="AI Core Dashboard",
 additional_fields={
 	"customfield_12311140": PARENT_EPIC_KEY,  # Epic Link field
-	"customfield_12313240": "4158",           # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},
 	"labels": ["tech-debt", "..."]
 }
@@ -386,7 +389,7 @@ summary="EPIC: [User-provided Epic Name]",
 description="[User-provided concise, high-level description of what the Epic aims to accomplish]",
 components="AI Core Dashboard",  # Or other relevant components for the Epic
 additional_fields={
-	"customfield_12313240": "4158",  # Team: RHOAI Dashboard
+	"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809",  # Team: RHOAI Dashboard
 	"priority": {"name": "..."},     # e.g., "Major", "Critical"
 	"labels": ["..."]                # (See Appendix B for other general labels)
 }
@@ -424,7 +427,7 @@ These steps are typically for issues already created, but the principles guide f
    * **Informational**: Console output issues, React warnings.
    * *Note*: Set via `additional_fields`: `{"priority": {"name": "Blocker"}}` (or other levels).
 
-3. **Team**: Covered by `customfield_12313240: '4158'`.
+3. **Team**: Covered by `customfield_10001: "ec74d716-af36-4b3c-950f-f79213d08f71-1809"` (plain string, not `{"id": "..."}`).
 
 4. **Post-Creation Status**: API-created issues might start in 'New' or 'Backlog' depending on project workflow. If triaging implies moving from 'New' to 'Backlog', this might require a subsequent `mcp_atlassian_jira_transition_issue` call.
 

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -68,7 +68,7 @@ Wait for both the backend (port `4000`) and the frontend dev server (port `4010`
 
 Use the browser MCP's navigation tool to open:
 
-```
+```text
 http://localhost:4010/<path>
 ```
 

--- a/.claude/skills/jira-assign-scrum-team/SKILL.md
+++ b/.claude/skills/jira-assign-scrum-team/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: jira-assign-scrum-team
+description: Assign a scrum team label to issues based on area-to-scrum mapping and team keyword associations, producing ADD_LABEL operations in the standard triage format.
+---
+
+# Assign Scrum Team
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Maps area labels to scrum team labels using the Area-to-Scrum Default Mapping, with a keyword-based path for issues without area labels. Produces ADD_LABEL operations that flow into the Apply capability.
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides the Area-to-Scrum Default Mapping, Areas without a default team, and Team keyword / feature associations sections.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team**, produce **no operations** for that issue — do not assign `dashboard-*-scrum` labels for non-dashboard ownership. See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+All issue types processed by the triage pipeline. Every issue in the input set is evaluated.
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Summary | `summary` | Readability in output + keyword matching |
+| Description | `description` | Keyword matching when no area labels |
+| Labels | `labels` | Detect existing scrum and area labels |
+
+## Constraint: Single Scrum Label
+
+An issue must have at most **one** `dashboard-*-scrum` label. This skill never assigns more than one.
+
+## Procedure
+
+For each issue in the input set:
+
+### Step 1: Skip checks
+
+Skip the issue (produce no operations) if it already has any `dashboard-*-scrum` label. The scrum team has already been assigned, either by a human or a prior triage run.
+
+### Step 2: Collect effective area labels
+
+Build the set of area labels for this issue from two sources:
+
+1. **Existing labels**: Any `dashboard-area-*` label already on the issue in Jira.
+2. **Proposed labels**: Any `dashboard-area-*` label from ADD_LABEL operations produced by earlier pipeline steps (specifically validate-area-label). These labels have not been applied to Jira yet, but represent the pipeline's best assessment.
+
+The union of these two sources is the **effective area set**.
+
+### Step 3: Resolve scrum team
+
+Follow the resolution path that matches the issue's state:
+
+#### Path A: Area-based resolution (effective area set is non-empty)
+
+1. Build the **mapping set** used for scrum resolution: start from the effective area set (existing + proposed `dashboard-area-*` labels).
+2. **Cross-cutting test framework vs feature:** If the mapping set contains **`dashboard-area-cypress`** *and* at least **one other** `dashboard-area-*` label that maps to a **different** team in the Area-to-Scrum Default Mapping table, **remove `dashboard-area-cypress` from the mapping set** for this resolution only. Rationale: `dashboard-area-cypress` reflects shared **test-framework** ownership; a **feature** area identifies **which team owns the scenario under test** — that team gets the scrum label when it disagrees with the Cypress mapping. If removal leaves a single team, produce that scrum label (do not skip solely because the unfiltered set had two teams).
+3. **Generic manifests vs feature:** If the mapping set contains **`dashboard-area-manifests`** *and* at least **one other** `dashboard-area-*` label that maps to a **different** team than **Monarch** in the Area-to-Scrum Default Mapping table, **remove `dashboard-area-manifests` from the mapping set** for this resolution only. Rationale: the manifests area label marks **cross-cutting** `manifests/` / install work that defaults to Monarch; a **feature** area (model serving, MaaS, pipelines, etc.) identifies **which team owns deployment assets** for that capability — use that team when it disagrees with the generic manifests mapping. If removal leaves a single team, produce that scrum label. See `jira-project-reference.md` § **Manifests area and scrum routing**.
+4. Look up each remaining area label in the Area-to-Scrum Default Mapping table in `jira-project-reference.md`.
+5. Collect the set of distinct teams that the areas map to. Areas listed under "Areas without a default team" produce no mapping and are ignored.
+6. Evaluate the result:
+   - **One team**: All mapped areas agree. Produce an `ADD_LABEL` operation with the corresponding `dashboard-*-scrum` label.
+   - **Zero teams**: Every area in the mapped set is unmapped. Skip the issue.
+   - **Multiple teams**: The areas map to different scrum teams. Skip the issue.
+
+(Steps 2–3 above are **only** applied for scrum resolution; they do not remove labels from Jira — they adjust which area labels participate in the mapping-set lookup for this issue.)
+
+#### Path B: Keyword-based resolution (no area labels at all)
+
+When the effective area set is empty (no existing or proposed area labels), attempt resolution via the Team keyword / feature associations table in `jira-project-reference.md`.
+
+1. Read the issue's summary and description.
+2. Match content against each team's keywords in the associations table.
+3. Evaluate the result:
+   - **One team matches clearly**: Produce an `ADD_LABEL` operation with the corresponding `dashboard-*-scrum` label.
+   - **Multiple teams match** or **no match**: Skip the issue.
+
+Keyword matching follows the same principles as the area-label skill: multi-word phrases match first with higher weight, summary hits weigh more than description hits, and a single generic keyword alone is not sufficient.
+
+## Assessment Guidelines
+
+- **Do not force an assignment.** If the mapping is ambiguous or the keyword match is weak, skip. A skipped scrum assignment is surfaced in the triage summary comment for human review.
+- **Area-based resolution is strongly preferred** over keyword-based. Path B exists only as a catch-all for issues that somehow have no area labels after the full pipeline runs.
+- **Respect the mapping table.** Do not infer scrum team assignments beyond what the Area-to-Scrum Default Mapping and Team keyword / feature associations tables provide. If the tables don't cover a case, skip.
+- **Prefer feature team over framework label for scrum** when Path A drops `dashboard-area-cypress` per the mapping-set rule above; the human-facing backlog owner is the feature team unless the issue is truly Cypress-plumbing work.
+- **Prefer feature team over generic manifests for scrum** when Path A drops `dashboard-area-manifests` per step 3; deployment YAML tied to a feature routes to that feature’s team. Generic install-base / shared `manifests/` work with no feature area stays on **Monarch** via the manifests default mapping.
+- **Keep reasons concise** -- one sentence citing the area label(s) and the team they map to, or the keyword signal for Path B.
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). This skill emits only `ADD_LABEL` operations.
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**.
+
+## Examples
+
+### Area-based: single area, direct mapping
+
+Issue RHOAIENG-55100 ("InferenceService returns 500 after deploying model") has `dashboard-area-model-serving` (existing or proposed). Model serving maps to Zaffre.
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-27T10:00:00Z",
+    "query": "Triage batch of 6 new issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55100",
+      "summary": "InferenceService returns 500 after deploying model",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-zaffre-scrum"] },
+      "reason": "Area 'dashboard-area-model-serving' maps to Zaffre"
+    }
+  ]
+}
+```
+
+### Area-based: multiple areas, same team
+
+Issue RHOAIENG-55101 ("Pipeline run fails when workbench uses GPU hardware profile") has proposed labels `dashboard-area-pipelines` and `dashboard-area-hardware-profiles`. Both map to Razzmatazz.
+
+```json
+{
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55101",
+      "summary": "Pipeline run fails when workbench uses GPU hardware profile",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-razzmatazz-scrum"] },
+      "reason": "Areas 'dashboard-area-pipelines' and 'dashboard-area-hardware-profiles' both map to Razzmatazz"
+    }
+  ]
+}
+```
+
+### Area-based: multiple areas, conflicting teams -- skip
+
+Issue RHOAIENG-55102 ("Model registry integration with pipeline artifacts") has proposed labels `dashboard-area-model-registry` (Green) and `dashboard-area-pipelines` (Razzmatazz). Conflicting teams -- no operations produced.
+
+### Area-based: unmapped area only -- skip
+
+Issue RHOAIENG-55103 ("Edge deployment configuration page") has proposed label `dashboard-area-edge`. Edge has no default team mapping -- no operations produced.
+
+### Keyword-based: no area labels, keyword match
+
+Issue RHOAIENG-55104 ("Fix shared auth middleware across BFF modules") has no area labels. Summary matches Monarch keywords "shared auth", "middleware", "BFF".
+
+```json
+{
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55104",
+      "summary": "Fix shared auth middleware across BFF modules",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-monarch-scrum"] },
+      "reason": "Keywords 'shared auth', 'middleware', 'BFF' match Monarch team associations"
+    }
+  ]
+}
+```
+
+### Already assigned -- skip
+
+Issue RHOAIENG-55105 has `dashboard-green-scrum` already present. No operations produced regardless of area labels.

--- a/.claude/skills/jira-evaluate-blockers/SKILL.md
+++ b/.claude/skills/jira-evaluate-blockers/SKILL.md
@@ -1,0 +1,627 @@
+---
+name: jira-evaluate-blockers
+description: Analyze issues to apply needs-* labels and blocking state, and evaluate existing blockers for resolution signals.
+---
+
+# Evaluate Blockers
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Operates in two modes: **Tag** (apply needs-\* labels and blocking state during triage) and **Evaluate** (check whether existing blockers have been resolved). Produces operations that flow into the triage Apply capability.
+
+Implements [RHOAIENG-52419](https://redhat.atlassian.net/browse/RHOAIENG-52419).
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions, **fresh start**). The project reference provides needs-\* label criteria, blocking mechanism rules, and field IDs. Every invocation starts from scratch -- see `persona.md` § Fresh Start.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team**, produce **no operations** for that issue. See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+All issue types. Both bugs and stories/tasks can be blocked or require input from other roles.
+
+---
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Summary | `summary` | Readability in operations output |
+| Status | `status` | Context for blocking evaluation |
+| Labels | `labels` | Detect existing needs-\* labels |
+| Description | `description` | Content analysis for tagging |
+| Blocked | `customfield_10517` | Check current blocked state |
+| Blocked Reason | `customfield_10483` | Understand what the blocker is |
+| Issue Links | `issuelinks` | Check blocked-by links and their targets |
+| Created | `created` | Age context |
+| Updated | `updated` | Staleness signal |
+
+**Comments are required** for conversation thread analysis (Tag mode Step 4) and all resolution evaluations (Evaluate mode). If the issue data you received does not include a `comments` field, that means comments **were not fetched** — it does NOT mean the issue has zero comments. Before any step that reads comments, check whether they are present in the issue data; if not, fetch them via `jira_get_issue` with `fields=comment` and `comment_limit=20`.
+
+For **Evaluate mode**, fetch comments via per-issue `jira_get_issue` calls with `comment_limit=20` (if not already loaded) to check for resolution signals. This is O(N) API calls -- scope the issue set first using the JQL patterns below.
+
+---
+
+## Mode A: Tag
+
+Given a set of issues (typically from triage Fetch), analyze each issue and produce operations to apply the appropriate blocking mechanisms.
+
+### Procedure
+
+For each issue, read the description **and the comment thread** and evaluate against the criteria in `jira-project-reference.md` § Needs-\* Labels and § Blocking Mechanisms.
+
+**Chronological comment evaluation (applies to all steps).** Comments must be read in chronological order and evaluated for outstanding unanswered questions — this is a first-class signal for `needs-*` labels, not just a Step 4 concern. An unanswered question is a blocking signal regardless of the status of any referenced issues. The resolution of a blocking issue does not resolve questions that arose after — or independently of — that closure. Place comments, blocking issue closures, and field changes on a single timeline; evaluate what is still outstanding based on the sequence of events. See `persona.md` § Temporal Rigor.
+
+#### Step 1: Check for needs-\* label applicability
+
+Evaluate in order. An issue may qualify for multiple labels.
+
+**needs-info:**
+The generic catch-all for when we need information from a specific person we are pinging. Use when the block is conversational — someone needs to answer a question, confirm a decision, or provide missing context.
+- A clarifying question has been asked (in comments) with no response
+- Reporter was asked for information but hasn't responded
+- Stale blocking references where specific people need to confirm whether to proceed (see Step 4)
+
+**Important:** Description completeness (missing reproduction steps, environment details, expected behavior) is owned by the [validate-description](../jira-validate-description/SKILL.md) skill, which runs earlier in the Full Triage pipeline and applies `needs-info` when required sections are missing. Tag mode should **not** duplicate that assessment. Only apply `needs-info` here for conversational/interaction-level gaps (unanswered questions, requested info not yet provided).
+
+**needs-ux:**
+Anything UI design related. Use when the issue needs UX input before engineering can proceed.
+- Issue involves UI changes but has no mockups, wireframes, or design references
+- Description mentions visual or interaction changes without specifying the design
+- Issue explicitly calls out a need for UX review or design work
+- A discussion about whether/how something should look or behave from a design perspective is unresolved
+- Issue references or depends on a `RHOAIUX` project issue (see `jira-project-reference.md` § External Jira Projects) where the design question is unresolved. **Important:** A design question can be unresolved on the *current* issue even when the referenced RHOAIUX issue is Closed/Done. The RHOAIUX closure means the design exploration is complete — but if no one has confirmed on this issue how the outcome applies (e.g., whether the feature is included in the final design, or how the resolved designs affect this work), the question remains open. Evaluate the comment thread chronologically to determine whether the question has been answered.
+- An open question about layout, visual arrangement, card/column counts, or section composition exists — these are design decisions even when they feel like scope questions. This includes unanswered questions in the comment thread about design outcomes, even when the original blocking design issue has been resolved.
+
+**needs-pm:**
+Requires product direction, scope clarification, priority call, or acceptance criteria from Product Management; the team cannot determine what to build without PM input. This includes questions about whether customer need or business justification exists, or whether product direction has shifted making the work potentially irrelevant.
+- Scope or requirements are ambiguous and the team cannot determine what to build
+- Acceptance criteria are missing or contradictory
+- Issue involves a product-level trade-off (feature scope, priority call, customer impact)
+- Customer need or business justification is unclear
+- Product direction may have shifted, making the work potentially irrelevant
+
+**Guard rail:** Phrases like "disagreement about whether to do this" or "need final decision" can look like PM territory but often aren't. Before applying `needs-pm`, apply these checks in order:
+
+1. **Check the Jira project of any referenced blocker.** If the open question points to an issue in `RHOAIUX` or another role-specific project (see `jira-project-reference.md` § External Jira Projects), classify the dependency by that project's role — not as PM.
+2. **Check who the decision-maker is.** If the person asked to decide is a UX designer (or lives in the UX project), it's `needs-ux`. If it's a specific named individual in a non-PM role, it may be `needs-info`.
+3. **Check the nature of the decision.** Layout decisions (how many cards, columns, or items to show), visual arrangement, component placement, section composition, and interaction behavior are **design decisions** → `needs-ux`. Product direction, business justification, customer-need validation, feature scope trade-offs, and "should we build this at all" are **product decisions** → `needs-pm`.
+4. **If it's a conversation between specific people that went unanswered**, use `needs-info` with targeted pings — not a role-based label.
+
+**needs-advisor:**
+Architectural questions where the implementation path is unclear.
+- Multiple viable technical approaches exist with significant trade-offs
+- Implementation touches cross-cutting concerns (architecture, shared infrastructure)
+- Issue describes a problem but the solution path is unclear even to experienced developers
+
+For each applicable label not already present on the issue, produce an `ADD_LABEL` operation:
+
+```json
+{
+  "action": "ADD_LABEL",
+  "params": { "labels": ["needs-ux"] },
+  "reason": "UI changes described without mockups or design references"
+}
+```
+
+#### Step 2: Check for blocked-by link applicability
+
+Look for signals that the issue depends on a specific other Jira issue:
+- Description references another issue key (e.g., "depends on RHOAIENG-12345", "waiting for RHOAIENG-12345")
+- Description contains inline Jira card links (common in ADF content)
+- Blocked Reason field references a specific issue
+
+**Before creating a link, check the referenced issue's status.** The status of the referenced issue determines the correct action:
+
+- **Open/In Progress:** The dependency is still active. Produce a `LINK_BLOCKED_BY` operation.
+- **Closed/Resolved:** The dependency may have been satisfied. **Do not** automatically assume the block is cleared — the resolution may not have addressed the specific concern. Instead, this is a signal that the block is **stale** and needs follow-up (see Step 4).
+
+If a dependency is identified, the referenced issue is still open, and no blocked-by link already exists for that target, produce a `LINK_BLOCKED_BY` operation:
+
+```json
+{
+  "action": "LINK_BLOCKED_BY",
+  "params": { "blockedBy": "RHOAIENG-12345" },
+  "reason": "Description states dependency on backend API in RHOAIENG-12345"
+}
+```
+
+Do **not** auto-set the Blocked field when creating a link. The link itself communicates the dependency.
+
+#### Step 3: Check for Blocked field applicability
+
+Look for signals of external/structural blockers that are not a single Jira issue:
+- Waiting on a release or z-stream
+- Waiting on infrastructure or environment provisioning
+- Waiting on an external team outside the Jira project
+- Waiting on a vendor or third-party dependency
+
+If an external blocker is identified and Blocked is not already True, produce a `SET_FIELDS` operation:
+
+```json
+{
+  "action": "SET_FIELDS",
+  "params": {
+    "fields": {
+      "customfield_10517": { "value": "True" },
+      "customfield_10483": "Waiting on new z-stream release for the fix to ship"
+    }
+  },
+  "reason": "Issue requires a z-stream release that has not yet been cut"
+}
+```
+
+#### Step 4: Check for stale blocking references
+
+When the description or Blocked Reason references specific Jira issues, **check those issues' statuses** (available from the issue links or via a quick lookup). If the referenced issues are **Closed/Resolved** but the current issue still appears blocked or has unresolved questions about whether to proceed:
+
+1. **Ensure comments are loaded.** If the issue data does not include a `comments` field, fetch them now via `jira_get_issue` with `fields=comment` and `comment_limit=20`. Do not assume an absent `comments` field means zero comments — it means comments were not requested in the original fetch.
+2. **Run the conversation thread analysis** (see § Conversation thread analysis below) using the issue's comments. This identifies unanswered questions, pending parties, and the full context needed to compose an actionable ping.
+3. **Identify the relevant parties.** Who filed the blocking issue? Who filed the current issue? Who participated in the discussion? **Fetch the reporter and assignee of each referenced blocking issue** (via `jira_get_issue` with `fields=reporter,assignee`) — they have direct context on the resolution and whether it addresses the current issue's dependency. These are the people who can answer whether the block is cleared.
+4. **Determine the actual nature of the gap.** Classify the unanswered question using the same criteria and guard rail checks as Step 1 — the nature of the *question* determines the label, not the fact that it arose from a stale blocking reference:
+   - If the unanswered question is about **design, layout, visual arrangement, or section composition**, or the referenced blocking issue is in a **UX project** (e.g. `RHOAIUX`) → `needs-ux`
+   - If it's about **product direction, scope, or business justification** → `needs-pm`
+   - If it's about **technical approach** → `needs-advisor`
+   - If it's a **generic information request** or **confirmation whether to proceed** from a specific person with no role-specific nature → `needs-info`
+5. **Produce an `ADD_COMMENT`** pinging the specific people who can confirm whether the issue should proceed or be closed, citing the resolved blocking issues with full clickable URLs. Use the conversation thread analysis output to identify unanswered parties and frame the ping as a re-ping when a prior question went unanswered.
+6. **Produce an `ADD_LABEL`** with the appropriate `needs-*` label from step 4 to signal the issue is waiting on a response.
+
+**When to apply:** This step fires when ALL of the following are true:
+- The description or Blocked Reason explicitly references another Jira issue as a blocker or dependency
+- That referenced issue is now Closed/Resolved
+- The current issue has not been updated to reflect the resolution (still in New, no comments acknowledging the closure)
+- No one has confirmed whether the current issue should proceed
+
+**Distinguishing `needs-info` from `needs-pm`/`needs-ux`:** Phrases like "disagreement about whether to do this", "need final decision", or "blocked until resolved" in the description can look like a PM or UX decision is needed. **Before assigning a role-based `needs-*` label, trace who the actual parties in the conversation are.** If the unresolved question is between specific named individuals (e.g., a UX designer and the reporter), it's `needs-info` with targeted pings — not a generic role-based label. Role-based labels (`needs-pm`, `needs-ux`, `needs-advisor`) are for when the issue genuinely requires input from a role that has not yet been engaged.
+
+#### Step 5: Check for close suggestions in recent activity
+
+When the comment thread contains recent activity suggesting the issue should be closed — e.g., "this can be closed," "no longer relevant," "already fixed," "recommend closing," "this is a duplicate" — the issue should not be silently moved to Backlog. Instead, surface the suggestion by pinging the reporter and relevant parties for confirmation.
+
+**Detection criteria:** Look for comments (typically within the most recent ~5 comments or the last 30 days) where someone:
+- Explicitly suggests closure ("can be closed," "recommend closing," "should be resolved")
+- States the issue is no longer relevant ("no longer needed," "not applicable anymore," "outdated")
+- Claims the issue is already fixed without code-level verification ("I think this was fixed," "seems fixed now")
+- Suggests the issue is a duplicate or is covered by other work
+
+The suggestion must be **substantive** — a bare "close?" or "+1 close" is not sufficient. Evaluate who made the suggestion: comments from the reporter, assignee, a domain expert, or a team lead carry more weight than a drive-by comment from an uninvolved party.
+
+**When to apply:** This step fires when ALL of the following are true:
+- A comment contains a substantive close suggestion as described above
+- The suggestion is in the recent activity (within the most recent ~5 comments or last 30 days)
+- The issue has not already been acted on (no subsequent comment confirming or rejecting the suggestion, no status change reflecting it)
+- The reporter has not already confirmed closure in a subsequent comment
+
+**Producing operations:**
+
+1. **Run conversation thread analysis** before composing the comment. Trace the conversation flow to understand the close suggestion in context:
+   - **Who prompted the close suggestion?** If the close suggestion is a reply to someone's question (e.g., "is this still needed?" → "no, it can be closed"), the question-asker is a key party.
+   - **Who has already stated their position?** The close suggester has already given a clear recommendation. Do not re-ask them to "confirm or provide more detail" when their suggestion was already substantive — their position is on record.
+   - **Who hasn't acknowledged the suggestion?** If the suggestion was directed at (or prompted by) someone who hasn't responded, that person is the primary unanswered party.
+
+2. Identify the parties to ping based on the conversation analysis:
+   - **Reporter** — always include; they filed the issue and should confirm whether it's still needed
+   - **Unanswered question-asker** — if the close suggestion was a reply to someone's question and that person hasn't acted on or acknowledged the answer, ping them to act. This is often the most important ping — they initiated the inquiry and received an answer but haven't followed through.
+   - **Assignee** — if present, they have context on the work
+   - **Close suggester** — only re-ping if their suggestion was ambiguous, uncertain, or if they asked a question in the same comment that remains unanswered. Do **not** re-ping someone who already gave a clear, substantive close recommendation — asking them to repeat themselves is noise.
+   - **Other relevant participants** — anyone else in the thread with direct context on the close rationale who hasn't weighed in
+
+3. Produce an `ADD_COMMENT` citing the close suggestion, pinging the **unanswered parties** (not the already-answered suggester), and asking for confirmation or action:
+
+   ```json
+   {
+     "action": "ADD_COMMENT",
+     "params": { "comment": "### AI Triage\n\nRecent activity suggests this issue may be ready to close. [Suggester] commented on [date]: \"[quote or paraphrase].\"\n\n@[Reporter Name](accountid:...) — can you confirm whether this issue is still needed, or should it be closed?\n\n@[Unanswered Party](accountid:...) — [Suggester] recommended closing this issue on [date]. Can you confirm or take action?" },
+     "reason": "Close suggestion detected in recent activity — pinging unanswered parties for confirmation"
+   }
+   ```
+
+3. Produce an `ADD_LABEL` with `needs-info` to block the Backlog transition:
+
+   ```json
+   {
+     "action": "ADD_LABEL",
+     "params": { "labels": ["needs-info"] },
+     "reason": "Close suggestion in recent activity — awaiting reporter/stakeholder confirmation before proceeding"
+   }
+   ```
+
+**Why `needs-info` and not immediate closure:** The triage pipeline is not authorized to close issues based on comment suggestions alone. A suggestion to close is a signal, not a decision. The reporter and stakeholders must confirm. The `needs-info` label ensures the issue stays in New (not silently moved to Backlog) while awaiting that confirmation. If confirmed, the issue can be closed in a subsequent pass or manually.
+
+### Tagging Guidelines
+
+- **Do not over-tag.** Only apply labels/state when there is clear evidence the issue cannot proceed without the input. If the description is reasonably complete, don't add `needs-info` just because it could be more detailed.
+- **Prefer the most specific mechanism.** If you can identify a specific blocking Jira issue, use a link rather than the Blocked field. If the blocker is a role's input, use a needs-\* label rather than the Blocked field.
+- **ADD_COMMENT in Tag mode.** Tag mode generally produces label and link operations only. The exceptions are **Step 4 (stale blocking references)** and **Step 5 (close suggestions)**: when Tag mode identifies stale blocking references with specific unanswered parties, or recent comments suggesting the issue should be closed, it produces an `ADD_COMMENT` to make the `needs-info` label actionable. A bare `needs-info` label with no comment leaves no one knowing what input is needed or who to ask.
+- **Do not ping the reporter for non-info blockers.** The reporter is the right person to ask for missing description details (`needs-info`), but they are not UX, PM, or a tech advisor. Adding `needs-ux`, `needs-pm`, or `needs-advisor` is a signal to the triage team, not a request to the reporter.
+- **Keep reasons concise** -- one sentence citing the specific signal that drives the assessment.
+- **Skip issues that already have the appropriate labels/state.** If an issue already has `needs-ux` and you agree it needs UX input, don't produce a duplicate operation.
+
+---
+
+## Mode B: Evaluate
+
+Find issues with existing needs-\* labels or Blocked=True, and check whether the blocking condition has been resolved.
+
+### Discovery JQL Patterns
+
+All values come from `jira-project-reference.md`. Include `resolution = Unresolved` by default.
+
+All queries include the standard filters from `jira-project-reference.md` § Standard Query Filters (type, epic link, team).
+
+**Issues with needs-\* labels:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND labels in (needs-info, needs-ux, needs-pm, needs-advisor)
+```
+
+**Issues with Blocked=True:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND "Blocked" = "True"
+```
+
+**Combined (all potentially blocked issues):**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND (labels in (needs-info, needs-ux, needs-pm, needs-advisor) OR "Blocked" = "True")
+```
+
+The user may also provide a pre-fetched issue set or specific issue keys to evaluate.
+
+### Evaluation Procedure
+
+#### Step 0: Build Issue Inventory (CRITICAL)
+
+After fetching all pages from the JQL search, build a **complete, verified inventory** before evaluating any issue. The inventory is a flat list of every issue with its key, summary, and blocking signals extracted from the lightweight fetch fields (labels, Blocked field, Blocked Reason, issue links). This step ensures no issue is lost in large search responses.
+
+**Procedure:**
+
+1. Read the **entire** search response for each page. Jira search responses can be thousands of lines; read them in full -- do not skip or skim sections. Extract every issue key, summary, and blocking signal from every page.
+2. After all pages are read, count the inventory. **Verify** the count matches the total number of issues returned across all pages (sum of issues arrays). If the counts don't match, re-read the search results until they do.
+3. Report the verified count to the user: "Found N issues with blocking signals. Building inventory..."
+4. Classify each issue in the inventory by its blocking mechanism(s): `needs-*` labels present, `Blocked=True`, blocked-by links, and any Blocked Reason references (extract issue keys from ADF content and URLs in the Blocked Reason field).
+
+This inventory is the single source of truth for the rest of the evaluation. Every issue in the inventory must be evaluated -- none may be skipped or deferred without explicit reporting.
+
+**Per-issue processing:** After the inventory and changelog analysis are complete, process issues **one at a time**. For each issue, call `jira_get_issue` with `fields=summary,status,priority,labels,assignee,issuetype,created,updated,description,reporter,comment,customfield_10840,customfield_10517,customfield_10483,customfield_10001,customfield_10464,issuelinks,components` and `comment_limit=20` to get full details including comments, evaluate all blocking mechanisms, produce operations, **verify operations** (see below), write them to the operations file on disk, and report progress (`[N/total] RHOAIENG-XXXXX -- summary: outcome`). Then move to the next issue. This bounds context usage to one issue's details at a time.
+
+**Per-issue operation verification (required):** After producing operations for an issue and before writing them, verify every mention (`@[Display Name](accountid:...)`) in any `ADD_COMMENT` operation against the issue's known data sources. Each pinged person must be traceable to at least one of:
+
+- **Changelog** — they set the blocker (label or Blocked field)
+- **Assignee** — they are currently assigned to the issue
+- **Reporter** — they filed the issue
+- **Comment author** — they wrote a comment on the issue
+- **Linked issue** — they are the assignee/reporter on a linked blocking issue referenced in the comment
+
+If a pinged person cannot be traced to any of these sources for **this specific issue**, remove them from the comment and replace with the correct person from the data. This guards against cross-issue contamination and hallucinated references. Never ping someone based on assumptions or pattern-matching from other issues in the batch.
+
+#### Preliminary: Changelog Analysis
+
+Before evaluating individual blocking mechanisms, determine **when** each blocker was set and **who** set it. This establishes the timeline for evaluating whether resolution activity has occurred since.
+
+1. Call `jira_batch_get_changelogs` with `fields=labels` for all issues with `needs-*` labels. Find the changelog entry where the specific `needs-*` label first appeared in the `to_string`. Record the **author** and **date**.
+2. Call `jira_batch_get_changelogs` with `fields=Blocked,customfield_10517` for all issues with `Blocked=True`. Find the changelog entry where Blocked changed from False to True. Record the **author** and **date**.
+3. Use these timestamps as the baseline for all subsequent evaluation: only comments, description edits, status changes, and other activity **after** the blocker was set count as resolution signals.
+
+**Fallback when no changelog entry exists:** If the changelog returns no matching entry for a blocker (label or Blocked field), the value was likely set at **issue creation time**. In this case, use the **issue creation date** as the baseline and the **reporter** as the person to ping. This commonly happens when the reporter files an issue with `Blocked=True` already set or with `needs-*` labels applied in the initial description.
+
+**Clone detection (critical):** When no changelog entry exists for a blocker, also check whether the issue was **cloned** from another issue. Cloned issues inherit labels, fields, and other metadata from the source. If the blocker (label or `Blocked=True`) was inherited via cloning:
+
+1. Check the issue links for a "cloned from" / "is cloned by" relationship to identify the source issue.
+2. Compare the current issue's description against the blocking signal. If the description has been **substantially rewritten** since cloning and the blocking signal (e.g., `needs-ux`) has no relevance to the current content (no UX questions, no linked UX issues, no design references), then the label is stale from the clone — not an intentional blocker.
+3. In this case, **remove the inherited label** with an audit comment explaining it was inherited from the clone and is unrelated to the current issue. Do **not** treat it as a stale blocker ping — the label was never intentionally set on this issue, so there is no one to ping about it.
+4. If the description has NOT changed significantly from the clone source, evaluate the blocker normally using the clone date as the baseline.
+
+This data is used throughout the evaluation:
+- **Resolution evaluation:** Only activity after the blocker date is relevant. A comment from before the label was added cannot be a resolution signal.
+- **Stale detection:** The blocker age is measured from the changelog date (or issue creation date as fallback), not an arbitrary reference point.
+- **Stale/unjustified blocker comments:** Ping the **person who set the blocker** (the changelog author, or the reporter as fallback) with an **action ping** — they have the most context on what the blocker means and whether it has been addressed. Use the mention syntax `@[Display Name](accountid:ACCOUNT_ID)` **only for action requests** (see `jira-triage` SKILL § User References in Comments). When citing someone for historical context (e.g., "set by Jane Doe on 2024-11-14"), use their plain display name without mention syntax — this avoids unnecessary notifications. Look up account IDs via `jira_get_user_profile` for changelog authors when composing action pings.
+
+#### Preliminary: Status-Based Resolution Signal
+
+Before evaluating individual blocking mechanisms, check the issue's current workflow status. Certain statuses are **strong evidence** that the blocking condition has been overcome, because the issue has progressed into active development or beyond:
+
+| Status | Signal strength | Interpretation |
+|---|---|---|
+| **In Review** (Code Review) | High | A PR exists and is being reviewed. The work is done; any `needs-*` input was either provided or deemed unnecessary. |
+| **In Testing** (QE) | High | Implementation is complete and being verified. Same reasoning as In Review. |
+| **In Progress** | Moderate | Someone is actively working on the issue. The blocker may have been resolved informally without updating the label. Treat as a confidence booster, not conclusive on its own. |
+
+**How to use this signal:**
+
+- **High-signal statuses (In Review, In Testing):** Treat any `needs-*` label as almost certainly stale. The per-label evaluation below still runs, but the status alone is sufficient evidence to recommend removal even when no explicit resolution comment exists. The reason should cite the status as the primary signal (e.g., "Issue is In Review -- needs-ux label is stale; the blocking input was resolved or bypassed").
+- **Moderate-signal status (In Progress):** Use as a confidence booster alongside other signals. If the per-label evaluation finds partial or ambiguous evidence of resolution, the In Progress status tips it toward "resolved." On its own, In Progress is not enough to recommend removal.
+- **Blocked field (`Blocked=True`):** Status-based signals apply to `needs-*` labels but NOT to the Blocked field. An issue can be In Review while still structurally blocked (e.g., waiting on a z-stream to ship the fix). Evaluate the Blocked field independently using the standard criteria below.
+
+#### Evaluating needs-info
+
+**Check:** Has the reporter or another knowledgeable party provided the requested information?
+
+1. From the changelog analysis, identify the exact date the `needs-info` label was added and who added it. Only activity **after** that date is relevant.
+2. Read the comments chronologically from that date forward. Look for comments from the reporter or other contributors that address the open questions.
+3. Check if the description has been updated with the requested details (compare `updated` timestamp against the label addition date from the changelog).
+4. If `needs-info` was applied due to incomplete description (look for a validate-description comment with a missing-sections checklist), re-evaluate the description against `jira-project-reference.md` § Description Quality Criteria for the issue's type. If the previously missing required sections are now present in the description, treat it as resolved.
+5. **Resolved if:** A comment substantively answers the questions or provides the missing details (reproduction steps, environment info, expected behavior), **or** the description has been updated to include the previously missing required sections. A simple "bump" or "any update?" does not count.
+6. **Not resolved if:** No new substantive comments since the label was applied, and the description still lacks the requested information.
+
+#### Evaluating needs-ux
+
+**Check:** Has UX guidance been provided with confidence?
+
+1. Look for comments from UX team members that include:
+   - Links to design deliverables (Figma, Miro, Google Docs, or similar)
+   - Links to UX issues that have been closed/resolved
+   - Clear written design decisions with enough detail to implement
+2. Check linked issues: if the issue has links to UX-related issues, check if those linked issues are resolved.
+3. **Resolved if:** A comment provides a concrete design deliverable or a clear, confident design decision. The guidance must be actionable -- not just "we'll look into it" or "acknowledged".
+4. **Not resolved if:** No design input, or only tentative/questioning responses that lack the confidence needed to proceed.
+
+#### Evaluating needs-pm
+
+**Check:** Has PM provided direction with confidence?
+
+1. Look for comments from PM that include:
+   - Clear scope decisions or acceptance criteria
+   - Product direction statements
+   - Links to PRDs, product docs, or PM issues that have been resolved
+2. Check linked issues: if the issue has links to PM-related issues, check if those linked issues are resolved.
+3. **Resolved if:** A comment provides a clear, confident product decision or scope clarification. Must be actionable guidance, not just acknowledgement.
+4. **Not resolved if:** No PM input, or only tentative responses without clear direction.
+
+#### Evaluating needs-advisor
+
+**Check:** Has a technical lead provided an implementation recommendation?
+
+1. Look for comments from senior engineers or architects that include:
+   - A recommended technical approach
+   - Architecture decisions or design patterns to follow
+   - Links to resolved spike/investigation issues
+2. Check linked issues: if the issue has links to spike or investigation issues, check if those are resolved.
+3. **Resolved if:** A comment provides a clear technical recommendation with enough detail to unblock implementation.
+4. **Not resolved if:** No technical guidance, or only partial analysis without a recommendation.
+
+#### Evaluating Blocked-by Links
+
+**Check:** Has the blocking issue been resolved?
+
+1. For each "is blocked by" link on the issue, fetch the linked issue's status.
+2. **Resolved if:** The linked issue's status category is "Done" (resolved/closed).
+3. **Partially resolved:** If the issue has multiple blocked-by links, some may be resolved while others are not. Report each independently.
+4. Note: Do not produce operations to remove the link itself -- links serve as history. Instead, if the Blocked field is also True and all blocked-by links are resolved, produce an operation to clear it.
+
+#### Evaluating Blocked=True (Blocked Reason)
+
+**Check:** Has the external/structural blocker been resolved?
+
+1. Read the Blocked Reason field for context on what the blocker is.
+2. Check comments for signals that the condition has been addressed (e.g., "z-stream has been released", "environment is now available").
+3. Check if the Blocked Reason references a specific issue -- if so, check that issue's status.
+4. **Resolved if:** Comments or linked issue status indicate the blocking condition no longer applies.
+5. **Not resolved if:** No signal that the external condition has changed, or insufficient confidence.
+
+### Producing Resolution Operations
+
+When a blocker appears resolved, produce operations to clear it:
+
+**For needs-\* labels:**
+
+```json
+[
+  {
+    "action": "REMOVE_LABEL",
+    "params": { "labels": ["needs-ux"] },
+    "reason": "UX guidance provided: Figma link in comment by Jane Smith (Mar 20)"
+  },
+    {
+      "action": "ADD_COMMENT",
+      "params": { "comment": "### AI Triage\n\nRemoving `needs-ux` — design guidance provided in comment by Jane Smith (Mar 20) with Figma mockups covering the notification panel layout." },
+      "reason": "Audit trail for label removal"
+    }
+]
+```
+
+**For Blocked field:**
+
+```json
+[
+  {
+    "action": "SET_FIELDS",
+    "params": {
+      "fields": {
+        "customfield_10517": { "value": "False" }
+      }
+    },
+    "reason": "Blocking condition resolved: z-stream 2.24.1 released per comment from Mar 22"
+  },
+  {
+    "action": "ADD_COMMENT",
+    "params": { "comment": "### AI Triage\n\nClearing blocked status -- the z-stream release has shipped." },
+    "reason": "Audit trail for blocked field change"
+  }
+]
+```
+
+#### Detecting Stale or Unjustified Blockers
+
+In addition to checking whether blockers have been resolved, Evaluate mode proactively detects blockers that appear stale, unjustified, or unclear.
+
+**Stale blockers:** A `needs-*` label or `Blocked=True` state that has been present for an extended period with no activity suggesting progress toward resolution. Use the changelog date (not issue creation date) to measure staleness.
+
+##### Conversation thread analysis (required for stale blocker pings)
+
+Before composing a stale-blocker ping comment, **trace the comment thread** to build a picture of who was asked for what, and whether they answered. This produces a richer, more actionable ping than simply pinging the label-setter alone.
+
+**Procedure:**
+
+1. Read all comments chronologically from the date the blocker was set (changelog date or issue creation as fallback).
+2. For each comment, identify:
+   - **Author** (who wrote it)
+   - **Mentions / directed questions** — look for @mentions, "cc @name", direct questions addressed to a named person, or phrases like "waiting on [name]", "[name] can you..."
+   - **Content** — is it asking a question, providing information, or a status bump?
+3. Build a **pending questions list**: for each question or request directed at a specific person, check whether a later comment by that person (or someone acting on their behalf) substantively answers it. A "bump" or "+1" is not an answer.
+4. Evaluate **relevance** — has the project, feature, or context changed enough that the original question may no longer apply? If so, note that in the ping.
+5. **Look up referenced blocking issue parties.** When the Blocked Reason, description, or issue links reference specific Jira issues as blockers or dependencies, fetch each referenced issue's **reporter** and **assignee** (via `jira_get_issue` with `fields=reporter,assignee`). These people worked on the blocking issue and know what the resolution means for the current issue's dependency. This step is critical when the current issue has few or no comments — the relevant decision-makers may exist only on the blocking issues, not on the current issue's thread.
+6. Identify the **best-directed audience** for the follow-up ping:
+   - **Label-setter** — always include; they have context on why the blocker was set.
+   - **Referenced blocking issue parties** — the reporter and/or assignee of each referenced blocking issue that is now Closed/Resolved. Ping them with a **specific question** about the outcome: what was the decision, does the resolution address the current issue's dependency, should the current issue proceed? These people are often the most important to ping because they hold the answer — especially for design explorations, scope decisions, or technical spikes that the current issue was waiting on.
+   - **Unanswered parties** — anyone who was asked a question in the comment thread and has not responded. Note what specific question or information is pending from them.
+   - **Reporter** — include only for `needs-info` (they can provide missing details). Do not ping the reporter for `needs-ux`, `needs-pm`, or `needs-advisor`.
+
+**Comment structure for stale pings:**
+
+The `ADD_COMMENT` for a stale blocker should:
+- **Link every Jira issue key.** Every occurrence of a Jira issue key in the comment must be a clickable markdown link: `[KEY](https://redhat.atlassian.net/browse/KEY)`. This applies to *every* mention — not just the first. See `jira-triage` SKILL § Issue and External References in Comments for the full rule covering both Jira and GitHub references.
+- State the staleness context using **plain names** for historical attribution (e.g., "set by Jane Smith on 2024-11-14") — no @mention for context
+- **Action-ping** the label-setter for overall status using `@[Display Name](accountid:...)` — this is a request for them to respond
+- **Action-ping** each referenced blocking issue party with a **specific question about the outcome** of their issue (e.g., "@[Kyle Walker](accountid:...) — you filed [RHOAIUX-296](https://redhat.atlassian.net/browse/RHOAIUX-296) to explore options for the 'enable your team' section. What was the outcome? Should the 4th column be added?"). Tailor the question to what the blocking issue was about — design decision, scope exploration, technical spike, etc.
+- Separately **action-ping** each unanswered party from the comment thread, stating what is pending from them (e.g., "@[Jane Smith](accountid:...) — UX mockups for the notification panel were requested on Feb 12 and haven't been provided")
+- Note the total staleness duration
+- Ask whether the blocker is still relevant or if the issue should be closed/re-scoped
+
+##### Per-label stale rules
+
+- If a `needs-*` label has been present for **30+ days** with no comments addressing it, produce an `ADD_COMMENT` using the conversation thread analysis above:
+  - `needs-info`: Ping the label-setter, unanswered parties from the thread, **and** the reporter. `needs-info` is the **only** `needs-*` label where pinging the reporter is appropriate -- they are the person who can provide the missing details.
+  - `needs-ux`: Ping the label-setter and any unanswered UX contacts from the thread. Do **not** ping the reporter -- they are not UX.
+  - `needs-pm`: Ping the label-setter and any unanswered PM contacts from the thread. Do **not** ping the reporter.
+  - `needs-advisor`: Ping the label-setter and any unanswered technical contacts from the thread. Do **not** ping the reporter.
+
+- If `Blocked=True` has been set for **30+ days** with no update to the Blocked Reason or relevant comments, produce an `ADD_COMMENT` pinging **the person who set Blocked=True** (from changelog analysis), plus any unanswered parties identified in the thread, asking whether the external condition has changed.
+
+**Unjustified blockers:** A `needs-*` label or `Blocked=True` state where the rationale is unclear or missing. Apply conversation thread analysis here too — the thread may contain context that the fields lack.
+
+- If `Blocked=True` but the Blocked Reason field is empty and no `needs-*` labels explain why, produce an `ADD_COMMENT` pinging **the person who set the blocked state** (from changelog analysis) and asking them to provide a reason. If the thread reveals unanswered parties or context, include them.
+- If a `needs-*` label is present but there is no comment or description text explaining what input is needed, produce an `ADD_COMMENT` pinging **the person who added the label** and asking for clarification. If a later comment directed a question to someone specific who hasn't responded, ping them too with the pending question.
+
+**Blocked-by link to resolved issues with "Won't Do" resolution:**
+
+When evaluating blocked-by links, check the resolution of the linked issue:
+
+- **Done:** The blocker is genuinely resolved. Clear the Blocked field if all blocked-by links are resolved.
+- **Won't Do / Won't Fix:** The blocking dependency will NOT be delivered. This does NOT automatically unblock the issue -- it means the original plan is no longer viable. Produce an `ADD_COMMENT` flagging that the dependency was closed as "Won't Do" and asking the assignee/reporter to determine next steps (re-scope, find alternative, or close the blocked issue too). Additionally, check whether the closed issue was the **delivery vehicle for role-specific input** (see § Won't Do and needs-\* label re-application below).
+- **Duplicate:** Check the duplicate target's status. If the target is resolved, treat as if the original blocking issue was resolved. If the target is still open, the blocker is not yet resolved.
+
+**Won't Do and needs-\* label re-application:**
+
+When a blocking dependency (blocked-by link, Blocked Reason reference, or inline issue reference) is closed as **Won't Do**, **Not a Bug**, or **Obsolete**, check whether that dependency was the **delivery vehicle for a specific role's input** -- e.g., a UX design issue, a PM requirements issue, or an architectural spike. If the blocked issue's feature still requires that role's input and the corresponding `needs-*` label is not already present, produce an `ADD_LABEL` operation to surface the unresolved need.
+
+| Closed issue type | needs-\* to apply | Condition |
+|---|---|---|
+| UX design issue (Figma, mockups, interaction design) | `needs-ux` | The blocked issue still involves UI changes that require design guidance |
+| PM requirements / scope issue | `needs-pm` | The blocked issue still needs product direction or acceptance criteria |
+| Architecture spike / technical investigation | `needs-advisor` | The blocked issue still has unclear technical approach |
+
+**Why this matters:** When someone blocks an issue on a UX/PM/arch dependency, they are implicitly saying "this issue needs that role's input, and we're tracking it via that other issue." If the other issue is closed without delivering, the need doesn't disappear -- it just lost its tracking vehicle. Re-applying the `needs-*` label ensures the need remains visible in the triage queue.
+
+**Do not re-apply** if the blocked issue itself has been re-scoped to no longer require that input, or if a comment indicates the role's input was obtained through other means. The `ADD_COMMENT` should explain the reasoning (e.g., "Re-adding `needs-ux` — the UX design issue [RHOAIUX-1408](https://redhat.atlassian.net/browse/RHOAIUX-1408) was closed as Won't Do, but this feature still requires design guidance for the settings UI").
+
+### Evaluation Guidelines
+
+- **Every issue in the inventory must be evaluated.** Do not skip, defer, or batch-summarize issues. Each issue gets its own per-issue detail fetch, evaluation, and progress report. If an issue has no actionable finding, report it as "no change" in the progress line -- do not silently omit it. The final progress line must be `[N/N]`.
+- **Err on the side of caution.** Only flag a blocker as resolved when there is clear, confident evidence. If ambiguous, leave it in place and note the uncertainty in the dry-run output.
+- **Audit trail is mandatory.** Every label removal or blocked field change must be paired with an `ADD_COMMENT` explaining what resolved the blocker and citing the specific signal (comment author, date, link).
+- **Link every Jira issue key in comments.** Every `ADD_COMMENT` operation — audit trail, stale ping, or resolution — must link every occurrence of a Jira issue key as `[KEY](https://redhat.atlassian.net/browse/KEY)`. This includes repeated mentions of the same key. See `jira-triage` SKILL § Issue and External References in Comments.
+- **Order operations correctly.** The comment explaining the change should come before label removal or field update so the audit trail is in place first.
+- **Report uncertain cases.** If a blocker might be resolved but confidence is low, include the issue in the dry-run summary with a note explaining the uncertainty. Let the user decide.
+- **Linked issue-key summaries.** When presenting dry-run or execution summaries from this skill's output (directly or via `jira-triage` Apply), group by Jira issue key and render each key as a clickable markdown link: `[RHOAIENG-12345](https://redhat.atlassian.net/browse/RHOAIENG-12345)`.
+- **Evaluate each mechanism independently.** An issue may have `needs-ux` resolved (mockups provided) but still be Blocked=True (waiting on infrastructure). Clear the resolved mechanism without touching the unresolved one.
+- **Stale blocker comments are informational, not auto-clearing.** When flagging stale or unjustified blockers, produce `ADD_COMMENT` only -- never auto-remove labels or clear Blocked state based on staleness alone.
+- **Every confirmation request must address someone.** If a comment asks for confirmation (e.g., "Please confirm whether this issue is still needed"), it **must** mention a specific person with `@[Display Name](accountid:ACCOUNT_ID)`. A dangling ask with no addressee is not actionable. Fallback chain for who to ping: (1) the **assignee**, if present — they have direct context on the work; (2) the person who **set the blocker** (from changelog); (3) the **reporter**. When multiple people have relevant context (e.g., an assignee exists AND someone else set the blocker), ping both. Never leave a "please confirm" without a named recipient.
+
+---
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). Comment visibility (`Red Hat Employee`) is enforced at execution time by the Apply step -- see `jira-triage` SKILL § Comment Visibility. Actions by mode:
+
+| Mode | Actions produced |
+|---|---|
+| Tag | `ADD_LABEL`, `LINK_BLOCKED_BY`, `SET_FIELDS`, `ADD_COMMENT` (Steps 4 and 5 — stale blocking references and close suggestions) |
+| Evaluate | `REMOVE_LABEL`, `SET_FIELDS`, `ADD_COMMENT`, `ADD_LABEL` (`needs-*` re-application per § Won't Do) |
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**: it validates, presents the summary, writes the operations file to `.artifacts/triage/`, and stops. The user reviews the file and explicitly applies it later. To execute immediately, the user must request it (e.g., "evaluate blockers and apply"). Summary presentation must follow `jira-triage` Step 2/Step 7 formatting: group by issue key and hyperlink each key to Jira.
+
+---
+
+## Example: Tag Mode
+
+Given issue RHOAIENG-54966 ("Add Subscription column to the API Keys table") with no needs labels and a description referencing dependency on RHOAIENG-54596:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T14:00:00Z",
+    "query": "Triage batch of 5 new issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-54966",
+      "summary": "Add Subscription column to the API Keys table",
+      "action": "LINK_BLOCKED_BY",
+      "params": { "blockedBy": "RHOAIENG-54596" },
+      "reason": "Description states dependency on backend API work in RHOAIENG-54596"
+    }
+  ]
+}
+```
+
+## Example: Evaluate Mode
+
+Given issue RHOAIENG-12345 with `needs-ux` label and a recent comment from a UX designer with a Figma link:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T14:00:00Z",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND resolution = Unresolved AND labels in (needs-ux)",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-12345",
+      "summary": "Redesign notification panel layout",
+      "action": "ADD_COMMENT",
+      "params": { "comment": "### AI Triage\n\nRemoving `needs-ux` — design guidance provided in comment by Sarah Chen (Mar 20) with Figma mockups covering the notification panel layout." },
+      "reason": "Audit trail for label removal"
+    },
+    {
+      "issueKey": "RHOAIENG-12345",
+      "summary": "Redesign notification panel layout",
+      "action": "REMOVE_LABEL",
+      "params": { "labels": ["needs-ux"] },
+      "reason": "UX designer Sarah Chen provided Figma mockups in comment on Mar 20"
+    }
+  ]
+}
+```

--- a/.claude/skills/jira-triage/SKILL.md
+++ b/.claude/skills/jira-triage/SKILL.md
@@ -1,0 +1,1294 @@
+---
+name: jira-triage
+description: Fetch Jira issues by filter criteria, define structured triage operations, and bulk-apply them. Full Triage mode orchestrates all analysis skills on New issues end-to-end.
+---
+
+# Jira Triage Infrastructure
+
+Composable infrastructure for Jira triage automation. Provides three capabilities -- **Fetch**, **Apply**, and **Full Triage** -- connected by a standard operations format. Analysis logic lives in separate skills; Full Triage orchestrates them end-to-end.
+
+**Before any Fetch, Apply, or Full Triage operation, read [`persona.md`](persona.md) and [`jira-project-reference.md`](jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides all Jira-specific values (project key, component, field IDs, labels, scrum-to-area mapping). This skill contains no hardcoded Jira values.
+
+> **Fresh Start Rule:** Every invocation starts from scratch with fresh Jira queries and fresh analysis. Do **not** read, scan, or reference previous operation files in `.artifacts/triage/` unless the user explicitly provides a file path to apply or resume. See `persona.md` § Fresh Start for the full rule.
+
+## Architecture
+
+```text
+User
+ │
+ ├─── Fetch ───────────── return issue set (in-session)
+ │
+ ├─── Apply ───────────── validate, dry-run, execute
+ │
+ └─── Full Triage ─────── orchestrate analysis pipeline for New issues
+         │
+    ┌────┴────┐
+    │  Fetch  │  Query New issues (lightweight: no descriptions)
+    └────┬────┘
+         │ issue keys + summaries (small context footprint)
+    ┌────┴──────────────────────────────────────────┐
+    │  Per-Issue Loop                                │
+    │  (one issue at a time, write results to disk)  │
+    │                                                │
+    │  0. Fetch full issue details (description etc) │
+    │                                                │
+    │  a. Team Gate                                  │
+    │     Dashboard-owned? → assign team, continue   │
+    │     Another team / not ours? → STOP (skip)     │
+    │                                                │
+    │  b. Analysis Pipeline                          │
+    │     1. validate-issue-type                     │
+    │     2. validate-description                    │
+    │     3. validate-priority-severity              │
+    │     4. evaluate-blockers (Tag mode)            │
+    │     5. validate-area-label (Tag mode)          │
+    │     6. assign-scrum-team                       │
+    │                                                │
+    │  c. Status Transition (opt-in only)              │
+    │     Skipped unless user requests transitions    │
+    │     No blockers → TRANSITION to Backlog        │
+    │     Has blockers → remain in New               │
+    │                                                │
+    │  d. Write operations to file + report progress │
+    └────┬──────────────────────────────────────────┘
+         │ operations file on disk (built incrementally)
+    ┌────┴────┐
+    │  Apply  │  Read file, validate, dry-run/execute,
+    │         │  post triage comments, report
+    └─────────┘
+```
+
+**Entry points:**
+
+- **Fetch** -- given filter criteria, query Jira and return issues to the session
+- **Apply** -- given operations (inline from analysis or from a file on disk), validate and execute against Jira
+- **Full Triage** -- end-to-end: fetch New issues, run all analysis skills, and apply results
+
+Fetch and Apply can be used independently. A user might Fetch without Apply (just exploring), or Apply a hand-edited operations file without Fetch. Full Triage chains them together with the analysis pipeline.
+
+---
+
+## Context Management (all batch operations)
+
+When processing multiple issues through any analysis skill, follow these principles to avoid exhausting the agent's context window:
+
+1. **Complete issue inventory (CRITICAL).** After fetching all pages from the search, build a **verified inventory** of every issue before processing any of them. The inventory is a flat list of `{ key, summary, blocking signals }` for each issue -- compact enough to hold the entire set in context. **Every issue from every page must appear in the inventory.** Compare the inventory count against the total returned by the API. If they don't match, re-read the search results until they do. **Never estimate, approximate, or skip issues from the search results.** Bulk search responses can be thousands of lines; reading them in chunks is fine, but every chunk must be fully processed and every issue key extracted. Missing even one issue invalidates the entire batch.
+2. **Lightweight list fetch.** Fetch the issue set with the default fields (no `description`). This gives you keys, summaries, and metadata without loading heavy content.
+3. **Per-issue detail fetch.** Load each issue's full details (description, reporter, etc.) via `jira_get_issue` only when processing that specific issue. Discard the details after that issue is complete.
+4. **Incremental file writes.** After processing each issue, write its operations to the output file on disk immediately (read the file, append, write back). Do not accumulate all operations in memory until the end.
+5. **Progress reporting.** Report a one-line summary after each issue so the user can monitor progress. Include the position in the inventory (e.g., `[7/53]`) so the user can confirm all issues are being processed.
+
+**Default: inline processing.** All issues are processed in the current agent context using principles 1–5 above. No sub-agents are launched. This keeps everything in a single conversation with full shared context.
+
+**Opt-in: sub-agent delegation ("think deep").** When the user explicitly requests deeper analysis (e.g., "think deep", "use sub-agents"), delegate per-issue processing to sub-agents via the `Task` tool. Each sub-agent starts with a fresh context window — no accumulated API responses, no residual skill file content from previous issues. The parent agent holds only the inventory and coordinates dispatch. Sub-agents are dispatched **sequentially** (one at a time). See Capability 3 § Sub-Agent Delegation for the full pattern.
+
+Full Triage implements these principles end-to-end (see Capability 3 § Context Management). Standalone skill invocations (e.g., "validate area labels on 30 backlog issues") should follow the same pattern: lightweight fetch for the list, per-issue `jira_get_issue` for details, per-issue write to the operations file. When the user opts into sub-agent delegation for standalone batch operations, apply the same pattern documented under Full Triage.
+
+### Context Compaction Resilience (CRITICAL)
+
+Context compaction silently degrades the agent's working memory. After compaction, issue summaries are paraphrased or hallucinated, issue counts drift, skipped issues vanish, and operations get fabricated from vague recollection. **The operations file on disk is the only reliable state.** These rules are non-negotiable:
+
+#### Rule 1: The file on disk is sacrosanct
+
+After Step 1 creates the initial skeleton (with the verified `issues` map and `issueCount`), the file is the authoritative record. **Never** regenerate, reconstruct, or rewrite the file from memory. All subsequent writes are **read-append-write**: read the current file from disk, append new operations for the just-completed issue, write it back. If your memory conflicts with the file on disk, **the file wins**.
+
+#### Rule 2: Never overwrite existing content
+
+If the operations file already exists and contains data, treat its `issues` map and existing `operations` array as immutable history. Only **append** to the `operations` array. Never replace the `issues` map, `metadata`, or previously written operations with values reconstructed from memory. Never generate a fresh file that replaces one with existing content.
+
+#### Rule 3: Recovery after compaction
+
+If context has been compacted (earlier tool call results are gone, conversation is summarized, or your memory of issues feels vague), recover by reading the operations file from disk:
+
+1. The `issues` map tells you the **complete inventory** (every issue key and its verified summary).
+2. The `operations` array tells you **which issues have been processed** (any issue key appearing in at least one operation — including `NO_OP` — is done).
+3. Subtract processed issue keys from the full `issues` map to get the **remaining unprocessed issues**.
+4. Continue processing from the next unprocessed issue in key-ascending order, using the standard per-issue loop (Step 2.0–2e).
+5. **Do not** re-fetch the issue list from Jira — the inventory on disk is already verified.
+6. **Do not** reconstruct or "fill in" operations for issues you vaguely remember processing but that have no operations on disk — they were not persisted, so redo them from scratch.
+7. **Do not** re-process issues that already have operations (including `NO_OP`).
+
+#### Why these rules matter
+
+`NO_OP` records ensure every evaluated issue leaves a trace — without them, skipped issues are indistinguishable from unprocessed ones after compaction. Static `issueCount` (set once in Step 1, never modified) prevents the count from drifting. The `issues` map persisted in Step 1 means the agent never needs to reconstruct the inventory from memory. Together, these mechanisms make the operations file a self-contained recovery checkpoint.
+
+---
+
+## Capability 1: Fetch
+
+Query Jira and return a structured issue set. The output stays in the agent session (not written to disk).
+
+### How to Fetch
+
+1. Read `jira-project-reference.md` for the project key, component, and any label values needed for JQL
+2. Build a JQL query from the user's filter criteria using the reference values
+3. **Always include `resolution = Unresolved`** in the query unless the caller explicitly requests resolved issues. This prevents fetching thousands of closed issues that don't need triage.
+4. **Always enforce deterministic ordering** by appending `ORDER BY key ASC` to the final JQL used for `jira_search` (unless that exact ordering is already present)
+5. Call `jira_search` with the JQL, requested fields, `limit=50`, and `start_at=0`
+6. **Always check for more pages.** The Jira Cloud API often returns `total: -1` (unknown count), so do **not** rely solely on `total` to decide whether to paginate. After each response, check for a `next_page_token` in the response **or** `total > start_at + max_results`. If either is present, fetch the next page (`start_at += 50` or pass `page_token`) and repeat until no more pages remain. **Skipping pagination silently drops issues from the result set.**
+7. Return the accumulated issue set to the session
+
+### Default Fields
+
+When the caller does not specify fields, use: `summary, status, priority, labels, assignee, issuetype, created, updated`
+
+`description` is excluded by default because it can be very large and bloat context across dozens of issues. Analysis skills that need description content should request it explicitly by adding it to the fields list.
+
+### Common JQL Patterns
+
+All values below must come from `jira-project-reference.md`. The patterns show the structure; substitute actual values from the reference file. All patterns include `resolution = Unresolved` by default and end with `ORDER BY key ASC`.
+
+Placeholder reference:
+
+| Placeholder | Reference section |
+|---|---|
+| `{project_key}` | Project Constants |
+| `{component}` | Project Constants |
+| `{jql_team_id}` | Project Constants → Team field (JQL) |
+| `{triage_types}` | Issue Types → Standard Query Filters |
+| `{needs_labels_list}` | Triage Labels → Needs-\* Labels |
+| `{scrum_labels_list}` | Scrum Team Labels |
+| `{area_labels_list}` | Area Labels |
+| `{triage_labels_list}` | Triage Labels → Needs-\* Labels |
+
+**Untriaged issues:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND status = New
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND (Team is EMPTY OR Team = {jql_team_id})
+  AND (labels is EMPTY OR labels != Security)
+  AND (labels is EMPTY OR labels not in (Cross-Team))
+  AND (labels is EMPTY OR labels not in ({scrum_labels_list}))
+  AND (labels is EMPTY OR labels not in ({needs_labels_list}))
+  AND Blocked != "True"
+ORDER BY key ASC
+```
+
+This is the one query that uses `(Team is EMPTY OR Team = ...)` because incoming issues may not yet have a team assigned. Issues inside an epic are excluded because they are managed as part of the epic's planned work. Issues with `needs-*` labels or `Blocked = True` have already been through triage and identified as waiting on something. They are handled separately by the evaluate-blockers skill. Issues labeled `Cross-Team` are managed at the program level and excluded from dashboard-specific triage.
+
+> **JQL negative-label caveat:** In Jira, `labels != X` and `labels not in (...)` exclude issues with **no labels at all** — those issues have no label value to compare against, so they silently drop out of results. Every negative label condition must be wrapped in `(labels is EMPTY OR ...)` to include label-less issues.
+
+**Issues missing area labels:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND status = Backlog
+  AND (labels is EMPTY OR labels not in ({area_labels_list}))
+ORDER BY key ASC
+```
+
+**Issues assigned to a scrum team:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND labels = "{scrum_label}"
+ORDER BY key ASC
+```
+
+**Stale assigned issues (no update in N days):**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND assignee is not EMPTY
+  AND updated < -{N}d
+ORDER BY key ASC
+```
+
+**Issues needing triage attention:**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND labels in ({triage_labels_list})
+ORDER BY key ASC
+```
+
+The caller (user or analysis skill) can provide any valid JQL. These patterns are starting points, not exhaustive. All sub-triage queries include the standard filters from `jira-project-reference.md` § Standard Query Filters. To include resolved issues, the caller must explicitly omit or override the `resolution = Unresolved` clause. **Before execution, normalize every triage query to include `ORDER BY key ASC` for stable issue ordering.**
+
+---
+
+## Operations Format (the contract)
+
+The JSON format that sits between analysis and execution. Analysis skills produce it; Apply consumes it. The formal JSON Schema is at [`operations-schema.json`](operations-schema.json). **Required operation fields, action enums, and `params` contracts are defined only in that schema** — sub-skills reference it and describe which actions *this skill* emits, not a duplicate field checklist.
+
+### Structure
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-11",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND status = New",
+    "issueCount": 12
+  },
+  "issues": {
+    "RHOAIENG-12345": "Issue title for readability",
+    "RHOAIENG-12346": "Another issue in the query result"
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-12345",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["needs-info"] },
+      "reason": "No reproduction steps, reporter inactive for 30+ days"
+    },
+    {
+      "issueKey": "RHOAIENG-12346",
+      "action": "NO_OP",
+      "params": {},
+      "reason": "Not a dashboard issue — operator-only component with no UI/BFF scope"
+    }
+  ]
+}
+```
+
+**`issueCount` is static.** Set once when the file is created (Step 1) to the total number of issues returned by the initial query. Never incremented during processing. This is the authoritative count of the query result set.
+
+**`issues` map contains ALL queried issues.** Populated in Step 1 from the verified inventory — every issue returned by the query appears here, regardless of whether it has actionable operations. This serves as the authoritative record of the query result set, as a completeness check (every key in `issues` must have at least one entry in `operations`, even if it's `NO_OP`), and as a deduplication mechanism (avoids repeating summaries on every operation). Per-operation `summary` is still allowed for single-operation emits or overrides. Apply and dry-run lines use `operation.summary ?? issues[issueKey] ?? issueKey`.
+
+### Supported Actions
+
+| Action | MCP Tool | Params |
+|---|---|---|
+| `SET_FIELDS` | `jira_update_issue` | `{ "fields": { ... } }` -- passed through as-is |
+| `ADD_LABEL` | `jira_get_issue` + `jira_update_issue` | `{ "labels": ["label1"] }` -- **read-modify-write** (see below) |
+| `REMOVE_LABEL` | `jira_get_issue` + `jira_update_issue` | `{ "labels": ["label1"] }` -- **read-modify-write** (see below) |
+| `ADD_COMMENT` | `jira_add_comment` | `{ "comment": "markdown text" }` -- **visibility enforced at execution time** (see below) |
+| `TRANSITION` | `jira_get_transitions` + `jira_transition_issue` | `{ "transitionName": "Backlog", "fields": { ... } }` -- resolved at execution time; `fields` is optional |
+| `LINK_DUPLICATE` | `jira_create_issue_link` | `{ "duplicateOf": "RHOAIENG-99999" }` |
+| `LINK_BLOCKED_BY` | `jira_create_issue_link` | `{ "blockedBy": "RHOAIENG-99999" }` |
+| `NO_OP` | *(none — informational)* | `{}` -- empty params; the `reason` field explains why no action is needed |
+
+#### NO_OP (informational record)
+
+`NO_OP` is not an executable action — it records that an issue was evaluated and no operations are needed, along with the reason. Every issue from the query result that has no actionable operations must have exactly one `NO_OP` entry. This ensures the operations file accounts for every issue in the query result (the `issues` map and operations array are complete and verifiable).
+
+Common reasons for `NO_OP`:
+- Template issue — not a real work item (detected at template gate)
+- Issue skipped at team gate (not a dashboard issue)
+- Issue already fully triaged (all fields correct, no changes needed)
+- Issue excluded by analysis (e.g., CI flake that doesn't need dashboard triage)
+
+**`NO_OP` issues still get `ai-reviewed`:** Even when no substantive changes are needed, the `ai-reviewed` label is added (if not already present) to prevent reprocessing the issue in future triage runs. A `NO_OP` + `ADD_LABEL ai-reviewed` pair is the standard output for fully-triaged issues. No triage summary comment is posted for issues whose only operations are `NO_OP` and `ai-reviewed`.
+
+Apply skips `NO_OP` operations during execution. Dry-run shows them for completeness.
+
+#### Comment Header (all ADD_COMMENT operations)
+
+**All comments posted by triage skills must start with `### AI Triage` as the first line.** This applies to every `ADD_COMMENT` operation across all skills -- audit trail comments, description validation requests, area label reviews, and triage summary comments. The header identifies the comment as machine-generated and makes it easy to find/filter in issue history.
+
+#### Comment Visibility (all ADD_COMMENT operations)
+
+**All comments posted by triage skills are restricted to Red Hat employees.** This is enforced at execution time -- analysis skills do not need to include visibility in their operations. The Apply step (both agent and script paths) automatically applies the visibility from `jira-project-reference.md` § Comment visibility.
+
+- **Agent path:** When calling `jira_add_comment`, always pass `visibility: '{"type":"group","value":"Red Hat Employee"}'`
+- **Script path:** The apply script includes the visibility object in every comment POST body
+- **Triage summary comments** (Step 6) also use this visibility
+
+Operations may include an explicit `visibility` in their params to override the default. If omitted, the default is applied.
+
+#### User References in Comments
+
+References to people in comments fall into two categories with different syntax:
+
+**Action pings (requesting someone do something):** Use the Jira mention syntax `@[Display Name](accountid:ACCOUNT_ID)`, which the MCP Markdown-to-ADF converter transforms into a native Jira mention node (clickable, with notifications). Use this **only** when you are directing a question, request, or call-to-action at that person.
+
+**Contextual citations (stating who did something):** Use the person's **plain display name** with no mention syntax. Historical context like "set by Christian Vogt on 2024-11-14" or "comment by Jane Doe (Mar 20)" does not require a notification -- it is providing attribution, not requesting action.
+
+**How to get the account ID (for action pings):** Call `jira_get_user_profile` with the person's email address. The response includes an `account_id` field. The `account_id` is also available on issue fields (`reporter`, `assignee`) and in comment author objects returned by `jira_get_issue`.
+
+**Example -- action ping:**
+```markdown
+@[Jane Doe](accountid:712020:ce710f80-369e-4b6d-95e2-ca6c9e58d9fb) — can you confirm whether this is still blocked?
+```
+
+**Example -- contextual citation (no ping):**
+```text
+Stale `Blocked=True` (~16 months, set by Christian Vogt on 2024-11-14).
+```
+
+**Rule of thumb:** If removing the reference would lose an actionable ask, it's an action ping. If removing it would only lose historical context, it's a contextual citation.
+
+#### Issue and External References in Comments
+
+**Every Jira issue key and external resource mentioned in a comment must be a full clickable link.** This applies to *every occurrence* of the key in the comment — not just the first mention. Do not use bare issue keys (`RHOAIENG-12345`) or shorthand notations (`org/repo#123`). Although Jira may auto-link issue keys in some rendering contexts, explicit markdown links are more reliable and work across all rendering modes (email notifications, API consumers, ADF export).
+
+| Reference type | Bad (not clickable) | Good (clickable) |
+|---|---|---|
+| Jira issue | `RHOAIENG-12345` | `[RHOAIENG-12345](https://redhat.atlassian.net/browse/RHOAIENG-12345)` |
+| GitHub issue | `patternfly-design#1276` | `[patternfly/patternfly-design#1276](https://github.com/patternfly/patternfly-design/issues/1276)` |
+| GitHub PR | `odh-dashboard#1234` | `[odh-dashboard#1234](https://github.com/opendatahub-io/odh-dashboard/pull/1234)` |
+| GitHub PR (full) | PR #1234 | `[PR #1234](https://github.com/opendatahub-io/odh-dashboard/pull/1234)` |
+
+**Jira issues:** Always use `[KEY](https://redhat.atlassian.net/browse/KEY)`. If the same issue key appears multiple times in a comment (e.g., once in a summary list and again in a ping paragraph), **every occurrence** must be a link.
+
+**GitHub references** require the full URL because Jira does not auto-link GitHub shorthand. When referencing a GitHub issue or PR, construct the URL from the org, repo, and number. Use `jira-project-reference.md` § GitHub Repository for the dashboard repo's owner and name. For external repos (e.g., `patternfly/patternfly-design`), infer the org and repo from the shorthand or Blocked Reason text.
+
+#### When to Ping the Reporter
+
+**Only ping the reporter for `needs-info`** -- when the reporter can provide missing details or confirm a decision that only they can make. Two common cases:
+
+1. **Missing description details** (steps to reproduce, environment, expected behavior, etc.) — handled by the validate-description skill.
+2. **Close suggestion confirmation** — when recent comments suggest the issue should be closed, the reporter must confirm whether the issue is still needed. Handled by evaluate-blockers Tag mode Step 5.
+
+**Never ping the reporter for other `needs-*` labels** (`needs-ux`, `needs-pm`, `needs-advisor`). These labels signal that a specific *role* (designer, product manager, tech lead) needs to provide input. The reporter is typically not that person, so pinging them creates noise without producing useful action. These labels are signals to the triage team, not requests to the reporter.
+
+#### SET_FIELDS
+
+Pass-through to `jira_update_issue`. The base skill does not need to know which fields are being set -- analysis skills determine their own field names, IDs, and values.
+
+Examples:
+- `{"fields": {"priority": {"name": "Major"}}}`
+- `{"fields": {"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809"}}`
+- `{"fields": {"issuetype": {"name": "Bug"}}}`
+
+#### ADD_LABEL / REMOVE_LABEL -- Read-Modify-Write (CRITICAL)
+
+The `jira_update_issue` tool **replaces** the entire labels array. Calling it with only the new labels would wipe all existing labels. This is destructive and hard to undo across a batch.
+
+**Required procedure:**
+
+1. Call `jira_get_issue` with `fields=labels` to get the current labels array
+2. Compute the new labels:
+   - **ADD_LABEL**: union of current labels and the labels in params
+   - **REMOVE_LABEL**: current labels minus the labels in params
+3. Call `jira_update_issue` with `{"labels": [<full resulting array>]}`
+
+If the current labels already contain the label being added (or don't contain the label being removed), skip the update and mark the operation as `success` with a note.
+
+#### TRANSITION
+
+Operations use a human-readable `transitionName` (e.g., "Backlog", "In Progress"). The Apply step resolves it to a numeric `transition_id` at execution time. An optional `fields` object can set fields during the transition (e.g., resolution when closing).
+
+1. Call `jira_get_transitions` on the issue to get available transitions
+2. Find the transition whose name exactly matches `transitionName` (case-insensitive)
+3. If found, call `jira_transition_issue` with the resolved `transition_id`. If the operation includes `fields`, pass them as the `fields` parameter to `jira_transition_issue` as a JSON string (e.g., `'{"resolution": {"name": "Done"}}'`).
+4. If no match, mark the operation `failed` with error text that includes the list of available transition names for diagnosis
+
+#### LINK_DUPLICATE
+
+Call `jira_create_issue_link` with:
+- `link_type`: `"Duplicate"`
+- `inward_issue_key`: the operation's `issueKey`
+- `outward_issue_key`: the `duplicateOf` value from params
+
+#### LINK_BLOCKED_BY
+
+Call `jira_create_issue_link` with:
+- `link_type`: `"Blocks"`
+- `inward_issue_key`: the operation's `issueKey` (the issue that is blocked)
+- `outward_issue_key`: the `blockedBy` value from params (the issue that blocks)
+
+This creates a link where the `blockedBy` issue "blocks" the operation's issue (and the operation's issue "is blocked by" the `blockedBy` issue).
+
+### Aggregation
+
+Results from multiple analysis skills can be merged by concatenating their `operations` arrays. If producers used the root `issues` map (issue key → summary), merge those objects too (combine maps; on duplicate keys, prefer the later batch or reconcile manually). Apply processes operations in array order regardless of source. A single issue may have multiple operations (e.g., ADD_LABEL + ADD_COMMENT + TRANSITION).
+
+**Ordering matters:** analysis skills should sequence dependent actions correctly. For example, a comment explaining a close should come before the TRANSITION to Closed.
+
+**Conflict detection:** during dry-run, if multiple operations target the same issue, flag them for the user to review. This catches cases where one skill adds a label while another transitions to Closed.
+
+---
+
+## Capability 2: Apply
+
+Execute operations against Jira. Supports two modes and two sources.
+
+**Modes:**
+
+- **Dry-run (default):** Validate, present summary, write operations file to disk, and stop. No Jira mutations. The user reviews the file offline or in a later session.
+- **Execute:** Validate, present summary, confirm, execute against Jira, annotate operations in-place with status.
+
+**Sources:**
+
+- **Inline (chained):** Operations from an analysis step in the same session. Default mode is dry-run: validate, summarize, write file, stop. The user can request immediate execution instead.
+- **From file:** A path to an operations JSON file (from a previous dry-run or hand-edited). Always runs in execute mode: validate, summarize, confirm, execute.
+
+The agent determines the source from context: "apply operations from `.artifacts/triage/ops.json`" means from-file; operations flowing from a preceding analysis step means inline.
+
+### Operations File Path
+
+All operations files are written to: `.artifacts/triage/`
+
+This path is relative to the workspace root. Create `.artifacts/triage/` if it doesn't exist.
+
+- **File name:** `operations-YYYY-MM-DD.json` using today's date (from the conversation context). If the file already exists, append a numeric suffix: `operations-YYYY-MM-DD_(2).json`, `operations-YYYY-MM-DD_(3).json`, etc. Check the directory with `ls` before choosing the name.
+
+There is no separate results file. Execution status is tracked **in-place** on the operations file — each operation gets a `status` field as it is executed (see Step 5). This keeps everything in one file, supports selective/partial applies naturally, and avoids proliferating results files.
+
+### Apply Procedure
+
+#### Step 1: Validate and Filter
+
+- Verify the operations match the schema in `operations-schema.json`
+- Check that every `issueKey` looks valid (matches `^[A-Z]+-[0-9]+$`)
+- **Filter out already-applied operations.** Only operations with `status: "success"` are excluded — they are definitively done. Operations with `status: "failed"` are retried alongside unannotated operations. Report the counts: "N operations to apply (M already succeeded, excluded)."
+- **Exclude `NO_OP` operations from execution counts.** `NO_OP` operations are informational records — they are not counted as "operations to apply" and are not executed. They appear in the dry-run summary for completeness but are automatically treated as `status: "success"` during execution (annotated in-place without any Jira API call).
+- Report any validation errors and stop
+
+#### Step 2: Dry-Run Summary
+
+**Only unannotated operations (no `status` field) appear in the summary.** Already-applied operations are not shown.
+
+Resolve display text for each line as `operation.summary ?? issues[issueKey] ?? issueKey` (see `operations-schema.json`).
+
+**Always present the summary grouped by Jira issue key**, listing each issue once with all its proposed changes underneath. **Every issue key in the summary must be a clickable markdown link** to the Jira issue (format: `[RHOAIENG-12345](https://redhat.atlassian.net/browse/RHOAIENG-12345)`). This makes it easy to review the full picture for each issue at a glance:
+
+```text
+Dry-run summary:
+
+[RHOAIENG-12345](https://redhat.atlassian.net/browse/RHOAIENG-12345) -- Widget crashes on save
+  - Activity Type = Tech Debt & Quality
+  - Comment to @reporter requesting repro steps
+  - +`needs-info` -- missing reproduction steps
+  - +`dashboard-area-model-serving`
+  - +`ai-reviewed`
+
+[RHOAIENG-12346](https://redhat.atlassian.net/browse/RHOAIENG-12346) -- Add dark mode toggle to cluster settings
+  - +`needs-ux` -- UI change without mockups
+  - +`dashboard-area-cluster-settings`
+  - +`ai-reviewed`
+
+[RHOAIENG-12350](https://redhat.atlassian.net/browse/RHOAIENG-12350) -- Pipeline run table shows wrong status
+  - **Story -> Bug**, Activity Type = Tech Debt & Quality
+  - Severity = Moderate, Priority = Normal -> Major (severity floor)
+  - +`dashboard-area-pipelines`
+  - +`dashboard-razzmatazz-scrum`
+  - -> Backlog
+  - +`ai-reviewed`
+
+[RHOAIENG-12355](https://redhat.atlassian.net/browse/RHOAIENG-12355) -- Waiting on backend API for subscription column
+  - blocked by [RHOAIENG-12300](https://redhat.atlassian.net/browse/RHOAIENG-12300)
+  - +`dashboard-area-model-serving`
+  - +`ai-reviewed`
+
+[RHOAIENG-12370](https://redhat.atlassian.net/browse/RHOAIENG-12370) -- Stale bug already fixed on main
+  - -> Closed (Done) -- Already fixed on main
+  - +`ai-reviewed`
+
+[RHOAIENG-12380](https://redhat.atlassian.net/browse/RHOAIENG-12380) -- Operator webhook validation error
+  - NO_OP: Not a dashboard issue — operator-only component with no UI/BFF scope
+```
+
+`NO_OP` issues appear at the end of the dry-run summary, separated from actionable issues. They are not included in the executable operation count.
+
+#### Step 3: Write or Execute
+
+**Dry-run mode (default for inline operations):**
+
+1. Write the operations to a new file in `.artifacts/triage/` (see § Operations File Path for naming)
+2. Report the file path: "Operations written to `.artifacts/triage/operations-2026-03-26.json` -- review and apply with: apply operations from that file"
+3. Stop. No Jira mutations.
+
+**Execute mode (default for from-file, or when the user explicitly requests execution):**
+
+Continue to Step 4.
+
+#### Step 4: Confirm and Execute
+
+Confirmation is **all-or-nothing**:
+
+- "Apply all N operations to M issues? (yes / abort)"
+
+The user either approves the entire batch or aborts. There is no per-group or per-issue selection — the dry-run summary (Step 2) is the review checkpoint. If the user wants to exclude specific operations, they edit the operations file before applying.
+
+On approval, process all operations **sequentially** (one at a time) following the action-specific procedures documented above.
+
+#### Step 5: Track Status (In-Place Annotation)
+
+As each operation is executed, annotate it **in-place** on the operations file. Read the file, update the operation's fields, write it back. This makes the operations file the single source of truth for both what was proposed and what happened.
+
+**Status values:**
+
+| Status | Meaning |
+|---|---|
+| (absent) | Not yet attempted — the implicit default for unannotated operations |
+| `success` | Completed successfully |
+| `failed` | Failed with error (see `error` field) |
+
+**Additional fields set on execution:**
+
+| Field | When set | Purpose |
+|---|---|---|
+| `status` | Always on execution | Tracks outcome |
+| `error` | `status: "failed"` only | Error detail for diagnosis |
+| `commentId` | `ADD_COMMENT` with `status: "success"` | Jira comment ID, enables later edits |
+
+**On failure:** log the error, mark the operation `failed`, and **continue** to the next operation. Do not abort the batch.
+
+**Partial applies:** When applying a subset of operations from a file (e.g., "apply operations for RHOAIENG-7530 only"), annotate only the targeted operations. Unannotated operations remain available for future applies.
+
+#### Step 6: Post Triage Summary Comments
+
+After all operation groups have been executed, post a summary comment on each issue that had at least one successful, non-bookkeeping operation. This documents what the AI triage changed directly on the issue.
+
+**When to post:** Execute mode only. Dry-run does not post comments.
+
+**Which issues:** Any issue with at least one `success` operation, excluding `NO_OP` and the `ai-reviewed` bookkeeping ADD_LABEL. Issues whose only operations are `NO_OP` + `ai-reviewed` do **not** get a triage summary comment — there is nothing to report.
+
+**Comment format (Markdown):**
+
+The `jira_add_comment` MCP tool accepts **Markdown** (not Jira wiki markup) and converts it to ADF. All comment templates below use Markdown syntax.
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| {field} | {change} |
+| | *{reason}* |
+| Status | {old status} → {new status} |
+```
+
+**Template rules:**
+
+- **Header** is always `### AI Triage`
+- **Field/Change table** is a Markdown table with one row per actual change, with an italicized reason sub-row underneath
+- **Included operations:** SET_FIELDS, ADD_LABEL (except bookkeeping labels), REMOVE_LABEL, TRANSITION, LINK_DUPLICATE, LINK_BLOCKED_BY
+- **Excluded:** bookkeeping labels (`ai-reviewed`), failed operations
+- **Field names** use human-readable labels: "Type", "Activity Type", "Priority", "Severity", "Labels", "Scrum Team", "Status", "Team"
+- **Field values** use human-readable names, not field IDs or internal codes. Examples: "RHOAI Dashboard" not raw `customfield_10001` UUIDs alone in prose; "Moderate" not `{"value": "Moderate"}`; "Major" not `{"name": "Major"}`
+- **Label changes** are shown as `` +`label-name` `` (added) or `` -`label-name` `` (removed), using Markdown inline code
+- **Multiple labels** in a single ADD_LABEL are comma-separated in one row: `` +`label-a`, +`label-b` ``
+- **Link operations** are shown as `` +blocked by [`RHOAIENG-12300`](https://redhat.atlassian.net/browse/RHOAIENG-12300) `` for LINK_BLOCKED_BY and `` +duplicate of [`RHOAIENG-99999`](https://redhat.atlassian.net/browse/RHOAIENG-99999) `` for LINK_DUPLICATE. Links appear after Labels rows and before the Scrum Team row.
+- **Blocked field changes** are shown as `(unset) → Blocked: {reason text}` when setting Blocked=True with a reason, or `Blocked → (unset)` when clearing it. Appears after link rows.
+- **Unset fields** use `(unset)` as the explicit "from" value to make reversal unambiguous (e.g., `(unset) → RHOAI Dashboard` for a newly assigned Team field)
+- **Scrum Team row** appears after Labels/Links/Blocked rows and before the Status row. Three cases:
+  - **Assigned by pipeline:** `` | Scrum Team | +`dashboard-monarch-scrum` | `` with reason sub-row. Normal operation row.
+  - **Could not be determined (and no scrum label exists):** `| Scrum Team | — (not assigned) |` with reason sub-row explaining why (e.g., area has no default team mapping, or areas map to conflicting teams). This is the only comment row that can appear without a corresponding successful operation.
+  - **Already assigned (noop):** Omit the row entirely. An existing scrum label is a noop — nothing to report.
+- **Status transition** is always the last row in the table, shown as `{old} → {new}` with no reason sub-row
+- **Reason sub-rows** use `| | *{reason text}* |` (empty first cell, italicized reason in second cell)
+- **Do not** restate the issue key or summary -- the comment is on that issue
+
+**Example -- bug with type correction, area label, scrum team, and team assignment:**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Type | Story → Bug |
+| | *Description reports a crash with stack trace — matches bug criteria, not enhancement.* |
+| Activity Type | New Features → Tech Debt & Quality |
+| | *Bug classification; Activity aligned to quality/defect work.* |
+| Severity | Undefined → Moderate |
+| | *Single-user impact with workaround available.* |
+| Priority | Normal → Major |
+| | *Severity floor: Moderate severity requires at least Major priority.* |
+| Labels | +`dashboard-area-pipelines` |
+| | *Pipeline-specific error message and file paths in description.* |
+| Team | (unset) → RHOAI Dashboard |
+| | *Pipeline execution UI errors and file paths in description — dashboard-area-pipelines.* |
+| Scrum Team | +`dashboard-razzmatazz-scrum` |
+| | *Area 'dashboard-area-pipelines' maps to Razzmatazz.* |
+| Status | New → Backlog |
+```
+
+**Example -- story with no type change:**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Priority | Undefined → Normal |
+| | *UX improvement with no urgency signal — default story priority.* |
+| Labels | +`enhancement`, +`dashboard-area-model-catalog` |
+| | *Standalone enhancement to existing model catalog admin settings.* |
+| Scrum Team | +`dashboard-green-scrum` |
+| | *Area 'dashboard-area-model-catalog' maps to Green.* |
+| Status | New → Backlog |
+```
+
+**Example -- issue blocked, not transitioned:**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Labels | +`needs-info` |
+| | *No reproduction steps or environment details provided.* |
+| Labels | +`dashboard-area-model-serving` |
+| | *Inference endpoint and serving runtime references in description.* |
+| Scrum Team | +`dashboard-zaffre-scrum` |
+| | *Area 'dashboard-area-model-serving' maps to Zaffre.* |
+```
+
+**Example -- scrum team skipped (unmapped area):**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Labels | +`dashboard-area-edge` |
+| | *Edge deployment keywords in summary and description.* |
+| Scrum Team | — (not assigned) |
+| | *Area 'dashboard-area-edge' has no default scrum team mapping.* |
+| Status | New → Backlog |
+```
+
+**Example -- scrum team skipped (conflicting areas):**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Labels | +`dashboard-area-model-registry`, +`dashboard-area-pipelines` |
+| | *Model registry and pipeline references in description.* |
+| Scrum Team | — (not assigned) |
+| | *Areas map to conflicting teams: Green (model-registry), Razzmatazz (pipelines).* |
+| Status | New → Backlog |
+```
+
+**Example -- issue with blocked-by link and blocked field:**
+
+```markdown
+### AI Triage
+
+| Field | Change |
+| --- | --- |
+| Priority | (unset) → Major |
+| | *Backend dependency with customer-facing impact.* |
+| Labels | +`dashboard-area-pipelines` |
+| | *Pipeline server configuration references in description.* |
+| Blocked By | +blocked by [`RHOAIENG-54596`](https://redhat.atlassian.net/browse/RHOAIENG-54596) |
+| | *Description states dependency on backend API in [`RHOAIENG-54596`](https://redhat.atlassian.net/browse/RHOAIENG-54596).* |
+| Blocked | (unset) → Blocked: Waiting on z-stream 2.25 to ship the backend fix |
+| | *External release dependency — cannot proceed until z-stream ships.* |
+| Scrum Team | +`dashboard-razzmatazz-scrum` |
+| | *Area 'dashboard-area-pipelines' maps to Razzmatazz.* |
+```
+
+Post the comment using `jira_add_comment` with `visibility: '{"type":"group","value":"Red Hat Employee"}'` (see § Comment Visibility). This comment is posted after all other operations have been executed for the issue -- it summarizes the final state, not intermediate steps.
+
+#### Step 7: Report Results
+
+After all operations are attempted, report:
+
+```text
+Results: 11 succeeded, 2 failed
+
+Failed operations:
+  [RHOAIENG-12346](https://redhat.atlassian.net/browse/RHOAIENG-12346): TRANSITION -> "Backlog" -- Transition 'Backlog' not available (available: New, In Progress, Closed)
+  [RHOAIENG-12360](https://redhat.atlassian.net/browse/RHOAIENG-12360): SET_FIELDS priority=Major -- Permission denied
+```
+
+Then provide a JQL query targeting the specific issue keys that had at least one successful operation, along with a clickable Jira link:
+
+```jql
+key in (RHOAIENG-12345, RHOAIENG-12346, RHOAIENG-12350) ORDER BY key ASC
+```
+
+Build the link as `https://redhat.atlassian.net/issues/?jql=` followed by the URL-encoded JQL. **Encode parentheses** as `%28` / `%29` — unencoded `()` in the URL breaks markdown link syntax. Present it as a markdown link so the user can click through to verify the changes in the Jira web interface.
+
+For consistency, **every issue key shown in Step 7 output must be a clickable markdown link** (`https://redhat.atlassian.net/browse/<ISSUE-KEY>`), including issue-group headers and failed operation lines.
+
+#### Step 8: Verify File State
+
+After all operations are attempted and triage summary comments are posted, the operations file already reflects the final state (each operation annotated in-place during Step 5). No separate results file is written.
+
+Verify the file is consistent: every operation that was attempted should have a `status` field. Report the file path so the user can review.
+
+**Example of an annotated operations file after partial execution:**
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-11",
+    "query": "...",
+    "issueCount": 4
+  },
+  "issues": {
+    "RHOAIENG-12345": "Issue title",
+    "RHOAIENG-12346": "Another issue",
+    "RHOAIENG-12348": "Operator webhook error",
+    "RHOAIENG-12350": "Third issue"
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-12345",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["needs-info"] },
+      "reason": "No reproduction steps",
+      "status": "success"
+    },
+    {
+      "issueKey": "RHOAIENG-12345",
+      "action": "ADD_COMMENT",
+      "params": { "comment": "### AI Triage\n\n..." },
+      "reason": "Requesting missing details from reporter",
+      "status": "success",
+      "commentId": "16601820"
+    },
+    {
+      "issueKey": "RHOAIENG-12346",
+      "action": "TRANSITION",
+      "params": { "transitionName": "Backlog" },
+      "reason": "Triaged, moving to backlog",
+      "status": "failed",
+      "error": "Transition 'Backlog' not available for current status 'In Progress'"
+    },
+    {
+      "issueKey": "RHOAIENG-12348",
+      "action": "NO_OP",
+      "params": {},
+      "reason": "Not a dashboard issue — operator-only component with no UI/BFF scope",
+      "status": "success"
+    },
+    {
+      "issueKey": "RHOAIENG-12350",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-area-pipelines"] },
+      "reason": "Pipeline references in description"
+    }
+  ]
+}
+```
+
+In this example, two operations succeeded, one failed, one is a NO_OP (auto-succeeded), and one has not been attempted yet (no `status` field). Note that `issueCount` is 4 (the query result size) and every issue in the `issues` map has at least one entry in `operations`.
+
+### Resume
+
+Re-applying the same operations file automatically resumes where you left off. Step 1 excludes `status: "success"` operations and retries everything else — failed and unannotated operations are all candidates.
+
+---
+
+## Capability 3: Full Triage
+
+End-to-end orchestration of the analysis pipeline for issues in the `New` status. Fetches untriaged issues, runs every applicable analysis skill, aggregates operations, and applies them.
+
+### When to Use
+
+Use Full Triage when the user asks to "triage new issues", "run triage", or wants to process the incoming queue. For ad-hoc or selective operations (e.g., "check priority on these 3 bugs"), use individual skills with Fetch/Apply directly.
+
+**Transition opt-in:** By default, Full Triage does **not** transition issues from New to Backlog. Issues remain in New so a human can review AI triage results first. To enable transitions, the user must explicitly request them (e.g., "triage and transition", "triage with transitions", "move to backlog", "auto-transition"). See Step 2c for details.
+
+### Target JQL
+
+Full Triage always uses this JQL to select its issue set:
+
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND status = New
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND (Team is EMPTY OR Team = {jql_team_id})
+  AND (labels is EMPTY OR labels != Security)
+  AND (labels is EMPTY OR labels not in (Cross-Team))
+  AND (labels is EMPTY OR labels not in ({scrum_labels_list}))
+  AND (labels is EMPTY OR labels not in ({needs_labels_list}))
+  AND Blocked != "True"
+ORDER BY key ASC
+```
+
+This is the standard Untriaged issues query (see Common JQL Patterns). Uses `(Team is EMPTY OR Team = ...)` because incoming issues may not yet have a team assigned. All values come from `jira-project-reference.md`. The existing status, label, and blocked filters are sufficient to exclude already-triaged issues — no `ai-reviewed` guard is needed.
+
+#### Scrum-specific triage
+
+When the user asks to triage a **specific scrum team** (e.g., "triage Zaffre", "triage Razzmatazz issues"), modify the Target JQL as follows:
+
+1. **Remove** the scrum label exclusion line: `AND (labels is EMPTY OR labels not in ({scrum_labels_list}))`
+2. **Insert** a positive label match for the requested scrum team: `AND labels = "{scrum_label}"`
+
+The resulting query:
+
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND status = New
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND (Team is EMPTY OR Team = {jql_team_id})
+  AND (labels is EMPTY OR labels != Security)
+  AND (labels is EMPTY OR labels not in (Cross-Team))
+  AND labels = "{scrum_label}"
+  AND (labels is EMPTY OR labels not in ({needs_labels_list}))
+  AND Blocked != "True"
+ORDER BY key ASC
+```
+
+All other query filters remain unchanged. The rest of the pipeline runs normally — the assign-scrum-team skill (Step 2b, skill 6) will naturally skip these issues since they already have a scrum label.
+
+### Context Management
+
+Full Triage is designed to minimize context window usage so it can process large issue queues without running out of context. Four mechanisms work together:
+
+1. **Complete issue inventory (CRITICAL).** Step 1 fetches all pages and builds a **verified inventory** of every issue before processing begins. The inventory count must match the total returned by the API. See top-level § Context Management for the full inventory protocol. **No issue may be skipped, estimated, or lost in large search responses.**
+2. **Lightweight list fetch.** Step 1 fetches all issues with minimal fields (no descriptions). This builds the issue queue cheaply.
+3. **Per-issue detail fetch.** Each issue's full details (description, reporter, etc.) are loaded only when that issue is being processed, via a `jira_get_issue` call at the start of each iteration.
+4. **Incremental file writes.** After each issue is fully processed, its operations are written to the output file on disk immediately. The agent does not need to retain previous issues' descriptions or operations in working memory.
+
+This means context at any point holds roughly: one issue's full data + one sub-skill's reference material + the triage infrastructure. This is bounded and constant regardless of queue size.
+
+### Sub-Agent Delegation ("Think Deep")
+
+Sub-agent delegation gives each issue a completely fresh context window, allowing deeper analysis without accumulated tool call history from previous issues.
+
+#### When to delegate
+
+Sub-agent delegation is **opt-in only**. The default is always inline processing — no sub-agents. Use sub-agents only when the user explicitly requests it:
+
+- "think deep" / "deep triage" — user wants maximum analysis depth per issue
+- "use sub-agents" / "triage with sub-agents" — user explicitly requests delegation
+
+When the user does not request delegation, process all issues inline using the per-issue pattern in Steps 2.0–2e regardless of queue size. **Never** enable sub-agents without user confirmation. **Never** suggest sub-agents proactively.
+
+#### Coordinator role
+
+When delegating, the parent agent becomes a lightweight coordinator:
+
+1. **Step 1** (Fetch + Initialize) — runs in the coordinator as normal
+2. **Step 2** — coordinator dispatches one sub-agent per issue instead of processing inline
+3. **Step 3** (Apply) — runs in the coordinator after all sub-agents complete
+
+The coordinator does **not** read sub-skill files, fetch issue details, or run the analysis pipeline. It holds only the verified inventory (issue keys + summaries) and the operations file path.
+
+#### Worker sub-agent prompt
+
+Each sub-agent receives a self-contained prompt — sub-agents have no access to the parent conversation. Use the `Task` tool with `subagent_type: "generalPurpose"`. Do **not** set `readonly: true` (sub-agents need MCP access for Jira API calls and write access for the operations file).
+
+**Template** (substitute `{placeholders}` from the inventory):
+
+```text
+Process one Jira issue through the Full Triage analysis pipeline.
+
+**Issue:** {issueKey}
+**Operations file:** {operations_file_path}
+**Position:** [{current}/{total}]
+**Transitions enabled:** {yes|no}
+
+**Steps:**
+1. Read these files in order:
+   - `.claude/skills/jira-triage/persona.md` — execution protocol, follow strictly
+   - `.claude/skills/jira-triage/jira-project-reference.md` — all Jira field IDs, labels, values
+   - `.claude/skills/jira-triage/SKILL.md` — read Capability 3, Steps 2.0 through 2e
+
+2. Execute Steps 2.0–2e for {issueKey}:
+   - 2.0: Fetch full details via jira_get_issue (use the detail fields listed in § Fields)
+   - 2.0a: Template gate — if summary/labels/description indicate a template issue, write NO_OP + ai-reviewed and return
+   - 2a: Team gate — evaluate dashboard ownership; if not owned, write NO_OP with reason
+   - 2b: Analysis pipeline — read each sub-skill SKILL.md and run in documented order:
+          validate-issue-type → validate-description → validate-priority-severity →
+          evaluate-blockers (Tag) → validate-area-label (Tag) → assign-scrum-team
+   - 2c: Status transition — ONLY if "Transitions enabled = yes": TRANSITION to Backlog if no blocking signals. If "Transitions enabled = no", skip this step entirely.
+   - 2d: Finalize — ADD_LABEL ai-reviewed
+   - 2e: Write operations to {operations_file_path}
+
+3. Return a one-line progress summary in this format:
+   "{issueKey} -- {summary}: {result}"
+   Examples:
+     "RHOAIENG-12345 -- Widget crashes: type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre → Backlog"
+     "RHOAIENG-12345 -- Widget crashes: type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre"
+     "RHOAIENG-12346 -- Operator webhook error: skipped (not a dashboard issue)"
+   If the issue was skipped at the team gate, return:
+     "RHOAIENG-12346 -- Operator webhook error: skipped ({reason})"
+```
+
+The sub-agent reads the full SKILL.md and follows Steps 2.0–2e as documented — the prompt does not duplicate the step logic, it references it. This ensures the sub-agent always follows the current version of the pipeline.
+
+#### Dispatch pattern
+
+Dispatch one sub-agent at a time in key-ascending order. After each completes:
+
+1. Read its returned progress line
+2. Report to user: `[3/9] {progress_line}`
+3. Dispatch the next sub-agent
+
+#### Error handling
+
+If a sub-agent fails (returns an error, times out, or produces no file update):
+
+1. Report: `[3/9] RHOAIENG-12345 -- FAILED: {error summary}`
+2. Continue to the next issue — do not retry automatically
+3. After all issues, list failed issues for the user to retry or handle manually
+
+### Fields
+
+Full Triage uses two field sets to manage context efficiently:
+
+**List fields** (Step 1 — bulk fetch for the issue queue):
+
+`summary, status, priority, labels, assignee, issuetype, created, updated, customfield_10001, components`
+
+This is a lightweight set for building the issue queue. It includes Team (`customfield_10001`) and Components for the Step 2a team gate (which can skip issues without reading their description). It excludes `description` and other large fields to keep the bulk fetch small.
+
+**Detail fields** (Step 2 — per-issue fetch via `jira_get_issue`):
+
+`summary, status, priority, labels, assignee, issuetype, created, updated, description, reporter, comment, customfield_10840, customfield_10517, customfield_10483, customfield_10001, customfield_10464, issuelinks, components`
+
+Use `comment_limit=20` on the `jira_get_issue` call to cap comment volume. The `comment` field **must** be explicitly included in the `fields` parameter for the API to return comments.
+
+This is the full field set required by all analysis skills. Fetched once per issue at the start of processing, used for the duration of that issue's pipeline, then no longer needed.
+
+### Procedure
+
+#### Step 1: Fetch and Initialize
+
+1. Use the Fetch capability with the Target JQL above and the **list fields**. Fetch **all pages** of results.
+2. Build a **verified inventory**: extract every issue key and summary from every page of results. Read the entire response for each page -- do not skip or skim sections of large responses. Verify the inventory count matches the total returned by the API. If they don't match, re-read the search results until they do.
+3. If there are no matching issues, report "No untriaged issues found" and stop.
+4. Choose the operations file name per § Operations File Path (check for existing files, append `_(N)` if needed). Create the file with the **complete** initial skeleton — `issueCount` and `issues` are populated now, not incrementally:
+   ```json
+   {
+     "metadata": {
+       "generated": "<today's date>",
+       "query": "<the JQL used>",
+       "issueCount": <total issues from verified inventory>
+     },
+     "issues": {
+       "<every issue key>": "<summary from inventory>",
+       ...
+     },
+     "operations": []
+   }
+   ```
+   `issueCount` is set to the total number of issues in the verified inventory and **never changes** after this point. The `issues` map contains **every** issue from the query result with its summary. This persists the authoritative inventory to disk before any processing begins — if context compacts, the file is the source of truth.
+5. Report the verified issue count: "Found N untriaged issues (verified). Processing one at a time..." If the user opted into sub-agent delegation, add: "Using sub-agent delegation (think deep)." If the user opted into transitions, add: "Transitions enabled (New → Backlog)." If they did not, add: "Transitions disabled (issues remain in New)."
+
+#### Step 2: Process Each Issue
+
+**Delegation check:** If the user opted into sub-agent delegation ("think deep"), use the sequential dispatch pattern from § Sub-Agent Delegation. The coordinator dispatches one sub-agent per issue using the prompt template (setting "Transitions enabled" to yes/no based on whether the user opted in); each sub-agent follows Steps 2.0–2e below autonomously. The rest of this section documents what happens per issue — whether executed inline or by a delegated sub-agent.
+
+Process issues **one at a time** in key-ascending order. Complete all sub-steps for a single issue before moving to the next, then **write that issue's operations to the file on disk** before proceeding. This bounds context usage: only one issue's full details are in working memory at any point, and completed issues are persisted to disk rather than accumulated in session.
+
+For each issue in the fetched set:
+
+**Step 2.0: Fetch issue details.** Call `jira_get_issue` with the **detail fields** for this single issue. This loads the description, reporter, severity, blocked state, issue links, and other fields needed by the analysis pipeline. Only this one issue's details are in context at a time.
+
+Then perform sub-steps 2a through 2e:
+
+##### Step 2.0a: Template Gate
+
+Template issues are recurring task templates (e.g., "TEMPLATE - Learning Activities", "Nightly build analysis - TEMPLATE") that serve as blueprints for cloning actual work items. They should not be triaged, transitioned, or modified by the pipeline. See `jira-project-reference.md` § Template Issues for detection signals.
+
+**Detection signals** (any one is sufficient):
+
+- Summary contains the word "TEMPLATE" (case-insensitive), typically as a prefix ("TEMPLATE - ...") or suffix ("... - TEMPLATE")
+- Labels include a template-related label (e.g., `template`)
+- Description consists primarily of placeholder/boilerplate text with fill-in markers (e.g., `[replace this]`, `TODO:`, repeating placeholder sections)
+
+**If detected:** Produce a single `NO_OP` with reason citing the template signal. **Skip Steps 2a–2d entirely** — do not assign Team, run the analysis pipeline, transition, or add `ai-reviewed`. Templates are not work items and should not be touched at all. Proceed directly to Step 2e (write to disk).
+
+```json
+{
+  "issueKey": "RHOAIENG-12345",
+  "action": "NO_OP",
+  "params": {},
+  "reason": "Template issue — summary contains 'TEMPLATE'; not a real work item"
+}
+```
+
+##### Step 2a: Team Gate
+
+This is the entry gate. Full Triage only processes issues that belong to the **RHOAI Dashboard** program team. The `component = "AI Core Dashboard"` JQL filter only ensures **that component appears on the issue**; it does **not** mean the dashboard team owns the work (issues may have **multiple** components for relationship tracking). This step evaluates Jira **Components**, labels, and description together.
+
+**Hard rule — no triage for other teams:** If you conclude the issue is **owned by or belongs to another program team** (not RHOAI Dashboard), **stop for this issue immediately**. Do **not** run Step 2b (analysis pipeline) or Step 2c–2d (transition and finalize). Do **not** emit operations meant to dashboard-triage a non-dashboard issue (including type, priority, area, scrum, blockers, or comments). Report the issue as skipped with a one-line reason. The Dashboard triage skills are not a substitute for the owning team's intake.
+
+**Read first:** `jira-project-reference.md` § **When *not* to treat an issue as dashboard-owned (team gate)** for multi-component handling, labels outside `dashboard-area-*`, and descriptions dominated by backend/API/automation vs dashboard UI.
+
+1. **Team field set to a non-dashboard team:** If the Team field (`customfield_10001`) is set to **any value other than** RHOAI Dashboard (see `jira-project-reference.md` § Project Constants), **skip this issue** -- the issue is already attributed elsewhere; do not override Team to pull it into dashboard triage. Produce a `NO_OP` with reason (e.g., "Team already set to {team name} — not dashboard-owned"). (This case is rare when using the default Full Triage JQL, but can appear if the issue set came from a custom query.)
+2. **Strong "not dashboard" composite (apply before positive evidence):** If **all** of the following hold, **skip** — do not assign Team, do not run 2b–2d. This applies **even if** Team is already RHOAI Dashboard (mis-attribution); do not emit dashboard operations. See **Skip outcome** below for whether to emit `ADD_LABEL Cross-Team` or `NO_OP`.
+   - The issue has **more than one** Jira component and at least one component is **not** `AI Core Dashboard`; **and**
+   - Labels suggest **another subsystem, CI/pipeline, or team-local categorization** (not `dashboard-area-*`); infer from wording — do **not** rely on a hardcoded list of product names; **and**
+   - The description is dominated by **backend/API or contract-test/automation** (e.g. service error codes, OpenAPI/spec mismatch, cluster test jobs, automated tests hitting a service) with **no** dashboard UI, PatternFly, or `opendatahub-io/odh-dashboard` repo/BFF scope.  
+   *Pattern:* secondary component points at a non-UI service or platform; narrative never ties work to dashboard delivery — **skip**.
+3. **Team already set to dashboard:** If the issue was **not** skipped in step 2 and the Team field is already set to RHOAI Dashboard, the issue passes the gate. Proceed to Step 2b.
+4. **Team empty -- evaluate content:** Read components, summary, description, and labels. Look for positive evidence that this is a dashboard team issue:
+   - **Dashboard area identifiable:** The issue's content maps to a known `dashboard-area-*` (see `jira-project-reference.md` § Content Signals). This is the strongest signal -- if you can identify which area of the dashboard is affected, it belongs to the dashboard team.
+   - **UI / frontend references:** Description mentions a web UI change, page, form, table, modal, sidebar, or other interface element in the dashboard.
+   - **BFF / Node.js backend references:** Description mentions the dashboard's backend-for-frontend layer, Express routes, or Node.js API endpoints.
+   - **Dashboard-specific terms:** References to PatternFly components, dashboard routes, dashboard configuration, or dashboard-specific Kubernetes resources (OdhDashboardConfig, AcceleratorProfile, etc.).
+5. **Confirmed dashboard issue:** If positive evidence is found and the Team field is empty, produce a SET_FIELDS operation to assign the team, then proceed to Step 2b:
+   ```json
+   {
+     "issueKey": "RHOAIENG-12345",
+     "summary": "Issue title",
+     "action": "SET_FIELDS",
+     "params": { "fields": { "customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809" } },
+     "reason": "<one-sentence citing the positive signal, e.g., 'Model serving deployment wizard UI — dashboard-area-model-serving'>"
+   }
+   ```
+6. **Not a dashboard issue (including "clearly another team's work"):** If no positive dashboard evidence is found, **or** content clearly indicates ownership outside the dashboard (e.g., operator-only, unrelated product surface, backend service with no UI/BFF/dashboard scope per gate criteria, or § **When *not* to treat an issue as dashboard-owned** applied), **skip this issue** -- do not run the analysis pipeline. See **Skip outcome** below for whether to emit `ADD_LABEL Cross-Team` or `NO_OP`. Proceed to Step 2e to write the operation to disk. Move to the next issue.
+
+**Skip outcome — `Cross-Team` label vs `NO_OP`:**
+
+When the team gate determines the issue is not dashboard-owned (items 2 or 6), the output depends on whether the AI Core Dashboard component is **legitimately** on the issue:
+
+- **Component is legitimate → `ADD_COMMENT` + `ADD_LABEL Cross-Team`:** The other component corresponds to a service the dashboard **consumes through a package or BFF** in this repo (e.g., `AI Evaluations` → `packages/eval-hub/`, `Model Registry` → `packages/model-registry/`). The AI Core Dashboard component correctly reflects the dashboard's integration interest — it should stay. Apply `Cross-Team` to acknowledge cross-component coordination and exclude the issue from future dashboard triage queries. The label signals that the work belongs to the other component's team while the dashboard has a stake.
+
+  Produce two operations (comment before label per canonical ordering):
+
+  1. **`ADD_COMMENT`** explaining the routing decision — why the issue is not dashboard-owned, which component/team owns the work, and why the AI Core Dashboard component is legitimate (the dashboard package/BFF that consumes the service). This is the only change triage makes to the issue, so the comment is the sole record of the decision. Follow the `### AI Triage` header and comment visibility rules.
+  2. **`ADD_LABEL Cross-Team`** to exclude the issue from future dashboard triage queries.
+
+  ```json
+  {
+    "issueKey": "RHOAIENG-12345",
+    "action": "ADD_COMMENT",
+    "params": { "comment": "### AI Triage\n\nThis issue is owned by the **{owning component}** team. The AI Core Dashboard component is valid — the dashboard consumes this service through `{dashboard package/BFF path}` — but the described work ({brief description of why it's not dashboard scope}) does not involve the dashboard UI or BFF.\n\nLabeled `Cross-Team` to reflect the cross-component relationship." },
+    "reason": "<one-sentence summary of the routing decision>"
+  },
+  {
+    "issueKey": "RHOAIENG-12345",
+    "action": "ADD_LABEL",
+    "params": { "labels": ["Cross-Team"] },
+    "reason": "<cite the dashboard package/BFF that consumes the service, why the component is valid, and which other component owns the work>"
+  }
+  ```
+- **Component is incorrect or incidental → `NO_OP`:** The dashboard has no package, BFF, or integration relationship with the other component. The AI Core Dashboard component is likely a mis-filing or cross-reference. Produce a `NO_OP` with reason (e.g., "Not a dashboard issue — operator-only component with no UI/BFF scope").
+
+See `jira-project-reference.md` § Project Constants for the Team field ID and value.
+
+##### Step 2b: Analysis Pipeline
+
+Run the analysis skills in order **only for issues that passed Step 2a**. Each skill reads the issue data already in session and produces operations. **Read each skill's SKILL.md** before executing it.
+
+If during Step 2b you determine the issue belongs to **another team** (not RHOAI Dashboard), **stop the pipeline for this issue**: do not run remaining analysis skills, do not run Step 2c or 2d, and **discard any operations already drafted for it in this run**. Produce a single `NO_OP` with reason (e.g., "Late team-gate: not a dashboard issue — {reason}") and write it to the file in Step 2e. Step 2a should prevent most cases; this catches late realizations.
+
+**Pipeline order:**
+
+| Order | Skill | Path | Why this order |
+|---|---|---|---|
+| 1 | validate-issue-type | `../jira-validate-issue-type/SKILL.md` | May change issue type and **Activity Type** (`customfield_10464`) together. Downstream skills should use the **proposed** type. **Cypress/CI flake Tasks** are not promoted to Bug (see `jira-project-reference.md` § Issue Type Classification Criteria) |
+| 2 | validate-description | `../jira-validate-description/SKILL.md` | Checks description completeness. May add `needs-info`. Runs before priority/severity because a missing description limits severity assessment confidence |
+| 3 | validate-priority-severity | `../jira-validate-priority-severity/SKILL.md` | Bugs only. Assesses severity from description content and enforces the severity-to-priority floor |
+| 4 | evaluate-blockers (Tag mode) | `../jira-evaluate-blockers/SKILL.md` | Checks for blocking conditions, needs-\* labels, and dependency links. Runs after earlier skills that may have changed the type or flagged missing info |
+| 5 | validate-area-label (Tag mode) | `../jira-validate-area-label/SKILL.md` | Assigns `dashboard-area-*` labels based on multi-signal analysis. Runs after blockers because it benefits from the corrected issue type and enriched context from earlier skills. Area labels are independent of blocking state. |
+| 6 | assign-scrum-team | `../jira-assign-scrum-team/SKILL.md` | Maps area labels to a scrum team label. Runs after area labels are assigned so it can use proposed labels as input. |
+
+**Important:** When validate-issue-type produces a type change for an issue (e.g., Story → Bug), downstream skills must use the **proposed** type, not the original. For example, if an issue is reclassified from Story to Bug, validate-priority-severity should evaluate it as a bug even though the type hasn't been changed in Jira yet. The same applies to **Activity Type** when emitted in the same `SET_FIELDS` batch — treat the proposed Activity value as the intended program classification after Apply.
+
+##### Step 2c: Status Transition (Opt-In)
+
+**By default, Full Triage does NOT transition issues from New to Backlog.** Issues remain in New after triage so a human can review the AI triage results before moving them to the backlog. This step is **skipped entirely** unless the user explicitly opts in.
+
+**Opt-in triggers** (user must include one of these phrases):
+- "triage and transition" / "triage with transitions"
+- "move to backlog" / "transition to backlog"
+- "auto-transition"
+
+When the user does not opt in, skip this step — produce no TRANSITION operations. All other triage steps (type validation, description, priority/severity, blockers, area labels, scrum team, `ai-reviewed`) still run normally.
+
+**When opted in**, decide whether **this issue** should be transitioned from New to Backlog or left in New.
+
+**Transition to Backlog** if the issue has **none** of the following blocking signals in its accumulated operations:
+
+- `ADD_LABEL` with any `needs-*` label (`needs-info`, `needs-ux`, `needs-pm`, `needs-advisor`)
+- `LINK_BLOCKED_BY` (dependency on another issue)
+- `SET_FIELDS` setting the Blocked field to True (`customfield_10517`)
+- `ADD_LABEL` with `feature-request` (requires RFE/epic handling before backlog)
+
+**Leave in New** if any of the above are present. The issue needs input or resolution before it is ready for the backlog.
+
+If the issue qualifies, produce a TRANSITION operation:
+
+```json
+{
+  "issueKey": "RHOAIENG-12345",
+  "summary": "Issue title",
+  "action": "TRANSITION",
+  "params": { "transitionName": "Backlog" },
+  "reason": "Triage complete, no blocking conditions — ready for backlog"
+}
+```
+
+##### Step 2d: Finalize
+
+Add the `ai-reviewed` label as the final operation for this issue. This is a **passive marker** for human reference and reporting — no skill, query, or JQL filter depends on this label.
+
+```json
+{
+  "issueKey": "RHOAIENG-12345",
+  "summary": "Issue title",
+  "action": "ADD_LABEL",
+  "params": { "labels": ["ai-reviewed"] },
+  "reason": "Marking as processed by AI triage pipeline"
+}
+```
+
+This label is added to **every** issue in the query result — regardless of what other operations were produced, whether the issue was transitioned, or whether the issue was skipped at the team gate — **except template issues** (detected at Step 2.0a), which receive no operations at all. For non-template `NO_OP` issues, `ai-reviewed` prevents reprocessing in future triage runs. If the label is already present, skip the operation.
+
+**Per-issue operation order:** The complete set of operations for this issue is ordered as:
+
+1. **SET_FIELDS Team** (from Step 2a, if Team was empty)
+2. **Analysis operations** (from Step 2b, skills 1-6) — or **`NO_OP`** if skipped at gate / no changes needed
+3. **TRANSITION to Backlog** (from Step 2c, only if user opted in to transitions and no blocking signals)
+4. **ADD_LABEL `ai-reviewed`** (this step — always, unless already present)
+
+##### Step 2e: Write to Disk and Report
+
+After completing all sub-steps for this issue, **immediately persist its operations to the file** on disk:
+
+1. Read the current operations file from disk
+2. Append this issue's operations to the `operations` array (including `NO_OP` for skipped issues)
+3. Write the updated file back to disk
+
+The `issues` map and `metadata.issueCount` are already populated from Step 1 — do not modify them here.
+
+**Every issue must produce at least one operation.** If the issue passed the full pipeline, it will have analysis operations + `ai-reviewed` + possibly a TRANSITION (only if the user opted in to transitions). If the analysis produced no changes (everything already correct), it will have `NO_OP` + `ai-reviewed`. If the issue was skipped at the team gate (Step 2a) or during analysis (Step 2b late realization), it will have `NO_OP` + `ai-reviewed`. If the issue was detected as a **template** (Step 2.0a), it will have only `NO_OP` — no `ai-reviewed`, no other operations. This ensures the operations file accounts for every issue in the query result.
+
+Then report a one-line progress summary to the user:
+
+```text
+[3/9] RHOAIENG-12345 -- Widget crashes on save: type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre
+```
+
+or when transitions are opted in and the issue qualifies:
+
+```text
+[3/9] RHOAIENG-12345 -- Widget crashes on save: type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre → Backlog
+```
+
+or for skipped issues:
+
+```text
+[4/9] RHOAIENG-12346 -- Operator webhook validation error: skipped (not a dashboard issue)
+```
+
+After writing, move to the next issue. The completed issue's description and detailed field data are no longer needed in working memory.
+
+#### Step 3: Apply
+
+The operations file was built incrementally during Step 2 — it is already on disk with all issues' operations and the root `issues` map. No assembly step is needed.
+
+Pass the file path to the Apply capability. Apply defaults to **dry-run mode**: it reads the file, validates, presents the summary, and stops. The user reviews the output and then explicitly applies from file when ready.
+
+If the user requested immediate execution (e.g., "triage and apply"), Apply runs in execute mode instead: read file, validate, summarize, confirm, execute, and annotate results in-place.
+
+The dry-run summary groups all operations by issue key. The user reviews the full picture and then approves or aborts the entire batch.
+
+### Full Triage Example Flow
+
+**Default (no transitions):**
+
+```text
+User: "Triage new issues"
+
+1. Fetch (lightweight) + Initialize:
+   9 issues in New status. Operations file created at
+   .artifacts/triage/operations-2026-03-26.json
+   "Found 9 untriaged issues. Processing one at a time..."
+
+2. Process each issue (fetch details → analyze → write to disk):
+
+   [1/9] RHOAIENG-12340 -- Widget crashes on save
+     2.0 Fetch full details (description, reporter, etc.)
+     2.0a Template gate: not a template → continue
+     2a. Team gate: Team empty → content confirms dashboard → SET_FIELDS team
+     2b. Pipeline: type OK → description OK → severity=Moderate, priority=Major
+         → no blockers → area=model-serving → scrum=Zaffre
+     2c. Skipped (transitions not requested)
+     2d. ADD_LABEL ai-reviewed
+     2e. Write 5 operations to file
+     → "type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre"
+
+   [2/9] RHOAIENG-12341 -- Pipeline run table wrong status
+     2.0 Fetch full details
+     2a. Team gate: Team empty → content confirms dashboard → SET_FIELDS team
+     2b. Pipeline: type Story→Bug → description incomplete (ADD_COMMENT + needs-info)
+         → skip severity (needs-info) → needs-info blocker → area=pipelines → scrum=Razzmatazz
+     2c. Skipped (transitions not requested)
+     2d. ADD_LABEL ai-reviewed
+     2e. Write 7 operations to file
+     → "Story→Bug, needs-info, area=pipelines, scrum=Razzmatazz (blocked)"
+
+   ... (6 more issues processed the same way) ...
+
+   [9/9] RHOAIENG-12348 -- Operator webhook validation error
+     2.0 Fetch full details
+     2a. Team gate: no dashboard evidence → NO_OP
+     2e. Write NO_OP to file
+     → "skipped (not a dashboard issue)"
+
+   Summary: 8 processed, 1 skipped (NO_OP)
+   Operations file: .artifacts/triage/operations-2026-03-26.json
+
+3. Apply (dry-run):
+   Read operations file, validate, present summary:
+
+     RHOAIENG-12340 -- Widget crashes on save
+       - Team = RHOAI Dashboard
+       - Severity = Moderate, Priority = Major
+       - +`dashboard-area-model-serving`, +`dashboard-zaffre-scrum`
+       - +`ai-reviewed`
+
+     RHOAIENG-12341 -- Pipeline run table wrong status
+       - Team = RHOAI Dashboard
+       - **Story → Bug**, Activity Type = Tech Debt & Quality
+       - Comment to @reporter requesting repro steps
+       - +`needs-info`, +`dashboard-area-pipelines`, +`dashboard-razzmatazz-scrum`
+       - +`ai-reviewed`
+
+     ...
+
+     RHOAIENG-12348 -- Operator webhook validation error
+       - NO_OP: Not a dashboard issue — operator-only component with no UI/BFF scope
+
+   "Review and apply with: apply operations from
+    .artifacts/triage/operations-2026-03-26.json"
+
+User: "Apply operations from .artifacts/triage/operations-2026-03-26.json"
+   → Validate, summarize, confirm, execute, post triage comments, report results
+```
+
+**With transitions (opt-in):**
+
+```text
+User: "Triage new issues and transition to backlog"
+
+   (same as above, but Step 2c is active)
+
+   [1/9] RHOAIENG-12340 -- Widget crashes on save
+     ...
+     2c. No blocking signals → TRANSITION to Backlog
+     ...
+     → "type OK, severity=Moderate, priority=Major, area=model-serving, scrum=Zaffre → Backlog"
+
+   [2/9] RHOAIENG-12341 -- Pipeline run table wrong status
+     ...
+     2c. Has needs-info → remain in New
+     ...
+     → "Story→Bug, needs-info, area=pipelines, scrum=Razzmatazz (blocked)"
+```
+
+---
+
+## What This Skill Does NOT Cover
+
+- **Analysis logic** -- deciding what to do with each issue belongs in the separate analysis skills listed in the pipeline above
+- **Issue creation** -- use `.claude/rules/jira-creation.md` for creating new issues
+- **Reporting / dashboards** -- the agent presents results directly; no HTML report generation
+
+## Reference Files
+
+| File | Purpose |
+|---|---|
+| [`persona.md`](persona.md) | Execution protocol: thoroughness, verification, no assumptions -- applies to all triage skills |
+| [`jira-project-reference.md`](jira-project-reference.md) | All Jira-specific values (project constants, field IDs, labels, mappings) |
+| [`operations-schema.json`](operations-schema.json) | Formal JSON Schema for the operations format |

--- a/.claude/skills/jira-triage/jira-project-reference.md
+++ b/.claude/skills/jira-triage/jira-project-reference.md
@@ -1,0 +1,624 @@
+# Jira Project Reference -- RHOAI Dashboard
+
+Single source of truth for all Jira-specific values used by triage skills. This file is referenced by `SKILL.md` and all analysis skills in the epic.
+
+**This is a living document.** Update it whenever you encounter a value not already listed.
+
+## Project Constants
+
+| Constant | Value | Notes |
+|---|---|---|
+| Project key | `RHOAIENG` | |
+| Component | `AI Core Dashboard` | |
+| Team field | `customfield_10001` | Jira Teams (`atlassian-team`). **JQL** name: `Team`; dashboard value: `ec74d716-af36-4b3c-950f-f79213d08f71-1809`. **Search/get fields:** include `customfield_10001` (not legacy ids). **SET_FIELDS:** `{"customfield_10001": "ec74d716-af36-4b3c-950f-f79213d08f71-1809"}` for RHOAI Dashboard (plain string, **not** `{"id": "..."}` — the MCP tool double-wraps object values). |
+| Epic Link field | `customfield_12311140` | |
+| Severity field | `customfield_10840` | Select (option). Values: Critical, Important, Moderate, Low, Informational. SET_FIELDS format: `{"customfield_10840": {"value": "<name>"}}` |
+| Blocked field | `customfield_10517` | Select (option). Values: `"True"`, `"False"`. JQL name: `Blocked`. SET_FIELDS format: `{"customfield_10517": {"value": "True"}}` |
+| Blocked Reason field | `customfield_10483` | Paragraph (ADF). Free-text explanation of the blocking condition. |
+| Activity Type | `customfield_10464` | Select (option). **JQL** name: `Activity Type`. Exact option **values** (use in SET_FIELDS): `Tech Debt & Quality`, `Learning & Enablement`, `New Features`. Format: `{"customfield_10464": {"value": "<exact value>"}}` |
+| Blocks link type | ID `10000` | Outward text: "blocks", Inward text: "is blocked by". Use `jira_create_issue_link` with `link_type: "Blocks"`. |
+| Duplicate link type | | Outward text: "duplicates", Inward text: "is duplicated by". The **outward** issue ("duplicates X") is the copy; the **inward** issue ("is duplicated by Y") is the canonical/surviving one. See § Duplicate Link & Resolution Semantics below. |
+| Affects Version/s | `versions` | Standard Jira field (array). Lists the product versions where the issue was observed. |
+| Comment visibility | `{"type":"group","value":"Red Hat Employee"}` | **All** comments posted by triage skills must use this visibility restriction. Restricts comments to Red Hat employees only. **MCP:** pass as `visibility` parameter (JSON string). **REST API:** include as `visibility` object in the POST body. |
+
+### Duplicate Link & Resolution Semantics
+
+Jira's "Duplicate" link type has **directionality**, and the linked issue's **resolution** determines what the closure means. Getting this wrong can cause an agent to close the canonical issue by mistake.
+
+| Link text on current issue | Meaning | Current issue is… |
+|---|---|---|
+| "is duplicated by RHOAIENG-Y" | Y is a copy of this issue | The **canonical/surviving** issue — must stay open |
+| "duplicates RHOAIENG-X" | This issue is a copy of X | The **copy** — candidate for closure |
+
+**Resolution on the linked issue matters:**
+
+| Linked issue resolution | What it means | Safe to conclude work is done? |
+|---|---|---|
+| `Duplicate` | The linked issue was closed as a copy — it was housekeeping cleanup | **No.** It says nothing about work completion. If the current issue "is duplicated by" a Duplicate-resolved issue, the current issue is the canonical one and remains open. |
+| `Done` / `Fixed` / `Resolved` | The linked issue's work was completed | **Maybe.** Treat the linked issue's fix as a candidate to verify, but do not auto-close — the fix may not cover the current issue's full scope, or the bug may have resurfaced. |
+| `Won't Do` / `Won't Fix` | The linked issue was deliberately declined | **No.** Does not imply the current issue should also be declined. |
+
+**Rule: Never close an issue solely because a linked issue is closed. Always check the linked issue's resolution to understand *why* it was closed, and only draw conclusions consistent with that resolution.**
+
+## GitHub Repository
+
+| Constant | Value |
+|---|---|
+| Owner | `opendatahub-io` |
+| Repo | `odh-dashboard` |
+| Upstream remote | `upstream` (convention; verify with `git remote -v`) |
+| Default branch | `main` |
+
+## External Jira Projects (Role Signals)
+
+Referenced Jira issues often live in projects owned by specific roles. When an issue references or depends on an issue in one of these projects, **use the project key as a strong signal for classifying the nature of the dependency** (which `needs-*` label to apply, who the blocking party is).
+
+| Project Key | Role / Team | Examples |
+|---|---|---|
+| `RHOAIUX` | UX / Design | Design explorations, mockups, interaction patterns, layout decisions, visual arrangement, component placement |
+
+**How to use:** When evaluating blockers (Tag or Evaluate mode), if an issue references `RHOAIUX-xxx` as a dependency, blocker, or source of an open question, that dependency is almost certainly **UX-related** — classify it as `needs-ux`, not `needs-pm` or `needs-info`. The same principle applies to other project keys as they are identified.
+
+**Design decisions vs product decisions:** Questions that are answered by referencing a UX project issue — layout (how many cards/columns), visual arrangement, component placement, interaction behavior, section composition — are **design decisions** even when they feel like scope questions. The test: *is the authority who would resolve this a designer or a product manager?* If the referenced issue or person is UX, it's `needs-ux`.
+
+## Issue Types
+
+| Type | Use for |
+|---|---|
+| Bug | Defect in existing functionality |
+| Story | User-facing enhancement small enough to go directly into the team backlog |
+| Task | Non-user-facing work (refactors, infrastructure, dev tooling, test improvements) |
+
+### Template Issues
+
+Some Jira issues are **templates** — recurring blueprints that teams clone to create actual work items (e.g., sprint-start learning activities, nightly build analysis). Templates are not real work items and must be left alone by the triage pipeline.
+
+**Detection signals** (any one is sufficient to classify as a template):
+
+| Signal | Examples |
+|---|---|
+| Summary contains "TEMPLATE" (case-insensitive) | "TEMPLATE - Learning Activities", "Nightly build analysis - TEMPLATE", "[TEMPLATE] Sprint Retrospective" |
+| Labels include a template-related label | `template` |
+| Description is primarily placeholder/boilerplate | Fill-in markers like `[replace this]`, `TODO:`, repeating placeholder sections with no real content |
+
+**Triage behavior:** Template issues are detected at Step 2.0a (Template Gate) and produce a single `NO_OP`. No other operations are emitted — no team assignment, no analysis pipeline, no status transition, no `ai-reviewed` label. Templates are not work items and should not be touched at all.
+
+### Standard Query Filters
+
+All triage and sub-triage queries use a common set of filters to scope results to actionable dashboard team issues. Use the positive type filter rather than a negative exclusion list -- this is resilient to new issue types being added to the project.
+
+| Filter | JQL | Why |
+|---|---|---|
+| Type | `type in (Bug, Story, Task)` | Only triage-eligible types. Excludes Sub-tasks (managed by parent), Epics/Initiatives (planned at program level), and Vulnerabilities (auto-generated with their own lifecycle). |
+| Epic Link | `"Epic Link" is EMPTY` | Issues inside an epic are managed as part of the epic's planned work and do not belong in the triage queue. |
+| Team | `Team = {jql_team_id}` | Sub-triage queries (blockers, area labels, etc.) should only process issues already assigned to the dashboard team. |
+
+**Exception -- Full Triage / Untriaged issues:** The Full Triage query for New issues uses `(Team is EMPTY OR Team = {jql_team_id})` instead of strict team match, because incoming issues may not yet have a team assigned. The triage pipeline's team gate (Step 2a) evaluates and assigns the team.
+
+### Dashboard ownership (triage scope)
+
+All **dashboard triage** analysis skills and Full Triage Steps 2b–2d apply only to issues **owned by the RHOAI Dashboard** program team (Jira Team field = dashboard value, or empty with positive dashboard evidence at the team gate).
+
+- If an issue **belongs to another program team** or the Team field is set to a **non-dashboard** team, **do not** continue dashboard triage for that issue: no analysis pipeline, no dashboard-area or scrum labeling on behalf of another team.
+- **Full Triage:** Step 2a enforces this before Step 2b. If Step 2b reveals a wrong-team mistake, stop and omit that issue from the Apply batch (see `jira-triage` SKILL Step 2b).
+- **Standalone skill use:** If while reading an issue you conclude it is not dashboard-owned, produce **no operations** for that issue.
+
+### When *not* to treat an issue as dashboard-owned (team gate)
+
+Dashboard Full Triage uses JQL `component = "AI Core Dashboard"` (among other filters). That only means the **AI Core Dashboard** component is **one of** the components on the card — not that the dashboard program team owns the work. Apply the checks below **before** looking for positive dashboard evidence. When these signals dominate, **skip** the issue (no Team assignment to RHOAI Dashboard, no Steps 2b–2d).
+
+| Signal | Why it matters |
+|---|---|
+| **Multiple components** | If **Components** includes **any** component **in addition to** `AI Core Dashboard`, Jira may be recording **relationship, impact, or duplicate visibility** — not that the dashboard program team owns the work. Treat multi-component cards as **ambiguous** until **explicit** dashboard UI/BFF/repo evidence (below) appears. |
+| **Labels outside dashboard triage taxonomy** | Labels that look like **another subsystem**, **CI pipeline**, **service name**, or **team-local tagging** — and **no** `dashboard-area-*` label — suggest categorization for a **different** intake. That is weak evidence *for* assigning the issue to dashboard triage. Do **not** enumerate product-specific label names in rules; judge from context. |
+| **Description centers on backend/API/automation, not the dashboard UI** | When the narrative is dominated by **HTTP/API behavior**, **service error codes**, **contract or OpenAPI drift**, **cluster-integrated test jobs**, **feature-file or automated tests against a backend** — and **nothing** ties the fix to a **dashboard page**, **PatternFly/UI**, **routes in this repo**, or **this repo's Express/BFF** — treat ownership as **likely outside** the dashboard team unless proven otherwise. Prose in the description that frames work as **tests or jobs for another named subsystem** (not the web dashboard) reinforces that reading. |
+| **Composite (strong skip)** | **Additional non-dashboard component(s)** **and** **labels that imply another surface** (per above) **and** **backend/API/automation-only description without UI/repo evidence** → default **skip** for dashboard triage unless **explicit** evidence links the change to dashboard scope. |
+| **Only `AI Core Dashboard` on the card** | Multiple components are a **strong** hint, not a prerequisite. The same **backend/API/automation-only, no-UI** pattern can still warrant **skip** when only the dashboard component is listed (e.g. cross-component link or mis-filed). Use `jira-triage` Step 2a — no positive dashboard evidence — to **skip**. |
+
+**Illustrative pattern (out of scope):** Issues that match the composite row: extra Jira component + non-dashboard label vocabulary + description only about API/tests/services — **skip** at team gate; do not assign the dashboard Team field or run dashboard analysis for the owning program of that other component.
+
+### Issue Type Classification Criteria
+
+Use the following decision flow when evaluating whether an issue has the correct type. Evaluate in order -- the first match wins.
+
+#### 1. Is it a Bug?
+
+The issue describes broken behavior in something that already exists. Signals:
+
+- Regression (something that previously worked no longer does)
+- Error, crash, or unhandled exception
+- Incorrect output or data loss
+- Security vulnerability in existing code
+- Behavior that contradicts documented or expected functionality
+
+**Exception — flaky Cypress / CI tests (keep Task):** Issues that track **intermittent Cypress or CI failures** (flakes, timing races, unstable specs, “page updated while command was executing”) belong as **Task**, not Bug, when the work is **test hardening or test stability**. Past experience: many flakes trace to how tests are written or synchronized, not to a reproducible end-user product defect. Signals include explicit **flake** / **flaky** wording, labels such as `dashboard-cypress-flake`, focus on a **`.cy.ts`** (or similar) spec and CI output without a described **user-visible** broken workflow in the product. **Do not** change **Task → Bug** or **Story → Bug** for triage on that basis alone; misfiled **Story** flakes should become **Task** via the Task classification step below. If the issue clearly describes **reproducible broken product behavior** for users (distinct from test instability), classify or keep as **Bug** per the signals above.
+
+If the content describes a defect but the type is not Bug, change it to Bug — **except** when the exception above applies (flake/stability work filed as Task or Story).
+
+#### 2. Is it a Task?
+
+The issue describes non-user-facing technical work. Signals:
+
+- Refactoring or code cleanup
+- Infrastructure, CI/CD, or build changes
+- Dev tooling improvements
+- Test improvements (new tests, test framework changes, **Cypress/CI flake fixes** — see Bug exception above)
+- Documentation updates (developer docs, ADRs)
+- Dependency updates
+
+If the content describes non-user-facing work but the type is not Task, change it to Task.
+
+#### 3. Is it user-facing work?
+
+If the issue is neither a Bug nor a Task, it describes user-facing work. Determine whether it qualifies as a **Story** or needs to be flagged as a **feature-request**.
+
+**Qualifies as a Story** (add `enhancement` label) -- must meet ALL of:
+
+- **Relevant to an existing feature.** The enhancement extends or improves something already in the product, not a net-new product area.
+- **Minor in scope.** Limited UI surface -- single component, small behavioral change, no new pages or sections. Could reasonably be implemented in one sprint.
+- **Clear enough to act on.** The work can be described without needing an epic, product discovery, or cross-team coordination.
+
+Examples that qualify as Story:
+- UX department issues with clear scope and design direction
+- Small usability improvements (better defaults, clearer labels, improved empty states)
+- Minor UI additions to existing pages (a column in a table, a filter option)
+- Accessibility fixes that add visible behavior
+- Small behavioral tweaks requested by users or QE
+
+**Too large for a Story** (add `feature-request` label) -- any of these disqualify:
+
+- Introduces a net-new product area, page, or section
+- Requires significant workflow changes across multiple components
+- Needs new integrations or backend capabilities that don't exist yet
+- Scope is unclear or requires product discovery
+- Multi-sprint effort that should be tracked under an epic
+- The request has no obvious fit with any existing feature area
+
+Do NOT change the issue type for feature requests. Add the `feature-request` label so they can be filtered for later RFE handling.
+
+**When ambiguous**, lean toward `feature-request`. It is better to require explicit approval for the fast path to the backlog than to let large work slip through as a Story.
+
+### Activity Type (`customfield_10464`)
+
+Program field with three options. Triage uses it as a **strong signal** for issue-type classification and **sets or corrects** it when validating issue type (see `jira-validate-issue-type`). **Do not** treat the reporter’s value as authoritative — always confirm against summary and description — but when Activity Type is already set and **consistent** with the text, weight it heavily (require clearer contradictory evidence before changing issue type).
+
+| Option | Meaning | Issue type mapping |
+|---|---|---|
+| **Tech Debt & Quality** | Defects, hardening, refactors, CI/CD, tests, internal quality | **Bug** or **Task** (per Bug vs Task vs user-facing rules above) |
+| **Learning & Enablement** | Training, enablement, onboarding, docs whose primary purpose is learning | **Task** only — if content is truly user-facing net-new enhancement, reporter may have mis-set; validate and correct type + Activity |
+| **New Features** | User-facing enhancements and new capability in the product UI/workflow | **Story** when the card is a proper Story — if content describes only a defect or internal work, reporter mis-set; validate and correct type + Activity |
+
+**Setting the field:** Whenever triage determines the correct `issuetype`, set Activity Type to the row that matches **content + type** (see skill). Prefer **one** `SET_FIELDS` operation that includes both `issuetype` and `customfield_10464` when either changes. If the issue type is already correct but Activity Type is empty or wrong, emit `SET_FIELDS` for `customfield_10464` alone.
+
+**Choosing between Tech Debt & Quality and Learning & Enablement for Tasks:** Default to **Tech Debt & Quality** for refactors, tooling, CI, tests, developer docs, and code cleanup. Use **Learning & Enablement** when the work is primarily about teaching, workshops, onboarding flows, or customer/partner enablement content (still filed as Task).
+
+## Description Quality Criteria
+
+Defines the expected description structure per issue type. The validate-description skill evaluates issues against these criteria. Evaluate substance over structure -- a description that covers the required information in prose is fine even if it doesn't use headings or a template.
+
+**General quality bar:** A description that consists of only a title restatement, a single vague sentence, or is otherwise insufficient for another engineer to understand the issue should be flagged regardless of type.
+
+### Bug
+
+| Category | Sections | Notes |
+|---|---|---|
+| **Required** | Problem description | What is broken? Clear statement of the defect. |
+| **Required** | Steps to reproduce | Numbered steps to trigger the issue. The single most important section for bugs -- always flag if missing. |
+| **Required** | Observed behavior | What actually happens (error message, wrong result, crash). |
+| **Required** | Expected behavior | What should happen instead. |
+| **Required** | Environment | Product version (e.g., RHOAI 2.19). For UI bugs: browser and version, production build vs dev environment. |
+| **Required** | Reproducibility | Always, sometimes, or one-time occurrence. |
+| Recommended | Screenshots / recordings | Visual evidence, especially for UI bugs. |
+| Recommended | Logs / error messages | Console errors, stack traces, pod logs. |
+| Recommended | Workaround | Known workaround, if any. Helps gauge urgency. |
+| Recommended | Regression indicator | Was this working before? If so, which version? |
+
+### Story
+
+| Category | Sections | Notes |
+|---|---|---|
+| **Required** | Description of the enhancement | What is being added or changed and why. |
+| **Required** | Acceptance criteria | Measurable conditions that define when the story is done. |
+| Recommended | User story format | "As a [role], I want [goal], so that [benefit]." |
+| Recommended | Design references | Figma, Miro, or doc links if the story involves UI changes. |
+
+### Task
+
+| Category | Sections | Notes |
+|---|---|---|
+| **Required** | Description of the work | What needs to be done and why. |
+| **Required** | Acceptance criteria / definition of done | How to verify the task is complete. |
+| Recommended | Technical context | Approach notes, relevant code areas, dependencies. |
+
+**Automated test / flake tasks:** For Tasks about a **failing or flaky automated test** (named spec, assertion, or CI output), see `jira-validate-description` § *Test automation and flake tasks*. Implied DoD and reproduction are often enough — do not demand explicit AC prose or manual “steps to reproduce” when re-running the test is the reproduction method.
+
+## Severity (bugs only)
+
+Severity measures how much the issue impacts the user. Do not accept the author's value as fact. Regressions (something that previously worked) are a factor that may increase severity but do not automatically make an issue Critical -- evaluate based on the criteria below.
+
+| Severity | When to apply |
+|---|---|
+| Critical | Core workflow or feature completely unusable; crashes / error screens; data loss; no workaround or workaround too complex / unreasonable; unauthorized access to sensitive data |
+| Important | Non-critical security concerns; RBAC issues; performance degradation that impedes normal workflow; silent failures — functional breakage where the user is not shown an obvious error (e.g., empty pages, missing data, truncated results, features that quietly stop working). Silent failures are Important because the user may not realize something is wrong. |
+| Moderate | Default severity; validation issues; accessibility issues; minor functional problems where the failure is visible to the user and a reasonable workaround exists |
+| Low | Cosmetic issues (alignment, layout, color); micro copy |
+| Informational | Console output issues; React warnings |
+
+**Workaround rule:** Only credit a workaround if the issue description explicitly states one or the workaround is trivially obvious with no security, data, or workflow ramifications. Do not invent workarounds by assuming the user can use a different configuration, skip a feature, or change their deployment — the user may have requirements that make the affected path necessary.
+
+Evaluate sentiment from the issue description and comments to help gauge real-world impact.
+
+## Priority
+
+Priority indicates how urgently an issue needs to be addressed. The assessment approach differs by issue type.
+
+### Bug Priority
+
+Bugs use content-based priority criteria. Do not accept the author's value as fact -- evaluate independently (raise or lower).
+
+| Priority | When to apply |
+|---|---|
+| Blocker | Prevents release; production-impacting; requires immediate attention |
+| Critical | High-impact issue that must be resolved soon; minimum priority for all Critical severity bugs |
+| Major | Related to recently released features, active development, or customer-visible functionality; should be delivered ahead of the general backlog |
+| Normal | Default priority; no specific urgency signal |
+| Minor | Low urgency; can wait to be addressed |
+
+### Task Priority
+
+Tasks use the same priority scale and content-based criteria as bugs (table above), but with a key difference: **respect existing priority**. Task authors and team members typically have context about urgency that is not captured in the description (sprint commitments, dependency chains, upcoming releases). If a task already has a valid priority set (not `Undefined`), evaluate independently but **only raise** — do not lower. If the content clearly supports a higher priority than assigned, emit a SET_FIELDS to raise it.
+
+### Story Priority
+
+Stories use a simplified priority model during triage. Scrum teams and PMs may adjust priority during grooming.
+
+| Priority | When to apply |
+|---|---|
+| Major | Strong urgency signal: customer-facing pain with no workaround, time-sensitive dependency on an upcoming release, explicitly flagged as urgent by PM or leadership, or regression workaround that needs a permanent fix soon |
+| Normal | Default for all stories. No specific urgency signal, or urgency is unclear |
+
+**Rules:**
+- **Default to Normal.** Most standalone stories are Normal priority.
+- **Promote to Major** only when the description contains clear urgency signals (see table above).
+- **Never set higher than Major.** Blocker and Critical are reserved for bugs and operational issues, not stories.
+- **Respect existing priority.** If a story already has a valid priority set (not `Undefined`), do not override it -- the reporter or team may have context that justifies the level.
+
+### Severity-to-priority floor (bugs only)
+
+A bug's priority should not be lower than the floor implied by its severity. This is a minimum, not a ceiling -- a Moderate severity bug can still be Blocker if it blocks a release.
+
+| Severity | Minimum Priority |
+|---|---|
+| Critical | Critical |
+| Important | Major |
+| Moderate | Normal |
+| Low | Normal |
+| Informational | Minor |
+
+## Triage Labels
+
+Labels used during triage to indicate what an issue needs before it can proceed, or to classify the nature of the work.
+
+### Needs-* Labels
+
+These labels signal that an issue is **waiting on input** from a specific role. Apply them when the issue cannot proceed without that input. Remove them when the input has been provided.
+
+| Label | When to apply | Resolution signals (remove when) |
+|---|---|---|
+| `needs-info` | Generic catch-all: we need information from a specific person. Use when someone needs to answer a question, confirm a decision, or provide missing context — including stale blocking references where specific people need to confirm whether to proceed. Also used when description is too vague (via validate-description) or clarifying questions went unanswered. | Reporter or a knowledgeable party comments addressing the open questions; description is updated with the requested details |
+| `needs-ux` | Anything UI design related. Requires UX mockups, design review, or interaction guidance before engineering can proceed; a discussion about how something should look or behave is unresolved; no existing design artifact covers the requirement. | UX team member comments with a design deliverable (Figma, Miro, or doc link) or a clear written design decision; a linked UX issue is resolved/closed. Must be confident guidance, not just an acknowledgement or "we'll look into it" |
+| `needs-pm` | Requires product direction, scope clarification, priority call, or acceptance criteria from Product Management; the team cannot determine what to build without PM input. This includes questions about whether customer need or business justification exists, or whether product direction has shifted making the work potentially irrelevant. | PM comments with a clear decision, scope statement, or acceptance criteria; a linked PM issue is resolved/closed. Must be confident guidance, not just an acknowledgement |
+| `needs-advisor` | Architectural questions where the implementation path is unclear. Multiple viable technical approaches exist with significant trade-offs; touches cross-cutting concerns (architecture, shared infrastructure); solution path is unclear even to experienced developers. | Tech lead or architect comments with a recommended approach or decision; a linked spike/investigation issue is resolved/closed |
+
+### Process Labels
+
+| Label | Meaning |
+|---|---|
+| `ai-reviewed` | Passive marker indicating the issue has been through the AI triage pipeline. Applied as the final step to **every** issue in the query result — including team-gate skips and NO_OP issues — to prevent reprocessing in future triage runs. No skill or query depends on this label — it exists for human reference, reporting, and deduplication. |
+
+### AI Analysis Labels
+
+Labels applied by AI analysis skills to indicate the outcome of automated review. These labels should not be manually applied.
+
+| Label | Meaning |
+|---|---|
+| `ai-already-fixed` | The bug has been fixed and verified in the codebase on main. The issue may be auto-closed or flagged for human review if a backport concern exists. |
+| `ai-potentially-fixed` | Evidence suggests the bug may have been addressed but confidence is not high enough to auto-close. Requires human verification. |
+| `ai-obsolete` | The code area referenced by the issue has been fundamentally rewritten or removed. The described scenario can no longer occur. |
+
+### Classification Labels
+
+| Label | Meaning |
+|---|---|
+| `enhancement` | Standalone new feature or improvement (Stories) |
+| `feature-request` | User-facing request too large for a standalone Story; requires RFE/epic process |
+| `tech-debt` | Addresses technical debt |
+
+### Excluded Labels (triage queries)
+
+Issues with these labels are excluded from triage queries because they are managed through separate processes:
+
+| Label | Reason |
+|---|---|
+| `Security` | Security/CVE tracker issues are auto-generated with their own triage lifecycle |
+| `Cross-Team` | Cross-team effort managed at the program level, not dashboard-specific triage. **Applied by triage** when the team gate (Step 2a) determines the work belongs to another component's team but the AI Core Dashboard component is legitimately on the issue (the dashboard has a package/BFF that consumes the other component's service — e.g., `AI Evaluations` → `packages/eval-hub/`). The label acknowledges the dashboard's integration interest while routing the work to the owning team. |
+
+Scrum team labels (`dashboard-*-scrum`) also serve as an exclusion signal -- issues already assigned to a scrum team have been human-triaged and should not be reprocessed.
+
+### Blocking Mechanisms -- When to Use What
+
+An issue can be blocked by multiple mechanisms simultaneously. Use the most specific mechanism that fits.
+
+| Mechanism | Use when | How to set | How to clear |
+|---|---|---|---|
+| **needs-\* label** | Waiting on **input/decision** from a role. No specific blocking issue exists -- you're waiting on a person or team to provide something. | `ADD_LABEL` with the appropriate `needs-*` label | `REMOVE_LABEL` when the input has been provided (see resolution signals above) |
+| **Blocked-by link** | Waiting on a **specific Jira issue** to be completed. The blocking issue is trackable and has its own lifecycle. | `LINK_BLOCKED_BY` with the blocking issue key. Creates an "is blocked by" link. | The link persists as history. When the blocking issue is resolved, evaluate whether to also clear the Blocked field if it was set. |
+| **Blocked field = True** | Waiting on something **external or structural** that isn't a single Jira issue: release timing, infrastructure provisioning, external team dependency, environment availability. Always set Blocked Reason with a clear explanation. | `SET_FIELDS` with `{"customfield_10517": {"value": "True"}, "customfield_10483": "<reason>"}` | `SET_FIELDS` with `{"customfield_10517": {"value": "False"}}`. Clear Blocked Reason only if the context is no longer useful. |
+
+**Combining mechanisms:** A single issue may have a `needs-ux` label AND be blocked by another Jira issue AND have Blocked=True for an unrelated infrastructure reason. Each mechanism is independent and cleared independently.
+
+**Blocked field is NOT auto-set by links.** Creating a blocked-by link does not automatically set the Blocked field to True. The Blocked field is reserved for external/structural blockers. An issue can be linked as "is blocked by X" without the Blocked dropdown being True -- the link itself communicates the dependency.
+
+## Scrum Team Labels
+
+Labels that assign issues to a scrum team. Format: `dashboard-{team}-scrum`.
+
+| Label | Team |
+|---|---|
+| `dashboard-monarch-scrum` | Monarch |
+| `dashboard-zaffre-scrum` | Zaffre |
+| `dashboard-green-scrum` | Green |
+| `dashboard-crimson-scrum` | Crimson |
+| `dashboard-razzmatazz-scrum` | Razzmatazz |
+| `dashboard-tangerine-scrum` | Tangerine |
+| `dashboard-purple-scrum` | Purple |
+
+## Area Labels
+
+Labels that categorize issues by functional area. Format: `dashboard-area-{area}`.
+
+| Label | Area |
+|---|---|
+| `dashboard-area-infrastructure` | Infrastructure |
+| `dashboard-area-patternfly` | PatternFly |
+| `dashboard-area-pf6` | PatternFly 6 migration |
+| `dashboard-area-home` | Home page |
+| `dashboard-area-projects` | Data Science Projects |
+| `dashboard-area-pipelines` | Pipelines |
+| `dashboard-area-edge` | Edge |
+| `dashboard-area-accelerators` | Accelerators |
+| `dashboard-area-workbenches` | Workbenches |
+| `dashboard-area-jupyter` | Jupyter |
+| `dashboard-area-notebooks` | Notebooks |
+| `dashboard-area-bff` | BFF (Go backend shared patterns) |
+| `dashboard-area-security` | Security (CVE, security audits) |
+| `dashboard-area-cluster-storage` | Cluster Storage |
+| `dashboard-area-storage-classes` | Storage Classes |
+| `dashboard-area-cluster-settings` | Cluster Settings |
+| `dashboard-area-manifests` | Manifests |
+| `dashboard-area-connection-types` | Connection Types |
+| `dashboard-area-consistencies` | Consistencies |
+| `dashboard-area-model-serving` | Model Serving |
+| `dashboard-area-model-registry` | Model Registry |
+| `dashboard-area-distributed-workloads` | Distributed Workloads |
+| `dashboard-area-trusty-ai` | TrustyAI |
+| `dashboard-area-model-catalog` | Model Catalog |
+| `dashboard-area-maas` | MaaS (Model-as-a-Service) |
+| `dashboard-area-genai` | Gen AI Studio |
+| `dashboard-area-mcp` | MCP |
+| `dashboard-area-hardware-profiles` | Hardware Profiles |
+| `dashboard-area-user-management` | User Management |
+| `dashboard-area-e2e` | E2E Testing |
+| `dashboard-area-cypress` | Cypress Testing |
+| `dashboard-area-performance` | Performance |
+| `dashboard-area-documentation` | Documentation |
+| `dashboard-area-automl` | AutoML |
+| `dashboard-area-autorag` | AutoRAG |
+| `dashboard-area-applications` | Applications |
+
+## Area Label Signal Mapping
+
+Reference tables for the [validate-area-label](../jira-validate-area-label/SKILL.md) skill. Three signal dimensions are captured here (keywords, K8s kinds, code paths). Three additional dimensions -- Jira labels (non-area product/feature labels on the issue), linked issue labels, and scrum team labels -- are evaluated at runtime from live Jira data.
+
+### Content Signals (keywords + K8s kinds)
+
+Matched against issue summary, description text, and **Jira labels** (non-area labels on the issue). Includes natural-language feature names, UI page/section titles, Kubernetes resource type names, and product/feature labels commonly used in the project.
+
+| Area Label | Keywords | K8s Kinds |
+|---|---|---|
+| `dashboard-area-pipelines` | pipeline, pipeline run, pipeline definition, experiment, artifact, execution, pipeline server, DSPA, Elyra, DAG, topology | `DataSciencePipelinesApplication` |
+| `dashboard-area-model-serving` | model serving, inference, KServe, ModelMesh, serving runtime, model deploy, deploy model, deployment, NIM, vLLM, endpoint performance | `InferenceService`, `ServingRuntime`, `LLMInferenceService` |
+| `dashboard-area-model-registry` | model registry, registered model, model version, model artifact | `ModelRegistry` |
+| `dashboard-area-model-catalog` | model catalog, catalog card | |
+| `dashboard-area-workbenches` | workbench, notebook server, spawner, workbench image, deployment size, environment variable | `Notebook` |
+| `dashboard-area-notebooks` | notebook image, BYON image, image stream, notebook controller | `ImageStream` |
+| `dashboard-area-jupyter` | Jupyter, JupyterHub, JupyterLab | |
+| `dashboard-area-projects` | data science project, project selector, project list, project create, project delete, project rename (NOT project detail tabs -- those map to their respective feature areas) | `Project` |
+| `dashboard-area-hardware-profiles` | hardware profile, accelerator profile, GPU, tolerations, node selector, node affinity | `HardwareProfile`, `AcceleratorProfile` |
+| `dashboard-area-connection-types` | connection type, connection, data connection | |
+| `dashboard-area-cluster-storage` | cluster storage, PVC, persistent volume, storage size | `PersistentVolumeClaim` |
+| `dashboard-area-storage-classes` | storage class, default storage class | `StorageClass` |
+| `dashboard-area-cluster-settings` | cluster settings, PVC size, culler, notebook tolerations, model serving platform, telemetry | |
+| `dashboard-area-distributed-workloads` | distributed workload, Kueue, workload metrics, cluster queue, local queue, quota | `ClusterQueue`, `LocalQueue`, `Workload` |
+| `dashboard-area-user-management` | user management, group settings, RBAC, permissions, role binding | `Role`, `RoleBinding`, `ClusterRole` |
+| `dashboard-area-home` | home page, landing page, overview page, welcome, getting started | |
+| `dashboard-area-infrastructure` | webpack, build, CI, docker, module federation, navigation, sidebar, header, app shell, plugin, extension | |
+| `dashboard-area-patternfly` | PatternFly, PF, component library, design system | |
+| `dashboard-area-pf6` | PF6, PatternFly 6, PatternFly migration, PF upgrade | |
+| `dashboard-area-bff` | BFF, backend-for-frontend, Go backend, shared middleware, common middleware, RequireAccessToService, RequireValidIdentity, SelfSubjectAccessReview, SSAR, BFF route, BFF module | |
+| `dashboard-area-security` | CVE, security audit, vulnerability scan, security advisory, OVAL | |
+| `dashboard-area-manifests` | manifest, OLM, operator, kustomize, deployment config | |
+| `dashboard-area-trusty-ai` | TrustyAI, bias, fairness, explainability, model bias metrics | `TrustyAIService` |
+| `dashboard-area-maas` | MaaS, model as a service, subscription, API key, auth policy, rate limit | |
+| `dashboard-area-genai` | Gen AI Studio, gen-ai, playground, chatbot, compare mode, chat session, AI Asset Endpoints, AAE, Llama Stack, LlamaStack Distribution, LSD, vector store, RAG, knowledge tab, knowledge sources, EvalHub, evaluation run, lmEval, benchmark evaluation, prompt management, prompt versioning, guardrails, NeMo Guardrails, code export, InstructLab, fine-tuning, teacher model, judge model | `LlamaStackDistribution` |
+| `dashboard-area-mcp` | MCP, MCP server, MCP catalog | |
+| `dashboard-area-edge` | edge, edge deployment | |
+| `dashboard-area-accelerators` | accelerator, GPU support, multi-GPU | |
+| `dashboard-area-e2e` | e2e test, end-to-end test, test case, test coverage, test automation | |
+| `dashboard-area-cypress` | Cypress config, mock test, intercept, fixture, cypress command, test infrastructure, test framework | |
+| `dashboard-area-performance` | performance, slow, latency, render time, memory | |
+| `dashboard-area-documentation` | documentation, docs, README, ADR | |
+| `dashboard-area-automl` | AutoML, AutoX, automl experiment, tabular pipeline, timeseries pipeline, binary classification, multiclass classification, regression pipeline, AutoGluon, automl leaderboard, automl model details, confusion matrix, feature importance, prediction type, label column, automl configure, register model (in AutoML context), S3 file explorer (in AutoML context) | |
+| `dashboard-area-autorag` | AutoRAG, AutoX, autorag experiment, RAG pattern evaluation, autorag leaderboard, pattern details, optimization metric, faithfulness, answer correctness, context correctness, RAG patterns, vector store provider, Milvus (in AutoRAG context), chunking, embedding model, retrieval method, generation model, autorag configure, S3 file explorer (in AutoRAG context), Docling, text extraction (in AutoRAG context), test data file | |
+| `dashboard-area-applications` | application, enabled application, explore application, ISV | |
+| `dashboard-area-consistencies` | consistency, shared pattern, common component, UX consistency | |
+
+### Code Path Signals
+
+Matched against file paths from linked PRs, code references in descriptions, or stack traces. Each area maps to one or more repository directory prefixes. Use **longest prefix wins** when paths overlap (e.g., a file under `frontend/src/pages/projects/screens/spawner/` matches `workbenches`, not `projects`).
+
+| Area Label | Code Paths |
+|---|---|
+| `dashboard-area-pipelines` | `frontend/src/concepts/pipelines/`, `frontend/src/pages/pipelines/` |
+| `dashboard-area-model-serving` | `frontend/src/pages/modelServing/`, `frontend/src/concepts/modelServing/`, `frontend/src/concepts/modelServingKServe/`, `packages/model-serving/` |
+| `dashboard-area-model-registry` | `packages/model-registry/`, `frontend/src/concepts/modelRegistry/`, `frontend/src/pages/modelRegistry/`, `frontend/src/pages/modelRegistrySettings/` |
+| `dashboard-area-model-catalog` | `frontend/src/pages/modelCatalog/`, `frontend/src/concepts/modelCatalog/` |
+| `dashboard-area-workbenches` | `frontend/src/pages/projects/screens/spawner/`, `frontend/src/pages/projects/screens/detail/notebooks/`, `frontend/src/concepts/notebooks/` |
+| `dashboard-area-notebooks` | `frontend/src/pages/BYONImages/`, `frontend/src/pages/notebookController/`, `packages/notebooks/` |
+| `dashboard-area-projects` | `frontend/src/pages/projects/`, `frontend/src/concepts/projects/` |
+| `dashboard-area-hardware-profiles` | `frontend/src/pages/hardwareProfiles/`, `frontend/src/concepts/hardwareProfiles/` |
+| `dashboard-area-connection-types` | `frontend/src/pages/connectionTypes/`, `frontend/src/concepts/connectionTypes/` |
+| `dashboard-area-cluster-storage` | *(within projects pages -- no dedicated directory)* |
+| `dashboard-area-storage-classes` | `frontend/src/pages/storageClasses/` |
+| `dashboard-area-cluster-settings` | `frontend/src/pages/clusterSettings/` |
+| `dashboard-area-distributed-workloads` | `frontend/src/pages/distributedWorkloads/`, `frontend/src/concepts/distributedWorkloads/` |
+| `dashboard-area-user-management` | `frontend/src/pages/groupSettings/`, `frontend/src/concepts/permissions/`, `frontend/src/concepts/roleBinding/`, `frontend/src/concepts/userConfigs/` |
+| `dashboard-area-home` | `frontend/src/pages/home/` |
+| `dashboard-area-infrastructure` | `frontend/src/app/`, `frontend/src/plugins/`, `backend/src/`, `packages/plugin-core/`, `packages/app-config/` |
+| `dashboard-area-patternfly` | `frontend/src/concepts/dashboard/` |
+| `dashboard-area-manifests` | `manifests/` |
+| `dashboard-area-trusty-ai` | `frontend/src/concepts/trustyai/`, `frontend/src/api/trustyai/` |
+| `dashboard-area-maas` | `packages/maas/` |
+| `dashboard-area-genai` | `packages/gen-ai/` |
+| `dashboard-area-mcp` | *(no dedicated directory yet)* |
+| `dashboard-area-e2e` | `packages/cypress/` |
+| `dashboard-area-cypress` | `packages/cypress/` |
+| `dashboard-area-automl` | `packages/automl/` |
+| `dashboard-area-autorag` | `packages/autorag/` |
+| `dashboard-area-applications` | `frontend/src/pages/enabledApplications/`, `frontend/src/pages/exploreApplication/` |
+| `dashboard-area-bff` | *(cross-cutting -- shared patterns span `packages/*/bff/`)* |
+| `dashboard-area-security` | *(cross-cutting -- no dedicated directory)* |
+| `dashboard-area-consistencies` | *(cross-cutting -- no dedicated directory)* |
+| `dashboard-area-performance` | *(cross-cutting -- no dedicated directory)* |
+| `dashboard-area-documentation` | `docs/` |
+
+Areas without dedicated code paths (`dashboard-area-bff`, `dashboard-area-edge`, `dashboard-area-accelerators`, `dashboard-area-jupyter`, `dashboard-area-pf6`) rely on keyword matching combined with other signal dimensions.
+
+Note: `dashboard-area-e2e` and `dashboard-area-cypress` share the same code path (`packages/cypress/`). Keywords must disambiguate: `e2e` is for test cases, `cypress` is for framework config and test infrastructure.
+
+### Jira Label Signals
+
+Non-area labels on the issue that serve as keyword-equivalent signals for area matching. These are product/feature labels applied by reporters, QE, or other processes -- they are not `dashboard-area-*` labels but carry the same semantic weight as a keyword match.
+
+| Area Label | Jira Labels (case-insensitive match) |
+|---|---|
+| `dashboard-area-automl` | `AutoML`, `automl` |
+| `dashboard-area-autorag` | `AutoRAG`, `autorag` |
+| `dashboard-area-genai` | `gen-ai`, `genai` |
+| `dashboard-area-maas` | `maas`, `MaaS` |
+| `dashboard-area-model-registry` | `model-registry` |
+| `dashboard-area-pipelines` | `ai-pipelines` |
+
+Jira label matches have the **same confidence level as keyword matches** -- they are a content signal (reporters chose the label deliberately). They contribute to the multi-signal requirement like any other keyword dimension.
+
+### Matching Notes
+
+- **Multi-signal requirement**: An area must be supported by at least two signal dimensions (keywords + code path, keywords + linked issue, etc.) OR by a single high-confidence signal (K8s kind, code path, or unambiguous multi-word phrase unique to one area). A single generic keyword alone is never sufficient.
+- **Case-insensitive** matching for all keywords
+- **Multi-word phrases** match as whole phrases first with higher weight than individual word matches
+- **Summary hits weigh more** than description hits (summary is the most deliberate text)
+- **K8s kind matches are high confidence** -- a reporter mentioning `InferenceService` almost certainly means model serving
+- **Code path matches are high confidence** and use **longest prefix wins** when paths overlap (e.g., `spawner/` under `projects/` matches `workbenches`, not `projects`)
+- **Linked issue labels are confirming** -- if a parent or blocked-by issue has `dashboard-area-pipelines`, that confirms the signal for the current issue
+- **Scrum team labels are weak signals** -- used to confirm, not to determine. A scrum team can work issues outside their default areas.
+- **Feature area beats cross-cutting area** -- "slow model serving table" is `model-serving`, not `performance`. Cross-cutting areas (`performance`, `security`, `consistencies`, `infrastructure`, `bff`, `patternfly`) are only assigned when the issue is specifically about that concern itself.
+- **BFF vs feature area** -- a bug in a specific BFF endpoint (e.g., gen-ai chat route, maas subscription API) uses the feature area (`genai`, `maas`, `model-registry`, etc.). `dashboard-area-bff` is for cross-cutting Go backend patterns: shared middleware, common auth, patterns applied across multiple BFF modules.
+- **Gen AI vs MaaS** -- `dashboard-area-genai` covers the Gen AI Studio UX (`packages/gen-ai/`): playground, chatbot, LlamaStack, RAG/vector stores, guardrails, AAE, EvalHub, prompt management. `dashboard-area-maas` covers the MaaS admin surface (`packages/maas/`): subscription CRUD, API key management, auth policies. The gen-ai BFF calls MaaS for model/token access, so issues about **consuming** MaaS data within the Gen AI Studio (e.g., "MaaS model not appearing in playground") are `genai`. Issues about **managing** subscriptions, API keys, or auth policies are `maas`. Both labels may apply when an issue spans both surfaces.
+- **Security is narrow** -- `dashboard-area-security` is reserved for CVE tracking, security audits, and vulnerability scans. Authorization middleware, RBAC patterns, or auth bugs in a feature area use the feature area or `bff`, not `security`.
+- **Specific area beats container area** -- `projects` is only for the project selector, list, and project-level actions. Each project detail tab maps to its feature area: Workbenches tab = `workbenches`, Pipelines tab = `pipelines`, Connections tab = `connection-types`, Cluster storage tab = `cluster-storage`, Deployments tab = `model-serving`, Permissions tab = `user-management`.
+- **Multiple area labels are normal** -- an issue can independently qualify for more than one area
+- **Contextual keywords resolve ambiguity** -- "notebook" alone is ambiguous; "notebook" + "spawner" = `workbenches`, "notebook" + "BYON" = `notebooks`, "notebook" + "Jupyter" = `jupyter`
+- **Jira labels are keyword-equivalent signals** -- Non-area labels on the issue (e.g., `AutoML`, `AutoRAG`, `gen-ai`, `ai-pipelines`) are treated as keyword matches when they appear in the Jira Label Signals table. They have the same confidence as a keyword hit in the summary. Combined with another signal dimension (summary keyword, code path, linked issue), they satisfy the multi-signal requirement.
+- **AutoML vs AutoRAG** -- `dashboard-area-automl` covers the AutoML experiment experience (`packages/automl/`): tabular classification (binary, multiclass), regression, timeseries forecasting, AutoGluon, model leaderboard, confusion matrix, feature importance, model registration. `dashboard-area-autorag` covers the AutoRAG experiment experience (`packages/autorag/`): RAG pattern evaluation, vector stores, chunking, embedding, retrieval, generation, optimization metrics (faithfulness, answer correctness, context correctness), pattern leaderboard. Both share S3 file browsing and pipeline topology UI patterns; use the summary prefix (`[AutoML]` vs `[AutoRAG]`) or Jira labels (`AutoML`/`automl` vs `AutoRAG`/`autorag`) to disambiguate. Issues affecting both (e.g., shared UI patterns) can have both labels. The umbrella term "AutoX" covers both areas.
+- **Manifest paths** -- A reference to `manifests/` alone is often cross-cutting (see `dashboard-area-manifests`). If the description or PR links include **paths or resource names** that map to a feature’s Code Path Signals (e.g. serving, maas, pipelines), weight the **feature area** at least as highly as generic manifests; see § Manifests area and scrum routing.
+
+## Deprecated Labels
+
+Labels that have been retired. If encountered on an issue, replace with the canonical label. Do not assign deprecated labels to new issues.
+
+| Deprecated label | Replacement | Notes |
+|---|---|---|
+| `dashboard-area-homepage` | `dashboard-area-home` | Legacy variant; consolidated to `home` |
+
+## Area-to-Scrum Default Mapping
+
+An area label can appear on issues belonging to any team. This mapping provides the **default/primary** team for each area, used when skills need a best-guess association. Derived from label co-occurrence analysis of 450 unresolved stories/bugs (March 2026) plus manual corrections.
+
+| Area | Default Team |
+|---|---|
+| `dashboard-area-bff` | Monarch |
+| `dashboard-area-infrastructure` | Monarch |
+| `dashboard-area-patternfly` | Monarch |
+| `dashboard-area-pf6` | Monarch |
+| `dashboard-area-home` | Monarch |
+| `dashboard-area-projects` | Monarch |
+| `dashboard-area-consistencies` | Monarch |
+| `dashboard-area-security` | Monarch |
+| `dashboard-area-cluster-settings` | Monarch |
+| `dashboard-area-cypress` | Monarch |
+| `dashboard-area-applications` | Monarch |
+| `dashboard-area-workbenches` | Razzmatazz |
+| `dashboard-area-jupyter` | Razzmatazz |
+| `dashboard-area-notebooks` | Razzmatazz |
+| `dashboard-area-pipelines` | Razzmatazz |
+| `dashboard-area-storage-classes` | Razzmatazz |
+| `dashboard-area-hardware-profiles` | Razzmatazz |
+| `dashboard-area-user-management` | Razzmatazz |
+| `dashboard-area-performance` | Razzmatazz |
+| `dashboard-area-e2e` | Razzmatazz |
+| `dashboard-area-model-serving` | Zaffre |
+| `dashboard-area-maas` | Zaffre |
+| `dashboard-area-connection-types` | Zaffre |
+| `dashboard-area-manifests` | Monarch |
+| `dashboard-area-genai` | Crimson |
+| `dashboard-area-model-catalog` | Green |
+| `dashboard-area-model-registry` | Green |
+| `dashboard-area-distributed-workloads` | Green |
+| `dashboard-area-mcp` | Green |
+| `dashboard-area-automl` | Purple |
+| `dashboard-area-autorag` | Purple |
+
+### Manifests area and scrum routing
+
+The `dashboard-area-manifests` label covers **Kubernetes/OLM/kustomize YAML in this repo** (`manifests/` and related deployment config). **Default scrum mapping:** **Monarch** — shared install layout, operator bases, cross-cutting resources (e.g. broad RBAC refactors under `manifests/core-bases/`, repo-wide overlay structure), and manifest work that is **not** tied to a single product feature’s ownership.
+
+**Feature-specific deployment assets:** Many paths under `manifests/` are **owned by the feature** that ships those resources (model serving, MaaS, pipelines, gen-ai, etc.). When an issue cites **concrete paths, overlays, or resource kinds** that clearly belong to a feature (examples: KServe/serving runtime deployment YAML, `packages/maas` operator assets, pipeline/EvalHub-related deployment slices, gen-ai/LlamaStack operator resources), **prefer assigning the feature’s `dashboard-area-*` label** (e.g. `dashboard-area-model-serving`, `dashboard-area-maas`, `dashboard-area-genai`, `dashboard-area-pipelines`) — either **instead of** or **in addition to** `dashboard-area-manifests`, per confidence. Scrum routing then follows **that** feature area’s mapping (see assign-scrum-team: generic `dashboard-area-manifests` is dropped when it conflicts with a feature area’s team).
+
+**Zaffre and “manifests” in keywords:** Zaffre’s association with kustomize/OLM refers to **deployment and operator artifacts for model serving, MaaS, and connection types** — not every change under `manifests/`. Generic odh-dashboard manifest hygiene and shared base YAML default to **Monarch** unless the issue is clearly scoped to Zaffre-owned features.
+
+### Areas without a default team
+
+These area labels have no observed scrum co-occurrence. Assign based on context or leave unassigned:
+
+`dashboard-area-edge`, `dashboard-area-accelerators`, `dashboard-area-cluster-storage`, `dashboard-area-trusty-ai`, `dashboard-area-documentation`
+
+### Team keyword / feature associations
+
+When an issue lacks area labels, these keywords and feature associations can help identify the owning team. Match against summary, description, and component references.
+
+**Quality bar for keywords**: Keywords must be feature-specific or area-specific. Avoid cross-cutting terms (e.g., "tests", "E2E tests", "performance", "security") that match issues from many teams -- those should resolve through area labels (Path A), not keyword matching (Path B).
+
+| Team | Scrum label | Keywords / features | Reasoning |
+|---|---|---|---|
+| **Monarch** | `dashboard-monarch-scrum` | PatternFly, PF6, home page, projects page, navigation, infrastructure, cluster settings, shared UI, consistencies, BFF shared infrastructure (not feature-specific BFF), Go backend shared patterns, common middleware, shared auth, plugin-core, app-config, common libraries, cross-package utilities, applications, **generic `manifests/` / install-base / cross-cutting operator YAML** | Monarch owns app shell, shared infrastructure, cross-cutting UI foundations, cross-cutting BFF/Go backend patterns, and **default ownership of repo-wide manifest and install layout** when no feature-specific path dominates. "applications" refers to the enabled/explore applications pages (ISV integrations). |
+| **Razzmatazz** | `dashboard-razzmatazz-scrum` | workbenches, spawner, notebook server, notebooks, BYON image, Jupyter, JupyterLab, pipelines, pipeline server, DSPA, pipeline run, hardware profiles, accelerator profiles, tolerations, node selector, storage classes, user management, RBAC, permissions, group settings | Razzmatazz owns the core DS project experience: workbenches, notebooks, pipelines, hardware profiles, storage classes, and user management. |
+| **Zaffre** | `dashboard-zaffre-scrum` | model serving, inference, KServe, ModelMesh, serving runtime, model deploy, NIM, vLLM, connections, connection types, MaaS admin (subscriptions, API keys, auth policies), operator bundles, kustomize overlays, OLM resources for serving, MaaS, and connection types | Zaffre owns model serving infrastructure, the MaaS admin package (`packages/maas/`, `dashboard-area-maas` — subscriptions, API keys, auth policies), connection types, and the operator and deployment layers that ship those capabilities. Gen AI Studio's consumption of MaaS models/tokens is Crimson (`dashboard-area-genai`). |
+| **Green** | `dashboard-green-scrum` | model catalog, catalog card, model registry, registered model, model version, model artifact, distributed workloads, Kueue, cluster queue, local queue, workload metrics, Ray (when related to DW queue management), MCP, MCP server, MCP catalog | Green owns model catalog, model registry, distributed workloads (queue management side), and MCP. |
+| **Crimson** | `dashboard-crimson-scrum` | Gen AI Studio, gen-ai package, playground, chatbot, compare mode, chat session, AI Asset Endpoints, AAE, endpoint modal, Llamastack, LlamaStack Distribution, LSD install, vector store, RAG, knowledge tab, knowledge sources, EvalHub, evaluation run, lmEval, benchmark evaluation, prompt management, prompt versioning, save prompt, MaaS subscription, ephemeral API key, InstructLab, fine-tuning, teacher model, judge model, guardrails, NeMo Guardrails, code export | Crimson owns the Gen AI Studio experience (`packages/gen-ai/`, `dashboard-area-genai`): playground/chatbot, AAE, Llamastack integration, RAG/vector stores, guardrails, evaluation, prompt management, and MaaS subscriptions within the Gen AI context. |
+| **Tangerine** | `dashboard-tangerine-scrum` | RayJob, RayCluster, Ray dashboard URL, training job, TrainJob, model training, model-training package, checkpointing, Feature Store, Feast, feature view, feature store repository, lineage graph, Kubeflow Pipelines frontend, KFP frontend, MLMD, ML Metadata, artifact details, execution details, pipeline run routing | Tangerine owns model training (RayJob/RayCluster/TrainJob lifecycle), Feature Store (Feast UI), and Kubeflow Pipelines upstream frontend. |
+| **Purple** | `dashboard-purple-scrum` | AutoRAG, AutoML, AutoX, autorag experiment, automl experiment, RAG pattern evaluation, autorag leaderboard, automl leaderboard, pattern details, automl model details, experiment evaluation, tabular pipeline, timeseries pipeline, binary classification, multiclass classification, regression pipeline, AutoGluon, confusion matrix, feature importance, optimization metric, faithfulness, answer correctness, context correctness, vector store provider, Milvus (in AutoRAG context), chunking, embedding model (in AutoRAG context), retrieval method, generation model (in AutoRAG context), Docling, text extraction (in AutoRAG context), S3 file browser (in AutoRAG/AutoML context), AutoRAG configure, AutoML configure, model registration (in AutoML context) | Purple owns the AutoRAG (`packages/autorag/`, `dashboard-area-autorag`) and AutoML (`packages/automl/`, `dashboard-area-automl`) — collectively AutoX — automated experiment experiences: configuration, evaluation, leaderboards, and S3 storage browsing for experiment data. |
+
+## Future Additions
+
+- Additional custom field IDs as analysis skills discover them
+- Additional signal dimensions for area label mapping (API endpoints, feature flags, SupportedArea IDs) as needed

--- a/.claude/skills/jira-triage/operations-schema.json
+++ b/.claude/skills/jira-triage/operations-schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Jira Triage Operations",
+  "description": "Contract between analysis skills and the Apply capability of the jira-triage skill. Analysis skills produce this format; Apply consumes and executes it. Required properties, action enums, params shapes, optional summary vs root issues map, and execution-only fields are defined only here — do not duplicate field lists in skill docs; link to this schema instead.",
+  "type": "object",
+  "required": ["metadata", "operations"],
+  "properties": {
+    "issues": {
+      "type": "object",
+      "description": "Map of issue key → Jira summary (title) for ALL issues returned by the initial query. Populated in Step 1 from the verified inventory — every issue from the query appears here regardless of whether it has actionable operations. This serves as the authoritative record of the query result set and as a deduplication mechanism (avoids repeating summaries on every operation). Apply and dry-run display MUST resolve human-readable titles as: operation.summary if present, else issues[issueKey], else issue key only. When aggregating batches from multiple skills, merge these objects (later keys overwrite on conflict).",
+      "propertyNames": {
+        "pattern": "^[A-Z]+-[0-9]+$"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["generated", "query", "issueCount"],
+      "properties": {
+        "generated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 timestamp of when this file was generated"
+        },
+        "query": {
+          "type": "string",
+          "description": "JQL query or human-readable description of how the issue set was selected"
+        },
+        "issueCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of issues returned by the initial query. Set once when the file is created (Step 1) and never incremented. This is a static count reflecting the query result size, not the number of issues that have operations."
+        }
+      },
+      "additionalProperties": false
+    },
+    "operations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/operation"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "operation": {
+      "type": "object",
+      "required": ["issueKey", "action", "params", "reason"],
+      "properties": {
+        "issueKey": {
+          "type": "string",
+          "pattern": "^[A-Z]+-[0-9]+$",
+          "description": "Jira issue key (e.g., RHOAIENG-12345)"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Issue title for human readability in dry-run output. Omit on each operation when the root issues map includes this issueKey (deduplicated batch format)."
+        },
+        "action": {
+          "type": "string",
+          "enum": ["SET_FIELDS", "ADD_LABEL", "REMOVE_LABEL", "ADD_COMMENT", "TRANSITION", "LINK_DUPLICATE", "LINK_BLOCKED_BY", "NO_OP"],
+          "description": "The type of Jira operation to perform. NO_OP is an informational record indicating no action is needed for this issue, with the reason field explaining why."
+        },
+        "params": {
+          "oneOf": [
+            { "$ref": "#/definitions/setFieldsParams" },
+            { "$ref": "#/definitions/labelParams" },
+            { "$ref": "#/definitions/commentParams" },
+            { "$ref": "#/definitions/transitionParams" },
+            { "$ref": "#/definitions/linkDuplicateParams" },
+            { "$ref": "#/definitions/linkBlockedByParams" },
+            { "$ref": "#/definitions/noOpParams" }
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable explanation of why this operation is recommended"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["success", "failed"],
+          "description": "Execution status. Absent on unannotated operations (not yet attempted). Annotated in-place on the operations file as operations are executed."
+        },
+        "error": {
+          "type": "string",
+          "description": "Error detail when status is 'failed'."
+        },
+        "commentId": {
+          "type": "string",
+          "description": "Jira comment ID returned on successful ADD_COMMENT execution. Enables later edits to the comment."
+        }
+      },
+      "additionalProperties": false
+    },
+    "setFieldsParams": {
+      "type": "object",
+      "required": ["fields"],
+      "properties": {
+        "fields": {
+          "type": "object",
+          "description": "Field names/IDs and their values, passed through to jira_update_issue. Analysis skills determine the field names and values.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "labelParams": {
+      "type": "object",
+      "required": ["labels"],
+      "properties": {
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "Labels to add or remove"
+        }
+      },
+      "additionalProperties": false
+    },
+    "commentParams": {
+      "type": "object",
+      "required": ["comment"],
+      "properties": {
+        "comment": {
+          "type": "string",
+          "description": "Comment text in Markdown format"
+        },
+        "visibility": {
+          "type": "object",
+          "description": "Comment visibility restriction. All triage comments default to {\"type\":\"group\",\"value\":\"Red Hat Employee\"} at execution time (both agent and script paths). Only include explicitly to override the default.",
+          "properties": {
+            "type": { "type": "string", "enum": ["group", "role"] },
+            "value": { "type": "string" }
+          },
+          "required": ["type", "value"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "transitionParams": {
+      "type": "object",
+      "required": ["transitionName"],
+      "properties": {
+        "transitionName": {
+          "type": "string",
+          "description": "Human-readable transition name (e.g., 'Backlog', 'In Progress'). The Apply step resolves this to a numeric transition_id at execution time."
+        },
+        "fields": {
+          "type": "object",
+          "description": "Optional fields to set during the transition (e.g., resolution). Passed through to jira_transition_issue.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "linkDuplicateParams": {
+      "type": "object",
+      "required": ["duplicateOf"],
+      "properties": {
+        "duplicateOf": {
+          "type": "string",
+          "pattern": "^[A-Z]+-[0-9]+$",
+          "description": "Issue key of the original (the issue this one duplicates)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "linkBlockedByParams": {
+      "type": "object",
+      "required": ["blockedBy"],
+      "properties": {
+        "blockedBy": {
+          "type": "string",
+          "pattern": "^[A-Z]+-[0-9]+$",
+          "description": "Issue key of the blocker (the issue that blocks the operation's issue)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "noOpParams": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "description": "Empty params object for NO_OP operations. The reason field on the operation explains why no action is needed."
+    }
+  }
+}

--- a/.claude/skills/jira-triage/persona.md
+++ b/.claude/skills/jira-triage/persona.md
@@ -1,0 +1,60 @@
+# Execution Protocol
+
+You are a rigorous, detail-oriented agent. Follow these rules without exception across all Jira triage skills.
+
+## Fresh Start (Non-Negotiable)
+
+0. **Always start from scratch.** Every triage invocation begins with fresh Jira queries and fresh analysis. **Never** read, scan, or reference previous operation files in `.artifacts/triage/` unless the user explicitly asks you to (e.g., "apply operations from `.artifacts/triage/ops.json`" or "resume from the previous run"). Do not assume any prior analysis has been done. Do not look for existing artifacts to avoid "re-doing" work. Each run is independent and self-contained. The only exception is the Apply-from-file flow, where the user provides a specific file path to execute.
+
+## Mechanical Rigor
+
+1. **Read fully.** Read every piece of input data end-to-end. Never skim, skip, or truncate. If data is paginated, fetch every page before drawing conclusions.
+
+2. **Work in deterministic order.** For any set of issues, sort by issue key ascending (for example, `RHOAIENG-100` before `RHOAIENG-101`) and process one at a time in that order. Track what is processed and what remains. Never batch by assumption.
+
+3. **Verify before asserting.** Before stating any fact, trace it back to the source data. If you cannot point to the exact input that supports a conclusion, retract it.
+
+4. **Recheck every evaluation.** After completing each assessment, immediately re-read the relevant input and confirm your output matches. Correct any discrepancy before moving on.
+
+5. **Never assume.** If information is absent, ambiguous, or unclear, say so explicitly. Do not fill gaps with plausible guesses. Missing data is a finding, not a problem to paper over.
+
+6. **Prefer false negatives over false positives.** When uncertain, err on the side of "not enough information" rather than making a wrong call. Flag uncertain cases for human review.
+
+7. **Canonical operation ordering.** For each issue, emit operations in this order unless an explicit skill-level exception overrides it: `SET_FIELDS` -> `ADD_COMMENT` -> `ADD_LABEL` -> `REMOVE_LABEL` -> `LINK_DUPLICATE` -> `LINK_BLOCKED_BY` -> `TRANSITION`. Within label operations, sort labels alphabetically.
+
+8. **Final sweep.** After completing a task, do a complete pass over your outputs against the original inputs to catch anything missed or mischaracterized.
+
+## Cognitive Discipline
+
+9. **Don't conflate issues.** When processing a batch, treat each issue as an isolated evaluation. Do not carry issue-specific details from previous issues into the current one. If you catch yourself referencing content you did not read in the current issue's data, stop and re-read.
+
+10. **Anchor on content, not metadata.** The issue title, type, and priority are claims to evaluate, not facts to assume. Read the description on its own terms before checking whether the metadata matches. A title like "Widget crashes on save" does not mean there is a crash -- description and concrete evidence are the source of truth.
+
+11. **Use a fixed evidence precedence.** When signals conflict, apply this order: (1) concrete description details and reproducible evidence, (2) linked issue evidence and explicit dependencies, (3) current labels/components/custom fields, (4) summary/title phrasing. Higher-ranked evidence wins unless directly disproven.
+
+12. **Evaluate all evidence, including contradictory signals.** Do not latch onto the first pattern match and ignore the rest. Weigh all relevant evidence before deciding.
+
+13. **Use canonical reasoning templates with issue-specific evidence.** Reuse the same decision rule text when the same rule applies, then append concrete evidence from that issue. Consistency of logic is required; issue-specific evidence is also required.
+
+14. **One evaluation at a time.** When running the analysis pipeline (type, description, priority, blockers, area, scrum), finish each skill's assessment completely before starting the next. Do not let a half-formed hypothesis from a later skill influence an earlier classification that should already be locked in.
+
+15. **State uncertainty explicitly and consistently.** Every non-trivial decision reason should include a confidence level (`high`, `medium`, or `low`) and why.
+
+16. **Apply confidence action gates.**
+    - `high`: allow normal mutations per skill rules.
+    - `medium`: allow mutations only when evidence clearly satisfies a documented rule; otherwise prefer no-op and request clarification.
+    - `low`: do not make irreversible or high-impact classification changes; prefer `needs-info` style follow-up and explicit human review.
+
+17. **Single-vs-bulk equivalence is mandatory.** The same issue with the same input data must produce the same operations whether triaged alone, in a batch, or via sub-agent delegation. Batch context and execution mode must not change issue-level outcomes.
+
+18. **Run an equivalence self-check.** Before finalizing a batch, spot-check at least one issue by re-evaluating it from raw issue data with fresh context and compare outputs. If different, resolve the discrepancy and normalize. When using sub-agent delegation, the coordinator validates sub-agent outputs only for protocol compliance and completeness — for example, confirming that operations follow canonical ordering (rule 7), that required fields are present, and that the sub-agent's output aligns with documented pipeline expectations. The coordinator must not re-evaluate the sub-agent's issue-level judgments (e.g., chosen severity, area label, or type classification). If the coordinator detects a protocol or completeness discrepancy, it must either flag the issue for rework by re-running the sub-agent on that issue, or document a mandatory correction in the operation log — never silently patch the sub-agent's content in place.
+
+19. **Allowed cross-issue checks are only consistency checks.** You may compare outputs across issues to enforce consistent application of the same rule. You may not import issue-specific facts from one issue into another issue's reasoning.
+
+20. **Sub-agent autonomy.** When processing is delegated to a sub-agent, the sub-agent is a fully autonomous executor — it reads the skill files, follows the pipeline, and writes results. The coordinator does not second-guess, re-evaluate, or modify a sub-agent's issue-content judgments. The coordinator's review role is limited to the protocol/compliance validation described in the equivalence self-check (rule 18). If the coordinator suspects a sub-agent produced incorrect results, the remedy is to re-run that sub-agent on the affected issue — not to patch the operations in place.
+
+## Temporal Rigor
+
+21. **Evaluate data chronologically.** Every comment, field change, and linked-issue status transition has a timestamp. Build a timeline before drawing conclusions. A blocking issue being Closed does not resolve questions raised after — or independently of — that closure. An unanswered question in the comment thread is a blocking signal in its own right, regardless of the status of referenced issues. When multiple data sources interact (comments, linked issue statuses, field changes), place them on a single timeline and evaluate the sequence: what was asked, when, by whom, and whether it was answered before the next relevant event.
+
+22. **Resolved ≠ answered.** The closure of a referenced Jira issue means that issue's work is complete — it does not mean every question on the *current* issue has been addressed. After establishing that a blocking issue is Closed, always check whether new questions arose on the current issue (in comments or description updates) that remain unanswered. Those unanswered questions are independent blocking signals that must be evaluated on their own terms.

--- a/.claude/skills/jira-validate-area-label/SKILL.md
+++ b/.claude/skills/jira-validate-area-label/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: jira-validate-area-label
+description: Validate and assign dashboard-area-* labels on Jira issues using multi-signal analysis. Tag mode assigns missing labels; Validate mode audits existing labels for correctness.
+---
+
+# Validate Area Label
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Operates in two modes: **Tag** (assign area labels to unlabeled issues) and **Validate** (audit existing area labels for correctness). Produces operations that flow into the triage Apply capability.
+
+Implements [RHOAIENG-52417](https://redhat.atlassian.net/browse/RHOAIENG-52417).
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides the Area Label Signal Mapping section, which defines keywords, K8s kinds, code paths, and matching notes for each area.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team**, produce **no operations** for that issue — do not assign `dashboard-area-*` labels to reroute another team's work. See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+All issue types except excluded types (Epic, Sub-task, Initiative, Vulnerability).
+
+---
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Summary | `summary` | Primary content for keyword matching |
+| Description | `description` | Content analysis for signal extraction |
+| Labels | `labels` | Detect existing area and scrum labels |
+| Issue type | `issuetype` | Context for area assessment |
+| Issue Links | `issuelinks` | Check linked issue area labels |
+
+**Note:** Description is excluded from the triage Fetch default field list because it can be large. This skill must explicitly add it. Issue links are already included in the Full Triage required fields.
+
+---
+
+## Signal Dimensions
+
+The skill uses six signal dimensions to determine area labels. No single dimension is sufficient alone -- area association requires corroboration from multiple signals.
+
+1. **Keywords** -- Feature names, UI text, and domain terms matched against issue summary and description. Source: Content Signals table in `jira-project-reference.md`.
+2. **K8s resource kinds** -- Kubernetes CRD/resource type names referenced in descriptions. Source: Content Signals table.
+3. **Code paths** -- Repository file/directory paths from linked PRs, stack traces, or description references. Source: Code Path Signals table.
+4. **Jira labels** -- Non-area labels already on the issue (e.g., `AutoML`, `AutoRAG`, `gen-ai`, `ai-pipelines`) that serve as product/feature identifiers. Source: Jira Label Signals table in `jira-project-reference.md`. Treated as keyword-equivalent signals with the same confidence as a keyword match in the summary.
+5. **Linked issues** -- Area labels on linked Jira issues (parent, blocks/blocked-by, relates-to). If linked issues already have `dashboard-area-*` labels, those are a confirming signal. Fetch linked issue labels via `issuelinks` field data (inward/outward issue keys and their labels).
+6. **Scrum team label** -- If the issue has a `dashboard-*-scrum` label, use the Area-to-Scrum Default Mapping in `jira-project-reference.md` in reverse as a **weak confirming signal**. Not definitive: a scrum team may pick up issues outside their default areas.
+
+### Confidence Rule
+
+An area label must be supported by **at least two signal dimensions**, OR by a **single high-confidence signal**:
+
+- K8s kind match (e.g., `InferenceService` = model serving)
+- Code path match (e.g., `packages/model-registry/` = model registry)
+- Unambiguous multi-word keyword phrase unique to one area (e.g., "serving runtime" = model serving)
+
+A Jira label match (e.g., `AutoML` label on the issue) combined with a keyword match in the summary or description satisfies the two-dimension requirement. A Jira label alone does not meet the threshold unless the label itself is an unambiguous product identifier that uniquely maps to one area (e.g., `AutoML` maps only to `dashboard-area-automl`).
+
+A single generic keyword match alone (e.g., "deployment", "connection", "storage") is **never sufficient** to assign an area label.
+
+---
+
+## Shared Matching Procedure
+
+Used by both modes:
+
+1. **Extract signals** from summary, description, Jira labels (non-area labels), linked issues, and scrum team labels. Check issue labels against the Jira Label Signals table in `jira-project-reference.md` to identify product/feature label matches.
+2. **Score each area** against the Content Signals, Jira Label Signals, and Code Path Signals tables in `jira-project-reference.md`. For each area, check all six dimensions and compute a match score.
+3. **Rank areas** by score. The top-scoring area(s) with sufficient confidence become candidates.
+4. **Apply disambiguation rules** (below) to resolve conflicts
+5. **Multiple area labels are expected.** An issue can genuinely span multiple areas. Produce an `ADD_LABEL` for each area that independently meets the confidence threshold. Do not cap at one.
+
+### Disambiguation Rules
+
+When multiple areas match on the same keywords, apply these rules in order:
+
+#### Feature area beats cross-cutting area
+
+If a feature area (e.g., `model-serving`) and a cross-cutting area (e.g., `performance`, `security`, `consistencies`, `infrastructure`, `patternfly`) both match, assign the feature area. Only assign the cross-cutting area if the issue is specifically *about* that concern itself.
+
+- "Model serving table loads slowly" = `model-serving` (not `performance`)
+- "Improve overall app load time" = `performance`
+- "OAuth token issue in pipeline auth" = `pipelines` (not `security`)
+- "Add CSRF protection to backend" = `security`
+
+#### Feature-owned manifest paths vs generic manifests
+
+When the issue references **YAML under `manifests/`**, kustomize overlays, or operator packaging:
+
+- If **concrete paths, overlays, CRDs, or package names** clearly align with a **feature** Code Path or Content Signal (e.g. model serving / KServe, `packages/maas`, pipelines, gen-ai), **prefer labeling that feature area** (`dashboard-area-model-serving`, `dashboard-area-maas`, etc.) — it may be the **primary** label or paired with `dashboard-area-manifests`, depending on confidence.
+- Use **`dashboard-area-manifests`** for **repo-wide** install bases, shared RBAC/operator plumbing, cross-cutting directory layout, or when the scope is **not** attributable to a single feature subtree.
+
+Do not assign **only** `dashboard-area-manifests` when a high-confidence feature path is stated in the description or linked PRs. See `jira-project-reference.md` § **Manifests area and scrum routing** and § Matching Notes (**Manifest paths**).
+
+#### Specific area beats container area
+
+`dashboard-area-projects` is only for the project selector, project list, and project-level actions (create, delete, rename). Each tab in project details maps to a different area:
+
+| Project Detail Tab | Area Label |
+|---|---|
+| Workbenches | `dashboard-area-workbenches` |
+| Pipelines | `dashboard-area-pipelines` |
+| Connections | `dashboard-area-connection-types` |
+| Cluster storage | `dashboard-area-cluster-storage` |
+| Deployments | `dashboard-area-model-serving` |
+| Permissions | `dashboard-area-user-management` |
+| Feature Store | *(no area label yet)* |
+| Settings | `dashboard-area-projects` |
+
+If feature-specific keywords are present alongside "project", assign the feature area, not `projects`.
+
+#### Contextual keywords resolve ambiguous single keywords
+
+Some keywords appear in multiple areas. Co-occurring keywords disambiguate:
+
+| Ambiguous keyword | + Context keyword | Resolves to |
+|---|---|---|
+| "notebook" | + "spawner", "environment variable", "deployment size" | `workbenches` |
+| "notebook" | + "BYON", "image stream", "notebook controller" | `notebooks` |
+| "notebook" | + "Jupyter", "JupyterHub", "JupyterLab" | `jupyter` |
+| "storage" | + "class", "default storage class" | `storage-classes` |
+| "storage" | + "PVC", "persistent volume", "cluster storage" | `cluster-storage` |
+| "model" | + "serving", "inference", "deploy", "runtime" | `model-serving` |
+| "model" | + "registry", "registered", "version" | `model-registry` |
+| "model" | + "catalog", "card" | `model-catalog` |
+| "permissions" | + "project sharing", "project permissions" | `user-management` |
+| "deployment" | + "model", "inference", "serving" | `model-serving` |
+| "subscription" | + "playground", "Gen AI", "chatbot", "AAE" | `genai` |
+| "subscription" | + "admin", "auth policy", "rate limit" | `maas` |
+| "API key" | + "playground", "Gen AI", "chatbot" | `genai` |
+| "API key" | + "admin", "subscription management", "revoke" | `maas` |
+| "vector store" | + "playground", "RAG", "Gen AI" | `genai` |
+| "vector store" | + "AutoRAG", "autorag", "pattern evaluation" | `autorag` |
+| "experiment" | + "AutoML", "automl", "tabular", "timeseries", "classification", "regression" | `automl` |
+| "experiment" | + "AutoRAG", "autorag", "RAG pattern", "faithfulness", "answer correctness" | `autorag` |
+| "leaderboard" | + "AutoML", "automl", "model details", "confusion matrix" | `automl` |
+| "leaderboard" | + "AutoRAG", "autorag", "pattern details", "RAG pattern" | `autorag` |
+| "S3 file" | + "AutoML", "automl", "CSV", "tabular" | `automl` |
+| "S3 file" | + "AutoRAG", "autorag", "knowledge", "documents" | `autorag` |
+| "pipeline" | + "AutoML", "automl", "tabular pipeline", "timeseries pipeline" | `automl` |
+| "pipeline" | + "AutoRAG", "autorag", "RAG pipeline", "text extraction" | `autorag` |
+
+### Near-duplicate Area Labels
+
+- **Deprecated labels**: Check the **Deprecated Labels** table in `jira-project-reference.md`. Do not assign deprecated labels. If encountered in Validate mode, replace with the canonical label.
+- **`e2e` vs `cypress`**: `dashboard-area-e2e` is for end-to-end test cases and test automation. `dashboard-area-cypress` is for the Cypress framework itself -- mocks, config, test infrastructure, `packages/cypress/` plumbing. Both share the same code path, so keywords must disambiguate.
+- **`genai` vs `maas`**: `dashboard-area-genai` covers the Gen AI Studio UX (`packages/gen-ai/`): playground, chatbot, LlamaStack, RAG/vector stores, guardrails, AAE, EvalHub, prompt management. `dashboard-area-maas` covers MaaS admin (`packages/maas/`): subscription CRUD, API key management, auth policies. The gen-ai BFF *calls* MaaS for model/token access, so issues about **consuming** MaaS data within Gen AI Studio (e.g., "MaaS model not appearing in playground") are `genai`; issues about **managing** subscriptions or auth policies are `maas`. Both labels may apply when an issue spans both surfaces.
+- **`automl` vs `autorag`**: `dashboard-area-automl` covers the AutoML experiment experience (`packages/automl/`): tabular classification (binary, multiclass), regression, timeseries forecasting, AutoGluon, model leaderboard, confusion matrix, feature importance, model registration. `dashboard-area-autorag` covers the AutoRAG experiment experience (`packages/autorag/`): RAG pattern evaluation, vector stores, chunking, embedding, retrieval, generation, optimization metrics (faithfulness, answer correctness, context correctness), pattern leaderboard. Both share S3 file browsing and pipeline topology UI patterns. Use the summary prefix (`[AutoML]` vs `[AutoRAG]`), Jira labels (`AutoML`/`automl` vs `AutoRAG`/`autorag`), or domain-specific keywords to disambiguate. Issues affecting both (e.g., shared UI components) can have both labels. "AutoX" is an umbrella term covering both.
+- **Feature-area spec flake vs Cypress framework**: When the issue is a **flake or failure in a feature-oriented spec** (RBAC/permissions, distributed workloads, model serving, etc.) and you assign a **feature** `dashboard-area-*` with sufficient confidence, **do not** also add `dashboard-area-cypress` only because the file extension is `.cy.ts`. Reserve `dashboard-area-cypress` for work **about** Cypress as framework (shared helpers, config, intercepts, commands). This keeps routing aligned with the **owning feature team** and avoids inconsistent “cypress on one flake, not the other” outcomes for the same class of issue.
+
+---
+
+## Mode A: Tag
+
+Given a set of issues (typically from triage Fetch), analyze each issue and produce operations to assign area labels where missing.
+
+### Use Cases
+
+- **Full Triage pipeline step 5**: Runs on all New issues alongside other analysis skills
+- **Standalone backlog labeling**: Find backlog issues missing area labels. Includes the standard filters from `jira-project-reference.md` § Standard Query Filters:
+
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND status = Backlog
+  AND (labels is EMPTY OR labels not in ({area_labels_list}))
+```
+
+### Procedure
+
+For each issue:
+
+1. **Skip** if the issue already has any `dashboard-area-*` label
+2. Run the **shared matching procedure**
+3. For each area that meets the confidence threshold, produce an `ADD_LABEL` operation
+4. **Aim to assign at least one area when confidence supports it.** Multiple areas may be assigned if each independently meets the threshold. Do not force-assign a low-confidence best guess — if no area meets the confidence threshold, produce no operations.
+5. If the issue is truly unclassifiable (vague summary with no description and no linked issues), produce no operations
+
+---
+
+## Mode B: Validate
+
+Find issues with existing area labels and check whether the labels are correct. Used ad-hoc for backlog auditing.
+
+### Discovery JQL Patterns
+
+All values come from `jira-project-reference.md`. Include `resolution = Unresolved` by default.
+
+**Issues with area labels (audit for correctness):**
+```jql
+project = {project_key}
+  AND component = "{component}"
+  AND resolution = Unresolved
+  AND type in ({triage_types})
+  AND "Epic Link" is EMPTY
+  AND Team = {jql_team_id}
+  AND labels in ({area_labels_list})
+```
+
+Can be further scoped by status, scrum team, or date range.
+
+The user may also provide a pre-fetched issue set or specific issue keys to validate.
+
+### Procedure
+
+For each issue:
+
+1. Run the **shared matching procedure**
+2. If the existing label(s) match the top-scoring area(s), no operation
+3. If additional areas should be added (high confidence), produce `ADD_LABEL` for each
+4. If an existing label is clearly wrong (a different area scores much higher and the existing label scores low), produce `REMOVE_LABEL` + `ADD_LABEL` with the corrected label
+5. If the mismatch is ambiguous (close scores), produce `ADD_COMMENT` flagging the potential mismatch for human review -- do NOT auto-change
+6. If any deprecated label (per `jira-project-reference.md` § Deprecated Labels) is found, produce `REMOVE_LABEL` for the deprecated label and `ADD_LABEL` for its replacement
+
+---
+
+## Guidelines
+
+- **Multi-signal confidence is mandatory.** Area labels must be supported by multiple signal dimensions, not keywords alone.
+- **Feature areas take priority** over cross-cutting areas. Only assign cross-cutting areas when the issue is specifically about that concern.
+- **Specific areas take priority** over container areas, especially `projects`.
+- **Multiple area labels per issue are normal and expected.** Each area that independently meets the confidence threshold gets its own operation.
+- **Keep reasons concise**, citing the specific signals across dimensions that drove the match (e.g., "Summary mentions 'workbench spawner', code path in linked PR matches `pages/projects/screens/spawner/`, confirmed by linked issue RHOAIENG-12345 having `dashboard-area-workbenches`").
+- **Do not over-label.** Each area label must be a genuine match. An issue about model serving should not also get `performance` just because the word "slow" appears in passing.
+
+---
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). Actions by mode:
+
+| Mode | Actions produced |
+|---|---|
+| Tag | `ADD_LABEL` |
+| Validate | `ADD_LABEL`, `REMOVE_LABEL`, `ADD_COMMENT` |
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**: it validates, presents the summary, writes the operations file to `.artifacts/triage/`, and stops. The user reviews the file and explicitly applies it later. To execute immediately, the user must request it (e.g., "validate area labels and apply").
+
+---
+
+## Examples
+
+### Tag mode: single area assigned
+
+Issue RHOAIENG-55100 ("InferenceService returns 500 after deploying model with custom serving runtime") has no area labels. Summary contains "InferenceService" (K8s kind = model serving) and "serving runtime" (multi-word phrase unique to model serving).
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-26T10:00:00Z",
+    "query": "Triage batch of 6 new issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55100",
+      "summary": "InferenceService returns 500 after deploying model with custom serving runtime",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-area-model-serving"] },
+      "reason": "K8s kind 'InferenceService' and keyword 'serving runtime' both map to model-serving"
+    }
+  ]
+}
+```
+
+### Tag mode: multiple areas assigned
+
+Issue RHOAIENG-55101 ("Pipeline run fails when workbench notebook uses GPU hardware profile") has no area labels. Description references pipelines (pipeline run), workbenches (workbench notebook), and hardware profiles (GPU hardware profile). Linked parent issue has `dashboard-area-pipelines`.
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-26T10:00:00Z",
+    "query": "Triage batch of 6 new issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55101",
+      "summary": "Pipeline run fails when workbench notebook uses GPU hardware profile",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-area-pipelines"] },
+      "reason": "Keyword 'pipeline run' in summary, confirmed by parent issue RHOAIENG-55050 having dashboard-area-pipelines"
+    },
+    {
+      "issueKey": "RHOAIENG-55101",
+      "summary": "Pipeline run fails when workbench notebook uses GPU hardware profile",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-area-hardware-profiles"] },
+      "reason": "Keywords 'GPU hardware profile' in summary map uniquely to hardware-profiles"
+    }
+  ]
+}
+```
+
+### Validate mode: mismatch corrected
+
+Issue RHOAIENG-55102 ("Workbench spawner fails to set environment variables") has `dashboard-area-projects` but the content is clearly about the workbench spawner. Description references `frontend/src/pages/projects/screens/spawner/`.
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-26T10:00:00Z",
+    "query": "Validate area labels on Backlog issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55102",
+      "summary": "Workbench spawner fails to set environment variables",
+      "action": "REMOVE_LABEL",
+      "params": { "labels": ["dashboard-area-projects"] },
+      "reason": "Issue is about the workbench spawner (specific feature), not projects infrastructure"
+    },
+    {
+      "issueKey": "RHOAIENG-55102",
+      "summary": "Workbench spawner fails to set environment variables",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["dashboard-area-workbenches"] },
+      "reason": "Keywords 'workbench spawner' and 'environment variables' map to workbenches, code path 'pages/projects/screens/spawner/' confirms (longest prefix match)"
+    }
+  ]
+}
+```
+
+### Validate mode: ambiguous, comment for review
+
+Issue RHOAIENG-55103 ("Improve table performance for large datasets") has `dashboard-area-model-serving` but the description mentions both model serving tables and pipeline run tables. Cannot confidently determine which area the performance issue primarily affects.
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-26T10:00:00Z",
+    "query": "Validate area labels on Backlog issues",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55103",
+      "summary": "Improve table performance for large datasets",
+      "action": "ADD_COMMENT",
+      "params": { "comment": "### AI Triage\n\nArea label review: this issue is labeled `dashboard-area-model-serving` but the description references both model serving and pipeline run tables. Should this also have `dashboard-area-pipelines`, or is the model serving label sufficient?" },
+      "reason": "Keywords match both model-serving and pipelines with similar confidence; flagging for human review"
+    }
+  ]
+}
+```

--- a/.claude/skills/jira-validate-description/SKILL.md
+++ b/.claude/skills/jira-validate-description/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: jira-validate-description
+description: Validate issue descriptions for completeness against type-specific criteria, producing ADD_COMMENT and ADD_LABEL operations to request missing information from reporters.
+---
+
+# Validate Description Completeness
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Evaluates issue descriptions against type-specific quality criteria defined in `jira-project-reference.md`, producing operations to request missing information from reporters.
+
+Implements [RHOAIENG-52421](https://redhat.atlassian.net/browse/RHOAIENG-52421).
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides the Description Quality Criteria section, which defines required and recommended sections per issue type.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team**, produce **no operations** for that issue (do not request info on behalf of another team's backlog). See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+All issue types: Bug, Story, and Task. Each type has its own required and recommended sections.
+
+---
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Summary | `summary` | Readability in operations output |
+| Description | `description` | The content being validated |
+| Issue type | `issuetype` | Determines which criteria apply |
+| Labels | `labels` | Skip issues already tagged `needs-info` |
+| Reporter | `reporter` | Tag in the comment |
+| Created | `created` | Context for assessment |
+| Updated | `updated` | Detect recent edits |
+
+**Note:** Description is excluded from the triage Fetch default field list because it can be large. This skill must explicitly add it.
+
+---
+
+## Procedure
+
+For each issue in the input set:
+
+### Step 1: Skip checks
+
+Skip the issue (produce no operations) if any of the following are true:
+
+- The issue already has the `needs-info` label. Someone has already asked.
+- The description is null/empty **and** the issue was created less than 1 hour ago. Give the reporter a brief window to finish filling it in.
+
+### Step 2: Identify the issue type
+
+Map the issue's `issuetype` to one of: Bug, Story, Task. If the type doesn't match any of these (e.g., Epic, Sub-task), skip the issue.
+
+### Test automation and flake tasks (flexibility)
+
+Use this **before** flagging missing **acceptance criteria** or **description of the work** for **Tasks** (not Bugs) when **all** of the following hold:
+
+- The issue clearly concerns a **failing or flaky automated test** (e.g. named test file such as `*.cy.ts`, suite/command output, CI assertion text, timeout message).
+- The description states **what fails** (error, assertion, or screenshot reference) sufficiently for an engineer to locate the test.
+
+Then:
+
+- **Description of the work** — Treat as satisfied: the work is to **fix stabilization** of that test (or underlying app behavior the test covers) so it stops flaking or failing.
+- **Acceptance criteria / definition of done** — **Implied DoD is acceptable:** the cited test(s) pass **reliably** (or the described failure mode no longer reproduces when re-running the test). Do **not** require an explicit bulleted “AC” section or a formula like “N green runs” unless the issue is otherwise unclear.
+- **Do not** add `needs-info` for “missing AC” on this basis alone.
+
+**Bugs** are unchanged: human **steps to reproduce** in the product UI remain mandatory per bug criteria.
+
+### Step 3: Evaluate required sections
+
+Look up the required sections for the issue type from `jira-project-reference.md` § Description Quality Criteria. For each required section, check whether the description contains the substance of that section.
+
+**Evaluate substance, not format.** Read the **entire** description end-to-end before checking template headings. Information often appears in a different section than where a template expects it — e.g., reproduction steps embedded in a "Description of problem" paragraph, or expected behavior stated in the problem narrative rather than under an "Expected results" heading. A section counts as **present** if the substance appears **anywhere** in the description, regardless of which heading (or no heading) it sits under. **Empty template headings do not mean the information is missing** — always check whether the prose, screenshots, or other sections already provide it.
+
+**Bug-specific rules:**
+- Missing steps to reproduce is always flagged — but only when the description truly lacks enough context for a developer to understand the trigger. A prose narrative describing what the user did, supported by screenshots, satisfies this even without numbered steps.
+- Environment details: product version is always required. Browser version and build type (production vs dev) are required only when the bug involves UI behavior.
+- If the description is a single sentence like "X is broken" with no further detail, flag all required sections as missing.
+
+**Story/Task-specific rules:**
+- A one-line description may be acceptable if the issue is genuinely self-explanatory (e.g., "Upgrade PatternFly to v6.2"). Exercise judgment.
+- Acceptance criteria can take any form: bullet list, numbered list, prose. The key is that there is a testable definition of done.
+
+### Step 4: Evaluate recommended sections
+
+Check for the recommended sections. Note any that are missing but do not produce operations solely for missing recommended sections. Missing recommended sections are included in the comment only when required sections are also missing.
+
+### Step 5: Build the missing-sections list
+
+Collect the missing required sections. If none are missing, proceed to Step 6 to check for external link reliance.
+
+If required sections are missing, also collect missing recommended sections to include as suggestions, then skip to Step 7 to produce operations.
+
+### Step 6: Check for external link reliance
+
+Even when all required sections are present, scan the description for cases where **key substance** -- the proposed solution, approach, requirements, problem details, or other information essential to understanding or acting on the issue -- is conveyed only via an external link without being summarized in the description itself.
+
+**Ephemeral or access-restricted sources** that trigger this check:
+
+- Slack threads or messages
+- Google Docs, emails, or other access-restricted documents
+- Any link where the content may become unavailable over time or require separate tool access to read
+
+**Sources that do NOT trigger this check:**
+
+- Jira issue links (stable, cross-referenced)
+- GitHub PRs, issues, or commits (stable, publicly accessible)
+- Design tools (Figma, Miro) when referenced as supplementary context
+- Public documentation links
+
+**Judgment:** Not every external link triggers a comment. The link must carry **key substance** that the description delegates to rather than summarizes. A Slack link used as a casual "see also" alongside a self-contained description is fine. A Slack link that *is* the description's primary source of what to do or how to reproduce is not.
+
+If external link reliance is detected, produce a single **ADD_COMMENT** operation (no `ADD_LABEL`) using the External Link Reliance comment template below. This is a quality improvement suggestion, not a blocker -- it does not add `needs-info`.
+
+If no external link reliance is detected, stop -- the description passes validation.
+
+### Step 7: Produce operations
+
+For each issue with missing required sections, produce two operations in this order:
+
+**Operation 1: ADD_COMMENT**
+
+A constructive, professional comment that:
+- Tags the reporter using the proper mention syntax `@[{reporter displayName}](accountid:{reporter account_id})` -- this is appropriate here because `needs-info` requests details only the reporter can provide. **This is the only `needs-*` label where pinging the reporter is correct.** Other `needs-*` labels (needs-ux, needs-pm, needs-advisor) signal to the triage team, not the reporter. The reporter's `account_id` is available from the issue's `reporter` field.
+- Lists missing required sections as a checklist with brief guidance on what to include
+- Lists missing recommended sections as suggestions (not checkboxes)
+- Explains why the information is needed
+
+Use the comment template below. Adapt the specific checklist items based on what is actually missing -- do not include sections that are already present.
+
+**Operation 2: ADD_LABEL `needs-info`**
+
+Add the `needs-info` label to signal the issue is waiting on reporter input.
+
+---
+
+## Comment Templates
+
+### Bug
+
+```markdown
+### AI Triage
+
+Hi @[{reporter displayName}](accountid:{reporter account_id}), thanks for reporting this bug.
+
+To help us reproduce and fix it, could you update the description with the following?
+
+**Required:**
+- [ ] {missing section} -- {guidance}
+...
+
+{if recommended sections are missing}
+**Helpful to include (if available):**
+- {missing recommended section} -- {guidance}
+...
+{end if}
+
+This information helps the team reproduce the issue and assess its priority. Thanks!
+```
+
+**Guidance text per required section:**
+
+| Section | Guidance |
+|---|---|
+| Problem description | A clear statement of what is broken or behaving incorrectly |
+| Steps to reproduce | Numbered steps to trigger the issue, starting from a clean state |
+| Observed behavior | What actually happens -- error messages, wrong output, crash details |
+| Expected behavior | What should happen instead |
+| Environment | Product version (e.g., RHOAI 2.19); browser and version if UI-related; production or dev build |
+| Reproducibility | Does this happen every time, sometimes, or was it a one-time occurrence? |
+
+**Guidance text per recommended section:**
+
+| Section | Guidance |
+|---|---|
+| Screenshots / recordings | Visual evidence of the issue |
+| Logs / error messages | Browser console errors, stack traces, or pod logs |
+| Workaround | Any known workaround |
+| Regression indicator | Was this working in a previous version? If so, which one? |
+
+### Story
+
+```markdown
+### AI Triage
+
+Hi @[{reporter displayName}](accountid:{reporter account_id}), thanks for filing this story.
+
+To help us scope and plan the work, could you update the description with the following?
+
+**Required:**
+- [ ] {missing section} -- {guidance}
+...
+
+{if recommended sections are missing}
+**Helpful to include (if available):**
+- {missing recommended section} -- {guidance}
+...
+{end if}
+
+Clear requirements help the team estimate and deliver accurately. Thanks!
+```
+
+**Guidance text per required section:**
+
+| Section | Guidance |
+|---|---|
+| Description of the enhancement | What is being added or changed, and the motivation behind it |
+| Acceptance criteria | Measurable conditions that define when this story is complete |
+
+**Guidance text per recommended section:**
+
+| Section | Guidance |
+|---|---|
+| User story format | "As a [role], I want [goal], so that [benefit]" |
+| Design references | Links to Figma, Miro, or design docs if this involves UI changes |
+
+### Task
+
+```markdown
+### AI Triage
+
+Hi @[{reporter displayName}](accountid:{reporter account_id}), thanks for filing this task.
+
+To help us understand the scope, could you update the description with the following?
+
+**Required:**
+- [ ] {missing section} -- {guidance}
+...
+
+{if recommended sections are missing}
+**Helpful to include (if available):**
+- {missing recommended section} -- {guidance}
+...
+{end if}
+
+This information helps the team understand what needs to be done and verify completion. Thanks!
+```
+
+**Guidance text per required section:**
+
+| Section | Guidance |
+|---|---|
+| Description of the work | What needs to be done and why |
+| Acceptance criteria / definition of done | How to verify the task is complete |
+
+**Guidance text per recommended section:**
+
+| Section | Guidance |
+|---|---|
+| Technical context | Relevant code areas, approach notes, or dependencies |
+
+### External Link Reliance (all issue types)
+
+Use this template when the description passes required-section validation but delegates key substance to an ephemeral or access-restricted link.
+
+```markdown
+### AI Triage
+
+Hi @[{reporter displayName}](accountid:{reporter account_id}), the description references {link description, e.g., "a Slack thread"} for key details about this {issue type}.
+
+Could you summarize the relevant information from that link directly in the description? This keeps the issue self-contained so anyone can understand it without needing access to another tool.
+
+Thanks!
+```
+
+**Guidance for `{link description}`:** Use a natural phrase that identifies the source, e.g., "a Slack thread", "a Google Doc", "an internal email thread". If the description has multiple such links, list them (e.g., "a Slack thread and a Google Doc").
+
+---
+
+## Assessment Guidelines
+
+- **Substance over structure (the most important rule).** Read the full description before evaluating any individual section. Information is often in a different section than where a template expects it. Empty template headings ("Steps to Reproduce: #", "Actual results:", "Expected results:") do **not** mean the information is absent — the prose, screenshots, or other sections may already cover it. A description passes if a developer can understand and act on the issue, regardless of how the content is organized.
+- **Do not over-flag.** If the description is reasonably complete, don't flag it just because it could be more detailed. The bar is "can another engineer understand and act on this issue?" For older or general UX issues, missing environment version or reproducibility wording is often acceptable when the bug is clearly not environment-specific.
+- **Empty or near-empty descriptions always fail.** A description that is null, empty, or just restates the summary title should flag all required sections.
+- **Single-sentence descriptions need judgment.** For bugs, a one-liner almost always fails (no repro steps). For stories/tasks, a one-liner may be acceptable if the issue is genuinely self-explanatory.
+- **Bug repro steps require developer-sufficient context, not a numbered list.** A narrative describing what the user did, supported by screenshots showing the before/after state, satisfies the reproduction requirement. Only flag when a developer genuinely cannot determine how to trigger the issue.
+- **Environment details scale with context.** A backend bug doesn't need browser info. A UI rendering bug does.
+- **External links are not a substitute for inline substance.** When the description delegates key information (the solution, approach, repro steps, or requirements) to an ephemeral or access-restricted link (Slack, Google Docs, email) without summarizing it, produce a quality-improvement comment -- even if all required sections technically pass. The issue is not blocked (`needs-info` is not added), but the author should be nudged to make the description self-contained.
+- **Keep reasons concise** -- one sentence identifying the most important gap.
+
+---
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). This skill emits `ADD_COMMENT` and `ADD_LABEL` operations. For missing required sections, both operations are emitted together. For external link reliance (Step 6), only a standalone `ADD_COMMENT` is emitted -- no `ADD_LABEL`. Comment visibility (`Red Hat Employee`) is enforced at execution time by the Apply step -- see `jira-triage` SKILL § Comment Visibility.
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**: it validates, presents the summary, writes the operations file to `.artifacts/triage/`, and stops. The user reviews the file and explicitly applies it later. To execute immediately, the user must request it (e.g., "validate descriptions and apply").
+
+---
+
+## Example
+
+Given a bug RHOAIENG-55000 ("Model serving endpoint returns 500") with a description that says only "Model serving endpoint returns 500 error when deploying a model", reporter Jane Doe:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T14:00:00Z",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND issuetype = Bug AND status = New",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55000",
+      "summary": "Model serving endpoint returns 500",
+      "action": "ADD_COMMENT",
+      "params": {
+        "comment": "### AI Triage\n\nHi @[Jane Doe](accountid:712020:abcd1234-5678-90ab-cdef-1234567890ab), thanks for reporting this bug.\n\nTo help us reproduce and fix it, could you update the description with the following?\n\n**Required:**\n- [ ] Steps to reproduce -- Numbered steps to trigger the issue, starting from a clean state\n- [ ] Observed behavior -- What actually happens: error messages, wrong output, crash details\n- [ ] Expected behavior -- What should happen instead\n- [ ] Environment -- Product version (e.g., RHOAI 2.19); browser and version if UI-related; production or dev build\n- [ ] Reproducibility -- Does this happen every time, sometimes, or was it a one-time occurrence?\n\n**Helpful to include (if available):**\n- Logs / error messages -- Browser console errors, stack traces, or pod logs\n- Screenshots / recordings -- Visual evidence of the issue\n\nThis information helps the team reproduce the issue and assess its priority. Thanks!"
+      },
+      "reason": "Bug description lacks steps to reproduce, observed/expected behavior, environment, and reproducibility"
+    },
+    {
+      "issueKey": "RHOAIENG-55000",
+      "summary": "Model serving endpoint returns 500",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["needs-info"] },
+      "reason": "Incomplete description -- requesting missing details from reporter"
+    }
+  ]
+}
+```

--- a/.claude/skills/jira-validate-issue-type/SKILL.md
+++ b/.claude/skills/jira-validate-issue-type/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: jira-validate-issue-type
+description: Validate whether issues have the correct type (Bug, Story, Task), align Activity Type with classification, and label standalone stories as enhancement.
+---
+
+# Validate Issue Type
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Evaluates issues to determine whether the assigned type (Bug, Story, Task) matches the content, aligns **Activity Type** with the resolved classification, and produces SET_FIELDS and ADD_LABEL operations that flow into the Apply capability. Issues that are too large for a standalone Story are left as-is for a human to decide next steps.
+
+Implements [RHOAIENG-52420](https://redhat.atlassian.net/browse/RHOAIENG-52420).
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides issue type classification criteria, classification label definitions, and field IDs.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team** (or the Jira Team field is not Dashboard and was not cleared by the gate), produce **no operations** for that issue. See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+All issue types. Every issue in the input set is evaluated.
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Issue type | `issuetype` | Current type to validate |
+| Activity Type | `customfield_10464` | Strong classification signal; set or correct alongside issue type |
+| Summary | `summary` | Content analysis + readability in output |
+| Description | `description` | Content analysis for classification |
+| Labels | `labels` | Check for existing classification labels |
+
+## Activity Type as a classification signal
+
+Read `jira-project-reference.md` § **Activity Type** for option names and semantics. Jira values are **exactly**: `Tech Debt & Quality`, `Learning & Enablement`, `New Features`.
+
+**Reporter value is a hint, not ground truth.** Always validate against summary and description. When Activity Type is **already set** and **matches** what the text supports, treat that as **high confidence** — require **clearer contradictory evidence** than you would on an unset field before changing issue type. When Activity Type **conflicts** with content (e.g. **New Features** on a reproducible defect narrative), **trust content** and fix both issue type and Activity Type together.
+
+**Mapping after you resolve issue type** (apply the checks below first; Activity informs tie-breaks, not a bypass):
+
+| Resolved issue type | Activity Type to set |
+|---|---|
+| **Bug** | `Tech Debt & Quality` |
+| **Story** (Path A — qualifies as Story, including with `enhancement`) | `New Features` |
+| **Story** left as-is (Path B — too large, type unchanged) | `New Features` if Activity Type is empty and the work is user-facing; otherwise leave unchanged |
+| **Task** | `Learning & Enablement` if enablement/onboarding/training is the primary purpose; else `Tech Debt & Quality` (default for refactors, CI, tests, flake fixes, dev docs) |
+
+**Constraints from the program field:** **Learning & Enablement** implies **Task**; **New Features** implies **Story**. If the reporter set **New Features** but the issue is clearly a Bug or Task by content, reclassify the type and set Activity accordingly. If **Learning & Enablement** is set but the issue is user-facing enhancement work that should be a Story, reclassify to Story + `New Features`.
+
+**Emitting operations:** Prefer a **single** `SET_FIELDS` per issue that includes every field being updated. When you change `issuetype`, include `customfield_10464` in the **same** `params.fields` object whenever Activity Type should change or was empty. Use separate `SET_FIELDS` only when Activity alone needs correction.
+
+## Checks
+
+Process each issue through the checks below in order. The first match determines the classification. Each check produces zero or more operations.
+
+### Check 1: Bug misclassification
+
+**Condition:** Content describes a defect in existing functionality but the type is not Bug.
+
+**Procedure:**
+
+1. Read the issue's summary and description. Consider **Activity Type**: **New Features** with defect-like content is a strong mismatch signal; **Tech Debt & Quality** aligns with bugs. If Activity is unset but text is clearly a defect, classify as Bug regardless.
+2. **Cypress / CI flake — do not promote to Bug:** If the type is **Task** or **Story** and the issue matches the **flaky Cypress / CI tests (keep Task)** exception in `jira-project-reference.md` § Issue Type Classification Criteria (flake wording, `dashboard-cypress-flake` or similar labels, spec-focused intermittent failure without a user-visible product defect narrative), produce **no** operation here and **continue to Check 2**. Triage must **not** reclassify these as **Bug** merely because a test fails or times out; **Check 2** may reclassify a misfiled **Story** to **Task**.
+3. Otherwise evaluate against the Bug signals in `jira-project-reference.md` § Issue Type Classification Criteria:
+   - Regression, broken behavior, error/crash, incorrect output, data loss
+   - Security vulnerability in existing code
+   - Behavior contradicting documented or expected functionality
+4. If the content clearly describes a defect and the type is not Bug, produce a SET_FIELDS operation that sets **Bug** and **Activity Type** `Tech Debt & Quality` (unless Activity is already correct — then omit `customfield_10464`):
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": {
+       "fields": {
+         "issuetype": { "name": "Bug" },
+         "customfield_10464": { "value": "Tech Debt & Quality" }
+       }
+     },
+     "reason": "<one-sentence justification citing the defect signal; mention Activity if correcting a prior New Features>"
+   }
+   ```
+5. Stop processing further checks for this issue.
+
+### Check 2: Task misclassification
+
+**Condition:** Content describes non-user-facing technical work but the type is not Task.
+
+**Procedure:**
+
+1. Read the issue's summary and description. **Activity Type:** **Learning & Enablement** strongly supports Task — give it extra weight when the text matches enablement/training. **New Features** with purely internal work is a mismatch; set Activity to `Tech Debt & Quality` or `Learning & Enablement` per content when you set Task.
+2. Evaluate against the Task signals in `jira-project-reference.md` § Issue Type Classification Criteria:
+   - Refactoring, code cleanup, infrastructure, CI/CD, build changes
+   - Dev tooling, test improvements, documentation updates, dependency updates
+3. If the content clearly describes non-user-facing work and the type is not Task, produce a SET_FIELDS operation with **Task** and the appropriate Activity Type (`Learning & Enablement` vs `Tech Debt & Quality` per `jira-project-reference.md` § Activity Type):
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": {
+       "fields": {
+         "issuetype": { "name": "Task" },
+         "customfield_10464": { "value": "Tech Debt & Quality" }
+       }
+     },
+     "reason": "<one-sentence justification citing the technical work signal and, if non-obvious, why Tech Debt & Quality vs Learning & Enablement>"
+   }
+   ```
+4. Stop processing further checks for this issue.
+
+### Check 3: Story qualification
+
+**Condition:** Content describes user-facing work (not a Bug or Task).
+
+Evaluate whether the work qualifies as a Story. Use the criteria in `jira-project-reference.md` § Issue Type Classification Criteria → "Is it user-facing work?"
+
+#### Path A: Qualifies as a Story
+
+The work meets ALL of:
+- Relevant to an existing feature (not a net-new product area)
+- Minor in scope (single component, limited UI surface, no new pages/sections)
+- Clear enough to act on without an epic or product discovery
+
+**Positive signals** that an issue qualifies as a Story (not sufficient alone, but strengthen the case):
+- Triggered by or linked to a RHOAIUX issue (UX department work with design direction)
+- Labeled `ux-debt` (small UX improvements with known scope)
+- Has Figma/design links, specific component references, or clear acceptance criteria
+
+**Procedure:**
+
+1. If the type is not already Story, produce a SET_FIELDS operation with **Story** and **Activity Type** `New Features` when Activity is unset or wrong (omit `customfield_10464` only if already `New Features`):
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": {
+       "fields": {
+         "issuetype": { "name": "Story" },
+         "customfield_10464": { "value": "New Features" }
+       }
+     },
+     "reason": "<see reason text requirements below>"
+   }
+   ```
+2. If the type is already Story but Activity Type is empty or incorrect, produce a SET_FIELDS with only `customfield_10464` → `New Features` (or merge with other fields if emitted in the same batch).
+3. If the `enhancement` label is not already present, produce an ADD_LABEL operation:
+   ```json
+   {
+     "action": "ADD_LABEL",
+     "params": { "labels": ["enhancement"] },
+     "reason": "<see reason text requirements below>"
+   }
+   ```
+
+**Reason text for Story classifications** must explain why the issue qualifies as a standalone Story. Cover these points in 2-3 sentences:
+- What existing feature this extends (not net-new)
+- Why the scope is minor (what is the bounded UI surface)
+- What makes it clear enough to act on (design refs, explicit AC, backend already exists, etc.)
+
+#### Path B: Too large for a Story — leave as-is
+
+Any of the following disqualify the issue from being a Story:
+- Introduces a net-new product area, page, or section
+- Requires significant workflow changes across multiple components
+- Needs new integrations or backend capabilities that don't exist yet
+- Scope is unclear or requires product discovery
+- Multi-sprint effort that should be tracked under an epic
+- No obvious fit with any existing feature area
+
+**Procedure:**
+
+1. Do NOT change the issue type or add labels. A human decides next steps for these issues.
+2. If the type is **Story** and Activity Type is empty, produce `SET_FIELDS` with `customfield_10464` → `New Features` so the card reflects user-facing scope. Otherwise produce no operations.
+
+### Already correct
+
+If the issue type matches the content, required labels are satisfied, and Activity Type matches the § Activity Type mapping for that type, produce **no** operations.
+
+**Backfill / correction only:** If the issue type is already correct but Activity Type is **empty** or **wrong** (e.g. Story with `Tech Debt & Quality`), produce a single `SET_FIELDS` updating only `customfield_10464` — no duplicate issue-type change.
+
+## Content-Based Assessment Guidelines
+
+- **Read the full description.** The summary alone is often insufficient -- a summary like "Add export button" could be a minor Story or a major feature depending on the description.
+- **Use Activity Type with the confidence rules in § Activity Type as a classification signal** — stronger prior when set and consistent; override when it conflicts with clear content.
+- **Do not over-classify.** Only produce operations when there is clear evidence of a mismatch. If the type is plausible, leave it alone.
+- **When ambiguous between Story (Path A) and too-large (Path B), lean toward Path B (leave as-is).** It is safer to leave a large issue for human review than to prematurely classify it as a small Story.
+- **UX department issues** with clear scope and design direction typically qualify as Stories. Look for Figma/design links, specific component references, or clear acceptance criteria as positive signals. Issues triggered by RHOAIUX issues or labeled `ux-debt` are often standalone stories because they represent scoped UX improvements with known design direction.
+- **Story classification reasons must be detailed.** Unlike other checks where one sentence suffices, Story qualification is the highest-judgment call in this skill. The reason must explain which existing feature is being extended, why the scope is minor, and what evidence makes it actionable. See the reason text requirements under Path A.
+- **Do not evaluate priority or severity.** Those are handled by the validate-priority-severity skill.
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). This skill emits `SET_FIELDS` and `ADD_LABEL` operations.
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**: it validates, presents the summary, writes the operations file to `.artifacts/triage/`, and stops. The user reviews the file and explicitly applies it later. To execute immediately, the user must request it (e.g., "validate issue types and apply").
+
+## Examples
+
+### Type change: Story filed as Bug
+
+Given issue RHOAIENG-55000 ("Add dark mode toggle to cluster settings") with type=Bug:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T10:00:00Z",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND status = New",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55000",
+      "summary": "Add dark mode toggle to cluster settings",
+      "action": "SET_FIELDS",
+      "params": {
+        "fields": {
+          "issuetype": { "name": "Story" },
+          "customfield_10464": { "value": "New Features" }
+        }
+      },
+      "reason": "Describes a minor UI addition to existing cluster settings page, not a defect"
+    },
+    {
+      "issueKey": "RHOAIENG-55000",
+      "summary": "Add dark mode toggle to cluster settings",
+      "action": "ADD_LABEL",
+      "params": { "labels": ["enhancement"] },
+      "reason": "Standalone user-facing enhancement"
+    }
+  ]
+}
+```
+
+### Type change: Bug filed as Story
+
+Given issue RHOAIENG-55002 ("Pipeline run table shows wrong status after cancellation") with type=Story:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T10:00:00Z",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND status = New",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55002",
+      "summary": "Pipeline run table shows wrong status after cancellation",
+      "action": "SET_FIELDS",
+      "params": {
+        "fields": {
+          "issuetype": { "name": "Bug" },
+          "customfield_10464": { "value": "Tech Debt & Quality" }
+        }
+      },
+      "reason": "Describes incorrect display behavior after cancellation — defect in existing pipeline run table; Activity aligned to Tech Debt & Quality"
+    }
+  ]
+}
+```

--- a/.claude/skills/jira-validate-priority-severity/SKILL.md
+++ b/.claude/skills/jira-validate-priority-severity/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: jira-validate-priority-severity
+description: Analyze issues for missing or incorrect priority (all types) and severity (bugs only), producing SET_FIELDS operations in the standard triage format.
+---
+
+# Validate Priority & Severity
+
+Analysis skill for the [jira-triage infrastructure](../jira-triage/SKILL.md). Evaluates all issue types for missing or misaligned priority, and bugs specifically for severity, producing SET_FIELDS operations that flow into the Apply capability.
+
+Implements [RHOAIENG-52416](https://redhat.atlassian.net/browse/RHOAIENG-52416).
+
+**Before running this skill, read [`persona.md`](../jira-triage/persona.md) and [`jira-project-reference.md`](../jira-triage/jira-project-reference.md).** The persona defines the execution protocol (thoroughness, verification, no assumptions). The project reference provides severity criteria (bugs), priority criteria (all types), the severity-to-priority floor (bugs), and the severity field ID.
+
+## Dashboard ownership prerequisite
+
+This skill applies only to issues **owned by the RHOAI Dashboard** program team. **Full Triage:** run only after `jira-triage` Step 2a passes. If the issue **belongs to another team**, produce **no operations** for that issue. See `jira-project-reference.md` § Dashboard ownership (triage scope).
+
+## Scope
+
+**All issue types.** Severity assessment is bugs only. Priority assessment applies to all types with different rules per type:
+
+| Type | Severity | Priority |
+|---|---|---|
+| Bug | Full assessment (Checks 1-3) | Content-based, full scale, severity floor applies (raise or lower) |
+| Task | Skip | Content-based, full scale; **respect existing — raise only, never lower** |
+| Story | Skip | Default Normal, promote to Major on urgency signals only; respect existing |
+
+## Required Fields
+
+When fetching issues (via the triage Fetch capability or directly), request these fields:
+
+| Field | ID | Why |
+|---|---|---|
+| Issue type | `issuetype` | Determines which checks apply |
+| Priority | `priority` | Priority assessment for all types |
+| Severity | `customfield_10840` | Severity checks (bugs only) |
+| Description | `description` | Content-based assessment |
+
+**Comments (recommended):** If the issue data includes a `comments` field, use them for deeper signal. If comments are not present in the issue data, that means they **were not fetched** — it does NOT mean zero comments exist. When running standalone (not via Full Triage), fetch comments via per-issue `jira_get_issue` calls with `fields=comment` and `comment_limit=20` when the added signal justifies the cost (e.g., small targeted sets, or ambiguous descriptions where comment context could change the assessment).
+
+## Bug Checks
+
+Process each bug through three checks in order. Each check produces zero or more SET_FIELDS operations.
+
+### Check 1: Severity missing
+
+**Condition:** severity (`customfield_10840`) is null or empty.
+
+**Procedure:**
+
+1. Read the bug's description (and comments if fetched).
+2. Evaluate against the severity criteria in `jira-project-reference.md` § Severity. Look for impact signals:
+   - Crashes, error screens, data loss → Critical
+   - Security concerns, RBAC, performance degradation impeding workflow → Important
+   - Silent failures (empty pages, missing data, truncated results, features that quietly stop working without an obvious error) → Important
+   - Validation issues, accessibility, functional problems where the failure is visible and a workaround exists → Moderate
+   - Cosmetic (alignment, layout, color), micro copy → Low
+   - Console output, React warnings → Informational
+3. Regressions increase severity but do not automatically make an issue Critical.
+4. Produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "customfield_10840": { "value": "<suggested severity>" } } },
+     "reason": "<one-sentence justification citing the impact signal>"
+   }
+   ```
+5. **Cascade to priority:** look up the floor for the suggested severity in `jira-project-reference.md` § Severity-to-priority floor. If the bug's current priority is below that floor, emit an additional SET_FIELDS:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "priority": { "name": "<floor priority>" } } },
+     "reason": "Priority raised to floor: <severity> severity requires minimum <priority> priority"
+   }
+   ```
+
+### Check 2: Severity-to-priority floor violation
+
+**Condition:** severity and priority are both set, and priority is below the floor defined in `jira-project-reference.md` § Severity-to-priority floor.
+
+The floor (for reference -- always read the canonical values from `jira-project-reference.md`):
+
+| Severity | Minimum Priority |
+|---|---|
+| Critical | Critical |
+| Important | Major |
+| Moderate | Normal |
+| Low | Normal |
+| Informational | Minor |
+
+Priority ordering from highest to lowest: Blocker > Critical > Major > Normal > Minor.
+
+**Procedure:**
+
+1. Look up the floor for the bug's current severity.
+2. If current priority is below the floor, produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "priority": { "name": "<floor priority>" } } },
+     "reason": "Priority raised to floor: <severity> severity requires minimum <priority> priority"
+   }
+   ```
+3. If priority meets or exceeds the floor, no operation.
+
+**Note:** if Check 3 also fires on the same issue, both checks may produce priority operations based on different severities (Check 2 uses the current severity; Check 3's cascade uses the suggested severity). The dry-run conflict detection in the base infrastructure surfaces this for user review.
+
+### Check 3: Severity content mismatch
+
+**Condition:** severity is set, but the described impact does not match the assigned severity.
+
+**Procedure:**
+
+1. Read the bug's description (and comments if fetched).
+2. Evaluate against the severity criteria in `jira-project-reference.md` § Severity, using the same impact signals as Check 1.
+3. Compare the assessed severity against the assigned severity.
+4. If they match, no operation. If they differ, produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "customfield_10840": { "value": "<suggested severity>" } } },
+     "reason": "<one-sentence justification explaining why the current severity is too high/low>"
+   }
+   ```
+5. **Cascade to priority:** same as Check 1 -- evaluate the floor for the suggested severity and emit an additional priority SET_FIELDS if the current priority is below that floor.
+
+## Task Priority Checks
+
+Tasks use the same content-based priority criteria as bugs (see `jira-project-reference.md` § Task Priority). Severity does not apply to tasks. **Key difference from bugs: respect existing task priority.** Task authors typically have context about urgency not captured in the description. When priority is already set, evaluate independently but only raise — do not lower.
+
+### Check T1: Priority missing or Undefined
+
+**Condition:** priority is null, empty, or `Undefined`.
+
+**Procedure:**
+
+1. Read the task's description (and comments if fetched).
+2. Evaluate against the priority criteria in `jira-project-reference.md` § Task Priority. Look for urgency signals:
+   - Blocks a release or other team → Blocker
+   - High-impact, must be resolved soon → Critical
+   - Related to active development, recently released features → Major
+   - No specific urgency → Normal
+   - Low urgency, can wait → Minor
+3. Produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "priority": { "name": "<assessed priority>" } } },
+     "reason": "<one-sentence justification citing the urgency signal>"
+   }
+   ```
+
+### Check T2: Priority raise check (raise only)
+
+**Condition:** priority is set (not Undefined).
+
+**Procedure:**
+
+1. Read the task's description (and comments if fetched).
+2. Evaluate against the priority criteria, using the same urgency signals as Check T1.
+3. Compare the assessed priority against the assigned priority.
+4. If the content supports a **higher** priority than assigned, produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "priority": { "name": "<assessed priority>" } } },
+     "reason": "<one-sentence justification explaining why the current priority should be raised>"
+   }
+   ```
+5. If the assessed priority matches or is **lower** than the assigned priority, **no operation** — respect the existing value.
+
+## Story Priority Checks
+
+Stories use a simplified priority model. See `jira-project-reference.md` § Story Priority for the criteria. Severity does not apply to stories.
+
+### Check S1: Priority missing or Undefined
+
+**Condition:** priority is null, empty, or `Undefined`.
+
+**Procedure:**
+
+1. Read the story's description.
+2. Look for urgency signals that warrant Major:
+   - Customer-facing pain with no workaround
+   - Time-sensitive dependency on an upcoming release
+   - Explicitly flagged as urgent by PM or leadership
+   - Regression workaround that needs a permanent fix soon
+3. If urgency signals are present, set to Major. Otherwise, set to Normal.
+4. Produce a SET_FIELDS operation:
+   ```json
+   {
+     "action": "SET_FIELDS",
+     "params": { "fields": { "priority": { "name": "<Normal or Major>" } } },
+     "reason": "<one-sentence justification>"
+   }
+   ```
+
+### Respect existing Story priority
+
+If a story already has a valid priority set (anything other than `Undefined`), **do not override it**. The reporter or team may have context that justifies the level. Produce no operations.
+
+**Never set a story above Major.** Blocker and Critical are reserved for bugs and operational issues.
+
+## Content-Based Assessment Guidelines
+
+Severity checks (bugs) and priority checks (all types) require reading issue content. Follow these guidelines:
+
+- **Read the full description.** Look for concrete impact: what breaks, who is affected, is there a workaround.
+- **Silent failures are Important.** If the bug causes something to quietly not work — empty pages, missing data, truncated results, features that stop working without an error message — classify as Important. The user may not realize something is wrong, which makes the impact worse than an obvious error.
+- **Do not assume workarounds.** Only credit a workaround if the issue description explicitly states one or the workaround is trivially obvious with no security, data, or workflow ramifications. Do not invent workarounds by assuming the user can use a different configuration, skip a feature, or change their deployment — the user may have requirements that make the affected path necessary.
+- **If comments are available**, scan them for additional context: customer reports, workaround discoveries, scope clarifications.
+- **Do not accept the author's severity/priority claim as fact.** Evaluate independently against the criteria (exception: story priority is respected when already set).
+- **Regressions** (something that previously worked) are a factor that may increase severity but do not automatically make an issue Critical.
+- **When ambiguous**, lean toward Moderate (the default severity) and Normal (the default priority). Avoid over-escalating based on vague descriptions.
+- **Keep reasons concise** -- one sentence citing the specific impact or urgency signal that drives the assessment.
+
+## Output
+
+Output MUST validate against [`operations-schema.json`](../jira-triage/operations-schema.json). This skill emits only `SET_FIELDS` operations.
+
+Wrap the operations in the standard metadata envelope:
+
+```json
+{
+  "metadata": {
+    "generated": "<ISO-8601 timestamp>",
+    "query": "<JQL or description of how issues were selected>",
+    "issueCount": "<total issues in the evaluated set (static, set from initial query)>"
+  },
+  "operations": [ ... ]
+}
+```
+
+The output flows into the Apply capability of the triage infrastructure. When invoked standalone (outside Full Triage), Apply defaults to **dry-run mode**: it validates, presents the summary, writes the operations file to `.artifacts/triage/`, and stops. The user reviews the file and explicitly applies it later. To execute immediately, the user must request it (e.g., "validate priority and apply").
+
+## Examples
+
+### Bug: severity missing, priority cascade
+
+Given a bug RHOAIENG-12345 ("Widget crashes on save") with severity=null, priority=Normal:
+
+```json
+{
+  "metadata": {
+    "generated": "2026-03-25T10:00:00Z",
+    "query": "project = RHOAIENG AND component = \"AI Core Dashboard\" AND issuetype = Bug AND Severity is EMPTY",
+    "issueCount": 1
+  },
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-12345",
+      "summary": "Widget crashes on save",
+      "action": "SET_FIELDS",
+      "params": { "fields": { "customfield_10840": { "value": "Critical" } } },
+      "reason": "Crash on save with no workaround — core workflow completely unusable"
+    },
+    {
+      "issueKey": "RHOAIENG-12345",
+      "summary": "Widget crashes on save",
+      "action": "SET_FIELDS",
+      "params": { "fields": { "priority": { "name": "Critical" } } },
+      "reason": "Priority raised to floor: Critical severity requires minimum Critical priority"
+    }
+  ]
+}
+```
+
+### Task: priority Undefined
+
+Given a task RHOAIENG-55577 ("Cypress flake in globalDistributedWorkloads.cy.ts") with priority=Major:
+
+Priority is already set and plausible for a test flake — no operations produced.
+
+Given a task RHOAIENG-55600 ("Update webpack config for module federation") with priority=Undefined:
+
+```json
+{
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55600",
+      "summary": "Update webpack config for module federation",
+      "action": "SET_FIELDS",
+      "params": { "fields": { "priority": { "name": "Normal" } } },
+      "reason": "Build tooling update with no urgency signal — default priority"
+    }
+  ]
+}
+```
+
+### Story: priority Undefined, default to Normal
+
+Given a story RHOAIENG-53778 ("Add helper text for Allowed Org in Admin settings") with priority=Undefined:
+
+```json
+{
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-53778",
+      "summary": "Add helper text for Allowed Org in Admin settings of model catalog",
+      "action": "SET_FIELDS",
+      "params": { "fields": { "priority": { "name": "Normal" } } },
+      "reason": "UX improvement with no urgency signal — default story priority"
+    }
+  ]
+}
+```
+
+### Story: priority Undefined, promoted to Major
+
+Given a story RHOAIENG-55700 ("Add timeout field to deployment wizard — customer workaround") with priority=Undefined and description mentioning customer-facing pain:
+
+```json
+{
+  "operations": [
+    {
+      "issueKey": "RHOAIENG-55700",
+      "summary": "Add timeout field to deployment wizard — customer workaround",
+      "action": "SET_FIELDS",
+      "params": { "fields": { "priority": { "name": "Major" } } },
+      "reason": "Customer-facing workaround for timeout failures with no alternative — promotes above default"
+    }
+  ]
+}
+```
+
+### Story: priority already set — respected
+
+Given a story RHOAIENG-47760 ("Support Timeout in KServe Raw Deployment Wizard") with priority=Critical:
+
+Priority is already set (Critical). Even though stories normally cap at Major, the existing value is respected — the reporter or team may have context. No operations produced.

--- a/.claude/skills/upstream-sync-status/SKILL.md
+++ b/.claude/skills/upstream-sync-status/SKILL.md
@@ -101,7 +101,7 @@ Output a report with a title and a summary table.
 
 **If there are no unsynced commits:**
 
-```
+```markdown
 ## <Package-Name> Sync Status
 
 odh-dashboard's copy of the <package-name> upstream is up to date at commit `<short-sha>`.
@@ -109,7 +109,7 @@ odh-dashboard's copy of the <package-name> upstream is up to date at commit `<sh
 
 **If there are unsynced commits:**
 
-```
+```markdown
 ## <Package-Name> Sync Status
 
 odh-dashboard's copy of the <package-name> upstream is not up to date. There are **N commits** on `<owner>/<repo>` `<branch>` (since synced commit `<short-sha>`) that touch `<src>`:
@@ -131,12 +131,12 @@ If `src` is empty, omit the "that touch `<src>`" clause from the summary.
 **Local branch status (always shown after the upstream report):**
 
 If local `main` matches `upstream/main`:
-```
+```markdown
 Local `main` is up to date with `upstream/main` (`opendatahub-io/odh-dashboard`).
 ```
 
 If local `main` is behind:
-```
+```markdown
 **Warning:** Local `main` is **N commits behind** `upstream/main` (`opendatahub-io/odh-dashboard`). Run `git pull upstream main` to update before syncing.
 ```
 

--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -150,12 +150,12 @@ Ask the user if they're ready to open a PR. If not, exit gracefully.
 First, read the PR template at `.github/pull_request_template.md` to get the current structure and "Request review criteria" checklist. The PR body should follow this template's structure.
 
 **[Normal Mode]** Title format:
-```
+```text
 Sync from <owner>/<repo> <7-char-sha>
 ```
 
 **[PR Test Mode]** Title format:
-```
+```text
 [DO NOT MERGE] Test sync for <owner>/<repo>#<pr-number>
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,12 @@ public-cypress/
 .npm/
 vendor/
 
+# Agent worktrees
+.claude/worktrees/
+
+# Triage artifacts
+.artifacts/
+
 # AgentReady reports
 .agentready/
 assessment-output.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,5 +107,12 @@ Skills provide multi-step workflows. They live in `.claude/skills/`. Read the re
 | **Dev Workflow**                   | `skills/dev-workflow/`                 | Implementing a feature, fix, or refactor — runs lint, type-check, tests, and optional browser verification |
 | **Upstream Sync Status**           | `skills/upstream-sync-status/`         | Checking whether a package's upstream copy is up to date (pass package name or be prompted) |
 | **Upstream Sync**                  | `skills/upstream-sync/`                | Syncing upstream changes for a package and opening a PR (pass package name or be prompted)  |
+| **Jira Triage**                   | `skills/jira-triage/`                  | Fetching Jira issues by filter criteria, running full triage on New issues (orchestrates all analysis skills), defining triage operations, and bulk-applying them |
+| **Jira Validate Priority/Severity** | `skills/jira-validate-priority-severity/` | Analyzing bugs for missing or incorrect severity and priority fields         |
+| **Jira Validate Description**     | `skills/jira-validate-description/`    | Validating issue descriptions for completeness per type, requesting missing information from reporters |
+| **Jira Evaluate Blockers**        | `skills/jira-evaluate-blockers/`       | Applying needs-\* labels and blocking state during triage, or evaluating whether existing blockers have been resolved |
+| **Jira Validate Issue Type**      | `skills/jira-validate-issue-type/`     | Validating or correcting issue types (Bug, Story, Task) and labeling feature requests |
+| **Jira Validate Area Label**      | `skills/jira-validate-area-label/`     | Validating or assigning `dashboard-area-*` labels based on multi-signal content analysis |
+| **Jira Assign Scrum Team**        | `skills/jira-assign-scrum-team/`       | Assigning a scrum team label based on area-to-scrum mapping during triage |
 
 **Important**: Always read the relevant rule or skill file before starting the task to ensure you follow the project's conventions and patterns.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-52404

## Description

Adds the Jira triage skill suite for AI-assisted issue triage, covering the full pipeline from fetching untriaged issues through validation, classification, and bulk Jira updates.

**New skills:**
- **jira-triage** — orchestrator: fetch, analyze, dry-run/apply operations pipeline
- **jira-validate-area-label** — assign/validate `dashboard-area-*` labels
- **jira-validate-priority-severity** — validate priority and severity fields
- **jira-validate-issue-type** — validate Bug/Story/Task classification
- **jira-validate-description** — check description completeness per type
- **jira-evaluate-blockers** — apply `needs-*` labels and blocking state
- **jira-assign-scrum-team** — map area labels to scrum team labels

**Supporting files:** persona, project reference (field IDs, label taxonomy, area-to-scrum mapping), operations JSON schema.

**Other changes:**
- Updated `jira-creation.md` with correct team field ID and clarified flakes as Tasks
- Added `.claude/worktrees/` and `.artifacts/` to `.gitignore`

**Open children of [RHOAIENG-52404](https://issues.redhat.com/browse/RHOAIENG-52404):**
- [RHOAIENG-52414](https://issues.redhat.com/browse/RHOAIENG-52414) — Triage skill infrastructure: issue filtering, output format, and bulk operations *(In Progress)*
- [RHOAIENG-52416](https://issues.redhat.com/browse/RHOAIENG-52416) — Validate priority and severity on issues
- [RHOAIENG-52417](https://issues.redhat.com/browse/RHOAIENG-52417) — Validate dashboard-area labels on issues
- [RHOAIENG-52419](https://issues.redhat.com/browse/RHOAIENG-52419) — Detect resolved blockers on needs-* and blocked issues
- [RHOAIENG-52420](https://issues.redhat.com/browse/RHOAIENG-52420) — Validate issue type classification
- [RHOAIENG-52421](https://issues.redhat.com/browse/RHOAIENG-52421) — Validate issue description completeness by type

Tested through application. Triaged new and blocked issues.
[Query of AI reviewed issues using triage skill.](https://redhat.atlassian.net/issues?filter=-1&jql=project%20%3D%20RHOAIENG%20and%20labels%20%3D%20ai-reviewed)

## How Has This Been Tested?

No runtime code changes. Skills are agent configuration files validated through iterative triage runs against live Jira data.

## Test Impact

N/A — agent skill definitions only; no application source changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Jira triage system with multiple analysis skills (issue-type, area labeling, description validation, priority/severity, blocker evaluation, detect-fixed) and an automated scrum-team assignment flow.

* **Documentation**
  * Added comprehensive triage docs: operations schema, execution persona/protocol, skill specs, examples, and clarified triage guidance including explicit handling that Cypress/CI flakes are treated as Tasks.

* **Chores**
  * Updated Jira team field mapping and payload examples; added ignore rules for local triage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->