### PR TITLE
fix(gen-ai): distinguish MaaS vs namespace models with the same model_id

### DIFF
--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -33,6 +33,7 @@ import {
 } from '~/app/types';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import { genAiAiAssetsTabRoute, genAiChatPlaygroundRoute } from '~/app/utilities/routes';
+import { isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import AIModelsTableRowInfo from './AIModelsTableRowInfo';
@@ -64,7 +65,7 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
   const navigate = useNavigate();
   const { namespace } = React.useContext(GenAiContext);
   const isVectorStoresEnabled = useAiAssetVectorStoresEnabled();
-  const enabledModel = playgroundModels.find((m) => m.modelId === model.model_id);
+  const enabledModel = playgroundModels.find((m) => isPlaygroundModelMatchForAIModel(m, model));
   const [isConfigurationModalOpen, setIsConfigurationModalOpen] = React.useState(false);
   const [isEndpointModalOpen, setIsEndpointModalOpen] = React.useState(false);
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
@@ -392,6 +392,39 @@ describe('AIModelTableRow', () => {
       );
     });
 
+    it('should not show Try in playground for a namespace model when only the MaaS variant of the same model_id is in the playground', () => {
+      // Regression: before the fix both source-type rows resolved to the same
+      // playground entry because the lookup only compared modelId.
+      const sharedModelId = 'shared-model-id';
+      const maasPlaygroundModel = createMockPlaygroundModel(sharedModelId, 'maas-vllm-inference-1');
+
+      // Render the NAMESPACE variant — the playground only contains the MaaS variant.
+      const namespaceModel = createMockAIModel({
+        model_id: sharedModelId,
+        model_source_type: 'namespace',
+      });
+
+      render(
+        <TestWrapper>
+          <AIModelTableRow
+            {...defaultProps}
+            model={namespaceModel}
+            playgroundModels={[maasPlaygroundModel]}
+          />
+        </TestWrapper>,
+      );
+
+      // Namespace row must show "Add to playground", not "Try in playground".
+      expect(screen.getByText('Add to playground')).toBeInTheDocument();
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+
+      // No tracking event should fire.
+      expect(mockFireMiscTrackingEvent).not.toHaveBeenCalledWith(
+        'Available Endpoints Playground Launched',
+        expect.objectContaining({ assetType: 'maas_model' }),
+      );
+    });
+
     it('should track assetType as model for non-MaaS models on playground launch', () => {
       const model = createMockAIModel({ model_id: 'ns-model-id', model_source_type: 'namespace' });
       const playgroundModel = createMockPlaygroundModel('ns-model-id');

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
@@ -96,8 +96,8 @@ const createMockAIModel = (overrides?: Partial<AIModel>): AIModel => ({
   ...overrides,
 });
 
-const createMockPlaygroundModel = (modelId: string): LlamaModel => ({
-  id: `provider/${modelId}`,
+const createMockPlaygroundModel = (modelId: string, providerPrefix = 'provider'): LlamaModel => ({
+  id: `${providerPrefix}/${modelId}`,
   modelId,
   object: 'model',
   created: Date.now(),
@@ -376,7 +376,7 @@ describe('AIModelTableRow', () => {
   describe('Tracking', () => {
     it('should track assetType as maas_model for MaaS models on playground launch', () => {
       const model = createMockAIModel({ model_id: 'maas-model-id', model_source_type: 'maas' });
-      const playgroundModel = createMockPlaygroundModel('maas-model-id');
+      const playgroundModel = createMockPlaygroundModel('maas-model-id', 'maas-vllm-inference-1');
 
       render(
         <TestWrapper>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/SubscriptionDropdown.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/SubscriptionDropdown.tsx
@@ -3,7 +3,7 @@ import { FormGroup, MenuToggle, Select, SelectList, SelectOption } from '@patter
 import FieldGroupHelpLabelIcon from '@odh-dashboard/internal/components/FieldGroupHelpLabelIcon';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { SubscriptionInfo } from '~/app/types';
-import { splitLlamaModelId } from '~/app/utilities/utils';
+import { isMaasLlamaModelId, splitLlamaModelId } from '~/app/utilities/utils';
 
 interface SubscriptionDropdownProps {
   selectedModel: string;
@@ -21,6 +21,11 @@ const SubscriptionDropdown: React.FunctionComponent<SubscriptionDropdownProps> =
 
   const subscriptions: SubscriptionInfo[] = React.useMemo(() => {
     if (!selectedModel) {
+      return [];
+    }
+    // Only look up subscriptions for MaaS models — without this guard, a namespace model
+    // sharing the same base model_id as a MaaS model would incorrectly pull up MaaS subscriptions.
+    if (!isMaasLlamaModelId(selectedModel)) {
       return [];
     }
     const { id: maasModelId } = splitLlamaModelId(selectedModel);

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SubscriptionDropdown.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SubscriptionDropdown.spec.tsx
@@ -89,6 +89,31 @@ describe('SubscriptionDropdown', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('does not resolve subscriptions or auto-select when selectedModel has a non-MaaS provider prefix', () => {
+    // Regression: before the isMaasLlamaModelId guard, a namespace/non-MaaS model whose
+    // base model_id matched a MaaS entry would incorrectly pull up MaaS subscriptions.
+    const onSubscriptionChange = jest.fn();
+    const model = createMaaSModel({
+      id: 'test-model',
+      subscriptions: [{ name: 'only-sub', displayName: 'Only Subscription' }],
+    });
+
+    const { container } = render(
+      <TestWrapper maasModels={[model]}>
+        <SubscriptionDropdown
+          selectedModel="provider/test-model"
+          selectedSubscription=""
+          onSubscriptionChange={onSubscriptionChange}
+        />
+      </TestWrapper>,
+    );
+
+    // Component must render nothing — the non-MaaS prefix should block resolution.
+    expect(container.firstChild).toBeNull();
+    // Auto-select must not fire even though the model has a subscription.
+    expect(onSubscriptionChange).not.toHaveBeenCalled();
+  });
+
   it('auto-selects when model has exactly one subscription', () => {
     const onSubscriptionChange = jest.fn();
     const model = createMaaSModel({

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SubscriptionDropdown.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/SubscriptionDropdown.spec.tsx
@@ -51,7 +51,7 @@ const TestWrapper: React.FC<{
 
 describe('SubscriptionDropdown', () => {
   const defaultProps = {
-    selectedModel: 'provider/test-model',
+    selectedModel: 'maas-provider/test-model',
     selectedSubscription: '',
     onSubscriptionChange: jest.fn(),
   };
@@ -197,7 +197,7 @@ describe('SubscriptionDropdown', () => {
     const { rerender } = render(
       <TestWrapper maasModels={[model, otherModel]}>
         <SubscriptionDropdown
-          selectedModel="provider/test-model"
+          selectedModel="maas-provider/test-model"
           selectedSubscription="premium-sub"
           onSubscriptionChange={onSubscriptionChange}
         />
@@ -209,7 +209,7 @@ describe('SubscriptionDropdown', () => {
     rerender(
       <TestWrapper maasModels={[model, otherModel]}>
         <SubscriptionDropdown
-          selectedModel="provider/other-model"
+          selectedModel="maas-provider/other-model"
           selectedSubscription="premium-sub"
           onSubscriptionChange={onSubscriptionChange}
         />

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -25,6 +25,7 @@ import {
 import {
   computeEmbeddingModelStatus,
   convertMaaSModelToAIModel,
+  isPlaygroundModelMatchForAIModel,
   splitLlamaModelId,
 } from '~/app/utilities/utils';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
@@ -106,8 +107,9 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
 
   const preSelectedModels = React.useMemo(() => {
     if (existingModels.length > 0) {
-      const existingModelsSet = new Set(existingModels.map((model) => model.modelId));
-      const existingAIModels = allModels.filter((model) => existingModelsSet.has(model.model_id));
+      const existingAIModels = allModels.filter((model) =>
+        existingModels.some((m) => isPlaygroundModelMatchForAIModel(m, model)),
+      );
 
       if (extraSelectedModels && extraSelectedModels.length > 0) {
         const extraSelectedModelsSet = new Set(

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -234,24 +234,28 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
           });
         };
 
-        // Only act on newly selected collections — never remove models when deselecting
+        // Only act on newly selected collections — never remove models when deselecting.
+        // Use composite key (model_source_type + model_id) so a MaaS and a namespace model
+        // sharing the same model_name are not collapsed into one entry.
+        const modelKey = (m: AIModel) => `${m.model_source_type}-${m.model_id}`;
         const nextRequired = new Map<string, AIModel>();
         next.forEach((c) => {
           const m = findEmbeddingModel(c.embedding_model);
           if (m) {
-            nextRequired.set(m.model_name, m);
+            nextRequired.set(modelKey(m), m);
           }
         });
 
         setSelectedModels((prevModels) => {
-          const byName = new Map(prevModels.map((m) => [m.model_name, m]));
-          nextRequired.forEach((model, name) => byName.set(name, model));
-          return Array.from(byName.values());
+          const byKey = new Map(prevModels.map((m) => [modelKey(m), m]));
+          nextRequired.forEach((model, key) => byKey.set(key, model));
+          return Array.from(byKey.values());
         });
 
         setModelTypeMap((prevMap) => {
           const newMap = new Map(prevMap);
-          nextRequired.forEach((_, name) => newMap.set(name, 'Embedding'));
+          // modelTypeMap is keyed by model_name everywhere else — keep that convention here.
+          nextRequired.forEach((model) => newMap.set(model.model_name, 'Embedding'));
           return newMap;
         });
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationTable.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationTable.tsx
@@ -82,9 +82,14 @@ const ChatbotConfigurationTable: React.FC<ChatbotConfigurationTableProps> = ({
         return Array.from(byKey.values());
       }
 
-      // Remove filtered models but keep locked ones
+      // Remove filtered models but keep locked ones.
+      // Build locked keys by composite key so a MaaS/namespace model sharing the
+      // same model_name as a locked embedding model isn't accidentally preserved.
+      const lockedModelKeys = new Set(
+        availableModels.filter((m) => lockedModelNames.has(m.model_name)).map(getModelKey),
+      );
       return prev.filter(
-        (m) => !availableKeys.has(getModelKey(m)) || lockedModelNames.has(m.model_name),
+        (m) => !availableKeys.has(getModelKey(m)) || lockedModelKeys.has(getModelKey(m)),
       );
     });
   };

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationTable.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationTable.tsx
@@ -38,11 +38,19 @@ const ChatbotConfigurationTable: React.FC<ChatbotConfigurationTableProps> = ({
   onEmbeddingDimensionChange,
   lockedModelNames,
 }) => {
+  // Composite key that is unique across models sharing the same model_id but
+  // with different model_source_types (e.g. a namespace model and a MaaS model
+  // for the same underlying model). Used for both checkbox tracking and React keys.
+  const getModelKey = React.useCallback(
+    (model: AIModel) => `${model.model_source_type}-${model.model_id}`,
+    [],
+  );
+
   const { tableProps, isSelected, toggleSelection } = useCheckboxTableBase<AIModel>(
     allModels,
     selectedModels,
     setSelectedModels,
-    React.useCallback((model) => model.model_name, []),
+    getModelKey,
   );
 
   const [search, setSearch] = React.useState('');
@@ -57,30 +65,26 @@ const ChatbotConfigurationTable: React.FC<ChatbotConfigurationTableProps> = ({
     [filteredModels],
   );
 
-  const selectedModelsIds = selectedModels.map((model) => model.model_name);
-  const availableModelsIds = availableModels.map((model) => model.model_name);
+  const selectedModelKeys = selectedModels.map(getModelKey);
+  const availableModelKeys = availableModels.map(getModelKey);
 
   const isAllSelected =
-    availableModels.length > 0 && availableModelsIds.every((id) => selectedModelsIds.includes(id));
+    availableModels.length > 0 &&
+    availableModelKeys.every((key) => selectedModelKeys.includes(key));
 
   const handleSelectAll = (value: boolean) => {
     setSelectedModels((prev) => {
-      // Create a set of the filtered model names
-      const availableIds = new Set(availableModels.map((m) => m.model_name));
+      const availableKeys = new Set(availableModels.map(getModelKey));
 
-      // If the select all checkbox is checked, we want to add the filtered models to the selected models
       if (value) {
-        // Create a map of the current selected models by model name
-        const byId = new Map(prev.map((m) => [m.model_name, m]));
-        // Add the filtered models to the map
-        availableModels.forEach((m) => byId.set(m.model_name, m));
-        // Return the selected model names as an array from the map
-        return Array.from(byId.values());
+        const byKey = new Map(prev.map((m) => [getModelKey(m), m]));
+        availableModels.forEach((m) => byKey.set(getModelKey(m), m));
+        return Array.from(byKey.values());
       }
 
-      // If the select all checkbox is unchecked, remove filtered models but keep locked ones
+      // Remove filtered models but keep locked ones
       return prev.filter(
-        (m) => !availableIds.has(m.model_name) || lockedModelNames.has(m.model_name),
+        (m) => !availableKeys.has(getModelKey(m)) || lockedModelNames.has(m.model_name),
       );
     });
   };
@@ -118,7 +122,7 @@ const ChatbotConfigurationTable: React.FC<ChatbotConfigurationTableProps> = ({
           columns={chatbotConfigurationColumns}
           rowRenderer={(model) => (
             <ChatbotConfigurationTableRow
-              key={model.model_name}
+              key={getModelKey(model)}
               isChecked={isSelected(model)}
               onToggleCheck={() => toggleSelection(model)}
               isLocked={lockedModelNames.has(model.model_name)}

--- a/packages/gen-ai/frontend/src/app/utilities/utils.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/utils.ts
@@ -55,6 +55,34 @@ export const splitLlamaModelId = (llamaModelId: string): { providerId: string; i
   return { providerId, id };
 };
 
+/**
+ * Returns true if a provider-qualified LlamaStack model ID belongs to a MaaS provider.
+ * MaaS providers are registered in LlamaStack with a "maas-" prefix (e.g. "maas-vllm-inference-1").
+ *
+ * NOTE: this is brittle. Ideally we should fetch /v1/providers from LLS
+ * and cross reference the MaaS URL with the provider URL.
+ */
+export const isMaasLlamaModelId = (llamaModelId: string): boolean =>
+  splitLlamaModelId(llamaModelId).providerId.startsWith('maas-');
+
+/**
+ * Returns true if a playground LlamaModel corresponds to the given AIModel, accounting for
+ * model_source_type. MaaS playground models have a "maas-" provider prefix in their full id;
+ * namespace and custom_endpoint models do not. Without this check, two AIModels that share the
+ * same model_id but differ in model_source_type would incorrectly match the same playground entry.
+ */
+export const isPlaygroundModelMatchForAIModel = (
+  playgroundModel: LlamaModel,
+  aiModel: AIModel,
+): boolean => {
+  if (playgroundModel.modelId !== aiModel.model_id) {
+    return false;
+  }
+  return aiModel.model_source_type === 'maas'
+    ? isMaasLlamaModelId(playgroundModel.id)
+    : !isMaasLlamaModelId(playgroundModel.id);
+};
+
 export const getLlamaModelDisplayName = (modelId: string, aiModels: AIModel[]): string => {
   const { id, providerId } = splitLlamaModelId(modelId);
   const enabledModel = aiModels.find((aiModel) => aiModel.model_id === id);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-57527

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Two AIModels sharing the same model_id but with different model_source_types (e.g. a namespace deployment and a MaaS model for the same underlying model) were incorrectly treated as duplicates in several places:

- AIModelTableRow: enabledModel lookup only compared modelId, causing both rows to show "Try in playground" when only one source type was in the playground.
- ChatbotConfigurationModal: preSelectedModels used a Set of modelIds, so opening the Configure playground modal pre-selected both source types when only one was in the playground.
- ChatbotConfigurationTable: useCheckboxTableBase key was model_name, so selecting one row also selected the other if names matched.
- SubscriptionDropdown: MaaS subscription lookup could match a namespace model sharing the same base model_id.

Fix by introducing isMaasLlamaModelId (checks the "maas-" provider prefix in the LlamaStack model ID) and isPlaygroundModelMatchForAIModel (matches a LlamaModel to an AIModel accounting for source type). These are used consistently across all four call sites.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Registered a maas model and llm-d model in playground & inferenced with them.

https://github.com/user-attachments/assets/eb65f358-b7ef-454e-9faa-655100098fcf

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Needed to update the provider ids in the mock tests and added two tests to prevent this from regressing.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x]  Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model-matching so models with the same ID from different sources are correctly distinguished, preventing incorrect "Try in playground" vs "Add to playground" behavior and spurious MaaS launch tracking.
  * Subscription dropdown now only appears for MaaS-compatible models; non-MaaS models show no options.
  * Selection, select-all, and row identity fixes prevent distinct models that share a name from being collapsed, preserving intended selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->