### PR TITLE
fix(observability): fix PF style overrides for Perses variable controls

### DIFF
--- a/packages/observability/src/perses/PersesBoard.tsx
+++ b/packages/observability/src/perses/PersesBoard.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Dashboard, DashboardStickyToolbar } from '@perses-dev/dashboards';
 
+/**
+ * Perses Dashboard component - renders the actual dashboard with variable controls
+ */
 const PersesBoard: React.FC = () => (
   <>
     <DashboardStickyToolbar initialVariableIsSticky={false} />

--- a/packages/observability/src/perses/PersesBoard.tsx
+++ b/packages/observability/src/perses/PersesBoard.tsx
@@ -1,51 +1,16 @@
 import * as React from 'react';
 import { Dashboard, DashboardStickyToolbar } from '@perses-dev/dashboards';
 
-const POPPER_SELECTOR = '.MuiAutocomplete-popper';
-const DROPDOWN_MIN_WIDTH = 500;
-
-/**
- * MUI Autocomplete sets an inline `width` on the Popper that matches the
- * input field, which truncates long options when the input is narrow.
- * Perses caps variable inputs at 500 px (MAX_VARIABLE_WIDTH) so we apply the
- * same value as a min-width on the Popper to guarantee all option text is
- * visible regardless of the current input width.
- */
-const useAutoSizePoppers = (ref: React.RefObject<HTMLElement | null>): void => {
-  React.useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    const resizePopper = (el: HTMLElement): void => {
-      const { style } = el;
-      style.minWidth = `${DROPDOWN_MIN_WIDTH}px`;
-    };
-
-    const observer = new MutationObserver(() => {
-      document.body.querySelectorAll<HTMLElement>(POPPER_SELECTOR).forEach(resizePopper);
-    });
-
-    observer.observe(document.body, { childList: true, subtree: true });
-    return () => observer.disconnect();
-  }, [ref]);
-};
-
-const PersesBoard: React.FC = () => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  useAutoSizePoppers(containerRef);
-
-  return (
-    <div ref={containerRef}>
-      <DashboardStickyToolbar initialVariableIsSticky={false} />
-      <Dashboard
-        emptyDashboardProps={{
-          title: 'Empty Dashboard',
-          description: 'To get started add something to your dashboard',
-        }}
-      />
-    </div>
-  );
-};
+const PersesBoard: React.FC = () => (
+  <div>
+    <DashboardStickyToolbar initialVariableIsSticky={false} />
+    <Dashboard
+      emptyDashboardProps={{
+        title: 'Empty Dashboard',
+        description: 'To get started add something to your dashboard',
+      }}
+    />
+  </div>
+);
 
 export default PersesBoard;

--- a/packages/observability/src/perses/PersesBoard.tsx
+++ b/packages/observability/src/perses/PersesBoard.tsx
@@ -13,8 +13,7 @@ const DROPDOWN_MIN_WIDTH = 500;
  */
 const useAutoSizePoppers = (ref: React.RefObject<HTMLElement | null>): void => {
   React.useEffect(() => {
-    const container = ref.current;
-    if (!container) {
+    if (!ref.current) {
       return;
     }
 
@@ -24,10 +23,10 @@ const useAutoSizePoppers = (ref: React.RefObject<HTMLElement | null>): void => {
     };
 
     const observer = new MutationObserver(() => {
-      container.querySelectorAll<HTMLElement>(POPPER_SELECTOR).forEach(resizePopper);
+      document.body.querySelectorAll<HTMLElement>(POPPER_SELECTOR).forEach(resizePopper);
     });
 
-    observer.observe(container, { childList: true, subtree: true });
+    observer.observe(document.body, { childList: true, subtree: true });
     return () => observer.disconnect();
   }, [ref]);
 };

--- a/packages/observability/src/perses/PersesBoard.tsx
+++ b/packages/observability/src/perses/PersesBoard.tsx
@@ -1,19 +1,52 @@
 import * as React from 'react';
 import { Dashboard, DashboardStickyToolbar } from '@perses-dev/dashboards';
 
+const POPPER_SELECTOR = '.MuiAutocomplete-popper';
+const DROPDOWN_MIN_WIDTH = 500;
+
 /**
- * Perses Dashboard component - renders the actual dashboard with variable controls
+ * MUI Autocomplete sets an inline `width` on the Popper that matches the
+ * input field, which truncates long options when the input is narrow.
+ * Perses caps variable inputs at 500 px (MAX_VARIABLE_WIDTH) so we apply the
+ * same value as a min-width on the Popper to guarantee all option text is
+ * visible regardless of the current input width.
  */
-const PersesBoard: React.FC = () => (
-  <>
-    <DashboardStickyToolbar initialVariableIsSticky={false} />
-    <Dashboard
-      emptyDashboardProps={{
-        title: 'Empty Dashboard',
-        description: 'To get started add something to your dashboard',
-      }}
-    />
-  </>
-);
+const useAutoSizePoppers = (ref: React.RefObject<HTMLElement | null>): void => {
+  React.useEffect(() => {
+    const container = ref.current;
+    if (!container) {
+      return;
+    }
+
+    const resizePopper = (el: HTMLElement): void => {
+      const { style } = el;
+      style.minWidth = `${DROPDOWN_MIN_WIDTH}px`;
+    };
+
+    const observer = new MutationObserver(() => {
+      container.querySelectorAll<HTMLElement>(POPPER_SELECTOR).forEach(resizePopper);
+    });
+
+    observer.observe(container, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [ref]);
+};
+
+const PersesBoard: React.FC = () => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  useAutoSizePoppers(containerRef);
+
+  return (
+    <div ref={containerRef}>
+      <DashboardStickyToolbar initialVariableIsSticky={false} />
+      <Dashboard
+        emptyDashboardProps={{
+          title: 'Empty Dashboard',
+          description: 'To get started add something to your dashboard',
+        }}
+      />
+    </div>
+  );
+};
 
 export default PersesBoard;

--- a/packages/observability/src/perses/PersesBoard.tsx
+++ b/packages/observability/src/perses/PersesBoard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Dashboard, DashboardStickyToolbar } from '@perses-dev/dashboards';
 
 const PersesBoard: React.FC = () => (
-  <div>
+  <>
     <DashboardStickyToolbar initialVariableIsSticky={false} />
     <Dashboard
       emptyDashboardProps={{
@@ -10,7 +10,7 @@ const PersesBoard: React.FC = () => (
         description: 'To get started add something to your dashboard',
       }}
     />
-  </div>
+  </>
 );
 
 export default PersesBoard;

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -178,18 +178,13 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
           endAdornment: {
             right: 'var(--pf-t--global--spacer--sm)',
           },
-          popper: {
-            // Perses's StyledPopper sets minWidth: fit-content via sx, which truncates long options.
-            // !important is needed to override it until Perses adopts PF styling natively.
-            minWidth: '500px !important',
+          option: {
+            paddingRight: 'var(--pf-t--global--spacer--lg) !important',
           },
         },
       },
       MuiSelect: {
         styleOverrides: {
-          select: {
-            paddingRight: 'var(--pf-t--global--spacer--2xl)',
-          },
           icon: {
             color: primaryTextColor,
           },

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -168,10 +168,41 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
           },
         },
       },
