### PR TITLE
Update the subscription view page title to use display name

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -336,7 +336,7 @@ describe('Edit Subscription Page', () => {
     editSubscriptionPage.visit(subscriptionName);
     editSubscriptionPage.findTitle().should('contain.text', 'Edit subscription');
 
-    editSubscriptionPage.findNameInput().should('have.value', 'basic-team-sub');
+    editSubscriptionPage.findNameInput().should('have.value', 'Basic Team Subscription');
     editSubscriptionPage.findPriorityInput().should('have.value', '0');
     editSubscriptionPage.findGroupsSelect().should('contain.text', 'system:authenticated');
     editSubscriptionPage.findModelsTable().should('contain.text', 'flan-t5-small');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -62,15 +62,15 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findRows().should('have.length', 5);
     subscriptionsPage.findCreateSubscriptionButton().should('exist');
 
-    const premiumRow = subscriptionsPage.getRow('premium-team-sub');
-    premiumRow.findName().should('contain.text', 'premium-team-sub');
+    const premiumRow = subscriptionsPage.getRow('Premium Team Subscription');
     premiumRow.findPhase().should('contain.text', 'Active');
+    premiumRow.findName().should('contain.text', 'Premium Team Subscription');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
     premiumRow.findPriority().should('contain.text', '10');
 
-    const basicRow = subscriptionsPage.getRow('basic-team-sub');
-    basicRow.findName().should('contain.text', 'basic-team-sub');
+    const basicRow = subscriptionsPage.getRow('Basic Team Subscription');
+    basicRow.findName().should('contain.text', 'Basic Team Subscription');
     basicRow.findPhase().should('contain.text', 'Active');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
@@ -108,7 +108,10 @@ describe('Subscriptions Page', () => {
       { data: { message: "MaaSSubscription 'premium-team-sub' deleted successfully" } },
     ).as('deleteSubscription');
 
-    subscriptionsPage.getRow('premium-team-sub').findKebabAction('Delete subscription').click();
+    subscriptionsPage
+      .getRow('Premium Team Subscription')
+      .findKebabAction('Delete subscription')
+      .click();
     deleteSubscriptionModal.findInput().type('premium-team-sub');
 
     cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
@@ -141,17 +144,19 @@ describe('View Subscription Page', () => {
   it('should display the page content with title, breadcrumb, details, groups, and models', () => {
     cy.interceptOdh('GET /maas/api/v1/all-subscriptions', { data: mockSubscriptions() });
     subscriptionsPage.visit();
-    subscriptionsPage.getRow(subscriptionName).findKebabAction('View details').click();
+    subscriptionsPage.getRow('Premium Team Subscription').findKebabAction('View details').click();
     cy.url().should('include', `/maas/subscriptions/view/${subscriptionName}`);
 
-    viewSubscriptionPage.findTitle().should('contain.text', subscriptionName);
+    viewSubscriptionPage.findTitle().should('contain.text', 'Premium Team Subscription');
 
     viewSubscriptionPage
       .findDetailsSection()
-      .should('contain.text', subscriptionName)
       .and('contain.text', 'Phase')
       .and('contain.text', 'Active')
+      .should('contain.text', 'Premium Team Subscription')
       .and('contain.text', 'Name')
+      .and('contain.text', 'Resource name')
+      .and('contain.text', 'premium-team-sub')
       .and('contain.text', 'Date created');
 
     viewSubscriptionPage.findGroupsSection().should('exist');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -157,7 +157,7 @@ describe('View Subscription Page', () => {
       .and('contain.text', 'Name')
       .and('contain.text', 'Resource name')
       .and('contain.text', 'premium-team-sub')
-      .and('contain.text', 'Date created');
+      .and('contain.text', 'Created');
 
     viewSubscriptionPage.findGroupsSection().should('exist');
     viewSubscriptionPage.findGroupsTable().should('contain.text', 'premium-users');

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -120,6 +120,7 @@ export const mockPendingSubscription = (): MaaSSubscription => ({
 export const mockSubscriptions = (): MaaSSubscription[] => [
   {
     name: 'premium-team-sub',
+    displayName: 'Premium Team Subscription',
     namespace: 'maas-system',
     phase: 'Active',
     statusMessage: 'successfully reconciled',
@@ -147,6 +148,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
   },
   {
     name: 'basic-team-sub',
+    displayName: 'Basic Team Subscription',
     namespace: 'maas-system',
     phase: 'Active',
     statusMessage: 'successfully reconciled',

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -64,7 +64,7 @@ const ViewSubscriptionPage: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [subscriptionInfo, loaded, loadError] = useGetSubscriptionInfo(subscriptionName);
   const displaySubscriptionName =
-    subscriptionInfo?.subscription.displayName?.trim() ?? subscriptionName;
+    subscriptionInfo?.subscription.displayName?.trim() || subscriptionName;
 
   const breadcrumb = (
     <Breadcrumb>

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -63,6 +63,8 @@ const ViewSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [subscriptionInfo, loaded, loadError] = useGetSubscriptionInfo(subscriptionName);
+  const displaySubscriptionName =
+    subscriptionInfo?.subscription.displayName?.trim() ?? subscriptionName;
 
   const breadcrumb = (
     <Breadcrumb>
@@ -71,13 +73,13 @@ const ViewSubscriptionPage: React.FC = () => {
           Subscriptions
         </Link>
       </BreadcrumbItem>
-      <BreadcrumbItem isActive>{subscriptionName}</BreadcrumbItem>
+      <BreadcrumbItem isActive>{displaySubscriptionName}</BreadcrumbItem>
     </Breadcrumb>
   );
 
   return (
     <ApplicationsPage
-      title={subscriptionName}
+      title={displaySubscriptionName}
       breadcrumb={breadcrumb}
       headerAction={
         subscriptionInfo && <SubscriptionActions subscription={subscriptionInfo.subscription} />

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -28,7 +28,7 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
     <StackItem>
       <DescriptionList columnModifier={{ default: '2Col' }}>
         <DescriptionListGroup>
-          <DescriptionListTerm>Display name</DescriptionListTerm>
+          <DescriptionListTerm>Name</DescriptionListTerm>
           <DescriptionListDescription>
             {subscription.displayName ?? subscription.name}
           </DescriptionListDescription>
@@ -44,7 +44,7 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
           <DescriptionListDescription>{subscription.description ?? '—'}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Name</DescriptionListTerm>
+          <DescriptionListTerm>Resource name</DescriptionListTerm>
           <DescriptionListDescription>{subscription.name}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -30,7 +30,7 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
         <DescriptionListGroup>
           <DescriptionListTerm>Name</DescriptionListTerm>
           <DescriptionListDescription>
-            {subscription.displayName ?? subscription.name}
+            {subscription.displayName?.trim() || subscription.name}
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
@@ -48,7 +48,7 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
           <DescriptionListDescription>{subscription.name}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Date created</DescriptionListTerm>
+          <DescriptionListTerm>Created</DescriptionListTerm>
           <DescriptionListDescription>
             {subscription.creationTimestamp ? (
               <Timestamp


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-57319](https://redhat.atlassian.net/browse/RHOAIENG-57319)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Just a quick change to the subscription view page

Changes the title to the display name instead of the resource name (same for the breadcrumb)

Updates some of the headers in the details section -> `Display name` to just `Name` and `Name` to `Resource name`

https://github.com/user-attachments/assets/74062075-c48c-4de9-b95b-b1a2efe1e588




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

to test:
- Pull up a subscription with a display name
- See that that name is in the title is the display name and the details section headers are updated
- go pull up a subscription that doesn't have a display name (even go into the console and delete the display name) and see that everything falls back to the resource name if the display name is not present

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated some mock tests to check for the display name

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now show user-friendly display names across pages, breadcrumbs and titles; details prefer Display Name with fallback to resource name. Labels changed to "Name", "Resource name" and "Created". Edit form pre-fills the display name where applicable.

* **Tests**
  * End-to-end tests updated to interact with and assert on display names; mocked subscriptions include displayName and delete/view flows use display names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->