### PR TITLE
feat(autox): Add auto-discovery support for managed MinIO DSPAs

### DIFF
--- a/packages/automl/bff/README.md
+++ b/packages/automl/bff/README.md
@@ -247,6 +247,45 @@ curl -H "kubeflow-userid: user@example.com" \
   "http://localhost:4003/api/v1/s3/file?namespace=<namespace>&secretName=<secret>&bucket=<bucket>&key=<key>"
 ```
 
+#### Managed MinIO in port-forward mode
+
+When the DSPA uses managed MinIO (`minio.deploy: true`) instead of external S3, the BFF auto-discovers the MinIO configuration and constructs an in-cluster endpoint URL of the form `http://minio-<dspa-name>.<namespace>.svc.cluster.local:9000`. For this to work locally you need to port-forward the MinIO service and add a `/etc/hosts` entry so the BFF can resolve the in-cluster hostname.
+
+**1. Identify the MinIO service and DSPA name**
+
+```shell
+# Find the MinIO service in your namespace
+oc get svc -n <namespace> | grep minio
+
+# The service is typically named "minio-<dspa-name>", e.g. "minio-dspa"
+```
+
+**2. Port-forward the MinIO service**
+
+```shell
+oc port-forward -n <namespace> svc/minio-<dspa-name> 9000:9000
+```
+
+**3. Add a `/etc/hosts` entry**
+
+The BFF constructs the MinIO endpoint using the in-cluster DNS name. Add an entry to `/etc/hosts` so this resolves to your local port-forward:
+
+```shell
+# Add to /etc/hosts (requires sudo)
+echo "127.0.0.1 minio-<dspa-name>.<namespace>.svc.cluster.local" | sudo tee -a /etc/hosts
+```
+
+For example, if your DSPA is named `dspa` in namespace `my-project`:
+
+```shell
+oc port-forward -n my-project svc/minio-dspa 9000:9000
+echo "127.0.0.1 minio-dspa.my-project.svc.cluster.local" | sudo tee -a /etc/hosts
+```
+
+After this, the BFF will auto-discover the MinIO storage config from the DSPA spec and connect to MinIO via your port-forward. No `secretName` query parameter is needed.
+
+> **Cleanup:** Remember to remove the `/etc/hosts` entry when you're done testing.
+
 ### Federated development with a live cluster
 
 To run the AutoML module as a federated micro-frontend against the main ODH Dashboard with a real pipeline server, you need three things running:

--- a/packages/automl/bff/internal/api/middleware.go
+++ b/packages/automl/bff/internal/api/middleware.go
@@ -346,62 +346,89 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspa.Spec != nil &&
-				dspa.Spec.ObjectStorage != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-				ext := dspa.Spec.ObjectStorage.ExternalStorage
-				cred := ext.S3CredentialsSecret
+			if dspa.Spec != nil && dspa.Spec.ObjectStorage != nil {
+				// Handle external storage
+				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+					ext := dspa.Spec.ObjectStorage.ExternalStorage
+					cred := ext.S3CredentialsSecret
 
-				// Construct the endpoint URL from scheme, host, and optional port.
-				// Only "http" and "https" schemes are accepted; any other value is
-				// logged as a warning and the endpoint URL is left empty so that
-				// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
-				endpointURL := ""
-				scheme := strings.ToLower(ext.Scheme)
-				if ext.Host != "" && (scheme == "http" || scheme == "https") {
-					if ext.Port != "" {
-						endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-					} else {
-						endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+					// Construct the endpoint URL from scheme, host, and optional port.
+					// Only "http" and "https" schemes are accepted; any other value is
+					// logged as a warning and the endpoint URL is left empty so that
+					// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
+					endpointURL := ""
+					scheme := strings.ToLower(ext.Scheme)
+					if ext.Host != "" && (scheme == "http" || scheme == "https") {
+						if ext.Port != "" {
+							endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
+						} else {
+							endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+						}
+					} else if ext.Scheme != "" && ext.Host != "" {
+						logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
+							"scheme", ext.Scheme,
+							"namespace", namespace,
+						)
 					}
-				} else if ext.Scheme != "" && ext.Host != "" {
-					logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-						"scheme", ext.Scheme,
+
+					accessKeyField := cred.AccessKey
+					if accessKeyField == "" {
+						accessKeyField = "AWS_ACCESS_KEY_ID"
+					}
+					secretKeyField := cred.SecretKey
+					if secretKeyField == "" {
+						secretKeyField = "AWS_SECRET_ACCESS_KEY"
+					}
+
+					dspaObjectStorage := &models.DSPAObjectStorage{
+						SecretName:     cred.SecretName,
+						AccessKeyField: accessKeyField,
+						SecretKeyField: secretKeyField,
+						EndpointURL:    endpointURL,
+						Bucket:         ext.Bucket,
+						Region:         ext.Region,
+					}
+					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					logger.Debug("Found DSPA external storage config",
+						"secretName", cred.SecretName,
+						"namespace", namespace,
+						"hasEndpoint", endpointURL != "",
+						"hasBucket", ext.Bucket != "",
+					)
+				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+					// Handle managed MinIO
+					minio := dspa.Spec.ObjectStorage.Minio
+
+					// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
+					secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
+
+					// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+					endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
+						dspa.Metadata.Name, namespace)
+
+					dspaObjectStorage := &models.DSPAObjectStorage{
+						SecretName:     secretName,
+						AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
+						SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+						EndpointURL:    endpointURL,
+						Bucket:         minio.Bucket,
+						Region:         "us-east-1",   // Default region for MinIO
+					}
+					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					logger.Debug("Found managed MinIO storage config",
+						"secretName", secretName,
+						"namespace", namespace,
+						"bucket", minio.Bucket,
+						"endpoint", endpointURL,
+					)
+				} else {
+					logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
+						"dspa", dspa.Metadata.Name,
 						"namespace", namespace,
 					)
 				}
-
-				accessKeyField := cred.AccessKey
-				if accessKeyField == "" {
-					accessKeyField = "AWS_ACCESS_KEY_ID"
-				}
-				secretKeyField := cred.SecretKey
-				if secretKeyField == "" {
-					secretKeyField = "AWS_SECRET_ACCESS_KEY"
-				}
-
-				dspaObjectStorage := &models.DSPAObjectStorage{
-					SecretName:     cred.SecretName,
-					AccessKeyField: accessKeyField,
-					SecretKeyField: secretKeyField,
-					EndpointURL:    endpointURL,
-					Bucket:         ext.Bucket,
-					Region:         ext.Region,
-				}
-				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-				logger.Debug("Found DSPA object storage config",
-					"secretName", cred.SecretName,
-					"namespace", namespace,
-					"hasEndpoint", endpointURL != "",
-					"hasBucket", ext.Bucket != "",
-				)
-			} else {
-				logger.Warn("DSPA found but has no external storage config (managed MinIO or unconfigured externalStorage); S3 endpoints require explicit secretName",
-					"dspa", dspa.Metadata.Name,
-					"namespace", namespace,
-				)
 			}
 
 			// Extract auth token from request identity to forward to Pipeline Server
@@ -471,78 +498,113 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Use the first DSPA that has external storage configured.
+	// Use the first DSPA that has external storage OR managed MinIO configured.
 	var dspa *models.DSPipelineApplication
 	for i := range dspaItems {
 		d := &dspaItems[i]
-		if d.Spec != nil &&
-			d.Spec.ObjectStorage != nil &&
-			d.Spec.ObjectStorage.ExternalStorage != nil &&
-			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-			dspa = d
-			break
+		if d.Spec != nil && d.Spec.ObjectStorage != nil {
+			// Check for external storage first
+			if d.Spec.ObjectStorage.ExternalStorage != nil &&
+				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+				dspa = d
+				break
+			}
+			// Also check for managed MinIO
+			if d.Spec.ObjectStorage.Minio != nil && d.Spec.ObjectStorage.Minio.Deploy {
+				dspa = d
+				break
+			}
 		}
 	}
 	if dspa == nil {
-		logger.Warn("DSPA found but has no external storage config (managed MinIO or unconfigured externalStorage); S3 requires explicit secretName",
+		logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
 			"namespace", namespace)
 		return ctx
 	}
 
-	if dspa.Spec == nil ||
-		dspa.Spec.ObjectStorage == nil ||
-		dspa.Spec.ObjectStorage.ExternalStorage == nil ||
-		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret == nil ||
-		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName == "" {
-		logger.Warn("DSPA found but has no external storage config (managed MinIO or unconfigured externalStorage); S3 requires explicit secretName",
-			"dspa", dspa.Metadata.Name,
+	// Handle external storage case
+	if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+
+		ext := dspa.Spec.ObjectStorage.ExternalStorage
+		cred := ext.S3CredentialsSecret
+
+		endpointURL := ""
+		scheme := strings.ToLower(ext.Scheme)
+		if ext.Host != "" && (scheme == "http" || scheme == "https") {
+			if ext.Port != "" {
+				endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
+			} else {
+				endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+			}
+		} else if ext.Scheme != "" && ext.Host != "" {
+			logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
+				"scheme", ext.Scheme,
+				"namespace", namespace,
+			)
+		}
+
+		accessKeyField := cred.AccessKey
+		if accessKeyField == "" {
+			accessKeyField = "AWS_ACCESS_KEY_ID"
+		}
+		secretKeyField := cred.SecretKey
+		if secretKeyField == "" {
+			secretKeyField = "AWS_SECRET_ACCESS_KEY"
+		}
+
+		dspaObjectStorage := &models.DSPAObjectStorage{
+			SecretName:     cred.SecretName,
+			AccessKeyField: accessKeyField,
+			SecretKeyField: secretKeyField,
+			EndpointURL:    endpointURL,
+			Bucket:         ext.Bucket,
+			Region:         ext.Region,
+		}
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+		logger.Debug("Injected DSPA external storage config (override-URL mode)",
+			"secretName", cred.SecretName,
 			"namespace", namespace,
+			"hasEndpoint", endpointURL != "",
+			"hasBucket", ext.Bucket != "",
 		)
 		return ctx
 	}
 
-	ext := dspa.Spec.ObjectStorage.ExternalStorage
-	cred := ext.S3CredentialsSecret
+	// Handle managed MinIO case
+	if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+		minio := dspa.Spec.ObjectStorage.Minio
 
-	endpointURL := ""
-	scheme := strings.ToLower(ext.Scheme)
-	if ext.Host != "" && (scheme == "http" || scheme == "https") {
-		if ext.Port != "" {
-			endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-		} else {
-			endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+		// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
+		secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
+
+		// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+		endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
+			dspa.Metadata.Name, namespace)
+
+		dspaObjectStorage := &models.DSPAObjectStorage{
+			SecretName:     secretName,
+			AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
+			SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+			EndpointURL:    endpointURL,
+			Bucket:         minio.Bucket,
+			Region:         "us-east-1",   // Default region for MinIO
 		}
-	} else if ext.Scheme != "" && ext.Host != "" {
-		logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-			"scheme", ext.Scheme,
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+		logger.Debug("Injected managed MinIO storage config (override-URL mode)",
+			"secretName", secretName,
 			"namespace", namespace,
+			"bucket", minio.Bucket,
+			"endpoint", endpointURL,
 		)
+		return ctx
 	}
 
-	accessKeyField := cred.AccessKey
-	if accessKeyField == "" {
-		accessKeyField = "AWS_ACCESS_KEY_ID"
-	}
-	secretKeyField := cred.SecretKey
-	if secretKeyField == "" {
-		secretKeyField = "AWS_SECRET_ACCESS_KEY"
-	}
-
-	dspaObjectStorage := &models.DSPAObjectStorage{
-		SecretName:     cred.SecretName,
-		AccessKeyField: accessKeyField,
-		SecretKeyField: secretKeyField,
-		EndpointURL:    endpointURL,
-		Bucket:         ext.Bucket,
-		Region:         ext.Region,
-	}
-	ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-	logger.Debug("Injected DSPA object storage config (override-URL mode)",
-		"secretName", cred.SecretName,
+	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
+		"dspa", dspa.Metadata.Name,
 		"namespace", namespace,
-		"hasEndpoint", endpointURL != "",
-		"hasBucket", ext.Bucket != "",
 	)
 	return ctx
 }
@@ -819,6 +881,51 @@ func getMockDSPipelineApplications(namespace string) []models.DSPipelineApplicat
 					APIServer: &models.DSPipelineApplicationAPIServerStatus{
 						URL:         "https://ds-pipeline-dspa-not-ready.not-ready-namespace.svc.cluster.local:8443",
 						ExternalURL: "https://ds-pipeline-ui-dspa-not-ready-not-ready-namespace.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with managed MinIO in minio-test namespace
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "pipelines",
+				Namespace: "minio-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					Minio: &models.MinioStorage{
+						Deploy:  true,
+						Bucket:  "mlpipeline",
+						Image:   "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance",
+						PvcSize: "10Gi",
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-pipelines.minio-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-pipelines-minio-test.apps.cluster.local",
 					},
 				},
 			},

