### PR TITLE
Auth policy detail

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1155,6 +1155,58 @@ class DeleteAuthPolicyModal extends DeleteModal {
   }
 }
 
+class ViewAuthPolicyPage {
+  visit(name: string): void {
+    cy.visitWithLogin(`/maas/auth-policies/view/${name}`);
+    this.wait();
+  }
+
+  private wait(): void {
+    cy.findByTestId('app-page-title').should('exist');
+    cy.testA11y();
+  }
+
+  findTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findBreadcrumbPoliciesLink(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('breadcrumb-policies-link');
+  }
+
+  findDetailsTab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('policy-details-tab');
+  }
+
+  findDetailsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('policy-details-section');
+  }
+
+  findGroupsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('policy-groups-section');
+  }
+
+  findGroupsTable(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('policy-groups-table');
+  }
+
+  findModelsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('subscription-models-section');
+  }
+
+  findModelsTable(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('subscription-models-table');
+  }
+
+  findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('policy-actions-toggle');
+  }
+
+  findPageError(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('error-empty-state-body');
+  }
+}
+
 export const tiersPage = new TiersPage();
 export const createTierPage = new CreateTierPage();
 export const deleteTierModal = new DeleteTierModal();
@@ -1176,3 +1228,4 @@ export const editSubscriptionPage = new EditSubscriptionPage();
 export const policyPage = new PolicyPage();
 export const authPoliciesPage = new AuthPoliciesPage();
 export const deleteAuthPolicyModal = new DeleteAuthPolicyModal();
