### PR TITLE
fix(automl,autorag): show project display name instead of resource name

### DIFF
--- a/packages/automl/bff/internal/models/namespace.go
+++ b/packages/automl/bff/internal/models/namespace.go
@@ -5,8 +5,13 @@ type NamespaceModel struct {
 	DisplayName *string `json:"displayName,omitempty"`
 }
 
-func NewNamespaceModelFromNamespace(name string) NamespaceModel {
-	displayName := name // For now, use name as display name, but this can be customized later
+// NewNamespaceModelFromNamespace creates a NamespaceModel using the namespace name
+// and its OpenShift display name annotation if available.
+func NewNamespaceModelFromNamespace(name string, annotations map[string]string) NamespaceModel {
+	displayName := name
+	if dn, ok := annotations["openshift.io/display-name"]; ok && dn != "" {
+		displayName = dn
+	}
 	return NamespaceModel{
 		Name:        name,
 		DisplayName: &displayName,

--- a/packages/automl/bff/internal/models/namespace.go
+++ b/packages/automl/bff/internal/models/namespace.go
@@ -1,5 +1,7 @@
 package models
 
+import "strings"
+
 type NamespaceModel struct {
 	Name        string  `json:"name"`
 	DisplayName *string `json:"displayName,omitempty"`
@@ -9,7 +11,7 @@ type NamespaceModel struct {
 // and its OpenShift display name annotation if available.
 func NewNamespaceModelFromNamespace(name string, annotations map[string]string) NamespaceModel {
 	displayName := name
-	if dn, ok := annotations["openshift.io/display-name"]; ok && dn != "" {
+	if dn := strings.TrimSpace(annotations["openshift.io/display-name"]); dn != "" {
 		displayName = dn
 	}
 	return NamespaceModel{

--- a/packages/automl/bff/internal/repositories/namespace.go
+++ b/packages/automl/bff/internal/repositories/namespace.go
@@ -23,7 +23,7 @@ func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface
 
 	var namespaceModels = []models.NamespaceModel{}
 	for _, ns := range namespaces {
-		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name))
+		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name, ns.Annotations))
 	}
 
 	return namespaceModels, nil

--- a/packages/autorag/bff/internal/models/namespace.go
+++ b/packages/autorag/bff/internal/models/namespace.go
@@ -5,8 +5,13 @@ type NamespaceModel struct {
 	DisplayName *string `json:"displayName,omitempty"`
 }
 
-func NewNamespaceModelFromNamespace(name string) NamespaceModel {
-	displayName := name // For now, use name as display name, but this can be customized later
+// NewNamespaceModelFromNamespace creates a NamespaceModel using the namespace name
+// and its OpenShift display name annotation if available.
+func NewNamespaceModelFromNamespace(name string, annotations map[string]string) NamespaceModel {
+	displayName := name
+	if dn, ok := annotations["openshift.io/display-name"]; ok && dn != "" {
+		displayName = dn
+	}
 	return NamespaceModel{
 		Name:        name,
 		DisplayName: &displayName,

--- a/packages/autorag/bff/internal/models/namespace.go
+++ b/packages/autorag/bff/internal/models/namespace.go
@@ -1,5 +1,7 @@
 package models
 
+import "strings"
+
 type NamespaceModel struct {
 	Name        string  `json:"name"`
 	DisplayName *string `json:"displayName,omitempty"`
@@ -9,7 +11,7 @@ type NamespaceModel struct {
 // and its OpenShift display name annotation if available.
 func NewNamespaceModelFromNamespace(name string, annotations map[string]string) NamespaceModel {
 	displayName := name
-	if dn, ok := annotations["openshift.io/display-name"]; ok && dn != "" {
+	if dn := strings.TrimSpace(annotations["openshift.io/display-name"]); dn != "" {
 		displayName = dn
 	}
 	return NamespaceModel{

--- a/packages/autorag/bff/internal/repositories/namespace.go
+++ b/packages/autorag/bff/internal/repositories/namespace.go
@@ -23,7 +23,7 @@ func (r *NamespaceRepository) GetNamespaces(client k8s.KubernetesClientInterface
 
 	var namespaceModels = []models.NamespaceModel{}
 	for _, ns := range namespaces {
-		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name))
+		namespaceModels = append(namespaceModels, models.NewNamespaceModelFromNamespace(ns.Name, ns.Annotations))
 	}
 
 	return namespaceModels, nil


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-57275

## Description

When users rename projects in RHOAI (via the `openshift.io/display-name` annotation), the updated display name was not shown in the automl or autorag project selectors. Both modules were using the Kubernetes resource name (e.g. `my-project`) instead of the user-set display name (e.g. `My Project`).

The root cause: `NewNamespaceModelFromNamespace` only accepted the resource name and copied it to the `displayName` field. The `corev1.Namespace` object returned by `GetNamespaces` includes full metadata with annotations, but the repository was discarding everything except `ns.Name`.

**Fix:** Extract `openshift.io/display-name` from the namespace annotations, falling back to the resource name when the annotation is not set. This matches how the main dashboard resolves project names via `getDisplayNameFromK8sResource`.

**Files changed:**
- `packages/automl/bff/internal/models/namespace.go` — accept annotations, extract display name
- `packages/automl/bff/internal/repositories/namespace.go` — pass `ns.Annotations` to model
- `packages/autorag/bff/internal/models/namespace.go` — same fix
- `packages/autorag/bff/internal/repositories/namespace.go` — same fix

## How Has This Been Tested?

- All automl and autorag BFF tests pass
- Manually verified that renamed projects show the display name in the project selector

## Test Impact

- No new tests required — existing namespace handler tests cover the data flow; the fix is a one-line annotation lookup

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

> N/A — no visual UI changes beyond correct project name display.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespaces now support custom display names via namespace metadata; the UI shows the configured display name when provided (trimmed), otherwise it falls back to the namespace name. This behavior is applied consistently across the services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->