### PR TITLE
fix(automl): dynamically size topology nodes to fit long task labels

### DIFF
--- a/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
@@ -1,0 +1,120 @@
+jest.mock('@patternfly/react-topology', () => ({
+  DEFAULT_TASK_NODE_TYPE: 'DEFAULT_TASK_NODE',
+  RunStatus: {
+    Succeeded: 'Succeeded',
+    Failed: 'Failed',
+    Running: 'Running',
+    InProgress: 'InProgress',
+    Idle: 'Idle',
+    Pending: 'Pending',
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { RunStatus } from '@patternfly/react-topology';
+// eslint-disable-next-line import/first
+import { NODE_WIDTH } from '~/app/topology/const';
+// eslint-disable-next-line import/first
+import type { PipelineTask } from '~/app/types/topology';
+// eslint-disable-next-line import/first
+import { createNode } from '~/app/topology/utils';
+
+const mockTask = (name: string): PipelineTask => ({
+  type: 'task',
+  name,
+});
+
+describe('createNode', () => {
+  it('should create a node with the correct id and label', () => {
+    const node = createNode('task-1', 'My Task', mockTask('task-1'));
+
+    expect(node.id).toBe('task-1');
+    expect(node.label).toBe('My Task');
+  });
+
+  it('should set runAfterTasks when provided', () => {
+    const node = createNode('task-2', 'Second Task', mockTask('task-2'), ['task-1']);
+
+    expect(node.runAfterTasks).toEqual(['task-1']);
+  });
+
+  it('should set runStatus in data when provided', () => {
+    const node = createNode(
+      'task-1',
+      'My Task',
+      mockTask('task-1'),
+      undefined,
+      RunStatus.Succeeded,
+    );
+
+    expect(node.data.runStatus).toBe(RunStatus.Succeeded);
+  });
+
+  it('should have width at least NODE_WIDTH for short labels', () => {
+    const node = createNode('t', 'Hi', mockTask('t'));
+
+    expect(node.width).toBeGreaterThanOrEqual(NODE_WIDTH);
+  });
+});
+
+describe('measureTextWidth via createNode', () => {
+  it('should return NODE_WIDTH when canvas context is unavailable', () => {
+    jest.resetModules();
+
+    const originalCreateElement = document.createElement.bind(document);
+    jest
+      .spyOn(document, 'createElement')
+      .mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag === 'canvas') {
+          return { getContext: () => null } as unknown as HTMLCanvasElement;
+        }
+        return originalCreateElement(tag, options);
+      });
+
+    // Re-import to get a fresh module with no cached context
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createNode: freshCreateNode } = require('~/app/topology/utils');
+
+    const node = freshCreateNode(
+      'task-1',
+      'A Very Long Task Name That Would Be Wide',
+      mockTask('task-1'),
+    );
+
+    expect(node.width).toBe(NODE_WIDTH);
+
+    jest.restoreAllMocks();
+  });
+
+  it('should return width wider than NODE_WIDTH for long labels when canvas is available', () => {
+    jest.resetModules();
+
+    const mockMeasureText = jest.fn((text: string) => ({ width: text.length * 10 }));
+    const originalCreateElement = document.createElement.bind(document);
+    jest
+      .spyOn(document, 'createElement')
+      .mockImplementation((tag: string, options?: ElementCreationOptions) => {
+        if (tag === 'canvas') {
+          return {
+            getContext: () => ({
+              font: '',
+              measureText: mockMeasureText,
+            }),
+          } as unknown as HTMLCanvasElement;
+        }
+        return originalCreateElement(tag, options);
+      });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createNode: freshCreateNode } = require('~/app/topology/utils');
+
+    // 30 chars * 10px = 300px + 40px padding = 340px > NODE_WIDTH (200)
+    const longLabel = 'A'.repeat(30);
+    const node = freshCreateNode('task-1', longLabel, mockTask('task-1'));
+
+    expect(node.width).toBeGreaterThan(NODE_WIDTH);
+    expect(mockMeasureText).toHaveBeenCalledWith(longLabel);
+
+    jest.restoreAllMocks();
+  });
+});

--- a/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
@@ -58,6 +58,11 @@ describe('createNode', () => {
 });
 
 describe('measureTextWidth via createNode', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
   it('should return NODE_WIDTH when canvas context is unavailable', () => {
     jest.resetModules();
 
@@ -82,8 +87,6 @@ describe('measureTextWidth via createNode', () => {
     );
 
     expect(node.width).toBe(NODE_WIDTH);
-
-    jest.restoreAllMocks();
   });
 
   it('should return width wider than NODE_WIDTH for long labels when canvas is available', () => {
@@ -114,7 +117,5 @@ describe('measureTextWidth via createNode', () => {
 
     expect(node.width).toBeGreaterThan(NODE_WIDTH);
     expect(mockMeasureText).toHaveBeenCalledWith(longLabel);
-
-    jest.restoreAllMocks();
   });
 });

--- a/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
+++ b/packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts
@@ -115,7 +115,8 @@ describe('measureTextWidth via createNode', () => {
     const longLabel = 'A'.repeat(30);
     const node = freshCreateNode('task-1', longLabel, mockTask('task-1'));
 
-    expect(node.width).toBeGreaterThan(NODE_WIDTH);
+    // 30 chars * 10px = 300px + NODE_PADDING (40) = 340px
+    expect(node.width).toBe(340);
     expect(mockMeasureText).toHaveBeenCalledWith(longLabel);
   });
 });