--- a/packages/automl/bff/internal/api/middleware.go
+++ b/packages/automl/bff/internal/api/middleware.go
@@ -346,89 +346,31 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspa.Spec != nil && dspa.Spec.ObjectStorage != nil {
-				// Handle external storage
+			if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+
+				// Log appropriate message based on storage type
 				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-					ext := dspa.Spec.ObjectStorage.ExternalStorage
-					cred := ext.S3CredentialsSecret
-
-					// Construct the endpoint URL from scheme, host, and optional port.
-					// Only "http" and "https" schemes are accepted; any other value is
-					// logged as a warning and the endpoint URL is left empty so that
-					// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
-					endpointURL := ""
-					scheme := strings.ToLower(ext.Scheme)
-					if ext.Host != "" && (scheme == "http" || scheme == "https") {
-						if ext.Port != "" {
-							endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-						} else {
-							endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
-						}
-					} else if ext.Scheme != "" && ext.Host != "" {
-						logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-							"scheme", ext.Scheme,
-							"namespace", namespace,
-						)
-					}
-
-					accessKeyField := cred.AccessKey
-					if accessKeyField == "" {
-						accessKeyField = "AWS_ACCESS_KEY_ID"
-					}
-					secretKeyField := cred.SecretKey
-					if secretKeyField == "" {
-						secretKeyField = "AWS_SECRET_ACCESS_KEY"
-					}
-
-					dspaObjectStorage := &models.DSPAObjectStorage{
-						SecretName:     cred.SecretName,
-						AccessKeyField: accessKeyField,
-						SecretKeyField: secretKeyField,
-						EndpointURL:    endpointURL,
-						Bucket:         ext.Bucket,
-						Region:         ext.Region,
-					}
-					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
 					logger.Debug("Found DSPA external storage config",
-						"secretName", cred.SecretName,
+						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
-						"hasEndpoint", endpointURL != "",
-						"hasBucket", ext.Bucket != "",
+						"hasEndpoint", dspaObjectStorage.EndpointURL != "",
+						"hasBucket", dspaObjectStorage.Bucket != "",
 					)
 				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
-					// Handle managed MinIO
-					minio := dspa.Spec.ObjectStorage.Minio
-
-					// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
-					secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
-
-					// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
-					endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
-						dspa.Metadata.Name, namespace)
-
-					dspaObjectStorage := &models.DSPAObjectStorage{
-						SecretName:     secretName,
-						AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
-						SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
-						EndpointURL:    endpointURL,
-						Bucket:         minio.Bucket,
-						Region:         "us-east-1", // Default region for MinIO
-					}
-					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 					logger.Debug("Found managed MinIO storage config",
-						"secretName", secretName,
+						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
-						"bucket", minio.Bucket,
-						"endpoint", endpointURL,
-					)
-				} else {
-					logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
-						"dspa", dspa.Metadata.Name,
-						"namespace", namespace,
+						"bucket", dspaObjectStorage.Bucket,
+						"endpoint", dspaObjectStorage.EndpointURL,
 					)
 				}
+			} else {
+				logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
+					"dspa", dspa.Metadata.Name,
+					"namespace", namespace,
+				)
 			}
 
 			// Extract auth token from request identity to forward to Pipeline Server
@@ -498,24 +440,29 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Use the first DSPA that has external storage OR managed MinIO configured.
-	var dspa *models.DSPipelineApplication
+	// Prefer external storage globally, then fall back to managed MinIO.
+	var externalDSPA *models.DSPipelineApplication
+	var minioDSPA *models.DSPipelineApplication
 	for i := range dspaItems {
 		d := &dspaItems[i]
-		if d.Spec != nil && d.Spec.ObjectStorage != nil {
-			// Check for external storage first
-			if d.Spec.ObjectStorage.ExternalStorage != nil &&
-				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-				dspa = d
-				break
-			}
-			// Also check for managed MinIO
-			if d.Spec.ObjectStorage.Minio != nil && d.Spec.ObjectStorage.Minio.Deploy {
-				dspa = d
-				break
-			}
+		if d.Spec == nil || d.Spec.ObjectStorage == nil {
+			continue
 		}
+		if externalDSPA == nil &&
+			d.Spec.ObjectStorage.ExternalStorage != nil &&
+			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+			externalDSPA = d
+		}
+		if minioDSPA == nil &&
+			d.Spec.ObjectStorage.Minio != nil &&
+			d.Spec.ObjectStorage.Minio.Deploy {
+			minioDSPA = d
+		}
+	}
+	dspa := externalDSPA
+	if dspa == nil {
+		dspa = minioDSPA
 	}
 	if dspa == nil {
 		logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
@@ -523,7 +470,87 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Handle external storage case
+	// Resolve and inject DSPA object storage config
+	if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+
+		// Log appropriate message based on storage type
+		if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+			dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+			logger.Debug("Injected DSPA external storage config (override-URL mode)",
+				"secretName", dspaObjectStorage.SecretName,
+				"namespace", namespace,
+				"hasEndpoint", dspaObjectStorage.EndpointURL != "",
+				"hasBucket", dspaObjectStorage.Bucket != "",
+			)
+		} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+			logger.Debug("Injected managed MinIO storage config (override-URL mode)",
+				"secretName", dspaObjectStorage.SecretName,
+				"namespace", namespace,
+				"bucket", dspaObjectStorage.Bucket,
+				"endpoint", dspaObjectStorage.EndpointURL,
+			)
+		}
+		return ctx
+	}
+
+	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
+		"dspa", dspa.Metadata.Name,
+		"namespace", namespace,
+	)
+	return ctx
+}
+
+const (
+	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
+	dsPipelineResource = "datasciencepipelinesapplications"
+)
+
+// buildMinIOObjectStorage constructs DSPAObjectStorage for managed MinIO deployments.
+// It follows the DSPA operator conventions:
+//   - Secret name: "ds-pipeline-s3-{dspaName}"
+//   - Endpoint: http://minio-{dspaName}.{namespace}.svc.cluster.local:9000
+//   - Lowercase credential key names: "accesskey", "secretkey"
+//   - Default region: "us-east-1"
+func buildMinIOObjectStorage(dspaName, namespace, bucket string) *models.DSPAObjectStorage {
+	return &models.DSPAObjectStorage{
+		SecretName:     fmt.Sprintf("ds-pipeline-s3-%s", dspaName),
+		AccessKeyField: "accesskey",
+		SecretKeyField: "secretkey",
+		EndpointURL:    fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000", dspaName, namespace),
+		Bucket:         bucket,
+		Region:         "us-east-1",
+	}
+}
+
+// resolveDSPAObjectStorage extracts S3-compatible object storage configuration from a DSPA spec.
+// It handles both external storage (e.g., AWS S3) and managed MinIO, with external storage
+// preferred when both are configured.
+//
+// Returns nil if the DSPA has no valid object storage configuration.
+//
+// For external storage:
+//   - Validates scheme (must be "http" or "https")
+//   - Constructs endpoint URL from scheme://host[:port]
+//   - Defaults accessKeyField to "AWS_ACCESS_KEY_ID" if empty
+//   - Defaults secretKeyField to "AWS_SECRET_ACCESS_KEY" if empty
+//   - Uses bucket and region from DSPA spec
+//
+// For managed MinIO:
+//   - Secret name follows convention: "ds-pipeline-s3-{dspa-name}"
+//   - Endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+//   - Uses lowercase key names: "accesskey", "secretkey"
+//   - Defaults region to "us-east-1"
+func resolveDSPAObjectStorage(
+	dspa *models.DSPipelineApplication,
+	namespace string,
+	logger *slog.Logger,
+) *models.DSPAObjectStorage {
+	if dspa == nil || dspa.Spec == nil || dspa.Spec.ObjectStorage == nil {
+		return nil
+	}
+
+	// Handle external storage (preferred)
 	if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
 		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
 		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
@@ -531,6 +558,10 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		ext := dspa.Spec.ObjectStorage.ExternalStorage
 		cred := ext.S3CredentialsSecret
 
+		// Construct the endpoint URL from scheme, host, and optional port.
+		// Only "http" and "https" schemes are accepted; any other value is
+		// logged as a warning and the endpoint URL is left empty so that
+		// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
 		endpointURL := ""
 		scheme := strings.ToLower(ext.Scheme)
 		if ext.Host != "" && (scheme == "http" || scheme == "https") {
@@ -555,7 +586,7 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			secretKeyField = "AWS_SECRET_ACCESS_KEY"
 		}
 
-		dspaObjectStorage := &models.DSPAObjectStorage{
+		return &models.DSPAObjectStorage{
 			SecretName:     cred.SecretName,
 			AccessKeyField: accessKeyField,
 			SecretKeyField: secretKeyField,
@@ -563,56 +594,20 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			Bucket:         ext.Bucket,
 			Region:         ext.Region,
 		}
-		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-		logger.Debug("Injected DSPA external storage config (override-URL mode)",
-			"secretName", cred.SecretName,
-			"namespace", namespace,
-			"hasEndpoint", endpointURL != "",
-			"hasBucket", ext.Bucket != "",
-		)
-		return ctx
 	}
 
-	// Handle managed MinIO case
+	// Handle managed MinIO (fallback)
 	if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
-		minio := dspa.Spec.ObjectStorage.Minio
-
-		// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
-		secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
-
-		// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
-		endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
-			dspa.Metadata.Name, namespace)
-
-		dspaObjectStorage := &models.DSPAObjectStorage{
-			SecretName:     secretName,
-			AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
-			SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
-			EndpointURL:    endpointURL,
-			Bucket:         minio.Bucket,
-			Region:         "us-east-1", // Default region for MinIO
-		}
-		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-		logger.Debug("Injected managed MinIO storage config (override-URL mode)",
-			"secretName", secretName,
-			"namespace", namespace,
-			"bucket", minio.Bucket,
-			"endpoint", endpointURL,
+		return buildMinIOObjectStorage(
+			dspa.Metadata.Name,
+			namespace,
+			dspa.Spec.ObjectStorage.Minio.Bucket,
 		)
-		return ctx
 	}
 
-	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
-		"dspa", dspa.Metadata.Name,
-		"namespace", namespace,
-	)
-	return ctx
+	// No valid storage configuration
+	return nil
 }
-
-const (
-	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
-	dsPipelineResource = "datasciencepipelinesapplications"
-)
 
 // isDSPAReady checks if the Pipeline Server is fully ready by looking for
 // the Ready condition. Ready is the aggregate condition set by the DSPA
@@ -926,6 +921,115 @@ func getMockDSPipelineApplications(namespace string) []models.DSPipelineApplicat
 					APIServer: &models.DSPipelineApplicationAPIServerStatus{
 						URL:         "https://ds-pipeline-pipelines.minio-test.svc.cluster.local:8443",
 						ExternalURL: "https://ds-pipeline-ui-pipelines-minio-test.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with external storage in external-storage-test namespace
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "dspa-external",
+				Namespace: "external-storage-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					ExternalStorage: &models.ExternalStorage{
+						Host:   "s3.amazonaws.com",
+						Port:   "",
+						Scheme: "https",
+						Region: "us-west-2",
+						Bucket: "my-external-bucket",
+						S3CredentialsSecret: &models.S3CredentialsSecret{
+							SecretName: "aws-s3-credentials",
+							AccessKey:  "", // Empty means use default AWS_ACCESS_KEY_ID
+							SecretKey:  "", // Empty means use default AWS_SECRET_ACCESS_KEY
+						},
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-dspa-external.external-storage-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-dspa-external-external-storage-test.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with BOTH external storage AND managed MinIO in both-storage-test namespace
+		// This tests that external storage is preferred when both are configured
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "dspa-both",
+				Namespace: "both-storage-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					ExternalStorage: &models.ExternalStorage{
+						Host:   "s3.amazonaws.com",
+						Port:   "",
+						Scheme: "https",
+						Region: "us-west-2",
+						Bucket: "my-external-bucket",
+						S3CredentialsSecret: &models.S3CredentialsSecret{
+							SecretName: "aws-s3-credentials",
+							AccessKey:  "", // Empty means use default AWS_ACCESS_KEY_ID
+							SecretKey:  "", // Empty means use default AWS_SECRET_ACCESS_KEY
+						},
+					},
+					Minio: &models.MinioStorage{
+						Deploy:  true,
+						Bucket:  "mlpipeline-minio",
+						Image:   "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance",
+						PvcSize: "10Gi",
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-dspa-both.both-storage-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-dspa-both-both-storage-test.apps.cluster.local",
 					},
 				},
 			},

