### PR TITLE
Add error message to token limits

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -949,6 +949,10 @@ class EditRateLimitsModal extends Modal {
   findSaveButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().findByTestId('save-rate-limits');
   }
+
+  findHelperText(index: number): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId(`edit-token-limit-${index}-helper-text`);
+  }
 }
 
 class DeleteSubscriptionModal extends DeleteModal {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -243,7 +243,19 @@ describe('Subscription Create Page', () => {
     createSubscriptionPage.findModelsTable().findByTestId('add-token-limit-0').click();
     editRateLimitsModal.shouldBeOpen();
     editRateLimitsModal.findCountInput(0).clear();
+    editRateLimitsModal.findCountInput(0).type('100000');
+    editRateLimitsModal.findSaveButton().should('be.disabled');
+    editRateLimitsModal
+      .findHelperText(0)
+      .should('contain.text', 'Token count exceeds maximum allowed value');
+    editRateLimitsModal.findCountInput(0).clear();
     editRateLimitsModal.findCountInput(0).type('5000');
+    editRateLimitsModal.findTimeInput(0).clear();
+    editRateLimitsModal.findTimeInput(0).type('100000');
+    editRateLimitsModal.findSaveButton().should('be.disabled');
+    editRateLimitsModal
+      .findHelperText(0)
+      .should('contain.text', 'Time value exceeds maximum allowed value');
     editRateLimitsModal.findTimeInput(0).clear();
     editRateLimitsModal.findTimeInput(0).type('1');
     editRateLimitsModal.findSaveButton().click();

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
@@ -22,6 +22,13 @@ type EditRateLimitsModalProps = {
 };
 
 const DEFAULT_RATE_LIMIT: RateLimit = { count: 1000, time: 1, unit: 'hour' };
+const MAX_FIVE_DIGIT_VALUE = 99_999;
+
+const exceedsFiveDigitLimit = (n: number): boolean =>
+  !Number.isNaN(n) && Math.trunc(Math.abs(n)) > MAX_FIVE_DIGIT_VALUE;
+
+const rateLimitExceedsMaxDigits = (limit: RateLimit): boolean =>
+  exceedsFiveDigitLimit(limit.count) || exceedsFiveDigitLimit(limit.time);
 
 const rateLimitSchema = z.object({
   count: z
@@ -57,6 +64,12 @@ const getTimeError = (limit: RateLimit): string | undefined => {
   return result.success ? undefined : result.error.issues[0].message;
 };
 
+const getCountDigitError = (limit: RateLimit): string | undefined =>
+  exceedsFiveDigitLimit(limit.count) ? 'Token count exceeds maximum allowed value' : undefined;
+
+const getTimeDigitError = (limit: RateLimit): string | undefined =>
+  exceedsFiveDigitLimit(limit.time) ? 'Time value exceeds maximum allowed value' : undefined;
+
 const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
   modelName,
   rateLimits,
@@ -71,7 +84,8 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
   const usedUnits = localLimits.map((l) => l.unit);
   const availableUnits = UNIT_OPTIONS.map((opt) => opt.value).filter((u) => !usedUnits.includes(u));
   const validation = rateLimitsSchema.safeParse(localLimits);
-  const canSave = validation.success;
+  const hasDigitLimitError = localLimits.some(rateLimitExceedsMaxDigits);
+  const canSave = validation.success && !hasDigitLimitError;
 
   const handleRowChange = (index: number, updated: RateLimit) => {
     setLocalLimits((prev) => prev.map((item, i) => (i === index ? updated : item)));
@@ -116,6 +130,8 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
                 availableUnits={availableUnits}
                 countError={submitted ? getCountError(limit) : undefined}
                 timeError={submitted ? getTimeError(limit) : undefined}
+                countDigitError={getCountDigitError(limit)}
+                timeDigitError={getTimeDigitError(limit)}
               />
             </StackItem>
           ))}
@@ -137,7 +153,7 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
         <Button
           variant="primary"
           onClick={handleSave}
-          isDisabled={submitted && !canSave}
+          isDisabled={hasDigitLimitError || (submitted && !canSave)}
           data-testid="save-rate-limits"
         >
           Save

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/RateLimitRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/RateLimitRow.tsx
@@ -15,7 +15,7 @@ import {
   StackItem,
   ValidatedOptions,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon } from '@patternfly/react-icons';
 import { RateLimit } from '~/app/types/subscriptions';
 import { UNIT_OPTIONS } from '~/app/utilities/rateLimits';
 
@@ -28,6 +28,8 @@ export type RateLimitRowProps = {
   availableUnits: RateLimit['unit'][];
   countError?: string;
   timeError?: string;
+  countDigitError?: string;
+  timeDigitError?: string;
 };
 
 const COUNT_STEP = 1000;
@@ -41,6 +43,8 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
   availableUnits,
   countError,
   timeError,
+  countDigitError,
+  timeDigitError,
 }) => {
   const [unitDropdownOpen, setUnitDropdownOpen] = React.useState(false);
 
@@ -53,8 +57,10 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
     (opt) => availableUnits.includes(opt.value) || opt.value === rateLimit.unit,
   );
 
-  const hasCountError = countError != null;
-  const hasTimeError = timeError != null;
+  const countMessage = countDigitError ?? countError;
+  const timeMessage = timeDigitError ?? timeError;
+  const hasCountError = countMessage != null;
+  const hasTimeError = timeMessage != null;
 
   return (
     <Stack hasGutter>
@@ -62,7 +68,7 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
         <Split hasGutter>
           <SplitItem>
             <NumberInput
-              validated={hasCountError ? ValidatedOptions.error : ValidatedOptions.default}
+              validated={countMessage != null ? ValidatedOptions.error : ValidatedOptions.default}
               id={`${id}-count`}
               data-testid={`${id}-count`}
               value={Number.isNaN(rateLimit.count) ? '' : rateLimit.count}
@@ -99,7 +105,7 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
           <SplitItem style={{ alignSelf: 'center' }}>tokens per</SplitItem>
           <SplitItem>
             <NumberInput
-              validated={hasTimeError ? ValidatedOptions.error : ValidatedOptions.default}
+              validated={timeMessage != null ? ValidatedOptions.error : ValidatedOptions.default}
               id={`${id}-time`}
               data-testid={`${id}-time`}
               value={Number.isNaN(rateLimit.time) ? '' : rateLimit.time}
@@ -175,17 +181,14 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
           )}
         </Split>
       </StackItem>
