### PR TITLE
remove prefix from jira creation tool summaries

### DIFF
--- a/.claude/rules/jira-creation.md
+++ b/.claude/rules/jira-creation.md
@@ -209,7 +209,7 @@ A user-impact addition/change to the product — e.g., feature work to add parti
 ```python
 project_key="RHOAIENG",
 issue_type="Story",
-summary="STORY: [User-provided summary]",
+summary="[User-provided summary]",
 description="[Formatted markdown string including Description of enhancement, Acceptance Criteria, and Additional info]",
 components="AI Core Dashboard",
 additional_fields={
@@ -258,7 +258,7 @@ A non-user facing change to the product — e.g., add a test, fix a test, or a r
 ```python
 project_key="RHOAIENG",
 issue_type="Task",
-summary="TASK: [User-provided summary]",
+summary="[User-provided summary]",
 description="[Formatted markdown string including Description of task, Acceptance Criteria, and Additional info]",
 components="AI Core Dashboard",
 additional_fields={
@@ -293,7 +293,7 @@ A user-impact Story that is part of a larger Epic. Follows Story definition abov
 
 project_key="RHOAIENG",  # Can be inferred if PARENT_EPIC_KEY is for RHOAIENG
 issue_type="Story",
-summary="STORY: [User-provided summary]",
+summary="[User-provided summary]",
 description="[Formatted markdown string for Story description, AC, and Additional Info]",
 components="AI Core Dashboard",
 additional_fields={
@@ -331,7 +331,7 @@ A non-user facing Task that is part of a larger Epic. Follows Task definition ab
 
 project_key="RHOAIENG",  # Can be inferred
 issue_type="Task",
-summary="TASK: [User-provided summary]",
+summary="[User-provided summary]",
 description="[Formatted markdown string for Task description, AC, and Additional Info]",
 components="AI Core Dashboard",
 additional_fields={
@@ -385,7 +385,7 @@ additional_fields={
 ```python
 project_key="RHOAIENG",
 issue_type="Epic",
-summary="EPIC: [User-provided Epic Name]",
+summary="[User-provided Epic Name]",
 description="[User-provided concise, high-level description of what the Epic aims to accomplish]",
 components="AI Core Dashboard",  # Or other relevant components for the Epic
 additional_fields={


### PR DESCRIPTION
## Description

Removes the `STORY:`, `TASK:`, and `EPIC:` prefixes from Jira issue summary templates in the creation rule. These prefixes are redundant since the issue type is already captured by the `issue_type` field, and Jira displays the type separately. This keeps summaries cleaner and avoids duplicating information that's already part of the issue metadata.

## How Has This Been Tested?

This is a documentation/rule change only — no runtime code is affected. Verified the updated templates are syntactically correct and consistent across all issue type examples (Story, Task, Epic, and their Epic-child variants).

## Test Impact

No tests are applicable — this change modifies an AI agent rule file (`.claude/rules/jira-creation.md`), not application code.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Jira issue creation examples by removing prefix labels from summary fields across Story, Task, and Epic creation templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->