--- a/packages/automl/bff/internal/api/middleware.go
+++ b/packages/automl/bff/internal/api/middleware.go
@@ -410,11 +410,11 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 
 					dspaObjectStorage := &models.DSPAObjectStorage{
 						SecretName:     secretName,
-						AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
-						SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+						AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
+						SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
 						EndpointURL:    endpointURL,
 						Bucket:         minio.Bucket,
-						Region:         "us-east-1",   // Default region for MinIO
+						Region:         "us-east-1", // Default region for MinIO
 					}
 					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 					logger.Debug("Found managed MinIO storage config",
@@ -586,11 +586,11 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 
 		dspaObjectStorage := &models.DSPAObjectStorage{
 			SecretName:     secretName,
-			AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
-			SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+			AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
+			SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
 			EndpointURL:    endpointURL,
 			Bucket:         minio.Bucket,
-			Region:         "us-east-1",   // Default region for MinIO
+			Region:         "us-east-1", // Default region for MinIO
 		}
 		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 		logger.Debug("Injected managed MinIO storage config (override-URL mode)",

--- a/packages/automl/bff/internal/api/middleware.go
+++ b/packages/automl/bff/internal/api/middleware.go
@@ -346,19 +346,20 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+			dspaObjectStorage, storageType := resolveDSPAObjectStorage(dspa, namespace, logger)
+			if dspaObjectStorage != nil {
 				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 
 				// Log appropriate message based on storage type
-				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+				switch storageType {
+				case dspaStorageExternal:
 					logger.Debug("Found DSPA external storage config",
 						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
 						"hasEndpoint", dspaObjectStorage.EndpointURL != "",
 						"hasBucket", dspaObjectStorage.Bucket != "",
 					)
-				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+				case dspaStorageMinIO:
 					logger.Debug("Found managed MinIO storage config",
 						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
@@ -459,6 +460,10 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			d.Spec.ObjectStorage.Minio.Deploy {
 			minioDSPA = d
 		}
+		// Break early if we've found both types
+		if externalDSPA != nil && minioDSPA != nil {
+			break
+		}
 	}
 	dspa := externalDSPA
 	if dspa == nil {
@@ -471,19 +476,20 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 	}
 
 	// Resolve and inject DSPA object storage config
-	if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+	dspaObjectStorage, storageType := resolveDSPAObjectStorage(dspa, namespace, logger)
+	if dspaObjectStorage != nil {
 		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 
 		// Log appropriate message based on storage type
-		if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-			dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+		switch storageType {
+		case dspaStorageExternal:
 			logger.Debug("Injected DSPA external storage config (override-URL mode)",
 				"secretName", dspaObjectStorage.SecretName,
 				"namespace", namespace,
 				"hasEndpoint", dspaObjectStorage.EndpointURL != "",
 				"hasBucket", dspaObjectStorage.Bucket != "",
 			)
-		} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+		case dspaStorageMinIO:
 			logger.Debug("Injected managed MinIO storage config (override-URL mode)",
 				"secretName", dspaObjectStorage.SecretName,
 				"namespace", namespace,
@@ -504,6 +510,15 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 const (
 	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
 	dsPipelineResource = "datasciencepipelinesapplications"
+)
+
+// dspaStorageType indicates the type of object storage configured in a DSPA.
+type dspaStorageType string
+
+const (
+	dspaStorageExternal dspaStorageType = "external"
+	dspaStorageMinIO    dspaStorageType = "minio"
+	dspaStorageNone     dspaStorageType = "none"
 )
 
 // buildMinIOObjectStorage constructs DSPAObjectStorage for managed MinIO deployments.
@@ -527,7 +542,8 @@ func buildMinIOObjectStorage(dspaName, namespace, bucket string) *models.DSPAObj
 // It handles both external storage (e.g., AWS S3) and managed MinIO, with external storage
 // preferred when both are configured.
 //
-// Returns nil if the DSPA has no valid object storage configuration.
+// Returns the DSPAObjectStorage config and its type. Returns (nil, dspaStorageNone) if the DSPA
+// has no valid object storage configuration.
 //
 // For external storage:
 //   - Validates scheme (must be "http" or "https")
@@ -545,9 +561,9 @@ func resolveDSPAObjectStorage(
 	dspa *models.DSPipelineApplication,
 	namespace string,
 	logger *slog.Logger,
-) *models.DSPAObjectStorage {
+) (*models.DSPAObjectStorage, dspaStorageType) {
 	if dspa == nil || dspa.Spec == nil || dspa.Spec.ObjectStorage == nil {
-		return nil
+		return nil, dspaStorageNone
 	}
 
 	// Handle external storage (preferred)
@@ -593,7 +609,7 @@ func resolveDSPAObjectStorage(
 			EndpointURL:    endpointURL,
 			Bucket:         ext.Bucket,
 			Region:         ext.Region,
-		}
+		}, dspaStorageExternal
 	}
 
 	// Handle managed MinIO (fallback)
@@ -602,11 +618,11 @@ func resolveDSPAObjectStorage(
 			dspa.Metadata.Name,
 			namespace,
 			dspa.Spec.ObjectStorage.Minio.Bucket,
-		)
+		), dspaStorageMinIO
 	}
 
 	// No valid storage configuration
-	return nil
+	return nil, dspaStorageNone
 }
 
 // isDSPAReady checks if the Pipeline Server is fully ready by looking for

--- a/packages/automl/bff/internal/api/middleware_discovery_test.go
+++ b/packages/automl/bff/internal/api/middleware_discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opendatahub-io/automl-library/bff/internal/config"
+	"github.com/opendatahub-io/automl-library/bff/internal/constants"
 	k8mocks "github.com/opendatahub-io/automl-library/bff/internal/integrations/kubernetes/k8mocks"
 	"github.com/opendatahub-io/automl-library/bff/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -334,17 +335,31 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 			kubernetesClientFactory: k8sFactory,
 		}
 
-		// Create a test namespace with a managed MinIO DSPA
 		namespace := "minio-test"
 
-		// Inject storage config using the function
-		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+		// TODO: Create a mock DSPA in the test environment with managed MinIO
+		// Expected DSPA structure:
+		// - metadata.name: "pipelines"
+		// - spec.objectStorage.minio.deploy: true
+		// - spec.objectStorage.minio.bucket: "mlpipeline"
 
-		// Verify context was returned (won't have injection without mock MinIO DSPA data)
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
 		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify the injected storage config
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		assert.Equal(t, "ds-pipeline-s3-pipelines", storage.SecretName)
+		assert.Equal(t, "accesskey", storage.AccessKeyField)
+		assert.Equal(t, "secretkey", storage.SecretKeyField)
+		assert.Equal(t, "http://minio-pipelines.minio-test.svc.cluster.local:9000", storage.EndpointURL)
+		assert.Equal(t, "mlpipeline", storage.Bucket)
+		assert.Equal(t, "us-east-1", storage.Region)
 	})
 
-	t.Run("should prefer external storage over managed MinIO when both exist", func(t *testing.T) {
+	t.Run("should inject external storage config when externalStorage is configured", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -375,12 +390,86 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 			kubernetesClientFactory: k8sFactory,
 		}
 
-		namespace := "test-namespace"
+		namespace := "external-storage-test"
 
-		// test-namespace has external storage DSPA - should use external storage
+		// TODO: Create a mock DSPA with external storage configuration
+		// Expected DSPA structure:
+		// - spec.objectStorage.externalStorage.scheme: "https"
+		// - spec.objectStorage.externalStorage.host: "s3.amazonaws.com"
+		// - spec.objectStorage.externalStorage.bucket: "my-external-bucket"
+		// - spec.objectStorage.externalStorage.region: "us-west-2"
+		// - spec.objectStorage.externalStorage.s3CredentialsSecret.secretName: "aws-s3-credentials"
+
 		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
-
 		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify the injected storage config
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		assert.Equal(t, "aws-s3-credentials", storage.SecretName)
+		assert.Equal(t, "AWS_ACCESS_KEY_ID", storage.AccessKeyField)
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", storage.SecretKeyField)
+		assert.Equal(t, "https://s3.amazonaws.com", storage.EndpointURL)
+		assert.Equal(t, "my-external-bucket", storage.Bucket)
+		assert.Equal(t, "us-west-2", storage.Region)
+	})
+
+	t.Run("should prefer external storage over managed MinIO when both are configured", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "both-storage-test"
+
+		// TODO: Create a mock DSPA with BOTH external storage AND managed MinIO configured
+		// The middleware should prefer external storage when both are present
+		// Expected DSPA structure:
+		// - spec.objectStorage.externalStorage (configured with AWS S3)
+		// - spec.objectStorage.minio.deploy: true (also configured)
+
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify that external storage is injected (not MinIO)
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		// Verify it's external storage (not MinIO) by checking the secret name and endpoint
+		assert.Equal(t, "aws-s3-credentials", storage.SecretName, "Should use external storage secret")
+		assert.NotEqual(t, "ds-pipeline-s3-pipelines", storage.SecretName, "Should not use MinIO secret convention")
+		assert.Equal(t, "https://s3.amazonaws.com", storage.EndpointURL, "Should use external storage endpoint")
+		assert.NotContains(t, storage.EndpointURL, "minio-", "Should not use MinIO endpoint")
+		assert.Equal(t, "AWS_ACCESS_KEY_ID", storage.AccessKeyField, "Should use AWS key names, not MinIO lowercase")
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", storage.SecretKeyField, "Should use AWS key names, not MinIO lowercase")
 	})
 
 	t.Run("should return original context when no DSPAs exist", func(t *testing.T) {
@@ -416,9 +505,42 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 
 		namespace := "empty-namespace"
 
-		// empty-namespace has no DSPAs
+		// Call injectDSPAObjectStorageIfAvailable on a namespace with no DSPAs
 		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
 
-		require.NotNil(t, resultCtx, "Context should not be nil")
+		// Verify the returned context is the exact same object as the input context
+		assert.Same(t, ctx, resultCtx)
+
+		// Verify no storage config was injected into the context
+		assert.Nil(t, resultCtx.Value(constants.DSPAObjectStorageKey))
+	})
+}
+
+// TestBuildMinIOObjectStorage tests the MinIO object storage builder helper
+func TestBuildMinIOObjectStorage(t *testing.T) {
+	t.Run("should construct MinIO object storage with correct conventions", func(t *testing.T) {
+		result := buildMinIOObjectStorage("my-dspa", "my-namespace", "my-bucket")
+
+		assert.Equal(t, "ds-pipeline-s3-my-dspa", result.SecretName, "Secret name should follow convention")
+		assert.Equal(t, "accesskey", result.AccessKeyField, "Should use lowercase accesskey")
+		assert.Equal(t, "secretkey", result.SecretKeyField, "Should use lowercase secretkey")
+		assert.Equal(t, "http://minio-my-dspa.my-namespace.svc.cluster.local:9000", result.EndpointURL, "Endpoint should follow MinIO URL pattern")
+		assert.Equal(t, "my-bucket", result.Bucket)
+		assert.Equal(t, "us-east-1", result.Region, "Should default to us-east-1")
+	})
+
+	t.Run("should handle different DSPA names", func(t *testing.T) {
+		result := buildMinIOObjectStorage("pipelines", "test-ns", "mlpipeline")
+
+		assert.Equal(t, "ds-pipeline-s3-pipelines", result.SecretName)
+		assert.Equal(t, "http://minio-pipelines.test-ns.svc.cluster.local:9000", result.EndpointURL)
+		assert.Equal(t, "mlpipeline", result.Bucket)
+	})
+
+	t.Run("should handle empty bucket", func(t *testing.T) {
+		result := buildMinIOObjectStorage("test-dspa", "test-ns", "")
+
+		assert.Equal(t, "", result.Bucket, "Should preserve empty bucket")
+		assert.Equal(t, "ds-pipeline-s3-test-dspa", result.SecretName, "Secret name should still be constructed")
 	})
 }

--- a/packages/automl/bff/internal/api/middleware_discovery_test.go
+++ b/packages/automl/bff/internal/api/middleware_discovery_test.go
@@ -300,3 +300,125 @@ func TestGetMockDSPipelineApplications(t *testing.T) {
 		}
 	})
 }
