### PR TITLE
fix(gen-ai): always mount MCP modals and drive visibility via isOpen

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerConfigModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerConfigModal.tsx
@@ -20,7 +20,7 @@ import { MCPServer } from '~/app/types';
 interface MCPServerConfigModalProps {
   isOpen: boolean;
   onClose: () => void;
-  server: MCPServer;
+  server?: MCPServer;
   currentToken?: string;
   onTokenSave: (serverUrl: string, token: string) => Promise<{ success: boolean; error?: string }>;
   isValidating?: boolean;
@@ -54,14 +54,14 @@ const MCPServerConfigModal: React.FC<MCPServerConfigModalProps> = ({
   }, [validationError]);
 
   const handleSave = React.useCallback(async () => {
-    if (!accessToken.trim()) {
+    if (!accessToken.trim() || !server) {
       return;
     }
 
     setHasAttemptedValidation(true);
     await onTokenSave(server.connectionUrl, accessToken.trim());
     // Parent component handles modal transitions on success/error
-  }, [server.connectionUrl, accessToken, onTokenSave]);
+  }, [server, accessToken, onTokenSave]);
 
   const handleClear = React.useCallback(() => {
     setAccessToken('');
@@ -77,7 +77,7 @@ const MCPServerConfigModal: React.FC<MCPServerConfigModalProps> = ({
       <ModalHeader title="Authorize MCP server" />
       <ModalBody>
         <Form>
-          <p>{`Enter the access token for the ${server.name} MCP Server.`}</p>
+          <p>{`Enter the access token for the ${server?.name} MCP Server.`}</p>
           {validationError && <Alert variant="danger" title="Authorization failed. Try again." />}
           <FormGroup
             label="Access token"

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerSuccessModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerSuccessModal.tsx
@@ -14,11 +14,11 @@ import { MCPServer } from '~/app/types';
 interface MCPServerSuccessModalProps {
   isOpen: boolean;
   onClose: () => void;
-  server: MCPServer;
+  server?: MCPServer;
   selectedToolsCount?: number;
   totalToolsCount?: number;
-  onEditTools: () => void;
-  onDisconnect: () => void;
+  onEditTools?: () => void;
+  onDisconnect?: () => void;
 }
 
 const MCPServerSuccessModal: React.FC<MCPServerSuccessModalProps> = ({
@@ -43,7 +43,7 @@ const MCPServerSuccessModal: React.FC<MCPServerSuccessModalProps> = ({
       <ModalHeader title="Connection successful" titleIconVariant="success" />
       <ModalBody>
         <p className="pf-v6-u-mb-md">
-          You are now connected to <strong>{server.name}</strong>. You can use it directly in the
+          You are now connected to <strong>{server?.name}</strong>. You can use it directly in the
           playground chat.
         </p>
         {displaySelectedCount > 40 && (

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerToolsModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServerToolsModal.tsx
@@ -30,7 +30,7 @@ interface MCPServerToolsModalProps {
   configId: string;
   isOpen: boolean;
   onClose: () => void;
-  server: MCPServer;
+  server?: MCPServer;
   mcpBearerToken?: string;
 }
 
@@ -45,17 +45,23 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
 }) => {
   const { namespace } = React.useContext(GenAiContext);
 
+  const serverUrl = server?.connectionUrl ?? '';
+  const serverName = server?.name ?? '';
+  const serverId = server?.id ?? '';
+
   // Get tool selections functions from store
   const getToolSelections = React.useCallback(
-    (namespaceName: string, serverUrl: string) =>
-      useChatbotConfigStore.getState().getToolSelections(configId, namespaceName, serverUrl),
+    (namespaceName: string, serverConnectionUrl: string) =>
+      useChatbotConfigStore
+        .getState()
+        .getToolSelections(configId, namespaceName, serverConnectionUrl),
     [configId],
   );
   const saveToolSelections = React.useCallback(
-    (namespaceName: string, serverUrl: string, toolNames: string[] | undefined) => {
+    (namespaceName: string, serverConnectionUrl: string, toolNames: string[] | undefined) => {
       useChatbotConfigStore
         .getState()
-        .saveToolSelections(configId, namespaceName, serverUrl, toolNames);
+        .saveToolSelections(configId, namespaceName, serverConnectionUrl, toolNames);
     },
     [configId],
   );
@@ -66,7 +72,7 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
     toolsLoadError,
     toolsStatus,
     isLoading,
-  } = useMCPServerTools(server.connectionUrl, mcpBearerToken, isOpen);
+  } = useMCPServerTools(serverUrl, mcpBearerToken, isOpen);
 
   const [searchValue, setSearchValue] = React.useState('');
   const hasTrackedSearch = React.useRef(false);
@@ -77,12 +83,12 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
       // Track search usage once per modal open when user starts typing
       if (value && !hasTrackedSearch.current) {
         fireMiscTrackingEvent('Playground MCP Tools Search', {
-          mcpServerName: server.name,
+          mcpServerName: serverName,
         });
         hasTrackedSearch.current = true;
       }
     },
-    [server.name],
+    [serverName],
   );
 
   // Reset search tracking when modal closes/opens
@@ -95,13 +101,13 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
   const tools: MCPTool[] = React.useMemo(
     () =>
       apiTools.map((apiTool, index) => ({
-        id: `${server.id}-tool-${index}`,
+        id: `${serverId}-tool-${index}`,
         name: apiTool.name,
         description: apiTool.description,
         permissions: [],
         enabled: true,
       })),
-    [apiTools, server.id],
+    [apiTools, serverId],
   );
 
   const filteredTools = React.useMemo(
@@ -116,7 +122,7 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
       return null;
     }
 
-    const savedTools = getToolSelections(namespaceName, server.connectionUrl);
+    const savedTools = getToolSelections(namespaceName, serverUrl);
 
     // If undefined (never saved), select all tools by default
     if (savedTools === undefined) {
@@ -128,7 +134,7 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
       .filter((tool): tool is MCPTool => tool !== undefined);
 
     return savedToolObjects;
-  }, [namespaceName, server.connectionUrl, toolsLoaded, getToolSelections, tools]);
+  }, [namespaceName, serverUrl, toolsLoaded, getToolSelections, tools]);
 
   const [selectedTools, setSelectedTools] = React.useState<MCPTool[]>([]);
 
@@ -162,35 +168,27 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
 
     saveToolSelections(
       namespaceName,
-      server.connectionUrl,
+      serverUrl,
       isAllToolsSelected ? undefined : selectedToolNames,
     );
 
     fireFormTrackingEvent(MCP_TOOLS_EVENT_NAME, {
       outcome: TrackingOutcome.submit,
-      mcpServerName: server.name,
+      mcpServerName: serverName,
       selectedToolsCount: selectedToolNames.length,
       totalToolsCount: tools.length,
     });
 
     onClose();
-  }, [
-    namespaceName,
-    selections,
-    tools.length,
-    saveToolSelections,
-    server.connectionUrl,
-    server.name,
-    onClose,
-  ]);
+  }, [namespaceName, selections, tools.length, saveToolSelections, serverUrl, serverName, onClose]);
 
   const handleCancel = React.useCallback(() => {
     fireFormTrackingEvent(MCP_TOOLS_EVENT_NAME, {
       outcome: TrackingOutcome.cancel,
-      mcpServerName: server.name,
+      mcpServerName: serverName,
     });
     onClose();
-  }, [server.name, onClose]);
+  }, [serverName, onClose]);
 
   return (
     <Modal
@@ -202,7 +200,7 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
     >
       <ModalHeader>
         <Title headingLevel="h2" size="xl" id="mcp-tools-modal-title">
-          {server.name}
+          {serverName}
         </Title>
       </ModalHeader>
       <ModalBody className="pf-v6-u-pt-md">
@@ -215,7 +213,7 @@ const MCPServerToolsModal: React.FC<MCPServerToolsModalProps> = ({
         {toolsLoadError && (
           <Alert
             variant="danger"
-            title={`Failed to load tools from ${server.name}`}
+            title={`Failed to load tools from ${serverName}`}
             className="pf-v6-u-mb-md"
           >
             {toolsLoadError.message}

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServersPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/MCPServersPanel.tsx
@@ -362,35 +362,39 @@ const MCPServersPanel: React.FC<MCPServersPanelProps> = ({
           data-testid="mcp-servers-panel-table"
         />
       </div>
-      {configModal.selectedItem && (
-        <MCPServerConfigModal
-          isOpen={configModal.isOpen}
-          onClose={handleConfigModalClose}
-          server={configModal.selectedItem}
-          currentToken={
-            tokenManagement.getToken(configModal.selectedItem.connectionUrl)?.token || ''
-          }
-          onTokenSave={validation.validateServerToken}
-          isValidating={validation.validatingServers.has(configModal.selectedItem.connectionUrl)}
-          validationError={validation.validationErrors.get(configModal.selectedItem.connectionUrl)}
-        />
-      )}
-      {toolsModal.selectedItem && (
-        <MCPServerToolsModal
-          configId={configId}
-          isOpen={toolsModal.isOpen}
-          onClose={handleToolsModalClose}
-          server={toolsModal.selectedItem}
-          mcpBearerToken={tokenManagement.getToken(toolsModal.selectedItem.connectionUrl)?.token}
-        />
-      )}
-      {successModalProps && (
-        <MCPServerSuccessModal
-          isOpen={successModal.isOpen}
-          onClose={handleSuccessModalClose}
-          {...successModalProps}
-        />
-      )}
+      <MCPServerConfigModal
+        isOpen={configModal.isOpen}
+        onClose={handleConfigModalClose}
+        server={configModal.selectedItem}
+        currentToken={
+          tokenManagement.getToken(configModal.selectedItem?.connectionUrl ?? '')?.token ?? ''
+        }
+        onTokenSave={validation.validateServerToken}
+        isValidating={Boolean(
+          validation.validatingServers.has(configModal.selectedItem?.connectionUrl ?? ''),
+        )}
+        validationError={validation.validationErrors.get(
+          configModal.selectedItem?.connectionUrl ?? '',
+        )}
+      />
+      <MCPServerToolsModal
+        configId={configId}
+        isOpen={toolsModal.isOpen}
+        onClose={handleToolsModalClose}
+        server={toolsModal.selectedItem}
+        mcpBearerToken={
+          tokenManagement.getToken(toolsModal.selectedItem?.connectionUrl ?? '')?.token
+        }
+      />
+      <MCPServerSuccessModal
+        isOpen={successModal.isOpen}
+        onClose={handleSuccessModalClose}
+        server={successModal.selectedItem}
+        selectedToolsCount={successModalProps?.selectedToolsCount}
+        totalToolsCount={successModalProps?.totalToolsCount}
+        onEditTools={successModalProps?.onEditTools}
+        onDisconnect={successModalProps?.onDisconnect}
+      />
     </>
   );
 };

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/__tests__/useModalState.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/__tests__/useModalState.spec.ts
@@ -11,7 +11,7 @@ describe('useModalState', () => {
     const { result } = renderHook(() => useModalState<TestItem>());
 
     expect(result.current.isOpen).toBe(false);
-    expect(result.current.selectedItem).toBeNull();
+    expect(result.current.selectedItem).toBeUndefined();
   });
 
   it('should open modal with selected item', () => {
@@ -26,7 +26,7 @@ describe('useModalState', () => {
     expect(result.current.selectedItem).toEqual(testItem);
   });
 
-  it('should close modal and clear selected item', () => {
+  it('should close modal', () => {
     const { result } = renderHook(() => useModalState<TestItem>());
     const testItem: TestItem = { id: '1', name: 'Test Server' };
 
@@ -35,14 +35,12 @@ describe('useModalState', () => {
     });
 
     expect(result.current.isOpen).toBe(true);
-    expect(result.current.selectedItem).toEqual(testItem);
 
     act(() => {
       result.current.closeModal();
     });
 
     expect(result.current.isOpen).toBe(false);
-    expect(result.current.selectedItem).toBeNull();
   });
 
   it('should replace selected item when opening with new item', () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useModalState.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/mcp/hooks/useModalState.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export interface UseModalStateReturn<T> {
   isOpen: boolean;
-  selectedItem: T | null;
+  selectedItem: T | undefined;
   openModal: (item: T) => void;
   closeModal: () => void;
 }
@@ -16,7 +16,7 @@ export interface UseModalStateReturn<T> {
  */
 const useModalState = <T>(): UseModalStateReturn<T> => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selectedItem, setSelectedItem] = React.useState<T | null>(null);
+  const [selectedItem, setSelectedItem] = React.useState<T | undefined>(undefined);
 
   const openModal = React.useCallback((item: T) => {
     setSelectedItem(item);
@@ -25,7 +25,6 @@ const useModalState = <T>(): UseModalStateReturn<T> => {
 
   const closeModal = React.useCallback(() => {
     setIsOpen(false);
-    setSelectedItem(null);
   }, []);
 
   return {

--- a/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
@@ -32,6 +32,7 @@ export const useMCPServerTools = (
     }
 
     setIsLoading(true);
+    setToolsLoaded(false);
     setToolsLoadError(null);
 
     try {


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Conditionally rendering modals with `{selectedItem && <Modal />}` caused them to unmount immediately when closed, bypassing PatternFly's close lifecycle (focus restoration, body scroll cleanup, backdrop removal). This created a race condition in Cypress where the tools button DOM node was replaced between assertion and click, causing intermittent failures in the auto-unlock test.

- Remove conditional render guards from all three MCP modals in MCPServersPanel; modals are now always mounted and controlled solely via `isOpen`
- Update `useModalState` to use `undefined` instead of `null`, and stop clearing `selectedItem` on close so modals retain valid props during PF's close animation
- Make `server` prop optional (`server?: MCPServer`) on all three modals so they compile without a selected item; use `server?.name` etc. in place of guarded wrappers
- Fix `useMCPServerTools`: reset `toolsLoaded` to `false` at the start of each fetch so the loading spinner shows correctly on refetch

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Select an MCP server with auth
- Select an MCP server without auth
- Select tools from an MCP server
- Disconnect MCP server
- Provide incorrect auth credential

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Just a refactor, shouldn't require test updates.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x]  Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced modal dialogs to gracefully handle missing server data, preventing potential runtime errors.
  * Improved state management for modal interactions with safer property access patterns.

* **Refactor**
  * Restructured modal components to render unconditionally with optional props, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->