### PR TITLE
fix(RHOAIENG-57510): store raw input value in MultiSelection isCreatable option name

### DIFF
--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -144,15 +144,21 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
     ) {
       return {
         id: inputValueTrim,
-        name:
-          typeof createOptionMessage === 'string'
-            ? createOptionMessage
-            : createOptionMessage(inputValueTrim),
+        name: inputValueTrim,
         selected: false,
       };
     }
     return undefined;
-  }, [inputValue, isCreatable, createOptionMessage, allValues]);
+  }, [inputValue, isCreatable, allValues]);
+
+  const createOptionDisplayName = React.useMemo(() => {
+    if (!createOption) {
+      return undefined;
+    }
+    return typeof createOptionMessage === 'string'
+      ? createOptionMessage
+      : createOptionMessage(createOption.name);
+  }, [createOption, createOptionMessage]);
 
   const allOptions = React.useMemo(() => {
     const options = [...allValues];
@@ -341,7 +347,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
         {createOption && isCreateOptionOnTop && groupOptions.length > 0 ? (
           <SelectList isAriaMultiselectable>
             <SelectOption value={createOption.id} isFocused={focusedItemIndex === 0}>
-              {createOption.name}
+              {createOptionDisplayName}
             </SelectOption>
           </SelectList>
         ) : null}
@@ -377,7 +383,7 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
         (createOption && (!isCreateOptionOnTop || groupOptions.length === 0)) ? (
           <SelectList isAriaMultiselectable data-testid={listTestId}>
             {createOption && isCreateOptionOnTop && groupOptions.length === 0 ? (
-              <SelectOption value={createOption.id}>{createOption.name}</SelectOption>
+              <SelectOption value={createOption.id}>{createOptionDisplayName}</SelectOption>
             ) : null}
             {selectOptions.map((option) => (
               <SelectOption
@@ -395,11 +401,11 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
             ))}
             {createOption && !isCreateOptionOnTop ? (
               <SelectOption
-                data-testid={`select-multi-typeahead-${Option.name.replace(' ', '-')}`}
+                data-testid={`select-multi-typeahead-${createOption.name.replace(' ', '-')}`}
                 value={createOption.id}
                 isFocused={focusedItemIndex === visibleOptions.length - 1}
               >
-                {createOption.name}
+                {createOptionDisplayName}
               </SelectOption>
             ) : null}
           </SelectList>

--- a/frontend/src/components/MultiSelection.tsx
+++ b/frontend/src/components/MultiSelection.tsx
@@ -151,14 +151,11 @@ export const MultiSelection: React.FC<MultiSelectionProps> = ({
     return undefined;
   }, [inputValue, isCreatable, allValues]);
 
-  const createOptionDisplayName = React.useMemo(() => {
-    if (!createOption) {
-      return undefined;
-    }
-    return typeof createOptionMessage === 'string'
+  const createOptionDisplayName = createOption
+    ? typeof createOptionMessage === 'string'
       ? createOptionMessage
-      : createOptionMessage(createOption.name);
-  }, [createOption, createOptionMessage]);
+      : createOptionMessage(createOption.name)
+    : undefined;
 
   const allOptions = React.useMemo(() => {
     const options = [...allValues];

--- a/frontend/src/pages/groupSettings/GroupSettings.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettings.tsx
@@ -17,8 +17,7 @@ import TitleWithIcon from '#~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '#~/concepts/design/utils';
 import { GroupsConfigField, GroupStatus } from '#~/concepts/userConfigs/groupTypes';
 
-const CREATE_PREFIX = 'Define new group: ';
-const newGroupMessage = (value: string): string => `${CREATE_PREFIX}"${value}"`;
+const newGroupMessage = (value: string): string => `Define new group: "${value}"`;
 
 const GroupSettings: React.FC = () => {
   const {
@@ -45,8 +44,7 @@ const GroupSettings: React.FC = () => {
   const handleMenuItemSelection = (newState: SelectionOptions[], field: GroupsConfigField) => {
     const processGroup = (opt: SelectionOptions): GroupStatus => ({
       id: String(opt.id),
-      // Handle the create option situation -- show different in dropdown but not in selection
-      name: opt.name.startsWith(CREATE_PREFIX) ? String(opt.id) : opt.name,
+      name: opt.name,
       enabled: opt.selected || false,
     });
 

--- a/packages/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/connectionTypes/createConnectionType.cy.ts
@@ -59,7 +59,7 @@ describe('create', () => {
 
     categorySection.findMultiGroupInput().type('New category');
 
-    categorySection.findMultiGroupSelectButton('Option').click();
+    categorySection.findMultiGroupSelectButton('New-category').click();
     categorySection.findChipItem('New category').should('exist');
     categorySection.findMultiGroupInput().type('{esc}');
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-57510

## Description
The createOption was storing the createOptionMessage display text (e.g. `Define new group: "foo"`) as the option name instead of the raw input value, causing the duplicate check to fail on subsequent lookups. Separate the display text into createOptionDisplayName, used only for dropdown rendering, and remove the now-unnecessary prefix-stripping workaround in GroupSettings.

@Griffin-Sullivan i have fixed directly the main component, rather than your proposed solution in JIRA. This benefits all current and future consumers of this component

Fix in Create subscription form

https://github.com/user-attachments/assets/04a7cacc-2cd9-419f-97f0-740794c9b796

Fix in User Management page

https://github.com/user-attachments/assets/2005311e-4cb9-4940-90c5-379e3bfea90c

## How Has This Been Tested?
1. Navigate to Subscriptions → Create subscription
2. In the Groups multiselect, type a new group name (e.g., `test`) and select the create option
3. Verify the dropdown shows `Add group "test"` and the selected chip shows `test`
4. Remove the chip, then type `test` again
5. Verify only one `Add group "test"` entry appears (no duplicates)

## Test Impact
None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed create-option display so the rendered label shows correctly in multi-selection and corrected the create-option test identifier.

* **Refactor**
  * Simplified group-creation messaging and normalized how the created group's name is stored.

* **Tests**
  * Updated an end-to-end test to use the revised option label in the selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->