### PR TITLE
Fix(RHOAIENG-57847): added column width fix and ability to add multiple unit time tokens

### DIFF
--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/EditRateLimitsModal.tsx
@@ -11,7 +11,7 @@ import {
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { z } from 'zod';
 import { RateLimit, TokenRateLimit } from '~/app/types/subscriptions';
-import { UNIT_OPTIONS, toRateLimit, toTokenRateLimit } from '~/app/utilities/rateLimits';
+import { toRateLimit, toTokenRateLimit } from '~/app/utilities/rateLimits';
 import { RateLimitRow } from './RateLimitRow';
 
 type EditRateLimitsModalProps = {
@@ -81,8 +81,6 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
   );
   const [submitted, setSubmitted] = React.useState(false);
 
-  const usedUnits = localLimits.map((l) => l.unit);
-  const availableUnits = UNIT_OPTIONS.map((opt) => opt.value).filter((u) => !usedUnits.includes(u));
   const validation = rateLimitsSchema.safeParse(localLimits);
   const hasDigitLimitError = localLimits.some(rateLimitExceedsMaxDigits);
   const canSave = validation.success && !hasDigitLimitError;
@@ -96,9 +94,7 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
   };
 
   const handleAdd = () => {
-    if (availableUnits.length > 0) {
-      setLocalLimits((prev) => [...prev, { ...DEFAULT_RATE_LIMIT, unit: availableUnits[0] }]);
-    }
+    setLocalLimits((prev) => [...prev, { ...DEFAULT_RATE_LIMIT }]);
   };
 
   const handleSave = () => {
@@ -127,7 +123,6 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
                 onChange={(updated) => handleRowChange(index, updated)}
                 onRemove={() => handleRemove(index)}
                 showRemove={localLimits.length > 1}
-                availableUnits={availableUnits}
                 countError={submitted ? getCountError(limit) : undefined}
                 timeError={submitted ? getTimeError(limit) : undefined}
                 countDigitError={getCountDigitError(limit)}
@@ -135,18 +130,16 @@ const EditRateLimitsModal: React.FC<EditRateLimitsModalProps> = ({
               />
             </StackItem>
           ))}
