### PR TITLE
fix(maas): add empty state with Create tier button when no tiers exis…

### DIFF
--- a/packages/maas/frontend/src/app/pages/tiers/AllTiersPage.tsx
+++ b/packages/maas/frontend/src/app/pages/tiers/AllTiersPage.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
-import { PageSection } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateVariant,
+  PageSection,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useFetchTiers } from '~/app/hooks/useFetchTiers';
 import { Tier } from '~/app/types/tier';
@@ -18,6 +28,28 @@ const AllTiersPage: React.FC = () => {
       loaded={loaded}
       loadError={error}
       empty={loaded && !tiers.length}
+      emptyStatePage={
+        <EmptyState
+          headingLevel="h5"
+          icon={PlusCircleIcon}
+          titleText="No tiers"
+          variant={EmptyStateVariant.lg}
+          data-testid="tiers-empty-state"
+        >
+          <EmptyStateBody>To get started, create a tier.</EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button
+                variant="primary"
+                component={(props) => <Link {...props} to="/maas/tiers/create" />}
+                data-testid="create-tier-button"
+              >
+                Create tier
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      }
     >
       <PageSection isFilled>
         <TiersTable tiers={tiers} onDeleteTier={(tier) => setDeleteTier(tier)} />


### PR DESCRIPTION
Merging our 3.3.2-fixes & 3.3.0-fixes branches together.

3.3.2 was a misunderstanding and poor coordination on my part. It'll be impossible to handle z-streams this way, so we need to reinforce our process. 


```
* c42a026c9 (HEAD -> v3.3.0-fixes, upstream/v3.3.0-fixes) Trim response to just needed body (#7190) (#7202)
| * 0934c675c (upstream/v3.3.2-fixes, v3.3.2-fixes) fix(maas): add empty state with Create tier button when no tiers exist (#6915)
|/
* b3e0bb2f1 update rate limit policies when predicate (#6218) (#6230)
```