### PR TITLE
fix(model-registry): surface K8s name validation errors on MCP deploy name field

### DIFF
--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -182,6 +182,15 @@ class McpDeployModal {
     return this.findModal().findByTestId('mcp-deploy-name-helper');
   }
 
+  findProjectSelectorToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findModal().findByTestId('project-selector-toggle');
+  }
+
+  selectProject(name: string): void {
+    this.findProjectSelectorToggle().click();
+    cy.findByRole('menuitem', { name }).click();
+  }
+
   findSubmitError(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findModal().findByTestId('error-message-alert');
   }

--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -186,9 +186,13 @@ class McpDeployModal {
     return this.findModal().findByTestId('project-selector-toggle');
   }
 
+  findProjectSelectorOption(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('project-selector-menuList').findByRole('menuitem', { name });
+  }
+
   selectProject(name: string): void {
     this.findProjectSelectorToggle().click();
-    cy.findByRole('menuitem', { name }).click();
+    this.findProjectSelectorOption(name).click();
   }
 
   findSubmitError(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -178,6 +178,10 @@ class McpDeployModal {
     return this.findModal().findByTestId('modal-cancel-button');
   }
 
+  findResourceNameHelperText(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findModal().findByTestId('mcp-deploy-name-helper');
+  }
+
   findSubmitError(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findModal().findByTestId('error-message-alert');
   }

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -487,4 +487,51 @@ describe('MCP Deploy from Catalog', () => {
       .should('be.visible')
       .and('contain.text', 'Failed to load MCP server configuration');
   });
+
+  it('should enable deploy button when a valid name is entered', () => {
+    initDeployIntercepts();
+
+    cy.intercept('POST', `${MCP_DEPLOYMENTS_API}*`, {
+      body: { data: mockRunningDeployment() },
+    }).as('createDeployment');
+
+    cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
+    mcpServerDetailsPage.findDeployButton().click();
+    cy.wait('@getConverter');
+    mcpDeployModal.shouldBeOpen();
+    mcpDeployModal.findSubmitButton().should('be.disabled');
+
+    mcpDeployModal.findNameInput().type('My Server');
+    mcpDeployModal.findSubmitButton().should('not.be.disabled');
+    mcpDeployModal.findSubmitButton().click();
+
+    cy.wait('@createDeployment').then((interception) => {
+      expect(interception.request.body).to.have.property('name', 'my-server');
+      expect(interception.request.body).to.have.property('displayName', 'My Server');
+    });
+  });
+
+  it('should auto-generate a valid K8s name for dash-only display name input', () => {
+    initDeployIntercepts();
+
+    cy.intercept('POST', `${MCP_DEPLOYMENTS_API}*`, {
+      body: { data: mockRunningDeployment() },
+    }).as('createDeployment');
+
+    cy.visitWithLogin(`/ai-hub/mcp-servers/catalog/${TEST_SERVER_ID}`);
+    mcpServerDetailsPage.findDeployButton().click();
+    cy.wait('@getConverter');
+    mcpDeployModal.shouldBeOpen();
+
+    mcpDeployModal.findNameInput().type('----');
+    mcpDeployModal.findResourceNameHelperText().should('contain.text', 'The resource name will be');
+    mcpDeployModal.findSubmitButton().should('not.be.disabled');
+    mcpDeployModal.findSubmitButton().click();
+
+    cy.wait('@createDeployment').then((interception) => {
+      const { name } = interception.request.body;
+      expect(name).to.match(/^gen-[a-z0-9]+$/);
+      expect(name).to.not.equal('----');
+    });
+  });
 });

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -502,7 +502,7 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.findSubmitButton().should('be.disabled');
 
     mcpDeployModal.findNameInput().type('My Server');
-    mcpDeployModal.selectProject('test-project');
+    mcpDeployModal.selectProject('Test Project');
     mcpDeployModal.findSubmitButton().should('not.be.disabled');
     mcpDeployModal.findSubmitButton().click();
 
@@ -525,7 +525,7 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.shouldBeOpen();
 
     mcpDeployModal.findNameInput().type('----');
