### PR TITLE
feat(automl): add Prediction type column to AutoML runs table

### DIFF
--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/AutomlRunsTableRow.tsx
@@ -4,7 +4,9 @@ import { Td, Tr } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import RunStartTimestamp from '@odh-dashboard/internal/concepts/pipelines/content/tables/RunStartTimestamp';
 import type { PipelineRun } from '~/app/types';
+import { TASK_TYPE_LABELS } from '~/app/utilities/const';
 import { automlResultsPathname } from '~/app/utilities/routes';
+import { getTaskType } from '~/app/utilities/utils';
 import { automlRunsColumns } from './columns';
 
 /** Run state values (API / display). Use lowercase for case-insensitive matching. */
@@ -49,30 +51,36 @@ export const getStatusLabelProps = (
   return { color: 'grey' };
 };
 
-const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({ run, namespace }) => (
-  <Tr>
-    <Td dataLabel={automlRunsColumns[0].label}>
-      <Link
-        to={`${automlResultsPathname}/${namespace}/${run.run_id}`}
-        data-testid={`run-name-${run.run_id}`}
-      >
-        {run.display_name}
-      </Link>
-    </Td>
-    <Td dataLabel={automlRunsColumns[1].label}>{run.description ?? '—'}</Td>
-    <Td dataLabel={automlRunsColumns[2].label}>
-      <RunStartTimestamp run={run} />
-    </Td>
-    <Td dataLabel={automlRunsColumns[3].label}>
-      {run.state ? (
-        <Label variant="outline" isCompact {...getStatusLabelProps(run.state)}>
-          {run.state}
-        </Label>
-      ) : (
-        '—'
-      )}
-    </Td>
-  </Tr>
-);
+const AutomlRunsTableRow: React.FC<AutomlRunsTableRowProps> = ({ run, namespace }) => {
+  const taskType = getTaskType(run);
+  const predictionTypeLabel = taskType ? (TASK_TYPE_LABELS[taskType] ?? taskType) : '—';
+
+  return (
+    <Tr>
+      <Td dataLabel={automlRunsColumns[0].label}>
+        <Link
+          to={`${automlResultsPathname}/${namespace}/${run.run_id}`}
+          data-testid={`run-name-${run.run_id}`}
+        >
+          {run.display_name}
+        </Link>
+      </Td>
+      <Td dataLabel={automlRunsColumns[1].label}>{run.description ?? '—'}</Td>
+      <Td dataLabel={automlRunsColumns[2].label}>{predictionTypeLabel}</Td>
+      <Td dataLabel={automlRunsColumns[3].label}>
+        <RunStartTimestamp run={run} />
+      </Td>
+      <Td dataLabel={automlRunsColumns[4].label}>
+        {run.state ? (
+          <Label variant="outline" isCompact {...getStatusLabelProps(run.state)}>
+            {run.state}
+          </Label>
+        ) : (
+          '—'
+        )}
+      </Td>
+    </Tr>
+  );
+};
 
 export default AutomlRunsTableRow;

