### PR TITLE
feat(RHOAIENG-57711): add local upstream subtree sync script and skill

### DIFF
--- a/.claude/skills/upstream-sync-local/SKILL.md
+++ b/.claude/skills/upstream-sync-local/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: upstream-sync-local
+description: Sync upstream changes from a local repository clone. Pass a package name, local repo path, and branch as arguments. Supports cherry-pick (--commit=SHA) and range (--up-to=SHA) modes.
+---
+
+# Upstream Sync Local
+
+Sync upstream changes from a local clone of the upstream repository into the monorepo.
+
+This command orchestrates the local sync process: running the update-subtree-local script, resolving conflicts, running tests, and summarizing results. Unlike `/upstream-sync`, this does NOT create a PR — the branch is for local testing only.
+
+## Arguments
+
+- `$ARGUMENTS` — Required. Must include:
+  - A package name (e.g. `model-registry`, `notebooks`)
+  - A local repository path (absolute or relative path to the upstream clone)
+  - A branch name in the local repository
+
+  Optional flags (appended after the three required arguments):
+  - `--commit=SHA` — Cherry-pick a single commit
+  - `--up-to=SHA` — Apply all commits from current up to this commit
+
+  Examples:
+  - `model-registry /path/to/local/model-registry feature/my-changes`
+  - `model-registry /path/to/local/model-registry main --commit=abc1234`
+  - `model-registry /path/to/local/model-registry main --up-to=def5678`
+
+## Resolving the Package
+
+Packages with upstream subtrees have a `subtree` field in their `package.json` under `packages/<name>/package.json`.
+
+1. Use the first argument as `<package-name>`.
+2. Verify the package exists by reading `packages/<package-name>/package.json`.
+3. Confirm it has a `subtree` config block and an `update-subtree-local` script.
+
+If the package does not exist or lacks the required config, report the error and list available packages:
+
+```bash
+grep -rl '"subtree"' packages/*/package.json | sed 's|packages/||;s|/package.json||'
+```
+
+## Validating the Local Repo
+
+Before running the sync:
+
+1. Verify the local repo path exists and is a git repository:
+   ```bash
+   git -C <local-repo-path> rev-parse --is-inside-work-tree
+   ```
+
+2. Verify the branch exists in the local repo:
+   ```bash
+   git -C <local-repo-path> rev-parse --verify <branch>
+   ```
+
+3. If either check fails, report a clear error message with the expected format.
+
+## Workflow
+
+### Phase 1: Setup
+
+1. Run `git branch --show-current` to get the current branch name.
+2. Run `git status` to check for uncommitted changes.
+
+**If on `main`:**
+- Ensure working directory is clean.
+- Ask the user what branch name to use for the local sync test, or suggest one (e.g., `test/local-sync-<pkg>-YYYY-MM-DD`).
+- Create and switch to the branch: `git checkout -b <branch-name>`
+
+**If on an existing branch:**
+- Ask user if they want to continue on this branch or switch to main and start fresh.
+- If continuing, check for unresolved conflicts and handle accordingly.
+
+### Phase 2: Run Sync Script
+
+Run the update-subtree-local script from the repository root:
+
+```bash
+npm run update-subtree-local -w packages/<package-name> -- \
+  --local-repo=<local-repo-path> \
+  --branch=<branch>
+```
+
+**With optional flags:**
+
+```bash
+# Cherry-pick a single commit
+npm run update-subtree-local -w packages/<package-name> -- \
+  --local-repo=<local-repo-path> \
+  --branch=<branch> \
+  --commit=<sha>
+
+# Sync up to a specific commit
+npm run update-subtree-local -w packages/<package-name> -- \
+  --local-repo=<local-repo-path> \
+  --branch=<branch> \
+  --up-to=<sha>
+```
+
+**Continuing after conflict resolution:**
+
+```bash
+npm run update-subtree-local -w packages/<package-name> -- \
+  --local-repo=<local-repo-path> \
+  --branch=<branch> \
+  --continue
+```
+
+Parse the output to detect:
+- **Success messages** like "Applied commit X/Y: ..."
+- **Conflict detection**: Look for "Conflict detected" in output
+- **Completion**: Look for "Already up-to-date" or successful completion of all commits
+- **DO NOT MERGE warnings**: The script automatically adds safety markers
+
+### Phase 3: Conflict Resolution
+
+When conflicts are detected:
+
+1. **Identify conflicting files**: Run `git status` and look for files under "Unmerged paths".
+
+2. **For each conflicting file**:
+   - Read the file to find conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+   - Analyze what "ours" (HEAD) contains vs what "theirs" (incoming) contains
+   - Explain the conflict to the user and suggest a resolution strategy
+   - Offer to apply the suggested resolution OR let the user handle it manually
+
+3. **After resolution**:
+   - Stage the resolved files: `git add <file1> <file2> ...`
+   - Continue the sync:
+     ```bash
+     npm run update-subtree-local -w packages/<package-name> -- \
+       --local-repo=<local-repo-path> \
+       --branch=<branch> \
+       --continue
+     ```
+   - Repeat this phase if more conflicts are encountered
+
+### Phase 4: Run Tests
+
+After the sync completes successfully, run tests. Check which test scripts are available in the package's upstream frontend:
+
+```bash
+jq -r '.scripts | keys[] | select(test("^(test:|type-check)"))' packages/<package-name>/upstream/frontend/package.json
+```
+
+Run whichever of these are available:
+
+```bash
+cd packages/<package-name>/upstream/frontend && npm run test:unit
+```
+
+```bash
+cd packages/<package-name>/upstream/frontend && npm run test:type-check
+```
+
+Report results to the user. If there are failures, let the user decide how to proceed.
+
+### Phase 5: Summary
+
+Report the sync results to the user:
+
+```markdown
+## Local Sync Complete
+
+**Package:** <package-name>
+**Source:** <local-repo-path> @ <branch>
+**Commits applied:** <count>
+**Branch:** <branch-name>
+
+### Applied Commits
+- <commit-hash> <commit-message>
+- ...
+
+### Test Results
+- Unit tests: <pass/fail>
+- Type check: <pass/fail>
+
+### ⚠️ DO NOT MERGE Warning
+This branch contains `[DO NOT MERGE - LOCAL SYNC]` commits.
+The `DO_NOT_MERGE_SYNCED_FROM_LOCAL` flag has been set in package.json.
+
+**This branch is for local testing only.** After validating:
+1. Discard this branch
+2. Open the upstream PR
+3. After the upstream PR merges, create a fresh branch from main
+4. Run a normal PR sync: `/upstream-sync <package-name>`
+```
+
+## Error Handling
+
+### Invalid package name
+Report available packages and ask user to try again.
+
+### Local repo path does not exist
+Report the error and ask for the correct path.
+
+### Branch does not exist
+Report the error, list available branches in the local repo, and ask user to specify.
+
+### Build failures
+Report the failure, show relevant output, and let user decide how to proceed.
+
+### Sync already up to date
+Report that no new commits were found and the package is already synced to the latest commit on the specified branch.

--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -113,7 +113,7 @@ When conflicts are detected:
 After the sync completes successfully, run lint and tests. Check which scripts are available in the package's upstream frontend:
 
 ```bash
-cd packages/<package-name>/upstream/frontend && cat package.json | grep -E '"test:|"type-check'
+jq -r '.scripts | keys[] | select(test("^(test:|type-check)"))' packages/<package-name>/upstream/frontend/package.json
 ```
 
 **Step 1: Lint (required before creating a PR)**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ Skills provide multi-step workflows. They live in `.claude/skills/`. Read the re
 | **Docs Update**                    | `skills/docs-update/`                  | Updating existing docs after code changes                                      |
 | **Upstream Sync Status**           | `skills/upstream-sync-status/`         | Checking whether a package's upstream copy is up to date (pass package name or be prompted) |
 | **Upstream Sync**                  | `skills/upstream-sync/`                | Syncing upstream changes for a package and opening a PR (pass package name or be prompted)  |
+| **Upstream Sync Local**            | `skills/upstream-sync-local/`          | Syncing upstream changes from a local repository clone (pass package name, local repo path, and branch) |
 | **Style Review**                   | `skills/style-review/`                 | Reviewing code for PF priority-order compliance, wrapper component usage, and class naming conventions per `css-patternfly.md` |
 | **RBAC Review**                    | `skills/rbac-review/`                  | Reviewing code for proper RBAC enforcement — catches missing SSAR gates, assumed access from `isAdmin`, and pages that break for limited-access users |
 | **Jira Triage**                   | `skills/jira-triage/`                  | Fetching Jira issues by filter criteria, running full triage on New issues (orchestrates all analysis skills), defining triage operations, and bulk-applying them |

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -37,6 +37,7 @@ Central index of key documentation in the ODH Dashboard monorepo.
 | [Multi-Agent Workflows](docs/multi-agent-workflows.md) | Running parallel agents locally and remotely |
 | [Large Tasks with Claude Code Goals](docs/ai-agent-large-tasks.md) | Using `/goal` for autonomous, multi-step development tasks |
 | [Prototype Reading Skills](docs/prototype-reading.md) | `/prototype-tickets` and `/prototype-spec` — extracting PF component details from UX prototype forks |
+| [Upstream Sync](docs/upstream-sync.md) | How to sync upstream changes into monorepo packages |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 [Workspace Dockerfiles]: workspace-dockerfiles.md
 [Dashboard environment variables]: dashboard-environment-variables.md
 [Large Tasks with Claude Code Goals]: ai-agent-large-tasks.md
+[Upstream Sync]: upstream-sync.md
 
 # Dashboard Documentation
 
@@ -30,3 +31,4 @@ This is the general documentation of the Dashboard component.
 * [Workspace Dockerfiles]
 * [Dashboard environment variables]
 * [Large Tasks with Claude Code Goals]
