### PR TITLE
Make MaaS UI rely on ModelAsServiceReady condition in DSC status

### DIFF
--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -242,5 +242,72 @@ describe('isAreaAvailable', () => {
         expect(isAvailable.devFlags).toEqual({ [testDevFlag]: 'on' });
       });
     });
+
+    describe('customCondition', () => {
+      const testArea = 'TestCustomConditionArea';
+
+      it('should enable area when customCondition returns true', () => {
+        const mockAreasStateMap = {
+          [testArea]: {
+            customCondition: () => true,
+          },
+        };
+
+        const isAvailable = isAreaAvailable(
+          testArea,
+          mockDashboardConfig({}).spec,
+          mockDscStatus({}),
+          mockDsciStatus({}),
+          { internalStateMap: mockAreasStateMap, flagState: {} },
+        );
+
+        expect(isAvailable.status).toBe(true);
+      });
+
+      it('should disable area when customCondition returns false', () => {
+        const mockAreasStateMap = {
+          [testArea]: {
+            customCondition: () => false,
+          },
+        };
+
+        const isAvailable = isAreaAvailable(
+          testArea,
+          mockDashboardConfig({}).spec,
+          mockDscStatus({}),
+          mockDsciStatus({}),
+          { internalStateMap: mockAreasStateMap, flagState: {} },
+        );
+
+        expect(isAvailable.status).toBe(false);
+      });
+
+      it('should pass dscStatus to customCondition', () => {
+        const dscStatus = mockDscStatus({});
+        const customCondition = jest.fn(() => true);
+        const mockAreasStateMap = { [testArea]: { customCondition } };
+
+        isAreaAvailable(testArea, mockDashboardConfig({}).spec, dscStatus, mockDsciStatus({}), {
+          internalStateMap: mockAreasStateMap,
+          flagState: {},
+        });
+
+        expect(customCondition).toHaveBeenCalledWith(expect.objectContaining({ dscStatus }));
+      });
+
+      it('should not affect status when customCondition is absent', () => {
+        const mockAreasStateMap = { [testArea]: {} };
+
+        const isAvailable = isAreaAvailable(
+          testArea,
+          mockDashboardConfig({}).spec,
+          mockDscStatus({}),
+          mockDsciStatus({}),
+          { internalStateMap: mockAreasStateMap, flagState: {} },
+        );
+
+        expect(isAvailable.status).toBe(true);
+      });
+    });
   });
 });

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -181,14 +181,24 @@ export type SupportedComponentFlagValue = {
        */
       featureFlags: FeatureFlag[];
     },
-    {
-      /**
-       * Refers to the related stack component names. If a backend component is not installed, this
-       * can prevent the feature flag from enabling the item. Omit to not be reliant on a backend
-       * component.
-       */
-      requiredComponents: DataScienceStackComponent[];
-    }
+    EitherOrBoth<
+      {
+        /**
+         * Refers to the related stack component names. If a backend component is not installed, this
+         * can prevent the feature flag from enabling the item. Omit to not be reliant on a backend
+         * component.
+         */
+        requiredComponents: DataScienceStackComponent[];
+      },
+      {
+        /**
+         * Optional function to check for a condition that is not covered by other checks.
+         *
+         * Example, checking there exists a specific condition in the DSC status.
+         */
+        customCondition: CustomConditionFunction;
+      }
+    >
   >
 >;
 

--- a/frontend/src/concepts/areas/utils.ts
+++ b/frontend/src/concepts/areas/utils.ts
@@ -43,8 +43,14 @@ export const isAreaAvailable = (
   const hasAreaConfig = !!(area in options.internalStateMap);
 
   // If area doesn't exist, use empty config to avoid errors
-  const { devFlags, featureFlags, requiredComponents, reliantAreas, requiredCapabilities } =
-    hasAreaConfig ? options.internalStateMap[area] : {};
+  const {
+    devFlags,
+    featureFlags,
+    requiredComponents,
+    reliantAreas,
+    requiredCapabilities,
+    customCondition,
+  } = hasAreaConfig ? options.internalStateMap[area] : {};
 
   const reliantAreasState = reliantAreas
     ? reliantAreas.reduce<IsAreaAvailableStatus['reliantAreas']>(
@@ -115,13 +121,18 @@ export const isAreaAvailable = (
     ? Object.values(requiredCapabilitiesState).every((v) => v)
     : true;
 
+  const hasMetCustomCondition = customCondition
+    ? customCondition({ dashboardConfigSpec, dscStatus, dsciStatus })
+    : true;
+
   return {
     status:
       hasAreaConfig &&
       hasMetReliantAreas &&
       hasMetFeatureFlags &&
       hasMetRequiredComponents &&
-      hasMetRequiredCapabilities,
+      hasMetRequiredCapabilities &&
+      hasMetCustomCondition,
     reliantAreas: reliantAreasState,
     devFlags: devFlagsState,
     featureFlags: featureFlagState,

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -64,6 +64,7 @@ describe('API Keys Page', () => {
         components: {
           [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
         },
+        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh(
@@ -590,6 +591,7 @@ describe('API Keys Page (Admin)', () => {
         components: {
           [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
         },
+        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -31,6 +31,7 @@ const setupAuthPoliciesCommon = () => {
       components: {
         [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
       },
+      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
     }),
   );
 };

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -42,6 +42,7 @@ describe('MaaS Deployment Wizard', () => {
           [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
           [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
         },
+        conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),
     );
     cy.interceptOdh(

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -29,6 +29,7 @@ const setupCommonIntercepts = () => {
       components: {
         [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
       },
+      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
     }),
   );
 };

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -9,6 +9,7 @@ export const MAAS_AUTH_POLICIES = 'maasAuthPolicies';
 
 export type ODHExtensions = NavExtension | RouteExtension | AreaExtension;
 const ADMIN_USER = 'ADMIN_USER';
+const MODELS_AS_SERVICE_READY = 'ModelsAsServiceReady';
 
 const ODH_EXTENSIONS: ODHExtensions[] = [
   {
@@ -16,6 +17,10 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     properties: {
       id: MODEL_AS_SERVICE_ID,
       featureFlags: ['modelAsService'],
+      customCondition: ({ dscStatus }) =>
+        !!dscStatus?.conditions.some(
+          (c) => c.type === MODELS_AS_SERVICE_READY && c.status === 'True',
+        ),
     },
   },
   {
@@ -23,6 +28,10 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     properties: {
       id: MAAS_AUTH_POLICIES,
       featureFlags: ['maasAuthPolicies'],
+      customCondition: ({ dscStatus }) =>
+        !!dscStatus?.conditions.some(
+          (c) => c.type === MODELS_AS_SERVICE_READY && c.status === 'True',
+        ),
     },
   },
   {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-58176
## Description
We turned on the MaaS feature flags by default, but we didn't make them rely on any backend being available. This PR adds the ability to look for DSC status conditions and use them for an area to be available. Specifically we check for `ModelsAsServiceReady` condition in the DSC status.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
Tested on dashboard-maas to make sure it doesn't break existing functionality and tested on Zaffre cluster (where the dsc status condition for `ModelsAsServiceReady` is false)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Updated jest tests for the new `customCondition` param in the nav extension and also updated cypress mocks for the dsc status
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced custom condition support for controlling feature area availability. Areas can now be dynamically enabled or disabled based on component readiness status in addition to existing feature flags and component requirements.
  * Models as a Service feature is now gated by a readiness condition check, ensuring the feature is only available when the underlying service is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->