### PR TITLE
feat(automl,autorag): support namespace persistence

### DIFF
--- a/packages/automl/frontend/package-lock.json
+++ b/packages/automl/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "dompurify": "^3.3.3",
         "es-toolkit": "^1.44.0",
         "lodash-es": "^4.17.15",
-        "mod-arch-core": "^1.2.2",
+        "mod-arch-core": "^1.6.0",
         "mod-arch-shared": "^1.5.0",
         "react": "^18",
         "react-dom": "^18",
@@ -17493,9 +17493,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeepwith": {
@@ -18366,16 +18366,16 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.5.0.tgz",
-      "integrity": "sha512-9BKD0nkj6XDjGyIV3X7/bN6hxGOm0LkBaYB478Ao7l27z77jkULCsbwMZpTlQ/VeCBuVL0WSQIfqhXNhkp3BSQ==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.15.3.tgz",
+      "integrity": "sha512-9DOdYqE7FFCciVJi2Ru9mL99/t87vVYFMAAHfLTfhmr1AS/JOPFpVFEn3NtTKAnKRxmOvUt8annx0o7YZkiFtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.15",
+        "lodash-es": "^4.18.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.26.1",

--- a/packages/automl/frontend/package.json
+++ b/packages/automl/frontend/package.json
@@ -112,7 +112,7 @@
     "dompurify": "^3.3.3",
     "es-toolkit": "^1.44.0",
     "lodash-es": "^4.17.15",
-    "mod-arch-core": "^1.2.2",
+    "mod-arch-core": "^1.6.0",
     "mod-arch-shared": "^1.5.0",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/automl/frontend/src/app/App.tsx
+++ b/packages/automl/frontend/src/app/App.tsx
@@ -30,7 +30,9 @@ const App: React.FC = () => {
     loadError: configError,
   } = useSettings();
 
