### PR TITLE
fix(e2e): add --wait=false to deleteKueueResources cleanup

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/distributedWorkloads.ts
+++ b/packages/cypress/cypress/utils/oc_commands/distributedWorkloads.ts
@@ -68,9 +68,9 @@ export const deleteKueueResources = (
   // Use ';' so each delete runs independently — '&&' would skip
   // ClusterQueue/ResourceFlavor if LocalQueue deletion fails or hangs.
   const ocCommand = [
-    `oc delete LocalQueue ${localQueueName} -n ${projectName}${ignoreFlag}`,
-    `oc delete ClusterQueue ${clusterQueueName}${ignoreFlag}`,
-    `oc delete ResourceFlavor ${resourceFlavor}${ignoreFlag}`,
+    `oc delete LocalQueue ${localQueueName} -n ${projectName}${ignoreFlag} --wait=false`,
+    `oc delete ClusterQueue ${clusterQueueName}${ignoreFlag} --wait=false`,
+    `oc delete ResourceFlavor ${resourceFlavor}${ignoreFlag} --wait=false`,
   ].join(' ; ');
 
   cy.log(`Executing: ${ocCommand}`);


### PR DESCRIPTION
## Description

The `deleteKueueResources` helper in `distributedWorkloads.ts` was the only e2e cleanup function not using `--wait=false` on its `oc delete` commands. This caused cleanup to block on resource finalizers, contributing to Jenkins pipeline timeouts when other slow tests (e.g. testPauseAndScaleRayjob) consumed the timeout budget.

Added `--wait=false` to all three `oc delete` commands (LocalQueue, ClusterQueue, ResourceFlavor), matching the pattern already used by `deleteTrainingRuntime` and `deleteOpenShiftProject`.

## How Has This Been Tested?

- Verified the fix compiles and lints cleanly
- Ran `testProjectAccessPermissions` locally against a cluster (test skipped due to Trainer not being managed on the available cluster — full validation requires a RHOAI cluster with Trainer enabled, which CI provides)
- Code-reviewed against existing cleanup helpers (`deleteTrainingRuntime`, `deleteOpenShiftProject`) that already use `--wait=false` successfully

## Test Impact

No new tests needed — this is a behavioral change to existing cleanup infrastructure. The `--wait=false` flag only affects how quickly `oc delete` returns; resources are still deleted asynchronously. Existing e2e tests exercising Kueue cleanup paths will validate this in CI.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved resource cleanup performance for distributed workloads testing by removing wait conditions on deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->