### PR TITLE
fix(automl): resolve duplicated model name in predictor and notebook paths

### DIFF
--- a/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
@@ -143,16 +143,23 @@ export function useAutomlResults(
             return {
               name,
               directory: prefix,
+              // Parent path up to models_artifact/ (excludes the model name).
+              // Used as the base for resolving predictor and notebook paths,
+              // which already include the model name as their first segment.
+              artifactDirectory: `${parts.slice(0, -1).join('/')}/`,
             };
           })
-          .filter((item): item is { name: string; directory: string } => item !== null);
+          .filter(
+            (item): item is { name: string; directory: string; artifactDirectory: string } =>
+              item !== null,
+          );
       }),
     [modelArtifactQueries.data],
   );
 
   // Step 4: Fetch model.json for each model directory
   const modelQueries = useQueries({
-    queries: modelDirectories.map(({ name, directory }) => {
+    queries: modelDirectories.map(({ name, directory, artifactDirectory }) => {
       const modelJsonPath = `${directory}model.json`;
       return {
         queryKey: ['s3File', namespace, name, modelJsonPath],
@@ -172,8 +179,8 @@ export function useAutomlResults(
             location: {
               // eslint-disable-next-line camelcase
               model_directory: directory,
-              predictor: `${directory}${validated.location.predictor}`,
-              notebook: `${directory}${validated.location.notebook}`,
+              predictor: `${artifactDirectory}${validated.location.predictor}`,
+              notebook: `${artifactDirectory}${validated.location.notebook}`,
             },
           };
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-57295

## Description
Fixes a path duplication bug in `useAutomlResults` where the model name was doubled in the resolved predictor and notebook S3 paths.

The `location.predictor` and `location.notebook` values already include the model name as their first segment (e.g., `WeightedEnsemble_L5_FULL/predictor.pkl`). Previously, these were prefixed with the full model directory (which also ends with the model name), producing invalid paths like:
```
.../models_artifact/WeightedEnsemble_L5_FULL/WeightedEnsemble_L5_FULL/predictor.pkl
```

This PR introduces `artifactDirectory` — the parent path up to `models_artifact/` — as the correct base for resolving these relative paths.

| | Before | After |
|------|--------|-------|
| **predictor** | <img width="1469" height="742" alt="MR before" src="https://github.com/user-attachments/assets/def0cf8f-4eab-4d5f-87fb-90e40420b482" /> | ... |
| **notebook** | <video src="https://github.com/user-attachments/assets/fb71730e-dc2d-44d9-95c5-24f55c567782"/>| ... |


## How Has This Been Tested?
- Manual verification of resolved S3 paths for both tabular and time-series runs
- Existing unit and integration tests continue to pass

## Screenshot / Design
N/A — no UI changes

## Merge criteria
- [ ] All CI checks pass
- [ ] Verified path resolution for tabular runs
- [ ] Verified path resolution for time-series runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal path resolution for artifact directories to use a more efficient approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->