-      {(hasCountError || hasTimeError) && (
-        <StackItem>
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
-                {countError || timeError}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </StackItem>
-      )}
+      <StackItem>
+        <FormHelperText data-testid={`${id}-helper-text`}>
+          <HelperText>
+            {hasCountError && <HelperTextItem variant="error">{countMessage}</HelperTextItem>}
+            {hasTimeError && <HelperTextItem variant="error">{timeMessage}</HelperTextItem>}
+          </HelperText>
+        </FormHelperText>
+      </StackItem>
     </Stack>
   );
 };


### PR DESCRIPTION
Closes: [RHOAIENG-57030](https://redhat.atlassian.net/browse/RHOAIENG-57030)

## Description
Prevents the user from typing in more than 5 digits for the token limits. If they exceed 5 digits, the 'Save' button will disable, and a warning will pop up

## How Has This Been Tested?
Tested locally

## Test Impact
Updates existing cypress test 

## Screenshots
<img width="835" height="327" alt="Screenshot 2026-04-08 at 4 20 00 PM" src="https://github.com/user-attachments/assets/82986e99-9965-41a3-97a0-9e40a9982e96" />
<img width="832" height="332" alt="Screenshot 2026-04-08 at 4 20 24 PM" src="https://github.com/user-attachments/assets/a74e92c8-4139-446c-872d-7c6ddb73899a" />
<img width="830" height="304" alt="Screenshot 2026-04-08 at 4 20 37 PM" src="https://github.com/user-attachments/assets/c57cab60-090a-4774-9e15-8652aad6d41a" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-field digit-limit messages shown on each rate-limit row; helper text always rendered.
  * Save button disabled when any five-digit limit violation exists.

* **Bug Fixes**
  * Enforced five-digit cap (99,999) for count and time inputs.
  * Improved field-level error messaging and pre-submit validation for digit errors.

* **Tests**
  * End-to-end tests updated to validate upper-bound constraints and related UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->