### PR TITLE
feat(manifests): introduce dedicated ServiceAccount for modular architecture BFF modules

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -6,6 +6,75 @@
       configMapKeyRef:
         key: module-federation-config.json
         name: federation-config
+# --- SA isolation: disable auto-mount and add per-container SA tokens ---
+- op: add
+  path: /spec/template/spec/automountServiceAccountToken
+  value: false
+# Projected volume with the pod's own SA token (odh-dashboard) for containers 0-1
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: dashboard-sa-token
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            expirationSeconds: 3607
+            path: token
+        - configMap:
+            name: kube-root-ca.crt
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - downwardAPI:
+            items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace
+        - configMap:
+            name: openshift-service-ca.crt
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+# Secret-based volume with the modules SA token (odh-dashboard-modules) for BFF containers
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: modules-sa-token
+    projected:
+      defaultMode: 420
+      sources:
+        - secret:
+            name: odh-dashboard-modules-token
+            items:
+              - key: token
+                path: token
+              - key: ca.crt
+                path: ca.crt
+        - downwardAPI:
+            items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace
+        - configMap:
+            name: openshift-service-ca.crt
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+# Mount dashboard SA token into odh-dashboard (container 0) and kube-rbac-proxy (container 1)
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: dashboard-sa-token
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    readOnly: true
+- op: add
+  path: /spec/template/spec/containers/1/volumeMounts/-
+  value:
+    name: dashboard-sa-token
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    readOnly: true
+# --- End SA isolation infrastructure ---
 - op: add
   path: /spec/template/spec/containers/-
   value:
@@ -61,6 +130,9 @@
       - name: odh-ca-cert
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         readOnly: true
     args:
       - '--deployment-mode=federated'
@@ -134,6 +206,9 @@
       - name: odh-ca-cert
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         readOnly: true
     args:
       - '--auth-method=user_token'
@@ -225,6 +300,9 @@
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
         readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
     args:
       - '--auth-method=user_token'
       - '--auth-token-header=x-forwarded-access-token'
@@ -302,6 +380,9 @@
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
         readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
     args:
       - '--deployment-mode=federated'
       - '--auth-method=user_token'
@@ -372,6 +453,9 @@
       - name: odh-ca-cert
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         readOnly: true
     args:
       - '--deployment-mode=federated'
@@ -444,6 +528,9 @@
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
         readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
     args:
       - '--auth-method=user_token'
       - '--auth-token-header=x-forwarded-access-token'
@@ -513,6 +600,9 @@
       - name: odh-ca-cert
         mountPath: /etc/ssl/certs/odh-ca-bundle.crt
         subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         readOnly: true
     args:
       - '--auth-method=user_token'

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../core-bases/base
   - federation-configmap.yaml
   - networkpolicy.yaml
+  - modules-service-account.yaml
+  - modules-cluster-role.yaml
+  - modules-cluster-role-binding.yaml
+  - modules-sa-token-secret.yaml
 configMapGenerator:
   - name: modular-architecture-params
     env: params.env

--- a/manifests/modular-architecture/modules-cluster-role-binding.yaml
+++ b/manifests/modular-architecture/modules-cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard-modules
+subjects:
+  - kind: ServiceAccount
+    name: odh-dashboard-modules
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odh-dashboard-modules

--- a/manifests/modular-architecture/modules-cluster-role.yaml
+++ b/manifests/modular-architecture/modules-cluster-role.yaml
@@ -1,0 +1,30 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard-modules
+rules:
+  # MLflow CR auto-discovery (mlflow-ui, gen-ai-ui)
+  - apiGroups:
+      - mlflow.opendatahub.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - mlflows
+  # Cluster domain discovery (gen-ai-ui, maas-ui)
+  - apiGroups:
+      - config.openshift.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - ingresses
+  # SubjectAccessReview for namespace access checks
+  - apiGroups:
+      - authorization.k8s.io
+    verbs:
+      - create
+    resources:
+      - subjectaccessreviews

--- a/manifests/modular-architecture/modules-sa-token-secret.yaml
+++ b/manifests/modular-architecture/modules-sa-token-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: odh-dashboard-modules-token
+  annotations:
+    kubernetes.io/service-account.name: odh-dashboard-modules
+type: kubernetes.io/service-account-token

--- a/manifests/modular-architecture/modules-service-account.yaml
+++ b/manifests/modular-architecture/modules-service-account.yaml
@@ -1,0 +1,4 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: odh-dashboard-modules

--- a/manifests/rhoai/base/kustomization.yaml
+++ b/manifests/rhoai/base/kustomization.yaml
@@ -67,5 +67,11 @@ patchesJson6902:
       version: v1
       kind: NetworkPolicy
       name: odh-dashboard-allow-ports
+  - path: modules-cluster-role-binding.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: odh-dashboard-modules
 patchesStrategicMerge:
   - federation-configmap.yaml

--- a/manifests/rhoai/base/modules-cluster-role-binding.yaml
+++ b/manifests/rhoai/base/modules-cluster-role-binding.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /subjects/0/namespace
+  value: redhat-ods-applications


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58232

## Description

All BFF sidecar containers currently share the `odh-dashboard` ServiceAccount, which has a broad ClusterRole with cluster-wide permissions (secrets, configmaps, RBAC, etc.). This PR introduces a dedicated `odh-dashboard-modules` ServiceAccount with a minimal ClusterRole scoped to only the permissions BFF modules actually need.

