### PR TITLE
fix(cypress): fix correctness bugs, flakiness sources, and injection risk across test suite

### DIFF
--- a/packages/cypress/cypress/pages/clusterStorage.ts
+++ b/packages/cypress/cypress/pages/clusterStorage.ts
@@ -275,7 +275,7 @@ class ClusterStorage {
   }
 
   shouldNotHaveDeprecatedAlertMessage() {
-    return cy.get('[date-testid="storage-class-deprecated-alert"]').should('not.exist');
+    return cy.get('[data-testid="storage-class-deprecated-alert"]').should('not.exist');
   }
 
   closeDeprecatedAlert() {

--- a/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -288,7 +288,6 @@ describe('NotebookServer', () => {
     cy.interceptOdh('PATCH /api/notebooks', mockStartNotebookData({})).as('stopNotebookServer');
     notebookServer.visit();
     notebookServer.findStopServerButton().should('be.visible');
-    notebookServer.findStopServerButton().click();
 
     cy.interceptOdh(
       'GET /api/notebooks/openshift-ai-notebooks/:username/status',
@@ -299,6 +298,7 @@ describe('NotebookServer', () => {
       },
     );
 
+    notebookServer.findStopServerButton().click();
     stopNotebookModal.findStopNotebookServerButton().should('be.enabled');
     stopNotebookModal.findStopNotebookServerButton().click();
 

--- a/packages/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/connectionTypes/connectionTypes.cy.ts
@@ -18,8 +18,6 @@ it('Connection types should not be available for non product admins', () => {
 it('Connection types should be hidden by feature flag', () => {
   asProductAdminUser();
 
-  cy.visitWithLogin('/settings/environment-setup/connection-types');
-
   cy.interceptOdh(
     'GET /api/config',
     mockDashboardConfig({

--- a/packages/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -179,7 +179,7 @@ describe('duplicate', () => {
     row1.findName().should('contain.text', 'Short text 1');
     row1.findType().should('have.text', 'Text - Short');
     row1.findDefault().should('have.text', '-');
-    row1.findRequired().not('be.checked');
+    row1.findRequired().should('not.be.checked');
 
     // Row 2 - Short text field
     const row2 = createConnectionTypePage.getFieldsTableRow(2);

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureDataSources.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureDataSources.cy.ts
@@ -89,7 +89,7 @@ const initCommonIntercepts = () => {
         mockFeatureStoreProject({ spec: { name: fsProjectName2 } }),
       ],
       pagination: {
-        total_count: 1,
+        total_count: 2,
         total_pages: 1,
         has_next: false,
         has_previous: false,

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureEntities.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureEntities.cy.ts
@@ -86,7 +86,7 @@ const initCommonIntercepts = () => {
         mockFeatureStoreProject({ spec: { name: fsProjectName2 } }),
       ],
       pagination: {
-        total_count: 1,
+        total_count: 2,
         total_pages: 1,
         has_next: false,
         has_previous: false,

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -1035,7 +1035,24 @@ describe('EditModelRegistry', () => {
     modelRegistrySettings.findSubmitButton().click();
 
     cy.wait('@updateModelRegistry').then((interception) => {
-      expect(interception.request.body).to.containSubset({});
+      expect(interception.request.body).to.containSubset({
+        modelRegistry: {
+          metadata: {
+            annotations: {
+              'openshift.io/display-name': 'test-2',
+            },
+          },
+          spec: {
+            mysql: {
+              host: 'model-registry-db',
+              port: 5432,
+              database: 'model-registry',
+              username: 'mlmduser',
+            },
+          },
+        },
+        databasePassword: 'test-password',
+      });
     });
   });
 

--- a/packages/cypress/cypress/tests/mocked/projects/projectList.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/projectList.cy.ts
@@ -96,12 +96,12 @@ describe('Projects details', () => {
 
   it('should delete project', () => {
     initIntercepts();
-    projectListPage.visit();
     cy.interceptK8s(
       'POST',
       SelfSubjectAccessReviewModel,
       mockSelfSubjectAccessReview({ allowed: true }),
     ).as('selfSubjectAccessReviewsCall');
+    projectListPage.visit();
     const deleteProject = projectListPage
       .getProjectRow('Test Project')
       .findKebabAction('Delete project');

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/modelServingNim.cy.ts
@@ -359,7 +359,7 @@ describe('NIM Model Serving', () => {
       // go the Models tab in the created project
       projectDetails.visitSection('test-project', 'model-server');
       // grab the deployed models table and click the kebab menu
-      cy.findByTestId('kserve-model-row-item').get('button[aria-label="Kebab toggle"').click();
+      cy.findByTestId('kserve-model-row-item').get('button[aria-label="Kebab toggle"]').click();
       cy.get('ul[role="menu"]').should('have.length', 1);
       cy.get('button').contains('Delete').should('exist');
     });
@@ -371,7 +371,7 @@ describe('NIM Model Serving', () => {
       // go the Models tab in the created project
       projectDetails.visitSection('test-project', 'model-server');
       // grab the deployed models table and click the kebab menu
-      cy.findByTestId('kserve-model-row-item').get('button[aria-label="Kebab toggle"').click();
+      cy.findByTestId('kserve-model-row-item').get('button[aria-label="Kebab toggle"]').click();
       // grab the delete menu and click it
       cy.get('button').contains('Delete').click();
       // grab the delete menu window and put in the project name

--- a/packages/cypress/cypress/utils/oc_commands/imageStreams.ts
+++ b/packages/cypress/cypress/utils/oc_commands/imageStreams.ts
@@ -168,25 +168,19 @@ export const getNotebookImageNames = (namespace: string): Cypress.Chainable<Note
       }
       const imageNames = result.stdout.trim().split(' ');
       const imageInfos: NotebookImageInfo[] = [];
+      const filteredNames = imageNames.filter((imageName) => imageName.includes('notebook'));
 
-      // Create a chain of promises for each notebook image
-      const imagePromises = imageNames
-        .filter((imageName) => imageName.includes('notebook'))
-        .map((imageName) =>
-          cy
-            .exec(
-              `oc get imagestream ${imageName} -n ${namespace} -o jsonpath='{.spec.tags[*].name}'`,
-            )
-            .then((tagResult: ExecResult) => {
-              if (tagResult.code !== 0) {
-                const maskedStderr = maskSensitiveInfo(tagResult.stderr);
-                throw new Error(`Failed to get image stream tags: ${maskedStderr}`);
-              }
-              const versions = tagResult.stdout.trim().split(' ');
-              imageInfos.push({ image: imageName, name: imageName, versions });
-            }),
-        );
-
-      // Wait for all image version queries to complete
-      return cy.wrap(Promise.all(imagePromises)).then(() => imageInfos);
+      cy.wrap(filteredNames).each((imageName: string) => {
+        cy.exec(
+          `oc get imagestream ${imageName} -n ${namespace} -o jsonpath='{.spec.tags[*].name}'`,
+        ).then((tagResult: ExecResult) => {
+          if (tagResult.code !== 0) {
+            const maskedStderr = maskSensitiveInfo(tagResult.stderr);
+            throw new Error(`Failed to get image stream tags: ${maskedStderr}`);
+          }
+          const versions = tagResult.stdout.trim().split(' ');
+          imageInfos.push({ image: imageName, name: imageName, versions });
+        });
+      });
+      return cy.wrap(imageInfos);
     });

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -685,8 +685,8 @@ export const cleanupRegisteredModelsFromDatabase = (
 
       const podName = podResult.stdout.trim();
 
-      // SQL commands to clean up contexts for the specified registeredmodels
-      const modelNamesStr = modelNames.map((name) => `'${name}'`).join(', ');
+      const escapeSql = (name: string) => name.replace(/'/g, "''");
+      const modelNamesStr = modelNames.map((name) => `'${escapeSql(name)}'`).join(', ');
       const sqlCommands = [
         `DELETE cp FROM ContextProperty cp JOIN Context c ON cp.context_id = c.id WHERE c.name IN (${modelNamesStr});`,
         `DELETE pc FROM ParentContext pc JOIN Context c ON pc.context_id = c.id OR pc.parent_context_id = c.id WHERE c.name IN (${modelNamesStr});`,
@@ -695,7 +695,10 @@ export const cleanupRegisteredModelsFromDatabase = (
         `DELETE FROM Context WHERE name IN (${modelNamesStr});`,
       ].join(' ');
 
-      const cleanupCommand = `oc exec ${podName} -n ${targetNamespace} -- mysql -u mlmduser -pTheBlurstOfTimes --database="model-registry" -e "${sqlCommands}"`;
+      const escapeShellDoubleQuotes = (s: string) => s.replace(/["$`\\]/g, '\\$&');
+      const cleanupCommand = `oc exec ${podName} -n ${targetNamespace} -- mysql -u mlmduser -pTheBlurstOfTimes --database="model-registry" -e "${escapeShellDoubleQuotes(
+        sqlCommands,
+      )}"`;
 
       cy.log(`Cleaning up registered models: ${modelNames.join(', ')}`);
 

--- a/packages/cypress/cypress/utils/storageClass.ts
+++ b/packages/cypress/cypress/utils/storageClass.ts
@@ -286,7 +286,7 @@ export const verifyStorageClassConfig = (
       }
     }
 
-    if (expectedDescription !== undefined) {
+    if (expectedAccessModes !== undefined) {
       cy.wrap(config.accessModeSettings).should('equal', expectedAccessModes);
     }
     cy.log('Storage Class Config:', JSON.stringify(config));


### PR DESCRIPTION
## Description

Systematic review of the Cypress test suite (`packages/cypress/`) identified verified correctness bugs, flakiness sources, and an injection risk across 12 files. Each issue was validated by reading the actual source code, checking Cypress/Chai documentation, and deep-reviewing every proposed fix before implementation.

### Correctness Bugs (9)
- **modelServingNim.cy.ts**: Missing `]` in CSS attribute selector — `querySelectorAll` throws `SyntaxError`
- **clusterStorage.ts**: `date-testid` typo instead of `data-testid` — selector never matches, `.should('not.exist')` passes vacuously
- **storageClass.ts**: Wrong condition guard (`expectedDescription` instead of `expectedAccessModes`) — access modes never validated
- **imageStreams.ts**: `Promise.all()` on Cypress chainables (not real Promises) — `imageInfos` can be incomplete; replaced with `cy.wrap().each()`
- **createConnectionType.cy.ts**: `.not('be.checked')` is jQuery element filtering (no-op), not a Cypress assertion — changed to `.should('not.be.checked')`
- **connectionTypes.cy.ts**: Redundant `cy.visitWithLogin` before intercepts registered; misleading test title
- **modelRegistrySettings.cy.ts**: `containSubset({})` always passes any object — added actual expected fields
- **featureDataSources.cy.ts** / **featureEntities.cy.ts**: `total_count: 1` with 2 mock projects

### Flakiness Fixes (2 files)
- **notebookServer.cy.ts**: `isRunning: false` intercept registered after stop button click — moved before the click
- **projectList.cy.ts**: `SelfSubjectAccessReview` intercept registered after `visit()` — moved before visit

### Security
- **modelRegistry.ts**: SQL escaping added to cleanup path (matching existing read path), plus shell double-quote escaping

## How Has This Been Tested?

- TypeScript type-check passes (`npx tsc --noEmit -p packages/cypress/tsconfig.json`)
- No linter errors introduced
- Mocked Cypress tests pass locally
- Each fix was validated by reading surrounding test context, Cypress/Chai docs, and verifying the fix does not change test semantics beyond correcting the identified bug

## Test Impact

This PR **only** modifies Cypress test files, page objects, and test utilities. No application source code is changed. The fixes correct silent test failures, reduce flakiness, and improve test reliability.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed test selectors and assertions across multiple test suites for improved reliability.
  * Updated test control flow to ensure proper API intercept ordering.
  * Improved test data setup for consistent validation across feature and model registry tests.

* **Bug Fixes**
  * Enhanced SQL query safety by properly escaping special characters in test utilities.
  * Corrected test element selectors to target the correct components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->