+      MuiAutocomplete: {
+        styleOverrides: {
+          root: {
+            '& .MuiOutlinedInput-root': {
+              paddingRight: 'var(--pf-t--global--spacer--2xl)',
+            },
+          },
+          endAdornment: {
+            right: 'var(--pf-t--global--spacer--sm)',
+          },
+        },
+      },
       MuiSelect: {
         styleOverrides: {
+          select: {
+            paddingRight: 'var(--pf-t--global--spacer--2xl)',
+          },
           icon: {
             color: primaryTextColor,
+          },
+        },
+      },
+      MuiCheckbox: {
+        styleOverrides: {
+          root: {
+            color: 'var(--pf-t--global--border--color--default)',
+            '& .MuiSvgIcon-root': {
+              color: 'inherit',
+            },
+            '&.Mui-checked': {
+              color: 'var(--pf-t--global--color--brand--default)',
+            },
+            '&.MuiCheckbox-indeterminate': {
+              color: 'var(--pf-t--global--color--brand--default)',
+            },
           },
         },
       },

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -170,11 +170,6 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
       },
       MuiAutocomplete: {
         styleOverrides: {
-          root: {
-            '& .MuiOutlinedInput-root': {
-              paddingRight: 'var(--pf-t--global--spacer--2xl)',
-            },
-          },
           option: {
             paddingRight: 'var(--pf-t--global--spacer--lg) !important',
           },

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -178,6 +178,9 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
           endAdornment: {
             right: 'var(--pf-t--global--spacer--sm)',
           },
+          popper: {
+            minWidth: '500px !important',
+          },
         },
       },
       MuiSelect: {

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -179,6 +179,8 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
             right: 'var(--pf-t--global--spacer--sm)',
           },
           popper: {
+            // Perses's StyledPopper sets minWidth: fit-content via sx, which truncates long options.
+            // !important is needed to override it until Perses adopts PF styling natively.
             minWidth: '500px !important',
           },
         },

--- a/packages/observability/src/perses/theme.ts
+++ b/packages/observability/src/perses/theme.ts
@@ -175,9 +175,6 @@ const mapPatterflyThemeToMUI = (theme: PatternFlyTheme): ThemeOptions => {
               paddingRight: 'var(--pf-t--global--spacer--2xl)',
             },
           },
-          endAdornment: {
-            right: 'var(--pf-t--global--spacer--sm)',
-          },
           option: {
             paddingRight: 'var(--pf-t--global--spacer--lg) !important',
           },


### PR DESCRIPTION
## Description

Fixes PF style overrides for Perses variable controls:
- Adds right-side padding to dropdown options using PF spacer tokens
- Styles checkboxes with PF brand colors (were rendering black due to global `MuiSvgIcon` override)

Before:
<img width="494" height="219" alt="image (39)" src="https://github.com/user-attachments/assets/3a5f17dd-e42f-43e9-b7bf-bf86fdc203ed" />

<img width="494" height="223" alt="Screenshot 2026-04-10 at 9 57 57 AM" src="https://github.com/user-attachments/assets/c26c1ec5-9185-4739-9999-da3e7a01e5aa" />



After:
<img width="494" height="310" alt="Screenshot 2026-04-10 at 9 45 18 AM" src="https://github.com/user-attachments/assets/b3ce3c0f-860f-404c-a335-461d474029de" />
<img width="494" height="310" alt="Screenshot 2026-04-10 at 9 45 18 AM" src="https://github.com/user-attachments/assets/03b87708-dae3-4fad-9508-0609464e40d2" />
<img width="494" height="227" alt="Screenshot 2026-04-10 at 9 54 10 AM" src="https://github.com/user-attachments/assets/2aab4c6a-1e09-4db0-b852-e42bd201704a" />


## How Has This Been Tested?

Manually verified on dev server in light and dark themes. Lint and type-check pass.

## Test Impact

Style-only changes — no new tests. Visual regression testing is not currently set up for the observability package.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved autocomplete dropdown styling for clearer option spacing and consistent input padding.
  * Revised checkbox colors and interaction states (default, checked, indeterminate) for better visual consistency with brand tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->