### PR TITLE
RHOAIENG-50913-Part 2: A workbench cannot be stopped if it's hardware profile doesn't exist

### DIFF
--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -1380,7 +1380,7 @@ describe('Workbench page', () => {
         statusCode: 404,
         body: mock404Error({}),
       },
-    );
+    ).as('getDeletedHwProfile');
 
     cy.interceptK8sList(
       { model: NotebookModel, ns: 'test-project' },
@@ -1410,6 +1410,7 @@ describe('Workbench page', () => {
     workbenchPage.visit('test-project');
     const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
     notebookRow.findHaveNotebookStatusText().should('have.text', 'Stopped');
+    cy.wait('@getDeletedHwProfile');
 
     cy.interceptK8s('PATCH', NotebookModel, mockNotebookK8sResource({})).as('startWorkbench');
     cy.interceptK8s(

--- a/frontend/src/concepts/hardwareProfiles/useDeletedHardwareProfilePatches.ts
+++ b/frontend/src/concepts/hardwareProfiles/useDeletedHardwareProfilePatches.ts
@@ -13,9 +13,9 @@ const useDeletedHardwareProfilePatches = (notebook: NotebookKind): Patch[] => {
     notebook.metadata.annotations?.['opendatahub.io/hardware-profile-namespace'] ||
     dashboardNamespace;
 
-  const [, loaded, loadError] = useHardwareProfile(hardwareProfileNamespace, hardwareProfileName);
+  const [, , loadError] = useHardwareProfile(hardwareProfileNamespace, hardwareProfileName);
 
-  if (hardwareProfileName && loaded && loadError && getGenericErrorCode(loadError) === 404) {
+  if (hardwareProfileName && loadError && getGenericErrorCode(loadError) === 404) {
     return REMOVE_HARDWARE_PROFILE_ANNOTATIONS_PATCH;
   }
   return [];


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-50913

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The `useDeletedHardwareProfilePatches` hook had a condition `loaded && loadError` added in https://github.com/opendatahub-io/odh-dashboard/pull/6947 that was impossible to satisfy — `useFetch` only sets `loaded=true` on success, never on error. This prevented hardware profile annotation removal patches from being generated, blocking workbench stop/start when the hardware profile was deleted.

Fix: remove the `loaded` check. `loadError` being set already implies the fetch completed.

https://github.com/user-attachments/assets/82d9d650-ed12-40b0-ac05-43820cdaa022

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested against RHOAI 2.25.4 cluster:
- Stop a running workbench with a deleted hardware profile — succeeds, PATCH includes annotation removal
- Start a stopped workbench with a deleted hardware profile — succeeds, PATCH includes annotation removal

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Existing Cypress tests cover both scenarios — no changes needed:
- `Should stop a running workbench with a deleted hardware profile`
- `Should start a stopped workbench with a deleted hardware profile`


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
