### PR TITLE
fix(maas): subscription filter matches displayName and description 

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -102,6 +102,23 @@ describe('Subscriptions Page', () => {
     premiumRow.findKebabAction('Delete subscription').should('exist');
   });
 
+  it('should filter subscriptions by display name and description', () => {
+    subscriptionsPage.findFilterInput().type('Team Subscription');
+    subscriptionsPage.findRows().should('have.length', 2);
+    subscriptionsPage.findFilterResetButton().click();
+    subscriptionsPage.findRows().should('have.length', 5);
+
+    subscriptionsPage.findFilterInput().type('enterprise');
+    subscriptionsPage.findRows().should('have.length', 1);
+    subscriptionsPage.findFilterResetButton().click();
+    subscriptionsPage.findRows().should('have.length', 5);
+
+    subscriptionsPage.findFilterInput().type('general users');
+    subscriptionsPage.findRows().should('have.length', 1);
+    subscriptionsPage.findFilterResetButton().click();
+    subscriptionsPage.findRows().should('have.length', 5);
+  });
+
   it('should delete a subscription', () => {
     cy.interceptOdh(
       'DELETE /maas/api/v1/subscription/:name',

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -121,6 +121,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
   {
     name: 'premium-team-sub',
     displayName: 'Premium Team Subscription',
+    description: 'Access to premium AI models for enterprise teams',
     namespace: 'maas-system',
     phase: 'Active',
     statusMessage: 'successfully reconciled',
@@ -149,6 +150,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
   {
     name: 'basic-team-sub',
     displayName: 'Basic Team Subscription',
+    description: 'Standard access for general users',
     namespace: 'maas-system',
     phase: 'Active',
     statusMessage: 'successfully reconciled',

--- a/packages/maas/frontend/src/app/pages/subscriptions/AllSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/AllSubscriptionsPage.tsx
@@ -30,7 +30,12 @@ const AllSubscriptionsPage: React.FC = () => {
   const filteredSubscriptions = React.useMemo(() => {
     const keyword = filterData[SubscriptionsFilterOptions.keyword]?.toLowerCase();
     return keyword
-      ? subscriptions.filter((sub) => sub.name.toLowerCase().includes(keyword))
+      ? subscriptions.filter(
+          (sub) =>
+            sub.name.toLowerCase().includes(keyword) ||
+            sub.displayName?.toLowerCase().includes(keyword) ||
+            sub.description?.toLowerCase().includes(keyword),
+        )
       : subscriptions;
   }, [subscriptions, filterData]);
 

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
@@ -31,8 +31,9 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
         [SubscriptionsFilterOptions.keyword]: ({ onChange, ...props }) => (
           <SearchInput
             {...props}
-            aria-label="Filter by keyword"
-            placeholder="Filter by keyword"
+            style={{ minWidth: '300px' }}
+            aria-label="Filter by name or description"
+            placeholder="Filter by name or description"
             onChange={(_event, value) => onChange(value)}
             data-testid="subscriptions-filter-input"
           />


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58289

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description

The keyword filter on the Subscriptions list page only matched against the resource name field. Now it also matches displayName and description, and the placeholder text reflects this.


https://github.com/user-attachments/assets/781177ad-8470-4d0d-aa04-7445bc8ccbf1



## How Has This Been Tested?
On subscription list page try to filter using display name, description and k8s name

## Test Impact
Adds Cypress tests for the new filter behavior.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription search now filters results by both subscription name and description fields, providing more comprehensive discovery
  * Updated search input interface with clearer labeling and expanded input width for improved usability

* **Tests**
  * Added comprehensive test coverage for subscription filter functionality, validating search queries and filter reset behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->