-    mcpDeployModal.selectProject('test-project');
+    mcpDeployModal.selectProject('Test Project');
     mcpDeployModal.findResourceNameHelperText().should('contain.text', 'The resource name will be');
     mcpDeployModal.findSubmitButton().should('not.be.disabled');
     mcpDeployModal.findSubmitButton().click();

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -507,8 +507,9 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.findSubmitButton().click();
 
     cy.wait('@createDeployment').then((interception) => {
-      expect(interception.request.body).to.have.property('name', 'my-server');
-      expect(interception.request.body).to.have.property('displayName', 'My Server');
+      const body = interception.request.body.data || interception.request.body;
+      expect(body).to.have.property('name', 'my-server');
+      expect(body).to.have.property('displayName', 'My Server');
     });
   });
 
@@ -531,9 +532,9 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.findSubmitButton().click();
 
     cy.wait('@createDeployment').then((interception) => {
-      const { name } = interception.request.body;
-      expect(name).to.match(/^gen-[a-z0-9]+$/);
-      expect(name).to.not.equal('----');
+      const body = interception.request.body.data || interception.request.body;
+      expect(body.name).to.match(/^gen-[a-z0-9]+$/);
+      expect(body.name).to.not.equal('----');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -502,6 +502,7 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.findSubmitButton().should('be.disabled');
 
     mcpDeployModal.findNameInput().type('My Server');
+    mcpDeployModal.selectProject('test-project');
     mcpDeployModal.findSubmitButton().should('not.be.disabled');
     mcpDeployModal.findSubmitButton().click();
 
@@ -524,6 +525,7 @@ describe('MCP Deploy from Catalog', () => {
     mcpDeployModal.shouldBeOpen();
 
     mcpDeployModal.findNameInput().type('----');
+    mcpDeployModal.selectProject('test-project');
     mcpDeployModal.findResourceNameHelperText().should('contain.text', 'The resource name will be');
     mcpDeployModal.findSubmitButton().should('not.be.disabled');
     mcpDeployModal.findSubmitButton().click();

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -6,6 +6,7 @@ import {
   HelperTextItem,
   TextArea,
   TextInput,
+  ValidatedOptions,
 } from '@patternfly/react-core';
 import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTooltip';
 import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
@@ -15,7 +16,12 @@ import {
   UseK8sNameDescriptionDataConfiguration,
   UseK8sNameDescriptionFieldData,
 } from './types';
-import { handleUpdateLogic, setupDefaults } from './utils';
+import {
+  handleUpdateLogic,
+  setupDefaults,
+  getMaxLengthErrorMessage,
+  INVALID_K8S_NAME_CHARACTERS_MESSAGE,
+} from './utils';
 import ResourceNameField from './ResourceNameField';
 
 /** Companion data hook */
@@ -60,6 +66,13 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
 
   const { name, description, k8sName } = data;
 
+  const hasEmptyResourceName = !!name && !k8sName.value && !k8sName.state.immutable;
+  const hasHiddenValidationError =
+    !showK8sField &&
+    !k8sName.state.immutable &&
+    (k8sName.state.invalidLength || k8sName.state.invalidCharacters);
+  const hasNameError = hasEmptyResourceName || hasHiddenValidationError;
+
   const nameInput = (
     <TextInput
       aria-readonly={!onDataChange}
@@ -69,6 +82,7 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
       value={name}
       onChange={(_e, value) => onDataChange?.('name', value)}
       isRequired
+      validated={hasNameError ? ValidatedOptions.error : ValidatedOptions.default}
     />
   );
 
@@ -95,9 +109,23 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
             {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
             {!showK8sField && !k8sName.state.immutable && (
               <>
-                {k8sName.value && (
+                {hasEmptyResourceName ? (
+                  <HelperTextItem variant="error">
+                    The name must contain at least one alphanumeric character.
+                  </HelperTextItem>
+                ) : k8sName.value ? (
                   <HelperTextItem>
                     The resource name will be <b>{k8sName.value}</b>.
+                  </HelperTextItem>
+                ) : null}
+                {k8sName.state.invalidLength && (
+                  <HelperTextItem variant="error">
+                    {getMaxLengthErrorMessage(k8sName.state.maxLength)}
+                  </HelperTextItem>
+                )}
+                {k8sName.state.invalidCharacters && (
+                  <HelperTextItem variant="error">
+                    {INVALID_K8S_NAME_CHARACTERS_MESSAGE}
                   </HelperTextItem>
                 )}
                 <HelperTextItem>

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -105,7 +105,7 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
       <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
         <FormFieldset component={nameInput} field="Name" />
         {nameHelperText || (!showK8sField && !k8sName.state.immutable) ? (
-          <HelperText>
+          <HelperText data-testid={`${dataTestId}-name-helper`}>
             {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
             {!showK8sField && !k8sName.state.immutable && (
               <>

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -8,6 +8,7 @@ import {
 } from '@patternfly/react-core';
 import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import { K8sNameDescriptionFieldData, K8sNameDescriptionFieldUpdateFunction } from './types';
+import { getMaxLengthErrorMessage, INVALID_K8S_NAME_CHARACTERS_MESSAGE } from './utils';
 
 type ResourceNameFieldProps = {
   allowEdit: boolean;
@@ -69,13 +70,12 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
       <HelperText>
         {k8sName.state.invalidLength && (
           <HelperTextItem variant="error">
-            Cannot exceed {k8sName.state.maxLength} characters
+            {getMaxLengthErrorMessage(k8sName.state.maxLength)}
           </HelperTextItem>
         )}
         {k8sName.state.invalidCharacters && (
           <HelperTextItem variant="error">
-            Must start and end with a lowercase letter or number. Valid characters include lowercase
-            letters, numbers, and hyphens (-).
+            {INVALID_K8S_NAME_CHARACTERS_MESSAGE}
           </HelperTextItem>
         )}
         {!k8sName.state.invalidLength && !k8sName.state.invalidCharacters && (

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -74,9 +74,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
           </HelperTextItem>
         )}
         {k8sName.state.invalidCharacters && (
-          <HelperTextItem variant="error">
-            {INVALID_K8S_NAME_CHARACTERS_MESSAGE}
-          </HelperTextItem>
+          <HelperTextItem variant="error">{INVALID_K8S_NAME_CHARACTERS_MESSAGE}</HelperTextItem>
         )}
         {!k8sName.state.invalidLength && !k8sName.state.invalidCharacters && (
           <HelperTextItem>

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -4,7 +4,7 @@ import {
   UseK8sNameDescriptionDataConfiguration,
 } from './types';
 
-const MAX_K8S_NAME_LENGTH = 253;
+export const MAX_K8S_NAME_LENGTH = 253;
 
 export const getMaxLengthErrorMessage = (maxLength: number): string =>
   `Cannot exceed ${maxLength} characters`;

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/K8sNameDescriptionField/utils.ts
@@ -6,6 +6,12 @@ import {
 
 const MAX_K8S_NAME_LENGTH = 253;
 
+export const getMaxLengthErrorMessage = (maxLength: number): string =>
+  `Cannot exceed ${maxLength} characters`;
+
+export const INVALID_K8S_NAME_CHARACTERS_MESSAGE =
+  'Must start and end with a lowercase letter or number. Valid characters include lowercase letters, numbers, and hyphens (-).';
+
 /**
  * Translates a name to a k8s-safe value.
  * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

--- a/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
@@ -187,10 +187,7 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   ]);
 
   const hasValidName =
-    !!displayName &&
-    !!k8sName &&
-    isValidK8sName(k8sName) &&
-    k8sName.length <= MAX_K8S_NAME_LENGTH;
+    !!displayName && !!k8sName && isValidK8sName(k8sName) && k8sName.length <= MAX_K8S_NAME_LENGTH;
 
   const dataReady = !!existingDeployment || crLoaded;
 

--- a/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
@@ -24,12 +24,11 @@ import NamespaceSelectorFieldWrapper from '~/odh/components/NamespaceSelectorFie
 import useMcpServerConverter from '~/app/hooks/mcpCatalogDeployment/useMcpServerConverter';
 import K8sNameDescriptionField from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
+import { MAX_K8S_NAME_LENGTH } from '~/concepts/k8s/K8sNameDescriptionField/utils';
 import { createMcpDeployment, updateMcpDeployment } from '~/app/api/mcpCatalogDeployment/service';
 import { mcpDeploymentsUrl } from '~/app/routes/mcpCatalog/mcpCatalog';
 import { mcpServerCRToYaml } from '~/app/utils/mcpServerYaml';
 import { McpDeployment } from '~/app/mcpDeploymentTypes';
-
-const MAX_K8S_NAME_LENGTH = 253;
 
 type McpDeployModalProps = {
   isOpen?: boolean;
@@ -125,11 +124,8 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
     setSelectedNamespace(projectName);
   }, []);
 
-  const displayName = displayNameValue;
-  const k8sName = effectiveK8sName;
-
   const handleDeploy = React.useCallback(async () => {
-    if (!ociImageValue || !selectedNamespace || !k8sName) {
+    if (!ociImageValue || !selectedNamespace || !effectiveK8sName) {
       return;
     }
 
@@ -147,7 +143,7 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
           opts,
           existingDeployment.name,
           {
-            displayName,
+            displayName: displayNameValue,
             image: ociImageValue,
             yaml: yamlContent,
           },
@@ -155,8 +151,8 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
         onClose(true);
       } else {
         await createMcpDeployment('', { ...queryParams, namespace: selectedNamespace })(opts, {
-          name: k8sName,
-          displayName,
+          name: effectiveK8sName,
+          displayName: displayNameValue,
           serverName: crData?.metadata.name || undefined,
           image: ociImageValue,
           yaml: yamlContent,
@@ -176,8 +172,8 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   }, [
     ociImageValue,
     selectedNamespace,
-    k8sName,
-    displayName,
+    effectiveK8sName,
+    displayNameValue,
     yamlContent,
     crData,
     queryParams,
@@ -187,7 +183,10 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   ]);
 
   const hasValidName =
-    !!displayName && !!k8sName && isValidK8sName(k8sName) && k8sName.length <= MAX_K8S_NAME_LENGTH;
+    !!displayNameValue &&
+    !!effectiveK8sName &&
+    isValidK8sName(effectiveK8sName) &&
+    effectiveK8sName.length <= MAX_K8S_NAME_LENGTH;
 
   const dataReady = !!existingDeployment || crLoaded;
 

--- a/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
@@ -16,15 +16,20 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { APIOptions, useQueryParamNamespaces } from 'mod-arch-core';
 import { DashboardModalFooter, FieldGroupHelpLabelIcon } from 'mod-arch-shared';
 import { useThemeContext } from '@odh-dashboard/internal/app/ThemeContext';
+import {
+  translateDisplayNameForK8s,
+  isValidK8sName,
+} from '@odh-dashboard/internal/concepts/k8s/utils';
 import NamespaceSelectorFieldWrapper from '~/odh/components/NamespaceSelectorFieldWrapper';
 import useMcpServerConverter from '~/app/hooks/mcpCatalogDeployment/useMcpServerConverter';
-import K8sNameDescriptionField, {
-  useK8sNameDescriptionFieldData,
-} from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import K8sNameDescriptionField from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { K8sNameDescriptionFieldData } from '~/concepts/k8s/K8sNameDescriptionField/types';
 import { createMcpDeployment, updateMcpDeployment } from '~/app/api/mcpCatalogDeployment/service';
 import { mcpDeploymentsUrl } from '~/app/routes/mcpCatalog/mcpCatalog';
 import { mcpServerCRToYaml } from '~/app/utils/mcpServerYaml';
 import { McpDeployment } from '~/app/mcpDeploymentTypes';
+
+const MAX_K8S_NAME_LENGTH = 253;
 
 type McpDeployModalProps = {
   isOpen?: boolean;
@@ -43,15 +48,51 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   const { theme } = useThemeContext();
   const [crData, crLoaded, crError] = useMcpServerConverter(existingDeployment ? '' : serverId);
 
-  const { data: nameDescData, onDataChange: onNameDescChange } = useK8sNameDescriptionFieldData(
-    existingDeployment
-      ? {
-          initialData: {
-            name: existingDeployment.displayName ?? existingDeployment.name,
-            k8sName: existingDeployment.name,
-          },
-        }
-      : {},
+  const [displayNameValue, setDisplayNameValue] = React.useState(
+    existingDeployment ? (existingDeployment.displayName ?? existingDeployment.name) : '',
+  );
+  const [k8sNameManual, setK8sNameManual] = React.useState('');
+  const [k8sTouched, setK8sTouched] = React.useState(false);
+
+  const autoK8sName = React.useMemo(
+    () => translateDisplayNameForK8s(displayNameValue),
+    [displayNameValue],
+  );
+  const effectiveK8sName = existingDeployment
+    ? existingDeployment.name
+    : k8sTouched
+      ? k8sNameManual
+      : autoK8sName;
+
+  const nameDescData = React.useMemo<K8sNameDescriptionFieldData>(
+    () => ({
+      name: displayNameValue,
+      description: '',
+      k8sName: {
+        value: effectiveK8sName,
+        state: {
+          immutable: !!existingDeployment,
+          invalidCharacters:
+            effectiveK8sName.length > 0 ? !isValidK8sName(effectiveK8sName) : false,
+          invalidLength: effectiveK8sName.length > MAX_K8S_NAME_LENGTH,
+          maxLength: MAX_K8S_NAME_LENGTH,
+          touched: k8sTouched,
+        },
+      },
+    }),
+    [displayNameValue, effectiveK8sName, k8sTouched, existingDeployment],
+  );
+
+  const onNameDescChange = React.useCallback(
+    (key: keyof K8sNameDescriptionFieldData, value: string) => {
+      if (key === 'name') {
+        setDisplayNameValue(value);
+      } else if (key === 'k8sName') {
+        setK8sNameManual(value);
+        setK8sTouched(true);
+      }
+    },
+    [],
   );
 
   const [selectedNamespace, setSelectedNamespace] = React.useState(
@@ -84,8 +125,8 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
     setSelectedNamespace(projectName);
   }, []);
 
-  const displayName = nameDescData.name;
-  const k8sName = nameDescData.k8sName.value;
+  const displayName = displayNameValue;
+  const k8sName = effectiveK8sName;
 
   const handleDeploy = React.useCallback(async () => {
     if (!ociImageValue || !selectedNamespace || !k8sName) {
@@ -148,8 +189,8 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   const hasValidName =
     !!displayName &&
     !!k8sName &&
-    !nameDescData.k8sName.state.invalidCharacters &&
-    !nameDescData.k8sName.state.invalidLength;
+    isValidK8sName(k8sName) &&
+    k8sName.length <= MAX_K8S_NAME_LENGTH;
 
   const dataReady = !!existingDeployment || crLoaded;
 


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/RHOAIENG-57460

The "Deployment name" field in the MCP Deploy Server modal provides no visible validation feedback when the user enters invalid input — the Deploy button becomes silently disabled with no indication of what's wrong.

**Two scenarios fixed:**

1. **Symbols only** — If the user enters only special characters (e.g., `!!!@@@`), the auto-generated resource name becomes an empty string. The "The resource name will be xyz" helper text disappears entirely and the Deploy button is disabled with no error or warning shown.  
   **Fix:** An inline error now appears: *"The name must contain at least one alphanumeric character."*

2. **Excessive length** — If the user enters a very long name that exceeds the 253-character K8s resource name limit, the Deploy button is disabled but the warning is only visible inside the collapsed "Edit resource name" section.  
   **Fix:** The `invalidLength` and `invalidCharacters` errors are now surfaced directly below the name field, visible without expanding the resource name editor.

Additionally:
- The name `TextInput` now shows a red validation border (`validated="error"`) when any of these conditions are present.
- Duplicated validation message strings between `K8sNameDescriptionField.tsx` and `ResourceNameField.tsx` were extracted into shared constants in `utils.ts` (DRY).

Tests not added coz this is already unit tested.

<img width="542" height="91" alt="Screenshot 2026-04-16 at 4 45 24 PM" src="https://github.com/user-attachments/assets/d0ce4885-5fe3-49ef-8dfa-ac37315c33bc" />
<img width="545" height="84" alt="Screenshot 2026-04-16 at 12 46 35 PM" src="https://github.com/user-attachments/assets/47f5e5fd-cabf-4cb9-8a2f-a0b2a02ecc7a" />
<img width="542" height="119" alt="Screenshot 2026-04-16 at 12 47 10 PM" src="https://github.com/user-attachments/assets/dc148f37-f78c-46bb-86ea-15a4ba89d62d" />

### Files changed

- `K8sNameDescriptionField.tsx` — validation flags, red border on input, inline error messages
- `ResourceNameField.tsx` — use shared message constants
- `utils.ts` — new exports: `getMaxLengthErrorMessage()`, `INVALID_K8S_NAME_CHARACTERS_MESSAGE`

## How Has This Been Tested?

- Type-check passes (`npx tsc --noEmit`)
- Linter passes (no new warnings)
- Manual verification of the two reported scenarios against the component logic

## Test Impact

No existing unit tests for `K8sNameDescriptionField` — this is a UI-only validation feedback change. Tests can be added as a follow-up.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the "Deploy from Catalog" modal: validating name input behavior, helper text for invalid names, automatic resource-name generation when input is invalid, project selection interaction, submit button state transitions, and request payload verification.
  * Added test helpers to support deployment modal validation and project selection in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->