### PR TITLE
Cherry-Pick -> Feat(RHOAIENG-56731): type guards strengthening  (#7204)

### DIFF
--- a/packages/maas/bff/internal/integrations/maas/maas_client.go
+++ b/packages/maas/bff/internal/integrations/maas/maas_client.go
@@ -82,6 +82,10 @@ func (c *MaasClient) SearchAPIKeys(ctx context.Context, request models.APIKeySea
 		return nil, err
 	}
 
+	if apiResponse.Data == nil {
+		apiResponse.Data = []models.APIKey{}
+	}
+
 	return &apiResponse, nil
 }
 
@@ -148,6 +152,17 @@ func (c *MaasClient) ListSubscriptionsForApiKeys(ctx context.Context) ([]models.
 
 	if err != nil {
 		return nil, err
+	}
+
+	for i := range apiResponse {
+		if apiResponse[i].ModelRefs == nil {
+			apiResponse[i].ModelRefs = []models.ModelRefInfo{}
+		}
+		for j := range apiResponse[i].ModelRefs {
+			if apiResponse[i].ModelRefs[j].TokenRateLimits == nil {
+				apiResponse[i].ModelRefs[j].TokenRateLimits = []models.TokenRateLimitInfo{}
+			}
+		}
 	}
 
 	return apiResponse, nil

--- a/packages/maas/bff/internal/integrations/maas/maas_client_test.go
+++ b/packages/maas/bff/internal/integrations/maas/maas_client_test.go
@@ -1,0 +1,149 @@
+package maas
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// newTestClient spins up an httptest.Server with the given handler and wires it to a MaasClient.
+func newTestClient(t *testing.T, handler http.Handler) *MaasClient {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	u, _ := url.Parse(ts.URL)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return NewMaasClient(logger, u)
+}
+
+// jsonHandler returns an HTTP handler that responds with the JSON encoding of v.
+func jsonHandler(t *testing.T, v any) http.Handler {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal test response: %v", err)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(b)
+	})
+}
+
+func TestSearchAPIKeys_NilDataNormalized(t *testing.T) {
+	// Simulate the upstream MaaS API returning null for data (e.g. no keys exist)
+	body := map[string]any{
+		"object":   "list",
+		"data":     nil,
+		"has_more": false,
+	}
+	client := newTestClient(t, jsonHandler(t, body))
+
+	result, err := client.SearchAPIKeys(context.Background(), models.APIKeySearchRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Data == nil {
+		t.Error("Data must not be nil after normalization")
+	}
+	if len(result.Data) != 0 {
+		t.Errorf("expected empty Data slice, got %v", result.Data)
+	}
+}
+
+func TestListSubscriptionsForApiKeys_NilModelRefsNormalized(t *testing.T) {
+	// Simulate the upstream MaaS API returning null for model_refs
+	body := []map[string]any{
+		{
+			"subscription_id_header":   "test-sub",
+			"subscription_description": "Test",
+			"priority":                 1,
+			"model_refs":               nil,
+		},
+	}
+	client := newTestClient(t, jsonHandler(t, body))
+
+	result, err := client.ListSubscriptionsForApiKeys(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	if result[0].ModelRefs == nil {
+		t.Error("ModelRefs must not be nil after normalization")
+	}
+	if len(result[0].ModelRefs) != 0 {
+		t.Errorf("expected empty ModelRefs slice, got %v", result[0].ModelRefs)
+	}
+}
+
+func TestListSubscriptionsForApiKeys_NilTokenRateLimitsNormalized(t *testing.T) {
+	// Simulate the upstream MaaS API returning null for token_rate_limits inside a model ref
+	body := []map[string]any{
+		{
+			"subscription_id_header":   "test-sub",
+			"subscription_description": "Test",
+			"priority":                 1,
+			"model_refs": []map[string]any{
+				{
+					"name":              "my-model",
+					"namespace":         "llm",
+					"token_rate_limits": nil,
+				},
+			},
+		},
+	}
+	client := newTestClient(t, jsonHandler(t, body))
+
+	result, err := client.ListSubscriptionsForApiKeys(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 || len(result[0].ModelRefs) != 1 {
+		t.Fatalf("expected 1 sub with 1 model ref, got %+v", result)
+	}
+	if result[0].ModelRefs[0].TokenRateLimits == nil {
+		t.Error("TokenRateLimits must not be nil after normalization")
+	}
+	if len(result[0].ModelRefs[0].TokenRateLimits) != 0 {
+		t.Errorf("expected empty TokenRateLimits slice, got %v", result[0].ModelRefs[0].TokenRateLimits)
+	}
+}
+
+func TestListSubscriptionsForApiKeys_ValidDataPassedThrough(t *testing.T) {
+	// Upstream returns well-formed data with actual rate limits — must not be altered
+	body := []models.SubscriptionListItem{
+		{
+			SubscriptionIDHeader: "premium-sub",
+			Priority:             10,
+			ModelRefs: []models.ModelRefInfo{
+				{
+					Name: "granite-3-8b",
+					TokenRateLimits: []models.TokenRateLimitInfo{
+						{Limit: 1000, Window: "1h"},
+					},
+				},
+			},
+		},
+	}
+	client := newTestClient(t, jsonHandler(t, body))
+
+	result, err := client.ListSubscriptionsForApiKeys(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(result))
+	}
+	got := result[0].ModelRefs[0].TokenRateLimits[0]
+	if got.Limit != 1000 || got.Window != "1h" {
+		t.Errorf("rate limit data was altered: got %+v", got)
+	}
+}

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -41,7 +41,7 @@ type GroupReference struct {
 
 // OwnerSpec defines who owns a subscription.
 type OwnerSpec struct {
-	Groups []GroupReference `json:"groups,omitempty"`
+	Groups []GroupReference `json:"groups"`
 }
 
 // TokenRateLimit defines a token-based rate limit.
@@ -87,7 +87,7 @@ type MaaSSubscription struct {
 
 // SubjectSpec defines subjects (groups) that have access.
 type SubjectSpec struct {
-	Groups []GroupReference `json:"groups,omitempty"`
+	Groups []GroupReference `json:"groups"`
 }
 
 // ModelRef is a simple reference to a MaaSModelRef by name and namespace.

--- a/packages/maas/bff/internal/models/subscription_test.go
+++ b/packages/maas/bff/internal/models/subscription_test.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// These tests guard against accidentally re-adding omitempty to the groups field
+// on OwnerSpec and SubjectSpec. If groups is omitted from JSON entirely, the
+// frontend Array.isArray(v.groups) check fails and the page breaks.
+
+func TestOwnerSpec_EmptyGroupsSerializesAsArray(t *testing.T) {
+	b, err := json.Marshal(OwnerSpec{Groups: []GroupReference{}})
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !strings.Contains(string(b), `"groups":[]`) {
+		t.Errorf(`"groups":[] must be present in JSON, got: %s`, string(b))
+	}
+}
+
+func TestSubjectSpec_EmptyGroupsSerializesAsArray(t *testing.T) {
+	b, err := json.Marshal(SubjectSpec{Groups: []GroupReference{}})
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !strings.Contains(string(b), `"groups":[]`) {
+		t.Errorf(`"groups":[] must be present in JSON, got: %s`, string(b))
+	}
+}

--- a/packages/maas/bff/internal/repositories/policies.go
+++ b/packages/maas/bff/internal/repositories/policies.go
@@ -49,7 +49,8 @@ func (r *PoliciesRepository) ListPolicies(ctx context.Context) ([]models.MaaSAut
 	for _, item := range list.Items {
 		policy, err := convertUnstructuredToAuthPolicy(&item)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert MaaSAuthPolicy %s: %w", item.GetName(), err)
+			r.logger.Warn("Failed to convert MaaSAuthPolicy", slog.String("name", item.GetName()), slog.Any("error", err))
+			continue
 		}
 		policies = append(policies, *policy)
 	}

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -287,7 +287,7 @@ func (r *SubscriptionsRepository) GetModelRefSummaries(ctx context.Context, refs
 		refSet[ref.Namespace+"/"+ref.Name] = true
 	}
 
-	var result []models.MaaSModelRefSummary
+	result := make([]models.MaaSModelRefSummary, 0)
 	for _, ref := range allRefs {
 		if refSet[ref.Namespace+"/"+ref.Name] {
 			result = append(result, ref)
@@ -361,6 +361,7 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 		}
 	}
 
+	sub.Owner.Groups = []models.GroupReference{}
 	ownerGroups, _, _ := unstructured.NestedSlice(content, "spec", "owner", "groups")
 	for _, g := range ownerGroups {
 		if gMap, ok := g.(map[string]interface{}); ok {
@@ -370,6 +371,7 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 		}
 	}
 
+	sub.ModelRefs = []models.ModelSubscriptionRef{}
 	modelRefs, _, _ := unstructured.NestedSlice(content, "spec", "modelRefs")
 	for _, mr := range modelRefs {
 		if mrMap, ok := mr.(map[string]interface{}); ok {
@@ -454,6 +456,7 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 
 	policy.StatusMessage = extractReadyConditionMessage(content)
 
+	policy.ModelRefs = []models.ModelRef{}
 	modelRefs, _, _ := unstructured.NestedSlice(content, "spec", "modelRefs")
 	for _, mr := range modelRefs {
 		if mrMap, ok := mr.(map[string]interface{}); ok {
@@ -468,6 +471,7 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 		}
 	}
 
+	policy.Subjects.Groups = []models.GroupReference{}
 	subjectGroups, _, _ := unstructured.NestedSlice(content, "spec", "subjects", "groups")
 	for _, g := range subjectGroups {
 		if gMap, ok := g.(map[string]interface{}); ok {

--- a/packages/maas/bff/internal/repositories/subscriptions_mock.go
+++ b/packages/maas/bff/internal/repositories/subscriptions_mock.go
@@ -131,7 +131,7 @@ func (r *MockSubscriptionsRepository) GetFormData(_ context.Context) (*models.Su
 
 func (r *MockSubscriptionsRepository) GetAuthPoliciesForSubscription(_ context.Context, subscriptionName string) ([]models.MaaSAuthPolicy, error) {
 	r.logger.Debug("Getting auth policies for subscription (mock)", slog.String("subscription", subscriptionName))
-	var result []models.MaaSAuthPolicy
+	result := make([]models.MaaSAuthPolicy, 0)
 	for _, policy := range mocks.GetMockMaaSAuthPolicies() {
 		if policy.Name == subscriptionName+"-policy" {
 			result = append(result, policy)

--- a/packages/maas/frontend/src/app/api/__tests__/api-keys.spec.ts
+++ b/packages/maas/frontend/src/app/api/__tests__/api-keys.spec.ts
@@ -1,0 +1,232 @@
+/* eslint-disable camelcase */
+import * as modArchCore from 'mod-arch-core';
+import type {
+  APIKey,
+  APIKeyListResponse,
+  BulkRevokeResponse,
+  CreateAPIKeyResponse,
+} from '~/app/types/api-key';
+import { bulkRevokeApiKeys, createApiKey, revokeApiKey, searchApiKeys } from '~/app/api/api-keys';
+
+jest.mock('mod-arch-core', () => ({
+  ...jest.requireActual('mod-arch-core'),
+  handleRestFailures: jest.fn((p: Promise<unknown>) => p),
+  restCREATE: jest.fn(),
+  restDELETE: jest.fn(),
+  assembleModArchBody: jest.fn((body: unknown) => ({ data: body })),
+}));
+
+const mockRestCREATE = jest.mocked(modArchCore.restCREATE);
+const mockRestDELETE = jest.mocked(modArchCore.restDELETE);
+const mockHandleRestFailures = jest.mocked(modArchCore.handleRestFailures);
+
+const validKey: APIKey = {
+  id: 'key-1',
+  name: 'My Key',
+  status: 'active',
+  creationDate: '2025-01-01T00:00:00Z',
+};
+
+const validListResponse: APIKeyListResponse = {
+  object: 'list',
+  data: [validKey],
+  has_more: false,
+  subscriptionDetails: {
+    'premium-sub': { displayName: 'Premium', models: ['granite-3-8b-instruct'] },
+  },
+};
+
+describe('searchApiKeys', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRestFailures.mockImplementation((p: Promise<unknown>) => p);
+  });
+
+  it('should resolve with a valid API key list response', async () => {
+    mockRestCREATE.mockResolvedValue({ data: validListResponse });
+
+    const result = await searchApiKeys()({} as never);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('key-1');
+    expect(result.has_more).toBe(false);
+  });
+
+  it('should accept a response with no subscriptionDetails field', async () => {
+    const withoutDetails: Omit<APIKeyListResponse, 'subscriptionDetails'> = {
+      object: validListResponse.object,
+      data: validListResponse.data,
+      has_more: validListResponse.has_more,
+    };
+    mockRestCREATE.mockResolvedValue({ data: withoutDetails });
+
+    const result = await searchApiKeys()({} as never);
+    expect(result.subscriptionDetails).toBeUndefined();
+  });
+
+  it('should throw when any API key is missing status', async () => {
+    const keyMissingStatus = { id: 'key-1', name: 'My Key', creationDate: '2025-01-01' };
+    mockRestCREATE.mockResolvedValue({
+      data: { ...validListResponse, data: [keyMissingStatus] },
+    });
+
+    await expect(searchApiKeys()({} as never)).rejects.toThrow('Invalid response format');
+  });
+
+  it('should throw when any API key is missing id', async () => {
+    const keyMissingId = { name: 'My Key', status: 'active', creationDate: '2025-01-01' };
+    mockRestCREATE.mockResolvedValue({
+      data: { ...validListResponse, data: [keyMissingId] },
+    });
+
+    await expect(searchApiKeys()({} as never)).rejects.toThrow('Invalid response format');
+  });
+
+  it('should throw when has_more is missing from the response', async () => {
+    const withoutHasMore = {
+      object: validListResponse.object,
+      data: validListResponse.data,
+      subscriptionDetails: validListResponse.subscriptionDetails,
+    };
+    mockRestCREATE.mockResolvedValue({ data: withoutHasMore });
+
+    await expect(searchApiKeys()({} as never)).rejects.toThrow('Invalid response format');
+  });
+
+  it('should throw when response is not mod-arch wrapped', async () => {
+    mockRestCREATE.mockResolvedValue(validListResponse);
+
+    await expect(searchApiKeys()({} as never)).rejects.toThrow('Invalid response format');
+  });
+});
+
+describe('createApiKey', () => {
+  const validCreateResponse: CreateAPIKeyResponse = {
+    key: 'sk-abc123',
+    keyPrefix: 'sk-',
+    id: 'key-new',
+    name: 'New Key',
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRestFailures.mockImplementation((p: Promise<unknown>) => p);
+  });
+
+  it('should resolve with create response for a valid response', async () => {
+    mockRestCREATE.mockResolvedValue({ data: validCreateResponse });
+
+    const result = await createApiKey()({} as never, {
+      name: 'New Key',
+      subscription: 'premium-sub',
+    });
+    expect(result.id).toBe('key-new');
+    expect(result.key).toBe('sk-abc123');
+  });
+
+  it('should accept an optional expiresAt field', async () => {
+    mockRestCREATE.mockResolvedValue({
+      data: { ...validCreateResponse, expiresAt: '2026-01-01T00:00:00Z' },
+    });
+
+    const result = await createApiKey()({} as never, { name: 'New Key', subscription: 'sub' });
+    expect(result.expiresAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('should throw when the key field is missing', async () => {
+    const missingKey = {
+      keyPrefix: validCreateResponse.keyPrefix,
+      id: validCreateResponse.id,
+      name: validCreateResponse.name,
+      createdAt: validCreateResponse.createdAt,
+    };
+    mockRestCREATE.mockResolvedValue({ data: missingKey });
+
+    await expect(
+      createApiKey()({} as never, { name: 'New Key', subscription: 'sub' }),
+    ).rejects.toThrow('Invalid response format');
+  });
+
+  it('should throw when response is not mod-arch wrapped', async () => {
+    mockRestCREATE.mockResolvedValue(validCreateResponse);
+
+    await expect(
+      createApiKey()({} as never, { name: 'New Key', subscription: 'sub' }),
+    ).rejects.toThrow('Invalid response format');
+  });
+});
+
+describe('bulkRevokeApiKeys', () => {
+  const validBulkRevokeResponse: BulkRevokeResponse = {
+    revokedCount: 3,
+    message: '3 API keys revoked successfully',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRestFailures.mockImplementation((p: Promise<unknown>) => p);
+  });
+
+  it('should resolve with revoke count and message', async () => {
+    mockRestCREATE.mockResolvedValue({ data: validBulkRevokeResponse });
+
+    const result = await bulkRevokeApiKeys()({} as never, 'user@example.com');
+    expect(result.revokedCount).toBe(3);
+    expect(result.message).toBe('3 API keys revoked successfully');
+  });
+
+  it('should accept a zero revoke count', async () => {
+    mockRestCREATE.mockResolvedValue({ data: { revokedCount: 0, message: 'Nothing to revoke' } });
+
+    const result = await bulkRevokeApiKeys()({} as never, 'user@example.com');
+    expect(result.revokedCount).toBe(0);
+  });
+
+  it('should throw when revokedCount is missing', async () => {
+    mockRestCREATE.mockResolvedValue({ data: { message: 'ok' } });
+
+    await expect(bulkRevokeApiKeys()({} as never, 'user@example.com')).rejects.toThrow(
+      'Invalid response format',
+    );
+  });
+
+  it('should throw when response is not mod-arch wrapped', async () => {
+    mockRestCREATE.mockResolvedValue(validBulkRevokeResponse);
+
+    await expect(bulkRevokeApiKeys()({} as never, 'user@example.com')).rejects.toThrow(
+      'Invalid response format',
+    );
+  });
+});
+
+describe('revokeApiKey', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHandleRestFailures.mockImplementation((p: Promise<unknown>) => p);
+  });
+
+  it('should resolve with the revoked API key', async () => {
+    mockRestDELETE.mockResolvedValue({ data: validKey });
+
+    const result = await revokeApiKey()({} as never, 'key-1');
+    expect(result.id).toBe('key-1');
+    expect(result.status).toBe('active');
+  });
+
+  it('should throw when the revoked key is missing status', async () => {
+    const missingStatus = {
+      id: validKey.id,
+      name: validKey.name,
+      creationDate: validKey.creationDate,
+    };
+    mockRestDELETE.mockResolvedValue({ data: missingStatus });
+
+    await expect(revokeApiKey()({} as never, 'key-1')).rejects.toThrow('Invalid response format');
+  });
+
+  it('should throw when response is not mod-arch wrapped', async () => {
+    mockRestDELETE.mockResolvedValue(validKey);
+
+    await expect(revokeApiKey()({} as never, 'key-1')).rejects.toThrow('Invalid response format');
+  });
+});

--- a/packages/maas/frontend/src/app/api/__tests__/subscriptions.spec.ts
+++ b/packages/maas/frontend/src/app/api/__tests__/subscriptions.spec.ts
@@ -182,6 +182,16 @@ describe('listSubscriptions', () => {
 
     await expect(listSubscriptions()({} as never)).rejects.toThrow('Invalid response format');
   });
+
+  it('should filter out invalid items and return only valid ones', async () => {
+    const validSub = validSubscriptionInfoResponse.subscription;
+    const invalid = { name: 'bad-sub', namespace: 'ns' }; // missing owner, modelRefs
+    mockRestGET.mockResolvedValue({ data: [validSub, invalid] });
+
+    const result = await listSubscriptions()({} as never);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('test-sub');
+  });
 });
 
 describe('listUserSubscriptions', () => {
@@ -238,21 +248,32 @@ describe('listUserSubscriptions', () => {
     await expect(listUserSubscriptions()({} as never)).rejects.toThrow('Invalid response format');
   });
 
-  it('should throw when subscription_id_header is missing', async () => {
+  it('should filter out items where subscription_id_header is missing', async () => {
     const invalid = [{ subscription_description: 'desc', priority: 1, model_refs: [] }];
     mockRestGET.mockResolvedValue({ data: invalid });
 
-    await expect(listUserSubscriptions()({} as never)).rejects.toThrow('Invalid response format');
+    const result = await listUserSubscriptions()({} as never);
+    expect(result).toHaveLength(0);
   });
 
-  it('should throw when priority is not a number', async () => {
+  it('should filter out items where priority is not a number', async () => {
     const invalid = [{ ...validItem, priority: '10' }];
     mockRestGET.mockResolvedValue({ data: invalid });
 
-    await expect(listUserSubscriptions()({} as never)).rejects.toThrow('Invalid response format');
+    const result = await listUserSubscriptions()({} as never);
+    expect(result).toHaveLength(0);
   });
 
-  it('should throw when model_refs contains an item with an invalid token_rate_limit entry', async () => {
+  it('should return valid items while filtering out those that fail the guard', async () => {
+    const invalid = { subscription_description: 'desc', priority: 1, model_refs: [] }; // missing subscription_id_header
+    mockRestGET.mockResolvedValue({ data: [validItem, invalid] });
+
+    const result = await listUserSubscriptions()({} as never);
+    expect(result).toHaveLength(1);
+    expect(result[0].subscription_id_header).toBe('premium-team-sub');
+  });
+
+  it('should filter out items where model_refs contains an invalid token_rate_limit entry', async () => {
     const invalid = [
       {
         ...validItem,
@@ -263,7 +284,8 @@ describe('listUserSubscriptions', () => {
     ];
     mockRestGET.mockResolvedValue({ data: invalid });
 
-    await expect(listUserSubscriptions()({} as never)).rejects.toThrow('Invalid response format');
+    const result = await listUserSubscriptions()({} as never);
+    expect(result).toHaveLength(0);
   });
 });
 

--- a/packages/maas/frontend/src/app/api/api-keys.ts
+++ b/packages/maas/frontend/src/app/api/api-keys.ts
@@ -20,7 +20,10 @@ import type {
 const isRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object';
 
 const isAPIKey = (v: unknown): v is APIKey =>
-  isRecord(v) && typeof v.id === 'string' && typeof v.name === 'string';
+  isRecord(v) &&
+  typeof v.id === 'string' &&
+  typeof v.name === 'string' &&
+  typeof v.status === 'string';
 
 const isSubscriptionDetail = (v: unknown): v is SubscriptionDetail =>
   isRecord(v) &&
@@ -33,11 +36,11 @@ const isSubscriptionDetails = (v: unknown): v is Record<string, SubscriptionDeta
 
 const isAPIKeyListResponse = (v: unknown): v is APIKeyListResponse =>
   isRecord(v) &&
-  (Array.isArray(v.data) || v.data === null) &&
+  Array.isArray(v.data) &&
   typeof v.has_more === 'boolean' &&
   typeof v.object === 'string' &&
-  (v.data === null || v.data.every(isAPIKey)) &&
-  (v.subscriptionDetails === undefined || isSubscriptionDetails(v.subscriptionDetails));
+  v.data.every(isAPIKey) &&
+  (v.subscriptionDetails == null || isSubscriptionDetails(v.subscriptionDetails));
 
 const isCreateAPIKeyResponse = (v: unknown): v is CreateAPIKeyResponse =>
   isRecord(v) &&
@@ -65,8 +68,7 @@ export const searchApiKeys =
       ),
     ).then((response) => {
       if (isModArchResponse<unknown>(response) && isAPIKeyListResponse(response.data)) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        return { ...response.data, data: response.data.data ?? [] }; // this protects against the case where there are no keys, and the data is null
+        return response.data;
       }
       throw new Error('Invalid response format');
     });

--- a/packages/maas/frontend/src/app/api/subscriptions.ts
+++ b/packages/maas/frontend/src/app/api/subscriptions.ts
@@ -74,9 +74,6 @@ const isMaaSSubscription = (v: unknown): v is MaaSSubscription =>
   (v.tokenMetadata === undefined || typeof v.tokenMetadata === 'object') &&
   (v.creationTimestamp === undefined || typeof v.creationTimestamp === 'string');
 
-const isMaaSSubscriptionArray = (v: unknown): v is MaaSSubscription[] =>
-  Array.isArray(v) && v.every(isMaaSSubscription);
-
 export const isMaaSModelRefSummary = (v: unknown): v is MaaSModelRefSummary =>
   isRecord(v) &&
   typeof v.name === 'string' &&
@@ -130,7 +127,7 @@ const isModelRefInfo = (v: unknown): v is ModelRefInfo =>
   isRecord(v) &&
   typeof v.name === 'string' &&
   (v.namespace === undefined || typeof v.namespace === 'string') &&
-  (v.token_rate_limits === undefined ||
+  (v.token_rate_limits == null ||
     (Array.isArray(v.token_rate_limits) && v.token_rate_limits.every(isTokenRateLimitInfo)));
 
 const isUserSubscription = (v: unknown): v is UserSubscription =>
@@ -140,9 +137,6 @@ const isUserSubscription = (v: unknown): v is UserSubscription =>
   typeof v.priority === 'number' &&
   Array.isArray(v.model_refs) &&
   v.model_refs.every(isModelRefInfo);
-
-const isUserSubscriptionArray = (v: unknown): v is UserSubscription[] =>
-  Array.isArray(v) && v.every(isUserSubscription);
 
 const isSubscriptionPolicyFormDataResponse = (
   v: unknown,
@@ -169,8 +163,8 @@ export const listSubscriptions =
     handleRestFailures(
       restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/all-subscriptions`, {}, opts),
     ).then((response) => {
-      if (isModArchResponse<unknown>(response) && isMaaSSubscriptionArray(response.data)) {
-        return response.data.map(normalizeSubscription);
+      if (isModArchResponse<unknown>(response) && Array.isArray(response.data)) {
+        return response.data.filter(isMaaSSubscription).map(normalizeSubscription);
       }
       throw new Error('Invalid response format');
     });
@@ -291,8 +285,8 @@ export const listUserSubscriptions =
     handleRestFailures(
       restGET(hostPath, `${URL_PREFIX}/api/${BFF_API_VERSION}/subscriptions`, {}, opts),
     ).then((response) => {
-      if (isModArchResponse<unknown>(response) && isUserSubscriptionArray(response.data)) {
-        return response.data;
+      if (isModArchResponse<unknown>(response) && Array.isArray(response.data)) {
+        return response.data.filter(isUserSubscription);
       }
       throw new Error('Invalid response format');
     });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
for [RHOAIENG-56731](https://redhat.atlassian.net/browse/RHOAIENG-56731)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