-  const { namespacesLoaded, namespacesLoadError, initializationError } = useNamespaceSelector();
+  const { namespacesLoaded, namespacesLoadError, initializationError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const { config } = useModularArchContext();
   const { deploymentMode } = config;

--- a/packages/automl/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
+++ b/packages/automl/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
@@ -15,7 +15,9 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorNavigatorProps> = ({
   ...projectSelectorProps
 }) => {
   const navigate = useNavigate();
-  const { namespaces, updatePreferredNamespace, namespacesLoaded } = useNamespaceSelector();
+  const { namespaces, updatePreferredNamespace, namespacesLoaded } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   return (
     <ProjectSelector

--- a/packages/automl/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
+++ b/packages/automl/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
@@ -9,7 +9,8 @@ export function usePreferredNamespaceRedirect(): void {
   const { namespaces, preferredNamespace } = useNamespaceSelector({ storeLastNamespace: true });
 
   useEffect(() => {
-    const preferredOrFirstNamespace = preferredNamespace?.name ?? namespaces[0]?.name;
+    const validPreferredName = namespaces.find((n) => n.name === preferredNamespace?.name)?.name;
+    const preferredOrFirstNamespace = validPreferredName ?? namespaces[0]?.name;
     if (!namespace && preferredOrFirstNamespace) {
       navigate(preferredOrFirstNamespace, { replace: true });
     }

--- a/packages/automl/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
+++ b/packages/automl/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
@@ -6,7 +6,7 @@ export function usePreferredNamespaceRedirect(): void {
   const { namespace } = useParams();
   const navigate = useNavigate();
 
-  const { namespaces, preferredNamespace } = useNamespaceSelector();
+  const { namespaces, preferredNamespace } = useNamespaceSelector({ storeLastNamespace: true });
 
   useEffect(() => {
     const preferredOrFirstNamespace = preferredNamespace?.name ?? namespaces[0]?.name;

--- a/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlConfigurePage.tsx
@@ -37,7 +37,9 @@ function AutomlConfigurePage(): React.JSX.Element {
   const notification = useNotification();
 
   const { namespace } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const noNamespaces = namespacesLoaded && namespaces.length === 0;
   const invalidNamespace =

--- a/packages/automl/frontend/src/app/pages/AutomlExperimentsPage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlExperimentsPage.tsx
@@ -18,7 +18,9 @@ function AutomlExperimentsPage(): React.JSX.Element {
 
   const navigate = useNavigate();
   const { namespace } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const noNamespaces = namespacesLoaded && namespaces.length === 0;
   const invalidNamespace =

--- a/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
+++ b/packages/automl/frontend/src/app/pages/AutomlResultsPage.tsx
@@ -26,7 +26,9 @@ import { parseErrorStatus } from '~/app/utilities/utils';
 
 function AutomlResultsPage(): React.JSX.Element {
   const { namespace, runId } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const handleDrawerClose = React.useCallback(() => setIsDrawerOpen(false), []);
 

--- a/packages/automl/frontend/src/odh/AppWrapper.tsx
+++ b/packages/automl/frontend/src/odh/AppWrapper.tsx
@@ -1,6 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { DeploymentMode, ModularArchConfig, ModularArchContextProvider } from 'mod-arch-core';
+import {
+  BrowserStorageContextProvider,
+  DeploymentMode,
+  ModularArchConfig,
+  ModularArchContextProvider,
+} from 'mod-arch-core';
 import React from 'react';
 import AppRoutes from '~/app/AppRoutes';
 import ToastNotifications from '~/app/components/ToastNotifications';
@@ -26,18 +31,20 @@ const modularArchConfig: ModularArchConfig = {
 function AppWrapper(): React.JSX.Element {
   return (
     <ModularArchContextProvider config={modularArchConfig}>
-      <QueryClientProvider client={queryClient}>
-        <div
-          className={classNames(
-            'pf-v6-u-h-100',
-            'pf-v6-u-display-flex',
-            'pf-v6-u-flex-direction-column',
-          )}
-        >
-          <AppRoutes />
-        </div>
-        <ToastNotifications />
-      </QueryClientProvider>
+      <BrowserStorageContextProvider>
+        <QueryClientProvider client={queryClient}>
+          <div
+            className={classNames(
+              'pf-v6-u-h-100',
+              'pf-v6-u-display-flex',
+              'pf-v6-u-flex-direction-column',
+            )}
+          >
+            <AppRoutes />
+          </div>
+          <ToastNotifications />
+        </QueryClientProvider>
+      </BrowserStorageContextProvider>
     </ModularArchContextProvider>
   );
 }

--- a/packages/autorag/frontend/package-lock.json
+++ b/packages/autorag/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "dompurify": "^3.2.4",
         "echarts": "^5.6.0",
         "es-toolkit": "^1.44.0",
-        "mod-arch-core": "^1.2.2",
+        "mod-arch-core": "^1.6.0",
         "mod-arch-shared": "^1.5.0",
         "react": "^18",
         "react-dom": "^18",

--- a/packages/autorag/frontend/package.json
+++ b/packages/autorag/frontend/package.json
@@ -114,7 +114,7 @@
     "dompurify": "^3.2.4",
     "echarts": "^5.6.0",
     "es-toolkit": "^1.44.0",
-    "mod-arch-core": "^1.2.2",
+    "mod-arch-core": "^1.6.0",
     "mod-arch-shared": "^1.5.0",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/autorag/frontend/src/app/App.tsx
+++ b/packages/autorag/frontend/src/app/App.tsx
@@ -42,7 +42,9 @@ const App: React.FC = () => {
     loadError: configError,
   } = useSettings();
 
-  const { namespacesLoaded, namespacesLoadError, initializationError } = useNamespaceSelector();
+  const { namespacesLoaded, namespacesLoadError, initializationError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const { config } = useModularArchContext();
   const { deploymentMode } = config;

--- a/packages/autorag/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
+++ b/packages/autorag/frontend/src/app/components/common/ProjectSelectorNavigator.tsx
@@ -15,7 +15,9 @@ const ProjectSelectorNavigator: React.FC<ProjectSelectorNavigatorProps> = ({
   ...projectSelectorProps
 }) => {
   const navigate = useNavigate();
-  const { namespaces, updatePreferredNamespace, namespacesLoaded } = useNamespaceSelector();
+  const { namespaces, updatePreferredNamespace, namespacesLoaded } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   return (
     <ProjectSelector

--- a/packages/autorag/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
+++ b/packages/autorag/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
@@ -9,7 +9,8 @@ export function usePreferredNamespaceRedirect(): void {
   const { namespaces, preferredNamespace } = useNamespaceSelector({ storeLastNamespace: true });
 
   useEffect(() => {
-    const preferredOrFirstNamespace = preferredNamespace?.name ?? namespaces[0]?.name;
+    const validPreferredName = namespaces.find((n) => n.name === preferredNamespace?.name)?.name;
+    const preferredOrFirstNamespace = validPreferredName ?? namespaces[0]?.name;
     if (!namespace && preferredOrFirstNamespace) {
       navigate(preferredOrFirstNamespace, { replace: true });
     }

--- a/packages/autorag/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
+++ b/packages/autorag/frontend/src/app/hooks/usePreferredNamespaceRedirect.ts
@@ -6,7 +6,7 @@ export function usePreferredNamespaceRedirect(): void {
   const { namespace } = useParams();
   const navigate = useNavigate();
 
-  const { namespaces, preferredNamespace } = useNamespaceSelector();
+  const { namespaces, preferredNamespace } = useNamespaceSelector({ storeLastNamespace: true });
 
   useEffect(() => {
     const preferredOrFirstNamespace = preferredNamespace?.name ?? namespaces[0]?.name;

--- a/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragConfigurePage.tsx
@@ -39,7 +39,9 @@ function AutoragConfigurePage(): React.JSX.Element {
   const notification = useNotification();
 
   const { namespace } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const noNamespaces = namespacesLoaded && namespaces.length === 0;
   const invalidNamespace =

--- a/packages/autorag/frontend/src/app/pages/AutoragExperimentsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragExperimentsPage.tsx
@@ -18,7 +18,9 @@ function AutoragExperimentsPage(): React.JSX.Element {
 
   const navigate = useNavigate();
   const { namespace } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
 
   const noNamespaces = namespacesLoaded && namespaces.length === 0;
   const invalidNamespace =

--- a/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
+++ b/packages/autorag/frontend/src/app/pages/AutoragResultsPage.tsx
@@ -26,7 +26,9 @@ import { parseErrorStatus } from '~/app/utilities/utils';
 
 function AutoragResultsPage(): React.JSX.Element {
   const { namespace, runId } = useParams();
-  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector();
+  const { namespaces, namespacesLoaded, namespacesLoadError } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const handleDrawerClose = React.useCallback(() => setIsDrawerOpen(false), []);
 

--- a/packages/autorag/frontend/src/odh/AppWrapper.tsx
+++ b/packages/autorag/frontend/src/odh/AppWrapper.tsx
@@ -1,6 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { DeploymentMode, ModularArchConfig, ModularArchContextProvider } from 'mod-arch-core';
+import {
+  BrowserStorageContextProvider,
+  DeploymentMode,
+  ModularArchConfig,
+  ModularArchContextProvider,
+} from 'mod-arch-core';
 import React from 'react';
 import AppRoutes from '~/app/AppRoutes';
 import ToastNotifications from '~/app/components/ToastNotifications';
@@ -26,18 +31,20 @@ const modularArchConfig: ModularArchConfig = {
 function AppWrapper(): React.JSX.Element {
   return (
     <ModularArchContextProvider config={modularArchConfig}>
-      <QueryClientProvider client={queryClient}>
-        <div
-          className={classNames(
-            'pf-v6-u-h-100',
-            'pf-v6-u-display-flex',
-            'pf-v6-u-flex-direction-column',
-          )}
-        >
-          <AppRoutes />
-        </div>
-        <ToastNotifications />
-      </QueryClientProvider>
+      <BrowserStorageContextProvider>
+        <QueryClientProvider client={queryClient}>
+          <div
+            className={classNames(
+              'pf-v6-u-h-100',
+              'pf-v6-u-display-flex',
+              'pf-v6-u-flex-direction-column',
+            )}
+          >
+            <AppRoutes />
+          </div>
+          <ToastNotifications />
+        </QueryClientProvider>
+      </BrowserStorageContextProvider>
     </ModularArchContextProvider>
   );
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-56615

## Description
Persist the selected namespace across AutoRAG and AutoML routes, and across sessions, using `mod-arch-core`’s built-in last-namespace storage (`localStorage`, default key `mod-arch.namespace.lastUsed`).

- Pass `{ storeLastNamespace: true }` to `useNamespaceSelector`.
- Wrap federated `src/odh/AppWrapper.tsx` with `BrowserStorageContextProvider` from `mod-arch-core`.
- Bump `mod-arch-core` to `^1.6.0` (minimum version that includes namespace persistence and typed optional arguments for `useNamespaceSelector`); refresh lockfiles as needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Select a project in an AutoX tool; if you navigate between AutoRAG and AutoML, or navigate away and then back, the namespace selected is persisted:

https://github.com/user-attachments/assets/ecb12314-d0d2-47f7-b26f-2e2d16945ffd

## Test Impact
No tests added.
The behaviour lives mainly in `mod-arch-core` (`useNamespacePersistence`, `BrowserStorageContextProvider`); this PR mostly wires that API. Also, testing namespace persistence is likely better suited to an integration/E2E flow.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace persistence: the app now remembers and restores your last selected namespace across visits.
* **Improvements**
  * App now includes a browser storage layer to persist UI state and improve session continuity.
* **Chores**
  * Updated underlying library versions to support the new persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->