### PR TITLE
Replace run group text input with typeahead, clickable run group label

### DIFF
--- a/frontend/src/api/pipelines/custom.ts
+++ b/frontend/src/api/pipelines/custom.ts
@@ -257,8 +257,6 @@ export const listPipelineRecurringRuns: ListPipelineRecurringRunsAPI =
           ...pipelineParamsToQuery(params),
           // eslint-disable-next-line camelcase
           experiment_id: params?.experimentId,
-          // eslint-disable-next-line camelcase
-          pipeline_version_id: params?.pipelineVersionId,
         },
         opts,
       ),

--- a/frontend/src/api/pipelines/custom.ts
+++ b/frontend/src/api/pipelines/custom.ts
@@ -248,33 +248,21 @@ export const listPipelineArchivedRuns: ListPipelinesRunAPI = (hostPath) => (opts
 };
 
 export const listPipelineRecurringRuns: ListPipelineRecurringRunsAPI =
-  (hostPath) => (opts, params) => {
-    let predicates = params?.filter?.predicates ?? [];
-    if (params?.pipelineVersionId) {
-      predicates = [
-        ...predicates,
-        {
-          key: 'pipeline_version_id',
-          operation: PipelinesFilterOp.EQUALS,
-          // eslint-disable-next-line camelcase
-          string_value: params.pipelineVersionId,
-        },
-      ];
-    }
-
-    return handlePipelineFailures(
+  (hostPath) => (opts, params) =>
+    handlePipelineFailures(
       proxyGET(
         hostPath,
         '/apis/v2beta1/recurringruns',
         {
-          ...pipelineParamsToQuery({ ...params, filter: { predicates } }),
+          ...pipelineParamsToQuery(params),
           // eslint-disable-next-line camelcase
           experiment_id: params?.experimentId,
+          // eslint-disable-next-line camelcase
+          pipeline_version_id: params?.pipelineVersionId,
         },
         opts,
       ),
     );
-  };
 
 export const listPipelineVersions: ListPipelineVersionsAPI =
   (hostPath) => (opts, pipelineId, params) =>

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelineRecurringRuns.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelineRecurringRuns.ts
@@ -11,7 +11,6 @@ const usePipelineRecurringRuns = (
 ): FetchState<PipelineListPaged<PipelineRecurringRunKF>> => {
   const { api } = usePipelinesAPI();
   const experimentId = options?.experimentId;
-  const pipelineVersionId = options?.pipelineVersionId;
 
   const fetchLatestVersionId = React.useCallback(
     async (pipelineId: string, opts: K8sAPIOptions) => {
@@ -27,24 +26,19 @@ const usePipelineRecurringRuns = (
   return usePipelineQuery<PipelineRecurringRunKF>(
     React.useCallback(
       async (opts, params) => {
-        const unsupportedKeys = new Set(['experiment_id', 'pipeline_version_id']);
-        const unsupported = new Map(
-          params?.filter?.predicates
-            ?.filter((p) => unsupportedKeys.has(p.key))
-            .map((p) => [p.key, p.string_value]) ?? [],
+        const versionIdPredicate = params?.filter?.predicates?.find(
+          (p) => p.key === 'pipeline_version_id',
+        )?.string_value;
+        const predicatesWithoutVersion = params?.filter?.predicates?.filter(
+          (p) => p.key !== 'pipeline_version_id',
         );
-        const supportedPredicates = params?.filter?.predicates?.filter(
-          (p) => !unsupportedKeys.has(p.key),
-        );
-        const resolvedExperimentId = experimentId || unsupported.get('experiment_id');
-        const resolvedPipelineVersionId =
-          pipelineVersionId || unsupported.get('pipeline_version_id');
 
         const response = await api.listPipelineRecurringRuns(opts, {
           ...params,
-          ...(resolvedExperimentId && { experimentId: resolvedExperimentId }),
-          ...(resolvedPipelineVersionId && { pipelineVersionId: resolvedPipelineVersionId }),
-          filter: supportedPredicates ? { predicates: supportedPredicates } : params?.filter,
+          ...(experimentId && { experimentId }),
+          filter: predicatesWithoutVersion
+            ? { predicates: predicatesWithoutVersion }
+            : params?.filter,
         });
 
         if (!response.recurringRuns) {
@@ -71,9 +65,21 @@ const usePipelineRecurringRuns = (
             };
           }),
         );
-        return { ...response, items: completeRecurringRuns };
+
+        const filteredRuns = versionIdPredicate
+          ? completeRecurringRuns.filter(
+              (r) => r.pipeline_version_reference.pipeline_version_id === versionIdPredicate,
+            )
+          : completeRecurringRuns;
+
+        return {
+          ...response,
+          items: filteredRuns,
+          // eslint-disable-next-line camelcase
+          total_size: versionIdPredicate ? filteredRuns.length : response.total_size,
+        };
       },
-      [api, experimentId, pipelineVersionId, fetchLatestVersionId],
+      [api, experimentId, fetchLatestVersionId],
     ),
     options,
   );

--- a/frontend/src/concepts/pipelines/apiHooks/usePipelineRecurringRuns.ts
+++ b/frontend/src/concepts/pipelines/apiHooks/usePipelineRecurringRuns.ts
@@ -11,6 +11,7 @@ const usePipelineRecurringRuns = (
 ): FetchState<PipelineListPaged<PipelineRecurringRunKF>> => {
   const { api } = usePipelinesAPI();
   const experimentId = options?.experimentId;
+  const pipelineVersionId = options?.pipelineVersionId;
 
   const fetchLatestVersionId = React.useCallback(
     async (pipelineId: string, opts: K8sAPIOptions) => {
@@ -26,9 +27,24 @@ const usePipelineRecurringRuns = (
   return usePipelineQuery<PipelineRecurringRunKF>(
     React.useCallback(
       async (opts, params) => {
+        const unsupportedKeys = new Set(['experiment_id', 'pipeline_version_id']);
+        const unsupported = new Map(
+          params?.filter?.predicates
+            ?.filter((p) => unsupportedKeys.has(p.key))
+            .map((p) => [p.key, p.string_value]) ?? [],
+        );
+        const supportedPredicates = params?.filter?.predicates?.filter(
+          (p) => !unsupportedKeys.has(p.key),
+        );
+        const resolvedExperimentId = experimentId || unsupported.get('experiment_id');
+        const resolvedPipelineVersionId =
+          pipelineVersionId || unsupported.get('pipeline_version_id');
+
         const response = await api.listPipelineRecurringRuns(opts, {
           ...params,
-          ...(experimentId && { experimentId }),
+          ...(resolvedExperimentId && { experimentId: resolvedExperimentId }),
+          ...(resolvedPipelineVersionId && { pipelineVersionId: resolvedPipelineVersionId }),
+          filter: supportedPredicates ? { predicates: supportedPredicates } : params?.filter,
         });
 
         if (!response.recurringRuns) {
@@ -57,7 +73,7 @@ const usePipelineRecurringRuns = (
         );
         return { ...response, items: completeRecurringRuns };
       },
-      [api, experimentId, fetchLatestVersionId],
+      [api, experimentId, pipelineVersionId, fetchLatestVersionId],
     ),
     options,
   );

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -80,14 +80,15 @@ const CompareRunsRunList: React.FC = () => {
     runs.map((r) => r.run_id),
     experiment?.experiment_id,
   );
+  const { onFilterUpdate } = filterToolbarProps;
   const handleRunGroupClick = React.useCallback(
     (clickedExperiment: ExperimentKF) => {
-      filterToolbarProps.onFilterUpdate(FilterOptions.RUN_GROUP, {
+      onFilterUpdate(FilterOptions.RUN_GROUP, {
         value: clickedExperiment.experiment_id,
         label: clickedExperiment.display_name,
       });
     },
-    [filterToolbarProps],
+    [onFilterUpdate],
   );
 
   return (

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -21,6 +21,7 @@ import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
 import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 import useMlflowExperiments from '#~/concepts/mlflow/useMlflowExperiments';
+import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
 
 const CompareRunsRunList: React.FC = () => {
   const { namespace } = usePipelinesAPI();
@@ -91,6 +92,12 @@ const CompareRunsRunList: React.FC = () => {
     runs.map((r) => r.run_id),
     experiment?.experiment_id,
   );
+  const handleRunGroupClick = React.useCallback(
+    (clickedExperiment: ExperimentKF) => {
+      filterToolbarProps.onFilterUpdate(FilterOptions.RUN_GROUP, clickedExperiment.display_name);
+    },
+    [filterToolbarProps],
+  );
 
   return (
     <ExpandableSection
@@ -139,6 +146,7 @@ const CompareRunsRunList: React.FC = () => {
               loaded: mlflowExperimentsLoaded,
             }}
             hasRowActions={false}
+            onRunGroupClick={handleRunGroupClick}
             run={run}
           />
         )}

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -58,7 +58,7 @@ const CompareRunsRunList: React.FC = () => {
     const matchingRunGroups = runGroupFilter
       ? new Set(
           allExperiments
-            .filter((e) => e.display_name.toLowerCase().includes(runGroupFilter))
+            .filter((e) => e.display_name.toLowerCase() === runGroupFilter)
             .map((e) => e.experiment_id),
         )
       : undefined;

--- a/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
+++ b/frontend/src/concepts/pipelines/content/compareRuns/CompareRunsRunList.tsx
@@ -19,14 +19,12 @@ import PipelineRunTableToolbar from '#~/concepts/pipelines/content/tables/pipeli
 import { manageCompareRunsRoute } from '#~/routes/pipelines/runs';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
-import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 import useMlflowExperiments from '#~/concepts/mlflow/useMlflowExperiments';
 import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
 
 const CompareRunsRunList: React.FC = () => {
   const { namespace } = usePipelinesAPI();
   const { experiment } = React.useContext(ExperimentContext);
-  const { experiments: allExperiments } = React.useContext(PipelineRunExperimentsContext);
   const { status: isMlflowAvailable } = useIsAreaAvailable(SupportedArea.MLFLOW_PIPELINES);
   const { runs, loaded } = useCompareRuns();
   const { data: mlflowExperiments, loaded: mlflowExperimentsLoaded } = useMlflowExperiments({
@@ -47,27 +45,17 @@ const CompareRunsRunList: React.FC = () => {
     const startedTime = getDataValue(filterData[FilterOptions.CREATED_AT]);
     const startedDate = startedTime && new Date(startedTime);
     const state = getDataValue(filterData[FilterOptions.STATUS])?.toLowerCase();
-    const runGroupFilter = experiment
-      ? undefined
-      : getDataValue(filterData[FilterOptions.RUN_GROUP])?.toLowerCase();
+    const runGroupFilter = getDataValue(filterData[FilterOptions.RUN_GROUP]);
     const pipelineVersionId = getDataValue(filterData[FilterOptions.PIPELINE_VERSION]);
     const mlflowExperimentFilter = isMlflowAvailable
       ? getDataValue(filterData[FilterOptions.MLFLOW_EXPERIMENT])?.toLowerCase()
-      : undefined;
-
-    const matchingRunGroups = runGroupFilter
-      ? new Set(
-          allExperiments
-            .filter((e) => e.display_name.toLowerCase() === runGroupFilter)
-            .map((e) => e.experiment_id),
-        )
       : undefined;
 
     return runs.filter((run) => {
       const nameMatch = !runName || run.display_name.toLowerCase().includes(runName);
       const dateTimeMatch = !startedDate || new Date(run.created_at) >= startedDate;
       const stateMatch = !state || run.state.toLowerCase() === state;
-      const runGroupMatch = !matchingRunGroups || matchingRunGroups.has(run.experiment_id);
+      const runGroupIdMatch = !runGroupFilter || run.experiment_id === runGroupFilter;
       const pipelineVersionIdMatch =
         !pipelineVersionId ||
         run.pipeline_version_reference?.pipeline_version_id === pipelineVersionId;
@@ -80,12 +68,12 @@ const CompareRunsRunList: React.FC = () => {
         nameMatch &&
         dateTimeMatch &&
         stateMatch &&
-        runGroupMatch &&
+        runGroupIdMatch &&
         pipelineVersionIdMatch &&
         mlflowExperimentMatch
       );
     });
-  }, [runs, filterData, allExperiments, experiment, isMlflowAvailable]);
+  }, [runs, filterData, isMlflowAvailable]);
 
   const manageRunsHref = manageCompareRunsRoute(
     namespace,
@@ -94,7 +82,10 @@ const CompareRunsRunList: React.FC = () => {
   );
   const handleRunGroupClick = React.useCallback(
     (clickedExperiment: ExperimentKF) => {
-      filterToolbarProps.onFilterUpdate(FilterOptions.RUN_GROUP, clickedExperiment.display_name);
+      filterToolbarProps.onFilterUpdate(FilterOptions.RUN_GROUP, {
+        value: clickedExperiment.experiment_id,
+        label: clickedExperiment.display_name,
+      });
     },
     [filterToolbarProps],
   );

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -144,7 +144,7 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
 
         <FormGroup
           label="Run group"
-          fieldId="run-group-selector-toggle"
+          fieldId="run-group-selector"
           isRequired
           labelHelp={<DashboardHelpTooltip content={runGroupCreateModalPopoverText} />}
         >

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Form, FormGroup, FormSection, TextArea, TextInput } from '@patternfly/react-core';
-import { CharLimitHelperText } from '#~/components/CharLimitHelperText';
-import DashboardHelpTooltip from '#~/concepts/dashboard/DashboardHelpTooltip';
+import { Form, FormGroup, FormSection, Stack, StackItem } from '@patternfly/react-core';
+import NameDescriptionField from '#~/concepts/k8s/NameDescriptionField';
 import {
   MlflowFormData,
   PipelineVersionToUse,
@@ -19,19 +18,20 @@ import {
 } from '#~/concepts/pipelines/kfTypes';
 import ProjectSection from '#~/concepts/pipelines/content/createRun/contentSections/ProjectSection';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
+import { ActiveExperimentSelector } from '#~/concepts/pipelines/content/experiment/ExperimentSelector';
 import { useLatestPipelineVersion } from '#~/concepts/pipelines/apiHooks/useLatestPipelineVersion';
 import { getNameEqualsFilter } from '#~/concepts/pipelines/utils';
 import { DuplicateNameHelperText } from '#~/concepts/pipelines/content/DuplicateNameHelperText';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import useDebounceCallback from '#~/utilities/useDebounceCallback';
 import { isArgoWorkflow } from '#~/concepts/pipelines/content/tables/utils';
-import { ActiveExperimentSelector } from '#~/concepts/pipelines/content/experiment/ExperimentSelector';
 import {
   NAME_CHARACTER_LIMIT,
   DESCRIPTION_CHARACTER_LIMIT,
 } from '#~/concepts/pipelines/content/const';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { runGroupCreateModalPopoverText } from '#~/pages/pipelines/global/runs/const';
+import DashboardHelpTooltip from '#~/concepts/dashboard/DashboardHelpTooltip';
 import MlflowIntegrationSection from './contentSections/MlflowIntegrationSection';
 import PipelineSection from './contentSections/PipelineSection';
 import { RunTypeSection } from './contentSections/RunTypeSection';
@@ -128,57 +128,34 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
           ]
         }
       >
-        <FormGroup label="Name" isRequired fieldId="run-name">
-          <TextInput
-            isRequired
-            id="run-name"
-            data-testid="run-name"
-            name="run-name"
-            value={data.nameDesc.name}
-            onChange={(_e, value) => {
-              onValueChange('nameDesc', { ...data.nameDesc, name: value });
-              setHasDuplicateName(false);
-              checkForDuplicateName(value);
-            }}
-            maxLength={NAME_CHARACTER_LIMIT}
-          />
-          {hasDuplicateName ? <DuplicateNameHelperText name={name} /> : undefined}
-          <CharLimitHelperText
-            limit={NAME_CHARACTER_LIMIT}
-            currentLength={data.nameDesc.name.length}
-          />
-        </FormGroup>
+        <NameDescriptionField
+          nameFieldId="run-name"
+          descriptionFieldId="run-description"
+          data={data.nameDesc}
+          setData={(nameDesc) => onValueChange('nameDesc', nameDesc)}
+          maxLengthName={NAME_CHARACTER_LIMIT}
+          maxLengthDesc={DESCRIPTION_CHARACTER_LIMIT}
+          onNameChange={(value) => {
+            setHasDuplicateName(false);
+            checkForDuplicateName(value);
+          }}
+          nameHelperText={hasDuplicateName ? <DuplicateNameHelperText name={name} /> : undefined}
+        />
 
         <FormGroup
           label="Run group"
-          fieldId="run-group"
+          aria-label="Run group"
           isRequired
           labelHelp={<DashboardHelpTooltip content={runGroupCreateModalPopoverText} />}
         >
-          <ActiveExperimentSelector
-            dataTestId="run-group-selector"
-            selection={data.runGroup}
-            onSelect={(experiment) => onValueChange('runGroup', experiment.display_name)}
-          />
-          <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} currentLength={data.runGroup.length} />
-        </FormGroup>
-
-        <FormGroup label="Description" fieldId="run-description">
-          <TextArea
-            resizeOrientation="vertical"
-            id="run-description"
-            data-testid="run-description"
-            name="run-description"
-            value={data.nameDesc.description}
-            onChange={(_e, description) =>
-              onValueChange('nameDesc', { ...data.nameDesc, description })
-            }
-            maxLength={DESCRIPTION_CHARACTER_LIMIT}
-          />
-          <CharLimitHelperText
-            limit={DESCRIPTION_CHARACTER_LIMIT}
-            currentLength={data.nameDesc.description.length}
-          />
+          <Stack hasGutter>
+            <StackItem>
+              <ActiveExperimentSelector
+                selection={data.experiment?.display_name}
+                onSelect={(runGroup) => onValueChange('experiment', runGroup)}
+              />
+            </StackItem>
+          </Stack>
         </FormGroup>
 
         {isSchedule && data.runType.type === RunTypeOption.SCHEDULED && (

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, FormGroup, FormSection, Stack, StackItem } from '@patternfly/react-core';
+import { Form, FormGroup, FormSection } from '@patternfly/react-core';
 import NameDescriptionField from '#~/concepts/k8s/NameDescriptionField';
 import {
   MlflowFormData,
@@ -144,18 +144,15 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
 
         <FormGroup
           label="Run group"
-          aria-label="Run group"
+          fieldId="run-group-selector-toggle"
           isRequired
           labelHelp={<DashboardHelpTooltip content={runGroupCreateModalPopoverText} />}
         >
-          <Stack hasGutter>
-            <StackItem>
-              <ActiveExperimentSelector
-                selection={data.experiment?.display_name}
-                onSelect={(runGroup) => onValueChange('experiment', runGroup)}
-              />
-            </StackItem>
-          </Stack>
+          <ActiveExperimentSelector
+            dataTestId="run-group-selector"
+            selection={data.experiment?.display_name}
+            onSelect={(runGroup) => onValueChange('experiment', runGroup)}
+          />
         </FormGroup>
 
         {isSchedule && data.runType.type === RunTypeOption.SCHEDULED && (

--- a/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunForm.tsx
@@ -25,6 +25,7 @@ import { DuplicateNameHelperText } from '#~/concepts/pipelines/content/Duplicate
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import useDebounceCallback from '#~/utilities/useDebounceCallback';
 import { isArgoWorkflow } from '#~/concepts/pipelines/content/tables/utils';
+import { ActiveExperimentSelector } from '#~/concepts/pipelines/content/experiment/ExperimentSelector';
 import {
   NAME_CHARACTER_LIMIT,
   DESCRIPTION_CHARACTER_LIMIT,
@@ -154,13 +155,10 @@ const RunForm: React.FC<RunFormProps> = ({ data, onValueChange, isDuplicated }) 
           isRequired
           labelHelp={<DashboardHelpTooltip content={runGroupCreateModalPopoverText} />}
         >
-          <TextInput
-            id="run-group"
-            data-testid="run-group-field"
-            value={data.runGroup}
-            onChange={(_e, value) => onValueChange('runGroup', value)}
-            maxLength={NAME_CHARACTER_LIMIT}
-            isRequired
+          <ActiveExperimentSelector
+            dataTestId="run-group-selector"
+            selection={data.runGroup}
+            onSelect={(experiment) => onValueChange('runGroup', experiment.display_name)}
           />
           <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} currentLength={data.runGroup.length} />
         </FormGroup>

--- a/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
+++ b/frontend/src/concepts/pipelines/content/createRun/RunPage.tsx
@@ -23,6 +23,7 @@ import { ValueOf } from '#~/typeHelpers';
 import { useGetSearchParamValues } from '#~/utilities/useGetSearchParamValues';
 import { PipelineRunSearchParam } from '#~/concepts/pipelines/content/types';
 import { asEnumMember } from '#~/utilities/utils';
+import useDefaultExperiment from '#~/pages/pipelines/global/experiments/useDefaultExperiment';
 
 type RunPageProps = {
   duplicateRun?: PipelineRunKF | PipelineRecurringRunKF | null;
@@ -48,7 +49,7 @@ const RunPage: React.FC<RunPageProps> = ({
     nameDesc: locationNameDesc,
     pipeline: locationPipeline,
     version: locationVersion,
-    runGroup: locationRunGroup,
+    experiment: locationRunGroup,
     mlflow: locationMlflow,
   } = location.state?.locationData || {};
   const { triggerType: triggerTypeString } = useGetSearchParamValues([
@@ -57,6 +58,7 @@ const RunPage: React.FC<RunPageProps> = ({
   const triggerType = asEnumMember(triggerTypeString, ScheduledType);
   const isSchedule = runType === RunTypeOption.SCHEDULED;
   const { status: isMlflowAvailable } = useIsAreaAvailable(SupportedArea.MLFLOW_PIPELINES);
+  const [defaultExperiment] = useDefaultExperiment();
   const jumpToSections = Object.values(CreateRunPageSections).filter(
     (section) =>
       !(
@@ -99,7 +101,7 @@ const RunPage: React.FC<RunPageProps> = ({
     pipeline: locationPipeline || contextPipeline,
     version: locationVersion || contextPipelineVersion,
     versionToUse: versionToUseData,
-    runGroup: locationRunGroup || contextExperiment?.display_name || '',
+    experiment: locationRunGroup || contextExperiment || defaultExperiment,
     ...(locationMlflow ? { mlflow: locationMlflow } : {}),
   });
 

--- a/frontend/src/concepts/pipelines/content/createRun/const.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/const.ts
@@ -16,7 +16,6 @@ export const DEFAULT_PERIODIC_DATA: RunTypeScheduledData = {
 export const DATE_FORMAT = 'YYYY-MM-DD';
 export const DEFAULT_TIME = '12:00 AM';
 export const RUN_OPTION_LABEL_SIZE = 100;
-export const DEFAULT_RUN_GROUP = 'Default';
 
 export enum CreateRunPageSections {
   RUN_TYPE = 'run-section-run-type',

--- a/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/submitUtils.ts
@@ -11,10 +11,8 @@ import {
   CreatePipelineRecurringRunKFData,
   CreatePipelineRunKFData,
   DateTimeKF,
-  ExperimentKF,
   InputDefinitionParameterType,
   PipelineRecurringRunKF,
-  PipelinesFilterOp,
   PipelineRunKF,
   PipelineVersionKF,
   RecurringRunMode,
@@ -28,59 +26,6 @@ import {
   isFilledRunFormData,
 } from '#~/concepts/pipelines/content/createRun/utils';
 import { convertPeriodicTimeToSeconds, convertToDate } from '#~/utilities/time';
-
-const listRunGroupExperiments = async (
-  runGroupName: string,
-  api: Pick<PipelineAPIs, 'listExperiments'>,
-): Promise<ExperimentKF[]> => {
-  if (!runGroupName) {
-    return [];
-  }
-
-  const { experiments } = await api.listExperiments(
-    {},
-    {
-      filter: {
-        predicates: [
-          {
-            key: 'name',
-            operation: PipelinesFilterOp.EQUALS,
-            // eslint-disable-next-line camelcase
-            string_value: runGroupName,
-          },
-        ],
-      },
-    },
-  );
-
-  return experiments || [];
-};
-
-const getPreferredRunGroupExperiment = (experiments: ExperimentKF[]): ExperimentKF | undefined => {
-  const active = experiments
-    .filter((experiment) => experiment.storage_state !== StorageStateKF.ARCHIVED)
-    .toSorted((a, b) => a.experiment_id.localeCompare(b.experiment_id));
-  return active[0] ?? experiments[0];
-};
-
-const findOrCreateRunGroupExperiment = async (
-  runGroupName: string,
-  api: PipelineAPIs,
-  dryRun = false,
-): Promise<ExperimentKF | null> => {
-  const trimmed = runGroupName.trim();
-  const experiments = await listRunGroupExperiments(trimmed, api);
-  const preferredExperiment = getPreferredRunGroupExperiment(experiments);
-  if (preferredExperiment) {
-    return preferredExperiment;
-  }
-  if (dryRun) {
-    return null;
-  }
-
-  // eslint-disable-next-line camelcase
-  return api.createExperiment({}, { display_name: trimmed, description: '' });
-};
 
 const buildMlflowPluginsInput = (
   mlflow: MlflowFormData,
@@ -111,41 +56,13 @@ const buildMlflowPluginsInput = (
   };
 };
 
-const resolveRunFormContext = async (
-  formData: SafeRunFormData,
-  api: PipelineAPIs,
-  isMlflowAvailable: boolean,
-  dryRun = false,
-) => {
-  const runGroupExperiment = formData.runGroup.trim()
-    ? await findOrCreateRunGroupExperiment(formData.runGroup, api, dryRun)
-    : null;
-
-  const pluginsInput = buildMlflowPluginsInput(formData.mlflow, isMlflowAvailable);
-
-  return { runGroupExperiment, pluginsInput };
-};
-
 const createRun = async (
   formData: SafeRunFormData,
   api: PipelineAPIs,
   isMlflowAvailable: boolean,
   dryRun?: boolean,
 ): Promise<PipelineRunKF> => {
-  const { runGroupExperiment, pluginsInput } = await resolveRunFormContext(
-    formData,
-    api,
-    isMlflowAvailable,
-    dryRun,
-  );
-
-  if (runGroupExperiment?.storage_state === StorageStateKF.ARCHIVED) {
-    throw new Error(
-      `Run group "${formData.runGroup.trim()}" is archived. Use a different run group name or restore the archived run group.`,
-    );
-  }
-
-  const runGroupExperimentId = runGroupExperiment?.experiment_id || '';
+  const pluginsInput = buildMlflowPluginsInput(formData.mlflow, isMlflowAvailable);
 
   /* eslint-disable camelcase */
   const data: CreatePipelineRunKFData = {
@@ -159,7 +76,7 @@ const createRun = async (
       parameters: normalizeInputParams(formData.params, formData.version),
     },
     service_account: '',
-    experiment_id: runGroupExperimentId,
+    experiment_id: formData.experiment?.experiment_id || '',
     ...(pluginsInput && { plugins_input: pluginsInput }),
   };
 
@@ -185,12 +102,7 @@ const createRecurringRun = async (
     return Promise.reject(new Error('Cannot create a schedule with incomplete data.'));
   }
 
-  const { runGroupExperiment, pluginsInput } = await resolveRunFormContext(
-    formData,
-    api,
-    isMlflowAvailable,
-    dryRun,
-  );
+  const pluginsInput = buildMlflowPluginsInput(formData.mlflow, isMlflowAvailable);
   const startDate = convertDateDataToKFDateTime(formData.runType.data.start) ?? undefined;
   const endDate = convertDateDataToKFDateTime(formData.runType.data.end) ?? undefined;
   const periodicScheduleIntervalTime = convertPeriodicTimeToSeconds(formData.runType.data.value);
@@ -231,12 +143,12 @@ const createRecurringRun = async (
     },
     max_concurrency: String(formData.runType.data.maxConcurrency),
     mode:
-      runGroupExperiment?.storage_state === StorageStateKF.ARCHIVED
+      formData.experiment?.storage_state === StorageStateKF.ARCHIVED
         ? RecurringRunMode.DISABLE
         : RecurringRunMode.ENABLE,
     no_catchup: !formData.runType.data.catchUp,
     service_account: '',
-    experiment_id: runGroupExperiment?.experiment_id || '',
+    experiment_id: formData.experiment?.experiment_id || '',
     ...(pluginsInput && { plugins_input: pluginsInput }),
   };
   /* eslint-enable camelcase */

--- a/frontend/src/concepts/pipelines/content/createRun/types.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/types.ts
@@ -1,5 +1,6 @@
 import { ProjectKind } from '#~/k8sTypes';
 import {
+  ExperimentKF,
   PipelineKF,
   PipelineVersionKF,
   RuntimeConfigParameters,
@@ -80,7 +81,7 @@ export type RunFormData = {
   pipeline: PipelineKF | null;
   version: PipelineVersionKF | null;
   versionToUse: PipelineVersionToUse;
-  runGroup: string;
+  experiment: ExperimentKF | null;
   mlflow: MlflowFormData;
   runType: RunType;
   params?: RuntimeConfigParameters;

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -16,7 +16,6 @@ import {
   PipelineRecurringRunKF,
   PipelineRunKF,
   RuntimeConfigParameters,
-  StorageStateKF,
 } from '#~/concepts/pipelines/kfTypes';
 
 import { UpdateObjectAtPropAndValue } from '#~/pages/projects/types';
@@ -108,18 +107,10 @@ const useUpdateRunGroupFormData = (
   const [formData, setFormValue] = formState;
 
   React.useEffect(() => {
-    if (formData.experiment) {
-      if (formData.experiment.storage_state === StorageStateKF.ARCHIVED) {
-        setFormValue('experiment', null);
-      }
-    } else if (runGroup) {
-      if (runGroup.storage_state === StorageStateKF.ARCHIVED) {
-        setFormValue('experiment', null);
-      } else {
-        setFormValue('experiment', runGroup);
-      }
+    if (!formData.experiment && runGroup) {
+      setFormValue('experiment', runGroup);
     }
-  }, [formData.experiment, setFormValue, runGroup, formData.runType.type]);
+  }, [formData.experiment, setFormValue, runGroup]);
 };
 
 const useUpdateDuplicateData = (

--- a/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/useRunFormData.ts
@@ -12,9 +12,11 @@ import {
 } from '#~/concepts/pipelines/content/createRun/types';
 import {
   DateTimeKF,
+  ExperimentKF,
   PipelineRecurringRunKF,
   PipelineRunKF,
   RuntimeConfigParameters,
+  StorageStateKF,
 } from '#~/concepts/pipelines/kfTypes';
 
 import { UpdateObjectAtPropAndValue } from '#~/pages/projects/types';
@@ -99,25 +101,46 @@ const useUpdateRunType = (
   }, [setFunction, initialData]);
 };
 
+const useUpdateRunGroupFormData = (
+  formState: GenericObjectState<RunFormData>,
+  runGroup: ExperimentKF | null | undefined,
+) => {
+  const [formData, setFormValue] = formState;
+
+  React.useEffect(() => {
+    if (formData.experiment) {
+      if (formData.experiment.storage_state === StorageStateKF.ARCHIVED) {
+        setFormValue('experiment', null);
+      }
+    } else if (runGroup) {
+      if (runGroup.storage_state === StorageStateKF.ARCHIVED) {
+        setFormValue('experiment', null);
+      } else {
+        setFormValue('experiment', runGroup);
+      }
+    }
+  }, [formData.experiment, setFormValue, runGroup, formData.runType.type]);
+};
+
 const useUpdateDuplicateData = (
   setFunction: UpdateObjectAtPropAndValue<RunFormData>,
   initialData?: PipelineRunKF | PipelineRecurringRunKF | null,
 ) => {
   const duplicateRunPipelineId = initialData?.pipeline_version_reference?.pipeline_id || '';
   const duplicateRunVersionId = initialData?.pipeline_version_reference?.pipeline_version_id || '';
-  const duplicateRunExperimentId = initialData?.experiment_id || '';
+  const duplicateRunGroupId = initialData?.experiment_id || '';
   const [duplicateRunPipelineVersion] = usePipelineVersionById(
     duplicateRunPipelineId,
     duplicateRunVersionId,
   );
   const [duplicateRunPipeline] = usePipelineById(duplicateRunPipelineId);
-  const [duplicateExperiment] = useExperimentById(duplicateRunExperimentId);
+  const [duplicateRunGroup] = useExperimentById(duplicateRunGroupId);
 
   React.useEffect(() => {
     if (!initialData) {
       return;
     }
-    setFunction('runGroup', duplicateExperiment?.display_name ?? '');
+    setFunction('experiment', duplicateRunGroup);
     setFunction('pipeline', duplicateRunPipeline);
     setFunction('version', duplicateRunPipelineVersion);
     setFunction('versionToUse', PipelineVersionToUse.PROVIDED);
@@ -136,7 +159,7 @@ const useUpdateDuplicateData = (
   }, [
     setFunction,
     initialData,
-    duplicateExperiment,
+    duplicateRunGroup,
     duplicateRunPipeline,
     duplicateRunPipelineVersion,
   ]);
@@ -147,7 +170,7 @@ const useRunFormData = (
   initialFormData?: Partial<RunFormData>,
 ): GenericObjectState<RunFormData> => {
   const { project } = usePipelinesAPI();
-  const { pipeline, version, runGroup, nameDesc, versionToUse, mlflow } = initialFormData || {};
+  const { pipeline, version, experiment, nameDesc, versionToUse, mlflow } = initialFormData || {};
 
   const formState = useGenericObjectState<RunFormData>(() => ({
     project,
@@ -155,10 +178,10 @@ const useRunFormData = (
     pipeline: pipeline ?? null,
     version: version ?? null,
     versionToUse: versionToUse ?? PipelineVersionToUse.LATEST,
-    runGroup: runGroup ?? '',
+    experiment: experiment ?? null,
     mlflow: mlflow ?? getDefaultMlflowFormData(),
     runType: { type: RunTypeOption.ONE_TRIGGER },
-    params: {}, // Start with empty params
+    params: {},
     ...initialFormData,
   }));
   const [formData, setFormValue] = formState;
@@ -169,9 +192,6 @@ const useRunFormData = (
       const inputDefinitionParams = getInputDefinitionParams(formData.version) || {};
       const newParams = Object.entries(inputDefinitionParams).reduce(
         (acc: RuntimeConfigParameters, [paramKey, paramValue]) => {
-          // Use run params if available, otherwise use defaults
-          // else; when doing a duplicate run, only parameters that have values will be included
-          // (this way all the empty defaults are also included in a duplicate run)
           acc[paramKey] =
             run?.runtime_config?.parameters[paramKey] ?? paramValue.defaultValue ?? '';
           return acc;
@@ -182,6 +202,7 @@ const useRunFormData = (
     }
   }, [formData.version, run, setFormValue]);
 
+  useUpdateRunGroupFormData(formState, experiment);
   useUpdateRunType(setFormValue, run);
   useUpdateDuplicateData(setFormValue, run);
 

--- a/frontend/src/concepts/pipelines/content/createRun/utils.ts
+++ b/frontend/src/concepts/pipelines/content/createRun/utils.ts
@@ -62,7 +62,6 @@ export const isFilledRunFormData = (
   formData: RunFormData,
   isMlflowAvailable: boolean,
 ): formData is SafeRunFormData => {
-  const runGroupName = formData.runGroup.trim();
   const mlflowExperimentName = getMlflowExperimentName(formData.mlflow);
   const hasMlflowExperimentName =
     !isMlflowAvailable || !formData.mlflow.isExperimentTrackingEnabled || !!mlflowExperimentName;
@@ -76,7 +75,7 @@ export const isFilledRunFormData = (
 
   return (
     !!formData.nameDesc.name &&
-    !!runGroupName &&
+    !!formData.experiment &&
     !!formData.pipeline &&
     !!formData.version &&
     hasMlflowExperimentName &&

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
@@ -55,7 +55,7 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
       }}
       variant="small"
     >
-      <ModalHeader title="Create experiment" />
+      <ModalHeader title="Create run group" />
       <ModalBody>
         <Form>
           <Stack hasGutter>
@@ -65,7 +65,7 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
               </FormGroup>
             </StackItem>
             <StackItem>
-              <FormGroup label="Experiment name" isRequired fieldId="experiment-name">
+              <FormGroup label="Run group name" isRequired fieldId="experiment-name">
                 <TextInput
                   isRequired
                   type="text"
@@ -99,7 +99,7 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
             </StackItem>
             {error && (
               <StackItem>
-                <Alert title="Error creating experiment" isInline variant="danger">
+                <Alert title="Error creating run group" isInline variant="danger">
                   {error.message}
                 </Alert>
               </StackItem>
@@ -136,7 +136,7 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
               });
           }}
         >
-          Create experiment
+          Create run group
         </Button>
         <Button key="cancel-button" variant="secondary" onClick={() => onBeforeClose()}>
           Cancel

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
@@ -4,6 +4,8 @@ import {
   Button,
   Form,
   FormGroup,
+  HelperText,
+  HelperTextItem,
   Stack,
   StackItem,
   TextInput,
@@ -26,16 +28,23 @@ import { TrackingOutcome } from '#~/concepts/analyticsTracking/trackingPropertie
 
 type CreateExperimentModalProps = {
   onClose: (experiment?: ExperimentKF) => void;
+  existingNames?: string[];
 };
 
 const eventName = 'Experiment Created';
-const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }) => {
+const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({
+  onClose,
+  existingNames = [],
+}) => {
   const { project, api, apiAvailable } = usePipelinesAPI();
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
   const [{ name, description }, setData, resetData] = useCreateExperimentData();
 
-  const haveEnoughData = !!name;
+  const isDuplicate = existingNames.some(
+    (existing) => existing.toLowerCase() === name.trim().toLowerCase(),
+  );
+  const haveEnoughData = !!name && !isDuplicate;
 
   const onBeforeClose = (experiment?: ExperimentKF) => {
     onClose(experiment);
@@ -72,11 +81,19 @@ const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({ onClose }
                   id="experiment-name"
                   name="experiment-name"
                   value={name}
+                  validated={isDuplicate ? 'error' : 'default'}
                   onChange={(_, value) => setData('name', value)}
                   maxLength={NAME_CHARACTER_LIMIT}
                 />
-
-                <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} currentLength={name.length} />
+                {isDuplicate ? (
+                  <HelperText>
+                    <HelperTextItem variant="error">
+                      A run group with this name already exists.
+                    </HelperTextItem>
+                  </HelperText>
+                ) : (
+                  <CharLimitHelperText limit={NAME_CHARACTER_LIMIT} currentLength={name.length} />
+                )}
               </FormGroup>
             </StackItem>
             <StackItem>

--- a/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/CreateExperimentModal.tsx
@@ -31,7 +31,7 @@ type CreateExperimentModalProps = {
   existingNames?: string[];
 };
 
-const eventName = 'Experiment Created';
+const eventName = 'Run Group Created';
 const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({
   onClose,
   existingNames = [],

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -16,6 +16,7 @@ import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 type ExperimentSelectorProps = {
   selection?: string;
   onSelect: (experiment: ExperimentKF) => void;
+  dataTestId?: string;
 };
 
 const InnerExperimentSelector: React.FC<
@@ -32,6 +33,7 @@ const InnerExperimentSelector: React.FC<
   data: experiments,
   selection,
   onSelect,
+  dataTestId = 'experiment-selector',
 }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const { refreshAllAPI } = usePipelinesAPI();
@@ -39,7 +41,7 @@ const InnerExperimentSelector: React.FC<
   return (
     <>
       <SearchSelector
-        dataTestId="experiment-selector"
+        dataTestId={dataTestId}
         onSearchChange={(newValue) => searchProps.onChange(newValue)}
         onSearchClear={() => onSearchClear()}
         searchValue={searchProps.value ?? ''}
@@ -47,10 +49,10 @@ const InnerExperimentSelector: React.FC<
         isFullWidth
         toggleContent={
           initialLoaded
-            ? selection || (totalSize === 0 ? 'No experiments available' : 'Select an experiment')
-            : 'Loading experiments'
+            ? selection || (totalSize === 0 ? 'No run groups available' : 'Select a run group')
+            : 'Loading run groups'
         }
-        searchHelpText={`Type a name to search your ${totalSize} experiments.`}
+        searchHelpText={`Type a name to search your ${totalSize} run groups.`}
         isDisabled={totalSize === 0}
       >
         {({ menuClose }) => (
@@ -66,7 +68,7 @@ const InnerExperimentSelector: React.FC<
                     variant={EmptyStateVariant.xs}
                   />
                 }
-                data-testid="experiment-selector-table-list"
+                data-testid={`${dataTestId}-table-list`}
                 borders={false}
                 variant={TableVariant.compact}
                 columns={experimentSelectorColumns}
@@ -90,7 +92,7 @@ const InnerExperimentSelector: React.FC<
                     <PipelineViewMoreFooterRow
                       visibleLength={experiments.length}
                       totalSize={fetchedSize}
-                      errorTitle="Error loading more experiments"
+                      errorTitle="Error loading more run groups"
                       onClick={onLoadMore}
                       colSpan={2}
                     />
@@ -117,7 +119,7 @@ const InnerExperimentSelector: React.FC<
                   }}
                   style={{ paddingLeft: '20px' }}
                 >
-                  Create new experiment
+                  Create new run group
                 </Button>
               </div>
             )}

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -128,6 +128,7 @@ const InnerExperimentSelector: React.FC<
       </SearchSelector>
       {isModalOpen && (
         <CreateExperimentModal
+          existingNames={experiments.map((e) => e.display_name)}
           onClose={(experiment) => {
             setIsModalOpen(false);
             if (experiment) {

--- a/frontend/src/concepts/pipelines/content/experiment/columns.ts
+++ b/frontend/src/concepts/pipelines/content/experiment/columns.ts
@@ -3,7 +3,7 @@ import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
 
 export const experimentSelectorColumns: SortableData<ExperimentKF>[] = [
   {
-    label: 'Experiment name',
+    label: 'Run group name',
     field: 'name',
     sortable: (a, b) => a.display_name.localeCompare(b.display_name),
     width: 70,

--- a/frontend/src/concepts/pipelines/content/experiment/columns.ts
+++ b/frontend/src/concepts/pipelines/content/experiment/columns.ts
@@ -3,7 +3,7 @@ import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
 
 export const experimentSelectorColumns: SortableData<ExperimentKF>[] = [
   {
-    label: 'Run group name',
+    label: 'Run group',
     field: 'name',
     sortable: (a, b) => a.display_name.localeCompare(b.display_name),
     width: 70,

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
@@ -160,9 +160,9 @@ const InnerCustomPipelineRunToolbarSelect = <T extends PipelineVersionKF | Exper
 
 export const ExperimentFilterSelector: React.FC<FilterSelectorProps<ExperimentKF>> = (props) => (
   <InnerCustomPipelineRunToolbarSelect
-    resourceName="experiments"
-    toggleTestId="experiment-toggle-button"
-    tableTestId="experiment-selector-table-list"
+    resourceName="run groups"
+    toggleTestId="run-group-toggle-button"
+    tableTestId="run-group-selector-table-list"
     columns={experimentSelectorColumns}
     {...props}
   />

--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeDetailsTab.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/SelectedNodeDetailsTab.tsx
@@ -6,8 +6,11 @@ import {
   renderDetailItems,
 } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/utils';
 import { relativeDuration } from '#~/utilities/time';
-import { RuntimeStateKF } from '#~/concepts/pipelines/kfTypes';
+import { RuntimeStateKF, runtimeStateLabels } from '#~/concepts/pipelines/kfTypes';
 import { PipelineTask } from '#~/concepts/pipelines/topology';
+
+const getStateLabel = (state: string): string =>
+  Object.entries(runtimeStateLabels).find(([key]) => key === state)?.[1] ?? state;
 import TaskDetailsSection from '#~/concepts/pipelines/content/pipelinesDetails/taskDetails/TaskDetailsSection';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { getIsArtifactModelRegistered } from '#~/pages/pipelines/global/experiments/artifacts/utils';
@@ -60,7 +63,7 @@ const SelectedNodeDetailsTab: React.FC<SelectedNodeDetailsTabProps> = ({ task })
         taskName,
         {
           key: 'Status',
-          value: state ?? '-',
+          value: state ? getStateLabel(state) : '-',
         },
         {
           key: 'Started',

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
@@ -153,7 +153,7 @@ describe('usePipelineFilterSearchParams', () => {
       [FilterOptions.NAME]: 'test',
       [FilterOptions.CREATED_AT]: '2024-11-21',
       [FilterOptions.STATUS]: 'success',
-      [FilterOptions.RUN_GROUP]: { value: 'test-experiment', label: 'Loading...' },
+      [FilterOptions.RUN_GROUP]: { value: 'test-experiment', label: 'test-experiment' },
       [FilterOptions.PIPELINE_VERSION]: 'test-version',
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
@@ -22,7 +22,7 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: '',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
-      [FilterOptions.RUN_GROUP]: '',
+      [FilterOptions.RUN_GROUP]: undefined,
       [FilterOptions.PIPELINE_VERSION]: undefined,
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });
@@ -34,7 +34,7 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: 'test',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
-      [FilterOptions.RUN_GROUP]: '',
+      [FilterOptions.RUN_GROUP]: undefined,
       [FilterOptions.PIPELINE_VERSION]: undefined,
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });
@@ -46,7 +46,7 @@ describe('usePipelineFilter', () => {
       [FilterOptions.NAME]: '',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
-      [FilterOptions.RUN_GROUP]: '',
+      [FilterOptions.RUN_GROUP]: undefined,
       [FilterOptions.PIPELINE_VERSION]: undefined,
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });
@@ -153,7 +153,7 @@ describe('usePipelineFilterSearchParams', () => {
       [FilterOptions.NAME]: 'test',
       [FilterOptions.CREATED_AT]: '2024-11-21',
       [FilterOptions.STATUS]: 'success',
-      [FilterOptions.RUN_GROUP]: 'test-experiment',
+      [FilterOptions.RUN_GROUP]: { value: 'test-experiment', label: 'Loading...' },
       [FilterOptions.PIPELINE_VERSION]: 'test-version',
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });
@@ -201,7 +201,10 @@ describe('usePipelineFilterSearchParams', () => {
       [FilterOptions.NAME]: 'test',
       [FilterOptions.CREATED_AT]: '2024-11-21',
       [FilterOptions.STATUS]: 'success',
-      [FilterOptions.RUN_GROUP]: 'Test Experiment',
+      [FilterOptions.RUN_GROUP]: {
+        label: 'Test Experiment',
+        value: 'test-experiment',
+      },
       [FilterOptions.PIPELINE_VERSION]: {
         label: 'Test Version',
         value: 'test-version',
@@ -222,7 +225,7 @@ describe('usePipelineFilterSearchParams', () => {
       [FilterOptions.NAME]: '',
       [FilterOptions.CREATED_AT]: '',
       [FilterOptions.STATUS]: '',
-      [FilterOptions.RUN_GROUP]: '',
+      [FilterOptions.RUN_GROUP]: undefined,
       [FilterOptions.PIPELINE_VERSION]: undefined,
       [FilterOptions.MLFLOW_EXPERIMENT]: '',
     });
@@ -356,10 +359,6 @@ describe('usePipelineFilterSearchParams', () => {
       experiment_id: 'exp-alpha',
       display_name: 'Alpha Test',
     });
-    const experimentBeta = buildMockExperimentKF({
-      experiment_id: 'exp-beta',
-      display_name: 'Beta Test',
-    });
     const experimentGamma = buildMockExperimentKF({
       experiment_id: 'exp-gamma',
       display_name: 'Gamma',
@@ -367,7 +366,7 @@ describe('usePipelineFilterSearchParams', () => {
 
     const versionsContextValue = { versions: [] as never[], loaded: true };
     const experimentsContextValue = {
-      experiments: [experimentAlpha, experimentBeta, experimentGamma],
+      experiments: [experimentAlpha, experimentGamma],
       loaded: true,
     };
 
@@ -382,10 +381,10 @@ describe('usePipelineFilterSearchParams', () => {
       return Wrapper;
     };
 
-    it('should produce EQUALS predicate when run group matches an experiment by exact name', () => {
+    it('should produce EQUALS predicate when run group filter matches an experiment by ID', () => {
       const setFilterMock = jest.fn();
       renderHook(() => usePipelineFilterSearchParams(setFilterMock), {
-        wrapper: wrapperWithExperiments('/?run_group=Gamma'),
+        wrapper: wrapperWithExperiments('/?run_group=exp-gamma'),
       });
 
       jest.runAllTimers();
@@ -399,17 +398,6 @@ describe('usePipelineFilterSearchParams', () => {
           },
         ]),
       });
-    });
-
-    it('should not produce experiment predicate when run group has no exact match', () => {
-      const setFilterMock = jest.fn();
-      renderHook(() => usePipelineFilterSearchParams(setFilterMock), {
-        wrapper: wrapperWithExperiments('/?run_group=NoMatch'),
-      });
-
-      jest.runAllTimers();
-
-      expect(setFilterMock).toHaveBeenLastCalledWith(undefined);
     });
 
     it('should use exact experiment ID for legacy ?experiment= deep links', () => {

--- a/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/__tests__/usePipelineFilter.spec.tsx
@@ -382,7 +382,7 @@ describe('usePipelineFilterSearchParams', () => {
       return Wrapper;
     };
 
-    it('should produce IN predicate when run group matches a single experiment', () => {
+    it('should produce EQUALS predicate when run group matches an experiment by exact name', () => {
       const setFilterMock = jest.fn();
       renderHook(() => usePipelineFilterSearchParams(setFilterMock), {
         wrapper: wrapperWithExperiments('/?run_group=Gamma'),
@@ -394,36 +394,14 @@ describe('usePipelineFilterSearchParams', () => {
         predicates: expect.arrayContaining([
           {
             key: 'experiment_id',
-            operation: PipelinesFilterOp.IN,
-            string_values: { values: ['exp-gamma'] },
+            operation: PipelinesFilterOp.EQUALS,
+            string_value: 'exp-gamma',
           },
         ]),
       });
     });
 
-    it('should produce IN predicate when run group matches multiple experiments', () => {
-      const setFilterMock = jest.fn();
-      renderHook(() => usePipelineFilterSearchParams(setFilterMock), {
-        wrapper: wrapperWithExperiments('/?run_group=Test'),
-      });
-
-      jest.runAllTimers();
-
-      expect(setFilterMock).toHaveBeenLastCalledWith({
-        predicates: expect.arrayContaining([
-          {
-            key: 'experiment_id',
-            operation: PipelinesFilterOp.IN,
-            // eslint-disable-next-line camelcase
-            string_values: {
-              values: expect.arrayContaining(['exp-alpha', 'exp-beta']),
-            },
-          },
-        ]),
-      });
-    });
-
-    it('should produce empty IN predicate when run group matches no experiments', () => {
+    it('should not produce experiment predicate when run group has no exact match', () => {
       const setFilterMock = jest.fn();
       renderHook(() => usePipelineFilterSearchParams(setFilterMock), {
         wrapper: wrapperWithExperiments('/?run_group=NoMatch'),
@@ -431,15 +409,7 @@ describe('usePipelineFilterSearchParams', () => {
 
       jest.runAllTimers();
 
-      expect(setFilterMock).toHaveBeenLastCalledWith({
-        predicates: expect.arrayContaining([
-          {
-            key: 'experiment_id',
-            operation: PipelinesFilterOp.IN,
-            string_values: { values: [] },
-          },
-        ]),
-      });
+      expect(setFilterMock).toHaveBeenLastCalledWith(undefined);
     });
 
     it('should use exact experiment ID for legacy ?experiment= deep links', () => {

--- a/frontend/src/concepts/pipelines/content/tables/columns.ts
+++ b/frontend/src/concepts/pipelines/content/tables/columns.ts
@@ -70,7 +70,7 @@ export const pipelineVersionColumns: SortableData<PipelineVersionKF>[] = [
 export const experimentColumns: SortableData<ExperimentKF>[] = [
   checkboxTableColumn(),
   {
-    label: 'Experiment',
+    label: 'Run group',
     field: 'display_name',
     sortable: true,
     width: 40,

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -6,7 +6,11 @@ import { TableRowTitleDescription, CheckboxTd } from '#~/components/table';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import usePipelineRunVersionInfo from '#~/concepts/pipelines/content/tables/usePipelineRunVersionInfo';
 import { PipelineVersionLink } from '#~/concepts/pipelines/content/PipelineVersionLink';
-import { duplicateRecurringRunRoute, recurringRunDetailsRoute } from '#~/routes/pipelines/runs';
+import {
+  duplicateRecurringRunRoute,
+  globalPipelineRecurringRunsRoute,
+  recurringRunDetailsRoute,
+} from '#~/routes/pipelines/runs';
 import {
   RecurringRunCreated,
   RecurringRunScheduled,
@@ -18,6 +22,7 @@ import PipelineRunTableRowMlflowExperiment from '#~/concepts/pipelines/content/t
 import usePipelineRunExperimentInfo from '#~/concepts/pipelines/content/tables/usePipelineRunExperimentInfo';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
+import { buildLegacyExperimentFilterUrl } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 
 type PipelineRecurringRunTableRowProps = {
   isChecked: boolean;
@@ -49,6 +54,16 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
     loaded: isExperimentLoaded,
     error: experimentError,
   } = usePipelineRunExperimentInfo(recurringRun);
+  const runGroupLink = React.useMemo(() => {
+    if (!experiment) {
+      return undefined;
+    }
+
+    return buildLegacyExperimentFilterUrl(
+      globalPipelineRecurringRunsRoute(namespace),
+      experiment.experiment_id,
+    );
+  }, [experiment, namespace]);
 
   return (
     <Tr>
@@ -88,6 +103,7 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
             experiment={experiment}
             error={experimentError}
             loaded={isExperimentLoaded}
+            linkTo={runGroupLink}
           />
         </Td>
       )}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionsColumn, TableText, Td, Tr } from '@patternfly/react-table';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { PipelineRecurringRunKF } from '#~/concepts/pipelines/kfTypes';
 import { TableRowTitleDescription, CheckboxTd } from '#~/components/table';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
@@ -22,7 +22,7 @@ import PipelineRunTableRowMlflowExperiment from '#~/concepts/pipelines/content/t
 import usePipelineRunExperimentInfo from '#~/concepts/pipelines/content/tables/usePipelineRunExperimentInfo';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
-import { buildLegacyExperimentFilterUrl } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
+import { LEGACY_EXPERIMENT_FILTER_PARAM } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 
 type PipelineRecurringRunTableRowProps = {
   isChecked: boolean;
@@ -54,16 +54,18 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
     loaded: isExperimentLoaded,
     error: experimentError,
   } = usePipelineRunExperimentInfo(recurringRun);
-  const runGroupLink = React.useMemo(() => {
+  const [searchParams] = useSearchParams();
+  const handleRunGroupClick = React.useMemo(() => {
     if (!experiment) {
       return undefined;
     }
 
-    return buildLegacyExperimentFilterUrl(
-      globalPipelineRecurringRunsRoute(namespace),
-      experiment.experiment_id,
-    );
-  }, [experiment, namespace]);
+    return () => {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set(LEGACY_EXPERIMENT_FILTER_PARAM, experiment.experiment_id);
+      navigate(`${globalPipelineRecurringRunsRoute(namespace)}?${nextParams.toString()}`);
+    };
+  }, [experiment, namespace, navigate, searchParams]);
 
   return (
     <Tr>
@@ -103,7 +105,8 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
             experiment={experiment}
             error={experimentError}
             loaded={isExperimentLoaded}
-            linkTo={runGroupLink}
+            isClickable={!!handleRunGroupClick}
+            onClick={handleRunGroupClick}
           />
         </Td>
       )}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -22,7 +22,10 @@ import PipelineRunTableRowMlflowExperiment from '#~/concepts/pipelines/content/t
 import usePipelineRunExperimentInfo from '#~/concepts/pipelines/content/tables/usePipelineRunExperimentInfo';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
-import { LEGACY_EXPERIMENT_FILTER_PARAM } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
+import {
+  FilterOptions,
+  LEGACY_EXPERIMENT_FILTER_PARAM,
+} from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 
 type PipelineRecurringRunTableRowProps = {
   isChecked: boolean;
@@ -62,7 +65,8 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
 
     return () => {
       const nextParams = new URLSearchParams(searchParams);
-      nextParams.set(LEGACY_EXPERIMENT_FILTER_PARAM, experiment.experiment_id);
+      nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
+      nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
       navigate(`${globalPipelineRecurringRunsRoute(namespace)}?${nextParams.toString()}`);
     };
   }, [experiment, namespace, navigate, searchParams]);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableRow.tsx
@@ -58,17 +58,14 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
     error: experimentError,
   } = usePipelineRunExperimentInfo(recurringRun);
   const [searchParams] = useSearchParams();
-  const handleRunGroupClick = React.useMemo(() => {
+  const handleRunGroupClick = React.useCallback(() => {
     if (!experiment) {
-      return undefined;
+      return;
     }
-
-    return () => {
-      const nextParams = new URLSearchParams(searchParams);
-      nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
-      nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
-      navigate(`${globalPipelineRecurringRunsRoute(namespace)}?${nextParams.toString()}`);
-    };
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
+    nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
+    navigate(`${globalPipelineRecurringRunsRoute(namespace)}?${nextParams.toString()}`);
   }, [experiment, namespace, navigate, searchParams]);
 
   return (
@@ -109,8 +106,7 @@ const PipelineRecurringRunTableRow: React.FC<PipelineRecurringRunTableRowProps> 
             experiment={experiment}
             error={experimentError}
             loaded={isExperimentLoaded}
-            isClickable={!!handleRunGroupClick}
-            onClick={handleRunGroupClick}
+            onClick={experiment ? handleRunGroupClick : undefined}
           />
         </Td>
       )}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
@@ -12,8 +12,8 @@ import {
   ExperimentFilterSelector,
   PipelineVersionFilterSelector,
 } from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
-import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
+import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import MlflowExperimentSelector from '#~/concepts/mlflow/MlflowExperimentSelector';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 
@@ -30,8 +30,8 @@ const PipelineRecurringRunTableToolbar: React.FC<PipelineRecurringRunTableToolba
   dropdownActions,
   ...toolbarProps
 }) => {
-  const { versions } = React.useContext(PipelineRunVersionsContext);
   const { experiments } = React.useContext(PipelineRunExperimentsContext);
+  const { versions } = React.useContext(PipelineRunVersionsContext);
   const { isExperimentArchived } = useIsExperimentArchived();
   const { experiment } = React.useContext(ExperimentContext);
   const { status: isMlflowAvailable } = useIsAreaAvailable(SupportedArea.MLFLOW_PIPELINES);
@@ -62,11 +62,11 @@ const PipelineRecurringRunTableToolbar: React.FC<PipelineRecurringRunTableToolba
             onChange={(_event, value) => onChange(value)}
           />
         ),
-        [FilterOptions.RUN_GROUP]: ({ onChange, value }) => (
+        [FilterOptions.RUN_GROUP]: ({ onChange, label }) => (
           <ExperimentFilterSelector
             resources={experiments}
-            selection={value}
-            onSelect={(selected) => onChange(selected.display_name)}
+            selection={label}
+            onSelect={(e) => onChange(e.experiment_id, e.display_name)}
           />
         ),
         [FilterOptions.MLFLOW_EXPERIMENT]: ({ onChange, value }) => (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRecurringRun/PipelineRecurringRunTableToolbar.tsx
@@ -8,8 +8,12 @@ import {
   ExperimentContext,
   useContextExperimentArchivedOrDeleted as useIsExperimentArchived,
 } from '#~/pages/pipelines/global/experiments/ExperimentContext';
-import { PipelineVersionFilterSelector } from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
+import {
+  ExperimentFilterSelector,
+  PipelineVersionFilterSelector,
+} from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
+import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 import MlflowExperimentSelector from '#~/concepts/mlflow/MlflowExperimentSelector';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 
@@ -27,6 +31,7 @@ const PipelineRecurringRunTableToolbar: React.FC<PipelineRecurringRunTableToolba
   ...toolbarProps
 }) => {
   const { versions } = React.useContext(PipelineRunVersionsContext);
+  const { experiments } = React.useContext(PipelineRunExperimentsContext);
   const { isExperimentArchived } = useIsExperimentArchived();
   const { experiment } = React.useContext(ExperimentContext);
   const { status: isMlflowAvailable } = useIsAreaAvailable(SupportedArea.MLFLOW_PIPELINES);
@@ -57,13 +62,11 @@ const PipelineRecurringRunTableToolbar: React.FC<PipelineRecurringRunTableToolba
             onChange={(_event, value) => onChange(value)}
           />
         ),
-        [FilterOptions.RUN_GROUP]: ({ onChange, ...props }) => (
-          <TextInput
-            {...props}
-            data-testid="search-for-run-group-name"
-            aria-label="Search for a run group name"
-            placeholder="Search..."
-            onChange={(_event, value) => onChange(value)}
+        [FilterOptions.RUN_GROUP]: ({ onChange, value }) => (
+          <ExperimentFilterSelector
+            resources={experiments}
+            selection={value}
+            onSelect={(selected) => onChange(selected.display_name)}
           />
         ),
         [FilterOptions.MLFLOW_EXPERIMENT]: ({ onChange, value }) => (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -34,7 +34,10 @@ import RestoreRunWithArchivedExperimentModal from '#~/pages/pipelines/global/run
 import { useFetchRunArtifact } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/useFetchRunArtifact';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
-import { LEGACY_EXPERIMENT_FILTER_PARAM } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
+import {
+  FilterOptions,
+  LEGACY_EXPERIMENT_FILTER_PARAM,
+} from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 import { isPipelineRunRegistered } from './utils';
 
 type PipelineRunTableRowProps = {
@@ -92,7 +95,8 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
           ? globalArchivedPipelineRunsRoute(namespace)
           : globalPipelineRunsRoute(namespace);
       const nextParams = new URLSearchParams(searchParams);
-      nextParams.set(LEGACY_EXPERIMENT_FILTER_PARAM, experiment.experiment_id);
+      nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
+      nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
       navigate(`${basePath}?${nextParams.toString()}`);
     };
   }, [experiment, namespace, navigate, onRunGroupClick, runType, searchParams]);

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ExperimentKF, PipelineRunKF, RuntimeStateKF } from '#~/concepts/pipelines/kfTypes';
 import { CheckboxTd } from '#~/components/table';
 import {
@@ -34,7 +34,7 @@ import RestoreRunWithArchivedExperimentModal from '#~/pages/pipelines/global/run
 import { useFetchRunArtifact } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/useFetchRunArtifact';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
-import { buildLegacyExperimentFilterUrl } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
+import { LEGACY_EXPERIMENT_FILTER_PARAM } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 import { isPipelineRunRegistered } from './utils';
 
 type PipelineRunTableRowProps = {
@@ -76,18 +76,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
   const { status: modelRegistryAvailable } = useIsAreaAvailable(SupportedArea.MODEL_REGISTRY);
   const [mlmdData] = useFetchRunArtifact(modelRegistryAvailable ? run.run_id : undefined); // Prevent API call when model registry is not available
   const isRegistered = isPipelineRunRegistered(mlmdData);
-  const runGroupLink = React.useMemo(() => {
-    if (!experiment) {
-      return undefined;
-    }
-
-    return buildLegacyExperimentFilterUrl(
-      runType === PipelineRunType.ARCHIVED
-        ? globalArchivedPipelineRunsRoute(namespace)
-        : globalPipelineRunsRoute(namespace),
-      experiment.experiment_id,
-    );
-  }, [experiment, namespace, runType]);
+  const [searchParams] = useSearchParams();
   const handleRunGroupClick = React.useMemo(() => {
     if (!experiment) {
       return undefined;
@@ -97,12 +86,16 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
       return () => onRunGroupClick(experiment);
     }
 
-    if (!runGroupLink) {
-      return undefined;
-    }
-
-    return () => navigate(runGroupLink);
-  }, [experiment, navigate, onRunGroupClick, runGroupLink]);
+    return () => {
+      const basePath =
+        runType === PipelineRunType.ARCHIVED
+          ? globalArchivedPipelineRunsRoute(namespace)
+          : globalPipelineRunsRoute(namespace);
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.set(LEGACY_EXPERIMENT_FILTER_PARAM, experiment.experiment_id);
+      navigate(`${basePath}?${nextParams.toString()}`);
+    };
+  }, [experiment, namespace, navigate, onRunGroupClick, runType, searchParams]);
 
   const { isExperimentArchived: isContextExperimentArchived } =
     useContextExperimentArchivedOrDeleted();

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ActionsColumn, IAction, Td, Tr } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
-import { PipelineRunKF, RuntimeStateKF } from '#~/concepts/pipelines/kfTypes';
+import { ExperimentKF, PipelineRunKF, RuntimeStateKF } from '#~/concepts/pipelines/kfTypes';
 import { CheckboxTd } from '#~/components/table';
 import {
   RunCreated,
@@ -15,7 +15,12 @@ import usePipelineRunVersionInfo from '#~/concepts/pipelines/content/tables/useP
 import { PipelineVersionLink } from '#~/concepts/pipelines/content/PipelineVersionLink';
 import { PipelineRunType } from '#~/pages/pipelines/global/runs/types';
 import { RestoreRunModal } from '#~/pages/pipelines/global/runs/RestoreRunModal';
-import { compareRunsRoute, duplicateRunRoute } from '#~/routes/pipelines/runs';
+import {
+  compareRunsRoute,
+  duplicateRunRoute,
+  globalArchivedPipelineRunsRoute,
+  globalPipelineRunsRoute,
+} from '#~/routes/pipelines/runs';
 import { ArchiveRunModal } from '#~/pages/pipelines/global/runs/ArchiveRunModal';
 import PipelineRunTableRowExperiment from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment';
 import PipelineRunTableRowMlflowExperiment from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowMlflowExperiment';
@@ -29,6 +34,7 @@ import RestoreRunWithArchivedExperimentModal from '#~/pages/pipelines/global/run
 import { useFetchRunArtifact } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/useFetchRunArtifact';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { MlflowExperimentData } from '#~/concepts/mlflow/types';
+import { buildLegacyExperimentFilterUrl } from '#~/concepts/pipelines/content/tables/usePipelineFilter';
 import { isPipelineRunRegistered } from './utils';
 
 type PipelineRunTableRowProps = {
@@ -39,6 +45,7 @@ type PipelineRunTableRowProps = {
   customCells?: React.ReactNode;
   hasRowActions?: boolean;
   runType?: PipelineRunType;
+  onRunGroupClick?: (experiment: ExperimentKF) => void;
 };
 
 const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
@@ -47,6 +54,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
   customCells,
   mlflow,
   onDelete,
+  onRunGroupClick,
   run,
   runType,
 }) => {
@@ -68,6 +76,33 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
   const { status: modelRegistryAvailable } = useIsAreaAvailable(SupportedArea.MODEL_REGISTRY);
   const [mlmdData] = useFetchRunArtifact(modelRegistryAvailable ? run.run_id : undefined); // Prevent API call when model registry is not available
   const isRegistered = isPipelineRunRegistered(mlmdData);
+  const runGroupLink = React.useMemo(() => {
+    if (!experiment) {
+      return undefined;
+    }
+
+    return buildLegacyExperimentFilterUrl(
+      runType === PipelineRunType.ARCHIVED
+        ? globalArchivedPipelineRunsRoute(namespace)
+        : globalPipelineRunsRoute(namespace),
+      experiment.experiment_id,
+    );
+  }, [experiment, namespace, runType]);
+  const handleRunGroupClick = React.useMemo(() => {
+    if (!experiment) {
+      return undefined;
+    }
+
+    if (onRunGroupClick) {
+      return () => onRunGroupClick(experiment);
+    }
+
+    if (!runGroupLink) {
+      return undefined;
+    }
+
+    return () => navigate(runGroupLink);
+  }, [experiment, navigate, onRunGroupClick, runGroupLink]);
 
   const { isExperimentArchived: isContextExperimentArchived } =
     useContextExperimentArchivedOrDeleted();
@@ -178,6 +213,8 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
             isExperimentArchived={isExperimentArchived}
             error={experimentError}
             loaded={isExperimentLoaded}
+            isClickable={!!handleRunGroupClick}
+            onClick={handleRunGroupClick}
           />
         </Td>
       )}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow.tsx
@@ -80,25 +80,22 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
   const [mlmdData] = useFetchRunArtifact(modelRegistryAvailable ? run.run_id : undefined); // Prevent API call when model registry is not available
   const isRegistered = isPipelineRunRegistered(mlmdData);
   const [searchParams] = useSearchParams();
-  const handleRunGroupClick = React.useMemo(() => {
+  const handleRunGroupClick = React.useCallback(() => {
     if (!experiment) {
-      return undefined;
+      return;
     }
-
     if (onRunGroupClick) {
-      return () => onRunGroupClick(experiment);
+      onRunGroupClick(experiment);
+      return;
     }
-
-    return () => {
-      const basePath =
-        runType === PipelineRunType.ARCHIVED
-          ? globalArchivedPipelineRunsRoute(namespace)
-          : globalPipelineRunsRoute(namespace);
-      const nextParams = new URLSearchParams(searchParams);
-      nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
-      nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
-      navigate(`${basePath}?${nextParams.toString()}`);
-    };
+    const basePath =
+      runType === PipelineRunType.ARCHIVED
+        ? globalArchivedPipelineRunsRoute(namespace)
+        : globalPipelineRunsRoute(namespace);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
+    nextParams.set(FilterOptions.RUN_GROUP, experiment.experiment_id);
+    navigate(`${basePath}?${nextParams.toString()}`);
   }, [experiment, namespace, navigate, onRunGroupClick, runType, searchParams]);
 
   const { isExperimentArchived: isContextExperimentArchived } =
@@ -210,8 +207,7 @@ const PipelineRunTableRow: React.FC<PipelineRunTableRowProps> = ({
             isExperimentArchived={isExperimentArchived}
             error={experimentError}
             loaded={isExperimentLoaded}
-            isClickable={!!handleRunGroupClick}
-            onClick={handleRunGroupClick}
+            onClick={experiment ? handleRunGroupClick : undefined}
           />
         </Td>
       )}

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Label, Skeleton, Split, SplitItem } from '@patternfly/react-core';
+import TruncatedText from '#~/components/TruncatedText';
 import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
 import { NoRunContent } from '#~/concepts/pipelines/content/tables/renderUtils';
 
@@ -8,6 +10,9 @@ type PipelineRunTableRowExperimentProps = {
   isExperimentArchived?: boolean;
   loaded: boolean;
   error?: Error;
+  linkTo?: string;
+  isClickable?: boolean;
+  onClick?: () => void;
 };
 
 const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps> = ({
@@ -15,7 +20,12 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
   isExperimentArchived,
   loaded,
   error,
+  linkTo,
+  isClickable = false,
+  onClick,
 }) => {
+  const navigate = useNavigate();
+
   if (!loaded && !error) {
     return <Skeleton />;
   }
@@ -23,13 +33,28 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
   if (!experiment) {
     return <NoRunContent />;
   }
+
+  const handleClick = onClick ?? (linkTo ? () => navigate(linkTo) : undefined);
+  const showClickableStyles = isClickable || !!handleClick;
+
+  const runGroupLabel = (
+    <Label
+      {...(showClickableStyles
+        ? {
+            isClickable: true,
+            ...(handleClick ? { onClick: handleClick } : {}),
+          }
+        : {})}
+      isCompact
+      variant="outline"
+    >
+      <TruncatedText content={experiment.display_name} maxLines={1} />
+    </Label>
+  );
+
   return (
     <Split hasGutter>
-      <SplitItem>
-        <Label isCompact variant="outline">
-          {experiment.display_name}
-        </Label>
-      </SplitItem>
+      <SplitItem>{runGroupLabel}</SplitItem>
       {isExperimentArchived && (
         <SplitItem>
           <Label variant="outline" isCompact>

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Label, Skeleton, Split, SplitItem } from '@patternfly/react-core';
 import TruncatedText from '#~/components/TruncatedText';
 import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
@@ -10,7 +9,6 @@ type PipelineRunTableRowExperimentProps = {
   isExperimentArchived?: boolean;
   loaded: boolean;
   error?: Error;
-  linkTo?: string;
   isClickable?: boolean;
   onClick?: () => void;
 };
@@ -20,12 +18,9 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
   isExperimentArchived,
   loaded,
   error,
-  linkTo,
   isClickable = false,
   onClick,
 }) => {
-  const navigate = useNavigate();
-
   if (!loaded && !error) {
     return <Skeleton />;
   }
@@ -34,15 +29,14 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
     return <NoRunContent />;
   }
 
-  const handleClick = onClick ?? (linkTo ? () => navigate(linkTo) : undefined);
-  const showClickableStyles = isClickable || !!handleClick;
+  const showClickableStyles = isClickable || !!onClick;
 
   const runGroupLabel = (
     <Label
       {...(showClickableStyles
         ? {
             isClickable: true,
-            ...(handleClick ? { onClick: handleClick } : {}),
+            ...(onClick ? { onClick } : {}),
           }
         : {})}
       isCompact

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRowExperiment.tsx
@@ -9,7 +9,6 @@ type PipelineRunTableRowExperimentProps = {
   isExperimentArchived?: boolean;
   loaded: boolean;
   error?: Error;
-  isClickable?: boolean;
   onClick?: () => void;
 };
 
@@ -18,7 +17,6 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
   isExperimentArchived,
   loaded,
   error,
-  isClickable = false,
   onClick,
 }) => {
   if (!loaded && !error) {
@@ -29,14 +27,12 @@ const PipelineRunTableRowExperiment: React.FC<PipelineRunTableRowExperimentProps
     return <NoRunContent />;
   }
 
-  const showClickableStyles = isClickable || !!onClick;
-
   const runGroupLabel = (
     <Label
-      {...(showClickableStyles
+      {...(onClick
         ? {
             isClickable: true,
-            ...(onClick ? { onClick } : {}),
+            onClick,
           }
         : {})}
       isCompact

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbarBase.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbarBase.tsx
@@ -6,9 +6,13 @@ import { FilterOptions } from '#~/concepts/pipelines/content/tables/usePipelineF
 import { RuntimeStateKF, runtimeStateLabels } from '#~/concepts/pipelines/kfTypes';
 import DashboardDatePicker from '#~/components/DashboardDatePicker';
 import { PipelineRunVersionsContext } from '#~/pages/pipelines/global/runs/PipelineRunVersionsContext';
-import { PipelineVersionFilterSelector } from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
+import {
+  ExperimentFilterSelector,
+  PipelineVersionFilterSelector,
+} from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
 import MlflowExperimentSelector from '#~/concepts/mlflow/MlflowExperimentSelector';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
+import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 
 export type FilterProps = Pick<
   React.ComponentProps<typeof PipelineFilterBar>,
@@ -28,6 +32,7 @@ const PipelineRunTableToolbarBase: React.FC<PipelineRunTableToolbarBaseProps> = 
   ...toolbarProps
 }) => {
   const { versions } = React.useContext(PipelineRunVersionsContext);
+  const { experiments } = React.useContext(PipelineRunExperimentsContext);
   const { namespace } = usePipelinesAPI();
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
@@ -52,13 +57,11 @@ const PipelineRunTableToolbarBase: React.FC<PipelineRunTableToolbarBaseProps> = 
             onChange={(_event, value) => onChange(value)}
           />
         ),
-        [FilterOptions.RUN_GROUP]: ({ onChange, ...props }) => (
-          <TextInput
-            {...props}
-            data-testid="search-for-run-group-name"
-            aria-label="Search for a run group name"
-            placeholder="Search..."
-            onChange={(_event, value) => onChange(value)}
+        [FilterOptions.RUN_GROUP]: ({ onChange, value }) => (
+          <ExperimentFilterSelector
+            resources={experiments}
+            selection={value}
+            onSelect={(experiment) => onChange(experiment.display_name)}
           />
         ),
         [FilterOptions.PIPELINE_VERSION]: ({ onChange, label }) => (

--- a/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbarBase.tsx
+++ b/frontend/src/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbarBase.tsx
@@ -6,13 +6,13 @@ import { FilterOptions } from '#~/concepts/pipelines/content/tables/usePipelineF
 import { RuntimeStateKF, runtimeStateLabels } from '#~/concepts/pipelines/kfTypes';
 import DashboardDatePicker from '#~/components/DashboardDatePicker';
 import { PipelineRunVersionsContext } from '#~/pages/pipelines/global/runs/PipelineRunVersionsContext';
+import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 import {
   ExperimentFilterSelector,
   PipelineVersionFilterSelector,
 } from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
 import MlflowExperimentSelector from '#~/concepts/mlflow/MlflowExperimentSelector';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
-import { PipelineRunExperimentsContext } from '#~/pages/pipelines/global/runs/PipelineRunExperimentsContext';
 
 export type FilterProps = Pick<
   React.ComponentProps<typeof PipelineFilterBar>,
@@ -57,11 +57,11 @@ const PipelineRunTableToolbarBase: React.FC<PipelineRunTableToolbarBaseProps> = 
             onChange={(_event, value) => onChange(value)}
           />
         ),
-        [FilterOptions.RUN_GROUP]: ({ onChange, value }) => (
+        [FilterOptions.RUN_GROUP]: ({ onChange, label }) => (
           <ExperimentFilterSelector
             resources={experiments}
-            selection={value}
-            onSelect={(experiment) => onChange(experiment.display_name)}
+            selection={label}
+            onSelect={(runGroup) => onChange(runGroup.experiment_id, runGroup.display_name)}
           />
         ),
         [FilterOptions.PIPELINE_VERSION]: ({ onChange, label }) => (

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -69,14 +69,14 @@ const resolveExperimentPredicate = (
   if (!runGroupName) {
     return undefined;
   }
-  const lowerName = runGroupName.toLowerCase();
-  const matchingIds = experiments
-    .filter((e) => e.display_name.toLowerCase().includes(lowerName))
-    .map((e) => e.experiment_id);
+  const match = experiments.find((e) => e.display_name === runGroupName);
+  if (!match) {
+    return undefined;
+  }
   return {
     key: 'experiment_id',
-    operation: PipelinesFilterOp.IN,
-    string_values: { values: matchingIds },
+    operation: PipelinesFilterOp.EQUALS,
+    string_value: match.experiment_id,
   };
 };
 

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -23,7 +23,22 @@ export enum FilterOptions {
   MLFLOW_EXPERIMENT = 'mlflow_experiment',
 }
 
-const LEGACY_EXPERIMENT_FILTER_PARAM = 'experiment';
+export const LEGACY_EXPERIMENT_FILTER_PARAM = 'experiment';
+
+export const buildLegacyExperimentFilterUrl = (
+  pathname: string,
+  experimentId: string | undefined,
+): string => {
+  if (!experimentId) {
+    return pathname;
+  }
+
+  const searchParams = new URLSearchParams({
+    [LEGACY_EXPERIMENT_FILTER_PARAM]: experimentId,
+  });
+
+  return `${pathname}?${searchParams.toString()}`;
+};
 
 export const getDataValue = (data: string | { value: string } | undefined): string | undefined => {
   if (typeof data === 'string' || typeof data === 'undefined') {

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
-  ExperimentKF,
   PipelinesFilterOp,
   PipelinesFilterPredicate,
+  runtimeStateLabels,
 } from '#~/concepts/pipelines/kfTypes';
 
 import { PipelinesFilter } from '#~/concepts/pipelines/types';
@@ -41,53 +41,14 @@ const defaultFilterData: FilterProps['filterData'] = {
   [FilterOptions.NAME]: '',
   [FilterOptions.CREATED_AT]: '',
   [FilterOptions.STATUS]: '',
-  [FilterOptions.RUN_GROUP]: '',
+  [FilterOptions.RUN_GROUP]: undefined,
   [FilterOptions.PIPELINE_VERSION]: undefined,
   [FilterOptions.MLFLOW_EXPERIMENT]: '',
 };
 
-const resolveExperimentPredicate = (
-  runGroupName: string | undefined,
-  experiments: ExperimentKF[],
-  legacyExperimentRawId?: string,
-  legacyExperimentId?: string,
-): PipelinesFilterPredicate | undefined => {
-  if (legacyExperimentRawId) {
-    return {
-      key: 'experiment_id',
-      operation: PipelinesFilterOp.EQUALS,
-      string_value: legacyExperimentRawId,
-    };
-  }
-  if (legacyExperimentId) {
-    return {
-      key: 'experiment_id',
-      operation: PipelinesFilterOp.EQUALS,
-      string_value: legacyExperimentId,
-    };
-  }
-  if (!runGroupName) {
-    return undefined;
-  }
-  const match = experiments.find((e) => e.display_name === runGroupName);
-  if (!match) {
-    return undefined;
-  }
-  return {
-    key: 'experiment_id',
-    operation: PipelinesFilterOp.EQUALS,
-    string_value: match.experiment_id,
-  };
-};
-
-const EMPTY_EXPERIMENTS: ExperimentKF[] = [];
-
 const useSetFilter = (
   setFilter: (filter?: PipelinesFilter) => void,
   filterData: FilterProps['filterData'],
-  experiments: ExperimentKF[] = EMPTY_EXPERIMENTS,
-  legacyExperimentRawId?: string,
-  legacyExperimentId?: string,
 ) => {
   const doSetFilter = React.useCallback(
     (data: FilterProps['filterData']) => {
@@ -95,7 +56,7 @@ const useSetFilter = (
       const runName = getDataValue(data[FilterOptions.NAME]);
       const startedDateTime = getDataValue(data[FilterOptions.CREATED_AT]);
       const state = getDataValue(data[FilterOptions.STATUS]);
-      const runGroupName = getDataValue(data[FilterOptions.RUN_GROUP]);
+      const runGroupId = getDataValue(data[FilterOptions.RUN_GROUP]);
       const pipelineVersionId = getDataValue(data[FilterOptions.PIPELINE_VERSION]);
 
       if (runName) {
@@ -115,21 +76,21 @@ const useSetFilter = (
       }
 
       if (state) {
+        const stateEnumValue =
+          Object.entries(runtimeStateLabels).find(([, label]) => label === state)?.[0] ?? state;
         predicates.push({
           key: 'state',
           operation: PipelinesFilterOp.EQUALS,
-          string_value: state,
+          string_value: stateEnumValue,
         });
       }
 
-      const experimentPredicate = resolveExperimentPredicate(
-        runGroupName,
-        experiments,
-        legacyExperimentRawId,
-        legacyExperimentId,
-      );
-      if (experimentPredicate) {
-        predicates.push(experimentPredicate);
+      if (runGroupId) {
+        predicates.push({
+          key: 'experiment_id',
+          operation: PipelinesFilterOp.EQUALS,
+          string_value: runGroupId,
+        });
       }
 
       if (pipelineVersionId) {
@@ -148,7 +109,7 @@ const useSetFilter = (
           : undefined,
       );
     },
-    [setFilter, experiments, legacyExperimentRawId, legacyExperimentId],
+    [setFilter],
   );
 
   const doSetFilterDebounced = useDebounceCallback(doSetFilter);
@@ -162,18 +123,19 @@ const useSetFilter = (
   } = filterData;
 
   const pipelineVersionId = getDataValue(pipelineVersion);
+  const runGroupId = getDataValue(runGroup);
 
   React.useEffect(() => {
     doSetFilterDebounced(filterData);
-    // debounce filter change for text input changes
+    // debounce filter change for name changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [doSetFilterDebounced, name, runGroup]);
+  }, [doSetFilterDebounced, name]);
 
   React.useEffect(() => {
     doSetFilterDebounced.cancel();
     doSetFilter(filterData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [createdAt, state, pipelineVersionId, doSetFilter]);
+  }, [createdAt, state, pipelineVersionId, runGroupId, doSetFilter]);
 };
 
 const usePipelineFilter = (setFilter: (filter?: PipelinesFilter) => void): FilterProps => {
@@ -204,46 +166,36 @@ export const usePipelineFilterSearchParams = (
   const { experiments } = React.useContext(PipelineRunExperimentsContext);
   const { status: isMlflowAvailable } = useIsAreaAvailable(SupportedArea.MLFLOW_PIPELINES);
 
-  const isLegacyParam =
-    !searchParams.has(FilterOptions.RUN_GROUP) && searchParams.has(LEGACY_EXPERIMENT_FILTER_PARAM);
-
-  const {
-    filterData: filterDataFromSearchParams,
-    legacyExperimentRawId,
-    legacyExperimentId,
-  } = React.useMemo(() => {
-    const runGroupFromParams =
+  const filterDataFromSearchParams = React.useMemo(() => {
+    const runGroupParam =
       searchParams.get(FilterOptions.RUN_GROUP) || searchParams.get(LEGACY_EXPERIMENT_FILTER_PARAM);
-    const legacyExperimentRawIdFromParams = isLegacyParam
-      ? searchParams.get(LEGACY_EXPERIMENT_FILTER_PARAM) || undefined
-      : undefined;
     const versionFound = versions.find(
       (v) => v.pipeline_version_id === searchParams.get(FilterOptions.PIPELINE_VERSION),
     );
-    const experimentFoundById = experiments.find((e) => e.experiment_id === runGroupFromParams);
+    const runGroupFound = experiments.find((e) => e.experiment_id === runGroupParam);
     return {
-      legacyExperimentRawId: legacyExperimentRawIdFromParams,
-      legacyExperimentId:
-        isLegacyParam && experimentFoundById ? experimentFoundById.experiment_id : undefined,
-      filterData: {
-        [FilterOptions.NAME]: searchParams.get(FilterOptions.NAME) || '',
-        [FilterOptions.CREATED_AT]: searchParams.get(FilterOptions.CREATED_AT) || '',
-        [FilterOptions.STATUS]: searchParams.get(FilterOptions.STATUS) || '',
-        [FilterOptions.PIPELINE_VERSION]: versionFound
-          ? {
-              value: versionFound.pipeline_version_id,
-              label: versionFound.display_name,
-            }
-          : searchParams.get(FilterOptions.PIPELINE_VERSION) || undefined,
-        [FilterOptions.RUN_GROUP]: experimentFoundById
-          ? experimentFoundById.display_name
-          : runGroupFromParams || '',
-        [FilterOptions.MLFLOW_EXPERIMENT]: isMlflowAvailable
-          ? searchParams.get(FilterOptions.MLFLOW_EXPERIMENT) || ''
-          : '',
-      },
+      [FilterOptions.NAME]: searchParams.get(FilterOptions.NAME) || '',
+      [FilterOptions.CREATED_AT]: searchParams.get(FilterOptions.CREATED_AT) || '',
+      [FilterOptions.STATUS]: searchParams.get(FilterOptions.STATUS) || '',
+      [FilterOptions.PIPELINE_VERSION]: versionFound
+        ? {
+            value: versionFound.pipeline_version_id,
+            label: versionFound.display_name,
+          }
+        : searchParams.get(FilterOptions.PIPELINE_VERSION) || undefined,
+      [FilterOptions.RUN_GROUP]: runGroupFound
+        ? {
+            value: runGroupFound.experiment_id,
+            label: runGroupFound.display_name,
+          }
+        : runGroupParam
+        ? { value: runGroupParam, label: 'Loading...' }
+        : undefined,
+      [FilterOptions.MLFLOW_EXPERIMENT]: isMlflowAvailable
+        ? searchParams.get(FilterOptions.MLFLOW_EXPERIMENT) || ''
+        : '',
     };
-  }, [experiments, isLegacyParam, isMlflowAvailable, searchParams, versions]);
+  }, [experiments, isMlflowAvailable, searchParams, versions]);
 
   React.useEffect(() => {
     if (isMlflowAvailable || !searchParams.has(FilterOptions.MLFLOW_EXPERIMENT)) {
@@ -254,13 +206,7 @@ export const usePipelineFilterSearchParams = (
     setSearchParams(nextParams, { replace: true });
   }, [isMlflowAvailable, searchParams, setSearchParams]);
 
-  useSetFilter(
-    setFilter,
-    filterDataFromSearchParams,
-    experiments,
-    legacyExperimentRawId,
-    legacyExperimentId,
-  );
+  useSetFilter(setFilter, filterDataFromSearchParams);
 
   const toolbarProps: FilterProps = {
     filterData: filterDataFromSearchParams,
@@ -280,7 +226,6 @@ export const usePipelineFilterSearchParams = (
       [setSearchParams, searchParams],
     ),
     onClearFilters: React.useCallback(() => {
-      // In case of deleting manage run search params
       Object.values(FilterOptions).forEach((value) => searchParams.delete(value));
       searchParams.delete(LEGACY_EXPERIMENT_FILTER_PARAM);
       setSearchParams(searchParams, { replace: true });

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -189,7 +189,7 @@ export const usePipelineFilterSearchParams = (
             label: runGroupFound.display_name,
           }
         : runGroupParam
-        ? { value: runGroupParam, label: 'Loading...' }
+        ? { value: runGroupParam, label: runGroupParam }
         : undefined,
       [FilterOptions.MLFLOW_EXPERIMENT]: isMlflowAvailable
         ? searchParams.get(FilterOptions.MLFLOW_EXPERIMENT) || ''

--- a/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
+++ b/frontend/src/concepts/pipelines/content/tables/usePipelineFilter.ts
@@ -25,21 +25,6 @@ export enum FilterOptions {
 
 export const LEGACY_EXPERIMENT_FILTER_PARAM = 'experiment';
 
-export const buildLegacyExperimentFilterUrl = (
-  pathname: string,
-  experimentId: string | undefined,
-): string => {
-  if (!experimentId) {
-    return pathname;
-  }
-
-  const searchParams = new URLSearchParams({
-    [LEGACY_EXPERIMENT_FILTER_PARAM]: experimentId,
-  });
-
-  return `${pathname}?${searchParams.toString()}`;
-};
-
 export const getDataValue = (data: string | { value: string } | undefined): string | undefined => {
   if (typeof data === 'string' || typeof data === 'undefined') {
     return data;

--- a/frontend/src/pages/pipelines/global/experiments/ExperimentPipelineRuns.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/ExperimentPipelineRuns.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BreadcrumbItem, Label, Truncate } from '@patternfly/react-core';
 import { Outlet } from 'react-router';
 import {
-  experimentRunsPageDescription,
+  runGroupRunsPageDescription,
   pipelineRunsPageTitle,
 } from '#~/pages/pipelines/global/runs/const';
 import PipelineCoreApplicationPage from '#~/pages/pipelines/global/PipelineCoreApplicationPage';
@@ -26,7 +26,7 @@ const ExperimentPipelineRuns: PipelineCoreDetailsPageComponent = ({ breadcrumbPa
       title={
         <TitleWithIcon title={pipelineRunsPageTitle} objectType={ProjectObjectType.pipelineRun} />
       }
-      description={experimentRunsPageDescription}
+      description={runGroupRunsPageDescription}
       getRedirectPath={experimentsBaseRoute}
       overrideChildPadding
       accessDomain="pipeline runs"

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
@@ -64,14 +64,15 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
   } = useCheckboxTable(pageRunIds, selectedRunIds, true);
   const updateHref = compareRunsRoute(namespace, selections, experiment?.experiment_id);
   const isUpdateDisabled = selections.length < 1 || selections.length > 10;
+  const { onFilterUpdate } = filterProps;
   const handleRunGroupClick = React.useCallback(
     (clickedExperiment: ExperimentKF) => {
-      filterProps.onFilterUpdate(FilterOptions.RUN_GROUP, {
+      onFilterUpdate(FilterOptions.RUN_GROUP, {
         value: clickedExperiment.experiment_id,
         label: clickedExperiment.display_name,
       });
     },
-    [filterProps],
+    [onFilterUpdate],
   );
 
   const rowRenderer = React.useCallback(

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
@@ -13,7 +13,7 @@ import PipelineRunTable from '#~/concepts/pipelines/content/tables/pipelineRun/P
 import PipelineRunTableRow from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableRow';
 import PipelineRunTableToolbar from '#~/concepts/pipelines/content/tables/pipelineRun/PipelineRunTableToolbar';
 import { filterByMlflowExperiment } from '#~/concepts/pipelines/content/tables/pipelineRun/utils';
-import { PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
+import { ExperimentKF, PipelineRunKF } from '#~/concepts/pipelines/kfTypes';
 import { compareRunsRoute } from '#~/routes/pipelines/runs';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import { ExperimentContext } from '#~/pages/pipelines/global/experiments/ExperimentContext';
@@ -64,6 +64,12 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
   } = useCheckboxTable(pageRunIds, selectedRunIds, true);
   const updateHref = compareRunsRoute(namespace, selections, experiment?.experiment_id);
   const isUpdateDisabled = selections.length < 1 || selections.length > 10;
+  const handleRunGroupClick = React.useCallback(
+    (clickedExperiment: ExperimentKF) => {
+      filterProps.onFilterUpdate(FilterOptions.RUN_GROUP, clickedExperiment.display_name);
+    },
+    [filterProps],
+  );
 
   const rowRenderer = React.useCallback(
     (run: PipelineRunKF) => {
@@ -81,6 +87,7 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
           }}
           hasRowActions={false}
           run={run}
+          onRunGroupClick={handleRunGroupClick}
           mlflow={{
             isAvailable: isMlflowAvailable,
             experiments: mlflowExperiments,
@@ -89,7 +96,14 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
         />
       );
     },
-    [selections, toggleSelection, isMlflowAvailable, mlflowExperiments, mlflowExperimentsLoaded],
+    [
+      selections,
+      toggleSelection,
+      handleRunGroupClick,
+      isMlflowAvailable,
+      mlflowExperiments,
+      mlflowExperimentsLoaded,
+    ],
   );
 
   return (

--- a/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
+++ b/frontend/src/pages/pipelines/global/experiments/compareRuns/ManageRunsTable.tsx
@@ -66,7 +66,10 @@ export const ManageRunsTable: React.FC<ManageRunsTableProps> = ({
   const isUpdateDisabled = selections.length < 1 || selections.length > 10;
   const handleRunGroupClick = React.useCallback(
     (clickedExperiment: ExperimentKF) => {
-      filterProps.onFilterUpdate(FilterOptions.RUN_GROUP, clickedExperiment.display_name);
+      filterProps.onFilterUpdate(FilterOptions.RUN_GROUP, {
+        value: clickedExperiment.experiment_id,
+        label: clickedExperiment.display_name,
+      });
     },
     [filterProps],
   );

--- a/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
+++ b/frontend/src/pages/pipelines/global/modelCustomization/FineTunePageFooter.tsx
@@ -40,7 +40,6 @@ import {
 } from '#~/pages/pipelines/global/modelCustomization/utils';
 import { genRandomChars } from '#~/utilities/string';
 import { RunTypeOption } from '#~/concepts/pipelines/content/createRun/types';
-import { DEFAULT_RUN_GROUP } from '#~/concepts/pipelines/content/createRun/const';
 import { ValidationContext } from '#~/utilities/useValidation';
 import { FineTunedModelNewConnectionContext } from '#~/pages/pipelines/global/modelCustomization/fineTunedModelSection/FineTunedModelNewConnectionContext';
 import { InferenceServiceStorageType } from '#~/pages/modelServing/screens/types';
@@ -103,7 +102,6 @@ const FineTunePageFooter: React.FC<FineTunePageFooterProps> = ({
     runType: { type: RunTypeOption.ONE_TRIGGER },
     pipeline: ilabPipeline,
     version: ilabPipelineVersion,
-    runGroup: DEFAULT_RUN_GROUP,
     mlflow: { isExperimentTrackingEnabled: false },
   });
 

--- a/frontend/src/pages/pipelines/global/runs/GlobalPipelineRuns.tsx
+++ b/frontend/src/pages/pipelines/global/runs/GlobalPipelineRuns.tsx
@@ -8,7 +8,7 @@ import { pipelineRunsBaseRoute } from '#~/routes/pipelines/runs';
 import { ProjectObjectType } from '#~/concepts/design/utils';
 import TitleWithIcon from '#~/concepts/design/TitleWithIcon';
 import {
-  experimentRunsPageDescription,
+  runGroupRunsPageDescription,
   pipelineRunsPageTitle,
 } from '#~/pages/pipelines/global/runs/const';
 import GlobalPipelineRunsTabs from '#~/pages/pipelines/global/runs/GlobalPipelineRunsTabs';
@@ -29,7 +29,7 @@ const GlobalPipelineRuns: React.FC<GlobalPipelineRunsProps> = ({ tab }) => {
       title={
         <TitleWithIcon title={pipelineRunsPageTitle} objectType={ProjectObjectType.pipelineRun} />
       }
-      description={experimentRunsPageDescription}
+      description={runGroupRunsPageDescription}
       headerAction={<PipelineServerActions isDisabled={!pipelinesAPI.pipelinesServer.installed} />}
       getRedirectPath={pipelineRunsBaseRoute}
       overrideTimeout

--- a/frontend/src/pages/pipelines/global/runs/const.ts
+++ b/frontend/src/pages/pipelines/global/runs/const.ts
@@ -1,6 +1,6 @@
 export const pipelineRunsPageTitle = 'Runs';
 export const pipelineRunsPageDescription = 'Manage and view your runs.';
-export const experimentRunsPageDescription = 'Manage your experiment runs and schedules.';
+export const experimentRunsPageDescription = 'Manage your run group runs and schedules.';
 export const runGroupCreateModalPopoverText =
   'Run groups were formerly known as pipeline experiments. Use this field to group your pipeline runs for easier management.';
 export const runGroupTablePopoverText =

--- a/frontend/src/pages/pipelines/global/runs/const.ts
+++ b/frontend/src/pages/pipelines/global/runs/const.ts
@@ -1,6 +1,6 @@
 export const pipelineRunsPageTitle = 'Runs';
 export const pipelineRunsPageDescription = 'Manage and view your runs.';
-export const experimentRunsPageDescription = 'Manage your run group runs and schedules.';
+export const runGroupRunsPageDescription = 'Manage your run group runs and schedules.';
 export const runGroupCreateModalPopoverText =
   'Run groups were formerly known as pipeline experiments. Use this field to group your pipeline runs for easier management.';
 export const runGroupTablePopoverText =

--- a/packages/cypress/cypress/fixtures/e2e/pipelines/testCreateRunDeletePipeline.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/pipelines/testCreateRunDeletePipeline.yaml
@@ -4,6 +4,6 @@ pipelineName: test-iris-pipeline
 pipelineDescription: ""
 runName: test-pipelines-run
 runDescription: "Run Description"
-runGroupName: "Default"
+experimentName: "Default"
 dspaSecretName: test-custom-pip-dspa-secret
 pipelineUrl: ""

--- a/packages/cypress/cypress/fixtures/e2e/pipelines/testPipelines.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/pipelines/testPipelines.yaml
@@ -4,6 +4,6 @@ pipelineName: test-pipelines-pipeline
 pipelineDescription: "Pipeline Description"
 runName: test-pipelines-run
 runDescription: "Run Description"
-runGroupName: "Default"
+experimentName: "Default"
 dspaSecretName: dashboard-dspa-secret
 pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml

--- a/packages/cypress/cypress/fixtures/e2e/pipelines/testSchedulePipeline.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/pipelines/testSchedulePipeline.yaml
@@ -4,6 +4,6 @@ pipelineName: test-scheduled-pipeline
 pipelineDescription: Pipeline scheduled via E2E
 scheduleName: test-scheduled-run
 scheduleDescription: Scheduled run created by E2E
-runGroupName: "Default"
+experimentName: "Default"
 runEveryUnit: "Minute"
 pipelineUrl: https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/heads/main/packages/cypress/resources/pipelines_samples/dummy_pipeline_compiled.yaml

--- a/packages/cypress/cypress/pages/pipelines/createRunPage.ts
+++ b/packages/cypress/cypress/pages/pipelines/createRunPage.ts
@@ -33,6 +33,8 @@ export class CreateRunPage {
 
   private type;
 
+  runGroupSelect = new SearchSelector('run-group-selector');
+
   mlflowExperimentSelect = new SearchSelector('mlflow-experiment-selector');
 
   pipelineSelect = new SearchSelector('pipeline-selector');
@@ -55,8 +57,8 @@ export class CreateRunPage {
     return cy.findByTestId('run-description');
   }
 
-  findRunGroupInput(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().findByTestId('run-group-field');
+  findRunGroupToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.runGroupSelect.findToggleButton();
   }
 
   findProjectNavigatorLink(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -225,7 +227,7 @@ export class CreateRunPage {
   }
 
   fillRunGroup(value: string): void {
-    this.findRunGroupInput().clear().type(value);
+    this.runGroupSelect.openAndSelectItem(value);
   }
 
   selectMlflowExperimentByName(name: string): void {

--- a/packages/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -11,8 +11,14 @@ class PipelineRunFilterBar extends PipelineFilterBar {
     return cy.findByTestId('search-for-run-name');
   }
 
-  findRunGroupInput() {
-    return cy.findByTestId('search-for-run-group-name');
+  findRunGroupSelect() {
+    return cy.findByTestId('run-group-toggle-button');
+  }
+
+  selectRunGroupByName(name: string) {
+    this.findRunGroupSelect().click();
+    cy.findByTestId('run-group-selector-table-list').find('td').contains(name).click();
+    return this;
   }
 
   findMlflowExperimentSelect() {

--- a/packages/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineFilterBar.ts
@@ -17,7 +17,10 @@ class PipelineRunFilterBar extends PipelineFilterBar {
 
   selectRunGroupByName(name: string) {
     this.findRunGroupSelect().click();
-    cy.findByTestId('run-group-selector-table-list').find('td').contains(name).click();
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    cy.findByTestId('run-group-selector-table-list')
+      .contains('td', new RegExp(`^${escaped}$`))
+      .click();
     return this;
   }
 

--- a/packages/cypress/cypress/tests/e2e/pipelines/createRunDeletePipelineCustomPipMirror.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/pipelines/createRunDeletePipelineCustomPipMirror.cy.ts
@@ -94,7 +94,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
           pipelineRunsGlobal.findCreateRunButton().click();
 
           cy.step('Run the pipeline from the Runs view');
-          createRunPage.fillRunGroup(testData.runGroupName);
+          createRunPage.fillRunGroup(testData.experimentName);
           createRunPage.fillName(testData.runName);
           createRunPage.fillDescription(testData.runDescription);
           createRunPage.pipelineSelect.openAndSelectItem(testData.pipelineName);

--- a/packages/cypress/cypress/tests/e2e/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/pipelines/pipelines.cy.ts
@@ -68,7 +68,7 @@ describe('An admin user can import and run a pipeline', { testIsolation: false }
 
       cy.step('Run the pipeline from the Actions button in the pipeline detail view');
       pipelineDetails.selectActionDropdownItem('Create run');
-      createRunPage.fillRunGroup(testData.runGroupName);
+      createRunPage.fillRunGroup(testData.experimentName);
       createRunPage.fillName(testData.runName);
       createRunPage.fillDescription(testData.runDescription);
       createRunPage.findSubmitButton().click();

--- a/packages/cypress/cypress/tests/e2e/pipelines/testSchedulePipeline.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/pipelines/testSchedulePipeline.cy.ts
@@ -21,7 +21,7 @@ describe('Verify that a pipeline can be scheduled to run', { testIsolation: fals
   let scheduleName = '';
   let scheduleDescription = '';
   let pipelineUrl = '';
-  let runGroupName = '';
+  let experimentName = '';
   let runEveryUnit = '';
 
   retryableBefore(() => {
@@ -33,7 +33,7 @@ describe('Verify that a pipeline can be scheduled to run', { testIsolation: fals
       scheduleName = cfg.scheduleName;
       scheduleDescription = cfg.scheduleDescription;
       pipelineUrl = cfg.pipelineUrl;
-      runGroupName = cfg.runGroupName;
+      experimentName = cfg.experimentName;
       runEveryUnit = cfg.runEveryUnit;
       provisionProjectForPipelines(projectName, cfg.dspaSecretName, awsBucket);
     });
@@ -78,7 +78,7 @@ describe('Verify that a pipeline can be scheduled to run', { testIsolation: fals
       pipelineRunsGlobal.findScheduleRunButton().click();
 
       cy.step('Schedule the pipeline to run every 1 minute');
-      createSchedulePage.fillRunGroup(runGroupName);
+      createSchedulePage.fillRunGroup(experimentName);
       createSchedulePage.fillName(scheduleName);
       createSchedulePage.fillDescription(scheduleDescription);
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -365,7 +365,7 @@ describe('Pipeline create runs', () => {
       paramsSection.fillParamInputById('neighbors', '2');
       paramsSection.fillParamInputById('standard_scaler', 'yes');
 
-      createRunPage.findRunGroupToggle().should('have.text', 'Select a run group');
+      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Select a run group');
       createRunPage.findSubmitButton().should('be.disabled');
     });
 
@@ -448,7 +448,7 @@ describe('Pipeline create runs', () => {
       cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createRunPage.fillName('New run');
       createRunPage.fillDescription(veryLongDesc);
-      createRunPage.findRunGroupToggle().should('have.text', 'Select a run group');
+      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Select a run group');
       createRunPage.fillRunGroup('Test experiment 1');
       createRunPage.pipelineSelect.findToggleButton().should('not.be.disabled').click();
       createRunPage.selectPipelineByName('Test pipeline');
@@ -520,7 +520,9 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values & submit
-      duplicateRunPage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
+      duplicateRunPage.runGroupSelect
+        .findToggleButton()
+        .should('have.text', mockExperiment.display_name);
       duplicateRunPage.pipelineSelect
         .findToggleButton()
         .should('have.text', mockPipeline.display_name);
@@ -911,9 +913,9 @@ describe('Pipeline create runs', () => {
       );
     });
 
-    it('shows the run group input instead of the experiment dropdown', () => {
+    it('shows and opens the create new experiment button in the experiment dropdown', () => {
       pipelineRunsGlobal.visit(projectName);
-      // Mock experiments for run group validation
+      // Mock experiments for the dropdown
       createRunPage.mockGetExperiments(projectName, mockExperiments);
       createRunPage.mockGetPipelines(projectName, [mockPipeline]);
       createRunPage.mockGetPipelineVersions(
@@ -926,10 +928,10 @@ describe('Pipeline create runs', () => {
       pipelineRunsGlobal.findCreateRunButton().click();
       createRunPage.find();
 
-      createRunPage
-        .findRunGroupToggle()
+      createRunPage.runGroupSelect
+        .findToggleButton()
         .should('be.visible')
-        .and('have.text', 'Select a run group');
+        .and('contain.text', 'Select a run group');
     });
   });
 
@@ -957,7 +959,9 @@ describe('Pipeline create runs', () => {
 
     it('creates a schedule', () => {
       createScheduleRunCommonTest();
-      createSchedulePage.findRunGroupToggle().should('have.text', 'Select a run group');
+      createSchedulePage.runGroupSelect
+        .findToggleButton()
+        .should('contain.text', 'Select a run group');
       createSchedulePage.fillRunGroup('Test experiment 1');
       createSchedulePage
         .mockCreateRecurringRun(projectName, mockPipelineVersion, createRecurringRunParams)
@@ -1146,7 +1150,9 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values & submit
-      duplicateSchedulePage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
+      duplicateSchedulePage.runGroupSelect
+        .findToggleButton()
+        .should('have.text', mockExperiment.display_name);
       duplicateSchedulePage.pipelineSelect
         .findToggleButton()
         .should('have.text', mockPipeline.display_name);
@@ -1200,10 +1206,7 @@ describe('Pipeline create runs', () => {
       const mockExperiment = { ...mockExperiments[0], storage_state: StorageStateKF.ARCHIVED };
 
       // Mock experiments, pipelines & versions for form select dropdowns
-      duplicateSchedulePage.mockGetExperiments(projectName, [
-        mockExperiment,
-        ...mockExperiments.slice(1),
-      ]);
+      duplicateSchedulePage.mockGetExperiments(projectName, mockExperiments);
       duplicateSchedulePage.mockGetPipelines(projectName, [mockPipeline]);
       duplicateSchedulePage.mockGetPipelineVersions(
         projectName,
@@ -1226,7 +1229,9 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values
-      duplicateSchedulePage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
+      duplicateSchedulePage.runGroupSelect
+        .findToggleButton()
+        .should('have.text', mockExperiment.display_name);
     });
 
     it('shows cron & periodic fields', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -365,7 +365,7 @@ describe('Pipeline create runs', () => {
       paramsSection.fillParamInputById('neighbors', '2');
       paramsSection.fillParamInputById('standard_scaler', 'yes');
 
-      createRunPage.findRunGroupInput().should('have.value', '');
+      createRunPage.findRunGroupToggle().should('have.text', 'Select a run group');
       createRunPage.findSubmitButton().should('be.disabled');
     });
 
@@ -448,7 +448,7 @@ describe('Pipeline create runs', () => {
       cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createRunPage.fillName('New run');
       createRunPage.fillDescription(veryLongDesc);
-      createRunPage.findRunGroupInput().should('have.value', '');
+      createRunPage.findRunGroupToggle().should('have.text', 'Select a run group');
       createRunPage.fillRunGroup('Test experiment 1');
       createRunPage.pipelineSelect.findToggleButton().should('not.be.disabled').click();
       createRunPage.selectPipelineByName('Test pipeline');
@@ -520,7 +520,7 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values & submit
-      duplicateRunPage.findRunGroupInput().should('have.value', mockExperiment.display_name);
+      duplicateRunPage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
       duplicateRunPage.pipelineSelect
         .findToggleButton()
         .should('have.text', mockPipeline.display_name);
@@ -926,7 +926,10 @@ describe('Pipeline create runs', () => {
       pipelineRunsGlobal.findCreateRunButton().click();
       createRunPage.find();
 
-      createRunPage.findRunGroupInput().should('be.visible').and('have.value', '');
+      createRunPage
+        .findRunGroupToggle()
+        .should('be.visible')
+        .and('have.text', 'Select a run group');
     });
   });
 
@@ -954,7 +957,7 @@ describe('Pipeline create runs', () => {
 
     it('creates a schedule', () => {
       createScheduleRunCommonTest();
-      createSchedulePage.findRunGroupInput().should('have.value', '');
+      createSchedulePage.findRunGroupToggle().should('have.text', 'Select a run group');
       createSchedulePage.fillRunGroup('Test experiment 1');
       createSchedulePage
         .mockCreateRecurringRun(projectName, mockPipelineVersion, createRecurringRunParams)
@@ -1143,7 +1146,7 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values & submit
-      duplicateSchedulePage.findRunGroupInput().should('have.value', mockExperiment.display_name);
+      duplicateSchedulePage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
       duplicateSchedulePage.pipelineSelect
         .findToggleButton()
         .should('have.text', mockPipeline.display_name);
@@ -1223,7 +1226,7 @@ describe('Pipeline create runs', () => {
       );
 
       // Verify pre-populated values
-      duplicateSchedulePage.findRunGroupInput().should('have.value', mockExperiment.display_name);
+      duplicateSchedulePage.findRunGroupToggle().should('have.text', mockExperiment.display_name);
     });
 
     it('shows cron & periodic fields', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineCreateRuns.cy.ts
@@ -365,8 +365,8 @@ describe('Pipeline create runs', () => {
       paramsSection.fillParamInputById('neighbors', '2');
       paramsSection.fillParamInputById('standard_scaler', 'yes');
 
-      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Select a run group');
-      createRunPage.findSubmitButton().should('be.disabled');
+      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Default');
+      createRunPage.findSubmitButton().should('be.enabled');
     });
 
     it('switches to scheduled runs from triggered', () => {
@@ -448,7 +448,7 @@ describe('Pipeline create runs', () => {
       cy.findByTestId('duplicate-name-help-text').should('be.visible');
       createRunPage.fillName('New run');
       createRunPage.fillDescription(veryLongDesc);
-      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Select a run group');
+      createRunPage.runGroupSelect.findToggleButton().should('contain.text', 'Default');
       createRunPage.fillRunGroup('Test experiment 1');
       createRunPage.pipelineSelect.findToggleButton().should('not.be.disabled').click();
       createRunPage.selectPipelineByName('Test pipeline');
@@ -931,7 +931,7 @@ describe('Pipeline create runs', () => {
       createRunPage.runGroupSelect
         .findToggleButton()
         .should('be.visible')
-        .and('contain.text', 'Select a run group');
+        .and('contain.text', 'Default');
     });
   });
 
@@ -959,9 +959,7 @@ describe('Pipeline create runs', () => {
 
     it('creates a schedule', () => {
       createScheduleRunCommonTest();
-      createSchedulePage.runGroupSelect
-        .findToggleButton()
-        .should('contain.text', 'Select a run group');
+      createSchedulePage.runGroupSelect.findToggleButton().should('contain.text', 'Default');
       createSchedulePage.fillRunGroup('Test experiment 1');
       createSchedulePage
         .mockCreateRecurringRun(projectName, mockPipelineVersion, createRecurringRunParams)

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineDeleteRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineDeleteRuns.cy.ts
@@ -164,7 +164,6 @@ describe('Test deleting runs', () => {
       expect(interception.request.query).to.eql({
         sort_by: 'created_at desc',
         page_size: '10',
-        filter: encodeURIComponent('{"predicates":[]}'),
       });
 
       pipelineRecurringRunTable.findEmptyState().should('not.exist');
@@ -219,7 +218,6 @@ describe('Test deleting runs', () => {
       expect(interception.request.query).to.eql({
         sort_by: 'created_at desc',
         page_size: '10',
-        filter: encodeURIComponent('{"predicates":[]}'),
       });
     });
     pipelineRecurringRunTable.findEmptyState().should('exist');

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -410,7 +410,7 @@ describe('Pipeline runs', () => {
         it('navigate to duplicate run page', () => {
           duplicateRunPage.mockGetExperiments(projectName, mockExperiments);
           duplicateRunPage.mockGetExperiment(projectName, mockExperiments[0]);
-          pipelineRunsGlobal.visit(projectName, 'active');
+          cy.visitWithLogin(`/develop-train/experiments/${projectName}/test-experiment-1/runs`);
 
           activeRunsTable
             .getRowByName(mockActiveRuns[0].display_name)
@@ -418,7 +418,7 @@ describe('Pipeline runs', () => {
             .click();
 
           verifyRelativeURL(
-            `/develop-train/pipelines/runs/${projectName}/runs/duplicate/${mockActiveRuns[0].run_id}`,
+            `/develop-train/experiments/${projectName}/test-experiment-1/runs/duplicate/${mockActiveRuns[0].run_id}`,
           );
         });
 
@@ -521,7 +521,7 @@ describe('Pipeline runs', () => {
           // Verify initial run rows exist
           activeRunsTable.findRows().should('have.length', 3);
 
-          // Select the "Run group" filter, select a value to filter by
+          // Select the "Run group" filter, enter a value to filter by
           pipelineRunsGlobal
             .findActiveRunsToolbar()
             .within(() => pipelineRunsGlobal.selectFilterByName('Run group'));
@@ -532,6 +532,7 @@ describe('Pipeline runs', () => {
             projectName,
           );
 
+          // Select an experiment to filter by
           pipelineRunFilterBar.selectRunGroupByName('Test Experiment 1');
 
           // Verify only rows with selected experiment exist
@@ -800,7 +801,7 @@ describe('Pipeline runs', () => {
           // Verify initial run rows exist
           archivedRunsTable.findRows().should('have.length', 2);
 
-          // Select the "Run group" filter, select a value to filter by
+          // Select the "Run group" filter, enter a value to filter by
           pipelineRunsGlobal
             .findArchivedRunsToolbar()
             .within(() => pipelineRunsGlobal.selectFilterByName('Run group'));
@@ -811,6 +812,7 @@ describe('Pipeline runs', () => {
             projectName,
           );
 
+          // Select an experiment to filter by
           pipelineRunFilterBar.selectRunGroupByName('Test Experiment 1');
 
           // Verify only rows with selected experiment exist
@@ -1193,15 +1195,16 @@ describe('Pipeline runs', () => {
         it('navigate to duplicate scheduled run page', () => {
           duplicateSchedulePage.mockGetExperiments(projectName, mockExperiments);
           duplicateSchedulePage.mockGetExperiment(projectName, mockExperiments[0]);
-          pipelineRunsGlobal.visit(projectName, 'scheduled');
+          cy.visitWithLogin(`/develop-train/experiments/${projectName}/test-experiment-1/runs`);
 
+          pipelineRunsGlobal.findSchedulesTab().click();
           pipelineRecurringRunTable
             .getRowByName(mockRecurringRuns[0].display_name)
             .findKebabAction('Duplicate')
             .click();
 
           verifyRelativeURL(
-            `/develop-train/pipelines/runs/${projectName}/schedules/duplicate/${mockRecurringRuns[0].recurring_run_id}`,
+            `/develop-train/experiments/${projectName}/test-experiment-1/schedules/duplicate/${mockRecurringRuns[0].recurring_run_id}`,
           );
         });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -521,7 +521,7 @@ describe('Pipeline runs', () => {
           // Verify initial run rows exist
           activeRunsTable.findRows().should('have.length', 3);
 
-          // Select the "Run group" filter, enter a value to filter by
+          // Select the "Run group" filter, select a value to filter by
           pipelineRunsGlobal
             .findActiveRunsToolbar()
             .within(() => pipelineRunsGlobal.selectFilterByName('Run group'));
@@ -532,8 +532,7 @@ describe('Pipeline runs', () => {
             projectName,
           );
 
-          // Type a run group name to filter by
-          pipelineRunFilterBar.findRunGroupInput().type('Test Experiment 1');
+          pipelineRunFilterBar.selectRunGroupByName('Test Experiment 1');
 
           // Verify only rows with selected experiment exist
           activeRunsTable.findRows().should('have.length', 2);
@@ -801,7 +800,7 @@ describe('Pipeline runs', () => {
           // Verify initial run rows exist
           archivedRunsTable.findRows().should('have.length', 2);
 
-          // Select the "Run group" filter, enter a value to filter by
+          // Select the "Run group" filter, select a value to filter by
           pipelineRunsGlobal
             .findArchivedRunsToolbar()
             .within(() => pipelineRunsGlobal.selectFilterByName('Run group'));
@@ -812,8 +811,7 @@ describe('Pipeline runs', () => {
             projectName,
           );
 
-          // Type a run group name to filter by
-          pipelineRunFilterBar.findRunGroupInput().type('Test Experiment 1');
+          pipelineRunFilterBar.selectRunGroupByName('Test Experiment 1');
 
           // Verify only rows with selected experiment exist
           archivedRunsTable.findRows().should('have.length', 1);

--- a/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/runs/pipelineRuns.cy.ts
@@ -418,7 +418,7 @@ describe('Pipeline runs', () => {
             .click();
 
           verifyRelativeURL(
-            `/develop-train/experiments/${projectName}/test-experiment-1/runs/duplicate/${mockActiveRuns[0].run_id}`,
+            `/develop-train/pipelines/runs/${projectName}/runs/duplicate/${mockActiveRuns[0].run_id}`,
           );
         });
 
@@ -1032,7 +1032,6 @@ describe('Pipeline runs', () => {
 
         cy.wait('@getScheduledRuns').then((interception) => {
           expect(interception.request.query).to.eql({
-            filter: encodeURIComponent('{"predicates":[]}'),
             sort_by: 'created_at desc',
             page_size: '10',
           });
@@ -1059,7 +1058,6 @@ describe('Pipeline runs', () => {
 
         cy.wait('@refreshScheduledRuns').then((interception) => {
           expect(interception.request.query).to.eql({
-            filter: encodeURIComponent('{"predicates":[]}'),
             sort_by: 'created_at desc',
             page_size: '10',
             page_token: 'page-2-token',
@@ -1105,7 +1103,6 @@ describe('Pipeline runs', () => {
 
         cy.wait('@refreshPipelineRecurringRuns').then((interception) => {
           expect(interception.request.query).to.eql({
-            filter: encodeURIComponent('{"predicates":[]}'),
             sort_by: 'created_at desc',
             page_size: '10',
             page_token: 'new-page-token',
@@ -1204,7 +1201,7 @@ describe('Pipeline runs', () => {
             .click();
 
           verifyRelativeURL(
-            `/develop-train/experiments/${projectName}/test-experiment-1/schedules/duplicate/${mockRecurringRuns[0].recurring_run_id}`,
+            `/develop-train/pipelines/runs/${projectName}/schedules/duplicate/${mockRecurringRuns[0].recurring_run_id}`,
           );
         });
 

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -658,7 +658,7 @@ export type PipelineTestData = {
   pipelineDescription: string;
   runName: string;
   runDescription: string;
-  runGroupName: string;
+  experimentName: string;
   dspaSecretName: string;
   pipelineUrl: string;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Replaces the free-text run group input on the create/duplicate run form with a typeahead selector dropdown, and makes run group labels clickable in run tables to filter by group.


https://github.com/user-attachments/assets/0266995e-9eef-445e-bc1c-1c29a78b59cd



https://github.com/user-attachments/assets/a7a9af70-bf21-4aa9-8672-b4660ad13b46


<img width="490" height="400" alt="image" src="https://github.com/user-attachments/assets/442e9eb9-e685-4ae2-8ef0-fd60646b4f38" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create or duplicate a run — confirm the "Run group" field is a typeahead dropdown that lists existing run groups, and the "Create run group" modal uses "run group" terminology
2. In the active runs table, click a run group label — verify its filtered by that group
3. In the archived runs table, click a run group label — verify it filters to the archived view for that group
4. In compare runs or manage runs, click a run group label — verify it filters the in-page table by run group name
5. In the schedules table, click a run group label — verify it navigates to the runs page filtered by that group




## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Tested manually.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run group names are now clickable in tables and lists; clicking updates filters or navigates to filtered views.
  * Run creation and toolbar filters use a selector control for run group selection instead of freeform text.

* **Bug Fixes**
  * Run-group filtering now matches run group names by exact equality to avoid ambiguous results.

* **Style**
  * UI wording updated from "experiment" to "run group" across labels, buttons, placeholders, and descriptions.

* **Tests**
  * E2E and unit tests updated to use and assert the run group selector and exact-match behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->