### PR TITLE
feat(maas): add phase column to subscription and auth policy tables

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -744,6 +744,14 @@ class SubscriptionTableRow extends TableRow {
     return this.find().find('[data-label="Phase"]');
   }
 
+  findPhaseLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findPhase().findByTestId('phase-label');
+  }
+
+  findPhasePopover(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('phase-popover');
+  }
+
   findGroups(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Groups"]');
   }
@@ -1138,6 +1146,14 @@ class AuthPolicyTableRow extends TableRow {
 
   findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Phase"]');
+  }
+
+  findPhaseLabel(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findPhase().findByTestId('phase-label');
+  }
+
+  findPhasePopover(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('phase-popover');
   }
 
   findGroups(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -740,6 +740,10 @@ class SubscriptionTableRow extends TableRow {
     return this.find().find('[data-label="Name"]');
   }
 
+  findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().find('[data-label="Phase"]');
+  }
+
   findGroups(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Groups"]');
   }
@@ -1130,6 +1134,10 @@ class AuthPoliciesPage {
 class AuthPolicyTableRow extends TableRow {
   findName(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Name"]');
+  }
+
+  findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().find('[data-label="Phase"]');
   }
 
   findGroups(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -94,10 +94,12 @@ describe('MaaS Auth Policies', () => {
     authPoliciesPage.findRows().should('have.length', 3);
     const premiumRow = authPoliciesPage.getRow('premium-team-policy');
     premiumRow.findName().should('contain.text', 'premium-team-policy');
+    premiumRow.findPhase().should('contain.text', 'Active');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
     const basicRow = authPoliciesPage.getRow('basic-team-policy');
     basicRow.findName().should('contain.text', 'basic-team-policy');
+    basicRow.findPhase().should('contain.text', 'Active');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
   });
@@ -205,6 +207,8 @@ describe('View Auth Policy Page', () => {
     viewAuthPolicyPage
       .findDetailsSection()
       .should('contain.text', policyName)
+      .and('contain.text', 'Phase')
+      .and('contain.text', 'Active')
       .and('contain.text', 'Name')
       .and('contain.text', 'Resource name')
       .and('contain.text', 'Date created');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -102,6 +102,14 @@ describe('MaaS Auth Policies', () => {
     basicRow.findPhase().should('contain.text', 'Active');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
+
+    const failedRow = authPoliciesPage.getRow('failed-policy');
+    failedRow.findPhase().should('contain.text', 'Failed');
+    failedRow.findPhaseLabel().click();
+    failedRow.findPhasePopover().should('contain.text', 'Failed');
+
+    const pendingRow = authPoliciesPage.getRow('pending-policy');
+    pendingRow.findPhase().should('contain.text', 'Pending');
   });
 
   it('should delete an auth policy', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -91,7 +91,7 @@ describe('MaaS Auth Policies', () => {
   it('should display the auth policies table with correct page content', () => {
     authPoliciesPage.findTitle().should('contain.text', 'Policies');
     authPoliciesPage.findTable().should('exist');
-    authPoliciesPage.findRows().should('have.length', 3);
+    authPoliciesPage.findRows().should('have.length', 5);
     const premiumRow = authPoliciesPage.getRow('premium-team-policy');
     premiumRow.findName().should('contain.text', 'premium-team-policy');
     premiumRow.findPhase().should('contain.text', 'Active');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -59,7 +59,7 @@ describe('Subscriptions Page', () => {
       );
 
     subscriptionsPage.findTable().should('exist');
-    subscriptionsPage.findRows().should('have.length', 3);
+    subscriptionsPage.findRows().should('have.length', 5);
     subscriptionsPage.findCreateSubscriptionButton().should('exist');
 
     const premiumRow = subscriptionsPage.getRow('premium-team-sub');
@@ -86,7 +86,7 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findFilterInput().should('exist').type('premium');
     subscriptionsPage.findRows().should('have.length', 1);
     subscriptionsPage.findFilterResetButton().should('exist').click();
-    subscriptionsPage.findRows().should('have.length', 3);
+    subscriptionsPage.findRows().should('have.length', 5);
 
     premiumRow.findKebabAction('View details').should('exist');
     premiumRow.findKebabAction('Edit subscription').should('exist');
@@ -113,7 +113,7 @@ describe('Subscriptions Page', () => {
         data: { message: "MaaSSubscription 'premium-team-sub' deleted successfully" },
       });
     });
-    subscriptionsPage.findRows().should('have.length', 2);
+    subscriptionsPage.findRows().should('have.length', 4);
     subscriptionsPage.findTable().should('not.contain', 'premium-team-sub');
   });
 });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -83,6 +83,14 @@ describe('Subscriptions Page', () => {
     negativePriorityRow.findModels().should('contain.text', '1 Model');
     negativePriorityRow.findPriority().should('contain.text', '-10000');
 
+    const failedRow = subscriptionsPage.getRow('failed-sub');
+    failedRow.findPhase().should('contain.text', 'Failed');
+    failedRow.findPhaseLabel().click();
+    failedRow.findPhasePopover().should('contain.text', 'Failed');
+
+    const pendingRow = subscriptionsPage.getRow('pending-sub');
+    pendingRow.findPhase().should('contain.text', 'Pending');
+
     subscriptionsPage.findFilterInput().should('exist').type('premium');
     subscriptionsPage.findRows().should('have.length', 1);
     subscriptionsPage.findFilterResetButton().should('exist').click();

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -64,18 +64,21 @@ describe('Subscriptions Page', () => {
 
     const premiumRow = subscriptionsPage.getRow('premium-team-sub');
     premiumRow.findName().should('contain.text', 'premium-team-sub');
+    premiumRow.findPhase().should('contain.text', 'Active');
     premiumRow.findGroups().should('contain.text', '1 Group');
     premiumRow.findModels().should('contain.text', '2 Models');
     premiumRow.findPriority().should('contain.text', '10');
 
     const basicRow = subscriptionsPage.getRow('basic-team-sub');
     basicRow.findName().should('contain.text', 'basic-team-sub');
+    basicRow.findPhase().should('contain.text', 'Active');
     basicRow.findGroups().should('contain.text', '1 Group');
     basicRow.findModels().should('contain.text', '1 Model');
     basicRow.findPriority().should('contain.text', '0');
 
     const negativePriorityRow = subscriptionsPage.getRow('negative-priority-sub');
     negativePriorityRow.findName().should('contain.text', 'negative-priority-sub');
+    negativePriorityRow.findPhase().should('contain.text', 'Active');
     negativePriorityRow.findGroups().should('contain.text', '1 Group');
     negativePriorityRow.findModels().should('contain.text', '1 Model');
     negativePriorityRow.findPriority().should('contain.text', '-10000');
@@ -138,6 +141,8 @@ describe('View Subscription Page', () => {
     viewSubscriptionPage
       .findDetailsSection()
       .should('contain.text', subscriptionName)
+      .and('contain.text', 'Phase')
+      .and('contain.text', 'Active')
       .and('contain.text', 'Name')
       .and('contain.text', 'Date created');
 

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -318,6 +318,58 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
   },
 ];
 
+export const mockFailedSubscription = (): MaaSSubscription => ({
+  name: 'failed-sub',
+  namespace: 'maas-system',
+  phase: 'Failed',
+  priority: 99,
+  owner: {
+    groups: [{ name: 'system:authenticated' }],
+  },
+  modelRefs: [
+    {
+      name: 'granite-3-8b-instruct',
+      namespace: 'maas-models',
+      tokenRateLimits: [{ limit: 9999999, window: '24h' }],
+    },
+  ],
+  creationTimestamp: '2025-04-01T12:00:00Z',
+});
+
+export const mockPendingSubscription = (): MaaSSubscription => ({
+  name: 'pending-sub',
+  namespace: 'maas-system',
+  phase: 'Pending',
+  priority: 99,
+  owner: {
+    groups: [{ name: 'beta-testers' }],
+  },
+  modelRefs: [
+    {
+      name: 'flan-t5-small',
+      namespace: 'maas-models',
+      tokenRateLimits: [{ limit: 5000, window: '1h' }],
+    },
+  ],
+  creationTimestamp: '2025-04-05T09:00:00Z',
+});
+
+export const mockFailedAuthPolicy = (): MaaSAuthPolicy => ({
+  name: 'failed-policy',
+  namespace: 'maas-system',
+  phase: 'Failed',
+  modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
+  subjects: { groups: [{ name: 'system:authenticated' }] },
+});
+
+export const mockPendingAuthPolicy = (): MaaSAuthPolicy => ({
+  name: 'pending-policy',
+  namespace: 'maas-system',
+  phase: 'Pending',
+  modelRefs: [{ name: 'flan-t5-small', namespace: 'maas-models' }],
+  subjects: { groups: [{ name: 'beta-testers' }] },
+});
+
 export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {
   const policy = mockAuthPolicies().find((p) => p.name === name) ?? mockAuthPolicies()[0];
   const resolvedName = policy.name;

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -78,6 +78,42 @@ export const mockCreateAPIKeyRequest = (): CreateAPIKeyRequest => {
   };
 };
 
+export const mockFailedSubscription = (): MaaSSubscription => ({
+  name: 'failed-sub',
+  namespace: 'maas-system',
+  phase: 'Failed',
+  priority: 99,
+  owner: {
+    groups: [{ name: 'system:authenticated' }],
+  },
+  modelRefs: [
+    {
+      name: 'granite-3-8b-instruct',
+      namespace: 'maas-models',
+      tokenRateLimits: [{ limit: 9999999, window: '24h' }],
+    },
+  ],
+  creationTimestamp: '2025-04-01T12:00:00Z',
+});
+
+export const mockPendingSubscription = (): MaaSSubscription => ({
+  name: 'pending-sub',
+  namespace: 'maas-system',
+  phase: 'Pending',
+  priority: 99,
+  owner: {
+    groups: [{ name: 'beta-testers' }],
+  },
+  modelRefs: [
+    {
+      name: 'flan-t5-small',
+      namespace: 'maas-models',
+      tokenRateLimits: [{ limit: 5000, window: '1h' }],
+    },
+  ],
+  creationTimestamp: '2025-04-05T09:00:00Z',
+});
+
 export const mockSubscriptions = (): MaaSSubscription[] => [
   {
     name: 'premium-team-sub',
@@ -139,6 +175,8 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
     ],
     creationTimestamp: '2025-03-18T03:00:00Z',
   },
+  mockFailedSubscription(),
+  mockPendingSubscription(),
 ];
 
 export const mockSubscriptionListItems = (): UserSubscription[] => [
@@ -290,6 +328,22 @@ export const mockCreatePolicyResponse = (name = 'new-policy-from-test'): MaaSAut
   subjects: { groups: [{ name: 'premium-users' }] },
 });
 
+export const mockFailedAuthPolicy = (): MaaSAuthPolicy => ({
+  name: 'failed-policy',
+  namespace: 'maas-system',
+  phase: 'Failed',
+  modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
+  subjects: { groups: [{ name: 'system:authenticated' }] },
+});
+
+export const mockPendingAuthPolicy = (): MaaSAuthPolicy => ({
+  name: 'pending-policy',
+  namespace: 'maas-system',
+  phase: 'Pending',
+  modelRefs: [{ name: 'flan-t5-small', namespace: 'maas-models' }],
+  subjects: { groups: [{ name: 'beta-testers' }] },
+});
+
 export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
   {
     name: 'test-subscription-policy',
@@ -316,59 +370,9 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
       groups: mockSubscriptions()[1].owner.groups,
     },
   },
+  mockFailedAuthPolicy(),
+  mockPendingAuthPolicy(),
 ];
-
-export const mockFailedSubscription = (): MaaSSubscription => ({
-  name: 'failed-sub',
-  namespace: 'maas-system',
-  phase: 'Failed',
-  priority: 99,
-  owner: {
-    groups: [{ name: 'system:authenticated' }],
-  },
-  modelRefs: [
-    {
-      name: 'granite-3-8b-instruct',
-      namespace: 'maas-models',
-      tokenRateLimits: [{ limit: 9999999, window: '24h' }],
-    },
-  ],
-  creationTimestamp: '2025-04-01T12:00:00Z',
-});
-
-export const mockPendingSubscription = (): MaaSSubscription => ({
-  name: 'pending-sub',
-  namespace: 'maas-system',
-  phase: 'Pending',
-  priority: 99,
-  owner: {
-    groups: [{ name: 'beta-testers' }],
-  },
-  modelRefs: [
-    {
-      name: 'flan-t5-small',
-      namespace: 'maas-models',
-      tokenRateLimits: [{ limit: 5000, window: '1h' }],
-    },
-  ],
-  creationTimestamp: '2025-04-05T09:00:00Z',
-});
-
-export const mockFailedAuthPolicy = (): MaaSAuthPolicy => ({
-  name: 'failed-policy',
-  namespace: 'maas-system',
-  phase: 'Failed',
-  modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
-  subjects: { groups: [{ name: 'system:authenticated' }] },
-});
-
-export const mockPendingAuthPolicy = (): MaaSAuthPolicy => ({
-  name: 'pending-policy',
-  namespace: 'maas-system',
-  phase: 'Pending',
-  modelRefs: [{ name: 'flan-t5-small', namespace: 'maas-models' }],
-  subjects: { groups: [{ name: 'beta-testers' }] },
-});
 
 export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {
   const policy = mockAuthPolicies().find((p) => p.name === name) ?? mockAuthPolicies()[0];

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -82,6 +82,8 @@ export const mockFailedSubscription = (): MaaSSubscription => ({
   name: 'failed-sub',
   namespace: 'maas-system',
   phase: 'Failed',
+  statusMessage:
+    'failed to reconcile TokenRateLimitPolicies: token rate limit exceeds maximum allowed value',
   priority: 99,
   owner: {
     groups: [{ name: 'system:authenticated' }],
@@ -100,6 +102,7 @@ export const mockPendingSubscription = (): MaaSSubscription => ({
   name: 'pending-sub',
   namespace: 'maas-system',
   phase: 'Pending',
+  statusMessage: '',
   priority: 99,
   owner: {
     groups: [{ name: 'beta-testers' }],
@@ -119,6 +122,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
     name: 'premium-team-sub',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     priority: 10,
     owner: {
       groups: [{ name: 'premium-users' }],
@@ -145,6 +149,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
     name: 'basic-team-sub',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     owner: {
       groups: [{ name: 'system:authenticated' }],
     },
@@ -162,6 +167,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
     name: 'negative-priority-sub',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     priority: -10000,
     owner: {
       groups: [{ name: 'system:authenticated' }],
@@ -245,6 +251,7 @@ export const mockSubscriptionInfo = (name = 'premium-team-sub'): SubscriptionInf
         name: `${name}-policy`,
         namespace: subscription.namespace,
         phase: 'Active',
+        statusMessage: 'successfully reconciled',
         modelRefs: subscription.modelRefs.map((ref) => ({
           name: ref.name,
           namespace: ref.namespace,
@@ -291,6 +298,7 @@ export const mockCreateSubscriptionResponse = (): CreateSubscriptionResponse => 
     description: 'A test subscription',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     priority: 5,
     owner: {
       groups: [{ name: 'premium-users' }, { name: 'my-custom-group' }],
@@ -308,6 +316,7 @@ export const mockCreateSubscriptionResponse = (): CreateSubscriptionResponse => 
     name: 'test-subscription-policy',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
     subjects: { groups: [{ name: 'premium-users' }, { name: 'my-custom-group' }] },
   },
@@ -324,6 +333,7 @@ export const mockCreatePolicyResponse = (name = 'new-policy-from-test'): MaaSAut
   name,
   namespace: 'maas-system',
   phase: 'Pending',
+  statusMessage: '',
   modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
   subjects: { groups: [{ name: 'premium-users' }] },
 });
@@ -332,6 +342,7 @@ export const mockFailedAuthPolicy = (): MaaSAuthPolicy => ({
   name: 'failed-policy',
   namespace: 'maas-system',
   phase: 'Failed',
+  statusMessage: 'all 2 model references are invalid or missing',
   modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
   subjects: { groups: [{ name: 'system:authenticated' }] },
 });
@@ -340,6 +351,7 @@ export const mockPendingAuthPolicy = (): MaaSAuthPolicy => ({
   name: 'pending-policy',
   namespace: 'maas-system',
   phase: 'Pending',
+  statusMessage: '',
   modelRefs: [{ name: 'flan-t5-small', namespace: 'maas-models' }],
   subjects: { groups: [{ name: 'beta-testers' }] },
 });
@@ -349,6 +361,7 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
     name: 'test-subscription-policy',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
     subjects: { groups: [{ name: 'premium-users' }, { name: 'my-custom-group' }] },
   },
@@ -356,6 +369,7 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
     name: 'premium-team-policy',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     modelRefs: mockSubscriptions()[0].modelRefs,
     subjects: {
       groups: mockSubscriptions()[0].owner.groups,
@@ -365,6 +379,7 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
     name: 'basic-team-policy',
     namespace: 'maas-system',
     phase: 'Active',
+    statusMessage: 'successfully reconciled',
     modelRefs: mockSubscriptions()[1].modelRefs,
     subjects: {
       groups: mockSubscriptions()[1].owner.groups,

--- a/packages/maas/bff/internal/mocks/subscription_mock.go
+++ b/packages/maas/bff/internal/mocks/subscription_mock.go
@@ -14,12 +14,13 @@ func timePtr(t time.Time) *time.Time {
 func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 	return []models.MaaSSubscription{
 		{
-			Name:        "premium-team-sub",
-			Namespace:   "maas-system",
-			DisplayName: "Premium Team Subscription",
-			Description: "High-priority subscription for the premium team with extended token limits.",
-			Phase:       "Active",
-			Priority:    10,
+			Name:          "premium-team-sub",
+			Namespace:     "maas-system",
+			DisplayName:   "Premium Team Subscription",
+			Description:   "High-priority subscription for the premium team with extended token limits.",
+			Phase:         "Active",
+			StatusMessage: "successfully reconciled",
+			Priority:      10,
 			Owner: models.OwnerSpec{
 				Groups: []models.GroupReference{
 					{Name: "premium-users"},
@@ -48,12 +49,13 @@ func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 			CreationTimestamp: timePtr(time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)),
 		},
 		{
-			Name:        "basic-team-sub",
-			Namespace:   "maas-system",
-			DisplayName: "Basic Team Subscription",
-			Description: "Standard subscription for general team access.",
-			Phase:       "Active",
-			Priority:    0,
+			Name:          "basic-team-sub",
+			Namespace:     "maas-system",
+			DisplayName:   "Basic Team Subscription",
+			Description:   "Standard subscription for general team access.",
+			Phase:         "Active",
+			StatusMessage: "successfully reconciled",
+			Priority:      0,
 			Owner: models.OwnerSpec{
 				Groups: []models.GroupReference{
 					{Name: "system:authenticated"},
@@ -71,12 +73,13 @@ func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 			CreationTimestamp: timePtr(time.Date(2025, 2, 15, 8, 0, 0, 0, time.UTC)),
 		},
 		{
-			Name:        "negative-priority-sub",
-			Namespace:   "maas-system",
-			DisplayName: "Negative Priority Subscription",
-			Description: "Negative priority subscription for testing.",
-			Phase:       "Active",
-			Priority:    -10,
+			Name:          "negative-priority-sub",
+			Namespace:     "maas-system",
+			DisplayName:   "Negative Priority Subscription",
+			Description:   "Negative priority subscription for testing.",
+			Phase:         "Active",
+			StatusMessage: "successfully reconciled",
+			Priority:      -10,
 			Owner: models.OwnerSpec{
 				Groups: []models.GroupReference{
 					{Name: "system:authenticated"},
@@ -105,6 +108,7 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			DisplayName:       "Premium Team Policy",
 			Description:       "High-priority access policy for the premium team with extended model access.",
 			Phase:             "Active",
+			StatusMessage:     "successfully reconciled",
 			CreationTimestamp: timePtr(time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)),
 			ModelRefs: []models.ModelRef{
 				{Name: "granite-3-8b-instruct", Namespace: "maas-models"},
@@ -126,6 +130,7 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			DisplayName:       "Basic Team Policy",
 			Description:       "Standard access policy for general team usage.",
 			Phase:             "Active",
+			StatusMessage:     "successfully reconciled",
 			CreationTimestamp: timePtr(time.Date(2025, 2, 15, 8, 0, 0, 0, time.UTC)),
 			ModelRefs: []models.ModelRef{
 				{Name: "flan-t5-small", Namespace: "maas-models"},
@@ -137,9 +142,10 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			},
 		},
 		{
-			Name:      "negative-priority-sub-policy",
-			Namespace: "maas-system",
-			Phase:     "Active",
+			Name:          "negative-priority-sub-policy",
+			Namespace:     "maas-system",
+			Phase:         "Active",
+			StatusMessage: "successfully reconciled",
 			ModelRefs: []models.ModelRef{
 				{Name: "flan-t5-small", Namespace: "maas-models"},
 				{Name: "granite-3-8b-instruct", Namespace: "maas-models"},

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -77,6 +77,7 @@ type MaaSSubscription struct {
 	Description       string                 `json:"description,omitempty"`
 	Namespace         string                 `json:"namespace"`
 	Phase             string                 `json:"phase,omitempty"`
+	StatusMessage     string                 `json:"statusMessage,omitempty"`
 	Priority          int32                  `json:"priority"`
 	Owner             OwnerSpec              `json:"owner"`
 	ModelRefs         []ModelSubscriptionRef `json:"modelRefs"`
@@ -102,6 +103,7 @@ type MaaSAuthPolicy struct {
 	DisplayName       string         `json:"displayName,omitempty"`
 	Description       string         `json:"description,omitempty"`
 	Phase             string         `json:"phase,omitempty"`
+	StatusMessage     string         `json:"statusMessage,omitempty"`
 	CreationTimestamp *time.Time     `json:"creationTimestamp,omitempty"`
 	ModelRefs         []ModelRef     `json:"modelRefs"`
 	Subjects          SubjectSpec    `json:"subjects"`

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -349,6 +349,8 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 	phase, _, _ := unstructured.NestedString(content, "status", "phase")
 	sub.Phase = phase
 
+	sub.StatusMessage = extractReadyConditionMessage(content)
+
 	priority, _, _ := unstructured.NestedFieldNoCopy(content, "spec", "priority")
 	if priority != nil {
 		switch v := priority.(type) {
@@ -450,6 +452,8 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 	phase, _, _ := unstructured.NestedString(content, "status", "phase")
 	policy.Phase = phase
 
+	policy.StatusMessage = extractReadyConditionMessage(content)
+
 	modelRefs, _, _ := unstructured.NestedSlice(content, "spec", "modelRefs")
 	for _, mr := range modelRefs {
 		if mrMap, ok := mr.(map[string]interface{}); ok {
@@ -524,6 +528,21 @@ func convertUnstructuredToModelRefSummary(obj *unstructured.Unstructured) (*mode
 	summary.Endpoint = endpoint
 
 	return summary, nil
+}
+
+// extractReadyConditionMessage returns the message from the "Ready" condition in status.conditions.
+func extractReadyConditionMessage(content map[string]interface{}) string {
+	conditions, _, _ := unstructured.NestedSlice(content, "status", "conditions")
+	for _, c := range conditions {
+		if cMap, ok := c.(map[string]interface{}); ok {
+			if condType, _ := cMap["type"].(string); condType == "Ready" {
+				if msg, _ := cMap["message"].(string); msg != "" {
+					return msg
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // --- Builder helpers: Go models -> Unstructured ---

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1889,6 +1889,10 @@ components:
           enum: [Pending, Active, Failed]
           description: Current phase of the subscription (from status)
           example: Active
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
+          example: "successfully reconciled"
         priority:
           type: integer
           format: int32
@@ -1966,6 +1970,10 @@ components:
           enum: [Pending, Active, Failed]
           description: Current phase of the auth policy (from status)
           example: Active
+        statusMessage:
+          type: string
+          description: Human-readable status message from the Ready condition in status.conditions
+          example: "successfully reconciled"
         creationTimestamp:
           type: string
           format: date-time

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -53,7 +53,7 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
         />
       </Td>
       <Td dataLabel={columns[1].label}>
-        <PhaseLabel phase={authPolicy.phase} />
+        <PhaseLabel phase={authPolicy.phase} statusMessage={authPolicy.statusMessage} />
       </Td>
       <Td dataLabel={columns[2].label}>{labelHelper(groupsCount, 'Group', 'Groups')}</Td>
       <Td dataLabel={columns[3].label}>{labelHelper(modelsCount, 'Model', 'Models')}</Td>

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
+import PhaseLabel from '~/app/shared/PhaseLabel';
 
 type AuthPoliciesTableRowProps = {
   authPolicy: MaaSAuthPolicy;
@@ -51,8 +52,11 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
           truncateDescriptionLines={2}
         />
       </Td>
-      <Td dataLabel={columns[1].label}>{labelHelper(groupsCount, 'Group', 'Groups')}</Td>
-      <Td dataLabel={columns[2].label}>{labelHelper(modelsCount, 'Model', 'Models')}</Td>
+      <Td dataLabel={columns[1].label}>
+        <PhaseLabel phase={authPolicy.phase} />
+      </Td>
+      <Td dataLabel={columns[2].label}>{labelHelper(groupsCount, 'Group', 'Groups')}</Td>
+      <Td dataLabel={columns[3].label}>{labelHelper(modelsCount, 'Model', 'Models')}</Td>
       <Td isActionCell>
         <ActionsColumn
           data-testid="auth-policy-actions"

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/columns.ts
@@ -8,6 +8,13 @@ export const authPoliciesColumns: SortableData<MaaSAuthPolicy>[] = [
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number => a.name.localeCompare(b.name),
   },
   {
+    label: 'Phase',
+    field: 'phase',
+    width: 10,
+    sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>
+      (a.phase ?? '').localeCompare(b.phase ?? ''),
+  },
+  {
     label: 'Groups',
     field: 'subjects.groups',
     sortable: (a: MaaSAuthPolicy, b: MaaSAuthPolicy): number =>

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -33,8 +33,8 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>Phase</DescriptionListTerm>
-          <DescriptionListDescription data-testid="policy-status">
-            <PhaseLabel phase={policy.phase} />
+          <DescriptionListDescription data-testid="policy-phase">
+            <PhaseLabel phase={policy.phase} statusMessage={policy.statusMessage} />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/viewAuthPolicy/PolicyDetailsSection.tsx
@@ -10,6 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+import PhaseLabel from '~/app/shared/PhaseLabel';
 
 type PolicyDetailsSectionProps = {
   policy: MaaSAuthPolicy;
@@ -28,6 +29,12 @@ const PolicyDetailsSection: React.FC<PolicyDetailsSectionProps> = ({ policy }) =
           <DescriptionListTerm>Name</DescriptionListTerm>
           <DescriptionListDescription>
             {policy.displayName ?? policy.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Phase</DescriptionListTerm>
+          <DescriptionListDescription data-testid="policy-status">
+            <PhaseLabel phase={policy.phase} />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -45,7 +45,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
         />
       </Td>
       <Td dataLabel={subscriptionsColumns[1].label}>
-        <PhaseLabel phase={subscription.phase} />
+        <PhaseLabel phase={subscription.phase} statusMessage={subscription.statusMessage} />
       </Td>
       <Td dataLabel={subscriptionsColumns[2].label}>
         <Label color="grey">{`${subscription.owner.groups.length} Group${subscription.owner.groups.length === 1 ? '' : 's'}`}</Label>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -5,6 +5,7 @@ import { Content, Label } from '@patternfly/react-core';
 import { Link, useNavigate } from 'react-router-dom';
 import { MaaSSubscription } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
+import PhaseLabel from '~/app/shared/PhaseLabel';
 import { subscriptionsColumns } from './columns';
 
 type SubscriptionTableRowProps = {
@@ -44,12 +45,15 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
         />
       </Td>
       <Td dataLabel={subscriptionsColumns[1].label}>
-        <Label color="grey">{`${subscription.owner.groups.length} Group${subscription.owner.groups.length === 1 ? '' : 's'}`}</Label>
+        <PhaseLabel phase={subscription.phase} />
       </Td>
       <Td dataLabel={subscriptionsColumns[2].label}>
+        <Label color="grey">{`${subscription.owner.groups.length} Group${subscription.owner.groups.length === 1 ? '' : 's'}`}</Label>
+      </Td>
+      <Td dataLabel={subscriptionsColumns[3].label}>
         <Label color="grey">{`${subscription.modelRefs.length} Model${subscription.modelRefs.length === 1 ? '' : 's'}`}</Label>
       </Td>
-      <Td dataLabel={subscriptionsColumns[3].label} style={{ textAlign: 'center' }}>
+      <Td dataLabel={subscriptionsColumns[4].label} style={{ textAlign: 'center' }}>
         <Content component="p" style={{ fontWeight: 'bold' }}>
           {subscription.priority ?? '-'}
         </Content>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -8,6 +8,13 @@ export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number => a.name.localeCompare(b.name),
   },
   {
+    label: 'Phase',
+    field: 'phase',
+    width: 10,
+    sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
+      (a.phase ?? '').localeCompare(b.phase ?? ''),
+  },
+  {
     label: 'Groups',
     field: 'owner.groups',
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -35,8 +35,8 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>Phase</DescriptionListTerm>
-          <DescriptionListDescription data-testid="subscription-status">
-            <PhaseLabel phase={subscription.phase} />
+          <DescriptionListDescription data-testid="subscription-phase">
+            <PhaseLabel phase={subscription.phase} statusMessage={subscription.statusMessage} />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/SubscriptionDetailsSection.tsx
@@ -10,6 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { MaaSSubscription } from '~/app/types/subscriptions';
+import PhaseLabel from '~/app/shared/PhaseLabel';
 
 type SubscriptionDetailsSectionProps = {
   subscription: MaaSSubscription;
@@ -30,6 +31,12 @@ const SubscriptionDetailsSection: React.FC<SubscriptionDetailsSectionProps> = ({
           <DescriptionListTerm>Display name</DescriptionListTerm>
           <DescriptionListDescription>
             {subscription.displayName ?? subscription.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Phase</DescriptionListTerm>
+          <DescriptionListDescription data-testid="subscription-status">
+            <PhaseLabel phase={subscription.phase} />
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Label, LabelProps } from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
+
+type PhaseLabelProps = {
+  phase: string | undefined;
+};
+
+const getPhaseProps = (
+  phase: string | undefined,
+): { icon: React.ReactNode; status?: LabelProps['status']; color?: LabelProps['color'] } => {
+  switch (phase) {
+    case 'Active':
+    case 'Ready':
+      return { icon: <CheckCircleIcon />, status: 'success' };
+    case 'Failed':
+    case 'Unhealthy':
+      return { icon: <ExclamationCircleIcon />, status: 'danger' };
+    case 'Pending':
+      return { icon: <InProgressIcon />, color: 'blue' };
+    default:
+      return { icon: undefined, color: 'grey' };
+  }
+};
+
+const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase }) => {
+  if (!phase) {
+    return <>—</>;
+  }
+
+  return (
+    <Label isCompact data-testid="phase-label" {...getPhaseProps(phase)}>
+      {phase}
+    </Label>
+  );
+};
+
+export default PhaseLabel;

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Label, LabelProps } from '@patternfly/react-core';
+import { Label, LabelProps, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 
 type PhaseLabelProps = {
   phase: string | undefined;
+  statusMessage?: string;
 };
 
 const getPhaseProps = (
@@ -23,12 +24,42 @@ const getPhaseProps = (
   }
 };
 
-const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase }) => {
+const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, statusMessage }) => {
   const normalized = phase?.trim() || 'Unknown';
-  return (
-    <Label isCompact data-testid="phase-label" {...getPhaseProps(normalized)}>
+  const phaseProps = getPhaseProps(normalized);
+  const hasPopover = !!statusMessage;
+
+  const label = (
+    <Label
+      variant={hasPopover ? 'filled' : 'outline'}
+      isCompact
+      data-testid="phase-label"
+      {...phaseProps}
+      {...(hasPopover
+        ? {
+            onClick: () => {
+              /* Click handled by Popover parent */
+            },
+          }
+        : {})}
+    >
       {normalized}
     </Label>
+  );
+
+  if (!hasPopover) {
+    return label;
+  }
+
+  return (
+    <Popover
+      data-testid="phase-popover"
+      headerContent={normalized}
+      bodyContent={statusMessage}
+      position="top"
+    >
+      {label}
+    </Popover>
   );
 };
 

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -24,13 +24,10 @@ const getPhaseProps = (
 };
 
 const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase }) => {
-  if (!phase) {
-    return <>—</>;
-  }
-
+  const normalized = phase?.trim() || 'Unknown';
   return (
-    <Label isCompact data-testid="phase-label" {...getPhaseProps(phase)}>
-      {phase}
+    <Label isCompact data-testid="phase-label" {...getPhaseProps(normalized)}>
+      {normalized}
     </Label>
   );
 };

--- a/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
+++ b/packages/maas/frontend/src/app/shared/PhaseLabel.tsx
@@ -33,15 +33,9 @@ const PhaseLabel: React.FC<PhaseLabelProps> = ({ phase, statusMessage }) => {
     <Label
       variant={hasPopover ? 'filled' : 'outline'}
       isCompact
+      isClickable={hasPopover}
       data-testid="phase-label"
       {...phaseProps}
-      {...(hasPopover
-        ? {
-            onClick: () => {
-              /* Click handled by Popover parent */
-            },
-          }
-        : {})}
     >
       {normalized}
     </Label>

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -3,51 +3,52 @@ import { render, screen } from '@testing-library/react';
 import PhaseLabel from '~/app/shared/PhaseLabel';
 
 describe('PhaseLabel', () => {
-  it('should render a success label for Active phase', () => {
+  it('should render Active phase with correct text', () => {
     render(<PhaseLabel phase="Active" />);
-    const label = screen.getByText('Active').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-success');
+    expect(label.textContent).toContain('Active');
   });
 
-  it('should render a success label for Ready phase', () => {
+  it('should render Ready phase with correct text', () => {
     render(<PhaseLabel phase="Ready" />);
-    const label = screen.getByText('Ready').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-success');
+    expect(label.textContent).toContain('Ready');
   });
 
-  it('should render a danger label for Failed phase', () => {
+  it('should render Failed phase with correct text', () => {
     render(<PhaseLabel phase="Failed" />);
-    const label = screen.getByText('Failed').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-danger');
+    expect(label.textContent).toContain('Failed');
   });
 
-  it('should render a danger label for Unhealthy phase', () => {
+  it('should render Unhealthy phase with correct text', () => {
     render(<PhaseLabel phase="Unhealthy" />);
-    const label = screen.getByText('Unhealthy').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-danger');
+    expect(label.textContent).toContain('Unhealthy');
   });
 
-  it('should render a blue label for Pending phase', () => {
+  it('should render Pending phase with correct text', () => {
     render(<PhaseLabel phase="Pending" />);
-    const label = screen.getByText('Pending').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-blue');
+    expect(label.textContent).toContain('Pending');
   });
 
-  it('should render an em-dash when phase is undefined', () => {
-    const { container } = render(<PhaseLabel phase={undefined} />);
-    expect(container.textContent).toBe('—');
-    expect(screen.queryByTestId('phase-label')).toBeNull();
+  it('should render Unknown label when phase is undefined', () => {
+    render(<PhaseLabel phase={undefined} />);
+    const label = screen.getByTestId('phase-label');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain('Unknown');
   });
 
-  it('should render a compact filled label for an unknown phase value', () => {
+  it('should render unrecognized phase values as-is', () => {
     render(<PhaseLabel phase="SomethingElse" />);
-    const label = screen.getByText('SomethingElse').closest('.pf-v6-c-label');
+    const label = screen.getByTestId('phase-label');
     expect(label).not.toBeNull();
-    expect(label?.className).toContain('pf-m-compact');
+    expect(label.textContent).toContain('SomethingElse');
   });
 });

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import PhaseLabel from '~/app/shared/PhaseLabel';
+
+describe('PhaseLabel', () => {
+  it('should render a success label for Active phase', () => {
+    render(<PhaseLabel phase="Active" />);
+    const label = screen.getByText('Active').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-success');
+  });
+
+  it('should render a success label for Ready phase', () => {
+    render(<PhaseLabel phase="Ready" />);
+    const label = screen.getByText('Ready').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-success');
+  });
+
+  it('should render a danger label for Failed phase', () => {
+    render(<PhaseLabel phase="Failed" />);
+    const label = screen.getByText('Failed').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-danger');
+  });
+
+  it('should render a danger label for Unhealthy phase', () => {
+    render(<PhaseLabel phase="Unhealthy" />);
+    const label = screen.getByText('Unhealthy').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-danger');
+  });
+
+  it('should render a blue label for Pending phase', () => {
+    render(<PhaseLabel phase="Pending" />);
+    const label = screen.getByText('Pending').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-blue');
+  });
+
+  it('should render an em-dash when phase is undefined', () => {
+    const { container } = render(<PhaseLabel phase={undefined} />);
+    expect(container.textContent).toBe('—');
+    expect(screen.queryByTestId('phase-label')).toBeNull();
+  });
+
+  it('should render a compact filled label for an unknown phase value', () => {
+    render(<PhaseLabel phase="SomethingElse" />);
+    const label = screen.getByText('SomethingElse').closest('.pf-v6-c-label');
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain('pf-m-compact');
+  });
+});

--- a/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
+++ b/packages/maas/frontend/src/app/shared/__tests__/PhaseLabel.spec.tsx
@@ -51,4 +51,18 @@ describe('PhaseLabel', () => {
     expect(label).not.toBeNull();
     expect(label.textContent).toContain('SomethingElse');
   });
+
+  it('should render outline variant when no statusMessage is provided', () => {
+    render(<PhaseLabel phase="Active" />);
+    const label = screen.getByTestId('phase-label');
+    expect(label.className).toContain('pf-m-outline');
+    expect(screen.queryByTestId('phase-popover')).toBeNull();
+  });
+
+  it('should render filled variant with popover when statusMessage is provided', () => {
+    render(<PhaseLabel phase="Failed" statusMessage="Token limit exceeded." />);
+    const label = screen.getByTestId('phase-label');
+    expect(label.className).not.toContain('pf-m-outline');
+    expect(label.textContent).toContain('Failed');
+  });
 });

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -4,6 +4,7 @@ export type MaaSSubscription = {
   description?: string;
   namespace: string;
   phase?: string;
+  statusMessage?: string;
   priority?: number;
   owner: OwnerSpec;
   modelRefs: ModelSubscriptionRef[];
@@ -107,6 +108,7 @@ export type MaaSAuthPolicy = {
   name: string;
   namespace: string;
   phase?: string;
+  statusMessage?: string;
   creationTimestamp?: string;
   modelRefs: ModelRef[];
   subjects: SubjectSpec;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-57225

## Description
Adds a Phase status column and popover for message to the subscriptions and auth policies tables, and displays phase in the policy detail view. A new shared PhaseLabel component renders the phase as a color-coded PatternFly label (green for Active, blue for Pending, red for Failed, grey for unknown/missing).


<img width="1685" height="502" alt="Screenshot 2026-04-14 at 4 17 09 PM" src="https://github.com/user-attachments/assets/be06f95f-3247-464c-b454-b4df4ff48be8" />
 and
<img width="2305" height="954" alt="Screenshot 2026-04-14 at 4 17 25 PM" src="https://github.com/user-attachments/assets/176e1697-4374-4f4d-8e6b-c798118703ae" />
<img width="2243" height="1034" alt="Screenshot 2026-04-14 at 4 16 44 PM" src="https://github.com/user-attachments/assets/aeb1d491-15c5-47a7-8a79-fe15f29295e7" />
<img width="556" height="206" alt="Screenshot 2026-04-14 at 4 16 49 PM" src="https://github.com/user-attachments/assets/61f58661-c311-448f-adfa-b71ff15f84a7" />
<img width="2285" height="1071" alt="Screenshot 2026-04-14 at 4 17 00 PM" src="https://github.com/user-attachments/assets/90a99b39-c660-401c-bc3e-8296e9f01b86" />



## How Has This Been Tested?
Open the subscription and policy page and check the new column added for status.
Open the view details page for subscription and policy and check the policy added in description list.

## Test Impact
Added unit and updated cypress tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sortable "Phase" column to Subscriptions and Auth Policies tables.
  * Phase shown in subscription and auth policy detail views with compact visual indicators and contextual popovers when available.
* **Tests**
  * Updated tests and test data to cover Phase display, sorting, and popover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->