+export const viewAuthPolicyPage = new ViewAuthPolicyPage();

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -6,6 +6,7 @@ import {
   authPoliciesPage,
   deleteAuthPolicyModal,
   policyPage,
+  viewAuthPolicyPage,
 } from '../../../pages/modelsAsAService';
 import {
   mockAuthPolicies,
@@ -163,11 +164,9 @@ describe('Auth policy create and edit pages', () => {
       policyPage.visit('premium-team-policy');
       policyPage.findTitle().should('contain.text', 'Edit policy');
 
-      // cancel without editing navigates back without calling the API
       policyPage.findCancelButton().click();
       cy.url().should('match', /\/maas\/auth-policies$/);
 
-      // re-open and perform an actual update
       policyPage.visit('premium-team-policy');
       policyPage.findDescriptionInput().clear();
       policyPage.findDescriptionInput().type('Updated policy description');
@@ -180,5 +179,53 @@ describe('Auth policy create and edit pages', () => {
       });
       cy.url().should('match', /\/maas\/auth-policies$/);
     });
+  });
+});
+
+describe('View Auth Policy Page', () => {
+  const policyName = 'premium-team-policy';
+
+  beforeEach(() => {
+    setupAuthPoliciesCommon();
+    cy.interceptOdh(
+      'GET /maas/api/v1/view-policy/:name',
+      { path: { name: policyName } },
+      { data: mockPolicyInfo(policyName) },
+    );
+  });
+
+  it('should display the page content with title, breadcrumb, details, groups, and models', () => {
+    cy.interceptOdh('GET /maas/api/v1/all-policies', { data: mockAuthPolicies() });
+    authPoliciesPage.visit();
+    authPoliciesPage.getRow(policyName).findKebabAction('View details').click();
+    cy.url().should('include', `/maas/auth-policies/view/${policyName}`);
+
+    viewAuthPolicyPage.findTitle().should('contain.text', `${policyName} Display`);
+
+    viewAuthPolicyPage
+      .findDetailsSection()
+      .should('contain.text', policyName)
+      .and('contain.text', 'Name')
+      .and('contain.text', 'Date created');
+
+    viewAuthPolicyPage.findGroupsSection().should('exist');
+    viewAuthPolicyPage.findGroupsTable().should('contain.text', 'premium-users');
+
+    viewAuthPolicyPage.findModelsSection().should('exist');
+    viewAuthPolicyPage
+      .findModelsTable()
+      .should('contain.text', 'granite-3-8b-instruct Display')
+      .and('contain.text', 'maas-models');
+
+    viewAuthPolicyPage.findBreadcrumbPoliciesLink().click();
+    cy.url().should('include', '/maas/auth-policies');
+  });
+
+  it('should show error state when the view-policy API fails', () => {
+    cy.interceptOdh('GET /maas/api/v1/view-policy/:name', { path: { name: policyName } }, {
+      forceNetworkError: true,
+    } as never);
+    viewAuthPolicyPage.visit(policyName);
+    viewAuthPolicyPage.findPageError().should('exist');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -206,6 +206,7 @@ describe('View Auth Policy Page', () => {
       .findDetailsSection()
       .should('contain.text', policyName)
       .and('contain.text', 'Name')
+      .and('contain.text', 'Resource name')
       .and('contain.text', 'Date created');
 
     viewAuthPolicyPage.findGroupsSection().should('exist');

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -332,11 +332,12 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
 
 export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {
   const policy = mockAuthPolicies().find((p) => p.name === name) ?? mockAuthPolicies()[0];
+  const resolvedName = policy.name;
   return {
     policy: {
       ...policy,
-      displayName: `${name} Display`,
-      description: `Description for ${name}`,
+      displayName: `${resolvedName} Display`,
+      description: `Description for ${resolvedName}`,
       creationTimestamp: '2025-03-01T10:00:00Z',
     },
     modelRefs: policy.modelRefs.map((ref) => ({

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -7,6 +7,7 @@ import type { PolicyInfoResponse } from '@odh-dashboard/maas/types/auth-policies
 import type {
   MaaSSubscription,
   SubscriptionInfoResponse,
+  PolicyInfoResponse,
   UserSubscription,
   MaaSModelRefSummary,
   SubscriptionPolicyFormDataResponse,
@@ -328,3 +329,24 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
     },
   },
 ];
+
+export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {
+  const policy = mockAuthPolicies().find((p) => p.name === name) ?? mockAuthPolicies()[0];
+  return {
+    policy: {
+      ...policy,
+      displayName: `${name} Display`,
+      description: `Description for ${name}`,
+      creationTimestamp: '2025-03-01T10:00:00Z',
+    },
+    modelRefs: policy.modelRefs.map((ref) => ({
+      name: ref.name,
+      namespace: ref.namespace,
+      displayName: `${ref.name} Display`,
+      description: `Description for ${ref.name}`,
+      modelRef: { kind: 'LLMInferenceService', name: ref.name },
+      phase: 'Ready' as const,
+      endpoint: `https://${ref.name}.example.com`,
+    })),
+  };
+};

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -7,7 +7,6 @@ import type { PolicyInfoResponse } from '@odh-dashboard/maas/types/auth-policies
 import type {
   MaaSSubscription,
   SubscriptionInfoResponse,
-  PolicyInfoResponse,
   UserSubscription,
   MaaSModelRefSummary,
   SubscriptionPolicyFormDataResponse,
@@ -281,17 +280,6 @@ export const mockUpdateSubscriptionResponse = (
 ): CreateSubscriptionResponse => {
   const subscription = mockSubscriptions().find((s) => s.name === name) ?? mockSubscriptions()[1];
   return { subscription };
-};
-
-export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {
-  const policy = mockAuthPolicies().find((p) => p.name === name);
-  if (!policy) {
-    throw new Error(`mockPolicyInfo: no policy found with name "${name}"`);
-  }
-  return {
-    policy,
-    modelRefs: mockModelRefSummaries(),
-  };
 };
 
 export const mockCreatePolicyResponse = (name = 'new-policy-from-test'): MaaSAuthPolicy => ({

--- a/packages/maas/bff/internal/mocks/subscription_mock.go
+++ b/packages/maas/bff/internal/mocks/subscription_mock.go
@@ -100,9 +100,12 @@ func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 	return []models.MaaSAuthPolicy{
 		{
-			Name:      "premium-team-sub-policy",
-			Namespace: "maas-system",
-			Phase:     "Active",
+			Name:              "premium-team-sub-policy",
+			Namespace:         "maas-system",
+			DisplayName:       "Premium Team Policy",
+			Description:       "High-priority access policy for the premium team with extended model access.",
+			Phase:             "Active",
+			CreationTimestamp: timePtr(time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)),
 			ModelRefs: []models.ModelRef{
 				{Name: "granite-3-8b-instruct", Namespace: "maas-models"},
 				{Name: "flan-t5-small", Namespace: "maas-models"},
@@ -118,9 +121,12 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			},
 		},
 		{
-			Name:      "basic-team-sub-policy",
-			Namespace: "maas-system",
-			Phase:     "Active",
+			Name:              "basic-team-sub-policy",
+			Namespace:         "maas-system",
+			DisplayName:       "Basic Team Policy",
+			Description:       "Standard access policy for general team usage.",
+			Phase:             "Active",
+			CreationTimestamp: timePtr(time.Date(2025, 2, 15, 8, 0, 0, 0, time.UTC)),
 			ModelRefs: []models.ModelRef{
 				{Name: "flan-t5-small", Namespace: "maas-models"},
 			},

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -97,14 +97,15 @@ type ModelRef struct {
 
 // MaaSAuthPolicy is the BFF representation of a MaaSAuthPolicy CR.
 type MaaSAuthPolicy struct {
-	Name             string         `json:"name"`
-	Namespace        string         `json:"namespace"`
-	DisplayName      string         `json:"displayName,omitempty"`
-	Description      string         `json:"description,omitempty"`
-	Phase            string         `json:"phase,omitempty"`
-	ModelRefs        []ModelRef     `json:"modelRefs"`
-	Subjects         SubjectSpec    `json:"subjects"`
-	MeteringMetadata *TokenMetadata `json:"meteringMetadata,omitempty"`
+	Name              string         `json:"name"`
+	Namespace         string         `json:"namespace"`
+	DisplayName       string         `json:"displayName,omitempty"`
+	Description       string         `json:"description,omitempty"`
+	Phase             string         `json:"phase,omitempty"`
+	CreationTimestamp *time.Time     `json:"creationTimestamp,omitempty"`
+	ModelRefs         []ModelRef     `json:"modelRefs"`
+	Subjects          SubjectSpec    `json:"subjects"`
+	MeteringMetadata  *TokenMetadata `json:"meteringMetadata,omitempty"`
 }
 
 // ModelReference references a model endpoint.

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -493,6 +493,12 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 		policy.MeteringMetadata = meta
 	}
 
+	ct := obj.GetCreationTimestamp()
+	if !ct.IsZero() {
+		t := ct.Time
+		policy.CreationTimestamp = &t
+	}
+
 	return policy, nil
 }
 

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1953,11 +1953,24 @@ components:
           type: string
           description: Namespace of the MaaSAuthPolicy resource
           example: maas-system
+        displayName:
+          type: string
+          description: Human-readable display name for the policy
+          example: Premium Team Policy
+        description:
+          type: string
+          description: Description of the policy
+          example: High-priority access policy for the premium team.
         phase:
           type: string
           enum: [Pending, Active, Failed]
           description: Current phase of the auth policy (from status)
           example: Active
+        creationTimestamp:
+          type: string
+          format: date-time
+          description: Timestamp when the policy was created
+          example: "2025-03-01T10:00:00Z"
         modelRefs:
           type: array
           items:

--- a/packages/maas/frontend/src/app/api/auth-policies.ts
+++ b/packages/maas/frontend/src/app/api/auth-policies.ts
@@ -14,23 +14,10 @@ import type {
   PolicyInfoResponse,
   UpdatePolicyRequest,
 } from '~/app/types/auth-policies';
-import { MaaSAuthPolicy, MaaSModelRefSummary } from '~/app/types/subscriptions';
-import { isMaaSAuthPolicy } from './subscriptions';
+import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+import { isMaaSAuthPolicy, isMaaSModelRefSummary } from './subscriptions';
 
 const isRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object';
-
-const isModelReference = (v: unknown): v is { kind: string; name: string } =>
-  isRecord(v) && typeof v.kind === 'string' && typeof v.name === 'string';
-
-const isMaaSModelRefSummary = (v: unknown): v is MaaSModelRefSummary =>
-  isRecord(v) &&
-  typeof v.name === 'string' &&
-  typeof v.namespace === 'string' &&
-  (v.displayName === undefined || typeof v.displayName === 'string') &&
-  (v.description === undefined || typeof v.description === 'string') &&
-  isModelReference(v.modelRef) &&
-  (v.phase === undefined || typeof v.phase === 'string') &&
-  (v.endpoint === undefined || typeof v.endpoint === 'string');
 
 const isPolicyInfoResponse = (v: unknown): v is PolicyInfoResponse =>
   isRecord(v) &&
@@ -39,7 +26,7 @@ const isPolicyInfoResponse = (v: unknown): v is PolicyInfoResponse =>
   v.modelRefs.every(isMaaSModelRefSummary);
 
 const isDeleteAuthPolicyResponse = (v: unknown): v is { message: string } =>
-  typeof v === 'object' && v !== null && 'message' in v && typeof v.message === 'string';
+  isRecord(v) && typeof v.message === 'string';
 
 /** GET /api/v1/all-policies - List all policies */
 export const listAuthPolicies =
@@ -54,7 +41,7 @@ export const listAuthPolicies =
       throw new Error('Invalid response format');
     });
 
-/** GET /api/v1/view-policy/:name - Policy details for edit / view */
+/** GET /api/v1/view-policy/:name - Policy details for edit / view / view details */
 export const getPolicyInfo =
   (name: string, hostPath = '') =>
   (opts: APIOptions): Promise<PolicyInfoResponse> =>

--- a/packages/maas/frontend/src/app/api/subscriptions.ts
+++ b/packages/maas/frontend/src/app/api/subscriptions.ts
@@ -77,7 +77,7 @@ const isMaaSSubscription = (v: unknown): v is MaaSSubscription =>
 const isMaaSSubscriptionArray = (v: unknown): v is MaaSSubscription[] =>
   Array.isArray(v) && v.every(isMaaSSubscription);
 
-const isMaaSModelRefSummary = (v: unknown): v is MaaSModelRefSummary =>
+export const isMaaSModelRefSummary = (v: unknown): v is MaaSModelRefSummary =>
   isRecord(v) &&
   typeof v.name === 'string' &&
   typeof v.namespace === 'string' &&

--- a/packages/maas/frontend/src/app/api/subscriptions.ts
+++ b/packages/maas/frontend/src/app/api/subscriptions.ts
@@ -97,6 +97,7 @@ export const isMaaSAuthPolicy = (v: unknown): v is MaaSAuthPolicy =>
   isOptionalString(v.displayName) &&
   isOptionalString(v.description) &&
   isOptionalString(v.phase) &&
+  isOptionalString(v.creationTimestamp) &&
   Array.isArray(v.modelRefs) &&
   v.modelRefs.every(isModelRef) &&
   isSubjectSpec(v.subjects) &&

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -1,12 +1,124 @@
-import React from 'react';
+import * as React from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
+import SimpleMenuActions from '@odh-dashboard/internal/components/SimpleMenuActions';
+import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
+import { MaaSAuthPolicy, ModelSubscriptionRef } from '~/app/types/subscriptions';
+import { URL_PREFIX } from '~/app/utilities/const';
+import SubscriptionModelsSection from '~/app/pages/subscriptions/viewSubscription/SubscriptionModelsSection';
+import DeleteAuthPolicyModal from './DeleteAuthPolicyModal';
+import PolicyDetailsSection from './viewAuthPolicy/PolicyDetailsSection';
+import PolicyGroupsSection from './viewAuthPolicy/PolicyGroupsSection';
 
-const ViewAuthPoliciesPage: React.FC = () => (
-  <ApplicationsPage
-    title="View Policy"
-    description="View an existing policy."
-    empty={false}
-    loaded
-  />
-);
+const EMPTY_MODEL_REFS: ModelSubscriptionRef[] = [];
+
+type PolicyActionsProps = {
+  policy: MaaSAuthPolicy;
+};
+
+const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
+  const navigate = useNavigate();
+  const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
+
+  return (
+    <>
+      <SimpleMenuActions
+        testId="policy-actions-toggle"
+        dropdownItems={[
+          {
+            key: 'edit',
+            label: 'Edit policy',
+            onClick: () =>
+              navigate(`${URL_PREFIX}/auth-policies/edit/${encodeURIComponent(policy.name)}`),
+          },
+          { isSpacer: true },
+          {
+            key: 'delete',
+            label: 'Delete policy',
+            onClick: () => setIsDeleteOpen(true),
+          },
+        ]}
+      />
+      {isDeleteOpen && (
+        <DeleteAuthPolicyModal
+          authPolicy={policy}
+          onClose={(deleted) => {
+            setIsDeleteOpen(false);
+            if (deleted) {
+              navigate(`${URL_PREFIX}/auth-policies`);
+            }
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+const ViewAuthPoliciesPage: React.FC = () => {
+  const { authPolicyName = '' } = useParams<{ authPolicyName: string }>();
+  const [activeTab, setActiveTab] = React.useState<string | number>('details');
+  const [policyInfo, loaded, loadError] = useGetPolicyInfo(authPolicyName);
+
+  const breadcrumb = (
+    <Breadcrumb>
+      <BreadcrumbItem>
+        <Link to={`${URL_PREFIX}/auth-policies`} data-testid="breadcrumb-policies-link">
+          Policies
+        </Link>
+      </BreadcrumbItem>
+      <BreadcrumbItem isActive>{authPolicyName}</BreadcrumbItem>
+    </Breadcrumb>
+  );
+
+  return (
+    <ApplicationsPage
+      title={policyInfo?.policy.displayName ?? authPolicyName}
+      breadcrumb={breadcrumb}
+      headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} />}
+      empty={false}
+      loaded={loaded}
+      loadError={loadError}
+      errorMessage="Unable to load policy details."
+    >
+      {loaded && policyInfo && (
+        <Tabs
+          activeKey={activeTab}
+          onSelect={(_event, key) => setActiveTab(key)}
+          aria-label="Policy detail tabs"
+          inset={{ default: 'insetNone' }}
+        >
+          <Tab
+            eventKey="details"
+            title={<TabTitleText>Details</TabTitleText>}
+            aria-label="Policy details tab"
+            data-testid="policy-details-tab"
+          >
+            <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
+              <PolicyDetailsSection policy={policyInfo.policy} />
+            </PageSection>
+            <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
+              <PolicyGroupsSection groups={policyInfo.policy.subjects.groups ?? []} />
+            </PageSection>
+            <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
+              <SubscriptionModelsSection
+                modelRefSummaries={policyInfo.modelRefs}
+                subscriptionModelRefs={EMPTY_MODEL_REFS}
+                hideColumns={['tokenLimits']}
+              />
+            </PageSection>
+          </Tab>
+        </Tabs>
+      )}
+    </ApplicationsPage>
+  );
+};
+
 export default ViewAuthPoliciesPage;

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -11,14 +11,12 @@ import {
 } from '@patternfly/react-core';
 import SimpleMenuActions from '@odh-dashboard/internal/components/SimpleMenuActions';
 import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
-import { MaaSAuthPolicy, ModelSubscriptionRef } from '~/app/types/subscriptions';
+import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
-import SubscriptionModelsSection from '~/app/pages/subscriptions/viewSubscription/SubscriptionModelsSection';
+import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteAuthPolicyModal from './DeleteAuthPolicyModal';
 import PolicyDetailsSection from './viewAuthPolicy/PolicyDetailsSection';
 import PolicyGroupsSection from './viewAuthPolicy/PolicyGroupsSection';
-
-const EMPTY_MODEL_REFS: ModelSubscriptionRef[] = [];
 
 type PolicyActionsProps = {
   policy: MaaSAuthPolicy;
@@ -108,9 +106,8 @@ const ViewAuthPoliciesPage: React.FC = () => {
               <PolicyGroupsSection groups={policyInfo.policy.subjects.groups ?? []} />
             </PageSection>
             <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
-              <SubscriptionModelsSection
+              <MaasModelsSection
                 modelRefSummaries={policyInfo.modelRefs}
-                subscriptionModelRefs={EMPTY_MODEL_REFS}
                 hideColumns={['tokenLimits']}
               />
             </PageSection>

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -74,7 +74,7 @@ const ViewAuthPoliciesPage: React.FC = () => {
           Policies
         </Link>
       </BreadcrumbItem>
-      <BreadcrumbItem isActive>{authPolicyName}</BreadcrumbItem>
+      <BreadcrumbItem isActive>{policyInfo?.policy.displayName ?? authPolicyName}</BreadcrumbItem>
     </Breadcrumb>
   );
 

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -41,7 +41,7 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
         <DescriptionListGroup>
           <DescriptionListTerm>Date created</DescriptionListTerm>
           <DescriptionListDescription>
-            {policy.creationTimestamp ? (
+            {policy.creationTimestamp && !Number.isNaN(Date.parse(policy.creationTimestamp)) ? (
               <Timestamp
                 date={new Date(policy.creationTimestamp)}
                 dateFormat="long"

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -25,7 +25,7 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
     <StackItem>
       <DescriptionList columnModifier={{ default: '2Col' }}>
         <DescriptionListGroup>
-          <DescriptionListTerm>Display name</DescriptionListTerm>
+          <DescriptionListTerm>Name</DescriptionListTerm>
           <DescriptionListDescription>
             {policy.displayName ?? policy.name}
           </DescriptionListDescription>
@@ -35,7 +35,7 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
           <DescriptionListDescription>{policy.description ?? '—'}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Name</DescriptionListTerm>
+          <DescriptionListTerm>Resource name</DescriptionListTerm>
           <DescriptionListDescription>{policy.name}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Stack,
+  StackItem,
+  Timestamp,
+  Title,
+} from '@patternfly/react-core';
+import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+
+type PolicyDetailsSectionProps = {
+  policy: MaaSAuthPolicy;
+};
+
+const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) => (
+  <Stack hasGutter data-testid="policy-details-section">
+    <StackItem>
+      <Title headingLevel="h2" size="xl">
+        Policy details
+      </Title>
+    </StackItem>
+    <StackItem>
+      <DescriptionList columnModifier={{ default: '2Col' }}>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Display name</DescriptionListTerm>
+          <DescriptionListDescription>
+            {policy.displayName ?? policy.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Description</DescriptionListTerm>
+          <DescriptionListDescription>{policy.description ?? '—'}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Name</DescriptionListTerm>
+          <DescriptionListDescription>{policy.name}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Date created</DescriptionListTerm>
+          <DescriptionListDescription>
+            {policy.creationTimestamp ? (
+              <Timestamp
+                date={new Date(policy.creationTimestamp)}
+                dateFormat="long"
+                timeFormat="short"
+                is12Hour
+              />
+            ) : (
+              '—'
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </StackItem>
+  </Stack>
+);
+
+export default PolicyDetailsSection;

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyGroupsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyGroupsSection.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Bullseye, Content, Flex, FlexItem, Stack, StackItem, Title } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { GroupReference } from '~/app/types/subscriptions';
+
+type PolicyGroupsSectionProps = {
+  groups: GroupReference[];
+};
+
+const PolicyGroupsSection: React.FC<PolicyGroupsSectionProps> = ({ groups }) => (
+  <Stack hasGutter data-testid="policy-groups-section">
+    <StackItem>
+      <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>
+          <Title headingLevel="h2" size="xl">
+            Groups
+          </Title>
+        </FlexItem>
+        <FlexItem>
+          <Content component="p">Users in these groups are able to access this policy.</Content>
+        </FlexItem>
+      </Flex>
+    </StackItem>
+    <StackItem>
+      {groups.length === 0 ? (
+        <Bullseye>
+          <Content component="p">No groups assigned to this policy.</Content>
+        </Bullseye>
+      ) : (
+        <Table aria-label="Policy groups" variant="compact" data-testid="policy-groups-table">
+          <Thead>
+            <Tr>
+              <Th>Name</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {groups.map((group) => (
+              <Tr key={group.name}>
+                <Td dataLabel="Name">{group.name}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </StackItem>
+  </Stack>
+);
+
+export default PolicyGroupsSection;

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -107,6 +107,7 @@ export type MaaSAuthPolicy = {
   name: string;
   namespace: string;
   phase?: string;
+  creationTimestamp?: string;
   modelRefs: ModelRef[];
   subjects: SubjectSpec;
   meteringMetadata?: TokenMetadata;


### PR DESCRIPTION
[RHOAIENG-56187](https://redhat.atlassian.net/browse/RHOAIENG-56187)

## Description
Implements the auth policy view details page

<img width="1904" height="966" alt="Screenshot 2026-04-08 at 11 18 58 PM" src="https://github.com/user-attachments/assets/e6fb0b97-17ae-4aad-8d2f-7218995d4c61" />

- Builds the policy detail page at `/maas/auth-policies/view/:authPolicyName` following the `ViewSubscriptionPage` pattern
- Adds breadcrumb navigation (Policies > policy-name), kebab actions (Edit / Delete), and a tabbed layout with a "Details" tab
- **Policy details section** — DescriptionList showing Display name, Description, Name, Date created
- **Groups section** — compact table listing groups with empty state
- **Models section** — reuses `SubscriptionModelsSection` with hidden token limits column (per ticket requirement)
- Adds `creationTimestamp`, `displayName`, and `description` to the `MaaSAuthPolicy` schema end-to-end (OpenAPI → BFF model → repository mapper → mock data → frontend type)


## How Has This Been Tested?
1. Go to **Settings → Policies** in the sidebar
2. The policies list page loads with the table showing Name, Groups count, Models count
3. Click a **policy name link** (e.g. "premium-team-sub-policy") in the Name column
4. Check the details page

## Test Impact
Added cypress and unit tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View page for an auth policy with display name, description, name, and creation date.
  * Sections showing assigned groups and referenced models in tables.
  * Breadcrumb link back to policies list and header actions to edit or delete a policy.
  * Live refresh of policy details while viewing.

* **Tests**
  * Added tests for the auth policy view page, navigation, accessibility checks, and error path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->