**Mechanism:**
- Disable `automountServiceAccountToken` at the pod level
- Mount `odh-dashboard` SA token into dashboard + kube-rbac-proxy containers via a projected volume (rotating token, CA cert, namespace, service-ca)
- Mount `odh-dashboard-modules` SA token into all 7 BFF containers via a secret-based projected volume
- Both mount at `/var/run/secrets/kubernetes.io/serviceaccount` so `rest.InClusterConfig()` works transparently — **no code changes required**

**Modules ClusterRole permissions (minimal):**
- `mlflows` (get/list/watch) — MLflow CR auto-discovery
- `ingresses` on `config.openshift.io` (get/list/watch) — cluster domain discovery
- `subjectaccessreviews` (create) — namespace access checks

**RHOAI:** Only one patch needed (CRB subject namespace for `redhat-ods-applications`). No renames since the modules SA has no external references (no OAuth, no routes), following the precedent of other non-dashboard-specific RBAC resources.

**New files:**
- `manifests/modular-architecture/modules-service-account.yaml`
- `manifests/modular-architecture/modules-cluster-role.yaml`
- `manifests/modular-architecture/modules-cluster-role-binding.yaml`
- `manifests/modular-architecture/modules-sa-token-secret.yaml`
- `manifests/rhoai/shared/base/modules-cluster-role-binding.yaml`

**Modified files:**
- `manifests/modular-architecture/deployment.yaml` — automount disable, volumes, volumeMounts
- `manifests/modular-architecture/kustomization.yaml` — new resources
- `manifests/rhoai/shared/base/kustomization.yaml` — new CRB patch target

## How Has This Been Tested?

- Validated on a live OpenShift cluster by applying a JSON patch prototype with the same mechanism
- Verified all 9 containers (9/9) start and pass health checks
- Verified SA identity isolation (see commands below)
- Verified BFF containers CANNOT read secrets, configmaps, or RBAC resources (403 Forbidden)
- Verified BFF containers CAN read mlflows CRD and ingresses config (200 OK)
- Verified dashboard container retains full permissions (200 OK on secrets)
- `kustomize build` passes for both ODH (`manifests/modular-architecture/`) and RHOAI (`manifests/rhoai/shared/base/`) variants

### Verification commands

After deploying, run these commands to confirm SA isolation is working:

```bash
# Get the pod name
POD=$(oc get pods -n opendatahub -l app=odh-dashboard -o jsonpath='{.items[0].metadata.name}')

# 1. Verify SA identity isolation — dashboard vs BFF containers
echo "--- Dashboard container (should be odh-dashboard SA) ---"
oc exec -n opendatahub $POD -c odh-dashboard -- \
  cat /var/run/secrets/kubernetes.io/serviceaccount/token \
  | cut -d. -f2 | base64 -d 2>/dev/null | grep -o '"sub":"[^"]*"'

echo "--- gen-ai-ui container (should be odh-dashboard-modules SA) ---"
oc exec -n opendatahub $POD -c gen-ai-ui -- \
  cat /var/run/secrets/kubernetes.io/serviceaccount/token \
  | cut -d. -f2 | base64 -d 2>/dev/null | grep -o '"sub":"[^"]*"'

# 2. Verify BFF containers CANNOT read secrets (should get 403)
oc exec -n opendatahub $POD -c gen-ai-ui -- \
  sh -c 'TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) && \
  curl -sk -o /dev/null -w "secrets: HTTP %{http_code}\n" \
  -H "Authorization: Bearer $TOKEN" \
  https://kubernetes.default.svc/api/v1/namespaces/opendatahub/secrets'

# 3. Verify BFF containers CAN read ingresses (should get 200)
oc exec -n opendatahub $POD -c gen-ai-ui -- \
  sh -c 'TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) && \
  curl -sk -o /dev/null -w "ingresses: HTTP %{http_code}\n" \
  -H "Authorization: Bearer $TOKEN" \
  https://kubernetes.default.svc/apis/config.openshift.io/v1/ingresses'

# 4. Verify dashboard container CAN still read secrets (should get 200)
oc exec -n opendatahub $POD -c odh-dashboard -- \
  sh -c 'TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) && \
  curl -sk -o /dev/null -w "secrets: HTTP %{http_code}\n" \
  -H "Authorization: Bearer $TOKEN" \
  https://kubernetes.default.svc/api/v1/namespaces/opendatahub/secrets'
```

**Expected results:**
| Check | Container | Expected |
|-------|-----------|----------|
| SA identity | odh-dashboard | `system:serviceaccount:<ns>:odh-dashboard` |
| SA identity | gen-ai-ui (any BFF) | `system:serviceaccount:<ns>:odh-dashboard-modules` |
| Read secrets | BFF container | `HTTP 403` |
| Read ingresses | BFF container | `HTTP 200` |
| Read secrets | Dashboard container | `HTTP 200` |

## Test Impact

This is a manifest-only change with no code modifications. Existing Cypress and unit tests are unaffected. The change should be validated on a cluster deployment to confirm all containers start correctly with the new SA isolation.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Infrastructure**
  * Enhanced service account token isolation for dashboard pods to improve security posture.
  * Added fine-grained role-based access control for dashboard modules with namespace-specific permissions.
  * Introduced module-specific service account credentials for improved token management across dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->