### PR TITLE
fix(automl): hide run-level fields and empty values from model details modal

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/ModelInformationTab.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/ModelInformationTab.tsx
@@ -9,8 +9,10 @@ import {
 import type { TabContentProps } from '~/app/components/run-results/AutomlModelDetailsModal/tabConfig';
 import { formatMetricName, getOptimizedMetricForTask } from '~/app/utilities/utils';
 
-/** Keys excluded from the parameter list (not useful as experiment metadata). */
+/** Keys excluded from the parameter list (not useful as model-level metadata). */
 const HIDDEN_KEYS = new Set([
+  'display_name',
+  'description',
   'task_type',
   'train_data_secret_name',
   'train_data_bucket_name',
@@ -18,7 +20,12 @@ const HIDDEN_KEYS = new Set([
 ]);
 
 const ModelInformationTab: React.FC<TabContentProps> = ({ taskType, parameters, createdAt }) => {
-  const paramEntries = Object.entries(parameters ?? {}).filter(([key]) => !HIDDEN_KEYS.has(key));
+  const paramEntries = Object.entries(parameters ?? {}).filter(([key, value]) => {
+    if (HIDDEN_KEYS.has(key) || value === '') {
+      return false;
+    }
+    return !Array.isArray(value) || value.length > 0;
+  });
   const evalMetric = getOptimizedMetricForTask(taskType);
 
   return (

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/__tests__/ModelInformationTab.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/__tests__/ModelInformationTab.spec.tsx
@@ -13,6 +13,8 @@ const baseModel: AutomlModel = {
 };
 
 const baseParameters: MockAutomlParameters = {
+  display_name: 'My Experiment',
+  description: 'A test experiment',
   task_type: 'multiclass',
   label_column: 'type',
   top_n: 3,
@@ -42,6 +44,8 @@ describe('ModelInformationTab', () => {
     render(<ModelInformationTab {...defaultProps} />);
 
     // These keys are in HIDDEN_KEYS and should not render
+    expect(screen.queryByText('Display Name')).not.toBeInTheDocument();
+    expect(screen.queryByText('Description')).not.toBeInTheDocument();
     expect(screen.queryByText('Task Type')).not.toBeInTheDocument();
     expect(screen.queryByText('Train Data Secret Name')).not.toBeInTheDocument();
     expect(screen.queryByText('Train Data Bucket Name')).not.toBeInTheDocument();
@@ -68,6 +72,33 @@ describe('ModelInformationTab', () => {
 
     expect(screen.getByText('Created on')).toBeInTheDocument();
     expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should hide parameters with empty values', () => {
+    const tabularParams: MockAutomlParameters = {
+      task_type: 'multiclass',
+      label_column: 'type',
+      top_n: 3,
+      target: '',
+      id_column: '',
+      timestamp_column: '',
+      known_covariates_names: [],
+      train_data_bucket_name: 'bucket',
+      train_data_file_key: 'data.csv',
+      train_data_secret_name: 'secret',
+    };
+
+    render(<ModelInformationTab {...defaultProps} parameters={tabularParams} />);
+
+    // Tabular fields should be shown
+    expect(screen.getByText('Label Column')).toBeInTheDocument();
+    expect(screen.getByText('Top N')).toBeInTheDocument();
+
+    // Timeseries fields with empty values should not render
+    expect(screen.queryByText('Target')).not.toBeInTheDocument();
+    expect(screen.queryByText('Id Column')).not.toBeInTheDocument();
+    expect(screen.queryByText('Timestamp Column')).not.toBeInTheDocument();
+    expect(screen.queryByText('Known Covariates Names')).not.toBeInTheDocument();
   });
 
   it('should render timeseries-specific parameters', () => {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-57263
https://redhat.atlassian.net/browse/RHOAIENG-57292

## Summary
- Hide `display_name` and `description` from the Model Information tab in the model details modal, as these are run-level attributes not model-level metadata
- Filter out parameters with empty string or empty array values, preventing irrelevant fields from showing (e.g. timeseries fields on tabular runs and vice versa)

Before

<img width="1730" height="1296" alt="Screenshot 2026-04-08 at 5 10 10 PM" src="https://github.com/user-attachments/assets/079849ce-3410-4f2c-b612-72023bd67e21" />

After

<img width="1730" height="1296" alt="Screenshot 2026-04-08 at 5 07 09 PM" src="https://github.com/user-attachments/assets/8d0a86a2-c216-41dc-aa24-19aa1bd9d2ca" />

## How Has This Been Tested?
- Added unit test verifying empty-value filtering for cross-task-type parameters
- Updated existing unit tests to cover `display_name` and `description` in `HIDDEN_KEYS`
- All 675 automl unit tests pass
- Lint and type-check pass with no errors

## Screenshot / Design
**Before:** Tabular runs showed empty timeseries fields (Target, Id Column, etc.) and an empty Display Name
**After:** Only relevant, populated parameters are displayed

## Test plan
- [ ] Verify tabular run model details modal only shows tabular-relevant parameters
- [ ] Verify timeseries run model details modal only shows timeseries-relevant parameters
- [ ] Verify `display_name` and `description` are not shown in the parameter list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced parameter filtering in model details display to exclude internal metadata fields and empty parameter values.
  * Empty strings and empty array values are now properly filtered out to provide a cleaner, more focused model information view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->