### PR TITLE
fix(e2e): update default catalog sources ConfigMap name to match operator rename

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
@@ -59,25 +59,25 @@ print(yaml.dump(data, default_flow_style=False), end='')
 };
 
 /**
- * Verify that the model-catalog-default-sources ConfigMap exists in the model registry namespace.
+ * Verify that the default-catalog-sources ConfigMap exists in the model registry namespace.
  * @returns A Cypress chainable that resolves with the command result.
  */
 export const verifyModelCatalogSourcesConfigMap = (): Cypress.Chainable<CommandLineResult> => {
   const namespace = getModelRegistryNamespace();
-  const command = `oc get configmap model-catalog-default-sources -n ${namespace}`;
-  cy.log(`Verifying model-catalog-default-sources ConfigMap: ${command}`);
+  const command = `oc get configmap default-catalog-sources -n ${namespace}`;
+  cy.log(`Verifying default-catalog-sources ConfigMap: ${command}`);
 
   return execWithOutput(command, 30).then((result: CommandLineResult) => {
     if (result.code !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
-      cy.log(`ERROR: model-catalog-default-sources ConfigMap not found in ${namespace}`);
+      cy.log(`ERROR: default-catalog-sources ConfigMap not found in ${namespace}`);
       cy.log(`stdout: ${result.stdout}`);
       cy.log(`stderr: ${maskedStderr}`);
       throw new Error(
-        `model-catalog-default-sources ConfigMap not found in ${namespace}: ${maskedStderr}`,
+        `default-catalog-sources ConfigMap not found in ${namespace}: ${maskedStderr}`,
       );
     }
-    cy.log(`✓ model-catalog-default-sources ConfigMap exists in ${namespace}`);
+    cy.log(`✓ default-catalog-sources ConfigMap exists in ${namespace}`);
     return cy.wrap(result);
   });
 };
@@ -149,7 +149,7 @@ export const verifyModelCatalogBackend = (): Cypress.Chainable<CommandLineResult
 
 /**
  * Verify the enabled status of a specific source in the catalog configmaps.
- * First checks model-catalog-sources (user overrides), then falls back to model-catalog-default-sources.
+ * First checks model-catalog-sources (user overrides), then falls back to default-catalog-sources.
  * Polls until the expected value is found or max attempts is reached.
  * @param sourceId The ID of the source to check (e.g., 'redhat_ai')
  * @param expectedEnabled The expected enabled status (true or false)
@@ -165,10 +165,10 @@ export const verifyModelCatalogSourceEnabled = (
 ): Cypress.Chainable<undefined> => {
   const namespace = getModelRegistryNamespace();
   const parseCmd = getYamlParseCommand(sourceId);
-  // User changes are stored in model-catalog-sources, defaults in model-catalog-default-sources
+  // User changes are stored in model-catalog-sources, defaults in default-catalog-sources
   // Try user configmap first, fall back to default if source not found there
   const userCommand = `oc get configmap model-catalog-sources -n ${namespace} -o jsonpath='{.data.sources\\.yaml}' 2>/dev/null | ${parseCmd}`;
-  const defaultCommand = `oc get configmap model-catalog-default-sources -n ${namespace} -o jsonpath='{.data.sources\\.yaml}' | ${parseCmd}`;
+  const defaultCommand = `oc get configmap default-catalog-sources -n ${namespace} -o jsonpath='{.data.sources\\.yaml}' | ${parseCmd}`;
 
   cy.log(`Polling for source ${sourceId} enabled status to be ${expectedEnabled}`);
 
@@ -240,14 +240,14 @@ export const verifyModelCatalogSourceEnabled = (
 
 /**
  * Check if a specific model catalog source is currently enabled.
- * Checks the model-catalog-default-sources ConfigMap for the source's enabled status.
+ * Checks the default-catalog-sources ConfigMap for the source's enabled status.
  * @param sourceId The ID of the source to check (e.g., 'redhat_ai_models')
  * @returns A Cypress chainable that resolves with true if enabled, false otherwise.
  */
 export const isModelCatalogSourceEnabled = (sourceId: string): Cypress.Chainable<boolean> => {
   const namespace = getModelRegistryNamespace();
   const parseCmd = getYamlParseCommand(sourceId);
-  const command = `oc get configmap model-catalog-default-sources -n ${namespace} -o jsonpath='{.data.sources\\.yaml}' | ${parseCmd}`;
+  const command = `oc get configmap default-catalog-sources -n ${namespace} -o jsonpath='{.data.sources\\.yaml}' | ${parseCmd}`;
 
   return execWithOutput(command, 30).then((result: CommandLineResult) => {
     if (result.code !== 0) {


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-57826

## Description

The model-registry-operator renamed the default catalog sources ConfigMap from `model-catalog-default-sources` to `default-catalog-sources` in [opendatahub-io/model-registry-operator#489](https://github.com/opendatahub-io/model-registry-operator/pull/489). The Cypress E2E test utilities in `packages/cypress/cypress/utils/oc_commands/modelCatalog.ts` still referenced the old name, causing `testModelCatalogAvailable.cy.ts` and `testSourceEnableDisable.cy.ts` to fail on clusters running the updated operator.

This PR updates all references to use the new ConfigMap name `default-catalog-sources`:

- **`verifyModelCatalogSourcesConfigMap()`** — updated the `oc get configmap` command, log messages, and error messages
- **`verifyModelCatalogSourceEnabled()`** — updated the fallback `defaultCommand` that reads from the default ConfigMap
- **`isModelCatalogSourceEnabled()`** — updated the `oc get configmap` command

The user-override ConfigMap (`model-catalog-sources`) was intentionally left unchanged as it was not renamed by the operator.

## How Has This Been Tested?

- Verified all references to the old ConfigMap name `model-catalog-default-sources` are removed from the Cypress package via grep
- Confirmed no lint errors are introduced
- The change is a direct string rename with no logic changes, so existing test flows (`testModelCatalogAvailable.cy.ts` and `testSourceEnableDisable.cy.ts`) will work correctly on clusters running the updated operator

## Test Impact

No new tests added. This is a fix to existing E2E test utilities to align with an upstream operator rename. The affected tests (`testModelCatalogAvailable.cy.ts`, `testSourceEnableDisable.cy.ts`) use these utilities and will now pass on clusters with the updated operator.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing utilities for model catalog configuration to use revised naming conventions for configuration source validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->