### PR TITLE
Fix(RHOAIENG-57843): Added error indication on token limits when models are added

### DIFF
--- a/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
+++ b/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
@@ -121,21 +121,18 @@ describe('useSubscriptionModels', () => {
     expect(renderResult.result.current.allModelsHaveRateLimits).toBe(false);
   });
 
-  it('should track rateLimitErrorIndices after closing the modal', () => {
+  it('should include rows with no token limits in rateLimitErrorIndices', () => {
     const initial = [makeEntry('model-a', 'ns', [])];
     const renderResult = testHook(useSubscriptionModels)(initial);
 
-    expect(renderResult.result.current.rateLimitErrorIndices.size).toBe(0);
+    expect(renderResult.result.current.rateLimitErrorIndices.has(0)).toBe(true);
 
     act(() => {
-      renderResult.result.current.setEditLimitsTarget(0);
-    });
-    act(() => {
-      renderResult.result.current.handleCloseRateLimitsModal();
+      renderResult.result.current.handleAddModels([makeModelRef('model-b')]);
     });
 
     expect(renderResult.result.current.rateLimitErrorIndices.has(0)).toBe(true);
-    expect(renderResult.result.current.editLimitsTarget).toBeNull();
+    expect(renderResult.result.current.rateLimitErrorIndices.has(1)).toBe(true);
   });
 
   it('should return the editingModel when editLimitsTarget is set', () => {

--- a/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
+++ b/packages/maas/frontend/src/app/hooks/__tests__/useSubscriptionModels.spec.ts
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
-import { useSubscriptionModels } from '~/app/hooks/useSubscriptionModels';
+import { reindexAfterRemove, useSubscriptionModels } from '~/app/hooks/useSubscriptionModels';
 import { MaaSModelRefSummary, SubscriptionModelEntry } from '~/app/types/subscriptions';
 
 const makeModelRef = (name: string, namespace = 'maas-models'): MaaSModelRefSummary => ({
@@ -16,6 +16,21 @@ const makeEntry = (
 ): SubscriptionModelEntry => ({
   modelRefSummary: makeModelRef(name, namespace),
   tokenRateLimits,
+});
+
+describe('reindexAfterRemove', () => {
+  it('returns null when the edited row was removed', () => {
+    expect(reindexAfterRemove(1, [1])).toBeNull();
+  });
+
+  it('decrements the target when rows above it were removed', () => {
+    expect(reindexAfterRemove(2, [0])).toBe(1);
+    expect(reindexAfterRemove(3, [1, 2])).toBe(1);
+  });
+
+  it('leaves the target unchanged when only rows below it were removed', () => {
+    expect(reindexAfterRemove(0, [2])).toBe(0);
+  });
 });
 
 describe('useSubscriptionModels', () => {
@@ -76,6 +91,55 @@ describe('useSubscriptionModels', () => {
     expect(renderResult.result.current.models[1].modelRefSummary.name).toBe('model-c');
   });
 
+  it('should reindex editLimitsTarget when a row above the target is removed', () => {
+    const initial = [makeEntry('model-a'), makeEntry('model-b'), makeEntry('model-c')];
+    const renderResult = testHook(useSubscriptionModels)(initial);
+
+    act(() => {
+      renderResult.result.current.setEditLimitsTarget(2);
+    });
+    act(() => {
+      renderResult.result.current.handleRemoveModel(0);
+    });
+
+    expect(renderResult.result.current.editLimitsTarget).toBe(1);
+    expect(renderResult.result.current.editingModel?.modelRefSummary.name).toBe('model-c');
+  });
+
+  it('should clear editLimitsTarget when the edited row is removed', () => {
+    const initial = [makeEntry('model-a'), makeEntry('model-b')];
+    const renderResult = testHook(useSubscriptionModels)(initial);
+
+    act(() => {
+      renderResult.result.current.setEditLimitsTarget(1);
+    });
+    act(() => {
+      renderResult.result.current.handleRemoveModel(1);
+    });
+
+    expect(renderResult.result.current.editLimitsTarget).toBeNull();
+    expect(renderResult.result.current.editingModel).toBeNull();
+  });
+
+  it('should adjust editLimitsTarget when removing multiple models by ref', () => {
+    const initial = [makeEntry('model-a'), makeEntry('model-b'), makeEntry('model-c')];
+    const renderResult = testHook(useSubscriptionModels)(initial);
+
+    act(() => {
+      renderResult.result.current.setEditLimitsTarget(2);
+    });
+    act(() => {
+      renderResult.result.current.handleRemoveModelsByRef([
+        makeModelRef('model-a'),
+        makeModelRef('model-b'),
+      ]);
+    });
+
+    expect(renderResult.result.current.models).toHaveLength(1);
+    expect(renderResult.result.current.editLimitsTarget).toBe(0);
+    expect(renderResult.result.current.editingModel?.modelRefSummary.name).toBe('model-c');
+  });
+
   it('should remove models by ref', () => {
     const initial = [makeEntry('model-a'), makeEntry('model-b'), makeEntry('model-c')];
     const renderResult = testHook(useSubscriptionModels)(initial);
@@ -109,8 +173,9 @@ describe('useSubscriptionModels', () => {
   });
 
   it('should report allModelsHaveRateLimits correctly', () => {
-    const initial = [makeEntry('model-a', 'ns', [{ limit: 1000, window: '1h' }])];
-    const renderResult = testHook(useSubscriptionModels)(initial);
+    const renderResult = testHook(useSubscriptionModels)([
+      makeEntry('model-a', 'ns', [{ limit: 1000, window: '1h' }]),
+    ]);
 
     expect(renderResult.result.current.allModelsHaveRateLimits).toBe(true);
 
@@ -118,21 +183,13 @@ describe('useSubscriptionModels', () => {
       renderResult.result.current.handleAddModels([makeModelRef('model-b')]);
     });
 
+    // false as soon as a model with no limits is added
     expect(renderResult.result.current.allModelsHaveRateLimits).toBe(false);
-  });
+    expect(renderResult.result.current.models).toHaveLength(2);
 
-  it('should include rows with no token limits in rateLimitErrorIndices', () => {
-    const initial = [makeEntry('model-a', 'ns', [])];
-    const renderResult = testHook(useSubscriptionModels)(initial);
-
-    expect(renderResult.result.current.rateLimitErrorIndices.has(0)).toBe(true);
-
-    act(() => {
-      renderResult.result.current.handleAddModels([makeModelRef('model-b')]);
-    });
-
-    expect(renderResult.result.current.rateLimitErrorIndices.has(0)).toBe(true);
-    expect(renderResult.result.current.rateLimitErrorIndices.has(1)).toBe(true);
+    // also false when initialized with a model that already has no limits
+    const renderResult2 = testHook(useSubscriptionModels)([makeEntry('model-a', 'ns', [])]);
+    expect(renderResult2.result.current.allModelsHaveRateLimits).toBe(false);
   });
 
   it('should return the editingModel when editLimitsTarget is set', () => {

--- a/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
+++ b/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
@@ -5,6 +5,20 @@ import {
   TokenRateLimit,
 } from '~/app/types/subscriptions';
 
+/** Returns the corrected edit-modal row index after deletions, or null if that row was removed. */
+export const reindexAfterRemove = (
+  targetIndex: number | null,
+  removedIndices: number[],
+): number | null => {
+  if (targetIndex === null || removedIndices.length === 0) {
+    return targetIndex;
+  }
+  if (removedIndices.includes(targetIndex)) {
+    return null;
+  }
+  return targetIndex - removedIndices.filter((i) => i < targetIndex).length;
+};
+
 type UseSubscriptionModelsReturn = {
   models: SubscriptionModelEntry[];
   isAddModelsModalOpen: boolean;
@@ -12,7 +26,6 @@ type UseSubscriptionModelsReturn = {
   editLimitsTarget: number | null;
   setEditLimitsTarget: React.Dispatch<React.SetStateAction<number | null>>;
   editingModel: SubscriptionModelEntry | null;
-  rateLimitErrorIndices: Set<number>;
   allModelsHaveRateLimits: boolean;
   handleAddModels: (refs: MaaSModelRefSummary[]) => void;
   handleRemoveModel: (index: number) => void;
@@ -29,19 +42,6 @@ export const useSubscriptionModels = (
   const [editLimitsTarget, setEditLimitsTarget] = React.useState<number | null>(null);
 
   const allModelsHaveRateLimits = models.every((m) => m.tokenRateLimits.length > 0);
-
-  const rateLimitErrorIndices = React.useMemo(
-    () =>
-      new Set(
-        models.reduce<number[]>((acc, m, i) => {
-          if (m.tokenRateLimits.length === 0) {
-            acc.push(i);
-          }
-          return acc;
-        }, []),
-      ),
-    [models],
-  );
 
   const editingModel = editLimitsTarget != null ? models[editLimitsTarget] : null;
 
@@ -62,16 +62,27 @@ export const useSubscriptionModels = (
 
   const handleRemoveModel = React.useCallback((index: number) => {
     setModels((prev) => prev.filter((_, i) => i !== index));
+    setEditLimitsTarget((current) => reindexAfterRemove(current, [index]));
   }, []);
 
-  const handleRemoveModelsByRef = React.useCallback((refs: MaaSModelRefSummary[]) => {
-    const keysToRemove = new Set(refs.map((r) => `${r.namespace}/${r.name}`));
-    setModels((prev) =>
-      prev.filter(
-        (m) => !keysToRemove.has(`${m.modelRefSummary.namespace}/${m.modelRefSummary.name}`),
-      ),
-    );
-  }, []);
+  const handleRemoveModelsByRef = React.useCallback(
+    (refs: MaaSModelRefSummary[]) => {
+      const keysToRemove = new Set(refs.map((r) => `${r.namespace}/${r.name}`));
+      const removedIndices = models.reduce<number[]>((acc, m, i) => {
+        if (keysToRemove.has(`${m.modelRefSummary.namespace}/${m.modelRefSummary.name}`)) {
+          acc.push(i);
+        }
+        return acc;
+      }, []);
+      setModels((prev) =>
+        prev.filter(
+          (m) => !keysToRemove.has(`${m.modelRefSummary.namespace}/${m.modelRefSummary.name}`),
+        ),
+      );
+      setEditLimitsTarget((current) => reindexAfterRemove(current, removedIndices));
+    },
+    [models],
+  );
 
   const handleSaveRateLimits = React.useCallback(
     (rateLimits: TokenRateLimit[]) => {
@@ -98,7 +109,6 @@ export const useSubscriptionModels = (
     editLimitsTarget,
     setEditLimitsTarget,
     editingModel,
-    rateLimitErrorIndices,
     allModelsHaveRateLimits,
     handleAddModels,
     handleRemoveModel,

--- a/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
+++ b/packages/maas/frontend/src/app/hooks/useSubscriptionModels.ts
@@ -27,7 +27,6 @@ export const useSubscriptionModels = (
   const [models, setModels] = React.useState<SubscriptionModelEntry[]>(initialModels);
   const [isAddModelsModalOpen, setIsAddModelsModalOpen] = React.useState(false);
   const [editLimitsTarget, setEditLimitsTarget] = React.useState<number | null>(null);
-  const [rateLimitsTouched, setRateLimitsTouched] = React.useState<Set<number>>(new Set());
 
   const allModelsHaveRateLimits = models.every((m) => m.tokenRateLimits.length > 0);
 
@@ -35,13 +34,13 @@ export const useSubscriptionModels = (
     () =>
       new Set(
         models.reduce<number[]>((acc, m, i) => {
-          if (rateLimitsTouched.has(i) && m.tokenRateLimits.length === 0) {
+          if (m.tokenRateLimits.length === 0) {
             acc.push(i);
           }
           return acc;
         }, []),
       ),
-    [models, rateLimitsTouched],
+    [models],
   );
 
   const editingModel = editLimitsTarget != null ? models[editLimitsTarget] : null;
@@ -63,42 +62,15 @@ export const useSubscriptionModels = (
 
   const handleRemoveModel = React.useCallback((index: number) => {
     setModels((prev) => prev.filter((_, i) => i !== index));
-    setRateLimitsTouched((prev) => {
-      const next = new Set<number>();
-      prev.forEach((i) => {
-        if (i < index) {
-          next.add(i);
-        } else if (i > index) {
-          next.add(i - 1);
-        }
-      });
-      return next;
-    });
   }, []);
 
   const handleRemoveModelsByRef = React.useCallback((refs: MaaSModelRefSummary[]) => {
     const keysToRemove = new Set(refs.map((r) => `${r.namespace}/${r.name}`));
-    setModels((prev) => {
-      const removedIndices = new Set<number>();
-      prev.forEach((m, i) => {
-        if (keysToRemove.has(`${m.modelRefSummary.namespace}/${m.modelRefSummary.name}`)) {
-          removedIndices.add(i);
-        }
-      });
-      setRateLimitsTouched((prevTouched) => {
-        const next = new Set<number>();
-        let offset = 0;
-        for (let i = 0; i < prev.length; i++) {
-          if (removedIndices.has(i)) {
-            offset++;
-          } else if (prevTouched.has(i)) {
-            next.add(i - offset);
-          }
-        }
-        return next;
-      });
-      return prev.filter((_, i) => !removedIndices.has(i));
-    });
+    setModels((prev) =>
+      prev.filter(
+        (m) => !keysToRemove.has(`${m.modelRefSummary.namespace}/${m.modelRefSummary.name}`),
+      ),
+    );
   }, []);
 
   const handleSaveRateLimits = React.useCallback(
@@ -116,14 +88,8 @@ export const useSubscriptionModels = (
   );
 
   const handleCloseRateLimitsModal = React.useCallback(() => {
-    setRateLimitsTouched((prev) => {
-      if (editLimitsTarget == null) {
-        return prev;
-      }
-      return new Set(prev).add(editLimitsTarget);
-    });
     setEditLimitsTarget(null);
-  }, [editLimitsTarget]);
+  }, []);
 
   return {
     models,

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -113,7 +113,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     editLimitsTarget,
     setEditLimitsTarget,
     editingModel,
-    rateLimitErrorIndices,
     allModelsHaveRateLimits,
     handleAddModels,
     handleRemoveModel,
@@ -375,7 +374,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
               tokenRateLimits: m.tokenRateLimits,
             }))}
             editable
-            rateLimitErrorIndices={rateLimitErrorIndices}
             onAddModels={canAddModels ? () => setIsAddModelsModalOpen(true) : undefined}
             onEditLimits={(index) => setEditLimitsTarget(index)}
             onRemoveModel={handleRemoveModel}

--- a/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
+++ b/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
   FlexItem,
   FormGroup,
+  FormHelperText,
   HelperText,
   HelperTextItem,
   MenuToggle,
@@ -37,7 +38,6 @@ export type MaasModelsSectionProps = {
   titleHeadingLevel?: React.ComponentProps<typeof Title>['headingLevel'];
   titleSize?: React.ComponentProps<typeof Title>['size'];
   editable?: boolean;
-  rateLimitErrorIndices?: Set<number>;
   onAddModels?: () => void;
   onEditLimits?: (index: number) => void;
   onRemoveModel?: (index: number) => void;
@@ -57,7 +57,6 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
   titleHeadingLevel = 'h2',
   titleSize = 'xl',
   editable = false,
-  rateLimitErrorIndices,
   onAddModels,
   onEditLimits,
   onRemoveModel,
@@ -135,13 +134,13 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
                         </Button>
                       </StackItem>
                       <StackItem>
-                        <HelperText>
-                          <HelperTextItem
-                            variant={rateLimitErrorIndices?.has(index) ? 'error' : 'indeterminate'}
-                          >
-                            At least one token limit is required
-                          </HelperTextItem>
-                        </HelperText>
+                        <FormHelperText>
+                          <HelperText>
+                            <HelperTextItem variant="error">
+                              At least one token limit is required
+                            </HelperTextItem>
+                          </HelperText>
+                        </FormHelperText>
                       </StackItem>
                     </Stack>
                   )


### PR DESCRIPTION
Closes [RHOAIENG-57843](https://redhat.atlassian.net/browse/RHOAIENG-57843)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://github.com/user-attachments/assets/841347d4-7b45-43d1-8b59-f7d6b8f29e6d

**Subscriptions token limits**
- If a model has no token limits, we treat that as an error right away (including after you add a model). instead of showing the error only on editing the token  i.e the “at least one token limit” message is shown immediately.
- `useSubscriptionModels` we dropped the extra “touched” state tied to closing the modal. Rows with empty `tokenRateLimits` are what drive the error set now.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. create + edit subscription flows, add models without limits, add limits and confirm Save.


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Updated unit test cases 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently show the "At least one token limit is required" message as an error in model configuration.
  * Editing state now updates predictably when models are removed: the active edit target shifts to the correct index or clears if the edited model is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->