--- a/packages/automl/frontend/src/app/topology/const.ts
+++ b/packages/automl/frontend/src/app/topology/const.ts
@@ -3,4 +3,9 @@ export const PIPELINE_NODE_SEPARATION_VERTICAL = 20;
 export const PIPELINE_NODE_SEPARATION_HORIZONTAL = 70;
 
 export const NODE_WIDTH = 200;
+export const NODE_PADDING = 40;
 export const NODE_HEIGHT = 35;
+
+// Must match the font rendered by PatternFly topology task nodes
+// See: @patternfly/react-topology TaskNode component (font-size: 0.875rem, font-family: RedHatText)
+export const NODE_FONT = '0.875rem RedHatText';

--- a/packages/automl/frontend/src/app/topology/utils.ts
+++ b/packages/automl/frontend/src/app/topology/utils.ts
@@ -1,6 +1,23 @@
 import { DEFAULT_TASK_NODE_TYPE, RunStatus } from '@patternfly/react-topology';
 import { PipelineTask, PipelineNodeModelExpanded } from '~/app/types/topology';
-import { NODE_HEIGHT, NODE_WIDTH } from './const';
+import { NODE_FONT, NODE_HEIGHT, NODE_PADDING, NODE_WIDTH } from './const';
+
+let cachedCtx: CanvasRenderingContext2D | null = null;
+const getCanvasContext = (): CanvasRenderingContext2D | null => {
+  if (!cachedCtx && typeof document !== 'undefined') {
+    cachedCtx = document.createElement('canvas').getContext('2d');
+  }
+  return cachedCtx;
+};
+
+const measureTextWidth = (text: string): number => {
+  const ctx = getCanvasContext();
+  if (!ctx) {
+    return NODE_WIDTH;
+  }
+  ctx.font = NODE_FONT;
+  return Math.max(NODE_WIDTH, ctx.measureText(text).width + NODE_PADDING);
+};
 
 export const createNode = (
   id: string,
@@ -12,7 +29,7 @@ export const createNode = (
   id,
   label,
   type: DEFAULT_TASK_NODE_TYPE,
-  width: NODE_WIDTH,
+  width: measureTextWidth(label),
   height: NODE_HEIGHT,
   runAfterTasks,
   data: {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIUX-2271

## Description

Fixed topology pipeline nodes being truncated when task labels exceed the fixed `NODE_WIDTH` of 200px.

**Problem:** Pipeline topology nodes used a hardcoded width of 200px, causing long task names to be clipped inside the PatternFly `TaskNode` component.

**Solution:** Added a `measureTextWidth` utility that uses a cached Canvas 2D context to measure the rendered width of each label using the same font as PatternFly topology (`0.875rem RedHatText`). Node width is now `max(NODE_WIDTH, measuredText + NODE_PADDING)`, so short labels keep the default size while long labels expand.

Before
<img width="1181" height="742" alt="Before" src="https://github.com/user-attachments/assets/21ce6223-8526-4584-8ac8-e31e6055c02d" />

After
<img width="1181" height="742" alt="After" src="https://github.com/user-attachments/assets/c314457f-6c12-4b8f-b594-0358a1e5a4ab" />

**Changes:**
- `packages/automl/frontend/src/app/topology/const.ts` — added `NODE_PADDING` and `NODE_FONT` constants
- `packages/automl/frontend/src/app/topology/utils.ts` — added `measureTextWidth` helper; `createNode` now computes width dynamically
- `packages/automl/frontend/src/app/topology/__tests__/utils.spec.ts` — unit tests for `createNode` covering default width, long-label expansion, and run-status mapping

## How Has This Been Tested?

- Verified topology renders correctly with both short and long task names
- Unit tests for `createNode` validate width behavior and node properties

## Test Impact

Added new test file `utils.spec.ts` with tests covering:
- Default node width for short labels
- Dynamic width expansion for long labels
- RunStatus mapping from pipeline task status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Node sizing now adapts to label length for improved diagram layout, with a fallback to the previous fixed size when measurement isn't available.
* **Tests**
  * Added unit tests to validate node sizing behavior, label handling, task ordering, and run status storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->