### PR TITLE
Fix subscription view page when model refs do not exist

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -13,6 +13,7 @@ import {
 import {
   mockSubscriptions,
   mockSubscriptionInfo,
+  mockSubscriptionInfoMissingModelSummaries,
   mockSubscriptionFormData,
   mockCreateSubscriptionResponse,
   mockUpdateSubscriptionResponse,
@@ -173,6 +174,22 @@ describe('View Subscription Page', () => {
 
     viewSubscriptionPage.findBreadcrumbSubscriptionsLink().click();
     cy.url().should('include', '/maas/subscriptions');
+  });
+
+  it("should list models from the subscription when model ref doesn't exist", () => {
+    const orphanSubName = 'missing-model-summary-sub';
+    cy.interceptOdh(
+      'GET /maas/api/v1/subscription-info/:name',
+      { path: { name: orphanSubName } },
+      { data: mockSubscriptionInfoMissingModelSummaries() },
+    );
+    viewSubscriptionPage.visit(orphanSubName);
+    viewSubscriptionPage.findModelsSection().should('exist');
+    viewSubscriptionPage
+      .findModelsTable()
+      .should('contain.text', 'deleted-model-ref')
+      .and('contain.text', 'maas-models')
+      .and('contain.text', '50,000');
   });
 
   it('should show error state when the subscription-info API fails', () => {

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -236,6 +236,34 @@ export const mockSubscriptionListItems = (): UserSubscription[] => [
   },
 ];
 
+export const mockSubscriptionInfoMissingModelSummaries = (): SubscriptionInfoResponse => {
+  const subscription: MaaSSubscription = {
+    name: 'missing-model-summary-sub',
+    displayName: "Subscription with model refs that don't exist",
+    namespace: 'maas-system',
+    phase: 'Active',
+    statusMessage: 'successfully reconciled',
+    priority: 7,
+    owner: {
+      groups: [{ name: 'premium-users' }],
+    },
+    modelRefs: [
+      {
+        name: 'deleted-model-ref',
+        namespace: 'maas-models',
+        tokenRateLimits: [{ limit: 50000, window: '24h' }],
+      },
+    ],
+    creationTimestamp: '2025-03-01T10:00:00Z',
+  };
+
+  return {
+    subscription,
+    modelRefs: [],
+    authPolicies: [],
+  };
+};
+
 export const mockSubscriptionInfo = (name = 'premium-team-sub'): SubscriptionInfoResponse => {
   const subscription = mockSubscriptions().find((s) => s.name === name) ?? mockSubscriptions()[0];
   return {

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -63,9 +63,14 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription 
   );
 };
 
-const viewModelRefSummaries = (info: SubscriptionInfoResponse): MaaSModelRefSummary[] =>
-  info.subscription.modelRefs.map((ref) => {
-    const summary = info.modelRefs.find(
+const viewModelRefSummaries = (info: SubscriptionInfoResponse): MaaSModelRefSummary[] => {
+  const subscriptionRefs = Array.isArray(info.subscription.modelRefs)
+    ? info.subscription.modelRefs
+    : [];
+  const modelRefSummaries = Array.isArray(info.modelRefs) ? info.modelRefs : [];
+
+  return subscriptionRefs.map((ref) => {
+    const summary = modelRefSummaries.find(
       (s) => s.name === ref.name && s.namespace === ref.namespace,
     );
     return (
@@ -76,6 +81,7 @@ const viewModelRefSummaries = (info: SubscriptionInfoResponse): MaaSModelRefSumm
       }
     );
   });
+};
 
 const ViewSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -11,7 +11,11 @@ import {
 } from '@patternfly/react-core';
 import SimpleMenuActions from '@odh-dashboard/internal/components/SimpleMenuActions';
 import { useGetSubscriptionInfo } from '~/app/hooks/useGetSubscriptionInfo';
-import { MaaSSubscription } from '~/app/types/subscriptions';
+import {
+  MaaSModelRefSummary,
+  MaaSSubscription,
+  SubscriptionInfoResponse,
+} from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteSubscriptionModal from './DeleteSubscriptionModal';
@@ -58,6 +62,20 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription 
     </>
   );
 };
+
+const viewModelRefSummaries = (info: SubscriptionInfoResponse): MaaSModelRefSummary[] =>
+  info.subscription.modelRefs.map((ref) => {
+    const summary = info.modelRefs.find(
+      (s) => s.name === ref.name && s.namespace === ref.namespace,
+    );
+    return (
+      summary ?? {
+        name: ref.name,
+        namespace: ref.namespace,
+        modelRef: { kind: '', name: '' },
+      }
+    );
+  });
 
 const ViewSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();
@@ -110,7 +128,7 @@ const ViewSubscriptionPage: React.FC = () => {
             </PageSection>
             <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
               <MaasModelsSection
-                modelRefSummaries={subscriptionInfo.modelRefs}
+                modelRefSummaries={viewModelRefSummaries(subscriptionInfo)}
                 modelRefsWithRateLimits={subscriptionInfo.subscription.modelRefs}
               />
             </PageSection>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-58235](https://redhat.atlassian.net/browse/RHOAIENG-58235)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updates the view page to show the model refs from the model ref summaries, so even if the model ref itself is missing, you can still see it on the subscription


https://github.com/user-attachments/assets/6bc9af29-445d-47d5-9f27-a8d25f4022a7



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- On `dashboard-maas`, I have a subscription called `deletedmodelref`, also the `emily` subscription has missing model refs
- go to the view page, you should still be able to see the models that were added to this subscription

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a mock test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or deleted model references in the subscription details view to ensure the models section and models table render correctly even when some model references are unavailable or orphaned.

* **Tests**
  * Added test coverage for subscription pages with deleted or missing model references to verify proper rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->