+* [Upstream Sync]

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,0 +1,310 @@
+# Upstream Sync Guide
+
+This document explains how to sync upstream changes into odh-dashboard's monorepo packages.
+
+## Overview
+
+Several odh-dashboard packages (e.g., `model-registry`, `notebooks`) contain a copy of code from an upstream repository. The subtree sync scripts keep this copy up to date by applying upstream commits as incremental patches.
+
+There are two sync methods:
+
+| Method | Script | Use case |
+|--------|--------|----------|
+| **PR sync** | `update-subtree` | Sync from the official upstream repo (or test an upstream PR) |
+| **Local sync** | `update-subtree-local` | Sync from a local clone of the upstream repo |
+
+Both scripts live in `packages/app-config/scripts/` and are invoked via npm workspace scripts.
+
+## How It Works
+
+Each package with an upstream subtree has a `subtree` config block in its `package.json`:
+
+```json
+{
+  "subtree": {
+    "repo": "https://github.com/kubeflow/model-registry.git",
+    "branch": "main",
+    "src": "clients/ui",
+    "target": "upstream",
+    "commit": "5ea29b0d7d1638634880651f10c48d368af84344"
+  }
+}
+```
+
+- **repo** -- upstream GitHub repository URL
+- **branch** -- upstream branch to track
+- **src** -- subdirectory within the upstream repo to sync (e.g., `clients/ui`)
+- **target** -- directory within the package where upstream code lives (e.g., `upstream/`)
+- **commit** -- SHA of the last synced upstream commit
+
+The scripts compare the stored `commit` against the target branch, generate `git format-patch` patches for each new commit, filter them to the `src` subdirectory, transform paths, and apply them with `git apply --3way --index` into the `target` directory. Each upstream commit produces a corresponding monorepo commit.
+
+## Method 1: PR Sync (`update-subtree`)
+
+Use PR sync to pull changes from the official upstream repository.
+
+### When to Use
+
+- Regular sync to bring upstream changes into odh-dashboard
+- Testing an upstream PR before it merges (PR test mode)
+
+### Basic Usage
+
+```bash
+# From the repository root
+npm run update-subtree -w packages/model-registry
+```
+
+This fetches the upstream repo, finds all new commits since the last sync, and applies them.
+
+### PR Test Mode
+
+To test an upstream PR's changes before the PR merges:
+
+```bash
+npm run update-subtree -w packages/model-registry -- --pr=https://github.com/kubeflow/model-registry/pull/1234
+```
+
+This temporarily overrides the `package.json` config to point at the PR's branch, applies the changes, then marks all commits with `[DO NOT MERGE - PR TEST SYNC]`. After testing, discard this branch.
+
+### Using the Claude Code Skill
+
+The `/upstream-sync` Claude Code skill automates the full PR sync workflow:
+
+```text
+/upstream-sync model-registry
+/upstream-sync model-registry https://github.com/kubeflow/model-registry/pull/1234
+```
+
+See the [Claude Code Skills](#claude-code-skills) section below for details.
+
+## Method 2: Local Sync (`update-subtree-local`)
+
+Use local sync to test changes from a local clone of the upstream repository before they are merged upstream.
+
+### When to Use
+
+- Testing a local upstream branch in the monorepo context
+- Developing upstream + midstream changes simultaneously
+- Validating that upstream changes integrate correctly before opening an upstream PR
+
+### Basic Usage
+
+```bash
+# Sync all new commits from a local branch
+npm run update-subtree-local -w packages/model-registry -- \
+  --local-repo=/path/to/local/model-registry \
+  --branch=feature/my-changes
+```
+
+### Available Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--local-repo=PATH` | Yes | Path to the local upstream repository (absolute or relative) |
+| `--branch=BRANCH` | Yes | Branch in the local repository to sync from |
+| `--commit=SHA` | No | Apply only this specific commit (cherry-pick mode) |
+| `--up-to=SHA` | No | Apply all commits from current up to this commit (range mode) |
+| `--continue` | No | Resume after resolving conflicts |
+
+### Examples
+
+```bash
+# Sync all new commits from a branch
+npm run update-subtree-local -w packages/model-registry -- \
+  --local-repo=/path/to/local/model-registry \
+  --branch=feature/new-ui
+
+# Cherry-pick a single commit
+npm run update-subtree-local -w packages/model-registry -- \
+  --local-repo=/path/to/local/model-registry \
+  --branch=main \
+  --commit=abc1234
+
+# Sync up to a specific commit
+npm run update-subtree-local -w packages/model-registry -- \
+  --local-repo=/path/to/local/model-registry \
+  --branch=main \
+  --up-to=def5678
+
+# Continue after resolving conflicts
+npm run update-subtree-local -w packages/model-registry -- \
+  --local-repo=/path/to/local/model-registry \
+  --branch=feature/new-ui \
+  --continue
+```
+
+### DO NOT MERGE Safety
+
+Local sync automatically:
+
+1. Adds a `DO_NOT_MERGE_SYNCED_FROM_LOCAL` flag to `package.json`
+2. Prefixes all sync commits with `[DO NOT MERGE - LOCAL SYNC]`
+3. Shows a warning banner after completion
+
+These changes exist only for local testing. After validating, discard the branch. Once the upstream changes merge officially, create a fresh branch and run a normal PR sync.
+
+### Using the Claude Code Skill
+
+The `/upstream-sync-local` Claude Code skill automates the local sync workflow:
+
+```text
+/upstream-sync-local model-registry /path/to/local/model-registry feature/my-changes
+```
+
+See the [Claude Code Skills](#claude-code-skills) section below for details.
+
+## Resolving Conflicts
+
+Both sync methods stop when a patch cannot be applied cleanly. The script reports which commit caused the conflict and provides resolution steps.
+
+### Conflict Resolution Workflow
+
+1. **Find conflict markers** in the target directory:
+
+   ```bash
+   # Look for git conflict markers (exclude node_modules and binaries)
+   grep -rn '<<<<<<' packages/<package-name>/upstream/ --include='*.ts' --include='*.tsx' --include='*.go' --include='*.yaml'
+
+   # Look for script-injected markers
+   grep -rn 'PATCH FAILED' packages/<package-name>/upstream/ --include='*.ts' --include='*.tsx' --include='*.go'
+   ```
+
+2. **Resolve each conflict** by editing the files:
+   - Review what the patch intended to change
+   - Apply the changes manually
+   - Remove all conflict marker lines
+
+3. **Verify your changes**:
+
+   ```bash
+   git diff packages/<package-name>
+   ```
+
+4. **Stage resolved files**:
+
+   ```bash
+   git add packages/<package-name>
+   ```
+
+5. **Continue the sync**:
+
+   ```bash
+   # For PR sync
+   npm run update-subtree -w packages/<package-name> -- --continue
+
+   # For local sync (must pass --local-repo and --branch again)
+   npm run update-subtree-local -w packages/<package-name> -- \
+     --local-repo=/path/to/local/upstream-repo \
+     --branch=feature/my-changes \
+     --continue
+   ```
+
+6. If more conflicts appear, repeat from step 1.
+
+### Common Conflict Scenarios
+
+- **Import path differences**: Upstream uses different import conventions than downstream. Keep downstream conventions while incorporating the upstream change.
+- **Overlapping changes**: Both upstream and downstream modified the same code. Merge both sets of changes.
+- **File not in monorepo**: Upstream added or modified a file that doesn't exist in the monorepo. Decide whether to include it or skip it.
+
+## Differences Between the Two Methods
+
+| Aspect | PR Sync | Local Sync |
+|--------|---------|------------|
+| Source | Clones upstream repo from GitHub | Reads from a local directory |
+| Network | Requires internet access | Works offline |
+| Commit prefix | `[DO NOT MERGE - PR TEST SYNC]` (PR mode) | `[DO NOT MERGE - LOCAL SYNC]` |
+| Package.json flag | `DO_NOT_MERGE_OVERRIDDEN_FOR_PR` (PR mode) | `DO_NOT_MERGE_SYNCED_FROM_LOCAL` |
+| Use case | Official syncs, upstream PR testing | Local development, pre-merge testing |
+| Branch naming | `<pkg>-sync-YYYY-MM-DD` or `tmp-sync-pr-<N>` | Any branch name (your choice) |
+
+## Recommended Workflow
+
+### Developing upstream changes alongside midstream
+
+1. Create a feature branch in the upstream repo and make your changes
+2. Create a branch in odh-dashboard (e.g., `git checkout -b test/my-upstream-feature`)
+3. Run local sync to bring upstream changes into the monorepo:
+   ```bash
+   npm run update-subtree-local -w packages/model-registry -- \
+     --local-repo=/path/to/local/model-registry \
+     --branch=feature/my-changes
+   ```
+4. Test the integration locally
+5. Open the upstream PR
+6. After the upstream PR merges, discard the odh-dashboard test branch
+7. Create a fresh branch from main and run a normal PR sync
+
+### Regular upstream sync
+
+1. Check sync status: `/upstream-sync-status model-registry`
+2. Run sync: `/upstream-sync model-registry`
+3. Resolve any conflicts
+4. Run tests
+5. Open a PR
+
+## Claude Code Skills
+
+Three Claude Code skills automate the sync workflows. All are available via slash commands.
+
+### `/upstream-sync`
+
+Orchestrates the full PR sync workflow: branch creation, running the script, conflict resolution, tests, and PR creation.
+
+```text
+# Normal sync
+/upstream-sync model-registry
+
+# Test an upstream PR
+/upstream-sync model-registry https://github.com/kubeflow/model-registry/pull/1234
+```
+
+### `/upstream-sync-local`
+
+Orchestrates local sync from a local upstream repository clone.
+
+```text
+# Sync all new commits from a branch
+/upstream-sync-local model-registry /path/to/local/model-registry feature/my-changes
+
+# Cherry-pick a single commit
+/upstream-sync-local model-registry /path/to/local/model-registry main --commit=abc1234
+
+# Sync up to a specific commit
+/upstream-sync-local model-registry /path/to/local/model-registry main --up-to=def5678
+```
+
+### `/upstream-sync-status`
+
+Checks whether a package's upstream copy is up to date.
+
+```text
+/upstream-sync-status model-registry
+```
+
+## Discovering Packages with Subtree Config
+
+To find all packages that support upstream sync:
+
+```bash
+grep -rl '"subtree"' packages/*/package.json | sed 's|packages/||;s|/package.json||'
+```
+
+## Troubleshooting
+
+### "does not exist in index" errors
+
+This happens when a patch modifies a file that exists in the upstream repo but not in the monorepo's git index. The local sync script handles this automatically by pre-populating the index with base blob objects. If you still encounter this error, ensure you are using the latest version of the script.
+
+### Three-way merge failures
+
+The scripts use `git apply --3way` which requires the base blob objects from the upstream repo. The PR sync script handles this by cloning the upstream repo. The local sync script handles this by adding the local repo as a temporary git remote and fetching its objects.
+
+### "DO NOT MERGE" commits left over
+
+If you see `[DO NOT MERGE - LOCAL SYNC]` commits in your branch, you ran a local sync. These should never be merged to main. Create a fresh branch from main and run a normal PR sync after the upstream changes are merged.
+
+### Partial sync (some commits applied, then conflict)
+
+The `--continue` flag picks up where the script left off. After resolving conflicts, stage files and run with `--continue`. The script tracks progress in `package.json`'s `subtree.commit` field, which is updated after each successfully applied commit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36004,7 +36004,8 @@
       "name": "@odh-dashboard/app-config",
       "version": "0.0.0",
       "bin": {
-        "package-subtree": "scripts/package-subtree.sh"
+        "package-subtree": "scripts/package-subtree.sh",
+        "package-subtree-local": "scripts/package-subtree-local.sh"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/packages/app-config/package.json
+++ b/packages/app-config/package.json
@@ -4,7 +4,8 @@
   "description": "Configuration and utilities for application",
   "version": "0.0.0",
   "bin": {
-    "package-subtree": "./scripts/package-subtree.sh"
+    "package-subtree": "./scripts/package-subtree.sh",
+    "package-subtree-local": "./scripts/package-subtree-local.sh"
   },
   "exports": {
     ".": {

--- a/packages/app-config/scripts/package-subtree-common.sh
+++ b/packages/app-config/scripts/package-subtree-common.sh
@@ -1,0 +1,564 @@
+#!/bin/bash
+# package-subtree-common.sh — shared functions for package-subtree.sh and package-subtree-local.sh
+# Source this file; do not execute it directly.
+#
+# Required globals (set by caller before using most functions):
+#   PACKAGE_JSON       — path to the package's package.json
+#   MONOREPO_ROOT      — monorepo root directory
+#   WORKSPACE_LOCATION — workspace-relative path
+#   TARGET_RELATIVE    — subtree target directory relative to workspace
+#   PACKAGE_NAME       — npm package name
+#   TMP_DIR            — temporary directory for intermediate files
+
+export SKIP_LINT_HOOK=true
+export HUSKY=0
+
+# ── Colors & Icons ────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+if [ "${NO_COLOR:-}" = "1" ] || [ "${TERM:-}" = "dumb" ]; then
+  RED='' GREEN='' YELLOW='' BLUE='' CYAN='' NC=''
+fi
+
+ERROR_ICON="❌"
+SUCCESS_ICON="✅"
+WARNING_ICON="⚠️"
+INFO_ICON="ℹ️"
+PROGRESS_ICON="🔄"
+
+error_msg()    { echo -e "${RED}${ERROR_ICON} $1${NC}" >&2; }
+success_msg()  { echo -e "${GREEN}${SUCCESS_ICON} $1${NC}"; }
+warning_msg()  { echo -e "${YELLOW}${WARNING_ICON} $1${NC}"; }
+info_msg()     { echo -e "${CYAN}${INFO_ICON} $1${NC}"; }
+progress_msg() { echo -e "${BLUE}${PROGRESS_ICON} $1${NC}"; }
+
+# ── Utilities ─────────────────────────────────────────────────────
+
+update_package_json_commit() {
+  local commit="$1"
+  local temp_file="$PACKAGE_JSON.tmp"
+
+  if ! jq --arg commit "$commit" '.subtree.commit = $commit' "$PACKAGE_JSON" > "$temp_file"; then
+    error_msg "Failed to update package.json with commit $commit"
+    rm -f "$temp_file"
+    return 1
+  fi
+
+  if ! mv "$temp_file" "$PACKAGE_JSON"; then
+    error_msg "Failed to replace package.json"
+    rm -f "$temp_file"
+    return 1
+  fi
+
+  return 0
+}
+
+safe_git_commit_if_changes() {
+  local commit_message="$1"
+  local target_path="$2"
+
+  git add "$target_path"
+  if ! git diff --cached --quiet; then
+    if ! git commit -q -m "$commit_message"; then
+      error_msg "Failed to commit changes"
+      return 1
+    fi
+    return 0
+  fi
+  return 2
+}
+
+copy_upstream_files() {
+  local source_base="$1"
+  local upstream_subdir="$2"
+  local target_dir="$3"
+
+  if ! mkdir -p "$target_dir"; then
+    error_msg "Failed to create target directory: $target_dir"
+    return 1
+  fi
+
+  local source_dir="$source_base"
+  if [ -n "$upstream_subdir" ]; then
+    source_dir="$source_base/$upstream_subdir"
+  fi
+
+  if command -v rsync >/dev/null 2>&1; then
+    if ! rsync -a --delete --exclude='.git' "$source_dir"/ "$target_dir"/; then
+      error_msg "Failed to rsync files from $source_dir to $target_dir"
+      return 1
+    fi
+  else
+    if ! ( cd "$source_dir" && tar --exclude='.git' -cf - . ) | ( cd "$target_dir" && tar -xpf - ); then
+      error_msg "Failed to copy files from $source_dir to $target_dir using tar"
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+clean_exit() {
+  local exit_code=${1:-1}
+  local message="$2"
+  local is_user_error=${3:-false}
+
+  if [ -n "$message" ]; then
+    error_msg "$message"
+  fi
+
+  if [ "$is_user_error" = "true" ] && [ -n "${npm_config_user_agent:-}" ]; then
+    warning_msg "Exiting with code 0 for npm compatibility (original exit code: $exit_code)"
+    exit 0
+  fi
+
+  exit $exit_code
+}
+
+# ── Working-tree check ───────────────────────────────────────────
+
+check_working_tree_clean() {
+  if [ -n "$(git status --porcelain)" ]; then
+    if ! git diff --cached --quiet; then
+      error_msg "There are staged changes in the working tree"
+      echo "You have staged changes that need to be committed."
+      echo ""
+      echo "Choose one option:"
+      echo -e "1. Use ${GREEN}--continue${NC} to commit staged changes and proceed with update"
+      echo -e "2. Run ${YELLOW}git reset HEAD${NC} to unstage changes and start fresh"
+      echo -e "3. Run ${YELLOW}git commit${NC} to commit changes manually, then retry"
+      clean_exit 1 "" true
+    else
+      error_msg "Working tree has uncommitted changes"
+      echo "Please commit or stash your changes before running this script."
+      echo ""
+      echo -e "If you're resolving conflicts from a previous run, use the ${CYAN}--continue${NC} option."
+      clean_exit 1 "" true
+    fi
+  fi
+}
+
+# ── Patch helpers ────────────────────────────────────────────────
+
+filter_and_transform_patch() {
+  local input_patch="$1"
+  local upstream_subdir="$2"
+  local output_patch="$3"
+
+  if [ -z "$upstream_subdir" ]; then
+    cp "$input_patch" "$output_patch"
+    return 0
+  fi
+
+  awk -v subdir="$upstream_subdir" '
+    BEGIN {
+      in_relevant_file = 0
+      skip_file = 0
+      subdir_prefix = subdir "/"
+    }
+
+    /^diff --git/ {
+      split($0, parts, " ")
+      old_path_full = parts[3]
+      new_path_full = parts[4]
+
+      gsub(/^a\//, "", old_path_full)
+      gsub(/^b\//, "", new_path_full)
+      old_path = old_path_full
+      new_path = new_path_full
+
+      if (old_path ~ "^" subdir_prefix || new_path ~ "^" subdir_prefix) {
+        in_relevant_file = 1
+        skip_file = 0
+
+        gsub("a/" subdir_prefix, "a/", $0)
+        gsub("b/" subdir_prefix, "b/", $0)
+        print $0
+      } else {
+        in_relevant_file = 0
+        skip_file = 1
+      }
+      next
+    }
+
+    /^index / {
+      if (in_relevant_file && !skip_file) print $0
+      next
+    }
+
+    /^(new|deleted) file mode/ {
+      if (in_relevant_file && !skip_file) print $0
+      next
+    }
+
+    /^(rename|copy) (from|to)/ {
+      if (in_relevant_file && !skip_file) {
+        gsub(subdir_prefix, "", $0)
+        print $0
+      }
+      next
+    }
+
+    /^(---|[+][+][+])/ {
+      if (in_relevant_file && !skip_file) {
+        if ($0 ~ "^---.*/" subdir_prefix) {
+          gsub("/" subdir_prefix, "/", $0)
+        } else if ($0 ~ "^[+][+][+].*/" subdir_prefix) {
+          gsub("/" subdir_prefix, "/", $0)
+        }
+        print $0
+      }
+      next
+    }
+
+    {
+      if (in_relevant_file && !skip_file) print $0
+    }
+  ' "$input_patch" > "$output_patch"
+}
+
+extract_single_file_patch() {
+  local patch_file="$1"
+  local rel_file="$2"
+  local output_file="$3"
+
+  awk -v file="$rel_file" '
+    /^diff --git/ {
+      if (in_file) exit
+      in_file = ($0 ~ " b/" file "$" || $0 ~ " b/" file " ")
+      if (in_file) print
+      next
+    }
+    in_file { print }
+  ' "$patch_file" > "$output_file"
+}
+
+is_binary_file() {
+  local filepath="$1"
+  if [ ! -f "$filepath" ]; then
+    return 1
+  fi
+  if LC_ALL=C grep -q $'\x00' "$filepath" 2>/dev/null; then
+    return 0
+  fi
+  local mime_type
+  mime_type=$(file --mime-type -b "$filepath" 2>/dev/null || echo "text/plain")
+  case "$mime_type" in
+    text/*|application/json|application/xml|application/javascript)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+get_repo_commit_url() {
+  local repo_path="$1"
+  local commit_sha="$2"
+  local remote_url
+
+  remote_url=$(git -C "$repo_path" config --get remote.origin.url 2>/dev/null || echo "")
+
+  if [ -z "$remote_url" ]; then
+    echo "  (no remote origin configured — view commit locally: git -C $repo_path log -1 $commit_sha)"
+    return
+  fi
+
+  remote_url="${remote_url%.git}"
+  remote_url="${remote_url#git@github.com:}"
+  if [[ "$remote_url" == https://github.com/* ]]; then
+    remote_url="${remote_url#https://github.com/}"
+  fi
+
+  if [[ "$remote_url" == */* ]]; then
+    echo "  https://github.com/$remote_url/commit/$commit_sha"
+  else
+    echo "  (view commit locally: git -C $repo_path log -1 $commit_sha)"
+  fi
+}
+
+# ── Conflict marker injection ───────────────────────────────────
+# Injects conflict markers into files that failed to apply.
+# Handles both text and binary files.
+#
+# Args:
+#   $1 — patch file
+#   $2 — commit SHA
+#   $3 — commit message
+#   $4 — commit URL (human-readable)
+#   $5 — continue command for the user
+#   $6+ — list of failed file paths (relative to upstream root)
+
+inject_conflict_markers() {
+  local patch_file="$1"
+  local commit_sha="$2"
+  local commit_msg="$3"
+  local commit_url="$4"
+  local continue_cmd="$5"
+  shift 5
+  local failed_files=("$@")
+
+  for rel_file in "${failed_files[@]}"; do
+    [ -z "$rel_file" ] && continue
+
+    local target_file="$MONOREPO_ROOT/$WORKSPACE_LOCATION/$TARGET_RELATIVE/$rel_file"
+
+    if grep -q '^<<<<<<< ' "$target_file" 2>/dev/null; then
+      continue
+    fi
+
+    local temp_patch="$TMP_DIR/file_patch_$$.txt"
+    extract_single_file_patch "$patch_file" "$rel_file" "$temp_patch"
+
+    if [ -s "$temp_patch" ]; then
+      local is_binary_patch=false
+      if grep -q "^GIT binary patch" "$temp_patch" 2>/dev/null || grep -q "^Binary files" "$temp_patch" 2>/dev/null; then
+        is_binary_patch=true
+      fi
+
+      if [ "$is_binary_patch" = true ] || { [ -f "$target_file" ] && is_binary_file "$target_file"; }; then
+        local patch_sidecar="$MONOREPO_ROOT/$WORKSPACE_LOCATION/$TARGET_RELATIVE/${rel_file}.patch"
+        local meta_sidecar="$MONOREPO_ROOT/$WORKSPACE_LOCATION/$TARGET_RELATIVE/${rel_file}.patch-info.txt"
+
+        mkdir -p "$(dirname "$patch_sidecar")"
+        cp "$temp_patch" "$patch_sidecar"
+
+        cat > "$meta_sidecar" << METAEOF
+PATCH INFO — Binary file conflict
+==================================
+UPSTREAM COMMIT: $commit_sha
+COMMIT MESSAGE: $commit_msg
+FILE: $rel_file
+WORKSPACE: $WORKSPACE_LOCATION
+PACKAGE: $PACKAGE_NAME
+
+This file is binary and cannot have conflict markers embedded.
+The patch content has been saved to: ${rel_file}.patch
+Review the patch and apply changes manually.
+
+For more details, view the upstream commit at:
+$commit_url
+METAEOF
+
+        warning_msg "Binary file '$rel_file' — patch saved to ${rel_file}.patch and ${rel_file}.patch-info.txt"
+      else
+        if [ ! -f "$target_file" ]; then
+          mkdir -p "$(dirname "$target_file")"
+          touch "$target_file"
+          info_msg "Created new file for conflict markers: $rel_file"
+        fi
+
+        cat >> "$target_file" << EOF
+
+<<<<<<< PATCH FAILED TO APPLY
+UPSTREAM COMMIT: $commit_sha
+COMMIT MESSAGE: $commit_msg
+FILE: $rel_file
+=======
+The patch below could not be applied automatically.
+This usually means the file content differs from what upstream expects.
+
+WHAT THE PATCH WANTS TO DO:
+────────────────────────────────────────────────────────────
+EOF
+        cat "$temp_patch" >> "$target_file"
+
+        cat >> "$target_file" << EOF
+────────────────────────────────────────────────────────────
+
+INSTRUCTIONS:
+1. Review the patch above (lines with - are removed, lines with + are added)
+2. Manually apply the intended changes to this file
+3. Remove this entire conflict marker block (from <<<<<<< to >>>>>>>)
+4. Stage the file: git add $WORKSPACE_LOCATION
+5. Continue: $continue_cmd
+
+For more details, view the upstream commit at:
+$commit_url
+>>>>>>> END PATCH FAILED
+EOF
+      fi
+    fi
+    rm -f "$temp_patch"
+  done
+}
+
+# ── Conflict resolution handler ─────────────────────────────────
+# Called when git apply --3way fails during apply_patch_based_update.
+# This function never returns — it exits via clean_exit.
+#
+# Args:
+#   $1 — commit_count
+#   $2 — total_commits
+#   $3 — commit SHA
+#   $4 — commit_msg
+#   $5 — filtered_patch path
+#   $6 — continue_cmd (full command for the user to run)
+#   $7 — commit_url
+
+handle_apply_conflict() {
+  local commit_count="$1"
+  local total_commits="$2"
+  local commit="$3"
+  local commit_msg="$4"
+  local filtered_patch="$5"
+  local continue_cmd="$6"
+  local commit_url="$7"
+
+  error_msg "Conflict detected while applying commit $commit_count/$total_commits"
+  echo -e "   ${YELLOW}Commit message: $commit_msg${NC}"
+  echo -e "   ${YELLOW}Upstream commit: $commit${NC}"
+  echo ""
+
+  local apply_error
+  apply_error=$(cat "$TMP_DIR/apply_error.log" 2>/dev/null || echo "")
+  local has_git_conflicts=false
+  local has_rejected_patches=false
+  local failed_files=()
+  local succeeded_files=()
+  local git_conflict_files=()
+
+  while IFS= read -r conflict_file; do
+    [ -n "$conflict_file" ] && git_conflict_files+=("$conflict_file")
+  done < <(git diff --name-only --diff-filter=U 2>/dev/null)
+
+  if [ ${#git_conflict_files[@]} -gt 0 ]; then
+    has_git_conflicts=true
+  fi
+
+  if echo "$apply_error" | grep -q "patch does not apply"; then
+    has_rejected_patches=true
+    while IFS= read -r line; do
+      if [[ "$line" =~ error:\ (.+):\ patch\ does\ not\ apply ]]; then
+        local failed_file="${BASH_REMATCH[1]}"
+        failed_file="${failed_file#$WORKSPACE_LOCATION/$TARGET_RELATIVE/}"
+        failed_files+=("$failed_file")
+      fi
+    done <<< "$apply_error"
+
+    if [ "$has_git_conflicts" = false ] && [ ${#failed_files[@]} -gt 0 ]; then
+      info_msg "Attempting to apply other files from the patch individually..."
+      echo ""
+
+      local all_files
+      all_files=$(grep '^diff --git' "$filtered_patch" | sed 's/^diff --git a\/.* b\///' || true)
+
+      while IFS= read -r file; do
+        [ -z "$file" ] && continue
+
+        local is_failed=false
+        for failed in "${failed_files[@]}"; do
+          if [ "$file" = "$failed" ]; then
+            is_failed=true
+            break
+          fi
+        done
+
+        if [ "$is_failed" = false ]; then
+          local single_file_patch="$TMP_DIR/single_${file//\//_}.patch"
+          extract_single_file_patch "$filtered_patch" "$file" "$single_file_patch"
+
+          if [ -s "$single_file_patch" ] && git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$single_file_patch" 2>/dev/null; then
+            succeeded_files+=("$file")
+            echo -e "  ${GREEN}✓${NC} $file"
+          else
+            failed_files+=("$file")
+            echo -e "  ${RED}✗${NC} $file"
+          fi
+        fi
+      done <<< "$all_files"
+      echo ""
+    fi
+  fi
+
+  if [ "$has_git_conflicts" = true ] && [ "$has_rejected_patches" = false ]; then
+    warning_msg "Git created conflict markers (partial application succeeded)"
+    echo "Some changes were applied, but conflicts need manual resolution."
+    echo ""
+    echo -e "${YELLOW}Files with git conflict markers:${NC}"
+    for conflict_file in "${git_conflict_files[@]}"; do
+      echo "  $conflict_file"
+    done
+  elif [ "$has_git_conflicts" = false ] && [ "$has_rejected_patches" = true ]; then
+    warning_msg "Patch was completely rejected (no automatic application possible)"
+    echo "This typically means file content differs significantly from upstream."
+    echo ""
+    echo -e "${CYAN}Common causes:${NC}"
+    echo "  * Local customizations/modifications in the fork"
+    echo "  * Different code structure than upstream expects"
+    echo "  * Previous patches changed the context"
+  else
+    warning_msg "Mixed results: some changes applied with conflicts, others rejected"
+    if [ ${#git_conflict_files[@]} -gt 0 ]; then
+      echo ""
+      echo -e "${YELLOW}Files with git conflict markers:${NC}"
+      for conflict_file in "${git_conflict_files[@]}"; do
+        echo "  $conflict_file"
+      done
+    fi
+  fi
+
+  echo ""
+
+  if [ ${#succeeded_files[@]} -gt 0 ]; then
+    success_msg "Successfully applied ${#succeeded_files[@]} file(s):"
+    for file in "${succeeded_files[@]}"; do
+      echo "  ✓ $file"
+    done
+    echo ""
+  fi
+
+  if [ "$has_rejected_patches" = true ] && [ ${#failed_files[@]} -gt 0 ]; then
+    info_msg "Injecting conflict markers for ${#failed_files[@]} failed file(s)..."
+    inject_conflict_markers "$filtered_patch" "$commit" "$commit_msg" "$commit_url" "$continue_cmd" "${failed_files[@]}"
+    echo ""
+    warning_msg "Files that need manual resolution:"
+    for failed_file in "${failed_files[@]}"; do
+      echo "  ✗ $failed_file"
+    done
+    echo ""
+  fi
+
+  echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${CYAN}RESOLUTION STEPS:${NC}"
+  echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+  echo "1. Find conflict markers in: $WORKSPACE_LOCATION/$TARGET_RELATIVE/"
+  echo ""
+  echo "   Two types of markers to look for:"
+  echo -e "   ${RED}a)${NC} Git conflict markers:    ${RED}<<<<<<<${NC} ${YELLOW}=======${NC} ${RED}>>>>>>>${NC}"
+  echo -e "   ${RED}b)${NC} Script-injected markers: ${RED}<<<<<<< PATCH FAILED${NC} ... ${RED}>>>>>>> END PATCH${NC}"
+  echo ""
+  echo "2. For EACH conflict marker:"
+  echo "   * Review what the patch wants to change"
+  echo "   * Manually apply the intended changes"
+  echo "   * Remove all conflict marker lines"
+  echo ""
+  echo "3. Verify your changes make sense:"
+  echo -e "   ${YELLOW}git diff $WORKSPACE_LOCATION${NC}"
+  echo ""
+  echo "4. Stage all resolved files:"
+  echo -e "   ${YELLOW}git add $WORKSPACE_LOCATION${NC}"
+  echo ""
+  echo "5. Continue the update process:"
+  echo -e "   ${GREEN}$continue_cmd${NC}"
+  if [ ${#succeeded_files[@]} -gt 0 ]; then
+    echo ""
+    echo "   Note: Successfully applied files are already staged."
+    echo "   This will commit everything and proceed to the next patch."
+  fi
+  echo ""
+  echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+  info_msg "Progress: Applied $((commit_count - 1))/$total_commits commits successfully"
+  info_msg "Failed on commit: $commit ($commit_count/$total_commits)"
+  info_msg "Remaining: $((total_commits - commit_count + 1)) commits"
+  clean_exit 1 "" true
+}

--- a/packages/app-config/scripts/package-subtree-common.sh
+++ b/packages/app-config/scripts/package-subtree-common.sh
@@ -390,6 +390,154 @@ EOF
   done
 }
 
+# ── Patch-based update (shared) ─────────────────────────────────
+# Applies a sequence of commits from upstream to the target directory.
+# Uses callbacks/hooks for script-specific behaviors (git commands, URLs, etc).
+#
+# Required callbacks (caller must define these before calling):
+#   _git_upstream_cmd       — git command wrapper for upstream repo
+#   _get_continue_cmd       — returns --continue command for conflict resolution
+#   _get_commit_url         — returns commit URL for a given SHA
+#   _pre_apply_hook         — called once before iteration (setup, fetch, etc)
+#   _before_apply_hook      — called before git apply on each patch (receives filtered_patch path)
+#   _post_iteration_hook    — called after each commit iteration
+#   _filter_rev_list        — filters/customizes rev-list (e.g., add subdir filter)
+#
+# Args:
+#   $1 — from_commit
+#   $2 — to_commit
+#   $3 — upstream_subdir
+#   $4 — target_dir
+#   $5 — single_commit_mode (default: false)
+
+apply_patch_based_update() {
+  local from_commit="$1"
+  local to_commit="$2"
+  local upstream_subdir="$3"
+  local target_dir="$4"
+  local single_commit_mode="${5:-false}"
+
+  if [ "$single_commit_mode" = true ]; then
+    info_msg "Applying single commit: $to_commit"
+  else
+    echo "Applying patch-based update from $from_commit to $to_commit"
+  fi
+
+  if [ "$single_commit_mode" != true ]; then
+    if [ -z "$from_commit" ] || [ "$from_commit" = "null" ] || [ "$from_commit" = "" ]; then
+      clean_exit 1 "No starting commit provided for patch-based update"
+    fi
+
+    if ! $_git_upstream_cmd rev-parse --quiet --verify "$from_commit" >/dev/null; then
+      warning_msg "Current commit $from_commit not found in upstream repository"
+      clean_exit 1 "Cannot perform patch-based update - starting commit does not exist."
+    fi
+  fi
+
+  local commits
+  if [ "$single_commit_mode" = true ]; then
+    commits="$to_commit"
+  else
+    commits=$(_filter_rev_list "$from_commit" "$to_commit" "$upstream_subdir")
+  fi
+
+  if [ -z "$commits" ]; then
+    if [ "$single_commit_mode" = true ]; then
+      echo "Commit $to_commit has no relevant changes for the subtree"
+    else
+      echo "No commits to apply between $from_commit and $to_commit"
+    fi
+    return 0
+  fi
+
+  local total_commits
+  total_commits=$(echo "$commits" | wc -l | tr -d ' ')
+  echo -e "Found ${YELLOW}$total_commits${NC} commit(s) to apply"
+
+  _pre_apply_hook
+
+  local commit_count=0
+  for commit in $commits; do
+    commit_count=$((commit_count + 1))
+    progress_msg "Applying commit $commit_count/$total_commits: $commit"
+
+    local commit_msg
+    commit_msg=$($_git_upstream_cmd log -1 --format="%s" "$commit")
+
+    local patch_file="$TMP_DIR/patch_${commit}.patch"
+    $_git_upstream_cmd format-patch -1 "$commit" --stdout > "$patch_file"
+
+    local filtered_patch="$TMP_DIR/filtered_${commit}.patch"
+    filter_and_transform_patch "$patch_file" "$upstream_subdir" "$filtered_patch"
+
+    if [ -s "$filtered_patch" ]; then
+      cd "$MONOREPO_ROOT"
+
+      _before_apply_hook "$filtered_patch"
+
+      if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
+        local commit_url
+        commit_url=$(_get_commit_url "$commit")
+        local continue_cmd
+        continue_cmd=$(_get_continue_cmd)
+        handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
+      fi
+
+      set +e
+      safe_git_commit_if_changes "${COMMIT_PREFIX}Update $PACKAGE_NAME: $commit_msg
+
+Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
+      local commit_exit_code=$?
+      set -e
+
+      if [ $commit_exit_code -eq 0 ]; then
+        if update_package_json_commit "$commit"; then
+          git add "$PACKAGE_JSON"
+          git commit -q --amend --no-edit
+          success_msg "Applied commit $commit_count/$total_commits: $commit_msg"
+        else
+          warning_msg "Committed changes but failed to update package.json tracking"
+        fi
+      elif [ $commit_exit_code -eq 2 ]; then
+        if update_package_json_commit "$commit"; then
+          local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
+          set +e
+          safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
+          local tracking_exit_code=$?
+          set -e
+          if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
+            clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
+          fi
+          info_msg "No changes from commit $commit_count/$total_commits"
+        else
+          warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
+        fi
+      else
+        clean_exit 1 "Failed to commit changes for commit $commit_count/$total_commits"
+      fi
+
+    else
+      info_msg "No relevant changes in commit $commit_count/$total_commits for subtree"
+
+      cd "$MONOREPO_ROOT"
+      if update_package_json_commit "$commit"; then
+        local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
+        set +e
+        safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
+        local tracking_exit_code=$?
+        set -e
+        if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
+          clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
+        fi
+      else
+        warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
+      fi
+    fi
+
+    _post_iteration_hook
+  done
+}
+
 # ── Conflict resolution handler ─────────────────────────────────
 # Called when git apply --3way fails during apply_patch_based_update.
 # This function never returns — it exits via clean_exit.

--- a/packages/app-config/scripts/package-subtree-local.sh
+++ b/packages/app-config/scripts/package-subtree-local.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # This is the local variant of package-subtree.sh — reads from a local repository path instead of cloning.
 # Usage: ./package-subtree-local.sh --package=<package-name> --local-repo=<path> --branch=<branch> [--commit=<sha>] [--up-to=<sha>] [--continue]
 
-source "$(dirname "${BASH_SOURCE[0]}")/package-subtree-common.sh"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")" && pwd)"
+source "$SCRIPT_DIR/package-subtree-common.sh"
 
 TEMP_REMOTE_NAME="_subtree_local_temp"
 

--- a/packages/app-config/scripts/package-subtree-local.sh
+++ b/packages/app-config/scripts/package-subtree-local.sh
@@ -553,54 +553,35 @@ This commit should NOT be merged. It exists only to test changes from a local re
   echo ""
 fi
 
-apply_patch_based_update() {
+_git_upstream_cmd() {
+  git -C "$LOCAL_REPO_RESOLVED" "$@"
+}
+
+_filter_rev_list() {
   local from_commit="$1"
   local to_commit="$2"
   local upstream_subdir="$3"
-  local target_dir="$4"
-  local single_commit_mode="${5:-false}"
-
-  if [ "$single_commit_mode" = true ]; then
-    info_msg "Applying single commit: $to_commit"
+  if [ -n "$upstream_subdir" ]; then
+    git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit" -- "$upstream_subdir"
   else
-    echo "Applying patch-based update from $from_commit to $to_commit"
+    git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit"
   fi
+}
 
-  if [ "$single_commit_mode" != true ]; then
-    if [ -z "$from_commit" ] || [ "$from_commit" = "null" ] || [ "$from_commit" = "" ]; then
-      clean_exit 1 "No starting commit provided for patch-based update"
-    fi
+_get_commit_url() {
+  local commit="$1"
+  get_repo_commit_url "$LOCAL_REPO_RESOLVED" "$commit"
+}
 
-    if ! git -C "$LOCAL_REPO_RESOLVED" rev-parse --quiet --verify "$from_commit" >/dev/null; then
-      warning_msg "Current commit $from_commit not found in local repository"
-      clean_exit 1 "Cannot perform patch-based update - starting commit does not exist."
-    fi
+_get_continue_cmd() {
+  local continue_cmd="npm run update-subtree-local -w $WORKSPACE_LOCATION -- --local-repo=$LOCAL_REPO_RESOLVED --branch=$LOCAL_BRANCH"
+  if [ -n "$COMMIT_SHA" ]; then
+    continue_cmd="$continue_cmd --commit=$COMMIT_SHA"
   fi
+  echo "$continue_cmd --continue"
+}
 
-  local commits
-  if [ "$single_commit_mode" = true ]; then
-    commits="$to_commit"
-  else
-    if [ -n "$upstream_subdir" ]; then
-      commits=$(git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit" -- "$upstream_subdir")
-    else
-      commits=$(git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit")
-    fi
-  fi
-
-  if [ -z "$commits" ]; then
-    if [ "$single_commit_mode" = true ]; then
-      echo "Commit $to_commit has no relevant changes for the subtree"
-    else
-      echo "No commits to apply between $from_commit and $to_commit"
-    fi
-    return 0
-  fi
-
-  local total_commits
-  total_commits=$(echo "$commits" | wc -l | tr -d ' ')
-  echo -e "Found ${YELLOW}$total_commits${NC} commit(s) to apply"
-
+_pre_apply_hook() {
   progress_msg "Fetching git objects from local repository for three-way merge support..."
   cleanup_temp_remote
   git remote add "$TEMP_REMOTE_NAME" "$LOCAL_REPO_RESOLVED"
@@ -609,88 +590,15 @@ apply_patch_based_update() {
   else
     success_msg "Git objects fetched — three-way merge enabled"
   fi
+}
 
-  local commit_count=0
-  for commit in $commits; do
-    commit_count=$((commit_count + 1))
-    progress_msg "Applying commit $commit_count/$total_commits: $commit"
+_before_apply_hook() {
+  local filtered_patch="$1"
+  ensure_base_blobs_in_index "$filtered_patch" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
+}
 
-    local commit_msg
-    commit_msg=$(git -C "$LOCAL_REPO_RESOLVED" log -1 --format="%s" "$commit")
-
-    local patch_file="$TMP_DIR/patch_${commit}.patch"
-    git -C "$LOCAL_REPO_RESOLVED" format-patch -1 "$commit" --stdout > "$patch_file"
-
-    local filtered_patch="$TMP_DIR/filtered_${commit}.patch"
-    filter_and_transform_patch "$patch_file" "$upstream_subdir" "$filtered_patch"
-
-    if [ -s "$filtered_patch" ]; then
-      cd "$MONOREPO_ROOT"
-
-      ensure_base_blobs_in_index "$filtered_patch" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
-
-      if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
-        local commit_url
-        commit_url=$(get_repo_commit_url "$LOCAL_REPO_RESOLVED" "$commit")
-        local continue_cmd="npm run update-subtree-local -w $WORKSPACE_LOCATION -- --local-repo=$LOCAL_REPO_RESOLVED --branch=$LOCAL_BRANCH"
-        if [ -n "$COMMIT_SHA" ]; then
-          continue_cmd="$continue_cmd --commit=$COMMIT_SHA"
-        fi
-        continue_cmd="$continue_cmd --continue"
-        handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
-      fi
-
-      set +e
-      safe_git_commit_if_changes "${COMMIT_PREFIX}Update $PACKAGE_NAME: $commit_msg
-
-Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
-      local commit_exit_code=$?
-      set -e
-
-      if [ $commit_exit_code -eq 0 ]; then
-        if update_package_json_commit "$commit"; then
-          git add "$PACKAGE_JSON"
-          git commit -q --amend --no-edit
-          success_msg "Applied commit $commit_count/$total_commits: $commit_msg"
-        else
-          warning_msg "Committed changes but failed to update package.json tracking"
-        fi
-      elif [ $commit_exit_code -eq 2 ]; then
-        if update_package_json_commit "$commit"; then
-          local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
-          set +e
-          safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
-          local tracking_exit_code=$?
-          set -e
-          if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
-            clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
-          fi
-          info_msg "No changes from commit $commit_count/$total_commits"
-        else
-          warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
-        fi
-      else
-        clean_exit 1 "Failed to commit changes for commit $commit_count/$total_commits"
-      fi
-
-    else
-      info_msg "No relevant changes in commit $commit_count/$total_commits for subtree"
-
-      cd "$MONOREPO_ROOT"
-      if update_package_json_commit "$commit"; then
-        local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
-        set +e
-        safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
-        local tracking_exit_code=$?
-        set -e
-        if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
-          clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
-        fi
-      else
-        warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
-      fi
-    fi
-  done
+_post_iteration_hook() {
+  :
 }
 
 if [ ! -d "$TARGET_DIR" ]; then

--- a/packages/app-config/scripts/package-subtree-local.sh
+++ b/packages/app-config/scripts/package-subtree-local.sh
@@ -632,7 +632,7 @@ apply_patch_based_update() {
       if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
         local commit_url
         commit_url=$(get_repo_commit_url "$LOCAL_REPO_RESOLVED" "$commit")
-        local continue_cmd="npm run update-subtree-local -- --package=$PACKAGE_NAME --local-repo=$LOCAL_REPO_RESOLVED --branch=$LOCAL_BRANCH"
+        local continue_cmd="npm run update-subtree-local -w $WORKSPACE_LOCATION -- --local-repo=$LOCAL_REPO_RESOLVED --branch=$LOCAL_BRANCH"
         if [ -n "$COMMIT_SHA" ]; then
           continue_cmd="$continue_cmd --commit=$COMMIT_SHA"
         fi

--- a/packages/app-config/scripts/package-subtree-local.sh
+++ b/packages/app-config/scripts/package-subtree-local.sh
@@ -1,0 +1,708 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Script to sync local upstream repository content into monorepo using patch-based incremental updates
+# This is the local variant of package-subtree.sh — reads from a local repository path instead of cloning.
+# Usage: ./package-subtree-local.sh --package=<package-name> --local-repo=<path> --branch=<branch> [--commit=<sha>] [--up-to=<sha>] [--continue]
+
+source "$(dirname "${BASH_SOURCE[0]}")/package-subtree-common.sh"
+
+TEMP_REMOTE_NAME="_subtree_local_temp"
+
+cleanup_temp_remote() {
+  if git remote get-url "$TEMP_REMOTE_NAME" >/dev/null 2>&1; then
+    git remote remove "$TEMP_REMOTE_NAME" 2>/dev/null || true
+  fi
+}
+
+ensure_base_blobs_in_index() {
+  local patch_file="$1"
+  local target_dir="$2"
+  local current_file=""
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^diff\ --git\ a/(.*)\ b/(.*) ]]; then
+      current_file="${BASH_REMATCH[2]}"
+      continue
+    fi
+
+    if [ -z "$current_file" ]; then
+      continue
+    fi
+
+    if [[ "$line" =~ ^index\ ([0-9a-f]+)\.\.([0-9a-f]+)(\ ([0-9]+))? ]]; then
+      local old_hash="${BASH_REMATCH[1]}"
+      local mode="${BASH_REMATCH[4]:-100644}"
+      local full_path="$target_dir/$current_file"
+
+      current_file=""
+
+      if git ls-files --error-unmatch "$full_path" >/dev/null 2>&1; then
+        continue
+      fi
+
+      if [ "$old_hash" = "0000000" ] || [ "$old_hash" = "00000000" ]; then
+        continue
+      fi
+
+      local full_old_hash
+      full_old_hash=$(git rev-parse "$old_hash" 2>/dev/null || echo "")
+
+      if [ -n "$full_old_hash" ] && git cat-file -e "$full_old_hash" 2>/dev/null; then
+        git update-index --add --cacheinfo "$mode,$full_old_hash,$full_path" 2>/dev/null || true
+      fi
+    fi
+  done < "$patch_file"
+}
+
+show_do_not_merge_warning() {
+  echo ""
+  echo -e "${RED}╔══════════════════════════════════════════════════════════════════════════╗${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  WARNING: DO NOT MERGE THESE COMMITS!                                    ║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  These commits sync from a LOCAL repository and may reference commits    ║${NC}"
+  echo -e "${RED}║  that don't exist in the official upstream.                              ║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  All commits created during this sync have the prefix:                   ║${NC}"
+  echo -e "${RED}║  [DO NOT MERGE - LOCAL SYNC]                                             ║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  Local repo: $(printf '%-58s' "$LOCAL_REPO_RESOLVED")║${NC}"
+  echo -e "${RED}║  Branch: $(printf '%-62s' "$LOCAL_BRANCH")║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  Next steps:                                                             ║${NC}"
+  echo -e "${RED}║  1. Test the changes from the local repository                           ║${NC}"
+  echo -e "${RED}║  2. After the changes are merged upstream, start a fresh branch from     ║${NC}"
+  echo -e "${RED}║     odh-dashboard main                                                   ║${NC}"
+  echo -e "${RED}║  3. Run the sync script again WITHOUT the --local-repo option to get     ║${NC}"
+  echo -e "${RED}║     the official merged changes                                          ║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}║  DO NOT merge this branch into odh-dashboard main!                       ║${NC}"
+  echo -e "${RED}║                                                                          ║${NC}"
+  echo -e "${RED}╚══════════════════════════════════════════════════════════════════════════╝${NC}"
+  echo ""
+}
+
+show_usage() {
+  echo "Usage: $0 --package=<package-name> --local-repo=<path> --branch=<branch> [--commit=<commit-sha>] [--up-to=<commit-sha>] [--continue]"
+  echo ""
+  echo "Options:"
+  echo "  --package=NAME         Required. Name of the package to update (e.g., @odh-dashboard/model-registry)"
+  echo "  --local-repo=PATH      Required. Absolute or relative path to the local upstream repository"
+  echo "  --branch=BRANCH        Required. Branch in the local repository to sync from"
+  echo "  --commit=SHA           Optional. Apply ONLY this specific commit (cherry-pick mode)"
+  echo "  --up-to=SHA            Optional. Apply all commits from current up to this commit (range mode)"
+  echo "  --continue             Continue from a previous conflict resolution"
+  echo ""
+  echo "Examples:"
+  echo "  # Sync all new commits from the branch"
+  echo "  $0 --package=@odh-dashboard/model-registry --local-repo=../model-registry --branch=feature/new-ui"
+  echo ""
+  echo "  # Apply only one specific commit"
+  echo "  $0 --package=@odh-dashboard/model-registry --local-repo=../model-registry --branch=main --commit=abc123"
+  echo ""
+  echo "  # Apply all commits up to a specific one"
+  echo "  $0 --package=@odh-dashboard/model-registry --local-repo=../model-registry --branch=main --up-to=abc123"
+  echo ""
+  echo "  # Continue after resolving conflicts"
+  echo "  $0 --package=@odh-dashboard/model-registry --local-repo=../model-registry --branch=feature/new-ui --continue"
+}
+
+CONTINUE_MODE=false
+PACKAGE_NAME=""
+COMMIT_SHA=""
+UP_TO_SHA=""
+LOCAL_REPO=""
+LOCAL_BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --package=*)
+      PACKAGE_NAME="${1#*=}"
+      shift
+      ;;
+    --local-repo=*)
+      LOCAL_REPO="${1#*=}"
+      shift
+      ;;
+    --branch=*)
+      LOCAL_BRANCH="${1#*=}"
+      shift
+      ;;
+    --commit=*)
+      COMMIT_SHA="${1#*=}"
+      shift
+      ;;
+    --up-to=*)
+      UP_TO_SHA="${1#*=}"
+      shift
+      ;;
+    --continue)
+      CONTINUE_MODE=true
+      shift
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      error_msg "Unknown option: $1"
+      echo ""
+      show_usage
+      clean_exit 1 "" true
+      ;;
+  esac
+done
+
+if [ -z "$PACKAGE_NAME" ]; then
+  error_msg "--package is required"
+  echo ""
+  show_usage
+  clean_exit 1 "" true
+fi
+
+if [ -z "$LOCAL_REPO" ]; then
+  error_msg "--local-repo is required"
+  echo ""
+  show_usage
+  clean_exit 1 "" true
+fi
+
+if [ -z "$LOCAL_BRANCH" ]; then
+  error_msg "--branch is required"
+  echo ""
+  show_usage
+  clean_exit 1 "" true
+fi
+
+if [ -n "$COMMIT_SHA" ] && [ -n "$UP_TO_SHA" ]; then
+  error_msg "--commit and --up-to are mutually exclusive. Use --commit to apply a single commit or --up-to to apply a range."
+  echo ""
+  show_usage
+  clean_exit 1 "" true
+fi
+
+LOCAL_REPO="${LOCAL_REPO/#\~/$HOME}"
+
+for tool in git npm jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    clean_exit 1 "Required tool '$tool' not found in PATH" true
+  fi
+done
+
+if [ ! -d "$LOCAL_REPO" ]; then
+  clean_exit 1 "Path '$LOCAL_REPO' does not exist or is not a directory" true
+fi
+
+LOCAL_REPO_INPUT=$(cd "$LOCAL_REPO" && pwd)
+
+if ! git -C "$LOCAL_REPO_INPUT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  clean_exit 1 "Path '$LOCAL_REPO_INPUT' is not a valid Git repository" true
+fi
+
+LOCAL_REPO_RESOLVED=$(git -C "$LOCAL_REPO_INPUT" rev-parse --show-toplevel)
+if [ "$LOCAL_REPO_INPUT" != "$LOCAL_REPO_RESOLVED" ]; then
+  warning_msg "Path points to a subdirectory inside the Git repository"
+  echo "  Provided:  $LOCAL_REPO_INPUT"
+  echo "  Repo root: $LOCAL_REPO_RESOLVED"
+  echo "  Using repo root for sync operations."
+  echo ""
+fi
+LOCAL_REPO_ORIGIN=$(git -C "$LOCAL_REPO_RESOLVED" remote get-url origin 2>/dev/null || echo "")
+LOCAL_REPO_LABEL="$LOCAL_REPO_RESOLVED"
+
+if ! git -C "$LOCAL_REPO_RESOLVED" rev-parse --verify "$LOCAL_BRANCH" >/dev/null 2>&1; then
+  error_msg "Branch '$LOCAL_BRANCH' does not exist in $LOCAL_REPO_RESOLVED"
+  echo ""
+  echo "Available branches:"
+  git -C "$LOCAL_REPO_RESOLVED" branch -a --format='  %(refname:short)' | head -20
+  BRANCH_COUNT=$(git -C "$LOCAL_REPO_RESOLVED" branch -a | wc -l | tr -d ' ')
+  if [ "$BRANCH_COUNT" -gt 20 ]; then
+    echo "  ... and $((BRANCH_COUNT - 20)) more"
+  fi
+  clean_exit 1 "" true
+fi
+
+MONOREPO_ROOT="$(git rev-parse --show-toplevel)"
+
+WORKSPACE_INFO=$(npm query ".workspace[name=\"$PACKAGE_NAME\"]" 2>/dev/null)
+if [ -z "$WORKSPACE_INFO" ] || [ "$WORKSPACE_INFO" = "[]" ]; then
+  error_msg "Package '$PACKAGE_NAME' not found"
+  echo "Available packages:"
+  npm query ".workspace" | jq -r '.[].name' | sed 's/^/  /'
+  clean_exit 1 "" true
+fi
+
+WORKSPACE_LOCATION=$(echo "$WORKSPACE_INFO" | jq -r '.[0].location')
+if [ -z "$WORKSPACE_LOCATION" ] || [ "$WORKSPACE_LOCATION" = "null" ]; then
+  error_msg "Could not determine location for package '$PACKAGE_NAME'"
+  clean_exit 1 "" true
+fi
+
+PACKAGE_JSON="$MONOREPO_ROOT/$WORKSPACE_LOCATION/package.json"
+
+cd "$MONOREPO_ROOT"
+
+UPSTREAM_SUBDIR=$(jq -r '.subtree.src // ""' "$PACKAGE_JSON")
+TARGET_RELATIVE=$(jq -r '.subtree.target' "$PACKAGE_JSON")
+CURRENT_COMMIT=$(jq -r '.subtree.commit // ""' "$PACKAGE_JSON")
+
+COMMIT_PREFIX="[DO NOT MERGE - LOCAL SYNC] "
+
+if [ -z "$TARGET_RELATIVE" ] || [ "$TARGET_RELATIVE" = "null" ]; then
+  clean_exit 1 "Missing subtree.target in $PACKAGE_JSON" true
+fi
+
+if [ "$CONTINUE_MODE" = true ]; then
+  progress_msg "Continue mode: Processing staged changes from conflict resolution"
+
+  conflict_files=()
+  files_with_markers=()
+  while IFS= read -r -d '' file; do
+    [ -n "$file" ] && conflict_files+=("$file")
+    if [ -n "$file" ] && grep -qE '^<<<<<<< |^=======$|^>>>>>>> ' "$file"; then
+      files_with_markers+=("$file")
+    fi
+  done < <(git diff --name-only --diff-filter=U -z)
+
+  staged_files_with_markers=()
+  while IFS= read -r -d '' staged_file; do
+    [ -z "$staged_file" ] && continue
+
+    case "$staged_file" in
+      "$WORKSPACE_LOCATION"/*|"$PACKAGE_JSON")
+        ;;
+      *)
+        error_msg "Staged file '$staged_file' is outside the allowed scope ($WORKSPACE_LOCATION or $PACKAGE_JSON)"
+        clean_exit 1 "" true
+        ;;
+    esac
+
+    local_blob_content=$(git show ":$staged_file" 2>/dev/null || echo "")
+    if echo "$local_blob_content" | grep -qE '^<<<<<<< |^=======$|^>>>>>>> |^<<<<<<< PATCH FAILED TO APPLY'; then
+      staged_files_with_markers+=("$staged_file")
+    fi
+  done < <(git diff --cached --name-only -z)
+
+  if [ "${#staged_files_with_markers[@]}" -gt 0 ]; then
+    error_msg "Staged files still contain conflict markers"
+    echo "The following staged files contain unresolved conflict or patch markers:"
+    for file in "${staged_files_with_markers[@]}"; do
+      echo "  $file"
+    done
+    echo ""
+    echo -e "${INFO_ICON} Please resolve all conflicts before using ${CYAN}--continue${NC}"
+    clean_exit 1 "" true
+  fi
+
+  if [ "${#files_with_markers[@]}" -gt 0 ]; then
+    error_msg "There are still unresolved conflicts"
+    echo "The following files still contain conflict markers:"
+    for file in "${files_with_markers[@]}"; do
+      echo "  $file"
+    done
+    echo ""
+    echo -e "${INFO_ICON} Please resolve all conflicts before using ${CYAN}--continue${NC}"
+    clean_exit 1 "" true
+  fi
+
+  if [ "${#conflict_files[@]}" -gt 0 ]; then
+    warning_msg "Found resolved conflicts that need staging"
+    echo "Files with resolved conflicts:"
+    for file in "${conflict_files[@]}"; do
+      echo "  $file"
+    done
+  fi
+
+  if git diff --cached --quiet; then
+    error_msg "No staged changes found"
+    echo -e "Please stage your resolved conflicts: ${YELLOW}git add $WORKSPACE_LOCATION${NC}"
+    clean_exit 1 "" true
+  fi
+
+  info_msg "Committing staged changes..."
+
+  TARGET_COMMIT=$(git -C "$LOCAL_REPO_RESOLVED" rev-parse "$LOCAL_BRANCH")
+  if [ -n "$COMMIT_SHA" ]; then
+    TARGET_COMMIT="$COMMIT_SHA"
+  elif [ -n "$UP_TO_SHA" ]; then
+    TARGET_COMMIT="$UP_TO_SHA"
+  fi
+
+  if [ -n "$COMMIT_SHA" ]; then
+    continue_commit="$COMMIT_SHA"
+    continue_commit_msg=$(git -C "$LOCAL_REPO_RESOLVED" log -1 --format="%s" "$continue_commit")
+
+    git commit -q -m "${COMMIT_PREFIX}Update $PACKAGE_NAME: $continue_commit_msg (resolved conflicts)
+
+Upstream commit: $continue_commit"
+
+    success_msg "Committed resolved conflicts for $continue_commit: $continue_commit_msg"
+
+    if update_package_json_commit "$continue_commit"; then
+      if ! git add "$PACKAGE_JSON"; then
+        clean_exit 1 "Failed to stage package.json after committing conflicts"
+      fi
+      git commit -q --amend --no-edit
+      info_msg "Updated package.json to track commit $continue_commit"
+    else
+      clean_exit 1 "Failed to update package.json after committing conflicts"
+    fi
+  else
+    if ! git -C "$LOCAL_REPO_RESOLVED" merge-base --is-ancestor "$CURRENT_COMMIT" "$TARGET_COMMIT" 2>/dev/null; then
+      error_msg "Current commit $CURRENT_COMMIT not found in branch '$LOCAL_BRANCH' of $LOCAL_REPO_RESOLVED"
+      echo ""
+      echo "The local branch may be out of date. Rebase it and try again."
+      clean_exit 1 "" true
+    fi
+
+    commits=$(git -C "$LOCAL_REPO_RESOLVED" rev-list --reverse "$CURRENT_COMMIT..$TARGET_COMMIT")
+    if [ -n "$commits" ]; then
+      continue_commit=$(echo "$commits" | head -n 1)
+      continue_commit_msg=$(git -C "$LOCAL_REPO_RESOLVED" log -1 --format="%s" "$continue_commit")
+
+      git commit -q -m "${COMMIT_PREFIX}Update $PACKAGE_NAME: $continue_commit_msg (resolved conflicts)
+
+Upstream commit: $continue_commit"
+
+      success_msg "Committed resolved conflicts for $continue_commit: $continue_commit_msg"
+
+      if update_package_json_commit "$continue_commit"; then
+        if ! git add "$PACKAGE_JSON"; then
+          clean_exit 1 "Failed to stage package.json after committing conflicts"
+        fi
+        git commit -q --amend --no-edit
+        info_msg "Updated package.json to track commit $continue_commit"
+      else
+        clean_exit 1 "Failed to update package.json after committing conflicts"
+      fi
+
+      CURRENT_COMMIT="$continue_commit"
+    else
+      git commit -q -m "${COMMIT_PREFIX}Update $PACKAGE_NAME: Manual conflict resolution"
+      success_msg "Committed staged changes"
+    fi
+  fi
+
+else
+  check_working_tree_clean
+fi
+
+TARGET_DIR="$MONOREPO_ROOT/$WORKSPACE_LOCATION/$TARGET_RELATIVE"
+
+info_msg "Syncing $PACKAGE_NAME from local repository"
+echo "  Local repo: $LOCAL_REPO_RESOLVED"
+echo "  Branch: $LOCAL_BRANCH"
+if [ -n "$COMMIT_SHA" ]; then
+  echo "  Mode: Single commit (cherry-pick)"
+  echo "  Commit: $COMMIT_SHA"
+elif [ -n "$UP_TO_SHA" ]; then
+  echo "  Mode: Range (up to commit)"
+  echo "  Target: $UP_TO_SHA"
+else
+  echo "  Mode: Full sync (all new commits)"
+fi
+echo ""
+
+CURRENT_COMMIT=$(jq -r '.subtree.commit // ""' "$PACKAGE_JSON")
+
+if [ -n "$COMMIT_SHA" ]; then
+  if ! git -C "$LOCAL_REPO_RESOLVED" rev-parse --quiet --verify "$COMMIT_SHA" >/dev/null; then
+    clean_exit 1 "Commit '$COMMIT_SHA' not found in local repository" true
+  fi
+  TARGET_COMMIT="$COMMIT_SHA"
+  SINGLE_COMMIT_MODE=true
+elif [ -n "$UP_TO_SHA" ]; then
+  if ! git -C "$LOCAL_REPO_RESOLVED" rev-parse --quiet --verify "$UP_TO_SHA" >/dev/null; then
+    clean_exit 1 "Commit '$UP_TO_SHA' not found in local repository" true
+  fi
+  TARGET_COMMIT="$UP_TO_SHA"
+  SINGLE_COMMIT_MODE=false
+else
+  TARGET_COMMIT=$(git -C "$LOCAL_REPO_RESOLVED" rev-parse "$LOCAL_BRANCH")
+  SINGLE_COMMIT_MODE=false
+fi
+
+if [ "$SINGLE_COMMIT_MODE" != true ]; then
+  if [ -n "$CURRENT_COMMIT" ] && [ "$CURRENT_COMMIT" != "null" ] && [ "$CURRENT_COMMIT" != "" ]; then
+    if ! git -C "$LOCAL_REPO_RESOLVED" merge-base --is-ancestor "$CURRENT_COMMIT" "$TARGET_COMMIT" 2>/dev/null; then
+      error_msg "Current commit $CURRENT_COMMIT not found in branch '$LOCAL_BRANCH' of local repository"
+      echo ""
+      echo "This means the branch in the local repository doesn't contain the commit"
+      echo "that the monorepo was last synced to. Possible causes:"
+      echo "  * The local branch was rebased or reset"
+      echo "  * The local repo is pointing to a different fork"
+      echo "  * The branch doesn't share history with the upstream"
+      clean_exit 1 "" true
+    fi
+  fi
+fi
+
+if [ ! -d "$TARGET_DIR" ] && { [ -z "$CURRENT_COMMIT" ] || [ "$CURRENT_COMMIT" = "null" ] || [ "$CURRENT_COMMIT" = "" ]; }; then
+  progress_msg "Performing initial setup - no previous commit found"
+
+  if ! copy_upstream_files "$LOCAL_REPO_RESOLVED" "$UPSTREAM_SUBDIR" "$TARGET_DIR"; then
+    clean_exit 1 "Failed to copy files during initial setup"
+  fi
+
+  cd "$MONOREPO_ROOT"
+
+  bootstrap_tmp="$PACKAGE_JSON.tmp"
+  if ! jq --arg origin_url "$LOCAL_REPO_ORIGIN" \
+          --arg branch "$LOCAL_BRANCH" \
+          --arg commit "$TARGET_COMMIT" \
+          '.subtree = (
+            { DO_NOT_MERGE_SYNCED_FROM_LOCAL: (
+                { branch: $branch }
+                + if $origin_url != "" then { origin_url: $origin_url } else { source: "local repository" } end
+              ) }
+            + (if .subtree.repo then { repo: .subtree.repo } else {} end)
+            + { branch: $branch }
+            + (if .subtree.src then { src: .subtree.src } else {} end)
+            + { target: .subtree.target, commit: $commit }
+          )' "$PACKAGE_JSON" > "$bootstrap_tmp"; then
+    rm -f "$bootstrap_tmp"
+    clean_exit 1 "Failed to update package.json during initial setup"
+  fi
+  if ! mv "$bootstrap_tmp" "$PACKAGE_JSON"; then
+    rm -f "$bootstrap_tmp"
+    clean_exit 1 "Failed to write package.json during initial setup"
+  fi
+
+  if ! git add "$WORKSPACE_LOCATION" "$PACKAGE_JSON"; then
+    clean_exit 1 "Failed to stage files during initial setup"
+  fi
+
+  initial_commit_msg="${COMMIT_PREFIX}chore(subtree): initial sync of $PACKAGE_NAME to $TARGET_COMMIT"
+  if ! git commit -q -m "$initial_commit_msg"; then
+    clean_exit 1 "Failed to create initial setup commit"
+  fi
+
+  success_msg "Successfully performed initial setup: $initial_commit_msg"
+  show_do_not_merge_warning
+  exit 0
+fi
+
+if [ "$SINGLE_COMMIT_MODE" != true ] && [ "$CURRENT_COMMIT" = "$TARGET_COMMIT" ] && [ -d "$TARGET_DIR" ]; then
+  info_msg "Already up-to-date at $TARGET_COMMIT"
+  exit 0
+fi
+
+needs_sync_work=false
+if [ "$SINGLE_COMMIT_MODE" = true ]; then
+  needs_sync_work=true
+elif [ "$CURRENT_COMMIT" != "$TARGET_COMMIT" ]; then
+  needs_sync_work=true
+fi
+
+if [ "$needs_sync_work" = true ]; then
+  warning_msg "Temporarily updating package.json with local sync overrides"
+  echo -e "${RED}⚠️  DO NOT MERGE these changes!${NC}"
+  echo ""
+
+  temp_file="$PACKAGE_JSON.tmp"
+  if ! jq --arg origin_url "$LOCAL_REPO_ORIGIN" \
+          --arg branch "$LOCAL_BRANCH" \
+          '.subtree = {
+            DO_NOT_MERGE_SYNCED_FROM_LOCAL: (
+              { branch: $branch }
+              + if $origin_url != "" then { origin_url: $origin_url } else { source: "local repository" } end
+            ),
+            repo: .subtree.repo,
+            branch: $branch,
+            src: .subtree.src,
+            target: .subtree.target,
+            commit: .subtree.commit
+          } |
+          if .subtree.src == null then del(.subtree.src) else . end |
+          if .subtree.repo == null then del(.subtree.repo) else . end' \
+          "$PACKAGE_JSON" > "$temp_file"; then
+    error_msg "Failed to update package.json with local sync overrides"
+    rm -f "$temp_file"
+    clean_exit 1 "" true
+  fi
+
+  if ! mv "$temp_file" "$PACKAGE_JSON"; then
+    error_msg "Failed to write updated package.json"
+    rm -f "$temp_file"
+    clean_exit 1 "" true
+  fi
+
+  success_msg "Updated package.json with DO_NOT_MERGE_SYNCED_FROM_LOCAL flag"
+
+  if ! git add "$PACKAGE_JSON"; then
+    error_msg "Failed to stage package.json"
+    clean_exit 1 "" true
+  fi
+
+  commit_msg="${COMMIT_PREFIX}Override subtree config for local sync
+
+Syncing from local repository (path omitted)
+Branch: $LOCAL_BRANCH${LOCAL_REPO_ORIGIN:+
+Origin: $LOCAL_REPO_ORIGIN}
+
+This commit should NOT be merged. It exists only to test changes from a local repository."
+
+  if ! git commit -q -m "$commit_msg"; then
+    warning_msg "Failed to commit package.json changes (assuming changes were already present)"
+  else
+    success_msg "Committed package.json changes with DO NOT MERGE warning"
+  fi
+  echo ""
+fi
+
+apply_patch_based_update() {
+  local from_commit="$1"
+  local to_commit="$2"
+  local upstream_subdir="$3"
+  local target_dir="$4"
+  local single_commit_mode="${5:-false}"
+
+  if [ "$single_commit_mode" = true ]; then
+    info_msg "Applying single commit: $to_commit"
+  else
+    echo "Applying patch-based update from $from_commit to $to_commit"
+  fi
+
+  if [ "$single_commit_mode" != true ]; then
+    if [ -z "$from_commit" ] || [ "$from_commit" = "null" ] || [ "$from_commit" = "" ]; then
+      clean_exit 1 "No starting commit provided for patch-based update"
+    fi
+
+    if ! git -C "$LOCAL_REPO_RESOLVED" rev-parse --quiet --verify "$from_commit" >/dev/null; then
+      warning_msg "Current commit $from_commit not found in local repository"
+      clean_exit 1 "Cannot perform patch-based update - starting commit does not exist."
+    fi
+  fi
+
+  local commits
+  if [ "$single_commit_mode" = true ]; then
+    commits="$to_commit"
+  else
+    if [ -n "$upstream_subdir" ]; then
+      commits=$(git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit" -- "$upstream_subdir")
+    else
+      commits=$(git -C "$LOCAL_REPO_RESOLVED" rev-list --no-merges --reverse "$from_commit..$to_commit")
+    fi
+  fi
+
+  if [ -z "$commits" ]; then
+    if [ "$single_commit_mode" = true ]; then
+      echo "Commit $to_commit has no relevant changes for the subtree"
+    else
+      echo "No commits to apply between $from_commit and $to_commit"
+    fi
+    return 0
+  fi
+
+  local total_commits
+  total_commits=$(echo "$commits" | wc -l | tr -d ' ')
+  echo -e "Found ${YELLOW}$total_commits${NC} commit(s) to apply"
+
+  progress_msg "Fetching git objects from local repository for three-way merge support..."
+  cleanup_temp_remote
+  git remote add "$TEMP_REMOTE_NAME" "$LOCAL_REPO_RESOLVED"
+  if ! git fetch -q "$TEMP_REMOTE_NAME" "$LOCAL_BRANCH" 2>/dev/null; then
+    warning_msg "Failed to fetch branch objects — three-way merge may not work correctly"
+  else
+    success_msg "Git objects fetched — three-way merge enabled"
+  fi
+
+  local commit_count=0
+  for commit in $commits; do
+    commit_count=$((commit_count + 1))
+    progress_msg "Applying commit $commit_count/$total_commits: $commit"
+
+    local commit_msg
+    commit_msg=$(git -C "$LOCAL_REPO_RESOLVED" log -1 --format="%s" "$commit")
+
+    local patch_file="$TMP_DIR/patch_${commit}.patch"
+    git -C "$LOCAL_REPO_RESOLVED" format-patch -1 "$commit" --stdout > "$patch_file"
+
+    local filtered_patch="$TMP_DIR/filtered_${commit}.patch"
+    filter_and_transform_patch "$patch_file" "$upstream_subdir" "$filtered_patch"
+
+    if [ -s "$filtered_patch" ]; then
+      cd "$MONOREPO_ROOT"
+
+      ensure_base_blobs_in_index "$filtered_patch" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
+
+      if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
+        local commit_url
+        commit_url=$(get_repo_commit_url "$LOCAL_REPO_RESOLVED" "$commit")
+        local continue_cmd="npm run update-subtree-local -- --package=$PACKAGE_NAME --local-repo=$LOCAL_REPO_RESOLVED --branch=$LOCAL_BRANCH"
+        if [ -n "$COMMIT_SHA" ]; then
+          continue_cmd="$continue_cmd --commit=$COMMIT_SHA"
+        fi
+        continue_cmd="$continue_cmd --continue"
+        handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
+      fi
+
+      set +e
+      safe_git_commit_if_changes "${COMMIT_PREFIX}Update $PACKAGE_NAME: $commit_msg
+
+Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
+      local commit_exit_code=$?
+      set -e
+
+      if [ $commit_exit_code -eq 0 ]; then
+        if update_package_json_commit "$commit"; then
+          git add "$PACKAGE_JSON"
+          git commit -q --amend --no-edit
+          success_msg "Applied commit $commit_count/$total_commits: $commit_msg"
+        else
+          warning_msg "Committed changes but failed to update package.json tracking"
+        fi
+      elif [ $commit_exit_code -eq 2 ]; then
+        if update_package_json_commit "$commit"; then
+          local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
+          set +e
+          safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
+          local tracking_exit_code=$?
+          set -e
+          if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
+            clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
+          fi
+          info_msg "No changes from commit $commit_count/$total_commits"
+        else
+          warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
+        fi
+      else
+        clean_exit 1 "Failed to commit changes for commit $commit_count/$total_commits"
+      fi
+
+    else
+      info_msg "No relevant changes in commit $commit_count/$total_commits for subtree"
+
+      cd "$MONOREPO_ROOT"
+      if update_package_json_commit "$commit"; then
+        local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
+        set +e
+        safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
+        local tracking_exit_code=$?
+        set -e
+        if [ $tracking_exit_code -ne 0 ] && [ $tracking_exit_code -ne 2 ]; then
+          clean_exit 1 "Failed to commit tracking update for commit $commit_count/$total_commits"
+        fi
+      else
+        warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
+      fi
+    fi
+  done
+}
+
+if [ ! -d "$TARGET_DIR" ]; then
+  mkdir -p "$TARGET_DIR"
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'cd "$MONOREPO_ROOT"; cleanup_temp_remote; rm -rf "$TMP_DIR"' EXIT
+
+apply_patch_based_update "$CURRENT_COMMIT" "$TARGET_COMMIT" "$UPSTREAM_SUBDIR" "$TARGET_DIR" "$SINGLE_COMMIT_MODE"
+
+cd "$MONOREPO_ROOT"
+
+success_msg "Successfully updated $PACKAGE_NAME to $TARGET_COMMIT"
+
+show_do_not_merge_warning

--- a/packages/app-config/scripts/package-subtree.sh
+++ b/packages/app-config/scripts/package-subtree.sh
@@ -368,102 +368,36 @@ if [ "$CURRENT_COMMIT" = "$TARGET_COMMIT" ] && [ -d "$TARGET_DIR" ]; then
   exit 0
 fi
 
-apply_patch_based_update() {
+_git_upstream_cmd() {
+  git "$@"
+}
+
+_filter_rev_list() {
   local from_commit="$1"
   local to_commit="$2"
-  local upstream_subdir="$3"
-  local target_dir="$4"
+  git rev-list --no-merges --reverse "$from_commit..$to_commit"
+}
 
-  echo "Applying patch-based update from $from_commit to $to_commit"
+_get_commit_url() {
+  local commit="$1"
+  local repo_base="${UPSTREAM_REPO%.git}"
+  echo "  $repo_base/commit/$commit"
+}
 
-  if [ -z "$from_commit" ] || [ "$from_commit" = "null" ] || [ "$from_commit" = "" ]; then
-    clean_exit 1 "No starting commit provided for patch-based update - this should be handled at the main script level"
-  fi
+_get_continue_cmd() {
+  echo "npm run update-subtree -w $WORKSPACE_LOCATION -- --continue"
+}
 
-  if ! git rev-parse --quiet --verify "$from_commit" >/dev/null; then
-    warning_msg "Current commit $from_commit not found in upstream repository"
-    clean_exit 1 "Cannot perform patch-based update - starting commit does not exist. Consider running with no package.json commit to force initial setup."
-  fi
+_pre_apply_hook() {
+  :
+}
 
-  local commits
-  commits=$(git rev-list --no-merges --reverse "$from_commit..$to_commit")
+_before_apply_hook() {
+  :
+}
 
-  if [ -z "$commits" ]; then
-    echo "No commits to apply between $from_commit and $to_commit"
-    return 0
-  fi
-
-  local total_commits
-  total_commits=$(echo "$commits" | wc -l | tr -d ' ')
-  echo -e "Found ${YELLOW}$total_commits${NC} commits to apply"
-
-  local commit_count=0
-  for commit in $commits; do
-    commit_count=$((commit_count + 1))
-    progress_msg "Applying commit $commit_count/$total_commits: $commit"
-
-    local commit_msg
-    commit_msg=$(git log -1 --format="%s" "$commit")
-
-    local patch_file="$TMP_DIR/patch_${commit}.patch"
-    git format-patch -1 "$commit" --stdout > "$patch_file"
-
-    local filtered_patch="$TMP_DIR/filtered_${commit}.patch"
-    filter_and_transform_patch "$patch_file" "$upstream_subdir" "$filtered_patch"
-
-    if [ -s "$filtered_patch" ]; then
-      cd "$MONOREPO_ROOT"
-
-      if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
-        local repo_base="${UPSTREAM_REPO%.git}"
-        local commit_url="  $repo_base/commit/$commit"
-        local continue_cmd="npm run update-subtree -w $WORKSPACE_LOCATION -- --continue"
-        handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
-      fi
-
-      set +e
-      safe_git_commit_if_changes "${COMMIT_PREFIX}Update $PACKAGE_NAME: $commit_msg
-
-Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
-      local commit_exit_code=$?
-      set -e
-
-      if [ $commit_exit_code -eq 0 ]; then
-        if update_package_json_commit "$commit"; then
-          git add "$PACKAGE_JSON"
-          git commit -q --amend --no-edit
-          success_msg "Applied commit $commit_count/$total_commits: $commit_msg"
-        else
-          warning_msg "Committed changes but failed to update package.json tracking"
-        fi
-      elif [ $commit_exit_code -eq 2 ]; then
-        if update_package_json_commit "$commit"; then
-          local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
-          if safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null; then
-            info_msg "No changes from commit $commit_count/$total_commits"
-          fi
-        else
-          warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
-        fi
-      else
-        clean_exit 1 "Failed to commit changes for commit $commit_count/$total_commits"
-      fi
-
-      cd "$TMP_DIR/repo"
-    else
-      info_msg "No relevant changes in commit $commit_count/$total_commits for subtree"
-
-      cd "$MONOREPO_ROOT"
-      if update_package_json_commit "$commit"; then
-        local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
-        safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null
-      else
-        warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
-      fi
-
-      cd "$TMP_DIR/repo"
-    fi
-  done
+_post_iteration_hook() {
+  cd "$TMP_DIR/repo"
 }
 
 if [ ! -d "$TARGET_DIR" ]; then

--- a/packages/app-config/scripts/package-subtree.sh
+++ b/packages/app-config/scripts/package-subtree.sh
@@ -5,7 +5,8 @@ set -e
 # Script to sync upstream repository content into monorepo using patch-based incremental updates
 # Usage: ./package-subtree.sh --package=<package-name> [--commit=<commit-sha>] [--continue]
 
-source "$(dirname "${BASH_SOURCE[0]}")/package-subtree-common.sh"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")" && pwd)"
+source "$SCRIPT_DIR/package-subtree-common.sh"
 
 show_usage() {
   echo "Usage: $0 --package=<package-name> [--commit=<commit-sha>] [--continue] [--pr=<pr-url>]"

--- a/packages/app-config/scripts/package-subtree.sh
+++ b/packages/app-config/scripts/package-subtree.sh
@@ -417,7 +417,7 @@ apply_patch_based_update() {
       if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
         local repo_base="${UPSTREAM_REPO%.git}"
         local commit_url="  $repo_base/commit/$commit"
-        local continue_cmd="npm run update-subtree -- --continue"
+        local continue_cmd="npm run update-subtree -w $WORKSPACE_LOCATION -- --continue"
         handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
       fi
 

--- a/packages/app-config/scripts/package-subtree.sh
+++ b/packages/app-config/scripts/package-subtree.sh
@@ -5,153 +5,7 @@ set -e
 # Script to sync upstream repository content into monorepo using patch-based incremental updates
 # Usage: ./package-subtree.sh --package=<package-name> [--commit=<commit-sha>] [--continue]
 
-# Reduce git hook noise
-export SKIP_LINT_HOOK=true
-export HUSKY=0
-
-# Colors and icons for better UX
-# Enable colors unless explicitly disabled
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-
-# Disable colors if explicitly requested
-if [ "${NO_COLOR:-}" = "1" ] || [ "${TERM:-}" = "dumb" ]; then
-  RED=''
-  GREEN=''
-  YELLOW=''
-  BLUE=''
-  CYAN=''
-  NC=''
-fi
-
-# Icons
-ERROR_ICON="❌"
-SUCCESS_ICON="✅"
-WARNING_ICON="⚠️"
-INFO_ICON="ℹ️"
-PROGRESS_ICON="🔄"
-
-# Helper functions for colored output
-error_msg() {
-  echo -e "${RED}${ERROR_ICON} $1${NC}" >&2
-}
-
-success_msg() {
-  echo -e "${GREEN}${SUCCESS_ICON} $1${NC}"
-}
-
-warning_msg() {
-  echo -e "${YELLOW}${WARNING_ICON} $1${NC}"
-}
-
-info_msg() {
-  echo -e "${CYAN}${INFO_ICON} $1${NC}"
-}
-
-progress_msg() {
-  echo -e "${BLUE}${PROGRESS_ICON} $1${NC}"
-}
-
-# Helper function to safely update package.json commit hash
-update_package_json_commit() {
-  local commit="$1"
-  local temp_file="$PACKAGE_JSON.tmp"
-  
-  if ! jq --arg commit "$commit" '.subtree.commit = $commit' "$PACKAGE_JSON" > "$temp_file"; then
-    error_msg "Failed to update package.json with commit $commit"
-    rm -f "$temp_file"
-    return 1
-  fi
-  
-  if ! mv "$temp_file" "$PACKAGE_JSON"; then
-    error_msg "Failed to replace package.json"
-    rm -f "$temp_file"
-    return 1
-  fi
-  
-  return 0
-}
-
-# Helper function to safely commit changes if there are any
-safe_git_commit_if_changes() {
-  local commit_message="$1"
-  local target_path="$2"
-  
-  git add "$target_path"
-  if ! git diff --cached --quiet; then
-    if ! git commit -q -m "$commit_message"; then
-      error_msg "Failed to commit changes"
-      return 1
-    fi
-    return 0  # Changes were committed
-  fi
-  return 2  # No changes to commit
-}
-
-# Helper function to copy upstream files
-copy_upstream_files() {
-  local upstream_subdir="$1"
-  local target_dir="$2"
-  
-  # Ensure target directory exists
-  if ! mkdir -p "$target_dir"; then
-    error_msg "Failed to create target directory: $target_dir"
-    return 1
-  fi
-  
-  # Copy files based on whether we have a subdirectory filter, excluding VCS metadata
-  if command -v rsync >/dev/null 2>&1; then
-    if [ -n "$upstream_subdir" ]; then
-      if ! rsync -a --delete --exclude='.git' "$upstream_subdir"/ "$target_dir"/; then
-        error_msg "Failed to rsync files from $upstream_subdir to $target_dir"
-        return 1
-      fi
-    else
-      if ! rsync -a --delete --exclude='.git' ./ "$target_dir"/; then
-        error_msg "Failed to rsync files to $target_dir"
-        return 1
-      fi
-    fi
-  else
-    # Fallback to tar if rsync is unavailable
-    if [ -n "$upstream_subdir" ]; then
-      if ! ( cd "$upstream_subdir" && tar --exclude='.git' -cf - . ) | ( cd "$target_dir" && tar -xpf - ); then
-        error_msg "Failed to copy files from $upstream_subdir to $target_dir using tar"
-        return 1
-      fi
-    else
-      if ! ( tar --exclude='.git' -cf - . ) | ( cd "$target_dir" && tar -xpf - ); then
-        error_msg "Failed to copy files to $target_dir using tar"
-        return 1
-      fi
-    fi
-  fi
-  
-  return 0
-}
-
-# Clean exit function to reduce npm noise
-clean_exit() {
-  local exit_code=${1:-1}
-  local message="$2"
-  local is_user_error=${3:-false}
-  
-  if [ -n "$message" ]; then
-    error_msg "$message"
-  fi
-
-  # For user errors (conflicts, validation, etc.), exit with 0 to avoid npm noise
-  # Only system errors (git failures, file system issues) should cause npm to show errors
-  if [ "$is_user_error" = "true" ] && [ -n "${npm_config_user_agent:-}" ]; then
-    exit 0  # Exit with 0 to suppress npm error noise for user errors
-  fi
-  
-  exit $exit_code
-}
+source "$(dirname "${BASH_SOURCE[0]}")/package-subtree-common.sh"
 
 show_usage() {
   echo "Usage: $0 --package=<package-name> [--commit=<commit-sha>] [--continue] [--pr=<pr-url>]"
@@ -240,21 +94,16 @@ fi
 
 PACKAGE_JSON="$MONOREPO_ROOT/$WORKSPACE_LOCATION/package.json"
 
-# Change to monorepo root to ensure we're in a safe directory
 cd "$MONOREPO_ROOT"
 
 # Handle --pr option to temporarily override repo and branch
 if [ -n "$PR_URL" ]; then
-  # Verify gh CLI is available
   if ! command -v gh >/dev/null 2>&1; then
     clean_exit 1 "The 'gh' CLI tool is required for --pr option but not found in PATH" true
   fi
 
   progress_msg "Fetching PR information from $PR_URL"
 
-  # Extract PR information using gh CLI
-  # Use the PR URL directly with gh pr view
-  # We need headRepositoryOwner to get the owner login separately since it's not nested in headRepository
   PR_INFO=$(gh pr view "$PR_URL" --json headRepositoryOwner,headRepository,headRefName 2>&1)
   if [ $? -ne 0 ]; then
     error_msg "Failed to fetch PR information"
@@ -262,7 +111,6 @@ if [ -n "$PR_URL" ]; then
     clean_exit 1 "" true
   fi
 
-  # Extract repo owner, name, and branch
   PR_REPO_OWNER=$(echo "$PR_INFO" | jq -r '.headRepositoryOwner.login')
   PR_REPO_NAME=$(echo "$PR_INFO" | jq -r '.headRepository.name')
   PR_BRANCH=$(echo "$PR_INFO" | jq -r '.headRefName')
@@ -285,13 +133,11 @@ if [ -n "$PR_URL" ]; then
   echo "  Branch: $PR_BRANCH"
   echo ""
 
-  # Update package.json with temporary overrides
   warning_msg "Temporarily updating package.json with PR overrides"
   echo -e "${RED}⚠️  DO NOT MERGE these changes!${NC}"
   echo ""
 
   temp_file="$PACKAGE_JSON.tmp"
-  # Reconstruct the subtree object with DO_NOT_MERGE_OVERRIDDEN_FOR_PR first
   if ! jq --arg repo "$PR_REPO_URL" \
           --arg branch "$PR_BRANCH" \
           --arg pr_url "$PR_URL" \
@@ -318,7 +164,6 @@ if [ -n "$PR_URL" ]; then
 
   success_msg "Updated package.json with temporary PR overrides"
 
-  # Commit the package.json changes
   if ! git add "$PACKAGE_JSON"; then
     error_msg "Failed to stage package.json"
     clean_exit 1 "" true
@@ -348,13 +193,11 @@ CURRENT_COMMIT=$(jq -r '.subtree.commit // ""' "$PACKAGE_JSON")
 UPSTREAM_BRANCH=$(jq -r '.subtree.branch // "main"' "$PACKAGE_JSON")
 DO_NOT_MERGE_FLAG=$(jq -r '.subtree.DO_NOT_MERGE_OVERRIDDEN_FOR_PR // ""' "$PACKAGE_JSON")
 
-# Set commit message prefix if this is a PR test sync
 COMMIT_PREFIX=""
 if [ -n "$DO_NOT_MERGE_FLAG" ] && [ "$DO_NOT_MERGE_FLAG" != "null" ]; then
   COMMIT_PREFIX="[DO NOT MERGE - PR TEST SYNC] "
 fi
 
-# Validate required configuration fields
 if [ -z "$UPSTREAM_REPO" ] || [ "$UPSTREAM_REPO" = "null" ]; then
   clean_exit 1 "Missing subtree.repo in $PACKAGE_JSON" true
 fi
@@ -365,9 +208,7 @@ fi
 # Handle continue mode
 if [ "$CONTINUE_MODE" = true ]; then
   progress_msg "Continue mode: Processing staged changes from conflict resolution"
-  
-  # Check if there are files with actual conflict markers (not just UU status)
-  # Collect unmerged paths as an array, preserving NUL delimiters
+
   conflict_files=()
   files_with_markers=()
   while IFS= read -r -d '' file; do
@@ -388,35 +229,28 @@ if [ "$CONTINUE_MODE" = true ]; then
     clean_exit 1 "" true
   fi
 
-  # Check if there are any unmerged files at all (resolved or not)
   if [ "${#conflict_files[@]}" -gt 0 ]; then
-    # Files have UU status but no conflict markers - they're resolved, just need staging
     warning_msg "Found resolved conflicts that need staging"
     echo "Files with resolved conflicts:"
     for file in "${conflict_files[@]}"; do
       echo "  $file"
     done
   fi
-  
-  # Check if there are staged changes to commit
+
   if git diff --cached --quiet; then
     error_msg "No staged changes found"
     echo -e "Please stage your resolved conflicts: ${YELLOW}git add $WORKSPACE_LOCATION${NC}"
     clean_exit 1 "" true
   fi
-  
-  # Commit the staged changes before proceeding
+
   info_msg "Committing staged changes..."
-  
-  # Set up temp directory for continue mode
+
   TMP_DIR=$(mktemp -d)
   trap 'cd "$MONOREPO_ROOT"; rm -rf "$TMP_DIR"' EXIT
-  
-  # Clone repository to determine commit information
+
   git clone -q -b "$UPSTREAM_BRANCH" "$UPSTREAM_REPO" "$TMP_DIR/repo"
   cd "$TMP_DIR/repo"
 
-  # Get target commit SHA
   if [ -n "$COMMIT_SHA" ]; then
     git checkout -q "$COMMIT_SHA"
     TARGET_COMMIT=$(git rev-parse HEAD)
@@ -424,8 +258,6 @@ if [ "$CONTINUE_MODE" = true ]; then
     TARGET_COMMIT=$(git rev-parse HEAD)
   fi
 
-  # Validate that CURRENT_COMMIT exists in this branch's history
-  # Check if the commit is an ancestor of HEAD (i.e., it's in this branch's history)
   if ! git merge-base --is-ancestor "$CURRENT_COMMIT" HEAD 2>/dev/null; then
     cd "$MONOREPO_ROOT"
     error_msg "Current commit $CURRENT_COMMIT not found in branch '$UPSTREAM_BRANCH' of $UPSTREAM_REPO"
@@ -435,8 +267,6 @@ if [ "$CONTINUE_MODE" = true ]; then
     clean_exit 1 "" true
   fi
 
-  # We need to determine what commit we're continuing from
-  # This should be the next commit after the current one in package.json
   commits=$(git rev-list --reverse "$CURRENT_COMMIT..$TARGET_COMMIT")
   if [ -n "$commits" ]; then
     continue_commit=$(echo "$commits" | head -n 1)
@@ -446,10 +276,9 @@ if [ "$CONTINUE_MODE" = true ]; then
     git commit -q -m "${COMMIT_PREFIX}Update $PACKAGE_NAME: $continue_commit_msg (resolved conflicts)
 
 Upstream commit: $continue_commit"
-    
+
     success_msg "Committed resolved conflicts for $continue_commit: $continue_commit_msg"
-    
-    # Update package.json to reflect this commit was successfully applied
+
     if update_package_json_commit "$continue_commit"; then
       if ! git add "$PACKAGE_JSON"; then
         clean_exit 1 "Failed to stage package.json after committing conflicts"
@@ -459,36 +288,15 @@ Upstream commit: $continue_commit"
     else
       clean_exit 1 "Failed to update package.json after committing conflicts"
     fi
-    
-    # Update CURRENT_COMMIT so the main loop continues from the next commit
+
     CURRENT_COMMIT="$continue_commit"
   else
-    # No more commits, just commit with a generic message
     git commit -q -m "${COMMIT_PREFIX}Update $PACKAGE_NAME: Manual conflict resolution"
     success_msg "Committed staged changes"
   fi
-  
+
 else
-  # Normal mode - check clean working tree
-  if [ -n "$(git status --porcelain)" ]; then
-    # Check if there are staged changes
-    if ! git diff --cached --quiet; then
-      error_msg "There are staged changes in the working tree"
-      echo "You have staged changes that need to be committed."
-      echo ""
-      echo "Choose one option:"
-      echo -e "1. Use ${GREEN}--continue${NC} to commit staged changes and proceed with update"
-      echo -e "2. Run ${YELLOW}git reset HEAD${NC} to unstage changes and start fresh"
-      echo -e "3. Run ${YELLOW}git commit${NC} to commit changes manually, then retry"
-      clean_exit 1 "" true
-    else
-      error_msg "Working tree has uncommitted changes"
-      echo "Please commit or stash your changes before running this script."
-      echo ""
-      echo -e "If you're resolving conflicts from a previous run, use the ${CYAN}--continue${NC} option."
-      clean_exit 1 "" true
-    fi
-  fi
+  check_working_tree_clean
 fi
 
 # Derive target path (relative to workspace directory)
@@ -514,7 +322,6 @@ fi
 
 # Validate that CURRENT_COMMIT exists in this branch (skip for initial setup)
 if [ -n "$CURRENT_COMMIT" ] && [ "$CURRENT_COMMIT" != "null" ] && [ "$CURRENT_COMMIT" != "" ]; then
-  # Check if the commit is an ancestor of HEAD (i.e., it's in this branch's history)
   if ! git merge-base --is-ancestor "$CURRENT_COMMIT" HEAD 2>/dev/null; then
     error_msg "Current commit $CURRENT_COMMIT not found in branch '$UPSTREAM_BRANCH' of $UPSTREAM_REPO"
     echo ""
@@ -527,35 +334,29 @@ fi
 # Handle initial setup case
 if [ ! -d "$TARGET_DIR" ] && ([ -z "$CURRENT_COMMIT" ] || [ "$CURRENT_COMMIT" = "null" ] || [ "$CURRENT_COMMIT" = "" ]); then
   progress_msg "Performing initial setup - no previous commit found"
-  
-  # Checkout target commit
+
   cd "$TMP_DIR/repo"
   git checkout -q "$TARGET_COMMIT"
-  
-  # Copy files to target directory
-  if ! copy_upstream_files "$UPSTREAM_SUBDIR" "$TARGET_DIR"; then
+
+  if ! copy_upstream_files "$TMP_DIR/repo" "$UPSTREAM_SUBDIR" "$TARGET_DIR"; then
     clean_exit 1 "Failed to copy files during initial setup"
   fi
-  
-  # Switch to repo root for git operations
+
   cd "$MONOREPO_ROOT"
-  
-  # Update package.json to track the initial commit
+
   if ! update_package_json_commit "$TARGET_COMMIT"; then
     clean_exit 1 "Failed to update package.json during initial setup"
   fi
-  
-  # Stage the copied files and updated package.json
+
   if ! git add "$WORKSPACE_LOCATION" "$PACKAGE_JSON"; then
     clean_exit 1 "Failed to stage files during initial setup"
   fi
-  
-  # Create initial commit
+
   initial_commit_msg="${COMMIT_PREFIX}chore(subtree): initial sync of $PACKAGE_NAME to $TARGET_COMMIT"
   if ! git commit -q -m "$initial_commit_msg"; then
     clean_exit 1 "Failed to create initial setup commit"
   fi
-  
+
   success_msg "Successfully performed initial setup: $initial_commit_msg"
   exit 0
 fi
@@ -566,291 +367,67 @@ if [ "$CURRENT_COMMIT" = "$TARGET_COMMIT" ] && [ -d "$TARGET_DIR" ]; then
   exit 0
 fi
 
-# Function to inject helpful conflict markers for failed patches
-inject_conflict_markers() {
-  local patch_file="$1"
-  local commit_sha="$2"
-  local commit_msg="$3"
-  shift 3
-  local failed_files=("$@")
-  
-  # Only process files that actually failed
-  for rel_file in "${failed_files[@]}"; do
-    [ -z "$rel_file" ] && continue
-    
-    local target_file="$MONOREPO_ROOT/$WORKSPACE_LOCATION/$TARGET_RELATIVE/$rel_file"
-    
-    # Only inject if file exists and doesn't already have conflict markers
-    if [ -f "$target_file" ] && ! grep -q '^<<<<<<< ' "$target_file" 2>/dev/null; then
-      
-      # Extract the relevant patch section for this file
-      local temp_patch="$TMP_DIR/file_patch_$$.txt"
-      awk -v file="$rel_file" '
-        /^diff --git/ { 
-          in_file = ($0 ~ " b/" file "$" || $0 ~ " b/" file " ")
-          if (in_file) print
-          next
-        }
-        in_file { print }
-        /^diff --git/ && !in_file { exit }
-      ' "$patch_file" > "$temp_patch"
-      
-      if [ -s "$temp_patch" ]; then
-        # Append informative marker to the file
-        cat >> "$target_file" << EOF
-
-<<<<<<< PATCH FAILED TO APPLY
-UPSTREAM COMMIT: $commit_sha
-COMMIT MESSAGE: $commit_msg
-FILE: $rel_file
-=======
-The patch below could not be applied automatically.
-This usually means the file content differs from what upstream expects.
-
-WHAT THE PATCH WANTS TO DO:
-────────────────────────────────────────────────────────────
-EOF
-        # Append the actual patch content
-        cat "$temp_patch" >> "$target_file"
-        
-        cat >> "$target_file" << EOF
-────────────────────────────────────────────────────────────
-
-INSTRUCTIONS:
-1. Review the patch above (lines with - are removed, lines with + are added)
-2. Manually apply the intended changes to this file
-3. Remove this entire conflict marker block (from <<<<<<< to >>>>>>>)
-4. Stage the file: git add $WORKSPACE_LOCATION
-5. Continue: npm run update-subtree -- --continue
-
-For more details, view the upstream commit at:
-  https://github.com/<owner>/<repo>/commit/${commit_sha}
->>>>>>> END PATCH FAILED
-EOF
-      fi
-      rm -f "$temp_patch"
-    fi
-  done
-}
-
-# Function to apply patch-based updates
 apply_patch_based_update() {
   local from_commit="$1"
   local to_commit="$2"
   local upstream_subdir="$3"
   local target_dir="$4"
-  
+
   echo "Applying patch-based update from $from_commit to $to_commit"
-  
-  # Validate that we have a starting commit for patch-based updates
+
   if [ -z "$from_commit" ] || [ "$from_commit" = "null" ] || [ "$from_commit" = "" ]; then
     clean_exit 1 "No starting commit provided for patch-based update - this should be handled at the main script level"
   fi
-  
-  # Verify commits exist
+
   if ! git rev-parse --quiet --verify "$from_commit" >/dev/null; then
     warning_msg "Current commit $from_commit not found in upstream repository"
     clean_exit 1 "Cannot perform patch-based update - starting commit does not exist. Consider running with no package.json commit to force initial setup."
   fi
-  
-  # Get list of commits to apply (oldest first)
+
   local commits
   commits=$(git rev-list --no-merges --reverse "$from_commit..$to_commit")
-  
+
   if [ -z "$commits" ]; then
     echo "No commits to apply between $from_commit and $to_commit"
     return 0
   fi
-  
+
   local total_commits
   total_commits=$(echo "$commits" | wc -l | tr -d ' ')
   echo -e "Found ${YELLOW}$total_commits${NC} commits to apply"
-  
-  # Apply each commit as a patch with incremental commits
+
   local commit_count=0
   for commit in $commits; do
     commit_count=$((commit_count + 1))
     progress_msg "Applying commit $commit_count/$total_commits: $commit"
-    
-    # Get commit message from upstream
+
     local commit_msg
     commit_msg=$(git log -1 --format="%s" "$commit")
-    
-    # Generate patch for this specific commit
+
     local patch_file="$TMP_DIR/patch_${commit}.patch"
     git format-patch -1 "$commit" --stdout > "$patch_file"
-    
-    # Filter and transform the patch
+
     local filtered_patch="$TMP_DIR/filtered_${commit}.patch"
     filter_and_transform_patch "$patch_file" "$upstream_subdir" "$filtered_patch"
-    
-    # Apply the filtered patch in target directory
+
     if [ -s "$filtered_patch" ]; then
       cd "$MONOREPO_ROOT"
-      
-      # Try to apply the patch with 3-way merge for better conflict resolution
+
       if ! git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$filtered_patch" 2>"$TMP_DIR/apply_error.log"; then
-        error_msg "Conflict detected while applying commit $commit_count/$total_commits"
-        echo -e "   ${YELLOW}Commit message: $commit_msg${NC}"
-        echo -e "   ${YELLOW}Upstream commit: $commit${NC}"
-        echo ""
-        
-        # Parse error output
-        local apply_error=$(cat "$TMP_DIR/apply_error.log" 2>/dev/null || echo "")
-        local has_git_conflicts=false
-        local has_rejected_patches=false
-        local failed_files=()
-        local succeeded_files=()
-        
-        # Check if git created conflict markers (partial success with conflicts)
-        if git diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
-          has_git_conflicts=true
-        fi
-        
-        # Check for completely rejected patches and collect failed files
-        if echo "$apply_error" | grep -q "patch does not apply"; then
-          has_rejected_patches=true
-          # Extract file names that failed
-          while IFS= read -r line; do
-            if [[ "$line" =~ error:\ (.+):\ patch\ does\ not\ apply ]]; then
-              local failed_file="${BASH_REMATCH[1]}"
-              # Remove the directory prefix to get relative path
-              failed_file="${failed_file#$WORKSPACE_LOCATION/$TARGET_RELATIVE/}"
-              failed_files+=("$failed_file")
-            fi
-          done <<< "$apply_error"
-          
-          # If patch was completely rejected, try to apply files individually
-          if [ "$has_git_conflicts" = false ] && [ ${#failed_files[@]} -gt 0 ]; then
-            info_msg "Attempting to apply other files from the patch individually..."
-            echo ""
-            
-            # Extract all files from the patch
-            local all_files=$(grep '^diff --git' "$filtered_patch" | sed 's/^diff --git a\/.* b\///' || true)
-            
-            while IFS= read -r file; do
-              [ -z "$file" ] && continue
-              
-              # Skip if this is one of the files that already failed
-              local is_failed=false
-              for failed in "${failed_files[@]}"; do
-                if [ "$file" = "$failed" ]; then
-                  is_failed=true
-                  break
-                fi
-              done
-              
-              if [ "$is_failed" = false ]; then
-                # Extract patch for just this file
-                local single_file_patch="$TMP_DIR/single_${file//\//_}.patch"
-                awk -v target="$file" '
-                  /^diff --git/ { 
-                    in_target = ($0 ~ " b/" target "$")
-                    if (in_target) print
-                    next
-                  }
-                  in_target { print }
-                  /^diff --git/ && !in_target { exit }
-                ' "$filtered_patch" > "$single_file_patch"
-                
-                # Try to apply this single file
-                if [ -s "$single_file_patch" ] && git apply --directory="$WORKSPACE_LOCATION/$TARGET_RELATIVE" --3way --index "$single_file_patch" 2>/dev/null; then
-                  succeeded_files+=("$file")
-                  echo -e "  ${GREEN}✓${NC} $file"
-                else
-                  failed_files+=("$file")
-                  echo -e "  ${RED}✗${NC} $file"
-                fi
-              fi
-            done <<< "$all_files"
-            echo ""
-          fi
-        fi
-        
-        # Provide context about what happened
-        if [ "$has_git_conflicts" = true ] && [ "$has_rejected_patches" = false ]; then
-          warning_msg "Git created conflict markers (partial application succeeded)"
-          echo "Some changes were applied, but conflicts need manual resolution."
-        elif [ "$has_git_conflicts" = false ] && [ "$has_rejected_patches" = true ]; then
-          warning_msg "Patch was completely rejected (no automatic application possible)"
-          echo "This typically means file content differs significantly from upstream."
-          echo ""
-          echo -e "${CYAN}Common causes:${NC}"
-          echo "  • Local customizations/modifications in the fork"
-          echo "  • Different code structure than upstream expects"
-          echo "  • Previous patches changed the context"
-        else
-          warning_msg "Mixed results: some changes applied with conflicts, others rejected"
-        fi
-        
-        echo ""
-        
-        # Show summary of what succeeded and what failed
-        if [ ${#succeeded_files[@]} -gt 0 ]; then
-          success_msg "Successfully applied ${#succeeded_files[@]} file(s):"
-          for file in "${succeeded_files[@]}"; do
-            echo "  ✓ $file"
-          done
-          echo ""
-        fi
-        
-        # Try to inject helpful markers for completely failed files
-        if [ "$has_rejected_patches" = true ] && [ ${#failed_files[@]} -gt 0 ]; then
-          info_msg "Injecting conflict markers for ${#failed_files[@]} failed file(s)..."
-          inject_conflict_markers "$filtered_patch" "$commit" "$commit_msg" "${failed_files[@]}"
-          echo ""
-          warning_msg "Files that need manual resolution:"
-          for failed_file in "${failed_files[@]}"; do
-            echo "  ✗ $failed_file"
-          done
-          echo ""
-        fi
-        
-        echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo -e "${CYAN}RESOLUTION STEPS:${NC}"
-        echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo ""
-        echo "1. Find conflict markers in: $WORKSPACE_LOCATION/$TARGET_RELATIVE/"
-        echo ""
-        echo "   Two types of markers to look for:"
-        echo -e "   ${RED}a)${NC} Git conflict markers:    ${RED}<<<<<<<${NC} ${YELLOW}=======${NC} ${RED}>>>>>>>${NC}"
-        echo -e "   ${RED}b)${NC} Script-injected markers: ${RED}<<<<<<< PATCH FAILED${NC} ... ${RED}>>>>>>> END PATCH${NC}"
-        echo ""
-        echo "2. For EACH conflict marker:"
-        echo "   • Review what the patch wants to change"
-        echo "   • Manually apply the intended changes"
-        echo "   • Remove all conflict marker lines"
-        echo ""
-        echo "3. Verify your changes make sense:"
-        echo -e "   ${YELLOW}git diff $WORKSPACE_LOCATION${NC}"
-        echo ""
-        echo "4. Stage all resolved files:"
-        echo -e "   ${YELLOW}git add $WORKSPACE_LOCATION${NC}"
-        echo ""
-        echo "5. Continue the update process:"
-        echo -e "   ${GREEN}npm run update-subtree -- --continue${NC}"
-        if [ ${#succeeded_files[@]} -gt 0 ]; then
-          echo ""
-          echo "   Note: Successfully applied files are already staged."
-          echo "   This will commit everything and proceed to the next patch."
-        fi
-        echo ""
-        echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo ""
-        info_msg "Progress: Applied $((commit_count - 1))/$total_commits commits successfully"
-        info_msg "Failed on commit: $commit ($commit_count/$total_commits)"
-        info_msg "Remaining: $((total_commits - commit_count + 1)) commits"
-        clean_exit 1 "" true
+        local repo_base="${UPSTREAM_REPO%.git}"
+        local commit_url="  $repo_base/commit/$commit"
+        local continue_cmd="npm run update-subtree -- --continue"
+        handle_apply_conflict "$commit_count" "$total_commits" "$commit" "$commit_msg" "$filtered_patch" "$continue_cmd" "$commit_url"
       fi
-      
-      # Stage changes and create commit
+
+      set +e
       safe_git_commit_if_changes "${COMMIT_PREFIX}Update $PACKAGE_NAME: $commit_msg
 
 Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
       local commit_exit_code=$?
-      
+      set -e
+
       if [ $commit_exit_code -eq 0 ]; then
-        # Changes were committed, update package.json
         if update_package_json_commit "$commit"; then
           git add "$PACKAGE_JSON"
           git commit -q --amend --no-edit
@@ -859,7 +436,6 @@ Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
           warning_msg "Committed changes but failed to update package.json tracking"
         fi
       elif [ $commit_exit_code -eq 2 ]; then
-        # No changes to commit, but still update package.json for tracking
         if update_package_json_commit "$commit"; then
           local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
           if safe_git_commit_if_changes "$tracking_msg" "$PACKAGE_JSON" >/dev/null; then
@@ -869,15 +445,13 @@ Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
           warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
         fi
       else
-        # Commit failed
         clean_exit 1 "Failed to commit changes for commit $commit_count/$total_commits"
       fi
-      
+
       cd "$TMP_DIR/repo"
     else
       info_msg "No relevant changes in commit $commit_count/$total_commits for subtree"
-      
-      # Still update package.json to track progress
+
       cd "$MONOREPO_ROOT"
       if update_package_json_commit "$commit"; then
         local tracking_msg="${COMMIT_PREFIX}Update $PACKAGE_NAME tracking to $commit (no file changes)"
@@ -885,118 +459,22 @@ Upstream commit: $commit" "$WORKSPACE_LOCATION/$TARGET_RELATIVE"
       else
         warning_msg "Failed to update package.json tracking for commit $commit_count/$total_commits"
       fi
-      
+
       cd "$TMP_DIR/repo"
     fi
   done
 }
 
-# Function to filter and transform patch files
-filter_and_transform_patch() {
-  local input_patch="$1"
-  local upstream_subdir="$2"
-  local output_patch="$3"
-  
-  # If no subdirectory filter, just copy the patch
-  if [ -z "$upstream_subdir" ]; then
-    cp "$input_patch" "$output_patch"
-    return 0
-  fi
-  
-  # Use awk to filter and transform the patch
-  awk -v subdir="$upstream_subdir" '
-    BEGIN {
-      in_relevant_file = 0
-      skip_file = 0
-      subdir_prefix = subdir "/"
-    }
-    
-    # Handle file headers
-    /^diff --git/ {
-      # Extract file paths using split instead of match for better compatibility
-      split($0, parts, " ")
-      old_path_full = parts[3]  # a/path/to/file
-      new_path_full = parts[4]  # b/path/to/file
-      
-      # Remove a/ and b/ prefixes
-      gsub(/^a\//, "", old_path_full)
-      gsub(/^b\//, "", new_path_full)
-      old_path = old_path_full
-      new_path = new_path_full
-      
-      # Check if file is in our subdirectory
-      if (old_path ~ "^" subdir_prefix || new_path ~ "^" subdir_prefix) {
-        in_relevant_file = 1
-        skip_file = 0
-        
-        # Transform paths by removing subdirectory prefix
-        gsub("a/" subdir_prefix, "a/", $0)
-        gsub("b/" subdir_prefix, "b/", $0)
-        print $0
-      } else {
-        in_relevant_file = 0
-        skip_file = 1
-      }
-      next
-    }
-    
-    # Handle index lines
-    /^index / {
-      if (in_relevant_file && !skip_file) print $0
-      next
-    }
-    
-    # Handle file mode changes
-    /^(new|deleted) file mode/ {
-      if (in_relevant_file && !skip_file) print $0
-      next
-    }
-    
-    # Handle rename/copy headers
-    /^(rename|copy) (from|to)/ {
-      if (in_relevant_file && !skip_file) {
-        # Transform paths
-        gsub(subdir_prefix, "", $0)
-        print $0
-      }
-      next
-    }
-    
-    # Handle --- and +++ lines (file paths in unified diff)
-    /^(---|[+][+][+])/ {
-      if (in_relevant_file && !skip_file) {
-        # Transform paths
-        if ($0 ~ "^---.*/" subdir_prefix) {
-          gsub("/" subdir_prefix, "/", $0)
-        } else if ($0 ~ "^[+][+][+].*/" subdir_prefix) {
-          gsub("/" subdir_prefix, "/", $0)
-        }
-        print $0
-      }
-      next
-    }
-    
-    # Handle all other lines (hunks, context, etc.)
-    {
-      if (in_relevant_file && !skip_file) print $0
-    }
-  ' "$input_patch" > "$output_patch"
-}
-
-# Check if target directory exists, if not create it
 if [ ! -d "$TARGET_DIR" ]; then
   mkdir -p "$TARGET_DIR"
 fi
 
-# Apply patch-based update
 apply_patch_based_update "$CURRENT_COMMIT" "$TARGET_COMMIT" "$UPSTREAM_SUBDIR" "$TARGET_DIR"
 
-# Ensure we're back in monorepo root
 cd "$MONOREPO_ROOT"
 
 success_msg "Successfully updated $PACKAGE_NAME to $TARGET_COMMIT"
 
-# Display final warning if this was a PR test sync
 if [ -n "$DO_NOT_MERGE_FLAG" ] && [ "$DO_NOT_MERGE_FLAG" != "null" ]; then
   echo ""
   echo -e "${RED}╔════════════════════════════════════════════════════════════════════════════╗${NC}"

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "update-subtree": "package-subtree --package=@odh-dashboard/model-registry",
+    "update-subtree-local": "package-subtree-local --package=@odh-dashboard/model-registry",
     "test:contract": "odh-ct-bff-consumer --bff-dir upstream/bff",
     "cypress:server:build": "cd upstream/frontend && cross-env DIST_DIR=./public-cypress POLL_INTERVAL=9999999 DEPLOYMENT_MODE=federated npm run build",
     "cypress:server:build:coverage": "cross-env COVERAGE=true npm run cypress:server:build",

--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "update-subtree": "package-subtree --package=@odh-dashboard/notebooks",
+    "update-subtree-local": "package-subtree-local --package=@odh-dashboard/notebooks",
     "install:module": "npm install --prefix upstream/workspaces/frontend",
     "start:dev": "cd upstream/workspaces/frontend && PORT=9105 DEPLOYMENT_MODE=federated npm run start:dev",
     "start:dev:ext": "cd upstream/workspaces/frontend && DEPLOYMENT_MODE=federated PORT=9105 npm run start:dev",


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-57711

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a local variant of the existing `package-subtree.sh` script. The current sync workflow clones from the remote upstream repository on every run, which is slow and cannot test local branches or uncommitted work. The new `package-subtree-local.sh` reads directly from a local clone, enabling faster iteration when developing upstream and midstream changes in parallel.
Also generated docs regarding the usage of the previous script and new script, adding as well usage instruction form the existing claude skill and new claude skill.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was tested manually following these steps:
 - Create a new branch in the clone of the upstream repository
 - Adding some visible changes
 - Commit these changes in this branch
 - Try to sync it locally using the script
 - Also tried to sync only the commit in the branch
 - Test in midstream clone locally if the changes are visible and the files changed are there

I'm following the previous script didn't added unit tests/cypress since this is to run only in "dev mode"

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive upstream sync guide covering PR vs. local sync workflows, configuration, step-by-step conflict resolution, testing guidance, and troubleshooting.
  * Added a developer bookmark and README entry linking to the upstream sync guide.

* **New Features**
  * Added a local upstream sync command for incremental patch-based package updates with conflict detection, manual resolution + resume support, and DO-NOT-MERGE safety markers.
  * Added per-package npm scripts to invoke the local sync workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->