### PR TITLE
fix(e2e): shorten model registry test fixture prefixes to avoid DNS limit

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/modelRegistry/testModelRegistry.yaml
@@ -6,7 +6,7 @@ createRegistryName: "e2e-test-registry"
 operatorDeploymentName: "model-registry-operator-controller-manager"
 
 # First model (Object Storage)
-objectStorageModelName: "test-object-model"
+objectStorageModelName: "test-obj-model"
 objectStorageModelDescription: "E2E test model using object storage"
 version1Name: "v1.0"
 version1Description: "First version of the object storage test model"
@@ -37,7 +37,7 @@ uriVersion2: "s3://test-bucket/models/tensorflow-model-v2?endpoint=http%3A%2F%2F
 
 newNameSuffix: "-edited"
 newDescription: "Updated description for e2e test"
-deployProjectNamePrefix: "test-deploy-project"
+deployProjectNamePrefix: "test-deploy-prj"
 
 # Permissions management configuration
 permissionsRegistryNamePrefix: "test-mr-permissions-registry"


### PR DESCRIPTION
## Description
KServe constructs DNS hostnames by concatenating `{resourceName}-predictor-{namespace}`. The previous test fixture prefixes (`test-object-model` + `test-deploy-project`) combined with the UUID suffix produced hostnames exceeding the 63-character DNS label limit, causing the InferenceService to fail with `ReconcileFailed`.

Shortened `objectStorageModelName` from `test-object-model` to `test-obj-model` and `deployProjectNamePrefix` from `test-deploy-project` to `test-deploy-prj`, bringing the combined hostname from 72 to 58 characters.

**Note:** This is a test-only fix. The underlying product issue remains — there is no UI-side validation warning users when their model name + namespace would exceed the KServe hostname limit. A follow-up issue should be opened to add client-side validation in the deployment wizard.

## How Has This Been Tested?
- Verified the math: worst-case hostname `test-obj-model-XXXXXX-v10-predictor-test-deploy-prj-XXXXXX` = 58 chars (under 63 limit)
- Ran `testRegistryDeployModel` E2E test against a live RHOAI cluster — the previous prefixes caused `ReconcileFailed` due to DNS label length

## Test Impact
This PR fixes the `testRegistryDeployModel` E2E test fixture data. No new tests needed.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration values to ensure test infrastructure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->