### PR TITLE
fix(automl): fix leaderboard ranking for negated error metrics

### DIFF
--- a/packages/automl/frontend/src/app/components/run-results/AutomlLeaderboard.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlLeaderboard.tsx
@@ -356,11 +356,8 @@ function AutomlLeaderboard({
       };
     });
 
-    // Initial ranking by optimized metric value
-    // Error metrics (mase, mse, mae, etc.) where lower is better
-    const errorMetrics = ['mase', 'mse', 'mae', 'rmse', 'mape'];
-    const isErrorMetric = errorMetrics.includes(optimizedMetric.toLowerCase());
-
+    // Initial ranking by optimized metric value (higher is better).
+    // AutoGluon negates error/loss metrics so all metrics are uniformly "higher is better".
     const sortedByMetric = entries.toSorted((a, b) => {
       const aVal = a.optimizedMetricValue;
       const bVal = b.optimizedMetricValue;
@@ -376,12 +373,10 @@ function AutomlLeaderboard({
         return -1;
       }
 
-      // Both are numbers
+      // Both are numbers — descending (higher is better)
       const aNum = typeof aVal === 'number' ? aVal : 0;
       const bNum = typeof bVal === 'number' ? bVal : 0;
-      return isErrorMetric
-        ? aNum - bNum // Lower is better
-        : bNum - aNum; // Higher is better
+      return bNum - aNum;
     });
 
     // Assign initial rank

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModalHeader.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/AutomlModelDetailsModalHeader.tsx
@@ -10,7 +10,7 @@ import {
 import type { MenuToggleElement } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import type { AutomlModel } from '~/app/context/AutomlResultsContext';
-import { formatMetricName, formatMetricValue, isErrorMetric } from '~/app/utilities/utils';
+import { formatMetricName, formatMetricValue } from '~/app/utilities/utils';
 import './AutomlModelDetailsModal.scss';
 
 type AutomlModelDetailsModalHeaderProps = {
@@ -50,7 +50,7 @@ function getOptimizedMetric(
   const numericMetricValue = metrics[metricKey];
   return {
     name: evalMetric,
-    value: isErrorMetric(evalMetric) ? Math.abs(numericMetricValue) : numericMetricValue,
+    value: numericMetricValue,
   };
 }
 

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModalHeader.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/__tests__/AutomlModelDetailsModalHeader.spec.tsx
@@ -61,7 +61,7 @@ describe('AutomlModelDetailsModalHeader', () => {
     expect(screen.getByText('-0.123')).toBeInTheDocument();
   });
 
-  it('should use absolute value for error metrics like mase', () => {
+  it('should display negated error metric values as-is', () => {
     const errorModel = buildModel('Model', { mase: -0.082 });
     render(
       <AutomlModelDetailsModalHeader
@@ -71,7 +71,7 @@ describe('AutomlModelDetailsModalHeader', () => {
         currentModelName="Model"
       />,
     );
-    expect(screen.getByText('0.082')).toBeInTheDocument();
+    expect(screen.getByText('-0.082')).toBeInTheDocument();
   });
 
   it('should display N/A when eval_metric is missing from test_data', () => {

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/ModelEvaluationTab.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/ModelEvaluationTab.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import { Title } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import type { TabContentProps } from '~/app/components/run-results/AutomlModelDetailsModal/tabConfig';
-import {
-  formatMetricName,
-  formatMetricValue as formatValue,
-  toNumericMetric,
-  isErrorMetric,
-} from '~/app/utilities/utils';
-
-/** Format a metric value for display. Only apply Math.abs() for error metrics (lower-is-better). */
-function formatMetricValue(key: string, value: unknown): string {
-  const rawMetricValue = toNumericMetric(value);
-  const absoluteValue = isErrorMetric(key) ? Math.abs(rawMetricValue) : rawMetricValue;
-  return formatValue(absoluteValue);
-}
+import { formatMetricName, formatMetricValue, toNumericMetric } from '~/app/utilities/utils';
 
 const ModelEvaluationTab: React.FC<TabContentProps> = ({ model }) => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: test_data may be missing in malformed model.json
@@ -41,7 +29,7 @@ const ModelEvaluationTab: React.FC<TabContentProps> = ({ model }) => {
           {entries.map(([key, value]) => (
             <Tr key={key}>
               <Td dataLabel="Measures">{formatMetricName(key)}</Td>
-              <Td dataLabel="Holdout score">{formatMetricValue(key, value)}</Td>
+              <Td dataLabel="Holdout score">{formatMetricValue(toNumericMetric(value))}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/__tests__/ModelEvaluationTab.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/AutomlModelDetailsModal/tabs/__tests__/ModelEvaluationTab.spec.tsx
@@ -33,14 +33,14 @@ describe('ModelEvaluationTab', () => {
     expect(screen.getByText('0.658')).toBeInTheDocument();
   });
 
-  it('should display absolute values for error metrics like mse', () => {
+  it('should display negated error metric values as-is', () => {
     const model = buildModel({ mse: -12.45 });
     render(<ModelEvaluationTab {...defaultProps} model={model} />);
 
-    expect(screen.getByText('12.450')).toBeInTheDocument();
+    expect(screen.getByText('-12.450')).toBeInTheDocument();
   });
 
-  it('should preserve negative values for non-error metrics like r2', () => {
+  it('should display negative values for non-error metrics like r2', () => {
     const model = buildModel({ r2: -0.123 });
     render(<ModelEvaluationTab {...defaultProps} model={model} />);
 

--- a/packages/automl/frontend/src/app/components/run-results/__tests__/AutomlLeaderboard.spec.tsx
+++ b/packages/automl/frontend/src/app/components/run-results/__tests__/AutomlLeaderboard.spec.tsx
@@ -95,28 +95,28 @@ const mockRegressionModels: Record<string, AutomlModel> = {
   }),
 };
 
-// Timeseries models
+// Timeseries models — AutoGluon negates error/loss metrics so higher (closer to 0) is better
 const mockTimeseriesModels: Record<string, AutomlModel> = {
   'model-1': createMockModel('ARIMA', {
-    mase: 0.15,
-    mape: 0.18,
-    mae: 5.2,
-    mse: 45.3,
-    rmse: 6.73,
+    mase: -0.15,
+    mape: -0.18,
+    mae: -5.2,
+    mse: -45.3,
+    rmse: -6.73,
   }),
   'model-2': createMockModel('Prophet', {
-    mase: 0.12,
-    mape: 0.14,
-    mae: 4.1,
-    mse: 32.1,
-    rmse: 5.67,
+    mase: -0.12,
+    mape: -0.14,
+    mae: -4.1,
+    mse: -32.1,
+    rmse: -5.67,
   }),
   'model-3': createMockModel('LSTM', {
-    mase: 0.09,
-    mape: 0.11,
-    mae: 3.5,
-    mse: 25.6,
-    rmse: 5.06,
+    mase: -0.09,
+    mape: -0.11,
+    mae: -3.5,
+    mse: -25.6,
+    rmse: -5.06,
   }),
 };
 
@@ -616,13 +616,13 @@ describe('AutomlLeaderboard component', () => {
       expect(within(rank1Row).getByTestId('top-rank-label')).toBeInTheDocument();
     });
 
-    it('should rank models correctly for timeseries (lower MASE is better)', () => {
+    it('should rank models correctly for timeseries (higher negated MASE is better)', () => {
       renderWithContext({
         models: mockTimeseriesModels,
         pipelineRun: createMockPipelineRun(RuntimeStateKF.SUCCEEDED, 'timeseries'),
       });
 
-      // LSTM has lowest MASE (0.09), should be rank 1
+      // LSTM has highest negated MASE (-0.09, closest to 0), should be rank 1
       const rank1Row = screen.getByTestId('leaderboard-row-1');
       expect(within(rank1Row).getByText('LSTM')).toBeInTheDocument();
       expect(within(rank1Row).getByTestId('top-rank-label')).toBeInTheDocument();

--- a/packages/automl/frontend/src/app/utilities/__tests__/utils.spec.ts
+++ b/packages/automl/frontend/src/app/utilities/__tests__/utils.spec.ts
@@ -5,7 +5,6 @@ import {
   toNumericMetric,
   getOptimizedMetricForTask,
   computeRankMap,
-  isErrorMetric,
 } from '~/app/utilities/utils';
 
 describe('formatMetricName', () => {
@@ -155,15 +154,16 @@ describe('computeRankMap', () => {
     });
   });
 
-  it('should rank models by mase ascending for timeseries (lower is better)', () => {
+  it('should rank models by negated mase descending for timeseries (higher is better)', () => {
     const models = {
-      ModelA: buildModel(0.15, 'mase'),
-      ModelB: buildModel(0.05, 'mase'),
-      ModelC: buildModel(0.1, 'mase'),
+      ModelA: buildModel(-0.15, 'mase'),
+      ModelB: buildModel(-0.05, 'mase'),
+      ModelC: buildModel(-0.1, 'mase'),
     };
 
     const rankMap = computeRankMap(models, 'timeseries');
 
+    // -0.05 > -0.10 > -0.15, so ModelB (closest to 0) is best
     expect(rankMap).toEqual({
       ModelB: 1,
       ModelC: 2,
@@ -180,21 +180,6 @@ describe('computeRankMap', () => {
     const rankMap = computeRankMap(models, 'regression');
 
     // -0.084 > -0.097, so ModelB is better
-    expect(rankMap).toEqual({
-      ModelB: 1,
-      ModelA: 2,
-    });
-  });
-
-  it('should use absolute values for error metrics like mase', () => {
-    const models = {
-      ModelA: buildModel(-0.15, 'mase'),
-      ModelB: buildModel(-0.05, 'mase'),
-    };
-
-    const rankMap = computeRankMap(models, 'timeseries');
-
-    // |−0.05| < |−0.15|, so ModelB is better (lower error)
     expect(rankMap).toEqual({
       ModelB: 1,
       ModelA: 2,
@@ -232,15 +217,16 @@ describe('computeRankMap', () => {
     });
   });
 
-  it('should rank models with missing metrics last for error metrics', () => {
+  it('should rank models with missing metrics last for negated error metrics', () => {
     const models = {
-      ModelA: buildModel(0.15, 'mase'),
+      ModelA: buildModel(-0.15, 'mase'),
       ModelB: { metrics: { test_data: {} } }, // missing mase
-      ModelC: buildModel(0.05, 'mase'),
+      ModelC: buildModel(-0.05, 'mase'),
     };
 
     const rankMap = computeRankMap(models, 'timeseries');
 
+    // -0.05 > -0.15 > -Infinity (missing), so ModelC is best
     expect(rankMap).toEqual({
       ModelC: 1,
       ModelA: 2,
@@ -276,27 +262,5 @@ describe('computeRankMap', () => {
       ModelA: 1,
       ModelB: 2,
     });
-  });
-});
-
-describe('isErrorMetric', () => {
-  it('should return true for known error metrics', () => {
-    expect(isErrorMetric('mase')).toBe(true);
-    expect(isErrorMetric('mse')).toBe(true);
-    expect(isErrorMetric('mae')).toBe(true);
-    expect(isErrorMetric('rmse')).toBe(true);
-    expect(isErrorMetric('mape')).toBe(true);
-  });
-
-  it('should return false for non-error metrics', () => {
-    expect(isErrorMetric('accuracy')).toBe(false);
-    expect(isErrorMetric('r2')).toBe(false);
-    expect(isErrorMetric('f1')).toBe(false);
-    expect(isErrorMetric('precision')).toBe(false);
-  });
-
-  it('should be case-insensitive', () => {
-    expect(isErrorMetric('MASE')).toBe(true);
-    expect(isErrorMetric('MSE')).toBe(true);
   });
 });

--- a/packages/automl/frontend/src/app/utilities/utils.ts
+++ b/packages/automl/frontend/src/app/utilities/utils.ts
@@ -120,48 +120,23 @@ export function getOptimizedMetricForTask(taskType: string): string {
   }
 }
 
-/** Metrics where lower values indicate better performance. */
-const ERROR_METRICS = new Set(['mase', 'mse', 'mae', 'rmse', 'mape']);
-
-/**
- * Check whether a metric is an error metric (lower-is-better).
- * AutoGluon reports these as negative values; callers should use Math.abs()
- * only for these metrics to recover the true value.
- */
-export function isErrorMetric(metric: string): boolean {
-  return ERROR_METRICS.has(metric.toLowerCase());
-}
-
 /**
  * Build a mapping from model name → leaderboard rank (1-based).
- * Ranks are assigned by sorting on the optimized metric for the task type,
+ * Ranks are assigned by sorting on the optimized metric descending (higher is better).
+ * AutoGluon negates error/loss metrics so all metrics are uniformly "higher is better".
  */
 export function computeRankMap(
   models: Record<string, { metrics: { test_data?: Record<string, unknown> } }>,
   taskType: string,
 ): Record<string, number> {
   const optimizedMetric = getOptimizedMetricForTask(taskType);
-  const useAbs = isErrorMetric(optimizedMetric);
-
-  // Use worst-case for missing metrics so they sort last
-  const worstCase = useAbs ? Infinity : -Infinity;
 
   const sorted = Object.keys(models).toSorted((a, b) => {
     const aMetric = models[a].metrics.test_data?.[optimizedMetric];
     const bMetric = models[b].metrics.test_data?.[optimizedMetric];
-    const aVal =
-      aMetric != null
-        ? useAbs
-          ? Math.abs(toNumericMetric(aMetric))
-          : toNumericMetric(aMetric)
-        : worstCase;
-    const bVal =
-      bMetric != null
-        ? useAbs
-          ? Math.abs(toNumericMetric(bMetric))
-          : toNumericMetric(bMetric)
-        : worstCase;
-    return useAbs ? aVal - bVal : bVal - aVal;
+    const aVal = aMetric != null ? toNumericMetric(aMetric) : -Infinity;
+    const bVal = bMetric != null ? toNumericMetric(bMetric) : -Infinity;
+    return bVal - aVal;
   });
 
   return Object.fromEntries(sorted.map((name, i) => [name, i + 1]));


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-58390

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fix AutoML leaderboard ranking for metrics reported by AutoGluon.

AutoGluon negates all error/loss metrics (MASE, MAPE, MAE, MSE, RMSE, etc.) so they uniformly follow a "higher is better" convention. The previous implementation had a hardcoded `errorMetrics` array that attempted to sort these metrics ascending and used `Math.abs()` to convert negated values back to positive for display. This caused incorrect ranking — the worst values (most negative) were ranked first instead of the best values (closest to zero).

**Changes:**

- **`AutomlLeaderboard.tsx`**: Removed the hardcoded `errorMetrics` array and conditional sort logic. Ranking now always sorts descending (higher is better), matching AutoGluon's negation convention.
- **`utils.ts`**: Removed `isErrorMetric` helper, `ERROR_METRICS` set, and the `Math.abs`/conditional logic in `computeRankMap`. `computeRankMap` now sorts uniformly descending.
- **`AutomlModelDetailsModalHeader.tsx`**: Removed `isErrorMetric` import and `Math.abs` conversion — metric values display as-is.
- **`ModelEvaluationTab.tsx`**: Removed `isErrorMetric` import and the wrapping `formatMetricValue` function — raw metric values pass through `toNumericMetric` and `formatMetricValue` directly.



<img width="2519" height="470" alt="image" src="https://github.com/user-attachments/assets/f7a965d5-eca0-4392-aebd-a546f86047a7" />
<img width="1819" height="900" alt="image" src="https://github.com/user-attachments/assets/d14a5f61-aaf4-4ad6-a365-6c51945313e1" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Ran the full AutoML unit test suite — all tests pass (utils, leaderboard, modal header, evaluation tab).
- Verified timeseries ranking: LSTM (MASE = -0.09, closest to 0) correctly ranks first.
- Verified metric display: negated values render as-is (e.g., `-0.082` for MASE).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Four test files updated:

- **`AutomlLeaderboard.spec.tsx`**: Updated `mockTimeseriesModels` to use negated metric values matching real AutoGluon output. Updated timeseries ranking test description and comments.
- **`utils.spec.ts`**: Updated `computeRankMap` timeseries tests to use negated values. Removed the `isErrorMetric` test block entirely.
- **`AutomlModelDetailsModalHeader.spec.tsx`**: Updated test to expect raw negated MASE value (`-0.082`) instead of absolute value.
- **`ModelEvaluationTab.spec.tsx`**: Updated test to expect raw negated MSE value (`-12.450`) instead of absolute value.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
