### PR TITLE
fix(manifests): align container resources with K8s best practices and add ephemeral-storage

### DIFF
--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -37,9 +37,9 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
+              ephemeral-storage: 50Mi
             limits:
-              cpu: 1000m
               memory: 2Gi
           livenessProbe:
             tcpSocket:
@@ -111,12 +111,12 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           resources:
-            limits:
-              cpu: 1000m
-              memory: 2Gi
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
+              ephemeral-storage: 10Mi
+            limits:
+              memory: 2Gi
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls

--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -33,11 +33,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8043
@@ -106,11 +106,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8143
@@ -179,11 +179,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8243
@@ -256,11 +256,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8343
@@ -327,11 +327,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8543
@@ -398,11 +398,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8643
@@ -468,11 +468,11 @@
       successThreshold: 1
       failureThreshold: 3
     resources:
-      limits:
-        cpu: 300m
-        memory: 512Mi
       requests:
         cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
         memory: 512Mi
     ports:
       - containerPort: 8743


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-57523
https://issues.redhat.com/browse/RHOAIENG-58160

## Description

Addresses two related container resource issues in the dashboard deployment manifests:

**[RHOAIENG-57523](https://redhat.atlassian.net/browse/RHOAIENG-57523) — Align with Kubernetes best practices:**
- **Remove CPU limits** from all 9 containers (2 core + 7 sidecars). CPU limits cause unnecessary throttling even when the node has spare capacity ([reference](https://home.robusta.dev/blog/stop-using-cpu-limits)).
- **Set memory requests = limits** for `odh-dashboard` and `kube-rbac-proxy` (was 1Gi request / 2Gi limit, now both 2Gi). This guarantees QoS Guaranteed class for memory, preventing OOM kills from overcommit. Sidecar containers already had memory requests == limits (512Mi).

**[RHOAIENG-58160](https://redhat.atlassian.net/browse/RHOAIENG-58160) — Add ephemeral-storage requests:**
- The dashboard pod was being **evicted by kubelet** due to ephemeral storage pressure on OpenShift nodes. All 9 containers had `ephemeral-storage` request defaulting to `0`, making the entire pod an eviction candidate despite using only ~16MB total.
- Added `ephemeral-storage` requests: **50Mi** for `odh-dashboard` (observed 14MB), **10Mi** for `kube-rbac-proxy` and all 7 sidecar BFF containers (observed 4KB-72KB each).

### Summary of changes per container

| Container | CPU req | CPU limit | Mem req/limit | Ephemeral-storage req |
|---|---|---|---|---|
| `odh-dashboard` | 500m | ~~1000m~~ removed | ~~1Gi/2Gi~~ → 2Gi/2Gi | **50Mi** (new) |
| `kube-rbac-proxy` | 500m | ~~1000m~~ removed | ~~1Gi/2Gi~~ → 2Gi/2Gi | **10Mi** (new) |
| 7× sidecar BFFs | 300m | ~~300m~~ removed | 512Mi/512Mi (unchanged) | **10Mi** (new) |

### Files changed
- `manifests/core-bases/base/deployment.yaml`
- `manifests/modular-architecture/deployment.yaml`

Both ODH and RHOAI overlays inherit from these bases — no overlay changes needed.

## How Has This Been Tested?

- `kustomize build manifests/odh` — builds successfully, verified all 9 containers have correct resource blocks
- `kustomize build manifests/rhoai/onprem` — builds successfully
- `kustomize build manifests/rhoai/addon` — builds successfully
- Verified zero CPU limits appear in any overlay output
- Verified `ephemeral-storage` requests appear for all 9 containers
- Verified memory requests == limits for all containers
- Will validate on a live cluster with the built image

## Test Impact

Manifest-only change — no application code or tests affected. Validated via `kustomize build` for all overlays (ODH, RHOAI onprem, RHOAI addon).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`