### PR TITLE
fix(e2e): wait for projects page before filtering (RHOAIENG-57594)

### DIFF
--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageAccessModes.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/clusterStorage/testClusterStorageAccessModes.cy.ts
@@ -79,6 +79,7 @@ describe('Cluster Storage Access Modes Tests', () => {
   beforeEach(() => {
     cy.step('Log into the application');
     cy.visitWithLogin('/projects', HTPASSWD_CLUSTER_ADMIN_USER);
+    projectListPage.waitForPageAndToolbar();
 
     cy.step(`Navigate to the Project list tab and search for ${projectName}`);
     projectListPage.filterProjectByName(projectName);

--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchStorageClasses.cy.ts
@@ -111,6 +111,7 @@ describe('Workbench Storage Classes Tests', () => {
   beforeEach(() => {
     cy.step('Log into the application');
     cy.visitWithLogin('/projects', HTPASSWD_CLUSTER_ADMIN_USER);
+    projectListPage.waitForPageAndToolbar();
 
     cy.step(`Navigate to the Project list tab and search for ${projectName}`);
     projectListPage.filterProjectByName(projectName);

--- a/packages/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/storageClasses/clusterStorage.cy.ts
@@ -47,6 +47,7 @@ describe('Regular Users can make use of the Storage Classes in the Cluster Stora
     () => {
       // Authentication and navigation
       cy.visitWithLogin('/projects', LDAP_CONTRIBUTOR_USER);
+      projectListPage.waitForPageAndToolbar();
       // Open the project
       cy.step(`Navigate to the Project list tab and search for ${dspName}`);
       projectListPage.filterProjectByName(dspName);


### PR DESCRIPTION
## Summary

- Fixes [RHOAIENG-57594](https://redhat.atlassian.net/browse/RHOAIENG-57594): Projects view not loading after `visitWithLogin('/projects', ...)`
- After `visitWithLogin` completes, the React app may still be initializing — the page title and projects table toolbar haven't rendered yet. Calling `filterProjectByName` immediately races against the page render; if the toolbar doesn't appear within the default 4 s command timeout, the test fails.
- Adds `projectListPage.waitForPageAndToolbar()` (15 s title + 30 s toolbar timeout) after `visitWithLogin` in the three E2E tests that were missing it, matching the pattern already used in `testProjectContributorPermissions` and `testProjectAdminPermissions`.

### Files changed

| File | Change |
|------|--------|
| `testWorkbenchStorageClasses.cy.ts` | Add `waitForPageAndToolbar()` in `beforeEach` |
| `testClusterStorageAccessModes.cy.ts` | Add `waitForPageAndToolbar()` in `beforeEach` |
| `storageClasses/clusterStorage.cy.ts` | Add `waitForPageAndToolbar()` in test body |

## Test plan

- [ ] `testWorkbenchStorageClasses` passes in nightly E2E run
- [ ] `testClusterStorageAccessModes` passes in nightly E2E run
- [ ] `storageClasses/clusterStorage` passes in nightly E2E run
- [ ] No regressions in related storage-class E2E tests
- [ ] Lint + type-check pass (verified locally)


Made with [Cursor](https://cursor.com)