### PR TITLE
Fix(RHOAIENG-58437):Text overflow issue for subscription dropdown in create api modal 

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -109,10 +109,10 @@ describe('API Keys Page', () => {
   });
 
   it('should display all API keys when the status filter is cleared', () => {
+    apiKeysPage.findRows().should('have.length', 2);
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(
       'clearAllFilters',
     );
-    apiKeysPage.findRows().should('have.length', 2); // active keys show on page load
 
     apiKeysPage.clearAllFilters();
     cy.wait('@clearAllFilters');
@@ -151,14 +151,15 @@ describe('API Keys Page', () => {
 
   it('should filter api keys by username', () => {
     const aliceKeys = mockAPIKeys().filter((k) => k.username === 'alice');
+    apiKeysPage.findRows().should('have.length', 2);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(aliceKeys)).as(
       'searchByUsername',
     );
 
-    apiKeysPage.findFilterInput().type('alice');
+    apiKeysPage.findFilterInput().find('input').type('alice');
     apiKeysPage.findUsernameFilterTooltip().should('be.visible');
-    apiKeysPage.findFilterInput().type('{enter}');
+    apiKeysPage.findFilterSearchButton().click();
 
     cy.wait('@searchByUsername').then((interception) => {
       expect(interception.request.body.data.filters.username).to.eq('alice');
@@ -192,6 +193,7 @@ describe('API Keys Page', () => {
     const filteredKeys = mockAPIKeys().filter(
       (k) => k.status === 'active' || k.status === 'expired',
     );
+    apiKeysPage.findRows().should('have.length', 2);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(filteredKeys)).as(
       'filterByStatus',
@@ -219,6 +221,8 @@ describe('API Keys Page', () => {
 
   it('should sort api keys by name', () => {
     const keys = mockAPIKeys();
+
+    apiKeysPage.findRows().should('have.length', 2);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortNameAsc',
@@ -249,6 +253,8 @@ describe('API Keys Page', () => {
   it('should sort api keys by creation date', () => {
     const keys = mockAPIKeys();
 
+    apiKeysPage.findRows().should('have.length', 2);
+
     // Creation date is the default active sort (desc). First click toggles to asc.
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortCreationDateAsc',
@@ -278,6 +284,8 @@ describe('API Keys Page', () => {
   it('should sort api keys by expiration date', () => {
     const keys = mockAPIKeys();
 
+    apiKeysPage.findRows().should('have.length', 2);
+
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortExpirationAsc',
     );
@@ -305,6 +313,8 @@ describe('API Keys Page', () => {
 
   it('should sort api keys by last used', () => {
     const keys = mockAPIKeys();
+
+    apiKeysPage.findRows().should('have.length', 2);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortLastUsedAsc',
@@ -512,7 +522,10 @@ describe('API Keys Page', () => {
     createApiKeyModal.shouldBeOpen();
     cy.wait('@getSubscriptions');
 
-    createApiKeyModal.findSubscriptionToggle().should('contain.text', 'Select a subscription');
+    createApiKeyModal
+      .findSubscriptionToggle()
+      .find('input')
+      .should('have.attr', 'placeholder', 'Select a subscription');
     createApiKeyModal.findSubmitButton().should('be.disabled');
 
     createApiKeyModal.findSubscriptionToggle().click();

--- a/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
@@ -17,7 +17,6 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
-  Icon,
   MenuToggle,
   MenuToggleElement,
   Modal,
@@ -28,17 +27,20 @@ import {
   Select,
   SelectList,
   SelectOption,
-  Spinner,
   Stack,
   StackItem,
   TextArea,
   TextInput,
   Title,
 } from '@patternfly/react-core';
+import TypeaheadSelect, {
+  TypeaheadSelectOption,
+} from '@odh-dashboard/internal/components/TypeaheadSelect';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { z } from 'zod';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
+import TruncatedText from '@odh-dashboard/internal/components/TruncatedText';
 import { formatApiKeyError } from '~/app/pages/api-keys/utils';
 import { createApiKey } from '~/app/api/api-keys';
 import { useUserSubscriptions } from '~/app/hooks/useUserSubscriptions';
@@ -103,7 +105,6 @@ const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({ onClose }) => {
     subscription: '',
   });
   const [isSelectOpen, setIsSelectOpen] = React.useState(false);
-  const [isSubscriptionSelectOpen, setIsSubscriptionSelectOpen] = React.useState(false);
   const [isCreating, setIsCreating] = React.useState(false);
   const [error, setError] = React.useState<Error | undefined>();
   const [createdToken, setCreatedToken] = React.useState<string | undefined>();
@@ -337,52 +338,31 @@ const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({ onClose }) => {
                 </FormGroup>
 
                 <FormGroup label="Subscription" isRequired fieldId="api-key-subscription">
-                  <Select
+                  <TypeaheadSelect
                     id="api-key-subscription"
-                    isOpen={isSubscriptionSelectOpen}
-                    onOpenChange={(open) => setIsSubscriptionSelectOpen(open)}
+                    selectOptions={subscriptions.map<TypeaheadSelectOption>((sub) => ({
+                      value: sub.subscription_id_header,
+                      content: sub.display_name || sub.subscription_id_header,
+                      description: (
+                        <TruncatedText
+                          maxLines={2}
+                          content={`${sub.subscription_description} · ${sub.model_refs.length} ${sub.model_refs.length === 1 ? 'model' : 'models'}`}
+                        />
+                      ),
+                      'data-testid': `api-key-subscription-option-${sub.subscription_id_header}`,
+                    }))}
                     selected={formData.subscription}
-                    onSelect={(_event, value) => {
-                      if (typeof value === 'string') {
-                        setFormData({ ...formData, subscription: value });
-                      }
-                      setIsSubscriptionSelectOpen(false);
-                    }}
-                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                      <MenuToggle
-                        ref={toggleRef}
-                        onClick={() => setIsSubscriptionSelectOpen(!isSubscriptionSelectOpen)}
-                        isExpanded={isSubscriptionSelectOpen}
-                        isFullWidth
-                        isDisabled={!subscriptionsLoaded || subscriptions.length === 0}
-                        icon={
-                          !subscriptionsLoaded && !subscriptionsError ? (
-                            <Icon>
-                              <Spinner size="sm" aria-label="Loading subscriptions" />
-                            </Icon>
-                          ) : undefined
-                        }
-                        data-testid="api-key-subscription-toggle"
-                      >
-                        {selectedSubscription?.display_name ??
-                          selectedSubscription?.subscription_id_header ??
-                          'Select a subscription'}
-                      </MenuToggle>
-                    )}
-                  >
-                    <SelectList>
-                      {subscriptions.map((sub) => (
-                        <SelectOption
-                          key={sub.subscription_id_header}
-                          value={sub.subscription_id_header}
-                          description={`${sub.subscription_description} · ${sub.model_refs.length} ${sub.model_refs.length === 1 ? 'model' : 'models'}`}
-                          data-testid={`api-key-subscription-option-${sub.subscription_id_header}`}
-                        >
-                          {sub.display_name || sub.subscription_id_header}
-                        </SelectOption>
-                      ))}
-                    </SelectList>
-                  </Select>
+                    onSelect={(_e, value) =>
+                      setFormData({ ...formData, subscription: String(value) })
+                    }
+                    isDisabled={!subscriptionsLoaded || subscriptions.length === 0}
+                    placeholder="Select a subscription"
+                    dataTestId="api-key-subscription-toggle"
+                    previewDescription={false}
+                    isRequired={false}
+                    popperProps={{ maxWidth: 'trigger' }}
+                    isScrollable
+                  />
                   <FormHelperText>
                     <HelperText>
                       <HelperTextItem>


### PR DESCRIPTION
Closes [RHOAIENG-58437](https://redhat.atlassian.net/browse/RHOAIENG-58437)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

https://github.com/user-attachments/assets/0d51c319-b45f-4f7d-97a9-9b9e05a237b2

This PR contains the following fixes:

1. fixes the text overflow issues for subscription dropdown (swapped the subscription dropdown from using the patternfly select to typeahead as it supports `popperProps` which lets you pin the menu width to the trigger, so it stays within the modal.)
2. Cleaned out flaky tests in create api key

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Updated cypress test cases

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined subscription dropdown in API key creation modal for streamlined selection and filtering.

* **Tests**
  * Enhanced automated test assertions for API keys table verification.
  * Updated API keys filtering and subscription selection tests for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->