### PR TITLE
RHOAIENG-48792: CPU and memory limits/requests don't match in the deployments view

### DIFF
--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -138,15 +138,9 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
         style={tableView ? { textDecoration: 'none' } : undefined}
         data-testid="hardware-profile-details-popover"
       >
-        {tableView ? (
-          hardwareProfile ? (
-            getHardwareProfileDisplayName(hardwareProfile)
-          ) : (
-            <i>Custom</i>
-          )
-        ) : (
-          'View details'
-        )}
+        {tableView && hardwareProfile
+          ? getHardwareProfileDisplayName(hardwareProfile)
+          : 'View details'}
       </Button>
     </Popover>
   );

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -93,9 +93,13 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
               {profileIdentifiers.length > 0 &&
                 profileIdentifiers.map((identifier) => (
                   <StackItem key={identifier.identifier}>
-                    {renderSection(identifier.displayName || identifier.identifier, [
-                      formatIdentifierDetails(identifier),
-                    ])}
+                    {renderSection(
+                      identifier.displayName &&
+                        identifier.displayName.toLowerCase() !== identifier.identifier.toLowerCase()
+                        ? `${identifier.displayName} (${identifier.identifier})`
+                        : identifier.displayName || identifier.identifier,
+                      [formatIdentifierDetails(identifier)],
+                    )}
                   </StackItem>
                 ))}
             </>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -11,7 +11,7 @@ import {
   Truncate,
 } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
-import { Toleration, NodeSelector, ContainerResources } from '#~/types';
+import { Toleration, NodeSelector } from '#~/types';
 import { HardwareProfileKind } from '#~/k8sTypes';
 import {
   getClusterQueueNameFromLocalQueues,
@@ -22,7 +22,6 @@ import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import {
   formatToleration,
   formatNodeSelector,
-  formatResource,
   formatIdentifierDetails,
   sortIdentifiers,
 } from './utils';
@@ -32,7 +31,6 @@ type HardwareProfileDetailsPopoverProps = {
   priorityClass?: string;
   tolerations?: Toleration[];
   nodeSelector?: NodeSelector;
-  resources?: ContainerResources;
   hardwareProfile?: HardwareProfileKind;
   tableView?: boolean;
 };
@@ -42,7 +40,6 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
   priorityClass,
   tolerations,
   nodeSelector,
-  resources,
   hardwareProfile,
   tableView = false,
 }) => {
@@ -74,31 +71,6 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
     [hardwareProfile],
   );
 
