### PR TITLE
Add config form resource to yaml edit submit

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
@@ -66,6 +66,29 @@ describe('useFormYamlResources', () => {
     expect(renderResult.result.current.resources).not.toBe(resources);
   });
 
+  it('should include formResources server in resources when in editor mode', () => {
+    const mockServer: DeploymentAssemblyResources['server'] = {
+      apiVersion: 'serving.kserve.io/v1alpha1',
+      kind: 'ServingRuntime',
+      metadata: {
+        name: 'test-server',
+        namespace: 'test-ns',
+      },
+    };
+    const resources: DeploymentAssemblyResources = { model: mockModel, server: mockServer };
+    const renderResult = testHook(useFormYamlResources)(resources);
+
+    const editedModel = { ...mockModel, metadata: { ...mockModel.metadata, name: 'edited' } };
+    act(() => {
+      renderResult.result.current.setYaml(stringify(editedModel));
+    });
+
+    expect(renderResult.result.current.resources).toStrictEqual({
+      model: editedModel,
+      server: mockServer,
+    });
+  });
+
   it('should return editor yaml after setYaml is called', () => {
     const resources: DeploymentAssemblyResources = { model: mockModel };
     const renderResult = testHook(useFormYamlResources)(resources);

--- a/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/yaml/__tests__/useYamlResourcesResult.spec.ts
@@ -18,8 +18,8 @@ jest.mock('../../useWizardFieldApply');
 const mockUseWizardFieldApply = jest.mocked(useWizardFieldApply);
 
 const mockModel: ModelResourceType = {
-  apiVersion: 'serving.kserve.io/v1beta1',
-  kind: 'InferenceService',
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  kind: 'LLMInferenceService',
   metadata: {
     name: 'test-model',
     namespace: 'test-ns',
@@ -29,8 +29,8 @@ const mockModel: ModelResourceType = {
 const mockDeployment: Deployment = {
   modelServingPlatformId: 'test-platform',
   model: {
-    apiVersion: 'serving.kserve.io/v1beta1',
-    kind: 'InferenceService',
+    apiVersion: 'serving.kserve.io/v1alpha1',
+    kind: 'LLMInferenceService',
     metadata: {
       name: 'test-model',
       namespace: 'test-ns',
@@ -69,7 +69,7 @@ describe('useFormYamlResources', () => {
   it('should include formResources server in resources when in editor mode', () => {
     const mockServer: DeploymentAssemblyResources['server'] = {
       apiVersion: 'serving.kserve.io/v1alpha1',
-      kind: 'ServingRuntime',
+      kind: 'LLMInferenceServiceConfig',
       metadata: {
         name: 'test-server',
         namespace: 'test-ns',

--- a/packages/model-serving/src/components/deploymentWizard/yaml/useYamlResourcesResult.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/yaml/useYamlResourcesResult.tsx
@@ -69,9 +69,16 @@ export const useFormYamlResources = (
     return {
       yaml: lastUpdatedSource.current === 'editor' ? editorYaml : formAsYaml,
       setYaml,
-      resources: lastUpdatedSource.current === 'editor' ? yamlResources : formResources,
+      resources:
+        lastUpdatedSource.current === 'editor'
+          ? {
+              model: yamlResources.model,
+              // We are limiting the YAML to only the model, but we still want to include the server during submit if it exists in the form.
+              ...(formResources.server ? { server: formResources.server } : {}),
+            }
+          : formResources,
       error: lastUpdatedSource.current === 'editor' ? yamlResourcesError : formAsYamlError,
-    };
+    } satisfies UseFormYamlResourcesResult;
   }, [
     editorYaml,
     formAsYaml,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-58250

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
If an LLMInferenceServiceConfig was selected, and you went into the manual edit mode, you would lose it, and it would not be created on submit, thus breaking the deployment because the baseRef wouldn't resolve.

This was because the YAML view drops the config, and we are pushing the yaml into the submit resource. This makes it so the config will still come from the form even if you are in yaml edit

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. enable vLLMDeploymentOnMaaS
2. Deploy a generative model, select an LLMInferenceServiceConfig
3. before submitting, go to manual edit mode, hit submit
4. the LLMInferenceServiceConfig should now be created

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
small jest unit test added for this fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for LLMInferenceService deployments in the deployment wizard.

* **Bug Fixes**
  * YAML editor now preserves existing server configuration when updating model resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->