### PR TITLE
fix(kueue): migrate Kueue API from v1beta1 to v1beta2

### DIFF
--- a/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockClusterQueueK8sResource.ts
@@ -15,7 +15,7 @@ export const mockClusterQueueK8sResource = ({
   isCpuOverQuota = false,
   isMemoryOverQuota = false,
 }: MockResourceConfigType): ClusterQueueKind => ({
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'ClusterQueue',
   metadata: {
     creationTimestamp: '2024-02-22T17:26:19Z',

--- a/frontend/src/__mocks__/mockLocalQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockLocalQueueK8sResource.ts
@@ -15,7 +15,7 @@ export const mockLocalQueueK8sResource = ({
   isCpuOverQuota = false,
   isMemoryOverQuota = false,
 }: MockResourceConfigType): LocalQueueKind => ({
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'LocalQueue',
   metadata: {
     creationTimestamp: '2024-03-26T14:12:10Z',

--- a/frontend/src/__mocks__/mockLocalQueueK8sResource.ts
+++ b/frontend/src/__mocks__/mockLocalQueueK8sResource.ts
@@ -40,7 +40,7 @@ export const mockLocalQueueK8sResource = ({
         type: 'Active',
       },
     ],
-    flavorUsage: [
+    flavorsUsage: [
       {
         name: 'test-flavor',
         resources: [

--- a/frontend/src/__mocks__/mockWorkloadK8sResource.ts
+++ b/frontend/src/__mocks__/mockWorkloadK8sResource.ts
@@ -168,7 +168,7 @@ export const mockWorkloadK8sResource = ({
   podSets = [],
   mockStatusEmptyWorkload = false,
 }: MockResourceConfigType): WorkloadKind => ({
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'Workload',
   metadata: {
     creationTimestamp: '2024-03-18T19:15:28Z',

--- a/frontend/src/__mocks__/mockWorkloadPriorityClassK8Resource.ts
+++ b/frontend/src/__mocks__/mockWorkloadPriorityClassK8Resource.ts
@@ -11,7 +11,7 @@ export const mockWorkloadPriorityClassK8sResource = ({
   description = 'Test description',
   value = 1000,
 }: MockResourceConfigType): WorkloadPriorityClassKind => ({
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'WorkloadPriorityClass',
   description,
   metadata: {

--- a/frontend/src/api/models/kueue.ts
+++ b/frontend/src/api/models/kueue.ts
@@ -1,28 +1,28 @@
 import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
 
 export const ClusterQueueModel: K8sModelCommon = {
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   apiGroup: 'kueue.x-k8s.io',
   kind: 'ClusterQueue',
   plural: 'clusterqueues',
 };
 
 export const LocalQueueModel: K8sModelCommon = {
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   apiGroup: 'kueue.x-k8s.io',
   kind: 'LocalQueue',
   plural: 'localqueues',
 };
 
 export const WorkloadModel: K8sModelCommon = {
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   apiGroup: 'kueue.x-k8s.io',
   kind: 'Workload',
   plural: 'workloads',
 };
 
 export const WorkloadPriorityClassModel: K8sModelCommon = {
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   apiGroup: 'kueue.x-k8s.io',
   kind: 'WorkloadPriorityClass',
   plural: 'workloadpriorityclasses',

--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import { getKueueWorkloadStatusWithMessage, getKueueStatusInfo } from '#~/concep
 import { KueueWorkloadStatus } from '#~/concepts/kueue/types';
 
 const baseWorkload: WorkloadKind = {
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'Workload',
   metadata: { name: 'test-workload', namespace: 'test-ns' },
   spec: {

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -132,7 +132,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
     localQueueName ?? undefined,
     notebook != null ? notebook.metadata.name : undefined,
   );
-  const quotaSource = clusterQueue?.spec.cohort ?? '-';
+  const quotaSource = clusterQueue?.spec.cohortName ?? '-';
   const consumedResources = clusterQueue
     ? getAllConsumedResources(clusterQueue, assignedFlavorName)
     : [];

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -810,13 +810,12 @@ type ClusterQueueFlavorUsage = {
   }[];
 };
 
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueue
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-ClusterQueue
 export type ClusterQueueKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta1';
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
   kind: 'ClusterQueue';
   spec: {
-    admissionChecks?: string[];
-    cohort?: string;
+    cohortName?: string;
     flavorFungibility?: {
       whenCanBorrow: 'Borrow' | 'TryNextFlavor';
       whenCanPreempt: 'Preempt' | 'TryNextFlavor';
@@ -878,9 +877,9 @@ type LocalQueueFlavorUsage = {
   }[];
 };
 
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-LocalQueue
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-LocalQueue
 export type LocalQueueKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta1';
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
   kind: 'LocalQueue';
   spec: {
     clusterQueue: string;
@@ -1072,18 +1071,19 @@ export enum WorkloadOwnerType {
   Job = 'Job',
 }
 
-// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-Workload
+// https://kueue.sigs.k8s.io/docs/reference/kueue.v1beta2/#kueue-x-k8s-io-v1beta2-Workload
 export type WorkloadKind = K8sResourceCommon & {
-  apiVersion: 'kueue.x-k8s.io/v1beta1';
+  apiVersion: 'kueue.x-k8s.io/v1beta2';
   kind: 'Workload';
   spec: {
     active?: boolean;
     podSets: WorkloadPodSet[];
     priority?: number;
-    priorityClassName?: string;
-    priorityClassSource?:
-      | 'kueue.x-k8s.io/workloadpriorityclass'
-      | 'scheduling.k8s.io/priorityclass';
+    priorityClassRef?: {
+      group: string;
+      kind: string;
+      name: string;
+    };
     queueName?: string;
   };
   status?: {

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -815,6 +815,12 @@ export type ClusterQueueKind = K8sResourceCommon & {
   apiVersion: 'kueue.x-k8s.io/v1beta2';
   kind: 'ClusterQueue';
   spec: {
+    admissionChecksStrategy?: {
+      admissionChecks: {
+        name: string;
+        onFlavors?: string[];
+      }[];
+    };
     cohortName?: string;
     flavorFungibility?: {
       whenCanBorrow: 'Borrow' | 'TryNextFlavor';
@@ -886,7 +892,7 @@ export type LocalQueueKind = K8sResourceCommon & {
   };
   status?: {
     flavorsReservation?: LocalQueueFlavorUsage[];
-    flavorUsage?: LocalQueueFlavorUsage[];
+    flavorsUsage?: LocalQueueFlavorUsage[];
     pendingWorkloads?: number;
     reservingWorkloads?: number;
     admittedWorkloads?: number;

--- a/frontend/src/pages/hardwareProfiles/manage/__tests__/ManageResourceAllocationSection.spec.tsx
+++ b/frontend/src/pages/hardwareProfiles/manage/__tests__/ManageResourceAllocationSection.spec.tsx
@@ -36,21 +36,21 @@ describe('ManageResourceAllocationSection', () => {
   // Mock workload priority classes data
   const mockWorkloadPriorityClasses = [
     {
-      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
       kind: 'WorkloadPriorityClass',
       metadata: { name: 'high-priority', namespace: 'default' },
       description: 'High priority workloads',
       value: 100,
     },
     {
-      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
       kind: 'WorkloadPriorityClass',
       metadata: { name: 'medium-priority', namespace: 'default' },
       description: 'Medium priority workloads',
       value: 50,
     },
     {
-      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
       kind: 'WorkloadPriorityClass',
       metadata: { name: 'low-priority', namespace: 'default' },
       description: 'Low priority workloads',

--- a/frontend/src/utilities/__tests__/clusterQueueUtils.spec.ts
+++ b/frontend/src/utilities/__tests__/clusterQueueUtils.spec.ts
@@ -7,7 +7,7 @@ import {
 const COVERED_RESOURCES = ['cpu', 'memory', 'nvidia.com/gpu'];
 const DEFAULT_FLAVOR = 'default-flavor';
 const OTHER_FLAVOR = 'other-flavor';
-const KUEUE_API_VERSION = 'kueue.x-k8s.io/v1beta1';
+const KUEUE_API_VERSION = 'kueue.x-k8s.io/v1beta2';
 
 const DEFAULT_SPEC_RESOURCES = [
   { name: 'cpu', nominalQuota: 100 },

--- a/frontend/src/utilities/__tests__/useAssignedFlavor.spec.ts
+++ b/frontend/src/utilities/__tests__/useAssignedFlavor.spec.ts
@@ -19,7 +19,7 @@ const listWorkloadsMock = jest.mocked(listWorkloads);
 const getAssignedFlavorFromWorkloadMock = jest.mocked(getAssignedFlavorFromWorkload);
 
 const mockWorkloadWithFlavor = {
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'Workload',
   metadata: { name: WORKLOAD_NAME, namespace: NAMESPACE },
   spec: { queueName: LOCAL_QUEUE_NAME, podSets: [] },

--- a/frontend/src/utilities/__tests__/useClusterQueue.spec.ts
+++ b/frontend/src/utilities/__tests__/useClusterQueue.spec.ts
@@ -10,7 +10,7 @@ jest.mock('#~/api', () => ({
 const getClusterQueueMock = jest.mocked(getClusterQueue);
 
 const mockClusterQueue: ClusterQueueKind = {
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'ClusterQueue',
   metadata: { name: 'default-cq' },
   spec: {

--- a/packages/cypress/cypress/fixtures/resources/yaml/kueue-resources-training.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/kueue-resources-training.yaml
@@ -1,9 +1,9 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: ${flavorName}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: ${clusterQueueName}
@@ -27,7 +27,7 @@ spec:
       - name: nvidia.com/gpu
         nominalQuota: '${gpuQuota}'
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: ${localQueueName}

--- a/packages/cypress/cypress/fixtures/resources/yaml/kueue-resources-workbench.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/kueue-resources-workbench.yaml
@@ -1,9 +1,9 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: ${flavorName}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: ${clusterQueueName}
@@ -24,7 +24,7 @@ spec:
       - name: memory
         nominalQuota: ${memoryQuota}Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: ${localQueueName}

--- a/packages/cypress/cypress/fixtures/resources/yaml/kueue_reosources.yaml
+++ b/packages/cypress/cypress/fixtures/resources/yaml/kueue_reosources.yaml
@@ -1,9 +1,9 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "${flavorName}"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "${clusterQueueName}"
@@ -21,7 +21,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: 0
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "${namespace}"

--- a/packages/cypress/cypress/tests/mocked/modelTraining/modelTraining.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelTraining/modelTraining.cy.ts
@@ -231,7 +231,7 @@ const createGPUClusterQueue = () => {
     ...baseMock,
     spec: {
       ...baseMock.spec,
-      cohort: 'ml-training-cohort',
+      cohortName: 'ml-training-cohort',
       resourceGroups: [
         {
           coveredResources: [

--- a/packages/cypress/resources/distributedworkloads/kueue_reosources.yaml
+++ b/packages/cypress/resources/distributedworkloads/kueue_reosources.yaml
@@ -1,9 +1,9 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "${flavorName}"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "${clusterQueueName}"
@@ -21,7 +21,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: 0
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "${namespace}"

--- a/packages/model-training/src/api/__tests__/queue.spec.ts
+++ b/packages/model-training/src/api/__tests__/queue.spec.ts
@@ -14,7 +14,7 @@ describe('Queue API', () => {
 
   describe('getLocalQueue', () => {
     const mockLocalQueue: LocalQueueKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
       kind: 'LocalQueue',
       metadata: {
         name: 'test-queue',
@@ -50,13 +50,13 @@ describe('Queue API', () => {
 
   describe('getClusterQueue', () => {
     const mockClusterQueue: ClusterQueueKind = {
-      apiVersion: 'kueue.x-k8s.io/v1beta1',
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
       kind: 'ClusterQueue',
       metadata: {
         name: 'cluster-queue',
       },
       spec: {
-        cohort: 'default-cohort',
+        cohortName: 'default-cohort',
         resourceGroups: [],
       },
     };

--- a/packages/model-training/src/global/rayJobDetailsDrawer/RayJobResourcesTab.tsx
+++ b/packages/model-training/src/global/rayJobDetailsDrawer/RayJobResourcesTab.tsx
@@ -93,7 +93,7 @@ const RayJobResourcesTab: React.FC<RayJobResourcesTabProps> = ({
 
   const { clusterQueue, loaded: clusterQueueDataLoaded } = useClusterQueue(clusterQueueName);
 
-  const quotaSource = clusterQueue?.spec.cohort || '-';
+  const quotaSource = clusterQueue?.spec.cohortName || '-';
   const consumedResources = clusterQueue ? getAllConsumedResources(clusterQueue) : [];
 
   return (

--- a/packages/model-training/src/global/trainingJobDetailsDrawer/TrainingJobResourcesTab.tsx
+++ b/packages/model-training/src/global/trainingJobDetailsDrawer/TrainingJobResourcesTab.tsx
@@ -49,7 +49,7 @@ const TrainingJobResourcesTab: React.FC<TrainingJobResourcesTabProps> = ({
 
   const { clusterQueue, loaded: clusterQueueDataLoaded } = useClusterQueue(clusterQueueName);
 
-  const quotaSource = clusterQueue?.spec.cohort || '-';
+  const quotaSource = clusterQueue?.spec.cohortName || '-';
 
   const consumedResources = clusterQueue ? getAllConsumedResources(clusterQueue) : [];
 

--- a/packages/model-training/src/global/trainingJobList/__tests__/rayJobUtils.spec.ts
+++ b/packages/model-training/src/global/trainingJobList/__tests__/rayJobUtils.spec.ts
@@ -42,7 +42,7 @@ const makeWorkload = (
   active = true,
 ): WorkloadKind =>
   ({
-    apiVersion: 'kueue.x-k8s.io/v1beta1',
+    apiVersion: 'kueue.x-k8s.io/v1beta2',
     kind: 'Workload',
     metadata: { name: 'test-workload', namespace: 'test-ns' },
     spec: { active, podSets: [], priority: 0, queueName: 'default' },

--- a/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
+++ b/packages/model-training/src/global/trainingJobList/__tests__/utils.spec.ts
@@ -37,7 +37,7 @@ const TEST_TIMESTAMP = '2024-01-15T10:30:00Z';
 const TEST_TIMESTAMP_LATER = '2024-01-15T10:35:00Z';
 
 const createMockWorkload = (conditions: WorkloadCondition[] = [], active = true): WorkloadKind => ({
-  apiVersion: 'kueue.x-k8s.io/v1beta1',
+  apiVersion: 'kueue.x-k8s.io/v1beta2',
   kind: 'Workload',
   metadata: {
     name: 'test-workload',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58488

## Description
Migrates all Kueue API calls from `v1beta1` to `v1beta2` to fix pause/resume failures on clusters running Kueue 1.3.x.

**Problem:** The dashboard hardcodes `apiVersion: 'v1beta1'` for Kueue models. On clusters with Kueue 1.3.x (RHOAI 3.4), the Workload CRD storage version is `v1beta2`. When the dashboard patches `/spec/active` via the `v1beta1` API to pause/resume a workload, a CEL validation rule references `spec.priorityClassSource` — a field that no longer exists in `v1beta2`-stored objects — causing the patch to fail with:
> `no such key: priorityClassSource evaluating rule: priorityClassSource is immutable while workload quota reserved`

**Fix:**
- Update `apiVersion` from `v1beta1` to `v1beta2` in `ClusterQueueModel`, `LocalQueueModel`, `WorkloadModel`, and `WorkloadPriorityClassModel`
- Rename ClusterQueue field `cohort` → `cohortName` (v1beta2 schema change)
- Replace Workload field `priorityClassSource` → `priorityClassRef` (v1beta2 schema change)
- Update all related mocks, unit tests, Cypress YAML fixtures, and mocked Cypress tests

## How Has This Been Tested?
- Lint and type-check pass across all affected packages
- Unit tests pass for all changed files
- Mocked Cypress tests pass (`modelTraining.cy.ts`)
- E2E tested on a cluster with Kueue 1.3.x (`v1beta2` storage version):
  - `testPauseAndScaleRayjob` ✅
  - `testPauseAndScaleTrainjob` ✅
  - `testTrainjobLifecycle` ✅
  - `testTrainjobProgression` ✅
  - `testWorkloadMetricsDefaultPageContents` ✅
- Manually confirmed: `kubectl patch workloads.v1beta2.kueue.x-k8s.io` succeeds where `v1beta1` fails

## Test Impact
Updated all existing unit tests and Cypress fixtures to use `v1beta2` apiVersions and field names. No new tests needed — existing tests cover the changed paths.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded Kueue API support to v1beta2 across the app, tests, and test fixtures.
  * "Quota source" display now reads cohortName instead of cohort.
  * Workload priority class references standardized to a structured group/kind/name format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->