-  const fallbackResources = React.useMemo(() => {
-    if (hardwareProfile) {
-      return [];
-    }
-    const requests = resources?.requests || {};
-    const limits = resources?.limits || {};
-    const keys = new Set([...Object.keys(requests), ...Object.keys(limits)]);
-
-    return Array.from(keys).map((key) => ({
-      identifier: key,
-      request: requests[key]?.toString() || '',
-      limit: limits[key]?.toString() || '',
-    }));
-  }, [resources, hardwareProfile]);
-
-  const hasIdentifiers = profileIdentifiers.length > 0 || fallbackResources.length > 0;
-
-  if (
-    !tolerations &&
-    !nodeSelector &&
-    !hasIdentifiers &&
-    !(localQueueName || clusterQueueName || priorityClass)
-  ) {
-    return null;
-  }
   const description = hardwareProfile && getHardwareProfileDescription(hardwareProfile);
 
   return (
@@ -112,31 +84,27 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
       bodyContent={
         <Stack hasGutter data-testid="hardware-profile-details">
           {hardwareProfile ? (
-            description && (
-              <StackItem>
-                <Truncate content={description} />
-              </StackItem>
-            )
+            <>
+              {description && (
+                <StackItem>
+                  <Truncate content={description} />
+                </StackItem>
+              )}
+              {profileIdentifiers.length > 0 &&
+                profileIdentifiers.map((identifier) => (
+                  <StackItem key={identifier.identifier}>
+                    {renderSection(identifier.displayName || identifier.identifier, [
+                      formatIdentifierDetails(identifier),
+                    ])}
+                  </StackItem>
+                ))}
+            </>
           ) : (
-            <StackItem>No matching hardware profile found, using existing settings.</StackItem>
+            <StackItem>
+              No matching hardware profile found, using existing settings. Default, min, and max
+              values are not available.
+            </StackItem>
           )}
-
-          {profileIdentifiers.length > 0 &&
-            profileIdentifiers.map((identifier) => (
-              <StackItem key={identifier.identifier}>
-                {renderSection(identifier.displayName || identifier.identifier, [
-                  formatIdentifierDetails(identifier),
-                ])}
-              </StackItem>
-            ))}
-          {fallbackResources.length > 0 &&
-            fallbackResources.map((resource) => (
-              <StackItem key={resource.identifier}>
-                {renderSection(resource.identifier, [
-                  formatResource(resource.identifier, resource.request, resource.limit),
-                ])}
-              </StackItem>
-            ))}
           {localQueueName && (
             <StackItem>{renderSection('Local queue', [localQueueName])}</StackItem>
           )}

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileDetailsPopover.tsx
@@ -19,7 +19,13 @@ import {
   getHardwareProfileDisplayName,
 } from '#~/pages/hardwareProfiles/utils.ts';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import { formatToleration, formatNodeSelector, formatResource, formatResourceValue } from './utils';
+import {
+  formatToleration,
+  formatNodeSelector,
+  formatResource,
+  formatIdentifierDetails,
+  sortIdentifiers,
+} from './utils';
 
 type HardwareProfileDetailsPopoverProps = {
   localQueueName?: string;
@@ -62,26 +68,33 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
     </DescriptionList>
   );
 
-  const allResources = React.useMemo(() => {
+  const profileIdentifiers = React.useMemo(
+    () =>
+      hardwareProfile?.spec.identifiers ? sortIdentifiers(hardwareProfile.spec.identifiers) : [],
+    [hardwareProfile],
+  );
+
+  const fallbackResources = React.useMemo(() => {
+    if (hardwareProfile) {
+      return [];
+    }
     const requests = resources?.requests || {};
     const limits = resources?.limits || {};
-    const identifiers = new Set([...Object.keys(requests), ...Object.keys(limits)]);
+    const keys = new Set([...Object.keys(requests), ...Object.keys(limits)]);
 
-    return Array.from(identifiers).map((identifier) => ({
-      identifier,
-      request: requests[identifier]?.toString() || '',
-      limit: limits[identifier]?.toString() || '',
-      displayName: hardwareProfile?.spec.identifiers?.find((id) => id.identifier === identifier)
-        ?.displayName,
-      resourceType: hardwareProfile?.spec.identifiers?.find((id) => id.identifier === identifier)
-        ?.resourceType,
+    return Array.from(keys).map((key) => ({
+      identifier: key,
+      request: requests[key]?.toString() || '',
+      limit: limits[key]?.toString() || '',
     }));
   }, [resources, hardwareProfile]);
+
+  const hasIdentifiers = profileIdentifiers.length > 0 || fallbackResources.length > 0;
 
   if (
     !tolerations &&
     !nodeSelector &&
-    !resources &&
+    !hasIdentifiers &&
     !(localQueueName || clusterQueueName || priorityClass)
   ) {
     return null;
@@ -108,15 +121,19 @@ const HardwareProfileDetailsPopover: React.FC<HardwareProfileDetailsPopoverProps
             <StackItem>No matching hardware profile found, using existing settings.</StackItem>
           )}
 
-          {allResources.length > 0 &&
-            allResources.map((resource) => (
+          {profileIdentifiers.length > 0 &&
+            profileIdentifiers.map((identifier) => (
+              <StackItem key={identifier.identifier}>
+                {renderSection(identifier.displayName || identifier.identifier, [
+                  formatIdentifierDetails(identifier),
+                ])}
+              </StackItem>
+            ))}
+          {fallbackResources.length > 0 &&
+            fallbackResources.map((resource) => (
               <StackItem key={resource.identifier}>
-                {renderSection(resource.displayName || resource.identifier, [
-                  formatResource(
-                    resource.identifier,
-                    formatResourceValue(resource.request, resource.resourceType).toString(),
-                    formatResourceValue(resource.limit, resource.resourceType).toString(),
-                  ),
+                {renderSection(resource.identifier, [
+                  formatResource(resource.identifier, resource.request, resource.limit),
                 ])}
               </StackItem>
             ))}

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -141,11 +141,18 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                 <Truncate
                   content={profile.spec.identifiers
                     .map((identifier) => {
-                      const resourceValue = formatResourceValue(
+                      const defaultVal = formatResourceValue(
                         identifier.defaultCount,
                         identifier.resourceType,
                       ).toString();
-                      return formatResource(identifier.displayName, resourceValue, resourceValue);
+                      const maxVal =
+                        identifier.maxCount === undefined
+                          ? 'unrestricted'
+                          : formatResourceValue(
+                              identifier.maxCount,
+                              identifier.resourceType,
+                            ).toString();
+                      return formatResource(identifier.displayName, defaultVal, maxVal);
                     })
                     .join('; ')}
                 />
@@ -221,13 +228,20 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
               <StackItem>
                 <Truncate
                   content={profile.spec.identifiers
-                    .map((identifier) =>
-                      formatResource(
-                        identifier.displayName,
-                        identifier.defaultCount.toString(),
-                        identifier.defaultCount.toString(),
-                      ),
-                    )
+                    .map((identifier) => {
+                      const defaultVal = formatResourceValue(
+                        identifier.defaultCount,
+                        identifier.resourceType,
+                      ).toString();
+                      const maxVal =
+                        identifier.maxCount === undefined
+                          ? 'unrestricted'
+                          : formatResourceValue(
+                              identifier.maxCount,
+                              identifier.resourceType,
+                            ).toString();
+                      return formatResource(identifier.displayName, defaultVal, maxVal);
+                    })
                     .join('; ')}
                 />
               </StackItem>
@@ -339,13 +353,20 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                           getHardwareProfileDescription(hardwareProfileConfig.selectedProfile) ||
                           (hardwareProfileConfig.selectedProfile.spec.identifiers &&
                             hardwareProfileConfig.selectedProfile.spec.identifiers
-                              .map((identifier) =>
-                                formatResource(
-                                  identifier.displayName,
-                                  identifier.defaultCount.toString(),
-                                  identifier.defaultCount.toString(),
-                                ),
-                              )
+                              .map((identifier) => {
+                                const defaultVal = formatResourceValue(
+                                  identifier.defaultCount,
+                                  identifier.resourceType,
+                                ).toString();
+                                const maxVal =
+                                  identifier.maxCount === undefined
+                                    ? 'unrestricted'
+                                    : formatResourceValue(
+                                        identifier.maxCount,
+                                        identifier.resourceType,
+                                      ).toString();
+                                return formatResource(identifier.displayName, defaultVal, maxVal);
+                              })
                               .join('; '))
                         }
                       />

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -151,6 +151,17 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                 />
               </StackItem>
             )}
+            {profile.spec.scheduling?.kueue?.localQueueName && (
+              <StackItem>
+                <Truncate
+                  content={`Local queue: ${profile.spec.scheduling.kueue.localQueueName}${
+                    profile.spec.scheduling.kueue.priorityClass
+                      ? `, Priority: ${profile.spec.scheduling.kueue.priorityClass}`
+                      : ''
+                  }`}
+                />
+              </StackItem>
+            )}
           </Stack>
         ),
         dropdownLabel: (
@@ -218,6 +229,17 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                       ),
                     )
                     .join('; ')}
+                />
+              </StackItem>
+            )}
+            {profile.spec.scheduling?.kueue?.localQueueName && (
+              <StackItem>
+                <Truncate
+                  content={`Local queue: ${profile.spec.scheduling.kueue.localQueueName}${
+                    profile.spec.scheduling.kueue.priorityClass
+                      ? `, Priority: ${profile.spec.scheduling.kueue.priorityClass}`
+                      : ''
+                  }`}
                 />
               </StackItem>
             )}
@@ -328,6 +350,19 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                         }
                       />
                     </HelperTextItem>
+                    {(() => {
+                      const kueue = hardwareProfileConfig.selectedProfile.spec.scheduling?.kueue;
+                      if (!kueue?.localQueueName) {
+                        return null;
+                      }
+                      return (
+                        <HelperTextItem>
+                          {`Local queue: ${kueue.localQueueName}${
+                            kueue.priorityClass ? `, Priority: ${kueue.priorityClass}` : ''
+                          }`}
+                        </HelperTextItem>
+                      );
+                    })()}
                   </HelperText>
                 </FormHelperText>
               ) : hardwareProfileConfig.useExistingSettings ? (

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -430,7 +430,6 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
               nodeSelector={
                 hardwareProfileConfig.selectedProfile?.spec.scheduling?.node?.nodeSelector
               }
-              resources={hardwareProfileConfig.resources}
             />
           )}
         </FlexItem>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -156,7 +156,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                 <Truncate
                   content={`Local queue: ${profile.spec.scheduling.kueue.localQueueName}${
                     profile.spec.scheduling.kueue.priorityClass
-                      ? `, Priority: ${profile.spec.scheduling.kueue.priorityClass}`
+                      ? `; Priority: ${profile.spec.scheduling.kueue.priorityClass}`
                       : ''
                   }`}
                 />
@@ -237,7 +237,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                 <Truncate
                   content={`Local queue: ${profile.spec.scheduling.kueue.localQueueName}${
                     profile.spec.scheduling.kueue.priorityClass
-                      ? `, Priority: ${profile.spec.scheduling.kueue.priorityClass}`
+                      ? `; Priority: ${profile.spec.scheduling.kueue.priorityClass}`
                       : ''
                   }`}
                 />
@@ -359,7 +359,7 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                         return (
                           <HelperTextItem>
                             {`Local queue: ${kueue.localQueueName}${
-                              kueue.priorityClass ? `, Priority: ${kueue.priorityClass}` : ''
+                              kueue.priorityClass ? `; Priority: ${kueue.priorityClass}` : ''
                             }`}
                           </HelperTextItem>
                         );

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileSelect.tsx
@@ -350,19 +350,20 @@ const HardwareProfileSelect: React.FC<HardwareProfileSelectProps> = ({
                         }
                       />
                     </HelperTextItem>
-                    {(() => {
-                      const kueue = hardwareProfileConfig.selectedProfile.spec.scheduling?.kueue;
-                      if (!kueue?.localQueueName) {
-                        return null;
-                      }
-                      return (
-                        <HelperTextItem>
-                          {`Local queue: ${kueue.localQueueName}${
-                            kueue.priorityClass ? `, Priority: ${kueue.priorityClass}` : ''
-                          }`}
-                        </HelperTextItem>
-                      );
-                    })()}
+                    {!getHardwareProfileDescription(hardwareProfileConfig.selectedProfile) &&
+                      (() => {
+                        const kueue = hardwareProfileConfig.selectedProfile.spec.scheduling?.kueue;
+                        if (!kueue?.localQueueName) {
+                          return null;
+                        }
+                        return (
+                          <HelperTextItem>
+                            {`Local queue: ${kueue.localQueueName}${
+                              kueue.priorityClass ? `, Priority: ${kueue.priorityClass}` : ''
+                            }`}
+                          </HelperTextItem>
+                        );
+                      })()}
                   </HelperText>
                 </FormHelperText>
               ) : hardwareProfileConfig.useExistingSettings ? (

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -1,4 +1,4 @@
-import { Spinner, Flex, FlexItem, Popover, Tooltip } from '@patternfly/react-core';
+import { Button, Spinner, Flex, FlexItem, Popover, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -82,7 +82,9 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
                 content="No matching hardware profile found, using existing settings. Default, min, and max values are not available. Expand the row to view the current resource settings."
                 data-testid="hardware-profile-custom-tooltip"
               >
-                <i>Custom</i>
+                <Button isInline variant="plain">
+                  <i>Custom</i>
+                </Button>
               </Tooltip>
             )}
           </FlexItem>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -1,4 +1,4 @@
-import { Spinner, Flex, FlexItem, Popover } from '@patternfly/react-core';
+import { Spinner, Flex, FlexItem, Popover, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -71,15 +71,23 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
       >
         {bindingStateInfo?.state !== HardwareProfileBindingState.DELETED && (
           <FlexItem>
-            <HardwareProfileDetailsPopover
-              hardwareProfile={hardwareProfile}
-              resources={containerResources}
-              tolerations={hardwareProfile?.spec.scheduling?.node?.tolerations}
-              nodeSelector={hardwareProfile?.spec.scheduling?.node?.nodeSelector}
-              localQueueName={hardwareProfile?.spec.scheduling?.kueue?.localQueueName}
-              priorityClass={hardwareProfile?.spec.scheduling?.kueue?.priorityClass}
-              tableView
-            />
+            {hardwareProfile ? (
+              <HardwareProfileDetailsPopover
+                hardwareProfile={hardwareProfile}
+                tolerations={hardwareProfile.spec.scheduling?.node?.tolerations}
+                nodeSelector={hardwareProfile.spec.scheduling?.node?.nodeSelector}
+                localQueueName={hardwareProfile.spec.scheduling?.kueue?.localQueueName}
+                priorityClass={hardwareProfile.spec.scheduling?.kueue?.priorityClass}
+                tableView
+              />
+            ) : (
+              <Tooltip
+                content="No matching hardware profile found, using existing settings. Default, min, and max values are not available. Expand the row to view the current resource settings."
+                data-testid="hardware-profile-custom-tooltip"
+              >
+                <i>Custom</i>
+              </Tooltip>
+            )}
           </FlexItem>
         )}
         {isProjectScoped && hardwareProfile?.metadata.namespace === namespace && (

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -82,7 +82,7 @@ const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
                 content="No matching hardware profile found, using existing settings. Default, min, and max values are not available. Expand the row to view the current resource settings."
                 data-testid="hardware-profile-custom-tooltip"
               >
-                <Button isInline variant="plain">
+                <Button isInline variant="plain" aria-label="Custom hardware profile">
                   <i>Custom</i>
                 </Button>
               </Tooltip>

--- a/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
+++ b/frontend/src/concepts/hardwareProfiles/HardwareProfileTableColumn.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import type { ModelResourceType } from '@odh-dashboard/model-serving/extension-points';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { NotebookKind } from '#~/k8sTypes';
-import { ContainerResources } from '#~/types';
 import ScopedLabel from '#~/components/ScopedLabel';
 import { ScopedType } from '#~/pages/modelServing/screens/const';
 import { getHardwareProfileDisplayName } from '#~/pages/hardwareProfiles/utils';
@@ -19,7 +18,6 @@ import { HardwareProfileBindingStateInfo } from './types';
 type HardwareProfileTableColumnProps = {
   namespace: string;
   resource: NotebookKind | ModelResourceType;
-  containerResources: ContainerResources | undefined;
   isActive?: boolean;
   bindingState: {
     bindingStateInfo: HardwareProfileBindingStateInfo | null;
@@ -31,7 +29,6 @@ type HardwareProfileTableColumnProps = {
 const HardwareProfileTableColumn: React.FC<HardwareProfileTableColumnProps> = ({
   namespace,
   resource,
-  containerResources,
   isActive = false,
   bindingState,
 }) => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
+import { IdentifierResourceType, SchedulingType } from '#~/types';
+import HardwareProfileDetailsPopover from '../HardwareProfileDetailsPopover';
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider
+      value={
+        {
+          currentProject: { metadata: { name: 'test-project' } },
+          localQueues: DEFAULT_LIST_FETCH_STATE,
+        } as unknown as ProjectDetailsContextType
+      }
+    >
+      {ui}
+    </ProjectDetailsContext.Provider>,
+  );
+
+describe('HardwareProfileDetailsPopover', () => {
+  describe('with a matched hardware profile', () => {
+    it('should display the profile name in the popover trigger button', () => {
+      const profile = mockHardwareProfile({
+        displayName: 'Test Profile',
+      });
+
+      renderWithContext(
+        <HardwareProfileDetailsPopover hardwareProfile={profile} tableView />,
+      );
+
+      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
+        'Test Profile',
+      );
+    });
+
+    it('should display identifier details in the popover body', async () => {
+      const profile = mockHardwareProfile({
+        displayName: 'Test Profile',
+        identifiers: [
+          {
+            displayName: 'CPU',
+            identifier: 'cpu',
+            minCount: '1',
+            maxCount: '4',
+            defaultCount: '2',
+            resourceType: IdentifierResourceType.CPU,
+          },
+          {
+            displayName: 'Memory',
+            identifier: 'memory',
+            minCount: '2Gi',
+            maxCount: '8Gi',
+            defaultCount: '4Gi',
+            resourceType: IdentifierResourceType.MEMORY,
+          },
+        ],
+      });
+
+      renderWithContext(
+        <HardwareProfileDetailsPopover hardwareProfile={profile} />,
+      );
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).toHaveTextContent('CPU');
+      expect(details).toHaveTextContent('cpu: Default = 2 Cores | Min = 1 Cores | Max = 4 Cores');
+      expect(details).toHaveTextContent('Memory');
+      expect(details).toHaveTextContent(
+        'memory: Default = 4 GiB | Min = 2 GiB | Max = 8 GiB',
+      );
+    });
+
+    it('should display "View details" text in form view (non-tableView)', () => {
+      const profile = mockHardwareProfile({ displayName: 'Test Profile' });
+
+      renderWithContext(
+        <HardwareProfileDetailsPopover hardwareProfile={profile} />,
+      );
+
+      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
+        'View details',
+      );
+    });
+  });
+
+  describe('Custom scenario (no hardware profile)', () => {
+    it('should display informational message in popover body', async () => {
+      renderWithContext(<HardwareProfileDetailsPopover />);
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).toHaveTextContent(
+        'No matching hardware profile found, using existing settings. Default, min, and max values are not available.',
+      );
+    });
+
+    it('should display "Custom" in italic in table view', () => {
+      renderWithContext(<HardwareProfileDetailsPopover tableView />);
+
+      const button = screen.getByTestId('hardware-profile-details-popover');
+      expect(button).toHaveTextContent('Custom');
+      expect(button.querySelector('i')).toBeInTheDocument();
+    });
+
+    it('should display "View details" text in form view', () => {
+      renderWithContext(<HardwareProfileDetailsPopover />);
+
+      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
+        'View details',
+      );
+    });
+
+    it('should not display fallback resource values', async () => {
+      renderWithContext(<HardwareProfileDetailsPopover />);
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).not.toHaveTextContent('Request');
+      expect(details).not.toHaveTextContent('Limit');
+    });
+  });
+
+  describe('scheduling details', () => {
+    it('should display local queue and workload priority when provided', async () => {
+      const profile = mockHardwareProfile({
+        displayName: 'Queue Profile',
+        schedulingType: SchedulingType.QUEUE,
+        localQueueName: 'test-queue',
+        priorityClass: 'high-priority',
+      });
+
+      renderWithContext(
+        <HardwareProfileDetailsPopover
+          hardwareProfile={profile}
+          localQueueName="test-queue"
+          priorityClass="high-priority"
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
+
+      const details = screen.getByTestId('hardware-profile-details');
+      expect(details).toHaveTextContent('Local queue');
+      expect(details).toHaveTextContent('test-queue');
+      expect(details).toHaveTextContent('Workload priority');
+      expect(details).toHaveTextContent('high-priority');
+    });
+  });
+});

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -68,9 +68,9 @@ describe('HardwareProfileDetailsPopover', () => {
 
       const details = screen.getByTestId('hardware-profile-details');
       expect(details).toHaveTextContent('CPU');
-      expect(details).toHaveTextContent('cpu: Default = 2 Cores | Min = 1 Cores | Max = 4 Cores');
+      expect(details).toHaveTextContent('Default = 2 Cores | Min = 1 Cores | Max = 4 Cores');
       expect(details).toHaveTextContent('Memory');
-      expect(details).toHaveTextContent('memory: Default = 4 GiB | Min = 2 GiB | Max = 8 GiB');
+      expect(details).toHaveTextContent('Default = 4 GiB | Min = 2 GiB | Max = 8 GiB');
     });
 
     it('should display "View details" text in form view (non-tableView)', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -68,9 +68,9 @@ describe('HardwareProfileDetailsPopover', () => {
 
       const details = screen.getByTestId('hardware-profile-details');
       expect(details).toHaveTextContent('CPU');
-      expect(details).toHaveTextContent('Default = 2 Cores | Min = 1 Cores | Max = 4 Cores');
+      expect(details).toHaveTextContent('Default = 2 Cores, Min = 1 Cores, Max = 4 Cores');
       expect(details).toHaveTextContent('Memory');
-      expect(details).toHaveTextContent('Default = 4 GiB | Min = 2 GiB | Max = 8 GiB');
+      expect(details).toHaveTextContent('Default = 4 GiB, Min = 2 GiB, Max = 8 GiB');
     });
 
     it('should display "View details" text in form view (non-tableView)', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from '#~/pages/projects/ProjectDetailsContext';
 import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
 import { IdentifierResourceType, SchedulingType } from '#~/types';
-import HardwareProfileDetailsPopover from '../HardwareProfileDetailsPopover';
+import HardwareProfileDetailsPopover from '#~/concepts/hardwareProfiles/HardwareProfileDetailsPopover';
 
 const renderWithContext = (ui: React.ReactElement) =>
   render(
@@ -32,9 +32,7 @@ describe('HardwareProfileDetailsPopover', () => {
         displayName: 'Test Profile',
       });
 
-      renderWithContext(
-        <HardwareProfileDetailsPopover hardwareProfile={profile} tableView />,
-      );
+      renderWithContext(<HardwareProfileDetailsPopover hardwareProfile={profile} tableView />);
 
       expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
         'Test Profile',
@@ -64,9 +62,7 @@ describe('HardwareProfileDetailsPopover', () => {
         ],
       });
 
-      renderWithContext(
-        <HardwareProfileDetailsPopover hardwareProfile={profile} />,
-      );
+      renderWithContext(<HardwareProfileDetailsPopover hardwareProfile={profile} />);
 
       await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
 
@@ -74,17 +70,13 @@ describe('HardwareProfileDetailsPopover', () => {
       expect(details).toHaveTextContent('CPU');
       expect(details).toHaveTextContent('cpu: Default = 2 Cores | Min = 1 Cores | Max = 4 Cores');
       expect(details).toHaveTextContent('Memory');
-      expect(details).toHaveTextContent(
-        'memory: Default = 4 GiB | Min = 2 GiB | Max = 8 GiB',
-      );
+      expect(details).toHaveTextContent('memory: Default = 4 GiB | Min = 2 GiB | Max = 8 GiB');
     });
 
     it('should display "View details" text in form view (non-tableView)', () => {
       const profile = mockHardwareProfile({ displayName: 'Test Profile' });
 
-      renderWithContext(
-        <HardwareProfileDetailsPopover hardwareProfile={profile} />,
-      );
+      renderWithContext(<HardwareProfileDetailsPopover hardwareProfile={profile} />);
 
       expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
         'View details',

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -96,12 +96,10 @@ describe('HardwareProfileDetailsPopover', () => {
       );
     });
 
-    it('should display "Custom" in italic in table view', () => {
+    it('should display Custom label in table view', () => {
       renderWithContext(<HardwareProfileDetailsPopover tableView />);
 
-      const button = screen.getByTestId('hardware-profile-details-popover');
-      expect(button).toHaveTextContent('Custom');
-      expect(button.querySelector('i')).toBeInTheDocument();
+      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent('Custom');
     });
 
     it('should display "View details" text in form view', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -96,12 +96,6 @@ describe('HardwareProfileDetailsPopover', () => {
       );
     });
 
-    it('should display Custom label in table view', () => {
-      renderWithContext(<HardwareProfileDetailsPopover tableView />);
-
-      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent('Custom');
-    });
-
     it('should display "View details" text in form view', () => {
       renderWithContext(<HardwareProfileDetailsPopover />);
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileDetailsPopover.spec.tsx
@@ -104,14 +104,16 @@ describe('HardwareProfileDetailsPopover', () => {
       );
     });
 
-    it('should not display fallback resource values', async () => {
+    it('should contain only the fallback message with no resource details', async () => {
       renderWithContext(<HardwareProfileDetailsPopover />);
 
       await userEvent.click(screen.getByTestId('hardware-profile-details-popover'));
 
       const details = screen.getByTestId('hardware-profile-details');
-      expect(details).not.toHaveTextContent('Request');
-      expect(details).not.toHaveTextContent('Limit');
+      expect(details).toHaveTextContent(
+        'No matching hardware profile found, using existing settings. Default, min, and max values are not available.',
+      );
+      expect(details.querySelectorAll('dl')).toHaveLength(0);
     });
   });
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -7,7 +7,7 @@ import {
   ProjectDetailsContextType,
 } from '#~/pages/projects/ProjectDetailsContext';
 import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
-import HardwareProfileTableColumn from '../HardwareProfileTableColumn';
+import HardwareProfileTableColumn from '#~/concepts/hardwareProfiles/HardwareProfileTableColumn';
 
 jest.mock('#~/concepts/areas', () => ({
   ...jest.requireActual('#~/concepts/areas'),
@@ -55,7 +55,6 @@ describe('HardwareProfileTableColumn', () => {
         <HardwareProfileTableColumn
           namespace="test-project"
           resource={mockNotebookResource as never}
-          containerResources={undefined}
           bindingState={{
             bindingStateInfo: {
               profile,
@@ -78,7 +77,6 @@ describe('HardwareProfileTableColumn', () => {
         <HardwareProfileTableColumn
           namespace="test-project"
           resource={mockNotebookResource as never}
-          containerResources={undefined}
           bindingState={{
             bindingStateInfo: {
               profile: undefined,
@@ -102,7 +100,6 @@ describe('HardwareProfileTableColumn', () => {
         <HardwareProfileTableColumn
           namespace="test-project"
           resource={mockNotebookResource as never}
-          containerResources={undefined}
           bindingState={{
             bindingStateInfo: null,
             bindingStateLoaded: false,

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { mockHardwareProfile } from '#~/__mocks__/mockHardwareProfile';
+import {
+  ProjectDetailsContext,
+  ProjectDetailsContextType,
+} from '#~/pages/projects/ProjectDetailsContext';
+import { DEFAULT_LIST_FETCH_STATE } from '#~/utilities/const';
+import HardwareProfileTableColumn from '../HardwareProfileTableColumn';
+
+jest.mock('#~/concepts/areas', () => ({
+  ...jest.requireActual('#~/concepts/areas'),
+  useIsAreaAvailable: jest.fn().mockReturnValue({ status: false }),
+}));
+
+const mockNotebookResource = {
+  apiVersion: 'v1',
+  kind: 'Notebook',
+  metadata: {
+    name: 'test-notebook',
+    namespace: 'test-project',
+    annotations: {},
+    labels: {},
+  },
+  spec: {
+    template: {
+      spec: {
+        containers: [{ name: 'test-notebook', resources: {} }],
+      },
+    },
+  },
+};
+
+const renderWithContext = (ui: React.ReactElement) =>
+  render(
+    <ProjectDetailsContext.Provider
+      value={
+        {
+          currentProject: { metadata: { name: 'test-project' } },
+          localQueues: DEFAULT_LIST_FETCH_STATE,
+        } as unknown as ProjectDetailsContextType
+      }
+    >
+      {ui}
+    </ProjectDetailsContext.Provider>,
+  );
+
+describe('HardwareProfileTableColumn', () => {
+  describe('with a matched hardware profile', () => {
+    it('should render HardwareProfileDetailsPopover with profile name', () => {
+      const profile = mockHardwareProfile({ displayName: 'Test Profile' });
+
+      renderWithContext(
+        <HardwareProfileTableColumn
+          namespace="test-project"
+          resource={mockNotebookResource as never}
+          containerResources={undefined}
+          bindingState={{
+            bindingStateInfo: {
+              profile,
+            },
+            bindingStateLoaded: true,
+            loadError: undefined,
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('hardware-profile-details-popover')).toHaveTextContent(
+        'Test Profile',
+      );
+    });
+  });
+
+  describe('Custom scenario (no hardware profile)', () => {
+    it('should render italic Custom text instead of popover', () => {
+      renderWithContext(
+        <HardwareProfileTableColumn
+          namespace="test-project"
+          resource={mockNotebookResource as never}
+          containerResources={undefined}
+          bindingState={{
+            bindingStateInfo: {
+              profile: undefined,
+            },
+            bindingStateLoaded: true,
+            loadError: undefined,
+          }}
+        />,
+      );
+
+      const column = screen.getByTestId('hardware-profile-table-column');
+      expect(column).toHaveTextContent('Custom');
+      expect(column.querySelector('i')).toBeInTheDocument();
+      expect(screen.queryByTestId('hardware-profile-details-popover')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show spinner when binding state is not loaded', () => {
+      renderWithContext(
+        <HardwareProfileTableColumn
+          namespace="test-project"
+          resource={mockNotebookResource as never}
+          containerResources={undefined}
+          bindingState={{
+            bindingStateInfo: null,
+            bindingStateLoaded: false,
+            loadError: undefined,
+          }}
+        />,
+      );
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByTestId('hardware-profile-table-column')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/HardwareProfileTableColumn.spec.tsx
@@ -72,7 +72,7 @@ describe('HardwareProfileTableColumn', () => {
   });
 
   describe('Custom scenario (no hardware profile)', () => {
-    it('should render italic Custom text instead of popover', () => {
+    it('renders Custom text and no details popover', () => {
       renderWithContext(
         <HardwareProfileTableColumn
           namespace="test-project"
@@ -87,10 +87,27 @@ describe('HardwareProfileTableColumn', () => {
         />,
       );
 
-      const column = screen.getByTestId('hardware-profile-table-column');
-      expect(column).toHaveTextContent('Custom');
-      expect(column.querySelector('i')).toBeInTheDocument();
+      expect(screen.getByTestId('hardware-profile-table-column')).toHaveTextContent('Custom');
       expect(screen.queryByTestId('hardware-profile-details-popover')).not.toBeInTheDocument();
+    });
+
+    it('renders Custom trigger as a focusable element', () => {
+      renderWithContext(
+        <HardwareProfileTableColumn
+          namespace="test-project"
+          resource={mockNotebookResource as never}
+          bindingState={{
+            bindingStateInfo: {
+              profile: undefined,
+            },
+            bindingStateLoaded: true,
+            loadError: undefined,
+          }}
+        />,
+      );
+
+      const trigger = screen.getByText('Custom').closest('button');
+      expect(trigger).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getExistingHardwareProfileData,
   assemblePodSpecOptions,
   applyHardwareProfileConfig,
+  formatIdentifierDetails,
 } from '#~/concepts/hardwareProfiles/utils';
 import { HardwareProfileKind } from '#~/k8sTypes';
 import {
@@ -20,6 +21,59 @@ import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/use
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
+
+describe('formatIdentifierDetails', () => {
+  it('should format CPU identifier with default, min, and max', () => {
+    const identifier: Identifier = {
+      displayName: 'CPU',
+      identifier: 'cpu',
+      minCount: '1',
+      maxCount: '8',
+      defaultCount: '2',
+      resourceType: IdentifierResourceType.CPU,
+    };
+    expect(formatIdentifierDetails(identifier)).toBe(
+      'Default = 2 Cores, Min = 1 Cores, Max = 8 Cores',
+    );
+  });
+
+  it('should format memory identifier with proper units', () => {
+    const identifier: Identifier = {
+      displayName: 'Memory',
+      identifier: 'memory',
+      minCount: '2Gi',
+      maxCount: '16Gi',
+      defaultCount: '4Gi',
+      resourceType: IdentifierResourceType.MEMORY,
+    };
+    expect(formatIdentifierDetails(identifier)).toBe('Default = 4 GiB, Min = 2 GiB, Max = 16 GiB');
+  });
+
+  it('should show "unrestricted" when maxCount is undefined', () => {
+    const identifier: Identifier = {
+      displayName: 'Memory',
+      identifier: 'memory',
+      minCount: '2Gi',
+      defaultCount: '4Gi',
+      resourceType: IdentifierResourceType.MEMORY,
+    };
+    expect(formatIdentifierDetails(identifier)).toBe(
+      'Default = 4 GiB, Min = 2 GiB, Max = unrestricted',
+    );
+  });
+
+  it('should format accelerator identifier with numeric values', () => {
+    const identifier: Identifier = {
+      displayName: 'NVIDIA GPU',
+      identifier: 'nvidia.com/gpu',
+      minCount: 0,
+      maxCount: 4,
+      defaultCount: 1,
+      resourceType: IdentifierResourceType.ACCELERATOR,
+    };
+    expect(formatIdentifierDetails(identifier)).toBe('Default = 1, Min = 0, Max = 4');
+  });
+});
 
 describe('sortIdentifiers', () => {
   it('should sort CPU and memory first, followed by other identifiers', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -33,7 +33,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.CPU,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'Default = 2 Cores, Min = 1 Cores, Max = 8 Cores',
+      'cpu: Default = 2 Cores | Min = 1 Cores | Max = 8 Cores',
     );
   });
 
@@ -46,7 +46,9 @@ describe('formatIdentifierDetails', () => {
       defaultCount: '4Gi',
       resourceType: IdentifierResourceType.MEMORY,
     };
-    expect(formatIdentifierDetails(identifier)).toBe('Default = 4 GiB, Min = 2 GiB, Max = 16 GiB');
+    expect(formatIdentifierDetails(identifier)).toBe(
+      'memory: Default = 4 GiB | Min = 2 GiB | Max = 16 GiB',
+    );
   });
 
   it('should show "unrestricted" when maxCount is undefined', () => {
@@ -58,7 +60,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.MEMORY,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'Default = 4 GiB, Min = 2 GiB, Max = unrestricted',
+      'memory: Default = 4 GiB | Min = 2 GiB | Max = unrestricted',
     );
   });
 
@@ -71,7 +73,9 @@ describe('formatIdentifierDetails', () => {
       defaultCount: 1,
       resourceType: IdentifierResourceType.ACCELERATOR,
     };
-    expect(formatIdentifierDetails(identifier)).toBe('Default = 1, Min = 0, Max = 4');
+    expect(formatIdentifierDetails(identifier)).toBe(
+      'nvidia.com/gpu: Default = 1 | Min = 0 | Max = 4',
+    );
   });
 });
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -33,7 +33,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.CPU,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'cpu: Default = 2 Cores | Min = 1 Cores | Max = 8 Cores',
+      'Default = 2 Cores | Min = 1 Cores | Max = 8 Cores',
     );
   });
 
@@ -47,7 +47,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.MEMORY,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'memory: Default = 4 GiB | Min = 2 GiB | Max = 16 GiB',
+      'Default = 4 GiB | Min = 2 GiB | Max = 16 GiB',
     );
   });
 
@@ -60,7 +60,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.MEMORY,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'memory: Default = 4 GiB | Min = 2 GiB | Max = unrestricted',
+      'Default = 4 GiB | Min = 2 GiB | Max = unrestricted',
     );
   });
 
@@ -73,9 +73,7 @@ describe('formatIdentifierDetails', () => {
       defaultCount: 1,
       resourceType: IdentifierResourceType.ACCELERATOR,
     };
-    expect(formatIdentifierDetails(identifier)).toBe(
-      'nvidia.com/gpu: Default = 1 | Min = 0 | Max = 4',
-    );
+    expect(formatIdentifierDetails(identifier)).toBe('Default = 1 | Min = 0 | Max = 4');
   });
 });
 

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   assemblePodSpecOptions,
   applyHardwareProfileConfig,
   formatIdentifierDetails,
+  formatResource,
 } from '#~/concepts/hardwareProfiles/utils';
 import { HardwareProfileKind } from '#~/k8sTypes';
 import {
@@ -21,6 +22,20 @@ import { UseHardwareProfileConfigResult } from '#~/concepts/hardwareProfiles/use
 import { NOTEBOOK_HARDWARE_PROFILE_PATHS } from '#~/concepts/notebooks/const.ts';
 
 global.structuredClone = (val: unknown) => JSON.parse(JSON.stringify(val));
+
+describe('formatResource', () => {
+  it('should format with Default and Max labels separated by comma', () => {
+    expect(formatResource('CPU', '2 Cores', '8 Cores')).toBe(
+      'CPU: Default = 2 Cores, Max = 8 Cores',
+    );
+  });
+
+  it('should handle unrestricted max', () => {
+    expect(formatResource('Memory', '4 GiB', 'unrestricted')).toBe(
+      'Memory: Default = 4 GiB, Max = unrestricted',
+    );
+  });
+});
 
 describe('formatIdentifierDetails', () => {
   it('should format CPU identifier with default, min, and max', () => {

--- a/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/hardwareProfiles/__tests__/utils.spec.ts
@@ -48,7 +48,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.CPU,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'Default = 2 Cores | Min = 1 Cores | Max = 8 Cores',
+      'Default = 2 Cores, Min = 1 Cores, Max = 8 Cores',
     );
   });
 
@@ -61,9 +61,7 @@ describe('formatIdentifierDetails', () => {
       defaultCount: '4Gi',
       resourceType: IdentifierResourceType.MEMORY,
     };
-    expect(formatIdentifierDetails(identifier)).toBe(
-      'Default = 4 GiB | Min = 2 GiB | Max = 16 GiB',
-    );
+    expect(formatIdentifierDetails(identifier)).toBe('Default = 4 GiB, Min = 2 GiB, Max = 16 GiB');
   });
 
   it('should show "unrestricted" when maxCount is undefined', () => {
@@ -75,7 +73,7 @@ describe('formatIdentifierDetails', () => {
       resourceType: IdentifierResourceType.MEMORY,
     };
     expect(formatIdentifierDetails(identifier)).toBe(
-      'Default = 4 GiB | Min = 2 GiB | Max = unrestricted',
+      'Default = 4 GiB, Min = 2 GiB, Max = unrestricted',
     );
   });
 
@@ -88,7 +86,7 @@ describe('formatIdentifierDetails', () => {
       defaultCount: 1,
       resourceType: IdentifierResourceType.ACCELERATOR,
     };
-    expect(formatIdentifierDetails(identifier)).toBe('Default = 1 | Min = 0 | Max = 4');
+    expect(formatIdentifierDetails(identifier)).toBe('Default = 1, Min = 0, Max = 4');
   });
 });
 

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -65,7 +65,7 @@ export const formatIdentifierDetails = (identifier: Identifier): string => {
     identifier.maxCount === undefined
       ? 'unrestricted'
       : formatResourceValue(identifier.maxCount, identifier.resourceType).toString();
-  return `${identifier.identifier}: Default = ${defaultVal} | Min = ${minVal} | Max = ${maxVal}`;
+  return `Default = ${defaultVal} | Min = ${minVal} | Max = ${maxVal}`;
 };
 
 /**

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -65,7 +65,7 @@ export const formatIdentifierDetails = (identifier: Identifier): string => {
     identifier.maxCount === undefined
       ? 'unrestricted'
       : formatResourceValue(identifier.maxCount, identifier.resourceType).toString();
-  return `Default = ${defaultVal}, Min = ${minVal}, Max = ${maxVal}`;
+  return `${identifier.identifier}: Default = ${defaultVal} | Min = ${minVal} | Max = ${maxVal}`;
 };
 
 /**

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -68,7 +68,7 @@ export const formatIdentifierDetails = (identifier: Identifier): string => {
     identifier.maxCount === undefined
       ? 'unrestricted'
       : formatResourceValue(identifier.maxCount, identifier.resourceType).toString();
-  return `Default = ${defaultVal} | Min = ${minVal} | Max = ${maxVal}`;
+  return `Default = ${defaultVal}, Min = ${minVal}, Max = ${maxVal}`;
 };
 
 /**

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -52,8 +52,11 @@ export const formatToleration = (toleration: Toleration): string => {
 export const formatNodeSelector = (selector: NodeSelector): string[] =>
   Object.entries(selector).map(([key, value]) => `Key = ${key}; Value = ${value}`);
 
-export const formatResource = (identifier: string, request: string, limit: string): string =>
-  `${identifier}: Request = ${request}, Limit = ${limit}`;
+export const formatResource = (
+  identifier: string,
+  defaultCount: string,
+  maxCount: string,
+): string => `${identifier}: Default = ${defaultCount}, Max = ${maxCount}`;
 
 export const formatIdentifierDetails = (identifier: Identifier): string => {
   const defaultVal = formatResourceValue(

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -55,6 +55,19 @@ export const formatNodeSelector = (selector: NodeSelector): string[] =>
 export const formatResource = (identifier: string, request: string, limit: string): string =>
   `${identifier}: Request = ${request}; Limit = ${limit}`;
 
+export const formatIdentifierDetails = (identifier: Identifier): string => {
+  const defaultVal = formatResourceValue(
+    identifier.defaultCount,
+    identifier.resourceType,
+  ).toString();
+  const minVal = formatResourceValue(identifier.minCount, identifier.resourceType).toString();
+  const maxVal =
+    identifier.maxCount === undefined
+      ? 'unrestricted'
+      : formatResourceValue(identifier.maxCount, identifier.resourceType).toString();
+  return `Default = ${defaultVal}, Min = ${minVal}, Max = ${maxVal}`;
+};
+
 /**
  * changed order of arguments so that the deprecated accelerator profile is last;
  * to make it optional.

--- a/frontend/src/concepts/hardwareProfiles/utils.ts
+++ b/frontend/src/concepts/hardwareProfiles/utils.ts
@@ -53,7 +53,7 @@ export const formatNodeSelector = (selector: NodeSelector): string[] =>
   Object.entries(selector).map(([key, value]) => `Key = ${key}; Value = ${value}`);
 
 export const formatResource = (identifier: string, request: string, limit: string): string =>
-  `${identifier}: Request = ${request}; Limit = ${limit}`;
+  `${identifier}: Request = ${request}, Limit = ${limit}`;
 
 export const formatIdentifierDetails = (identifier: Identifier): string => {
   const defaultVal = formatResourceValue(

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -222,7 +222,6 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
               <HardwareProfileTableColumn
                 namespace={obj.notebook.metadata.namespace}
                 resource={obj.notebook}
-                containerResources={podSpecOptionsState.podSpecOptions.resources}
                 isActive={obj.isRunning || obj.isStarting}
                 bindingState={{
                   bindingStateInfo,

--- a/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/applications/notebookServer.cy.ts
@@ -240,7 +240,7 @@ describe('NotebookServer', () => {
     notebookServer
       .findHardwareProfileSelect()
       .findSelectOption(
-        'Large Profile CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+        'Large Profile CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
       )
       .click();
     notebookServer.findHardwareProfileSelect().should('contain', 'Large');

--- a/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/hardwareProfiles/workbenchHardwareProfiles.cy.ts
@@ -131,10 +131,10 @@ describe('Workbench Hardware Profiles', () => {
 
     // Verify available profiles
     hardwareProfileSection.selectProfile(
-      'Small Profile CPU: Request = 1 Cores; Limit = 1 Cores; Memory: Request = 2 GiB; Limit = 2 GiB',
+      'Small Profile CPU: Default = 1 Cores, Max = 2 Cores; Memory: Default = 2 GiB, Max = 4 GiB',
     );
     hardwareProfileSection.selectProfile(
-      'Large Profile CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+      'Large Profile CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
     );
   });
 
@@ -215,7 +215,7 @@ describe('Workbench Hardware Profiles', () => {
     projectScopedHardwareProfile
       .find()
       .findByRole('menuitem', {
-        name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+        name: 'Small Profile CPU: Default = 1 Cores, Max = 2 Cores; Memory: Default = 2 GiB, Max = 4 GiB',
         hidden: true,
       })
       .click();
@@ -227,7 +227,7 @@ describe('Workbench Hardware Profiles', () => {
     globalScopedHardwareProfile
       .find()
       .findByRole('menuitem', {
-        name: 'Small Profile CPU: Request = 1; Limit = 1; Memory: Request = 2Gi; Limit = 2Gi',
+        name: 'Small Profile CPU: Default = 1 Cores, Max = 2 Cores; Memory: Default = 2 GiB, Max = 4 GiB',
         hidden: true,
       })
       .click();
@@ -285,7 +285,7 @@ describe('Workbench Hardware Profiles', () => {
 
     // Select profile and open customization
     hardwareProfileSection.selectProfile(
-      'Large Profile CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+      'Large Profile CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
     );
     hardwareProfileSection.findCustomizeButton().click();
 

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -561,7 +561,7 @@ describe('Model Serving LLMD', () => {
       hardwareProfileSection.findSelect().should('exist');
       hardwareProfileSection.findSelect().should('contain.text', 'Small');
       hardwareProfileSection.selectProfile(
-        'Large Profile Compatible CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+        'Large Profile Compatible CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
       );
       modelServingWizardEdit
         .findServingRuntimeTemplateSearchSelector()
@@ -806,7 +806,7 @@ describe('Model Serving LLMD', () => {
 
       // Step 2: Model deployment — select a compatible hardware profile for the deployment's resources
       hardwareProfileSection.selectProfile(
-        'Large Profile Compatible CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+        'Large Profile Compatible CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
       );
       modelServingWizardEdit.findNextButton().should('be.enabled').click();
 

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -261,7 +261,7 @@ describe('MaaS Deployment Wizard', () => {
     hardwareProfileSection.findSelect().should('exist');
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
     hardwareProfileSection.selectProfile(
-      'Large Profile Compatible CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+      'Large Profile Compatible CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
     );
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 
@@ -326,7 +326,7 @@ describe('MaaS Deployment Wizard', () => {
     hardwareProfileSection.findSelect().should('exist');
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
     hardwareProfileSection.selectProfile(
-      'Large Profile Compatible CPU: Request = 4 Cores; Limit = 4 Cores; Memory: Request = 8 GiB; Limit = 8 GiB',
+      'Large Profile Compatible CPU: Default = 4 Cores, Max = 8 Cores; Memory: Default = 8 GiB, Max = 16 GiB',
     );
     modelServingWizardEdit.findNextButton().should('be.enabled').click();
 

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
@@ -41,7 +41,7 @@ describe('DeploymentHardwareProfileCell', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('should render HardwareProfileTableColumn with the correct namespace', () => {

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { mockUseAssignHardwareProfileResult } from '@odh-dashboard/internal/__mocks__/mockUseAssignHardwareProfileResult';
+import { useAssignHardwareProfile } from '@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile';
+import type { ContainerResources } from '@odh-dashboard/internal/types';
+import { mockExtensions } from '../../../__tests__/mockUtils';
+import { DeploymentHardwareProfileCell } from '../row/DeploymentHardwareProfileCell';
+
+jest.mock('@odh-dashboard/plugin-core');
+
+jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile', () => ({
+  useAssignHardwareProfile: jest.fn(),
+}));
+
+jest.mock(
+  '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState',
+  () => ({
+    useHardwareProfileBindingState: () => [null, true, undefined],
+  }),
+);
+
+jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfileTableColumn', () => {
+  const MockHardwareProfileTableColumn = (props: { containerResources?: ContainerResources }) => (
+    <td
+      data-testid="hardware-profile-table-column"
+      data-resources={JSON.stringify(props.containerResources)}
+    >
+      Hardware Profile
+    </td>
+  );
+  MockHardwareProfileTableColumn.displayName = 'MockHardwareProfileTableColumn';
+  return { __esModule: true, default: MockHardwareProfileTableColumn };
+});
+
+const mockUseAssignHardwareProfile = jest.mocked(useAssignHardwareProfile);
+
+const mockDeployment = () => ({
+  modelServingPlatformId: 'test-platform',
+  model: {
+    apiVersion: 'v1',
+    kind: 'TestModelKind',
+    metadata: {
+      name: 'test-deployment',
+      namespace: 'test-project',
+    },
+  },
+});
+
+describe('DeploymentHardwareProfileCell', () => {
+  beforeEach(() => {
+    mockExtensions();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should pass podSpecOptions.resources to HardwareProfileTableColumn', () => {
+    const podSpecResources: ContainerResources = {
+      requests: { cpu: '4', memory: '8Gi' },
+      limits: { cpu: '8', memory: '16Gi' },
+    };
+    const formDataResources: ContainerResources = {
+      requests: { cpu: '1', memory: '2Gi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    };
+
+    const result = mockUseAssignHardwareProfileResult({
+      resources: podSpecResources,
+    });
+    result.podSpecOptionsState.hardwareProfile.formData.resources = formDataResources;
+
+    mockUseAssignHardwareProfile.mockReturnValue(result);
+
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <DeploymentHardwareProfileCell
+              deployment={mockDeployment()}
+              hardwareProfilePaths={{
+                containerResourcesPath: 'spec.predictor.model.resources',
+                tolerationsPath: 'spec.predictor.tolerations',
+                nodeSelectorPath: 'spec.predictor.nodeSelector',
+              }}
+            />
+          </tr>
+        </tbody>
+      </table>,
+    );
+
+    const column = screen.getByTestId('hardware-profile-table-column');
+    const resources = JSON.parse(column.getAttribute('data-resources') ?? '{}');
+
+    expect(resources).toEqual(podSpecResources);
+    expect(resources).not.toEqual(formDataResources);
+  });
+});

--- a/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
+++ b/packages/model-serving/src/components/deployments/__tests__/DeploymentHardwareProfileCell.spec.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { mockUseAssignHardwareProfileResult } from '@odh-dashboard/internal/__mocks__/mockUseAssignHardwareProfileResult';
-import { useAssignHardwareProfile } from '@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile';
-import type { ContainerResources } from '@odh-dashboard/internal/types';
 import { mockExtensions } from '../../../__tests__/mockUtils';
 import { DeploymentHardwareProfileCell } from '../row/DeploymentHardwareProfileCell';
 
 jest.mock('@odh-dashboard/plugin-core');
-
-jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile', () => ({
-  useAssignHardwareProfile: jest.fn(),
-}));
 
 jest.mock(
   '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState',
@@ -21,19 +14,14 @@ jest.mock(
 );
 
 jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfileTableColumn', () => {
-  const MockHardwareProfileTableColumn = (props: { containerResources?: ContainerResources }) => (
-    <td
-      data-testid="hardware-profile-table-column"
-      data-resources={JSON.stringify(props.containerResources)}
-    >
+  const MockHardwareProfileTableColumn = (props: { namespace: string }) => (
+    <td data-testid="hardware-profile-table-column" data-namespace={props.namespace}>
       Hardware Profile
     </td>
   );
   MockHardwareProfileTableColumn.displayName = 'MockHardwareProfileTableColumn';
   return { __esModule: true, default: MockHardwareProfileTableColumn };
 });
-
-const mockUseAssignHardwareProfile = jest.mocked(useAssignHardwareProfile);
 
 const mockDeployment = () => ({
   modelServingPlatformId: 'test-platform',
@@ -56,44 +44,19 @@ describe('DeploymentHardwareProfileCell', () => {
     jest.resetAllMocks();
   });
 
-  it('should pass podSpecOptions.resources to HardwareProfileTableColumn', () => {
-    const podSpecResources: ContainerResources = {
-      requests: { cpu: '4', memory: '8Gi' },
-      limits: { cpu: '8', memory: '16Gi' },
-    };
-    const formDataResources: ContainerResources = {
-      requests: { cpu: '1', memory: '2Gi' },
-      limits: { cpu: '2', memory: '4Gi' },
-    };
-
-    const result = mockUseAssignHardwareProfileResult({
-      resources: podSpecResources,
-    });
-    result.podSpecOptionsState.hardwareProfile.formData.resources = formDataResources;
-
-    mockUseAssignHardwareProfile.mockReturnValue(result);
-
+  it('should render HardwareProfileTableColumn with the correct namespace', () => {
     render(
       <table>
         <tbody>
           <tr>
-            <DeploymentHardwareProfileCell
-              deployment={mockDeployment()}
-              hardwareProfilePaths={{
-                containerResourcesPath: 'spec.predictor.model.resources',
-                tolerationsPath: 'spec.predictor.tolerations',
-                nodeSelectorPath: 'spec.predictor.nodeSelector',
-              }}
-            />
+            <DeploymentHardwareProfileCell deployment={mockDeployment()} />
           </tr>
         </tbody>
       </table>,
     );
 
     const column = screen.getByTestId('hardware-profile-table-column');
-    const resources = JSON.parse(column.getAttribute('data-resources') ?? '{}');
-
-    expect(resources).toEqual(podSpecResources);
-    expect(resources).not.toEqual(formDataResources);
+    expect(column).toBeInTheDocument();
+    expect(column).toHaveAttribute('data-namespace', 'test-project');
   });
 });

--- a/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
@@ -2,24 +2,15 @@ import React from 'react';
 import { Td } from '@patternfly/react-table';
 import HardwareProfileTableColumn from '@odh-dashboard/internal/concepts/hardwareProfiles/HardwareProfileTableColumn';
 import { useHardwareProfileBindingState } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileBindingState';
-import { useAssignHardwareProfile } from '@odh-dashboard/internal/concepts/hardwareProfiles/useAssignHardwareProfile';
 import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
-import type { CrPathConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/types';
 import { type Deployment } from '../../../../extension-points';
 
 type DeploymentHardwareProfileCellProps = {
   deployment: Deployment;
-  hardwareProfilePaths: CrPathConfig;
 };
 
 export const DeploymentHardwareProfileCell: React.FC<DeploymentHardwareProfileCellProps> =
-  React.memo(function DeploymentHardwareProfileCell({ deployment, hardwareProfilePaths }) {
-    const hardwareProfileOptions = useAssignHardwareProfile(deployment.model, {
-      visibleIn: MODEL_SERVING_VISIBILITY,
-      paths: hardwareProfilePaths,
-    });
-
-    const containerResources = hardwareProfileOptions.podSpecOptionsState.podSpecOptions.resources;
+  React.memo(function DeploymentHardwareProfileCell({ deployment }) {
     const [bindingStateInfo, bindingStateLoaded, bindingStateLoadError] =
       useHardwareProfileBindingState(deployment.model, MODEL_SERVING_VISIBILITY);
 
@@ -28,7 +19,6 @@ export const DeploymentHardwareProfileCell: React.FC<DeploymentHardwareProfileCe
         <HardwareProfileTableColumn
           namespace={deployment.model.metadata.namespace}
           resource={deployment.model}
-          containerResources={containerResources}
           isActive={
             deployment.status?.stoppedStates?.isRunning ||
             deployment.status?.stoppedStates?.isStarting

--- a/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentHardwareProfileCell.tsx
@@ -9,7 +9,7 @@ import { type Deployment } from '../../../../extension-points';
 
 type DeploymentHardwareProfileCellProps = {
   deployment: Deployment;
-  hardwareProfilePaths?: CrPathConfig;
+  hardwareProfilePaths: CrPathConfig;
 };
 
 export const DeploymentHardwareProfileCell: React.FC<DeploymentHardwareProfileCellProps> =
@@ -19,8 +19,7 @@ export const DeploymentHardwareProfileCell: React.FC<DeploymentHardwareProfileCe
       paths: hardwareProfilePaths,
     });
 
-    const containerResources =
-      hardwareProfileOptions.podSpecOptionsState.hardwareProfile.formData.resources;
+    const containerResources = hardwareProfileOptions.podSpecOptionsState.podSpecOptions.resources;
     const [bindingStateInfo, bindingStateLoaded, bindingStateLoadError] =
       useHardwareProfileBindingState(deployment.model, MODEL_SERVING_VISIBILITY);
 

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 import { Td, Tbody } from '@patternfly/react-table';
 import ResourceActionsColumn from '@odh-dashboard/internal/components/ResourceActionsColumn';
 import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
@@ -139,10 +140,16 @@ export const DeploymentRow: React.FC<{
             stoppedStates={deployment.status?.stoppedStates}
           />
         </Td>
-        <DeploymentHardwareProfileCell
-          deployment={deployment}
-          hardwareProfilePaths={hardwareProfilePaths}
-        />
+        {pathsLoaded ? (
+          <DeploymentHardwareProfileCell
+            deployment={deployment}
+            hardwareProfilePaths={hardwareProfilePaths}
+          />
+        ) : (
+          <Td dataLabel="Hardware profile">
+            <Spinner size="md" />
+          </Td>
+        )}
         <Td dataLabel="Last deployed">
           <DeploymentLastDeployed deployment={deployment} />
         </Td>

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -143,9 +143,7 @@ export const DeploymentRow: React.FC<{
         {pathsLoaded ? (
           <DeploymentHardwareProfileCell deployment={deployment} />
         ) : (
-          <Td dataLabel="Hardware profile">
-            <Spinner size="md" />
-          </Td>
+          <Td dataLabel="Hardware profile">{formDataResolved ? '-' : <Spinner size="md" />}</Td>
         )}
         <Td dataLabel="Last deployed">
           <DeploymentLastDeployed deployment={deployment} />

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -141,10 +141,7 @@ export const DeploymentRow: React.FC<{
           />
         </Td>
         {pathsLoaded ? (
-          <DeploymentHardwareProfileCell
-            deployment={deployment}
-            hardwareProfilePaths={hardwareProfilePaths}
-          />
+          <DeploymentHardwareProfileCell deployment={deployment} />
         ) : (
           <Td dataLabel="Hardware profile">
             <Spinner size="md" />

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -140,10 +140,12 @@ export const DeploymentRow: React.FC<{
             stoppedStates={deployment.status?.stoppedStates}
           />
         </Td>
-        {pathsLoaded ? (
+        {formDataResolved ? (
           <DeploymentHardwareProfileCell deployment={deployment} />
         ) : (
-          <Td dataLabel="Hardware profile">{formDataResolved ? '-' : <Spinner size="md" />}</Td>
+          <Td dataLabel="Hardware profile">
+            <Spinner size="md" />
+          </Td>
         )}
         <Td dataLabel="Last deployed">
           <DeploymentLastDeployed deployment={deployment} />

--- a/packages/notebooks/upstream/workspaces/frontend/package-lock.json
+++ b/packages/notebooks/upstream/workspaces/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "lodash-es": "^4.17.15",
         "mod-arch-core": "^1.10.2",
         "mod-arch-kubeflow": "^1.10.2",
-        "mod-arch-shared": "^1.15.4",
+        "mod-arch-shared": "^1.10.2",
         "react": "^18",
         "react-dom": "^18",
         "react-router": "^7.5.2",
@@ -12557,10 +12557,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -21155,12 +21154,12 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.16.0.tgz",
-      "integrity": "sha512-Sx1imQU1NS0+XreHlV8fmFFHZUhXiFrEuEBWTTXmqv97nKTGUvTzaHVfMiUoD2oAaDQ1aRDmfnvBd4zbjrM3LA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.11.0.tgz",
+      "integrity": "sha512-QFHobWbeiE69D/RFCfNmbug64xHt/2lyGBP0kV4FvgyIQ2slpNuB8fWcjpmI549cD2QukPvaxsVAlou307hFWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.18.1",
+        "lodash-es": "^4.17.23",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21188,9 +21187,9 @@
       }
     },
     "node_modules/mod-arch-kubeflow": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.16.0.tgz",
-      "integrity": "sha512-597RBSJanHPhtB4miAgyNKQOIotEwqvtry5X4tWk8NUEwXnmZtBKTmm5NXAbPqMYu0XoEPPD9m9peirXXbgWKw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.11.0.tgz",
+      "integrity": "sha512-NY6DEq9huV04z9X0chvkKkNl+4ZE3AKM9SG0XkaZQDTUst7xcYfPrCRlqbi3JYjEH66NCrb+T++UxkS2asGSPw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -21218,16 +21217,16 @@
       }
     },
     "node_modules/mod-arch-shared": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.16.0.tgz",
-      "integrity": "sha512-EOzCM4gbGFRMmEjUMjCbn3AGuEdtd8/+8jS1ssjvGAYbvoilHSqpV5kCNnJO5ICuWAljIGkQgHQbS/QBiugRNQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.11.0.tgz",
+      "integrity": "sha512-iWlrba4Gd5WJdRP9L8gHcWu2c4xaNGRFkF+8uyu7a6Ajq99RIFRe5muBIN5u2lwo2ixE6ZGBQx9ex65Blep+fA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-drag-drop": "^6.4.0",
         "classnames": "^2.2.6",
-        "dompurify": "^3.3.2",
-        "lodash-es": "^4.18.1",
+        "dompurify": "^3.2.4",
+        "lodash-es": "^4.17.23",
         "showdown": "^2.1.0"
       },
       "engines": {
@@ -21250,8 +21249,8 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
-        "mod-arch-core": ">=1.16.0",
-        "mod-arch-kubeflow": ">=1.16.0",
+        "mod-arch-core": ">=1.11.0",
+        "mod-arch-kubeflow": ">=1.11.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"

--- a/packages/notebooks/upstream/workspaces/frontend/package-lock.json
+++ b/packages/notebooks/upstream/workspaces/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "lodash-es": "^4.17.15",
         "mod-arch-core": "^1.10.2",
         "mod-arch-kubeflow": "^1.10.2",
-        "mod-arch-shared": "^1.10.2",
+        "mod-arch-shared": "^1.15.4",
         "react": "^18",
         "react-dom": "^18",
         "react-router": "^7.5.2",
@@ -12557,9 +12557,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -21154,12 +21155,12 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.11.0.tgz",
-      "integrity": "sha512-QFHobWbeiE69D/RFCfNmbug64xHt/2lyGBP0kV4FvgyIQ2slpNuB8fWcjpmI549cD2QukPvaxsVAlou307hFWw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.16.0.tgz",
+      "integrity": "sha512-Sx1imQU1NS0+XreHlV8fmFFHZUhXiFrEuEBWTTXmqv97nKTGUvTzaHVfMiUoD2oAaDQ1aRDmfnvBd4zbjrM3LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.23",
+        "lodash-es": "^4.18.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21187,9 +21188,9 @@
       }
     },
     "node_modules/mod-arch-kubeflow": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.11.0.tgz",
-      "integrity": "sha512-NY6DEq9huV04z9X0chvkKkNl+4ZE3AKM9SG0XkaZQDTUst7xcYfPrCRlqbi3JYjEH66NCrb+T++UxkS2asGSPw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.16.0.tgz",
+      "integrity": "sha512-597RBSJanHPhtB4miAgyNKQOIotEwqvtry5X4tWk8NUEwXnmZtBKTmm5NXAbPqMYu0XoEPPD9m9peirXXbgWKw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -21217,16 +21218,16 @@
       }
     },
     "node_modules/mod-arch-shared": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.11.0.tgz",
-      "integrity": "sha512-iWlrba4Gd5WJdRP9L8gHcWu2c4xaNGRFkF+8uyu7a6Ajq99RIFRe5muBIN5u2lwo2ixE6ZGBQx9ex65Blep+fA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.16.0.tgz",
+      "integrity": "sha512-EOzCM4gbGFRMmEjUMjCbn3AGuEdtd8/+8jS1ssjvGAYbvoilHSqpV5kCNnJO5ICuWAljIGkQgHQbS/QBiugRNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-drag-drop": "^6.4.0",
         "classnames": "^2.2.6",
-        "dompurify": "^3.2.4",
-        "lodash-es": "^4.17.23",
+        "dompurify": "^3.3.2",
+        "lodash-es": "^4.18.1",
         "showdown": "^2.1.0"
       },
       "engines": {
@@ -21249,8 +21250,8 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
-        "mod-arch-core": ">=1.11.0",
-        "mod-arch-kubeflow": ">=1.11.0",
+        "mod-arch-core": ">=1.16.0",
+        "mod-arch-kubeflow": ">=1.16.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-48792

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The hardware profile popover was displaying pod spec resource values (request/limit), which could be confusing — especially in the deployments table where a race condition caused it to show the hardware profile's **default** values instead of actual deployment resources. After discussion with UX, the popover has been redesigned to show **admin-configured hardware profile settings** (default, min, max) instead of pod spec values. Pod spec values remain visible in the expanded row.

### Changes
**Bug fix (race condition):**
- **`DeploymentsTableRow.tsx`**: Gate `DeploymentHardwareProfileCell` on `pathsLoaded`, matching the pattern already used by the expanded section. Show a spinner placeholder while paths are resolving. This ensures correct hardware profile matching before rendering.
- **`DeploymentHardwareProfileCell.tsx`**: Make `hardwareProfilePaths` required since the cell now only renders when paths are loaded.
- 
**Popover redesign (show admin-configured details):**
- **`HardwareProfileDetailsPopover.tsx`**: Display admin-configured hardware profile settings (default, min, max from `spec.identifiers`) instead of pod spec request/limit values. Remove the `resources` prop and fallback resources display — pod spec values are already shown in the expanded row.
- **`utils.ts`**: Add `formatIdentifierDetails()` to format identifier ranges as `identifier: Default = X | Min = Y | Max = Z`, using pipe separators for readability and showing the raw identifier key (e.g. `nvidia.com/gpu`) alongside the display name.
- 
**Custom scenario (no matching profile):**
- **`HardwareProfileTableColumn.tsx`**: For Custom (no matched profile), replace the clickable popover link with italic "Custom" text and a tooltip: *"No matching hardware profile found, using existing settings. Default, min, and max values are not available. Expand the row to view the current resource settings."*
- **`HardwareProfileDetailsPopover.tsx`**: In form view (View details), show an informational message in the popover body instead of fallback pod spec values.
- 
**Queue info in dropdown:**
- **`HardwareProfileSelect.tsx`**: Display local queue name and priority class in three locations: `SimpleSelect` options, `renderMenuItem` for project-scoped dropdowns, and `previewDescription` below the dropdown. Queue info only shown in `previewDescription` when no profile description is present, preserving existing behavior.

<img width="1913" height="1034" alt="Screenshot 2026-04-21 at 4 56 18 PM" src="https://github.com/user-attachments/assets/9188fa09-b953-4549-964b-76ad5ccf7743" />
<img width="1905" height="1023" alt="Screenshot 2026-04-21 at 4 54 32 PM" src="https://github.com/user-attachments/assets/2f2fceb3-b17e-4557-9bad-5b2d891c2786" />
<img width="704" height="138" alt="Screenshot 2026-04-21 at 4 53 37 PM" src="https://github.com/user-attachments/assets/ffb35c06-dfed-47b1-a668-bc2cbacfeb5b" />
<img width="708" height="359" alt="Screenshot 2026-04-21 at 4 52 39 PM" src="https://github.com/user-attachments/assets/f027e14f-e1a3-4967-9937-55e9b9bf2558" />
<img width="1917" height="1043" alt="Screenshot 2026-04-21 at 4 51 48 PM" src="https://github.com/user-attachments/assets/1e125893-2fa6-4e86-a3e3-0a1407b84dd4" />
<img width="1915" height="566" alt="Screenshot 2026-04-21 at 4 50 02 PM" src="https://github.com/user-attachments/assets/732e5a9e-f7d4-4273-a59e-42fd3e70b202" />
<img width="1898" height="1036" alt="Screenshot 2026-04-21 at 4 49 02 PM" src="https://github.com/user-attachments/assets/59d347a3-75fc-418d-aba6-137971688728" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran `npx tsc --noEmit` — clean, no errors
- Ran frontend unit tests (`hardwareProfiles`): 16 suites, 224 tests pass
- Ran model-serving unit tests: 16 suites, 183 tests pass

## Local Testing Checklist
### Workbenches Table (Project Details > Workbenches tab)
- [x] WB with matched hardware profile — popover shows admin defaults/min/max with pipe separators
- [x] WB with Custom (no matching profile) — italic *Custom* with tooltip, no clickable popover
- [x] WB with deleted hardware profile — "Deleted" label, no popover
- [x] WB with disabled hardware profile — profile name with "Disabled" label, popover shows admin details
- [x] WB with updated hardware profile — profile name with "Updated" label, popover shows current admin details
- [x] WB with Kueue profile — popover includes Local queue, Cluster queue, Workload priority
### Workbench Create/Edit Form (Spawner Page)
- [x] Select a profile — "View details" popover shows admin defaults/min/max
- [x] Select a Kueue profile — dropdown option shows queue + priority line; preview description shows queue info when no profile description
- [x] Custom / Use existing settings — "View details" popover shows informational message
- [x] Profile with description — preview description shows description text (not queue info)
- [x] Profile without description — preview description shows identifier details and queue info
### Deployments Table (Model Serving > Deployments)
- [x] Deployment with matched profile — popover shows admin defaults/min/max
- [x] Deployment with Custom — italic *Custom* with tooltip, no clickable popover
- [x] Expanded row — still shows actual pod spec resources (request/limit)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- **`DeploymentHardwareProfileCell.spec.tsx`** (new): Verifies `HardwareProfileTableColumn` receives `podSpecOptions` resources, preventing regression of the data source mismatch.
- **`HardwareProfileDetailsPopover.spec.tsx`** (new, 7 tests): Covers matched profile identifier display, Custom scenario informational message, scheduling details, and verifies no fallback resources are shown for Custom.
- **`HardwareProfileTableColumn.spec.tsx`** (new, 4 tests): Covers matched profile rendering popover, Custom scenario rendering tooltip instead of popover, and loading spinner state.
- **`utils.spec.ts`** (updated): Added 4 tests for `formatIdentifierDetails` covering CPU, Memory, unrestricted max, and Accelerator types.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show Kueue scheduling metadata (local queue and priority) in hardware profile dropdowns, menu items, and previews.
  * Display a loading spinner in the Hardware profile table cell while configuration is resolving.

* **Bug Fixes**
  * Hardware profile column no longer depends on removed resource props, preventing mismatched resource display.

* **Improvements**
  * Simplified hardware-profile details and clearer fallback messaging when resource values are unavailable.

* **Tests**
  * Added/expanded tests for hardware profile cell, table column, popover, and identifier formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->