### PR TITLE
fix(autox): fix leaderboard svg repeatedly redownloading and flickering when devtools is open with cache disabled

### DIFF
--- a/packages/automl/frontend/src/app/components/empty-states/AutomlRunInProgress.tsx
+++ b/packages/automl/frontend/src/app/components/empty-states/AutomlRunInProgress.tsx
@@ -13,6 +13,8 @@ interface AutomlRunInProgressProps {
   namespace: string;
 }
 
+const EmptyStateImageIcon = () => <img src={emptyStateImage} alt="Run in progress" />;
+
 function AutomlRunInProgress({ namespace }: AutomlRunInProgressProps): React.JSX.Element {
   const navigate = useNavigate();
 
@@ -20,7 +22,7 @@ function AutomlRunInProgress({ namespace }: AutomlRunInProgressProps): React.JSX
     <EmptyState
       titleText="Your AutoML run is currently in progress"
       headingLevel="h4"
-      icon={() => <img src={emptyStateImage} alt="Run in progress" />}
+      icon={EmptyStateImageIcon}
     >
       <EmptyStateBody>
         Please check back soon for your run results. Runs can take some time to complete.

--- a/packages/automl/frontend/src/app/components/empty-states/NoProjects.tsx
+++ b/packages/automl/frontend/src/app/components/empty-states/NoProjects.tsx
@@ -9,15 +9,13 @@ import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import emptyStateImage from '~/app/bgimages/empty-state.svg';
 
+const EmptyStateImageIcon = () => <img src={emptyStateImage} alt="AutoML Infrastructure" />;
+
 function NoProjects(): React.JSX.Element {
   const navigate = useNavigate();
 
   return (
-    <EmptyState
-      titleText="No projects"
-      headingLevel="h4"
-      icon={() => <img src={emptyStateImage} alt="AutoML Infrastructure" />}
-    >
+    <EmptyState titleText="No projects" headingLevel="h4" icon={EmptyStateImageIcon}>
       <EmptyStateBody>To create an AutoML experiment, first create a project.</EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>

--- a/packages/autorag/frontend/src/app/components/empty-states/AutoragRunInProgress.tsx
+++ b/packages/autorag/frontend/src/app/components/empty-states/AutoragRunInProgress.tsx
@@ -13,6 +13,8 @@ interface AutoragRunInProgressProps {
   namespace: string;
 }
 
+const EmptyStateImageIcon = () => <img src={emptyStateImage} alt="Run in progress" />;
+
 function AutoragRunInProgress({ namespace }: AutoragRunInProgressProps): React.JSX.Element {
   const navigate = useNavigate();
 
@@ -20,7 +22,7 @@ function AutoragRunInProgress({ namespace }: AutoragRunInProgressProps): React.J
     <EmptyState
       titleText="Your AutoRAG run is currently in progress"
       headingLevel="h4"
-      icon={() => <img src={emptyStateImage} alt="Run in progress" />}
+      icon={EmptyStateImageIcon}
     >
       <EmptyStateBody>
         Please check back soon for your run results. Runs can take some time to complete.

--- a/packages/autorag/frontend/src/app/components/empty-states/NoProjects.tsx
+++ b/packages/autorag/frontend/src/app/components/empty-states/NoProjects.tsx
@@ -9,15 +9,13 @@ import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import emptyStateImage from '~/app/bgimages/empty-state.svg';
 
+const EmptyStateImageIcon = () => <img src={emptyStateImage} alt="AutoRAG Infrastructure" />;
+
 function NoProjects(): React.JSX.Element {
   const navigate = useNavigate();
 
   return (
-    <EmptyState
-      titleText="No projects"
-      headingLevel="h4"
-      icon={() => <img src={emptyStateImage} alt="AutoRAG Infrastructure" />}
-    >
+    <EmptyState titleText="No projects" headingLevel="h4" icon={EmptyStateImageIcon}>
       <EmptyStateBody>To create an AutoRAG experiment, first create a project.</EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>


### PR DESCRIPTION
## Description

Fixes SVG images being re-downloaded on every render in AutoML and AutoRAG empty state components.

**Problem:**
Empty state components were defining icon components inline using arrow functions:
```tsx
icon={() => <img src={emptyStateImage} alt="..." />}
```

This anti-pattern creates a new function component on every render, causing React to unmount and remount the img element, which triggers the browser to re-download the SVG file repeatedly. This causes unnecessary network requests and visual flickering.

https://github.com/user-attachments/assets/f79ccc15-3130-4336-8065-d5dfa9bed7d4

**Solution:**
Hoisted the icon components to module scope:
```tsx
const EmptyStateImageIcon = () => <img src={emptyStateImage} alt="..." />;
// Then used as: icon={EmptyStateImageIcon}
```

Now the icon component is created once when the module loads and reused on every render, preventing unnecessary remounts and re-downloads.

**Files fixed:**
- `packages/automl/frontend/src/app/components/empty-states/AutomlRunInProgress.tsx`
- `packages/automl/frontend/src/app/components/empty-states/NoProjects.tsx`
- `packages/autorag/frontend/src/app/components/empty-states/AutoragRunInProgress.tsx`
- `packages/autorag/frontend/src/app/components/empty-states/NoProjects.tsx`

## How Has This Been Tested?

Manually tested by:
1. Opening the affected empty state pages
2. Verifying in browser DevTools Network tab that SVG is only downloaded once
3. Confirming no visual flickering or re-renders of the icon

## Test Impact

No test changes needed - this is a performance optimization that doesn't change functionality or user-facing behavior.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

## Summary by CodeRabbit
- Refactor
  - Improved internal component structure across empty-state components in both AutoML and AutoRAG packages for better code maintainability.