### PR TITLE
fix: flaky argo workflow and v1 pipeline import tests in `pipelines.cy.ts`

### DIFF
--- a/packages/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -18,7 +18,7 @@ class PipelineImportModal extends Modal {
   }
 
   findSubmitButton() {
-    return cy.findByTestId('modal-submit-button');
+    return this.findFooter().findByTestId('modal-submit-button');
   }
 
   findVersionNameInput() {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -849,7 +849,11 @@ describe('Pipelines', () => {
     pipelineImportModal.shouldBeOpen();
     pipelineImportModal.fillPipelineName('New pipeline');
     pipelineImportModal.fillPipelineDescription('New pipeline description');
+    // Safety net: intercept the upload endpoint so the test never hangs if the
+    // client-side argo detection is bypassed due to a stale-closure race.
+    pipelineImportModal.mockUploadPipeline({}, projectName);
     pipelineImportModal.uploadPipelineYaml(argoWorkflowPipeline);
+    pipelineImportModal.findSubmitButton().should('be.enabled');
     pipelineImportModal.submit();
 
     pipelineImportModal.findImportModalError().should('exist');
@@ -868,6 +872,7 @@ describe('Pipelines', () => {
     pipelineImportModal.fillPipelineName('New pipeline');
     pipelineImportModal.fillPipelineDescription('New pipeline description');
     pipelineImportModal.uploadPipelineYaml(v1PipelineYamlPath);
+    pipelineImportModal.findSubmitButton().should('be.enabled');
     pipelineImportModal.submit();
 
     pipelineImportModal.findImportModalError().should('exist');
@@ -1107,7 +1112,11 @@ describe('Pipelines', () => {
     pipelineVersionImportModal.selectPipelineByName('Test pipeline');
     pipelineVersionImportModal.fillVersionName('Argo workflow version');
     pipelineVersionImportModal.fillVersionDescription('Argo workflow version description');
+    // Safety net: intercept the upload endpoint so the test never hangs if the
+    // client-side argo detection is bypassed due to a stale-closure race.
+    pipelineVersionImportModal.mockUploadVersion({}, projectName);
     pipelineVersionImportModal.uploadPipelineYaml(argoWorkflowPipeline);
+    pipelineVersionImportModal.findSubmitButton().should('be.enabled');
     pipelineVersionImportModal.submit();
 
     pipelineVersionImportModal.findImportModalError().should('exist');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://redhat.atlassian.net/browse/RHOAIENG-58263

The Cypress mock test "uploads fails with argo workflow" is flaky because `onSubmit` can fire with a stale closure where `isArgoWorkflow=false`, bypassing client-side argo detection and calling `submitAction()` against an un-intercepted upload endpoint that hangs forever. This PR scopes `pipelineVersionImportModal.findSubmitButton()` to the modal footer (matching the pattern used by `pipelineImportModal`), and adds defensive `mockUploadPipeline`/`mockUploadVersion` intercepts to the three affected tests so the request returns immediately if the race occurs, preventing the permanent loading state that causes the 10s timeout.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By checking if CI passes 5x in a row without failing.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pipeline import test reliability with enhanced mocking and UI assertion coverage for import workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->