### PR TITLE
chore(autorag+automl): Add error handling for invalid HTTP S3 connections

### DIFF
--- a/packages/automl/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
+++ b/packages/automl/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
@@ -449,7 +449,7 @@ const S3FileExplorer: React.FC<S3FileExplorerProps> = ({
             body: (
               <>
                 The connection {secretNameToRender} is configured using HTTP. Configure the
-                connection&#39;s endpoint using HTTPS and try again.
+                connection&apos;s endpoint using HTTPS and try again.
               </>
             ),
           },

--- a/packages/automl/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
+++ b/packages/automl/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
@@ -440,6 +440,22 @@ const S3FileExplorer: React.FC<S3FileExplorerProps> = ({
         };
       }
 
+      if (message.includes('endpoint URL must use HTTPS scheme, got: http')) {
+        return {
+          isEmpty: true,
+          emptyStateProps: {
+            status: 'danger',
+            titleText: 'S3 Connection must use HTTPS',
+            body: (
+              <>
+                The connection {secretNameToRender} is configured using HTTP. Configure the
+                connection&#39;s endpoint using HTTPS and try again.
+              </>
+            ),
+          },
+        };
+      }
+
       if (message.includes('not found')) {
         return {
           isEmpty: true,

--- a/packages/automl/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
+++ b/packages/automl/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
@@ -100,6 +100,15 @@ describe('S3FileExplorer', () => {
         expect(screen.getByText('Bucket not configured')).toBeInTheDocument();
       });
     });
+    it('should show HTTPS required error for HTTP connections', async () => {
+      mockGetFiles.mockRejectedValue(new Error('endpoint URL must use HTTPS scheme, got: http'));
+
+      render(<S3FileExplorer {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('S3 Connection must use HTTPS')).toBeInTheDocument();
+      });
+    });
     it('should show connection not found error', async () => {
       mockGetFiles.mockRejectedValue(new Error('not found'));
 

--- a/packages/automl/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
+++ b/packages/automl/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
@@ -100,6 +100,7 @@ describe('S3FileExplorer', () => {
         expect(screen.getByText('Bucket not configured')).toBeInTheDocument();
       });
     });
