### PR TITLE
Fix(RHOAIENG-57548):Removed days option for rate limit creation for subscription

### DIFF
--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
@@ -41,7 +41,7 @@ const rateLimitSchema = z.object({
     .int()
     .min(1, 'Time value must be greater than 0')
     .max(Number.MAX_SAFE_INTEGER, 'Time value exceeds maximum allowed value'),
-  unit: z.enum(['day', 'hour', 'minute', 'second']),
+  unit: z.enum(['hour', 'minute', 'second']),
 });
 
 const rateLimitsSchema = z

--- a/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/__tests__/utils.spec.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/viewSubscription/__tests__/utils.spec.ts
@@ -25,22 +25,25 @@ describe('formatTokenLimits', () => {
 
   it('formats a single token rate limit correctly', () => {
     const refs = [makeRef('model-a', [{ limit: 5000, window: '1h' }])];
-    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual(['5,000 / 1h']);
+    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual(['5,000 / 1 hour']);
   });
 
   it('formats all rate limits when multiple are defined', () => {
     const refs = [
       makeRef('model-a', [
         { limit: 1000, window: '1m' },
-        { limit: 50000, window: '1d' },
+        { limit: 50000, window: '1h' },
       ]),
     ];
-    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual(['1,000 / 1m', '50,000 / 1d']);
+    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual([
+      '1,000 / 1 minute',
+      '50,000 / 1 hour',
+    ]);
   });
 
   it('formats large limit numbers with locale separators', () => {
     const refs = [makeRef('model-a', [{ limit: 1_000_000, window: '24h' }])];
-    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual(['1,000,000 / 24h']);
+    expect(formatTokenLimits(refs, Namespace, 'model-a')).toEqual(['1,000,000 / 24 hours']);
   });
 
   it('returns an empty array when namespace does not match', () => {

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -155,5 +155,5 @@ export type UserSubscription = {
 export type RateLimit = {
   count: number;
   time: number;
-  unit: 'day' | 'hour' | 'minute' | 'second';
+  unit: 'hour' | 'minute' | 'second';
 };

--- a/packages/maas/frontend/src/app/utilities/rateLimits.ts
+++ b/packages/maas/frontend/src/app/utilities/rateLimits.ts
@@ -1,21 +1,18 @@
 import { RateLimit, TokenRateLimit } from '~/app/types/subscriptions';
 
 const WINDOW_SUFFIX_TO_UNIT: Record<string, RateLimit['unit']> = {
-  d: 'day',
   s: 'second',
   m: 'minute',
   h: 'hour',
 };
 
 const UNIT_TO_WINDOW_SUFFIX: Record<RateLimit['unit'], string> = {
-  day: 'd',
   second: 's',
   minute: 'm',
   hour: 'h',
 };
 
 export const UNIT_OPTIONS: { value: RateLimit['unit']; label: string }[] = [
-  { value: 'day', label: 'day' },
   { value: 'hour', label: 'hour' },
   { value: 'minute', label: 'minute' },
   { value: 'second', label: 'second' },
@@ -26,7 +23,7 @@ export const UNIT_OPTIONS: { value: RateLimit['unit']; label: string }[] = [
  * Falls back to { time: 1, unit: 'hour' } for unrecognized formats.
  */
 export const parseWindow = (window: string): { time: number; unit: RateLimit['unit'] } => {
-  const match = window.match(/^(\d+)(s|m|h|d)$/);
+  const match = window.match(/^(\d+)(s|m|h)$/);
   if (!match) {
     return { time: 1, unit: 'hour' };
   }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-57548](https://redhat.atlassian.net/browse/RHOAIENG-57548)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->


https://github.com/user-attachments/assets/6697062d-b107-4d09-a00e-65656ced2e06

<img width="991" height="607" alt="Screenshot 2026-04-13 at 3 07 43 PM" src="https://github.com/user-attachments/assets/0f567841-d1e5-4cd0-bffe-623f2f1f0863" />

1. Removed population of days option while creating/editing rate limits in the subscription form
2. Updated zod types

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Cypress and unit tests updated

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Cypress and unit tests updated

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limit time unit selection now supports only hour, minute, and second. The day unit option has been removed from dropdown menus and validation. Rate limit window formatting now displays full unit names with spaces (e.g., "1 hour" instead of "1h").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->