-          {availableUnits.length > 0 && (
-            <StackItem>
-              <Button
-                variant="link"
-                icon={<PlusCircleIcon />}
-                onClick={handleAdd}
-                data-testid="add-token-rate-limit"
-              >
-                Add token rate limit
-              </Button>
-            </StackItem>
-          )}
+          <StackItem>
+            <Button
+              variant="link"
+              icon={<PlusCircleIcon />}
+              onClick={handleAdd}
+              data-testid="add-token-rate-limit"
+            >
+              Add token rate limit
+            </Button>
+          </StackItem>
         </Stack>
       </ModalBody>
       <ModalFooter>

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/RateLimitRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/RateLimitRow.tsx
@@ -25,7 +25,6 @@ export type RateLimitRowProps = {
   onChange: (rateLimit: RateLimit) => void;
   onRemove?: () => void;
   showRemove: boolean;
-  availableUnits: RateLimit['unit'][];
   countError?: string;
   timeError?: string;
   countDigitError?: string;
@@ -40,7 +39,6 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
   onChange,
   onRemove,
   showRemove,
-  availableUnits,
   countError,
   timeError,
   countDigitError,
@@ -51,11 +49,6 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
   // Get the display label for the selected unit, falling back to the raw value
   const selectedUnitLabel =
     UNIT_OPTIONS.find((opt) => opt.value === rateLimit.unit)?.label ?? rateLimit.unit;
-
-  // Show available units plus the currently selected one
-  const selectableOptions = UNIT_OPTIONS.filter(
-    (opt) => availableUnits.includes(opt.value) || opt.value === rateLimit.unit,
-  );
 
   const countMessage = countDigitError ?? countError;
   const timeMessage = timeDigitError ?? timeError;
@@ -153,7 +146,7 @@ export const RateLimitRow: React.FC<RateLimitRowProps> = ({
               )}
             >
               <DropdownList>
-                {selectableOptions.map((option) => (
+                {UNIT_OPTIONS.map((option) => (
                   <DropdownItem
                     key={option.value}
                     onClick={() => {

--- a/packages/maas/frontend/src/app/shared/AddModelsModal.tsx
+++ b/packages/maas/frontend/src/app/shared/AddModelsModal.tsx
@@ -238,7 +238,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                   <Th sort={getSortParams('namespace')}>Project</Th>
                   <Th sort={getSortParams('modelId')}>Model ID</Th>
                   <Th width={20}>Subscriptions</Th>
-                  <Th>Policies</Th>
+                  <Th width={20}>Policies</Th>
                   <Th screenReaderText="Actions" />
                 </Tr>
               </Thead>
@@ -258,7 +258,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                       </Td>
                       <Td dataLabel="Project">{ref.namespace}</Td>
                       <Td dataLabel="Model ID">{ref.modelRef.name}</Td>
-                      <Td dataLabel="Subscriptions" width={20} modifier="breakWord">
+                      <Td dataLabel="Subscriptions" modifier="breakWord">
                         {selected && fromSubscription && (
                           <Label color="green" isCompact>
                             {currentSelectionLabel}
@@ -270,7 +270,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                         {(fromSubscription ? !selected && subs.length === 0 : subs.length === 0) &&
                           'None'}
                       </Td>
-                      <Td dataLabel="Policies" width={20} modifier="breakWord">
+                      <Td dataLabel="Policies" modifier="breakWord">
                         {selected && !fromSubscription && (
                           <Label color="green" isCompact>
                             {currentSelectionLabel}

--- a/packages/maas/frontend/src/app/shared/AddModelsModal.tsx
+++ b/packages/maas/frontend/src/app/shared/AddModelsModal.tsx
@@ -237,7 +237,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                   <Th sort={getSortParams('name')}>Model name</Th>
                   <Th sort={getSortParams('namespace')}>Project</Th>
                   <Th sort={getSortParams('modelId')}>Model ID</Th>
-                  <Th>Subscriptions</Th>
+                  <Th width={20}>Subscriptions</Th>
                   <Th>Policies</Th>
                   <Th screenReaderText="Actions" />
                 </Tr>
@@ -258,7 +258,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                       </Td>
                       <Td dataLabel="Project">{ref.namespace}</Td>
                       <Td dataLabel="Model ID">{ref.modelRef.name}</Td>
-                      <Td dataLabel="Subscriptions">
+                      <Td dataLabel="Subscriptions" width={20} modifier="breakWord">
                         {selected && fromSubscription && (
                           <Label color="green" isCompact>
                             {currentSelectionLabel}
@@ -270,7 +270,7 @@ const AddModelsModal: React.FC<AddModelsModalProps> = ({
                         {(fromSubscription ? !selected && subs.length === 0 : subs.length === 0) &&
                           'None'}
                       </Td>
-                      <Td dataLabel="Policies">
+                      <Td dataLabel="Policies" width={20} modifier="breakWord">
                         {selected && !fromSubscription && (
                           <Label color="green" isCompact>
                             {currentSelectionLabel}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes 

1. [RHOAIENG-57847](https://redhat.atlassian.net/browse/RHOAIENG-57847)
2. [RHOAIENG-58387](https://redhat.atlassian.net/browse/RHOAIENG-58387)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://github.com/user-attachments/assets/0d6a32d1-2727-43f1-840a-1b1398eca406


This PR contains the following fixes:

1. Contains Column width fixes in the add models for the subscription and policies column in case of large texts
3. Ability to add multiple rate limit rows of the same unit of time


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On opening the token limits modal, add several rows and set more than one to the same unit

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
NA

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined rate limit management—the "Add token rate limit" button is now always visible and functional without restrictions.
  * Rate limit unit selection dropdown now displays all available options for improved flexibility.

* **Style**
  * Enhanced table layout with optimized column widths and improved text-wrapping in Subscriptions and Policies columns for better content visibility and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->