### PR TITLE
Fix(RHOAIENG-57631):added bff changes for preserving unmanaged field in Policies and subscription

### DIFF
--- a/packages/maas/bff/internal/api/policy_handlers_test.go
+++ b/packages/maas/bff/internal/api/policy_handlers_test.go
@@ -482,9 +482,9 @@ var _ = Describe("PolicyHandlers", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue(), "spec.subjects.users should still be present after UI update")
 			Expect(users).To(HaveLen(1))
-			if userMap, ok := users[0].(map[string]interface{}); ok {
-				Expect(userMap["name"]).To(Equal("injected-user"))
-			}
+			userMap, ok := users[0].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "user entry should be a map")
+			Expect(userMap["name"]).To(Equal("injected-user"))
 		})
 	})
 

--- a/packages/maas/bff/internal/api/policy_handlers_test.go
+++ b/packages/maas/bff/internal/api/policy_handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,7 +11,10 @@ import (
 	"github.com/julienschmidt/httprouter"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
 )
@@ -412,6 +416,75 @@ var _ = Describe("PolicyHandlers", Ordered, func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("preserves spec.subjects.users set outside the UI when updating via the API", func() {
+			policyName := fmt.Sprintf("preserve-users-policy-%d", GinkgoRandomSeed())
+
+			// Create a policy via the API (groups only — as the UI does)
+			_, rs, err := setupApiTest[Envelope[models.MaaSAuthPolicy, None]](
+				http.MethodPost,
+				"/api/v1/new-policy",
+				Envelope[models.CreatePolicyRequest, None]{Data: models.CreatePolicyRequest{
+					Name: policyName,
+					ModelRefs: []models.ModelRef{
+						{Name: "granite-3-8b-instruct", Namespace: "maas-models"},
+					},
+					Subjects: models.SubjectSpec{
+						Groups: []models.GroupReference{{Name: "users"}},
+					},
+				}},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+
+			// Directly inject spec.subjects.users into the live K8s object (simulating a YAML apply)
+			ctx := context.Background()
+			existing, err := dynamicClient.Resource(constants.MaaSAuthPolicyGvr).Namespace("maas-system").Get(ctx, policyName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			subjects, _, _ := unstructured.NestedMap(existing.Object, "spec", "subjects")
+			if subjects == nil {
+				subjects = map[string]interface{}{}
+			}
+			subjects["users"] = []interface{}{
+				map[string]interface{}{"name": "injected-user"},
+			}
+			Expect(unstructured.SetNestedMap(existing.Object, subjects, "spec", "subjects")).To(Succeed())
+			_, err = dynamicClient.Resource(constants.MaaSAuthPolicyGvr).Namespace("maas-system").Update(ctx, existing, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update via the API (groups only — simulating a normal UI save)
+			_, rs, err = setupApiTest[Envelope[models.MaaSAuthPolicy, None]](
+				http.MethodPut,
+				"/api/v1/update-policy/"+policyName,
+				Envelope[models.UpdatePolicyRequest, None]{Data: models.UpdatePolicyRequest{
+					ModelRefs: []models.ModelRef{
+						{Name: "granite-3-8b-instruct", Namespace: "maas-models"},
+					},
+					Subjects: models.SubjectSpec{
+						Groups: []models.GroupReference{{Name: "premium-users"}},
+					},
+				}},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			// Read the raw K8s object and verify spec.subjects.users was not removed
+			updated, err := dynamicClient.Resource(constants.MaaSAuthPolicyGvr).Namespace("maas-system").Get(ctx, policyName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			users, found, err := unstructured.NestedSlice(updated.Object, "spec", "subjects", "users")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue(), "spec.subjects.users should still be present after UI update")
+			Expect(users).To(HaveLen(1))
+			if userMap, ok := users[0].(map[string]interface{}); ok {
+				Expect(userMap["name"]).To(Equal("injected-user"))
+			}
 		})
 	})
 

--- a/packages/maas/bff/internal/api/subscription_handlers_test.go
+++ b/packages/maas/bff/internal/api/subscription_handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -8,7 +9,10 @@ import (
 	"github.com/julienschmidt/httprouter"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
 	"github.com/opendatahub-io/maas-library/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/maas-library/bff/internal/models"
 )
@@ -412,6 +416,79 @@ var _ = Describe("SubscriptionHandlers", Ordered, func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("preserves spec.owner.users set outside the UI when updating via the API", func() {
+			subName := fmt.Sprintf("preserve-users-sub-%d", GinkgoRandomSeed())
+
+			// Create a subscription via the API (groups only — as the UI does)
+			_, rs, err := setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPost,
+				"/api/v1/new-subscription",
+				Envelope[models.CreateSubscriptionRequest, None]{
+					Data: models.CreateSubscriptionRequest{
+						Name: subName,
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{Name: "granite-3-8b-instruct", Namespace: "maas-models", TokenRateLimits: []models.TokenRateLimit{{Limit: 1000, Window: "1h"}}},
+						},
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+
+			// Directly inject spec.owner.users into the live K8s object (simulating a YAML apply)
+			ctx := context.Background()
+			existing, err := dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Get(ctx, subName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			owner, _, _ := unstructured.NestedMap(existing.Object, "spec", "owner")
+			if owner == nil {
+				owner = map[string]interface{}{}
+			}
+			owner["users"] = []interface{}{
+				map[string]interface{}{"name": "injected-user"},
+			}
+			Expect(unstructured.SetNestedMap(existing.Object, owner, "spec", "owner")).To(Succeed())
+			_, err = dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Update(ctx, existing, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update via the API (groups only — simulating a normal UI save)
+			_, rs, err = setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPut,
+				"/api/v1/update-subscription/"+subName,
+				Envelope[models.UpdateSubscriptionRequest, None]{
+					Data: models.UpdateSubscriptionRequest{
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "premium-users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{Name: "granite-3-8b-instruct", Namespace: "maas-models", TokenRateLimits: []models.TokenRateLimit{{Limit: 2000, Window: "1h"}}},
+						},
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			// Read the raw K8s object and verify spec.owner.users was not removed
+			updated, err := dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Get(ctx, subName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			users, found, err := unstructured.NestedSlice(updated.Object, "spec", "owner", "users")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue(), "spec.owner.users should still be present after UI update")
+			Expect(users).To(HaveLen(1))
+			if userMap, ok := users[0].(map[string]interface{}); ok {
+				Expect(userMap["name"]).To(Equal("injected-user"))
+			}
 		})
 	})
 

--- a/packages/maas/bff/internal/api/subscription_handlers_test.go
+++ b/packages/maas/bff/internal/api/subscription_handlers_test.go
@@ -490,6 +490,89 @@ var _ = Describe("SubscriptionHandlers", Ordered, func() {
 			Expect(ok).To(BeTrue(), "user entry should be a map")
 			Expect(userMap["name"]).To(Equal("injected-user"))
 		})
+
+		It("preserves spec.modelRefs[*].billingRate set outside the UI when updating via the API", func() {
+			subName := fmt.Sprintf("preserve-billing-sub-%d", GinkgoRandomSeed())
+
+			// Create a subscription via the API (no billingRate — as the UI does)
+			_, rs, err := setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPost,
+				"/api/v1/new-subscription",
+				Envelope[models.CreateSubscriptionRequest, None]{
+					Data: models.CreateSubscriptionRequest{
+						Name: subName,
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{Name: "granite-3-8b-instruct", Namespace: "maas-models", TokenRateLimits: []models.TokenRateLimit{{Limit: 1000, Window: "1h"}}},
+						},
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+
+			// Directly inject billingRate into the model ref on the live K8s object (simulating a YAML apply)
+			ctx := context.Background()
+			existing, err := dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Get(ctx, subName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			modelRefs, _, _ := unstructured.NestedSlice(existing.Object, "spec", "modelRefs")
+			Expect(modelRefs).To(HaveLen(1))
+			mrMap, ok := modelRefs[0].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			mrMap["billingRate"] = map[string]interface{}{"perToken": "0.001"}
+			Expect(unstructured.SetNestedSlice(existing.Object, modelRefs, "spec", "modelRefs")).To(Succeed())
+			_, err = dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Update(ctx, existing, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update via the API (no billingRate — simulating a normal UI save)
+			_, rs, err = setupApiTest[Envelope[*models.CreateSubscriptionResponse, None]](
+				http.MethodPut,
+				"/api/v1/update-subscription/"+subName,
+				Envelope[models.UpdateSubscriptionRequest, None]{
+					Data: models.UpdateSubscriptionRequest{
+						Owner: models.OwnerSpec{
+							Groups: []models.GroupReference{{Name: "premium-users"}},
+						},
+						ModelRefs: []models.ModelSubscriptionRef{
+							{Name: "granite-3-8b-instruct", Namespace: "maas-models", TokenRateLimits: []models.TokenRateLimit{{Limit: 2000, Window: "1h"}}},
+						},
+					},
+				},
+				k8Factory,
+				identity,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			// Read the raw K8s object and verify billingRate was not removed
+			updated, err := dynamicClient.Resource(constants.MaaSSubscriptionGvr).Namespace("maas-system").Get(ctx, subName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedRefs, found, err := unstructured.NestedSlice(updated.Object, "spec", "modelRefs")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue(), "spec.modelRefs should still be present after UI update")
+			Expect(updatedRefs).To(HaveLen(1))
+			refMap, ok := updatedRefs[0].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "modelRef entry should be a map")
+			billingRate, billingFound, err := unstructured.NestedMap(refMap, "billingRate")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(billingFound).To(BeTrue(), "billingRate should still be present after UI update")
+			Expect(billingRate["perToken"]).To(Equal("0.001"))
+
+			// Also verify the UI-managed field was actually updated (not just that billingRate survived)
+			trls, trlFound, err := unstructured.NestedSlice(refMap, "tokenRateLimits")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(trlFound).To(BeTrue(), "tokenRateLimits should be present after UI update")
+			Expect(trls).To(HaveLen(1))
+			trlMap, ok := trls[0].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "tokenRateLimits entry should be a map")
+			Expect(trlMap["limit"]).To(BeEquivalentTo(2000), "tokenRateLimits limit should have been updated by the UI")
+		})
 	})
 
 	var _ = Describe("DeleteSubscriptionHandler", Ordered, func() {

--- a/packages/maas/bff/internal/api/subscription_handlers_test.go
+++ b/packages/maas/bff/internal/api/subscription_handlers_test.go
@@ -486,9 +486,9 @@ var _ = Describe("SubscriptionHandlers", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue(), "spec.owner.users should still be present after UI update")
 			Expect(users).To(HaveLen(1))
-			if userMap, ok := users[0].(map[string]interface{}); ok {
-				Expect(userMap["name"]).To(Equal("injected-user"))
-			}
+			userMap, ok := users[0].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "user entry should be a map")
+			Expect(userMap["name"]).To(Equal("injected-user"))
 		})
 	})
 

--- a/packages/maas/bff/internal/repositories/policies.go
+++ b/packages/maas/bff/internal/repositories/policies.go
@@ -202,13 +202,21 @@ func updateAuthPolicySpec(obj *unstructured.Unstructured, modelRefs []models.Mod
 
 	// Merge fields instead of overwriting the entire spec
 	spec["modelRefs"] = mrList
-	spec["subjects"] = map[string]interface{}{
-		"groups": groupList,
-	}
+	existingSubjects, _ := spec["subjects"].(map[string]interface{})
+	spec["subjects"] = mergeSubjectGroups(existingSubjects, groupList)
 
 	if meteringMetadata != nil {
 		spec["meteringMetadata"] = buildTokenMetadata(meteringMetadata)
 	}
 
 	obj.Object["spec"] = spec
+}
+
+// mergeSubjectGroups updates only the groups key in the existing subjects map preserving unmanaged fields like users.
+func mergeSubjectGroups(existing map[string]interface{}, groups []interface{}) map[string]interface{} {
+	if existing == nil {
+		existing = map[string]interface{}{}
+	}
+	existing["groups"] = groups
+	return existing
 }

--- a/packages/maas/bff/internal/repositories/policies.go
+++ b/packages/maas/bff/internal/repositories/policies.go
@@ -179,29 +179,20 @@ func (r *PoliciesRepository) DeletePolicy(ctx context.Context, name string) erro
 
 // updateAuthPolicySpec updates the spec of an existing MaaSAuthPolicy unstructured object.
 func updateAuthPolicySpec(obj *unstructured.Unstructured, modelRefs []models.ModelRef, groups []models.GroupReference, meteringMetadata *models.TokenMetadata) {
-	mrList := make([]interface{}, len(modelRefs))
-	for i, mr := range modelRefs {
-		mrList[i] = map[string]interface{}{
-			"name":      mr.Name,
-			"namespace": mr.Namespace,
-		}
+	groupList := make([]interface{}, 0, len(groups))
+	for _, group := range groups {
+		groupList = append(groupList, map[string]interface{}{
+			"name": group.Name,
+		})
 	}
 
-	groupList := make([]interface{}, len(groups))
-	for i, g := range groups {
-		groupList[i] = map[string]interface{}{
-			"name": g.Name,
-		}
-	}
-
-	// Get existing spec or create empty map
-	spec, ok := obj.Object["spec"].(map[string]interface{})
-	if !ok {
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	if spec == nil {
 		spec = make(map[string]interface{})
 	}
 
-	// Merge fields instead of overwriting the entire spec
-	spec["modelRefs"] = mrList
+	existingModelRefs, _ := spec["modelRefs"].([]interface{})
+	spec["modelRefs"] = mergeAuthPolicyModelRefs(existingModelRefs, modelRefs)
 	existingSubjects, _ := spec["subjects"].(map[string]interface{})
 	spec["subjects"] = mergeSubjectGroups(existingSubjects, groupList)
 
@@ -210,6 +201,23 @@ func updateAuthPolicySpec(obj *unstructured.Unstructured, modelRefs []models.Mod
 	}
 
 	obj.Object["spec"] = spec
+}
+
+// mergeAuthPolicyModelRefs updates the ref list while keeping any unmanaged fields on each entry intact.
+func mergeAuthPolicyModelRefs(existing []interface{}, refs []models.ModelRef) []interface{} {
+	existingByKey := indexModelRefsByKey(existing)
+	result := make([]interface{}, 0, len(refs))
+	for _, ref := range refs {
+		refMap := existingByKey[ref.Namespace+"/"+ref.Name]
+		if refMap == nil {
+			refMap = map[string]interface{}{
+				"name":      ref.Name,
+				"namespace": ref.Namespace,
+			}
+		}
+		result = append(result, refMap)
+	}
+	return result
 }
 
 // mergeSubjectGroups updates only the groups key in the existing subjects map preserving unmanaged fields like users.

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -629,6 +629,49 @@ func mergeOwnerSpec(existing map[string]interface{}, owner models.OwnerSpec) map
 	return existing
 }
 
+// indexModelRefsByKey indexes existing refs by "namespace/name" for quick lookup during a merge.
+func indexModelRefsByKey(refs []interface{}) map[string]map[string]interface{} {
+	idx := make(map[string]map[string]interface{}, len(refs))
+	for _, r := range refs {
+		if m, ok := r.(map[string]interface{}); ok {
+			name, _ := m["name"].(string)
+			ns, _ := m["namespace"].(string)
+			idx[ns+"/"+name] = m
+		}
+	}
+	return idx
+}
+
+// mergeModelSubscriptionRefs merges the incoming refs with the existing ones, preserving fields the UI doesn't own (e.g. billingRate).
+func mergeModelSubscriptionRefs(existing []interface{}, refs []models.ModelSubscriptionRef) []interface{} {
+	existingByKey := indexModelRefsByKey(existing)
+	result := make([]interface{}, len(refs))
+	for i, ref := range refs {
+		refMap := existingByKey[ref.Namespace+"/"+ref.Name]
+		if refMap == nil {
+			refMap = map[string]interface{}{
+				"name":      ref.Name,
+				"namespace": ref.Namespace,
+			}
+		}
+		// only tokenRateLimits is owned by the UI; everything else (e.g. billingRate) is left untouched.
+		if len(ref.TokenRateLimits) > 0 {
+			tokenLimits := make([]interface{}, 0, len(ref.TokenRateLimits))
+			for _, limit := range ref.TokenRateLimits {
+				tokenLimits = append(tokenLimits, map[string]interface{}{
+					"limit":  limit.Limit,
+					"window": limit.Window,
+				})
+			}
+			refMap["tokenRateLimits"] = tokenLimits
+		} else {
+			delete(refMap, "tokenRateLimits")
+		}
+		result[i] = refMap
+	}
+	return result
+}
+
 func buildModelSubscriptionRefs(refs []models.ModelSubscriptionRef) []interface{} {
 	result := make([]interface{}, len(refs))
 	for i, ref := range refs {
@@ -698,7 +741,8 @@ func updateSubscriptionSpec(obj *unstructured.Unstructured, displayName, descrip
 	existingSpec["priority"] = int64(priority)
 	existingOwner, _ := existingSpec["owner"].(map[string]interface{})
 	existingSpec["owner"] = mergeOwnerSpec(existingOwner, owner)
-	existingSpec["modelRefs"] = buildModelSubscriptionRefs(modelRefs)
+	existingModelRefs, _ := existingSpec["modelRefs"].([]interface{})
+	existingSpec["modelRefs"] = mergeModelSubscriptionRefs(existingModelRefs, modelRefs)
 
 	if tokenMetadata != nil {
 		existingSpec["tokenMetadata"] = buildTokenMetadata(tokenMetadata)

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -620,6 +620,15 @@ func buildOwnerSpec(owner models.OwnerSpec) map[string]interface{} {
 	}
 }
 
+// mergeOwnerSpec updates only groups, preserving unmanaged fields like users.
+func mergeOwnerSpec(existing map[string]interface{}, owner models.OwnerSpec) map[string]interface{} {
+	if existing == nil {
+		existing = map[string]interface{}{}
+	}
+	existing["groups"] = buildOwnerSpec(owner)["groups"]
+	return existing
+}
+
 func buildModelSubscriptionRefs(refs []models.ModelSubscriptionRef) []interface{} {
 	result := make([]interface{}, len(refs))
 	for i, ref := range refs {
@@ -687,7 +696,8 @@ func updateSubscriptionSpec(obj *unstructured.Unstructured, displayName, descrip
 		existingSpec = map[string]interface{}{}
 	}
 	existingSpec["priority"] = int64(priority)
-	existingSpec["owner"] = buildOwnerSpec(owner)
+	existingOwner, _ := existingSpec["owner"].(map[string]interface{})
+	existingSpec["owner"] = mergeOwnerSpec(existingOwner, owner)
 	existingSpec["modelRefs"] = buildModelSubscriptionRefs(modelRefs)
 
 	if tokenMetadata != nil {


### PR DESCRIPTION
Closes [RHOAIENG-57631](https://redhat.atlassian.net/browse/RHOAIENG-57631)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
This PR contains the following fixes:

Fixes a bug where fields set on `MaaSAuthPolicy` or `MaaSSubscription` via YAML (outside the UI) were being deleted when the resource was updated through the UI.
1. On policies updation 

https://github.com/user-attachments/assets/e4c6230a-d4ad-42d9-8381-e5c053e98b36



2. On subscription updation



https://github.com/user-attachments/assets/904caca9-d83d-41a9-b99d-5f25d611c4ae

**on multiple updates** 

https://github.com/user-attachments/assets/8c6df505-8670-48b8-999b-8da7da691eb0


**After this fix**, the BFF only writes what it owns. Everything else is read from the
live object first and carried forward untouched and treating the update more like a patch.
| Field lost on UI save | Now preserved |
|---|---|
| `MaaSSubscription` — `spec.owner.users` | ✓ |
| `MaaSSubscription` — `spec.modelRefs[*].billingRate` | ✓ |
| `MaaSAuthPolicy` — `spec.subjects.users` | ✓ |


### Helpers added
- `mergeOwnerSpec` —> updates owner groups while keeping `users` intact
- `mergeSubjectGroups` —> updates subject groups while keeping `users` intact
- `indexModelRefsByKey` —> indexes existing refs by `namespace/name` for quick lookup
- `mergeModelSubscriptionRefs` —> merges subscription modelRefs entry by entry, preserving fields like `billingRate` that the UI doesn't touch
- `mergeAuthPolicyModelRefs` —> same for policy modelRefs


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  1. Create a resource via the API (groups only)
  2. Inject `users` directly into the K8s object (simulating a YAML apply)
  3. Call the update API (groups only — as the UI does)
  4. Assert `users` is still present on the K8s object afterward



## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- Added integration tests to `policy_handlers_test.go` and `subscription_handlers_test.go` that simulate the exact bug scenario
Added integration tests covering:
- `spec.owner.users` preserved on `MaaSSubscription`
- `spec.subjects.users` preserved on `MaaSAuthPolicy`
- `spec.modelRefs[*].billingRate` preserved on `MaaSSubscription` — also asserts
  `tokenRateLimits` was correctly updated by the UI


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updates now preserve user-specific and other unmanaged fields (e.g., injected user entries and per-model billing info) when API updates provide only UI-managed fields, preventing unintended data loss.

* **Tests**
  * Added end-to-end tests that verify API "UI update" semantics maintain existing, externally injected fields across policy and subscription updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->