+
+// TestInjectDSPAObjectStorageForMinIO tests the MinIO auto-discovery functionality
+func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
+	t.Run("should inject managed MinIO storage config when minio.deploy is true", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		// Create a test namespace with a managed MinIO DSPA
+		namespace := "minio-test"
+
+		// Inject storage config using the function
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		// Verify context was returned (won't have injection without mock MinIO DSPA data)
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+
+	t.Run("should prefer external storage over managed MinIO when both exist", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "test-namespace"
+
+		// test-namespace has external storage DSPA - should use external storage
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+
+	t.Run("should return original context when no DSPAs exist", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "empty-namespace"
+
+		// empty-namespace has no DSPAs
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+}

--- a/packages/automl/bff/internal/integrations/s3/client.go
+++ b/packages/automl/bff/internal/integrations/s3/client.go
@@ -466,13 +466,18 @@ func cloneDefaultTransport() *http.Transport {
 
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.
 //
-// HTTPS is required — plain HTTP is rejected because S3 credentials would be
-// transmitted in cleartext. Self-signed or cluster-issued certificates are
-// supported via the RootCAs option (populated from operator-mounted CA bundles).
+// HTTPS is required for external endpoints — plain HTTP is rejected because S3
+// credentials would be transmitted in cleartext. However, HTTP is permitted for
+// in-cluster endpoints (*.svc.cluster.local) since traffic never leaves the cluster
+// network and HTTPS overhead is unnecessary for internal-only communication.
+// In-cluster endpoints skip DNS resolution and IP validation because they are
+// trusted cluster-internal services.
 //
-// RFC-1918 private IPs are permitted because MinIO commonly runs on the same
-// cluster using service IPs (e.g. 10.x). Loopback, link-local, and reserved
-// IP ranges are always blocked.
+// For external endpoints, self-signed or cluster-issued certificates are supported
+// via the RootCAs option (populated from operator-mounted CA bundles). RFC-1918
+// private IPs are permitted because MinIO commonly runs on the same cluster using
+// service IPs (e.g. 10.x). Loopback, link-local, and reserved IP ranges are always
+// blocked.
 func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, error) {
 	if endpoint == "" {
 		return "", fmt.Errorf("endpoint URL cannot be empty")
@@ -483,15 +488,28 @@ func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, er
 		return "", fmt.Errorf("invalid endpoint URL format: %w", err)
 	}
 
-	if parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("endpoint URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
-	}
-
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
 		return "", fmt.Errorf("endpoint URL must have a valid hostname")
 	}
 
+	// Allow HTTP only for in-cluster endpoints (.svc.cluster.local)
+	// All external endpoints must use HTTPS to prevent credentials in cleartext
+	isInCluster := strings.HasSuffix(hostname, ".svc.cluster.local")
+	if parsedURL.Scheme == "http" && !isInCluster {
+		return "", fmt.Errorf("endpoint URL must use HTTPS scheme for external endpoints, got: %s", parsedURL.Scheme)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("endpoint URL must use http or https scheme, got: %s", parsedURL.Scheme)
+	}
+
+	// Skip DNS resolution and IP validation for in-cluster endpoints
+	// (.svc.cluster.local domains are cluster-internal and trusted)
+	if isInCluster {
+		return parsedURL.String(), nil
+	}
+
+	// For external endpoints, perform DNS resolution and IP validation
 	ip := net.ParseIP(hostname)
 	if ip != nil {
 		if err := c.validateIPAddress(ip); err != nil {

--- a/packages/automl/bff/internal/integrations/s3/client.go
+++ b/packages/automl/bff/internal/integrations/s3/client.go
@@ -464,6 +464,20 @@ func cloneDefaultTransport() *http.Transport {
 	return &http.Transport{}
 }
 
+// isInternalHost reports whether a hostname is a trusted internal host
+// (Kubernetes in-cluster service). These legitimately use HTTP internally and
+// resolve to private IPs, so HTTP scheme and SSRF validation is skipped for them.
+// All other hosts are subject to HTTPS requirement and SSRF checks.
+//
+// Requires a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
+// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+func isInternalHost(hostname string) bool {
+	// Require a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
+	// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+	isK8sService := strings.HasSuffix(hostname, ".svc.cluster.local") && len(strings.Split(hostname, ".")) >= 5
+	return isK8sService
+}
+
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.
 //
 // HTTPS is required for external endpoints — plain HTTP is rejected because S3
@@ -495,7 +509,7 @@ func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, er
 
 	// Allow HTTP only for in-cluster endpoints (.svc.cluster.local)
 	// All external endpoints must use HTTPS to prevent credentials in cleartext
-	isInCluster := strings.HasSuffix(hostname, ".svc.cluster.local")
+	isInCluster := isInternalHost(hostname)
 	if parsedURL.Scheme == "http" && !isInCluster {
 		return "", fmt.Errorf("endpoint URL must use HTTPS scheme for external endpoints, got: %s", parsedURL.Scheme)
 	}

--- a/packages/automl/bff/internal/integrations/s3/client.go
+++ b/packages/automl/bff/internal/integrations/s3/client.go
@@ -469,13 +469,20 @@ func cloneDefaultTransport() *http.Transport {
 // resolve to private IPs, so HTTP scheme and SSRF validation is skipped for them.
 // All other hosts are subject to HTTPS requirement and SSRF checks.
 //
-// Requires a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
-// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+// Requires exactly the Kubernetes service FQDN format: <service>.<namespace>.svc.cluster.local
+// (exactly 5 dot-separated labels), preventing overly-broad matches like "evil.cluster.local".
 func isInternalHost(hostname string) bool {
-	// Require a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
-	// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
-	isK8sService := strings.HasSuffix(hostname, ".svc.cluster.local") && len(strings.Split(hostname, ".")) >= 5
-	return isK8sService
+	parts := strings.Split(hostname, ".")
+	if len(parts) != 5 {
+		return false
+	}
+	if parts[2] != "svc" || parts[3] != "cluster" || parts[4] != "local" {
+		return false
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	return true
 }
 
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.

--- a/packages/automl/bff/internal/integrations/s3/client_test.go
+++ b/packages/automl/bff/internal/integrations/s3/client_test.go
@@ -145,6 +145,40 @@ func TestValidateAndNormalizeEndpoint_AcceptsHTTPForInClusterEndpoints(t *testin
 	}
 }
 
+func TestValidateAndNormalizeEndpoint_RejectsInvalidClusterLocalHostnames(t *testing.T) {
+	c := newTestClient()
+	testCases := []struct {
+		name     string
+		endpoint string
+		reason   string
+	}{
+		{
+			name:     "Too few labels (4) - missing namespace",
+			endpoint: "http://evil.svc.cluster.local",
+			reason:   "should reject .svc.cluster.local with fewer than 5 labels",
+		},
+		{
+			name:     "Too few labels (3) - just svc.cluster.local",
+			endpoint: "http://svc.cluster.local:9000",
+			reason:   "should reject partial cluster domain",
+		},
+		{
+			name:     "Malicious cluster.local suffix",
+			endpoint: "http://evil.cluster.local",
+			reason:   "should reject non-service cluster.local domains",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.validateAndNormalizeEndpoint(tc.endpoint)
+			assert.Error(t, err, tc.reason)
+			assert.Contains(t, err.Error(), "HTTPS scheme for external endpoints",
+				"should treat invalid cluster hostnames as external and require HTTPS")
+		})
+	}
+}
+
 func TestValidateAndNormalizeEndpoint_RejectsEmpty(t *testing.T) {
 	c := newTestClient()
 	_, err := c.validateAndNormalizeEndpoint("")

--- a/packages/automl/bff/internal/integrations/s3/client_test.go
+++ b/packages/automl/bff/internal/integrations/s3/client_test.go
@@ -109,11 +109,40 @@ func TestValidateAndNormalizeEndpoint_AcceptsHTTPSWithPort(t *testing.T) {
 	assert.Equal(t, "https://s3.amazonaws.com:9000", result)
 }
 
-func TestValidateAndNormalizeEndpoint_RejectsHTTP(t *testing.T) {
+func TestValidateAndNormalizeEndpoint_RejectsHTTPForExternalEndpoints(t *testing.T) {
 	c := newTestClient()
 	_, err := c.validateAndNormalizeEndpoint("http://s3.amazonaws.com")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "HTTPS")
+	assert.Contains(t, err.Error(), "HTTPS scheme for external endpoints")
+}
+
+func TestValidateAndNormalizeEndpoint_AcceptsHTTPForInClusterEndpoints(t *testing.T) {
+	c := newTestClient()
+	testCases := []struct {
+		name     string
+		endpoint string
+	}{
+		{
+			name:     "MinIO service with namespace",
+			endpoint: "http://minio-pipelines.yamcha.svc.cluster.local:9000",
+		},
+		{
+			name:     "MinIO service without port",
+			endpoint: "http://minio-dspa.default.svc.cluster.local",
+		},
+		{
+			name:     "Generic cluster service",
+			endpoint: "http://my-service.my-namespace.svc.cluster.local:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := c.validateAndNormalizeEndpoint(tc.endpoint)
+			assert.NoError(t, err, "should accept in-cluster HTTP endpoint")
+			assert.Equal(t, tc.endpoint, result)
+		})
+	}
 }
 
 func TestValidateAndNormalizeEndpoint_RejectsEmpty(t *testing.T) {

--- a/packages/automl/bff/internal/models/pipeline_server.go
+++ b/packages/automl/bff/internal/models/pipeline_server.go
@@ -27,6 +27,7 @@ type APIServer struct {
 // ObjectStorage captures the DSPA objectStorage spec fields needed to connect to S3.
 type ObjectStorage struct {
 	ExternalStorage *ExternalStorage `json:"externalStorage,omitempty"`
+	Minio           *MinioStorage    `json:"minio,omitempty"`
 }
 
 // ExternalStorage holds the external S3-compatible storage configuration.
@@ -44,6 +45,16 @@ type S3CredentialsSecret struct {
 	SecretName string `json:"secretName,omitempty"`
 	AccessKey  string `json:"accessKey,omitempty"` // field NAME inside the secret
 	SecretKey  string `json:"secretKey,omitempty"` // field NAME inside the secret
+}
+
+// MinioStorage holds the managed MinIO storage configuration.
+// When deploy is true, the DSPA operator creates a MinIO instance with a secret
+// named "ds-pipeline-s3-{dspa-name}" containing S3-compatible credentials.
+type MinioStorage struct {
+	Deploy bool   `json:"deploy,omitempty"`
+	Bucket string `json:"bucket,omitempty"`
+	Image  string `json:"image,omitempty"`
+	PvcSize string `json:"pvcSize,omitempty"`
 }
 
 // DSPAObjectStorage is the resolved object-storage configuration extracted from a

--- a/packages/automl/bff/internal/models/pipeline_server.go
+++ b/packages/automl/bff/internal/models/pipeline_server.go
@@ -51,9 +51,9 @@ type S3CredentialsSecret struct {
 // When deploy is true, the DSPA operator creates a MinIO instance with a secret
 // named "ds-pipeline-s3-{dspa-name}" containing S3-compatible credentials.
 type MinioStorage struct {
-	Deploy bool   `json:"deploy,omitempty"`
-	Bucket string `json:"bucket,omitempty"`
-	Image  string `json:"image,omitempty"`
+	Deploy  bool   `json:"deploy,omitempty"`
+	Bucket  string `json:"bucket,omitempty"`
+	Image   string `json:"image,omitempty"`
 	PvcSize string `json:"pvcSize,omitempty"`
 }
 

--- a/packages/automl/bff/internal/repositories/s3.go
+++ b/packages/automl/bff/internal/repositories/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -192,16 +193,28 @@ func (r *S3Repository) GetS3CredentialsFromDSPA(
 		region = "us-east-1"
 	}
 
-	// Try to read endpoint URL from the secret first (allows custom configurations)
-	// Fall back to the constructed endpoint from the DSPA spec if not present
+	// Try to read endpoint URL from the secret first (allows custom configurations).
+	// AWS_S3_ENDPOINT and AWS_S3_BUCKET are optional override keys that follow the
+	// DSPA operator convention for MinIO secrets. When present in the secret, they
+	// take precedence over the DSPA spec values.
+	// See: https://github.com/opendatahub-io/data-science-pipelines-operator
 	endpointURL := dspaStorage.EndpointURL
-	if secretEndpoint, err := getValue("AWS_S3_ENDPOINT"); err == nil && secretEndpoint != "" {
+	secretEndpoint, err := getValue("AWS_S3_ENDPOINT")
+	if err != nil {
+		// Log ambiguous key error but continue with DSPA-specified endpoint
+		slog.Warn("ignoring ambiguous AWS_S3_ENDPOINT in secret, using DSPA spec",
+			"secret", dspaStorage.SecretName, "error", err)
+	} else if secretEndpoint != "" {
 		endpointURL = secretEndpoint
 	}
 
 	// Similarly, try to read bucket from the secret (optional override)
 	bucket := dspaStorage.Bucket
-	if secretBucket, err := getValue("AWS_S3_BUCKET"); err == nil && secretBucket != "" {
+	secretBucket, err := getValue("AWS_S3_BUCKET")
+	if err != nil {
+		slog.Warn("ignoring ambiguous AWS_S3_BUCKET in secret, using DSPA spec",
+			"secret", dspaStorage.SecretName, "error", err)
+	} else if secretBucket != "" {
 		bucket = secretBucket
 	}
 

--- a/packages/automl/bff/internal/repositories/s3.go
+++ b/packages/automl/bff/internal/repositories/s3.go
@@ -192,11 +192,24 @@ func (r *S3Repository) GetS3CredentialsFromDSPA(
 		region = "us-east-1"
 	}
 
+	// Try to read endpoint URL from the secret first (allows custom configurations)
+	// Fall back to the constructed endpoint from the DSPA spec if not present
+	endpointURL := dspaStorage.EndpointURL
+	if secretEndpoint, err := getValue("AWS_S3_ENDPOINT"); err == nil && secretEndpoint != "" {
+		endpointURL = secretEndpoint
+	}
+
+	// Similarly, try to read bucket from the secret (optional override)
+	bucket := dspaStorage.Bucket
+	if secretBucket, err := getValue("AWS_S3_BUCKET"); err == nil && secretBucket != "" {
+		bucket = secretBucket
+	}
+
 	return &S3Credentials{
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
-		EndpointURL:     dspaStorage.EndpointURL,
-		Bucket:          dspaStorage.Bucket,
+		EndpointURL:     endpointURL,
+		Bucket:          bucket,
 		Region:          region,
 	}, nil
 }

--- a/packages/autorag/bff/README.md
+++ b/packages/autorag/bff/README.md
@@ -225,6 +225,45 @@ curl -H "kubeflow-userid: user@example.com" \
   "http://localhost:4000/api/v1/s3/file?namespace=<namespace>&secretName=<secret>&bucket=<bucket>&key=<key>"
 ```
 
+#### Managed MinIO in port-forward mode
+
+When the DSPA uses managed MinIO (`minio.deploy: true`) instead of external S3, the BFF auto-discovers the MinIO configuration and constructs an in-cluster endpoint URL of the form `http://minio-<dspa-name>.<namespace>.svc.cluster.local:9000`. For this to work locally you need to port-forward the MinIO service and add a `/etc/hosts` entry so the BFF can resolve the in-cluster hostname.
+
+**1. Identify the MinIO service and DSPA name**
+
+```shell
+# Find the MinIO service in your namespace
+oc get svc -n <namespace> | grep minio
+
+# The service is typically named "minio-<dspa-name>", e.g. "minio-dspa"
+```
+
+**2. Port-forward the MinIO service**
+
+```shell
+oc port-forward -n <namespace> svc/minio-<dspa-name> 9000:9000
+```
+
+**3. Add a `/etc/hosts` entry**
+
+The BFF constructs the MinIO endpoint using the in-cluster DNS name. Add an entry to `/etc/hosts` so this resolves to your local port-forward:
+
+```shell
+# Add to /etc/hosts (requires sudo)
+echo "127.0.0.1 minio-<dspa-name>.<namespace>.svc.cluster.local" | sudo tee -a /etc/hosts
+```
+
+For example, if your DSPA is named `dspa` in namespace `my-project`:
+
+```shell
+oc port-forward -n my-project svc/minio-dspa 9000:9000
+echo "127.0.0.1 minio-dspa.my-project.svc.cluster.local" | sudo tee -a /etc/hosts
+```
+
+After this, the BFF will auto-discover the MinIO storage config from the DSPA spec and connect to MinIO via your port-forward. No `secretName` query parameter is needed.
+
+> **Cleanup:** Remember to remove the `/etc/hosts` entry when you're done testing.
+
 This will configure the BFF to extract the raw token from the following header:
 
 ```shell

--- a/packages/autorag/bff/internal/api/middleware.go
+++ b/packages/autorag/bff/internal/api/middleware.go
@@ -560,19 +560,20 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+			dspaObjectStorage, storageType := resolveDSPAObjectStorage(dspa, namespace, logger)
+			if dspaObjectStorage != nil {
 				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 
 				// Log appropriate message based on storage type
-				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+				switch storageType {
+				case dspaStorageExternal:
 					logger.Debug("Found DSPA external storage config",
 						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
 						"hasEndpoint", dspaObjectStorage.EndpointURL != "",
 						"hasBucket", dspaObjectStorage.Bucket != "",
 					)
-				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+				case dspaStorageMinIO:
 					logger.Debug("Found managed MinIO storage config",
 						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
@@ -671,6 +672,10 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			d.Spec.ObjectStorage.Minio.Deploy {
 			minioDSPA = d
 		}
+		// Break early if we've found both types
+		if externalDSPA != nil && minioDSPA != nil {
+			break
+		}
 	}
 	dspa := externalDSPA
 	if dspa == nil {
@@ -683,19 +688,20 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 	}
 
 	// Resolve and inject DSPA object storage config
-	if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+	dspaObjectStorage, storageType := resolveDSPAObjectStorage(dspa, namespace, logger)
+	if dspaObjectStorage != nil {
 		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 
 		// Log appropriate message based on storage type
-		if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-			dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+		switch storageType {
+		case dspaStorageExternal:
 			logger.Debug("Injected DSPA external storage config (override-URL mode)",
 				"secretName", dspaObjectStorage.SecretName,
 				"namespace", namespace,
 				"hasEndpoint", dspaObjectStorage.EndpointURL != "",
 				"hasBucket", dspaObjectStorage.Bucket != "",
 			)
-		} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+		case dspaStorageMinIO:
 			logger.Debug("Injected managed MinIO storage config (override-URL mode)",
 				"secretName", dspaObjectStorage.SecretName,
 				"namespace", namespace,
@@ -716,6 +722,15 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 const (
 	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
 	dsPipelineResource = "datasciencepipelinesapplications"
+)
+
+// dspaStorageType indicates the type of object storage configured in a DSPA.
+type dspaStorageType string
+
+const (
+	dspaStorageExternal dspaStorageType = "external"
+	dspaStorageMinIO    dspaStorageType = "minio"
+	dspaStorageNone     dspaStorageType = "none"
 )
 
 // buildMinIOObjectStorage constructs DSPAObjectStorage for managed MinIO deployments.
@@ -739,7 +754,8 @@ func buildMinIOObjectStorage(dspaName, namespace, bucket string) *models.DSPAObj
 // It handles both external storage (e.g., AWS S3) and managed MinIO, with external storage
 // preferred when both are configured.
 //
-// Returns nil if the DSPA has no valid object storage configuration.
+// Returns the DSPAObjectStorage config and its type. Returns (nil, dspaStorageNone) if the DSPA
+// has no valid object storage configuration.
 //
 // For external storage:
 //   - Validates scheme (must be "http" or "https")
@@ -757,9 +773,9 @@ func resolveDSPAObjectStorage(
 	dspa *models.DSPipelineApplication,
 	namespace string,
 	logger *slog.Logger,
-) *models.DSPAObjectStorage {
+) (*models.DSPAObjectStorage, dspaStorageType) {
 	if dspa == nil || dspa.Spec == nil || dspa.Spec.ObjectStorage == nil {
-		return nil
+		return nil, dspaStorageNone
 	}
 
 	// Handle external storage (preferred)
@@ -805,7 +821,7 @@ func resolveDSPAObjectStorage(
 			EndpointURL:    endpointURL,
 			Bucket:         ext.Bucket,
 			Region:         ext.Region,
-		}
+		}, dspaStorageExternal
 	}
 
 	// Handle managed MinIO (fallback)
@@ -814,11 +830,11 @@ func resolveDSPAObjectStorage(
 			dspa.Metadata.Name,
 			namespace,
 			dspa.Spec.ObjectStorage.Minio.Bucket,
-		)
+		), dspaStorageMinIO
 	}
 
 	// No valid storage configuration
-	return nil
+	return nil, dspaStorageNone
 }
 
 // isDSPAReady checks if the Pipeline Server is fully ready by looking for

--- a/packages/autorag/bff/internal/api/middleware.go
+++ b/packages/autorag/bff/internal/api/middleware.go
@@ -560,63 +560,90 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspa.Spec != nil &&
-				dspa.Spec.ObjectStorage != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-				dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-				ext := dspa.Spec.ObjectStorage.ExternalStorage
-				cred := ext.S3CredentialsSecret
+			if dspa.Spec != nil && dspa.Spec.ObjectStorage != nil {
+				// Handle external storage
+				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+					ext := dspa.Spec.ObjectStorage.ExternalStorage
+					cred := ext.S3CredentialsSecret
 
-				// Construct the endpoint URL from scheme, host, and optional port.
-				// Only "http" and "https" schemes are accepted; any other value is
-				// logged as a warning and the endpoint URL is left empty so that
-				// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
-				endpointURL := ""
-				scheme := strings.ToLower(ext.Scheme)
-				if ext.Host != "" && (scheme == "http" || scheme == "https") {
-					if ext.Port != "" {
-						endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-					} else {
-						endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+					// Construct the endpoint URL from scheme, host, and optional port.
+					// Only "http" and "https" schemes are accepted; any other value is
+					// logged as a warning and the endpoint URL is left empty so that
+					// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
+					endpointURL := ""
+					scheme := strings.ToLower(ext.Scheme)
+					if ext.Host != "" && (scheme == "http" || scheme == "https") {
+						if ext.Port != "" {
+							endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
+						} else {
+							endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+						}
+					} else if ext.Scheme != "" && ext.Host != "" {
+						logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
+							"scheme", ext.Scheme,
+							"namespace", namespace,
+						)
 					}
-				} else if ext.Scheme != "" && ext.Host != "" {
-					logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-						"scheme", ext.Scheme,
+
+					// Apply default field names when the DSPA spec omits them.
+					accessKeyField := cred.AccessKey
+					if accessKeyField == "" {
+						accessKeyField = "AWS_ACCESS_KEY_ID"
+					}
+					secretKeyField := cred.SecretKey
+					if secretKeyField == "" {
+						secretKeyField = "AWS_SECRET_ACCESS_KEY"
+					}
+
+					dspaObjectStorage := &models.DSPAObjectStorage{
+						SecretName:     cred.SecretName,
+						AccessKeyField: accessKeyField,
+						SecretKeyField: secretKeyField,
+						EndpointURL:    endpointURL,
+						Bucket:         ext.Bucket,
+						Region:         ext.Region,
+					}
+					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					logger.Debug("Found DSPA external storage config",
+						"secretName", cred.SecretName,
+						"namespace", namespace,
+						"hasEndpoint", endpointURL != "",
+						"hasBucket", ext.Bucket != "",
+					)
+				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+					// Handle managed MinIO
+					minio := dspa.Spec.ObjectStorage.Minio
+
+					// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
+					secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
+
+					// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+					endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
+						dspa.Metadata.Name, namespace)
+
+					dspaObjectStorage := &models.DSPAObjectStorage{
+						SecretName:     secretName,
+						AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
+						SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+						EndpointURL:    endpointURL,
+						Bucket:         minio.Bucket,
+						Region:         "us-east-1",   // Default region for MinIO
+					}
+					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					logger.Debug("Found managed MinIO storage config",
+						"secretName", secretName,
+						"namespace", namespace,
+						"bucket", minio.Bucket,
+						"endpoint", endpointURL,
+					)
+				} else {
+					logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
+						"dspa", dspa.Metadata.Name,
 						"namespace", namespace,
 					)
 				}
-
-				// Apply default field names when the DSPA spec omits them.
-				accessKeyField := cred.AccessKey
-				if accessKeyField == "" {
-					accessKeyField = "AWS_ACCESS_KEY_ID"
-				}
-				secretKeyField := cred.SecretKey
-				if secretKeyField == "" {
-					secretKeyField = "AWS_SECRET_ACCESS_KEY"
-				}
-
-				dspaObjectStorage := &models.DSPAObjectStorage{
-					SecretName:     cred.SecretName,
-					AccessKeyField: accessKeyField,
-					SecretKeyField: secretKeyField,
-					EndpointURL:    endpointURL,
-					Bucket:         ext.Bucket,
-					Region:         ext.Region,
-				}
-				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-				logger.Debug("Found DSPA object storage config",
-					"secretName", cred.SecretName,
-					"namespace", namespace,
-					"hasEndpoint", endpointURL != "",
-					"hasBucket", ext.Bucket != "",
-				)
-			} else {
-				logger.Warn("DSPA found but has no external storage config (managed MinIO or unconfigured externalStorage); S3 endpoints require explicit secretName",
-					"dspa", dspa.Metadata.Name,
-					"namespace", namespace,
-				)
 			}
 
 			// Extract auth token from request identity to forward to Pipeline Server
@@ -684,66 +711,113 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Use the first DSPA that has external storage configured.
+	// Use the first DSPA that has external storage OR managed MinIO configured.
 	var dspa *models.DSPipelineApplication
 	for i := range dspaItems {
 		d := &dspaItems[i]
-		if d.Spec != nil &&
-			d.Spec.ObjectStorage != nil &&
-			d.Spec.ObjectStorage.ExternalStorage != nil &&
-			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-			dspa = d
-			break
+		if d.Spec != nil && d.Spec.ObjectStorage != nil {
+			// Check for external storage first
+			if d.Spec.ObjectStorage.ExternalStorage != nil &&
+				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+				dspa = d
+				break
+			}
+			// Also check for managed MinIO
+			if d.Spec.ObjectStorage.Minio != nil && d.Spec.ObjectStorage.Minio.Deploy {
+				dspa = d
+				break
+			}
 		}
 	}
 	if dspa == nil {
-		logger.Warn("DSPA found but has no external storage config (managed MinIO or unconfigured externalStorage); S3 requires explicit secretName",
+		logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
 			"namespace", namespace)
 		return ctx
 	}
 
-	ext := dspa.Spec.ObjectStorage.ExternalStorage
-	cred := ext.S3CredentialsSecret
+	// Handle external storage case
+	if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
 
-	endpointURL := ""
-	scheme := strings.ToLower(ext.Scheme)
-	if ext.Host != "" && (scheme == "http" || scheme == "https") {
-		if ext.Port != "" {
-			endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-		} else {
-			endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+		ext := dspa.Spec.ObjectStorage.ExternalStorage
+		cred := ext.S3CredentialsSecret
+
+		endpointURL := ""
+		scheme := strings.ToLower(ext.Scheme)
+		if ext.Host != "" && (scheme == "http" || scheme == "https") {
+			if ext.Port != "" {
+				endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
+			} else {
+				endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
+			}
+		} else if ext.Scheme != "" && ext.Host != "" {
+			logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
+				"scheme", ext.Scheme,
+				"namespace", namespace,
+			)
 		}
-	} else if ext.Scheme != "" && ext.Host != "" {
-		logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-			"scheme", ext.Scheme,
+
+		accessKeyField := cred.AccessKey
+		if accessKeyField == "" {
+			accessKeyField = "AWS_ACCESS_KEY_ID"
+		}
+		secretKeyField := cred.SecretKey
+		if secretKeyField == "" {
+			secretKeyField = "AWS_SECRET_ACCESS_KEY"
+		}
+
+		dspaObjectStorage := &models.DSPAObjectStorage{
+			SecretName:     cred.SecretName,
+			AccessKeyField: accessKeyField,
+			SecretKeyField: secretKeyField,
+			EndpointURL:    endpointURL,
+			Bucket:         ext.Bucket,
+			Region:         ext.Region,
+		}
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+		logger.Debug("Injected DSPA external storage config (override-URL mode)",
+			"secretName", cred.SecretName,
 			"namespace", namespace,
+			"hasEndpoint", endpointURL != "",
+			"hasBucket", ext.Bucket != "",
 		)
+		return ctx
 	}
 
-	accessKeyField := cred.AccessKey
-	if accessKeyField == "" {
-		accessKeyField = "AWS_ACCESS_KEY_ID"
-	}
-	secretKeyField := cred.SecretKey
-	if secretKeyField == "" {
-		secretKeyField = "AWS_SECRET_ACCESS_KEY"
+	// Handle managed MinIO case
+	if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+		minio := dspa.Spec.ObjectStorage.Minio
+
+		// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
+		secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
+
+		// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+		endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
+			dspa.Metadata.Name, namespace)
+
+		dspaObjectStorage := &models.DSPAObjectStorage{
+			SecretName:     secretName,
+			AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
+			SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+			EndpointURL:    endpointURL,
+			Bucket:         minio.Bucket,
+			Region:         "us-east-1",   // Default region for MinIO
+		}
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+		logger.Debug("Injected managed MinIO storage config (override-URL mode)",
+			"secretName", secretName,
+			"namespace", namespace,
+			"bucket", minio.Bucket,
+			"endpoint", endpointURL,
+		)
+		return ctx
 	}
 
-	dspaObjectStorage := &models.DSPAObjectStorage{
-		SecretName:     cred.SecretName,
-		AccessKeyField: accessKeyField,
-		SecretKeyField: secretKeyField,
-		EndpointURL:    endpointURL,
-		Bucket:         ext.Bucket,
-		Region:         ext.Region,
-	}
-	ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-	logger.Debug("Injected DSPA object storage config (override-URL mode)",
-		"secretName", cred.SecretName,
+	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
+		"dspa", dspa.Metadata.Name,
 		"namespace", namespace,
-		"hasEndpoint", endpointURL != "",
-		"hasBucket", ext.Bucket != "",
 	)
 	return ctx
 }
@@ -1020,6 +1094,51 @@ func getMockDSPipelineApplications(namespace string) []models.DSPipelineApplicat
 					APIServer: &models.DSPipelineApplicationAPIServerStatus{
 						URL:         "https://ds-pipeline-dspa-not-ready.not-ready-namespace.svc.cluster.local:8443",
 						ExternalURL: "https://ds-pipeline-ui-dspa-not-ready-not-ready-namespace.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with managed MinIO in minio-test namespace
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "pipelines",
+				Namespace: "minio-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					Minio: &models.MinioStorage{
+						Deploy:  true,
+						Bucket:  "mlpipeline",
+						Image:   "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance",
+						PvcSize: "10Gi",
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-pipelines.minio-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-pipelines-minio-test.apps.cluster.local",
 					},
 				},
 			},

--- a/packages/autorag/bff/internal/api/middleware.go
+++ b/packages/autorag/bff/internal/api/middleware.go
@@ -625,11 +625,11 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 
 					dspaObjectStorage := &models.DSPAObjectStorage{
 						SecretName:     secretName,
-						AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
-						SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+						AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
+						SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
 						EndpointURL:    endpointURL,
 						Bucket:         minio.Bucket,
-						Region:         "us-east-1",   // Default region for MinIO
+						Region:         "us-east-1", // Default region for MinIO
 					}
 					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 					logger.Debug("Found managed MinIO storage config",
@@ -799,11 +799,11 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 
 		dspaObjectStorage := &models.DSPAObjectStorage{
 			SecretName:     secretName,
-			AccessKeyField: "accesskey",   // MinIO secret uses lowercase key names
-			SecretKeyField: "secretkey",   // MinIO secret uses lowercase key names
+			AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
+			SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
 			EndpointURL:    endpointURL,
 			Bucket:         minio.Bucket,
-			Region:         "us-east-1",   // Default region for MinIO
+			Region:         "us-east-1", // Default region for MinIO
 		}
 		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 		logger.Debug("Injected managed MinIO storage config (override-URL mode)",

--- a/packages/autorag/bff/internal/api/middleware.go
+++ b/packages/autorag/bff/internal/api/middleware.go
@@ -560,90 +560,31 @@ func (app *App) AttachPipelineServerClient(next func(http.ResponseWriter, *http.
 			// Extract the full object storage configuration from the DSPA spec and store in
 			// context. This allows downstream handlers to connect to S3 (or compatible stores
 			// like managed MinIO) without an additional Kubernetes API call.
-			if dspa.Spec != nil && dspa.Spec.ObjectStorage != nil {
-				// Handle external storage
+			if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+				ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+
+				// Log appropriate message based on storage type
 				if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-					ext := dspa.Spec.ObjectStorage.ExternalStorage
-					cred := ext.S3CredentialsSecret
-
-					// Construct the endpoint URL from scheme, host, and optional port.
-					// Only "http" and "https" schemes are accepted; any other value is
-					// logged as a warning and the endpoint URL is left empty so that
-					// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
-					endpointURL := ""
-					scheme := strings.ToLower(ext.Scheme)
-					if ext.Host != "" && (scheme == "http" || scheme == "https") {
-						if ext.Port != "" {
-							endpointURL = fmt.Sprintf("%s://%s:%s", scheme, ext.Host, ext.Port)
-						} else {
-							endpointURL = fmt.Sprintf("%s://%s", scheme, ext.Host)
-						}
-					} else if ext.Scheme != "" && ext.Host != "" {
-						logger.Warn("DSPA external storage has unrecognised scheme; endpoint URL will be omitted",
-							"scheme", ext.Scheme,
-							"namespace", namespace,
-						)
-					}
-
-					// Apply default field names when the DSPA spec omits them.
-					accessKeyField := cred.AccessKey
-					if accessKeyField == "" {
-						accessKeyField = "AWS_ACCESS_KEY_ID"
-					}
-					secretKeyField := cred.SecretKey
-					if secretKeyField == "" {
-						secretKeyField = "AWS_SECRET_ACCESS_KEY"
-					}
-
-					dspaObjectStorage := &models.DSPAObjectStorage{
-						SecretName:     cred.SecretName,
-						AccessKeyField: accessKeyField,
-						SecretKeyField: secretKeyField,
-						EndpointURL:    endpointURL,
-						Bucket:         ext.Bucket,
-						Region:         ext.Region,
-					}
-					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+					dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
 					logger.Debug("Found DSPA external storage config",
-						"secretName", cred.SecretName,
+						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
-						"hasEndpoint", endpointURL != "",
-						"hasBucket", ext.Bucket != "",
+						"hasEndpoint", dspaObjectStorage.EndpointURL != "",
+						"hasBucket", dspaObjectStorage.Bucket != "",
 					)
 				} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
-					// Handle managed MinIO
-					minio := dspa.Spec.ObjectStorage.Minio
-
-					// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
-					secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
-
-					// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
-					endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
-						dspa.Metadata.Name, namespace)
-
-					dspaObjectStorage := &models.DSPAObjectStorage{
-						SecretName:     secretName,
-						AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
-						SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
-						EndpointURL:    endpointURL,
-						Bucket:         minio.Bucket,
-						Region:         "us-east-1", // Default region for MinIO
-					}
-					ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
 					logger.Debug("Found managed MinIO storage config",
-						"secretName", secretName,
+						"secretName", dspaObjectStorage.SecretName,
 						"namespace", namespace,
-						"bucket", minio.Bucket,
-						"endpoint", endpointURL,
-					)
-				} else {
-					logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
-						"dspa", dspa.Metadata.Name,
-						"namespace", namespace,
+						"bucket", dspaObjectStorage.Bucket,
+						"endpoint", dspaObjectStorage.EndpointURL,
 					)
 				}
+			} else {
+				logger.Warn("DSPA found but has no storage config; S3 endpoints require explicit secretName",
+					"dspa", dspa.Metadata.Name,
+					"namespace", namespace,
+				)
 			}
 
 			// Extract auth token from request identity to forward to Pipeline Server
@@ -711,24 +652,29 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Use the first DSPA that has external storage OR managed MinIO configured.
-	var dspa *models.DSPipelineApplication
+	// Prefer external storage globally, then fall back to managed MinIO.
+	var externalDSPA *models.DSPipelineApplication
+	var minioDSPA *models.DSPipelineApplication
 	for i := range dspaItems {
 		d := &dspaItems[i]
-		if d.Spec != nil && d.Spec.ObjectStorage != nil {
-			// Check for external storage first
-			if d.Spec.ObjectStorage.ExternalStorage != nil &&
-				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
-				d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
-				dspa = d
-				break
-			}
-			// Also check for managed MinIO
-			if d.Spec.ObjectStorage.Minio != nil && d.Spec.ObjectStorage.Minio.Deploy {
-				dspa = d
-				break
-			}
+		if d.Spec == nil || d.Spec.ObjectStorage == nil {
+			continue
 		}
+		if externalDSPA == nil &&
+			d.Spec.ObjectStorage.ExternalStorage != nil &&
+			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
+			d.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
+			externalDSPA = d
+		}
+		if minioDSPA == nil &&
+			d.Spec.ObjectStorage.Minio != nil &&
+			d.Spec.ObjectStorage.Minio.Deploy {
+			minioDSPA = d
+		}
+	}
+	dspa := externalDSPA
+	if dspa == nil {
+		dspa = minioDSPA
 	}
 	if dspa == nil {
 		logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
@@ -736,7 +682,87 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		return ctx
 	}
 
-	// Handle external storage case
+	// Resolve and inject DSPA object storage config
+	if dspaObjectStorage := resolveDSPAObjectStorage(dspa, namespace, logger); dspaObjectStorage != nil {
+		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
+
+		// Log appropriate message based on storage type
+		if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
+			dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil {
+			logger.Debug("Injected DSPA external storage config (override-URL mode)",
+				"secretName", dspaObjectStorage.SecretName,
+				"namespace", namespace,
+				"hasEndpoint", dspaObjectStorage.EndpointURL != "",
+				"hasBucket", dspaObjectStorage.Bucket != "",
+			)
+		} else if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
+			logger.Debug("Injected managed MinIO storage config (override-URL mode)",
+				"secretName", dspaObjectStorage.SecretName,
+				"namespace", namespace,
+				"bucket", dspaObjectStorage.Bucket,
+				"endpoint", dspaObjectStorage.EndpointURL,
+			)
+		}
+		return ctx
+	}
+
+	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
+		"dspa", dspa.Metadata.Name,
+		"namespace", namespace,
+	)
+	return ctx
+}
+
+const (
+	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
+	dsPipelineResource = "datasciencepipelinesapplications"
+)
+
+// buildMinIOObjectStorage constructs DSPAObjectStorage for managed MinIO deployments.
+// It follows the DSPA operator conventions:
+//   - Secret name: "ds-pipeline-s3-{dspaName}"
+//   - Endpoint: http://minio-{dspaName}.{namespace}.svc.cluster.local:9000
+//   - Lowercase credential key names: "accesskey", "secretkey"
+//   - Default region: "us-east-1"
+func buildMinIOObjectStorage(dspaName, namespace, bucket string) *models.DSPAObjectStorage {
+	return &models.DSPAObjectStorage{
+		SecretName:     fmt.Sprintf("ds-pipeline-s3-%s", dspaName),
+		AccessKeyField: "accesskey",
+		SecretKeyField: "secretkey",
+		EndpointURL:    fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000", dspaName, namespace),
+		Bucket:         bucket,
+		Region:         "us-east-1",
+	}
+}
+
+// resolveDSPAObjectStorage extracts S3-compatible object storage configuration from a DSPA spec.
+// It handles both external storage (e.g., AWS S3) and managed MinIO, with external storage
+// preferred when both are configured.
+//
+// Returns nil if the DSPA has no valid object storage configuration.
+//
+// For external storage:
+//   - Validates scheme (must be "http" or "https")
+//   - Constructs endpoint URL from scheme://host[:port]
+//   - Defaults accessKeyField to "AWS_ACCESS_KEY_ID" if empty
+//   - Defaults secretKeyField to "AWS_SECRET_ACCESS_KEY" if empty
+//   - Uses bucket and region from DSPA spec
+//
+// For managed MinIO:
+//   - Secret name follows convention: "ds-pipeline-s3-{dspa-name}"
+//   - Endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
+//   - Uses lowercase key names: "accesskey", "secretkey"
+//   - Defaults region to "us-east-1"
+func resolveDSPAObjectStorage(
+	dspa *models.DSPipelineApplication,
+	namespace string,
+	logger *slog.Logger,
+) *models.DSPAObjectStorage {
+	if dspa == nil || dspa.Spec == nil || dspa.Spec.ObjectStorage == nil {
+		return nil
+	}
+
+	// Handle external storage (preferred)
 	if dspa.Spec.ObjectStorage.ExternalStorage != nil &&
 		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret != nil &&
 		dspa.Spec.ObjectStorage.ExternalStorage.S3CredentialsSecret.SecretName != "" {
@@ -744,6 +770,10 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 		ext := dspa.Spec.ObjectStorage.ExternalStorage
 		cred := ext.S3CredentialsSecret
 
+		// Construct the endpoint URL from scheme, host, and optional port.
+		// Only "http" and "https" schemes are accepted; any other value is
+		// logged as a warning and the endpoint URL is left empty so that
+		// GetS3CredentialsFromDSPA surfaces a clear error to the caller.
 		endpointURL := ""
 		scheme := strings.ToLower(ext.Scheme)
 		if ext.Host != "" && (scheme == "http" || scheme == "https") {
@@ -768,7 +798,7 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			secretKeyField = "AWS_SECRET_ACCESS_KEY"
 		}
 
-		dspaObjectStorage := &models.DSPAObjectStorage{
+		return &models.DSPAObjectStorage{
 			SecretName:     cred.SecretName,
 			AccessKeyField: accessKeyField,
 			SecretKeyField: secretKeyField,
@@ -776,56 +806,20 @@ func (app *App) injectDSPAObjectStorageIfAvailable(ctx context.Context, namespac
 			Bucket:         ext.Bucket,
 			Region:         ext.Region,
 		}
-		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-		logger.Debug("Injected DSPA external storage config (override-URL mode)",
-			"secretName", cred.SecretName,
-			"namespace", namespace,
-			"hasEndpoint", endpointURL != "",
-			"hasBucket", ext.Bucket != "",
-		)
-		return ctx
 	}
 
-	// Handle managed MinIO case
+	// Handle managed MinIO (fallback)
 	if dspa.Spec.ObjectStorage.Minio != nil && dspa.Spec.ObjectStorage.Minio.Deploy {
-		minio := dspa.Spec.ObjectStorage.Minio
-
-		// Convention: DSPA operator creates secret named "ds-pipeline-s3-<dspa-name>"
-		secretName := fmt.Sprintf("ds-pipeline-s3-%s", dspa.Metadata.Name)
-
-		// MinIO endpoint URL: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
-		endpointURL := fmt.Sprintf("http://minio-%s.%s.svc.cluster.local:9000",
-			dspa.Metadata.Name, namespace)
-
-		dspaObjectStorage := &models.DSPAObjectStorage{
-			SecretName:     secretName,
-			AccessKeyField: "accesskey", // MinIO secret uses lowercase key names
-			SecretKeyField: "secretkey", // MinIO secret uses lowercase key names
-			EndpointURL:    endpointURL,
-			Bucket:         minio.Bucket,
-			Region:         "us-east-1", // Default region for MinIO
-		}
-		ctx = context.WithValue(ctx, constants.DSPAObjectStorageKey, dspaObjectStorage)
-		logger.Debug("Injected managed MinIO storage config (override-URL mode)",
-			"secretName", secretName,
-			"namespace", namespace,
-			"bucket", minio.Bucket,
-			"endpoint", endpointURL,
+		return buildMinIOObjectStorage(
+			dspa.Metadata.Name,
+			namespace,
+			dspa.Spec.ObjectStorage.Minio.Bucket,
 		)
-		return ctx
 	}
 
-	logger.Warn("DSPA found but has no storage config; S3 requires explicit secretName",
-		"dspa", dspa.Metadata.Name,
-		"namespace", namespace,
-	)
-	return ctx
+	// No valid storage configuration
+	return nil
 }
-
-const (
-	dsPipelineGroup    = "datasciencepipelinesapplications.opendatahub.io"
-	dsPipelineResource = "datasciencepipelinesapplications"
-)
 
 // isDSPAReady checks if the Pipeline Server is fully ready by looking for
 // the Ready condition. Ready is the aggregate condition set by the DSPA
@@ -1139,6 +1133,115 @@ func getMockDSPipelineApplications(namespace string) []models.DSPipelineApplicat
 					APIServer: &models.DSPipelineApplicationAPIServerStatus{
 						URL:         "https://ds-pipeline-pipelines.minio-test.svc.cluster.local:8443",
 						ExternalURL: "https://ds-pipeline-ui-pipelines-minio-test.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with external storage in external-storage-test namespace
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "dspa-external",
+				Namespace: "external-storage-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					ExternalStorage: &models.ExternalStorage{
+						Host:   "s3.amazonaws.com",
+						Port:   "",
+						Scheme: "https",
+						Region: "us-west-2",
+						Bucket: "my-external-bucket",
+						S3CredentialsSecret: &models.S3CredentialsSecret{
+							SecretName: "aws-s3-credentials",
+							AccessKey:  "", // Empty means use default AWS_ACCESS_KEY_ID
+							SecretKey:  "", // Empty means use default AWS_SECRET_ACCESS_KEY
+						},
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-dspa-external.external-storage-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-dspa-external-external-storage-test.apps.cluster.local",
+					},
+				},
+			},
+		},
+		// Ready DSPA with BOTH external storage AND managed MinIO in both-storage-test namespace
+		// This tests that external storage is preferred when both are configured
+		{
+			APIVersion: "datasciencepipelinesapplications.opendatahub.io/v1",
+			Kind:       "DSPipelineApplication",
+			Metadata: models.DSPipelineApplicationMetadata{
+				Name:      "dspa-both",
+				Namespace: "both-storage-test",
+			},
+			Spec: &models.DSPipelineApplicationSpec{
+				APIServer: &models.APIServer{
+					Deploy: true,
+				},
+				ObjectStorage: &models.ObjectStorage{
+					ExternalStorage: &models.ExternalStorage{
+						Host:   "s3.amazonaws.com",
+						Port:   "",
+						Scheme: "https",
+						Region: "us-west-2",
+						Bucket: "my-external-bucket",
+						S3CredentialsSecret: &models.S3CredentialsSecret{
+							SecretName: "aws-s3-credentials",
+							AccessKey:  "", // Empty means use default AWS_ACCESS_KEY_ID
+							SecretKey:  "", // Empty means use default AWS_SECRET_ACCESS_KEY
+						},
+					},
+					Minio: &models.MinioStorage{
+						Deploy:  true,
+						Bucket:  "mlpipeline-minio",
+						Image:   "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance",
+						PvcSize: "10Gi",
+					},
+				},
+			},
+			Status: &models.DSPipelineApplicationStatus{
+				Ready: true,
+				Conditions: []models.DSPipelineApplicationCondition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "MinimumReplicasAvailable",
+						Message: "All components are ready",
+					},
+					{
+						Type:    "APIServerReady",
+						Status:  "True",
+						Reason:  "Deployed",
+						Message: "API Server is ready",
+					},
+				},
+				Components: &models.DSPipelineApplicationComponents{
+					APIServer: &models.DSPipelineApplicationAPIServerStatus{
+						URL:         "https://ds-pipeline-dspa-both.both-storage-test.svc.cluster.local:8443",
+						ExternalURL: "https://ds-pipeline-ui-dspa-both-both-storage-test.apps.cluster.local",
 					},
 				},
 			},

--- a/packages/autorag/bff/internal/api/middleware_discovery_test.go
+++ b/packages/autorag/bff/internal/api/middleware_discovery_test.go
@@ -301,3 +301,125 @@ func TestGetMockDSPipelineApplications(t *testing.T) {
 		}
 	})
 }
+
+// TestInjectDSPAObjectStorageForMinIO tests the MinIO auto-discovery functionality
+func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
+	t.Run("should inject managed MinIO storage config when minio.deploy is true", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		// Create a test namespace with a managed MinIO DSPA
+		namespace := "minio-test"
+
+		// Inject storage config using the function
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		// Verify context was returned (won't have injection without mock MinIO DSPA data)
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+
+	t.Run("should prefer external storage over managed MinIO when both exist", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "test-namespace"
+
+		// test-namespace has external storage DSPA - should use external storage
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+
+	t.Run("should return original context when no DSPAs exist", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "empty-namespace"
+
+		// empty-namespace has no DSPAs
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+
+		require.NotNil(t, resultCtx, "Context should not be nil")
+	})
+}

--- a/packages/autorag/bff/internal/api/middleware_discovery_test.go
+++ b/packages/autorag/bff/internal/api/middleware_discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opendatahub-io/autorag-library/bff/internal/config"
+	"github.com/opendatahub-io/autorag-library/bff/internal/constants"
 	k8mocks "github.com/opendatahub-io/autorag-library/bff/internal/integrations/kubernetes/k8mocks"
 	"github.com/opendatahub-io/autorag-library/bff/internal/models"
 	"github.com/stretchr/testify/assert"
@@ -335,17 +336,31 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 			kubernetesClientFactory: k8sFactory,
 		}
 
-		// Create a test namespace with a managed MinIO DSPA
 		namespace := "minio-test"
 
-		// Inject storage config using the function
-		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+		// TODO: Create a mock DSPA in the test environment with managed MinIO
+		// Expected DSPA structure:
+		// - metadata.name: "pipelines"
+		// - spec.objectStorage.minio.deploy: true
+		// - spec.objectStorage.minio.bucket: "mlpipeline"
 
-		// Verify context was returned (won't have injection without mock MinIO DSPA data)
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
 		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify the injected storage config
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		assert.Equal(t, "ds-pipeline-s3-pipelines", storage.SecretName)
+		assert.Equal(t, "accesskey", storage.AccessKeyField)
+		assert.Equal(t, "secretkey", storage.SecretKeyField)
+		assert.Equal(t, "http://minio-pipelines.minio-test.svc.cluster.local:9000", storage.EndpointURL)
+		assert.Equal(t, "mlpipeline", storage.Bucket)
+		assert.Equal(t, "us-east-1", storage.Region)
 	})
 
-	t.Run("should prefer external storage over managed MinIO when both exist", func(t *testing.T) {
+	t.Run("should inject external storage config when externalStorage is configured", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -376,12 +391,86 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 			kubernetesClientFactory: k8sFactory,
 		}
 
-		namespace := "test-namespace"
+		namespace := "external-storage-test"
 
-		// test-namespace has external storage DSPA - should use external storage
+		// TODO: Create a mock DSPA with external storage configuration
+		// Expected DSPA structure:
+		// - spec.objectStorage.externalStorage.scheme: "https"
+		// - spec.objectStorage.externalStorage.host: "s3.amazonaws.com"
+		// - spec.objectStorage.externalStorage.bucket: "my-external-bucket"
+		// - spec.objectStorage.externalStorage.region: "us-west-2"
+		// - spec.objectStorage.externalStorage.s3CredentialsSecret.secretName: "aws-s3-credentials"
+
 		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
-
 		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify the injected storage config
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		assert.Equal(t, "aws-s3-credentials", storage.SecretName)
+		assert.Equal(t, "AWS_ACCESS_KEY_ID", storage.AccessKeyField)
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", storage.SecretKeyField)
+		assert.Equal(t, "https://s3.amazonaws.com", storage.EndpointURL)
+		assert.Equal(t, "my-external-bucket", storage.Bucket)
+		assert.Equal(t, "us-west-2", storage.Region)
+	})
+
+	t.Run("should prefer external storage over managed MinIO when both are configured", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		logger := slog.Default()
+		cfg := config.EnvConfig{
+			MockK8Client: true,
+			AuthMethod:   config.AuthMethodInternal,
+		}
+
+		testEnv, clientset, err := k8mocks.SetupEnvTest(k8mocks.TestEnvInput{
+			Logger: logger,
+			Ctx:    ctx,
+			Cancel: cancel,
+		})
+		require.NoError(t, err)
+		defer func() {
+			if testEnv != nil {
+				_ = testEnv.Stop()
+			}
+		}()
+
+		k8sFactory, err := k8mocks.NewMockedKubernetesClientFactory(clientset, testEnv, cfg, logger)
+		require.NoError(t, err)
+
+		app := &App{
+			config:                  cfg,
+			logger:                  logger,
+			kubernetesClientFactory: k8sFactory,
+		}
+
+		namespace := "both-storage-test"
+
+		// TODO: Create a mock DSPA with BOTH external storage AND managed MinIO configured
+		// The middleware should prefer external storage when both are present
+		// Expected DSPA structure:
+		// - spec.objectStorage.externalStorage (configured with AWS S3)
+		// - spec.objectStorage.minio.deploy: true (also configured)
+
+		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
+		require.NotNil(t, resultCtx, "Context should not be nil")
+
+		// Verify that external storage is injected (not MinIO)
+		storage, ok := resultCtx.Value(constants.DSPAObjectStorageKey).(*models.DSPAObjectStorage)
+		require.True(t, ok)
+		require.NotNil(t, storage)
+
+		// Verify it's external storage (not MinIO) by checking the secret name and endpoint
+		assert.Equal(t, "aws-s3-credentials", storage.SecretName, "Should use external storage secret")
+		assert.NotEqual(t, "ds-pipeline-s3-pipelines", storage.SecretName, "Should not use MinIO secret convention")
+		assert.Equal(t, "https://s3.amazonaws.com", storage.EndpointURL, "Should use external storage endpoint")
+		assert.NotContains(t, storage.EndpointURL, "minio-", "Should not use MinIO endpoint")
+		assert.Equal(t, "AWS_ACCESS_KEY_ID", storage.AccessKeyField, "Should use AWS key names, not MinIO lowercase")
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", storage.SecretKeyField, "Should use AWS key names, not MinIO lowercase")
 	})
 
 	t.Run("should return original context when no DSPAs exist", func(t *testing.T) {
@@ -415,11 +504,44 @@ func TestInjectDSPAObjectStorageForMinIO(t *testing.T) {
 			kubernetesClientFactory: k8sFactory,
 		}
 
-		namespace := "empty-namespace"
+		namespace := "no-dspas-namespace"
 
-		// empty-namespace has no DSPAs
+		// Call injectDSPAObjectStorageIfAvailable on a namespace with no DSPAs
 		resultCtx := app.injectDSPAObjectStorageIfAvailable(ctx, namespace, logger)
 
-		require.NotNil(t, resultCtx, "Context should not be nil")
+		// Verify the returned context is the exact same object as the input context
+		assert.Same(t, ctx, resultCtx)
+
+		// Verify no storage config was injected into the context
+		assert.Nil(t, resultCtx.Value(constants.DSPAObjectStorageKey))
+	})
+}
+
+// TestBuildMinIOObjectStorage tests the MinIO object storage builder helper
+func TestBuildMinIOObjectStorage(t *testing.T) {
+	t.Run("should construct MinIO object storage with correct conventions", func(t *testing.T) {
+		result := buildMinIOObjectStorage("my-dspa", "my-namespace", "my-bucket")
+
+		assert.Equal(t, "ds-pipeline-s3-my-dspa", result.SecretName, "Secret name should follow convention")
+		assert.Equal(t, "accesskey", result.AccessKeyField, "Should use lowercase accesskey")
+		assert.Equal(t, "secretkey", result.SecretKeyField, "Should use lowercase secretkey")
+		assert.Equal(t, "http://minio-my-dspa.my-namespace.svc.cluster.local:9000", result.EndpointURL, "Endpoint should follow MinIO URL pattern")
+		assert.Equal(t, "my-bucket", result.Bucket)
+		assert.Equal(t, "us-east-1", result.Region, "Should default to us-east-1")
+	})
+
+	t.Run("should handle different DSPA names", func(t *testing.T) {
+		result := buildMinIOObjectStorage("pipelines", "test-ns", "mlpipeline")
+
+		assert.Equal(t, "ds-pipeline-s3-pipelines", result.SecretName)
+		assert.Equal(t, "http://minio-pipelines.test-ns.svc.cluster.local:9000", result.EndpointURL)
+		assert.Equal(t, "mlpipeline", result.Bucket)
+	})
+
+	t.Run("should handle empty bucket", func(t *testing.T) {
+		result := buildMinIOObjectStorage("test-dspa", "test-ns", "")
+
+		assert.Equal(t, "", result.Bucket, "Should preserve empty bucket")
+		assert.Equal(t, "ds-pipeline-s3-test-dspa", result.SecretName, "Secret name should still be constructed")
 	})
 }

--- a/packages/autorag/bff/internal/integrations/s3/client.go
+++ b/packages/autorag/bff/internal/integrations/s3/client.go
@@ -290,13 +290,18 @@ func cloneDefaultTransport() *http.Transport {
 
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.
 //
-// HTTPS is required — plain HTTP is rejected because S3 credentials would be
-// transmitted in cleartext. Self-signed or cluster-issued certificates are
-// supported via the RootCAs option (populated from operator-mounted CA bundles).
+// HTTPS is required for external endpoints — plain HTTP is rejected because S3
+// credentials would be transmitted in cleartext. However, HTTP is permitted for
+// in-cluster endpoints (*.svc.cluster.local) since traffic never leaves the cluster
+// network and HTTPS overhead is unnecessary for internal-only communication.
+// In-cluster endpoints skip DNS resolution and IP validation because they are
+// trusted cluster-internal services.
 //
-// RFC-1918 private IPs are permitted because MinIO commonly runs on the same
-// cluster using service IPs (e.g. 10.x). Loopback, link-local, and reserved
-// IP ranges are always blocked.
+// For external endpoints, self-signed or cluster-issued certificates are supported
+// via the RootCAs option (populated from operator-mounted CA bundles). RFC-1918
+// private IPs are permitted because MinIO commonly runs on the same cluster using
+// service IPs (e.g. 10.x). Loopback, link-local, and reserved IP ranges are always
+// blocked.
 func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, error) {
 	if endpoint == "" {
 		return "", fmt.Errorf("endpoint URL cannot be empty")
@@ -308,16 +313,29 @@ func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, er
 		return "", fmt.Errorf("invalid endpoint URL format: %w", err)
 	}
 
-	if parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("endpoint URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
-	}
-
 	// Extract hostname (may be hostname or IP)
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
 		return "", fmt.Errorf("endpoint URL must have a valid hostname")
 	}
 
+	// Allow HTTP only for in-cluster endpoints (.svc.cluster.local)
+	// All external endpoints must use HTTPS to prevent credentials in cleartext
+	isInCluster := strings.HasSuffix(hostname, ".svc.cluster.local")
+	if parsedURL.Scheme == "http" && !isInCluster {
+		return "", fmt.Errorf("endpoint URL must use HTTPS scheme for external endpoints, got: %s", parsedURL.Scheme)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("endpoint URL must use http or https scheme, got: %s", parsedURL.Scheme)
+	}
+
+	// Skip DNS resolution and IP validation for in-cluster endpoints
+	// (.svc.cluster.local domains are cluster-internal and trusted)
+	if isInCluster {
+		return parsedURL.String(), nil
+	}
+
+	// For external endpoints, perform DNS resolution and IP validation
 	// Check if the hostname is an IP address
 	ip := net.ParseIP(hostname)
 	if ip != nil {

--- a/packages/autorag/bff/internal/integrations/s3/client.go
+++ b/packages/autorag/bff/internal/integrations/s3/client.go
@@ -288,6 +288,20 @@ func cloneDefaultTransport() *http.Transport {
 	return &http.Transport{}
 }
 
+// isInternalHost reports whether a hostname is a trusted internal host
+// (Kubernetes in-cluster service). These legitimately use HTTP internally and
+// resolve to private IPs, so HTTP scheme and SSRF validation is skipped for them.
+// All other hosts are subject to HTTPS requirement and SSRF checks.
+//
+// Requires a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
+// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+func isInternalHost(hostname string) bool {
+	// Require a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
+	// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+	isK8sService := strings.HasSuffix(hostname, ".svc.cluster.local") && len(strings.Split(hostname, ".")) >= 5
+	return isK8sService
+}
+
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.
 //
 // HTTPS is required for external endpoints — plain HTTP is rejected because S3
@@ -321,7 +335,7 @@ func (c *RealS3Client) validateAndNormalizeEndpoint(endpoint string) (string, er
 
 	// Allow HTTP only for in-cluster endpoints (.svc.cluster.local)
 	// All external endpoints must use HTTPS to prevent credentials in cleartext
-	isInCluster := strings.HasSuffix(hostname, ".svc.cluster.local")
+	isInCluster := isInternalHost(hostname)
 	if parsedURL.Scheme == "http" && !isInCluster {
 		return "", fmt.Errorf("endpoint URL must use HTTPS scheme for external endpoints, got: %s", parsedURL.Scheme)
 	}

--- a/packages/autorag/bff/internal/integrations/s3/client.go
+++ b/packages/autorag/bff/internal/integrations/s3/client.go
@@ -293,13 +293,20 @@ func cloneDefaultTransport() *http.Transport {
 // resolve to private IPs, so HTTP scheme and SSRF validation is skipped for them.
 // All other hosts are subject to HTTPS requirement and SSRF checks.
 //
-// Requires a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
-// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
+// Requires exactly the Kubernetes service FQDN format: <service>.<namespace>.svc.cluster.local
+// (exactly 5 dot-separated labels), preventing overly-broad matches like "evil.cluster.local".
 func isInternalHost(hostname string) bool {
-	// Require a fully-qualified Kubernetes service DNS name: <service>.<namespace>.svc.cluster.local
-	// (5 dot-separated labels minimum), preventing overly-broad matches like "evil.cluster.local".
-	isK8sService := strings.HasSuffix(hostname, ".svc.cluster.local") && len(strings.Split(hostname, ".")) >= 5
-	return isK8sService
+	parts := strings.Split(hostname, ".")
+	if len(parts) != 5 {
+		return false
+	}
+	if parts[2] != "svc" || parts[3] != "cluster" || parts[4] != "local" {
+		return false
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	return true
 }
 
 // validateAndNormalizeEndpoint validates the S3 endpoint URL to prevent SSRF attacks.

--- a/packages/autorag/bff/internal/integrations/s3/client_test.go
+++ b/packages/autorag/bff/internal/integrations/s3/client_test.go
@@ -111,12 +111,41 @@ func TestValidateAndNormalizeEndpoint_AcceptsHTTPSWithPort(t *testing.T) {
 	assert.Equal(t, "https://s3.amazonaws.com:9000", result)
 }
 
-func TestValidateAndNormalizeEndpoint_RejectsHTTP(t *testing.T) {
+func TestValidateAndNormalizeEndpoint_RejectsHTTPForExternalEndpoints(t *testing.T) {
 	c := newTestClient()
 	_, err := c.validateAndNormalizeEndpoint("http://s3.amazonaws.com")
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "HTTPS")
+	assert.Contains(t, err.Error(), "HTTPS scheme for external endpoints")
+}
+
+func TestValidateAndNormalizeEndpoint_AcceptsHTTPForInClusterEndpoints(t *testing.T) {
+	c := newTestClient()
+	testCases := []struct {
+		name     string
+		endpoint string
+	}{
+		{
+			name:     "MinIO service with namespace",
+			endpoint: "http://minio-pipelines.yamcha.svc.cluster.local:9000",
+		},
+		{
+			name:     "MinIO service without port",
+			endpoint: "http://minio-dspa.default.svc.cluster.local",
+		},
+		{
+			name:     "Generic cluster service",
+			endpoint: "http://my-service.my-namespace.svc.cluster.local:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := c.validateAndNormalizeEndpoint(tc.endpoint)
+			assert.NoError(t, err, "should accept in-cluster HTTP endpoint")
+			assert.Equal(t, tc.endpoint, result)
+		})
+	}
 }
 
 func TestValidateAndNormalizeEndpoint_RejectsEmptyEndpoint(t *testing.T) {
@@ -127,12 +156,12 @@ func TestValidateAndNormalizeEndpoint_RejectsEmptyEndpoint(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty")
 }
 
-func TestValidateAndNormalizeEndpoint_RejectsInvalidURL(t *testing.T) {
+func TestValidateAndNormalizeEndpoint_RejectsInvalidScheme(t *testing.T) {
 	c := newTestClient()
-	_, err := c.validateAndNormalizeEndpoint("not-a-url")
+	_, err := c.validateAndNormalizeEndpoint("ftp://s3.amazonaws.com")
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "endpoint URL must use HTTPS")
+	assert.Contains(t, err.Error(), "must use http or https scheme")
 }
 
 func TestValidateAndNormalizeEndpoint_AcceptsPrivateIPs(t *testing.T) {

--- a/packages/autorag/bff/internal/integrations/s3/client_test.go
+++ b/packages/autorag/bff/internal/integrations/s3/client_test.go
@@ -148,6 +148,40 @@ func TestValidateAndNormalizeEndpoint_AcceptsHTTPForInClusterEndpoints(t *testin
 	}
 }
 
+func TestValidateAndNormalizeEndpoint_RejectsInvalidClusterLocalHostnames(t *testing.T) {
+	c := newTestClient()
+	testCases := []struct {
+		name     string
+		endpoint string
+		reason   string
+	}{
+		{
+			name:     "Too few labels (4) - missing namespace",
+			endpoint: "http://evil.svc.cluster.local",
+			reason:   "should reject .svc.cluster.local with fewer than 5 labels",
+		},
+		{
+			name:     "Too few labels (3) - just svc.cluster.local",
+			endpoint: "http://svc.cluster.local:9000",
+			reason:   "should reject partial cluster domain",
+		},
+		{
+			name:     "Malicious cluster.local suffix",
+			endpoint: "http://evil.cluster.local",
+			reason:   "should reject non-service cluster.local domains",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.validateAndNormalizeEndpoint(tc.endpoint)
+			assert.Error(t, err, tc.reason)
+			assert.Contains(t, err.Error(), "HTTPS scheme for external endpoints",
+				"should treat invalid cluster hostnames as external and require HTTPS")
+		})
+	}
+}
+
 func TestValidateAndNormalizeEndpoint_RejectsEmptyEndpoint(t *testing.T) {
 	c := newTestClient()
 	_, err := c.validateAndNormalizeEndpoint("")

--- a/packages/autorag/bff/internal/models/pipeline_server.go
+++ b/packages/autorag/bff/internal/models/pipeline_server.go
@@ -27,6 +27,7 @@ type APIServer struct {
 // ObjectStorage captures the DSPA objectStorage spec fields needed to connect to S3.
 type ObjectStorage struct {
 	ExternalStorage *ExternalStorage `json:"externalStorage,omitempty"`
+	Minio           *MinioStorage    `json:"minio,omitempty"`
 }
 
 // ExternalStorage holds the external S3-compatible storage configuration.
@@ -44,6 +45,16 @@ type S3CredentialsSecret struct {
 	SecretName string `json:"secretName,omitempty"`
 	AccessKey  string `json:"accessKey,omitempty"` // field NAME inside the secret
 	SecretKey  string `json:"secretKey,omitempty"` // field NAME inside the secret
+}
+
+// MinioStorage holds the managed MinIO storage configuration.
+// When deploy is true, the DSPA operator creates a MinIO instance with a secret
+// named "ds-pipeline-s3-{dspa-name}" containing S3-compatible credentials.
+type MinioStorage struct {
+	Deploy  bool   `json:"deploy,omitempty"`
+	Bucket  string `json:"bucket,omitempty"`
+	Image   string `json:"image,omitempty"`
+	PvcSize string `json:"pvcSize,omitempty"`
 }
 
 // DSPAObjectStorage is the resolved object-storage configuration extracted from a

--- a/packages/autorag/bff/internal/repositories/s3.go
+++ b/packages/autorag/bff/internal/repositories/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -192,16 +193,28 @@ func (r *S3Repository) GetS3CredentialsFromDSPA(
 		region = "us-east-1" // MinIO and other compatible stores ignore region; SDK requires a value
 	}
 
-	// Try to read endpoint URL from the secret first (allows custom configurations)
-	// Fall back to the constructed endpoint from the DSPA spec if not present
+	// Try to read endpoint URL from the secret first (allows custom configurations).
+	// AWS_S3_ENDPOINT and AWS_S3_BUCKET are optional override keys that follow the
+	// DSPA operator convention for MinIO secrets. When present in the secret, they
+	// take precedence over the DSPA spec values.
+	// See: https://github.com/opendatahub-io/data-science-pipelines-operator
 	endpointURL := dspaStorage.EndpointURL
-	if secretEndpoint, err := getValue("AWS_S3_ENDPOINT"); err == nil && secretEndpoint != "" {
+	secretEndpoint, err := getValue("AWS_S3_ENDPOINT")
+	if err != nil {
+		// Log ambiguous key error but continue with DSPA-specified endpoint
+		slog.Warn("ignoring ambiguous AWS_S3_ENDPOINT in secret, using DSPA spec",
+			"secret", dspaStorage.SecretName, "error", err)
+	} else if secretEndpoint != "" {
 		endpointURL = secretEndpoint
 	}
 
 	// Similarly, try to read bucket from the secret (optional override)
 	bucket := dspaStorage.Bucket
-	if secretBucket, err := getValue("AWS_S3_BUCKET"); err == nil && secretBucket != "" {
+	secretBucket, err := getValue("AWS_S3_BUCKET")
+	if err != nil {
+		slog.Warn("ignoring ambiguous AWS_S3_BUCKET in secret, using DSPA spec",
+			"secret", dspaStorage.SecretName, "error", err)
+	} else if secretBucket != "" {
 		bucket = secretBucket
 	}
 

--- a/packages/autorag/bff/internal/repositories/s3.go
+++ b/packages/autorag/bff/internal/repositories/s3.go
@@ -192,11 +192,24 @@ func (r *S3Repository) GetS3CredentialsFromDSPA(
 		region = "us-east-1" // MinIO and other compatible stores ignore region; SDK requires a value
 	}
 
+	// Try to read endpoint URL from the secret first (allows custom configurations)
+	// Fall back to the constructed endpoint from the DSPA spec if not present
+	endpointURL := dspaStorage.EndpointURL
+	if secretEndpoint, err := getValue("AWS_S3_ENDPOINT"); err == nil && secretEndpoint != "" {
+		endpointURL = secretEndpoint
+	}
+
+	// Similarly, try to read bucket from the secret (optional override)
+	bucket := dspaStorage.Bucket
+	if secretBucket, err := getValue("AWS_S3_BUCKET"); err == nil && secretBucket != "" {
+		bucket = secretBucket
+	}
+
 	return &S3Credentials{
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
-		EndpointURL:     dspaStorage.EndpointURL,
-		Bucket:          dspaStorage.Bucket,
+		EndpointURL:     endpointURL,
+		Bucket:          bucket,
 		Region:          region,
 	}, nil
 }


### PR DESCRIPTION
Enable BFF to automatically discover and inject S3 credentials when DSPA uses managed MinIO (minio.deploy: true), eliminating the need for frontend to explicitly pass secretName parameter for MinIO-based deployments.

Changes:
- Add MinioStorage model to DSPipelineApplication ObjectStorage spec
- Enhance injectDSPAObjectStorageIfAvailable() to detect managed MinIO
- Update AttachPipelineServerClient middleware for MinIO auto-discovery
- Add mock MinIO DSPA to test data (minio-test namespace)
- Add unit tests for MinIO auto-discovery functionality

When DSPA uses managed MinIO, the BFF now:
1. Detects minio.deploy: true in DSPA spec
2. Constructs secret name: ds-pipeline-s3-{dspa-name}
3. Constructs endpoint: http://minio-{dspa-name}.{namespace}.svc.cluster.local:9000
4. Injects DSPAObjectStorage into request context
5. S3 handlers use auto-discovered config (no secretName needed)

External storage is still preferred when both external and MinIO exist.

Resolves the 400 Bad Request error when accessing S3 endpoints in namespaces with managed MinIO DSPAs.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for managed MinIO as an object storage option; discovery prefers external S3 and falls back to deployed MinIO.
  * Endpoint validation tightened: only http/https allowed; HTTPS required for external hosts, HTTP permitted for in-cluster service hostnames.
  * Endpoint and bucket can be overridden from referenced secrets when present.

* **Documentation**
  * Added “Managed MinIO in port-forward mode” guidance for local setup and connectivity.

* **Tests**
  * Added tests for discovery/preference, MinIO builder conventions, endpoint validation, and secret-based overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->