+
     it('should show HTTPS required error for HTTP connections', async () => {
       mockGetFiles.mockRejectedValue(new Error('endpoint URL must use HTTPS scheme, got: http'));
 

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.playground.tsx
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.playground.tsx
@@ -25,6 +25,8 @@ const AUTORAG_PLAYGROUND_S3_NAMESPACE = process.env.AUTORAG_PLAYGROUND_S3_NAMESP
 const AUTORAG_PLAYGROUND_S3_SECRET_NAME = process.env.AUTORAG_PLAYGROUND_S3_SECRET_NAME ?? '';
 const AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET =
   process.env.AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET ?? '';
+const AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP =
+  process.env.AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP ?? '';
 
 // Mocks ---------------------------------------------------------------------->
 
@@ -66,6 +68,16 @@ const scenarioGroups: Record<string, Scenario[]> = {
       s3Secret: {
         uuid: 'no-bucket-secret-uuid',
         name: AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET,
+        type: 'storage',
+        data: {},
+      },
+    },
+    {
+      label: 'Connection using HTTP',
+      namespace: AUTORAG_PLAYGROUND_S3_NAMESPACE,
+      s3Secret: {
+        uuid: 'http-secret-uuid',
+        name: AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP,
         type: 'storage',
         data: {},
       },
@@ -156,6 +168,16 @@ const App: React.FC = () => {
               <span className="pf-v6-u-text-color-status-success">
                 &nbsp;
                 {AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET || <em>not set</em>}
+              </span>
+            </p>
+            <p className="pf-v6-u-font-family-monospace">
+              <span className="pf-v6-u-text-color-status-danger">
+                AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP
+              </span>
+              :
+              <span className="pf-v6-u-text-color-status-success">
+                &nbsp;
+                {AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP || <em>not set</em>}
               </span>
             </p>
           </CardBody>

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
@@ -449,7 +449,7 @@ const S3FileExplorer: React.FC<S3FileExplorerProps> = ({
             body: (
               <>
                 The connection {secretNameToRender} is configured using HTTP. Configure the
-                connection&#39;s endpoint using HTTPS and try again.
+                connection&apos;s endpoint using HTTPS and try again.
               </>
             ),
           },

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/S3FileExplorer.tsx
@@ -440,6 +440,22 @@ const S3FileExplorer: React.FC<S3FileExplorerProps> = ({
         };
       }
 
+      if (message.includes('endpoint URL must use HTTPS scheme, got: http')) {
+        return {
+          isEmpty: true,
+          emptyStateProps: {
+            status: 'danger',
+            titleText: 'S3 Connection must use HTTPS',
+            body: (
+              <>
+                The connection {secretNameToRender} is configured using HTTP. Configure the
+                connection&#39;s endpoint using HTTPS and try again.
+              </>
+            ),
+          },
+        };
+      }
+
       if (message.includes('not found')) {
         return {
           isEmpty: true,

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
@@ -100,6 +100,15 @@ describe('S3FileExplorer', () => {
         expect(screen.getByText('Bucket not configured')).toBeInTheDocument();
       });
     });
+    it('should show HTTPS required error for HTTP connections', async () => {
+      mockGetFiles.mockRejectedValue(new Error('endpoint URL must use HTTPS scheme, got: http'));
+
+      render(<S3FileExplorer {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('S3 Connection must use HTTPS')).toBeInTheDocument();
+      });
+    });
     it('should show connection not found error', async () => {
       mockGetFiles.mockRejectedValue(new Error('not found'));
 

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/__tests__/S3FileExplorer.spec.tsx
@@ -100,6 +100,7 @@ describe('S3FileExplorer', () => {
         expect(screen.getByText('Bucket not configured')).toBeInTheDocument();
       });
     });
+
     it('should show HTTPS required error for HTTP connections', async () => {
       mockGetFiles.mockRejectedValue(new Error('endpoint URL must use HTTPS scheme, got: http'));
 

--- a/packages/autorag/frontend/src/app/components/common/S3FileExplorer/webpack.playground.ts
+++ b/packages/autorag/frontend/src/app/components/common/S3FileExplorer/webpack.playground.ts
@@ -47,6 +47,11 @@ const ENV_TO_INCLUDE = [
    * `AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET`: The odh secret name that should be used when rendering the error state for an S3-compatible connection secret with no provided bucket.
    */
   'AUTORAG_PLAYGROUND_S3_SECRET_NAME_NO_BUCKET',
+
+  /**
+   * `AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP`: The odh secret name that should be used when rendering the error state for an S3-compatible connection secret with http as the url scheme.
+   */
+  'AUTORAG_PLAYGROUND_S3_SECRET_NAME_HTTP',
 ];
 const ENV_STUB_FALSE = [
   'APP_ENV',


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Issues

- https://redhat.atlassian.net/browse/RHOAIENG-57092

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR adds better error handling for the S3FileExplorer when a connection that has only been configured with `HTTP` is provided.
Since an `HTTPS` connection is required by the S3 BFF, this gap in error handling made it unclear to users.

<img width="1700" height="1226" alt="image" src="https://github.com/user-attachments/assets/30f36699-6e1e-4631-9920-b5f46fc39725" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Manually
* Ran the S3FileExplorer.playground connected to a cluster with an invalid connection
* New test cases

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

New tests cases added in S3FileExplorer.spec

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * S3FileExplorer now shows a clear "S3 Connection must use HTTPS" error when an S3 endpoint uses HTTP, with guidance to configure HTTPS.

* **Tests**
  * Added tests covering the HTTP (non-HTTPS) S3 endpoint error case.

* **New Features**
  * Playground: added a "Connection using HTTP" scenario and a visible playground configuration entry for the HTTP secret variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->