--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/__tests__/AutomlRunsTableRow.spec.tsx
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/__tests__/AutomlRunsTableRow.spec.tsx
@@ -112,12 +112,52 @@ describe('AutomlRunsTableRow', () => {
     render(
       <MemoryRouter>
         <AutomlRunsTableRow
-          run={{ ...mockRun, description: undefined }}
+          run={{
+            ...mockRun,
+            description: undefined,
+            runtime_config: { parameters: { task_type: 'binary' } as never },
+          }}
           namespace={mockNamespace}
         />
       </MemoryRouter>,
     );
     expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('should render friendly prediction type label', () => {
+    render(
+      <MemoryRouter>
+        <AutomlRunsTableRow
+          run={{ ...mockRun, runtime_config: { parameters: { task_type: 'binary' } as never } }}
+          namespace={mockNamespace}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Binary classification')).toBeInTheDocument();
+  });
+
+  it('should render em dash when runtime_config is missing', () => {
+    render(
+      <MemoryRouter>
+        <AutomlRunsTableRow
+          run={{ ...mockRun, runtime_config: undefined }}
+          namespace={mockNamespace}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getAllByText('—')).toHaveLength(1);
+  });
+
+  it('should default prediction type to time series forecasting when task_type is missing', () => {
+    render(
+      <MemoryRouter>
+        <AutomlRunsTableRow
+          run={{ ...mockRun, runtime_config: { parameters: {} as never } }}
+          namespace={mockNamespace}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Time series forecasting')).toBeInTheDocument();
   });
 
   it('should render state with Label', () => {

--- a/packages/automl/frontend/src/app/components/AutomlRunsTable/columns.ts
+++ b/packages/automl/frontend/src/app/components/AutomlRunsTable/columns.ts
@@ -8,6 +8,7 @@ import type { PipelineRun } from '~/app/types';
 export const automlRunsColumns: SortableData<PipelineRun>[] = [
   { label: 'Name', field: 'display_name', sortable: false, width: 20 },
   { label: 'Description', field: 'description', sortable: false, width: 25 },
-  { label: 'Started', field: 'created_at', sortable: false, width: 20 },
-  { label: 'Status', field: 'state', sortable: false, width: 15 },
+  { label: 'Prediction type', field: 'task_type', sortable: false, width: 15 },
+  { label: 'Started', field: 'created_at', sortable: false, width: 15 },
+  { label: 'Status', field: 'state', sortable: false, width: 10 },
 ];

--- a/packages/automl/frontend/src/app/context/AutomlResultsContext.ts
+++ b/packages/automl/frontend/src/app/context/AutomlResultsContext.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { ConfigureSchema } from '~/app/schemas/configure.schema';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
 import type { PipelineRun } from '~/app/types';
+import { getTaskType } from '~/app/utilities/utils';
 
 const configureSchema = createConfigureSchema();
 
@@ -80,21 +81,14 @@ export function getAutomlContext({
   let parameters: Partial<ConfigureSchema> = {};
   if (parseResult.success) {
     parameters = parseResult.data;
-    // FYI default task_type to timeseries since it is the only task which will not have
-    // this as an actual parameter passed to the pipeline
-    // Check the original input, not the parsed result (which may have Zod defaults)
-    const hasTaskType =
-      inputParams && Object.prototype.hasOwnProperty.call(inputParams, 'task_type');
-    if (!hasTaskType) {
-      // eslint-disable-next-line camelcase
-      parameters.task_type = 'timeseries';
-    }
+    // eslint-disable-next-line camelcase
+    parameters.task_type = getTaskType(pipelineRun) ?? 'timeseries';
   } else {
     // Fallback to default task_type even on parse failure
     // eslint-disable-next-line no-console, camelcase
     console.warn('Failed to parse pipeline runtime parameters:', parseResult.error);
     // eslint-disable-next-line camelcase
-    parameters = { task_type: 'timeseries' };
+    parameters = { task_type: getTaskType(pipelineRun) ?? 'timeseries' };
   }
 
   return {

--- a/packages/automl/frontend/src/app/utilities/utils.ts
+++ b/packages/automl/frontend/src/app/utilities/utils.ts
@@ -1,4 +1,4 @@
-import type { PipelineRun } from '~/app/types';
+import type { PipelineRun, TaskType } from '~/app/types';
 import {
   TASK_TYPE_BINARY,
   TASK_TYPE_MULTICLASS,
@@ -25,12 +25,30 @@ export function parseErrorStatus(error: Error): number | undefined {
 }
 
 /**
+ * Extracts the task type from a pipeline run's runtime parameters.
+ * - Returns the task_type value when present.
+ * - Defaults to timeseries when parameters exist but task_type is missing
+ *   (timeseries is the only task that omits this parameter).
+ * - Returns undefined when runtime_config.parameters is absent.
+ */
+export const getTaskType = (pipelineRun?: PipelineRun): TaskType | undefined => {
+  const params = pipelineRun?.runtime_config?.parameters;
+  if (!params) {
+    return undefined;
+  }
+  if (!Object.prototype.hasOwnProperty.call(params, 'task_type')) {
+    return TASK_TYPE_TIMESERIES;
+  }
+  return params.task_type;
+};
+
+/**
  * Determines if a task type is tabular.
  * @param pipelineRun - The pipeline run to check
  * @returns true if the task type is tabular, false otherwise
  */
 export const isTabularRun = (pipelineRun?: PipelineRun): boolean => {
-  const taskType = pipelineRun?.runtime_config?.parameters?.task_type ?? TASK_TYPE_TIMESERIES;
+  const taskType = getTaskType(pipelineRun) ?? TASK_TYPE_TIMESERIES;
 
   return [TASK_TYPE_BINARY, TASK_TYPE_MULTICLASS, TASK_TYPE_REGRESSION].includes(taskType);
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://issues.redhat.com/browse/RHOAIENG-58441

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds a **Prediction type** column to the AutoML runs table, displayed after the Description column. The column shows the friendly label for the run's `task_type` (e.g., "Binary classification", "Regression", "Time series forecasting") using the existing `TASK_TYPE_LABELS` mapping.

**Changes:**
- **`columns.ts`** — Added a `"Prediction type"` column and rebalanced column widths (20/25/15/15/10) with Description remaining the largest.
- **`AutomlRunsTableRow.tsx`** — Renders the prediction type label using the new `getTaskType` utility. Shows `—` when `runtime_config.parameters` is absent; defaults to "Time series forecasting" when parameters exist but `task_type` is missing.
- **`utils.ts`** — Extracted a shared `getTaskType(pipelineRun)` utility that encapsulates the task type extraction and fallback logic. Also refactored `isTabularRun` to use it internally.
- **`AutomlResultsContext.ts`** — Refactored to use `getTaskType` instead of inline `hasOwnProperty` checks, consolidating the fallback logic in one place.

<table><tr><td>Before</td><td>After</td></tr>
<tr><td>
<img width="3708" height="1594" alt="image" src="https://github.com/user-attachments/assets/871e1bb8-8e6a-47b1-a78e-98dd31191209" />
</td><td>
<img width="1969" height="800" alt="image" src="https://github.com/user-attachments/assets/ae299254-0b7e-4a02-9083-783e9174715d" />
</td></tr></table>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Updated unit tests in `AutomlRunsTableRow.spec.tsx` — all 25 tests pass.
- Existing `AutomlResultsContext.spec.tsx` tests pass (19 tests).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

Added 3 new unit tests in `AutomlRunsTableRow.spec.tsx`:
- **`should render friendly prediction type label`** — verifies `'binary'` renders as `"Binary classification"`
- **`should render em dash when runtime_config is missing`** — verifies `—` when `runtime_config` is undefined
- **`should default prediction type to time series forecasting when task_type is missing`** — verifies the timeseries fallback when parameters exist but `task_type` is absent

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
