### PR TITLE
Disabled actions for deleting subs and policies

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -22,6 +22,8 @@ import {
 } from './types';
 import { ModelServingSize } from './pages/modelServing/screens/types';
 
+export type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
 export enum KnownLabels {
   DASHBOARD_RESOURCE = 'opendatahub.io/dashboard',
   PROJECT_SHARING = 'opendatahub.io/project-sharing',

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1047,12 +1047,12 @@ class ViewSubscriptionPage {
     return cy.findByTestId('subscription-actions-toggle');
   }
 
-  findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: 'Delete subscription' });
+  findDeleteActionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Delete' });
   }
 
-  findEditAction(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: 'Edit subscription' });
+  findEditActionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Edit' });
   }
 }
 
@@ -1266,12 +1266,12 @@ class ViewAuthPolicyPage {
     return cy.findByTestId('policy-actions-toggle');
   }
 
-  findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: 'Delete policy' });
+  findDeleteActionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Delete' });
   }
 
-  findEditAction(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: 'Edit policy' });
+  findEditActionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Edit' });
   }
 
   findPageError(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -744,6 +744,14 @@ class SubscriptionTableRow extends TableRow {
     return this.find().find('[data-label="Name"]');
   }
 
+  findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByLabelText('Kebab toggle');
+  }
+
+  findTitleButton(): Cypress.Chainable<JQuery<HTMLAnchorElement>> {
+    return this.find().findByTestId('table-row-title').find('a');
+  }
+
   findPhase(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Phase"]');
   }
@@ -1034,6 +1042,18 @@ class ViewSubscriptionPage {
   findDetailsTab(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('subscription-details-tab');
   }
+
+  findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('subscription-actions-toggle');
+  }
+
+  findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Delete subscription' });
+  }
+
+  findEditAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Edit subscription' });
+  }
 }
 
 class PolicyPage {
@@ -1177,7 +1197,11 @@ class AuthPolicyTableRow extends TableRow {
   }
 
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('[data-testid="auth-policy-actions"]');
+    return this.find().findByLabelText('Kebab toggle');
+  }
+
+  findTitleButton(): Cypress.Chainable<JQuery<HTMLAnchorElement>> {
+    return this.find().findByTestId('table-row-title').find('a');
   }
 }
 
@@ -1240,6 +1264,14 @@ class ViewAuthPolicyPage {
 
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('policy-actions-toggle');
+  }
+
+  findDeleteAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Delete policy' });
+  }
+
+  findEditAction(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: 'Edit policy' });
   }
 
   findPageError(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -92,7 +92,7 @@ describe('MaaS Auth Policies', () => {
   it('should display the auth policies table with correct page content', () => {
     authPoliciesPage.findTitle().should('contain.text', 'Authorization policies');
     authPoliciesPage.findTable().should('exist');
-    authPoliciesPage.findRows().should('have.length', 5);
+    authPoliciesPage.findRows().should('have.length', 6);
     const premiumRow = authPoliciesPage.getRow('premium-team-policy');
     premiumRow.findName().should('contain.text', 'premium-team-policy');
     premiumRow.findPhase().should('contain.text', 'Active');
@@ -125,6 +125,22 @@ describe('MaaS Auth Policies', () => {
 
     authPoliciesPage.clearAllFilters();
     authPoliciesPage.findRows().should('have.length', 5);
+  });
+
+  it('should disable the action buttons for a deleting policy in the table and view page', () => {
+    cy.interceptOdh('GET /maas/api/v1/all-policies', {
+      data: mockAuthPolicies(),
+    });
+    cy.interceptOdh(
+      'GET /maas/api/v1/view-policy/:name',
+      { path: { name: 'deleting-policy' } },
+      { data: mockPolicyInfo('deleting-policy') },
+    );
+    authPoliciesPage.visit();
+    authPoliciesPage.getRow('deleting-policy').findActionsToggle().should('be.disabled');
+    authPoliciesPage.getRow('deleting-policy').findTitleButton().click();
+    viewAuthPolicyPage.findActionsToggle().click();
+    viewAuthPolicyPage.findDeleteAction().should('be.disabled');
   });
 
   it('should delete an auth policy', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -114,7 +114,7 @@ describe('MaaS Auth Policies', () => {
   });
 
   it('should filter policies by keyword', () => {
-    authPoliciesPage.findRows().should('have.length', 5);
+    authPoliciesPage.findRows().should('have.length', 6);
 
     authPoliciesPage.findKeywordFilterInput().type('premium');
     authPoliciesPage.findRows().should('have.length', 1);
@@ -124,7 +124,7 @@ describe('MaaS Auth Policies', () => {
       .should('contain.text', 'premium-team-policy');
 
     authPoliciesPage.clearAllFilters();
-    authPoliciesPage.findRows().should('have.length', 5);
+    authPoliciesPage.findRows().should('have.length', 6);
   });
 
   it('should disable the action buttons for a deleting policy in the table and view page', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -138,9 +138,10 @@ describe('MaaS Auth Policies', () => {
     );
     authPoliciesPage.visit();
     authPoliciesPage.getRow('deleting-policy').findActionsToggle().should('be.disabled');
-    authPoliciesPage.getRow('deleting-policy').findTitleButton().click();
+    cy.visit(`/maas/auth-policies/view/deleting-policy`);
     viewAuthPolicyPage.findActionsToggle().click();
-    viewAuthPolicyPage.findDeleteAction().should('be.disabled');
+    viewAuthPolicyPage.findDeleteActionButton().should('be.disabled');
+    viewAuthPolicyPage.findEditActionButton().should('be.disabled');
   });
 
   it('should delete an auth policy', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -107,17 +107,17 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findFilterInput().type('Team Subscription');
     subscriptionsPage.findRows().should('have.length', 2);
     subscriptionsPage.findFilterResetButton().click();
-    subscriptionsPage.findRows().should('have.length', 5);
+    subscriptionsPage.findRows().should('have.length', 6);
 
     subscriptionsPage.findFilterInput().type('enterprise');
     subscriptionsPage.findRows().should('have.length', 1);
     subscriptionsPage.findFilterResetButton().click();
-    subscriptionsPage.findRows().should('have.length', 5);
+    subscriptionsPage.findRows().should('have.length', 6);
 
     subscriptionsPage.findFilterInput().type('general users');
     subscriptionsPage.findRows().should('have.length', 1);
     subscriptionsPage.findFilterResetButton().click();
-    subscriptionsPage.findRows().should('have.length', 5);
+    subscriptionsPage.findRows().should('have.length', 6);
   });
 
   it('should disable the action buttons for a deleting subscription in the table and view page', () => {
@@ -131,10 +131,10 @@ describe('Subscriptions Page', () => {
     );
     subscriptionsPage.visit();
     subscriptionsPage.getRow('deleting-sub').findActionsToggle().should('be.disabled');
-    subscriptionsPage.getRow('deleting-sub').findTitleButton().click();
+    cy.visit(`/maas/subscriptions/view/deleting-sub`);
     viewSubscriptionPage.findActionsToggle().click();
-    viewSubscriptionPage.findDeleteAction().should('be.disabled');
-    viewSubscriptionPage.findEditAction().should('be.disabled');
+    viewSubscriptionPage.findDeleteActionButton().should('be.disabled');
+    viewSubscriptionPage.findEditActionButton().should('be.disabled');
   });
 
   it('should delete a subscription', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -61,7 +61,7 @@ describe('Subscriptions Page', () => {
       );
 
     subscriptionsPage.findTable().should('exist');
-    subscriptionsPage.findRows().should('have.length', 5);
+    subscriptionsPage.findRows().should('have.length', 6);
     subscriptionsPage.findCreateSubscriptionButton().should('exist');
 
     const premiumRow = subscriptionsPage.getRow('Premium Team Subscription');
@@ -96,7 +96,7 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findFilterInput().should('exist').type('premium');
     subscriptionsPage.findRows().should('have.length', 1);
     subscriptionsPage.findFilterResetButton().should('exist').click();
-    subscriptionsPage.findRows().should('have.length', 5);
+    subscriptionsPage.findRows().should('have.length', 6);
 
     premiumRow.findKebabAction('View details').should('exist');
     premiumRow.findKebabAction('Edit').should('exist');
@@ -120,6 +120,23 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findRows().should('have.length', 5);
   });
 
+  it('should disable the action buttons for a deleting subscription in the table and view page', () => {
+    cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
+      data: mockSubscriptions(),
+    });
+    cy.interceptOdh(
+      'GET /maas/api/v1/subscription-info/:name',
+      { path: { name: 'deleting-sub' } },
+      { data: mockSubscriptionInfo('deleting-sub') },
+    );
+    subscriptionsPage.visit();
+    subscriptionsPage.getRow('deleting-sub').findActionsToggle().should('be.disabled');
+    subscriptionsPage.getRow('deleting-sub').findTitleButton().click();
+    viewSubscriptionPage.findActionsToggle().click();
+    viewSubscriptionPage.findDeleteAction().should('be.disabled');
+    viewSubscriptionPage.findEditAction().should('be.disabled');
+  });
+
   it('should delete a subscription', () => {
     cy.interceptOdh(
       'DELETE /maas/api/v1/subscription/:name',
@@ -140,7 +157,7 @@ describe('Subscriptions Page', () => {
         data: { message: "MaaSSubscription 'premium-team-sub' deleted successfully" },
       });
     });
-    subscriptionsPage.findRows().should('have.length', 4);
+    subscriptionsPage.findRows().should('have.length', 5);
     subscriptionsPage.findTable().should('not.contain', 'premium-team-sub');
   });
 });

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -117,6 +117,26 @@ export const mockPendingSubscription = (): MaaSSubscription => ({
   creationTimestamp: '2025-04-05T09:00:00Z',
 });
 
+export const mockDeletingSubscription = (): MaaSSubscription => ({
+  name: 'deleting-sub',
+  namespace: 'maas-system',
+  phase: 'Active',
+  statusMessage: 'successfully reconciled',
+  priority: 55,
+  owner: {
+    groups: [{ name: 'premium-users' }],
+  },
+  modelRefs: [
+    {
+      name: 'granite-3-8b-instruct',
+      namespace: 'maas-models',
+      tokenRateLimits: [{ limit: 50000, window: '24h' }],
+    },
+  ],
+  creationTimestamp: '2025-04-06T12:00:00Z',
+  isDeleting: true,
+});
+
 export const mockSubscriptions = (): MaaSSubscription[] => [
   {
     name: 'premium-team-sub',
@@ -187,6 +207,7 @@ export const mockSubscriptions = (): MaaSSubscription[] => [
   },
   mockFailedSubscription(),
   mockPendingSubscription(),
+  mockDeletingSubscription(),
 ];
 
 export const mockSubscriptionListItems = (): UserSubscription[] => [
@@ -388,6 +409,16 @@ export const mockPendingAuthPolicy = (): MaaSAuthPolicy => ({
   subjects: { groups: [{ name: 'beta-testers' }] },
 });
 
+export const mockDeletingAuthPolicy = (): MaaSAuthPolicy => ({
+  name: 'deleting-policy',
+  namespace: 'maas-system',
+  phase: 'Active',
+  statusMessage: 'successfully reconciled',
+  modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
+  subjects: { groups: [{ name: 'premium-users' }] },
+  isDeleting: true,
+});
+
 export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
   {
     name: 'test-subscription-policy',
@@ -419,6 +450,7 @@ export const mockAuthPolicies = (): MaaSAuthPolicy[] => [
   },
   mockFailedAuthPolicy(),
   mockPendingAuthPolicy(),
+  mockDeletingAuthPolicy(),
 ];
 
 export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse => {

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -134,7 +134,7 @@ export const mockDeletingSubscription = (): MaaSSubscription => ({
     },
   ],
   creationTimestamp: '2025-04-06T12:00:00Z',
-  isDeleting: true,
+  deletionTimestamp: '2025-04-07T12:00:00Z',
 });
 
 export const mockSubscriptions = (): MaaSSubscription[] => [
@@ -416,7 +416,7 @@ export const mockDeletingAuthPolicy = (): MaaSAuthPolicy => ({
   statusMessage: 'successfully reconciled',
   modelRefs: [{ name: 'granite-3-8b-instruct', namespace: 'maas-models' }],
   subjects: { groups: [{ name: 'premium-users' }] },
-  isDeleting: true,
+  deletionTimestamp: '2025-04-07T12:00:00Z',
 });
 
 export const mockAuthPolicies = (): MaaSAuthPolicy[] => [

--- a/packages/maas/bff/internal/mocks/subscription_mock.go
+++ b/packages/maas/bff/internal/mocks/subscription_mock.go
@@ -85,7 +85,7 @@ func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 					{Name: "system:authenticated"},
 				},
 			},
-			IsDeleting: true,
+			DeletionTimestamp: timePtr(time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC)),
 			ModelRefs: []models.ModelSubscriptionRef{
 				{
 					Name:      "flan-t5-small",
@@ -143,11 +143,11 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			},
 		},
 		{
-			Name:          "negative-priority-sub-policy",
-			Namespace:     "maas-system",
-			Phase:         "Active",
-			IsDeleting:    true,
-			StatusMessage: "successfully reconciled",
+			Name:              "negative-priority-sub-policy",
+			Namespace:         "maas-system",
+			Phase:             "Active",
+			DeletionTimestamp: timePtr(time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC)),
+			StatusMessage:     "successfully reconciled",
 			ModelRefs: []models.ModelRef{
 				{Name: "flan-t5-small", Namespace: "maas-models"},
 				{Name: "granite-3-8b-instruct", Namespace: "maas-models"},

--- a/packages/maas/bff/internal/mocks/subscription_mock.go
+++ b/packages/maas/bff/internal/mocks/subscription_mock.go
@@ -85,6 +85,7 @@ func GetMockMaaSSubscriptions() []models.MaaSSubscription {
 					{Name: "system:authenticated"},
 				},
 			},
+			IsDeleting: true,
 			ModelRefs: []models.ModelSubscriptionRef{
 				{
 					Name:      "flan-t5-small",
@@ -145,6 +146,7 @@ func GetMockMaaSAuthPolicies() []models.MaaSAuthPolicy {
 			Name:          "negative-priority-sub-policy",
 			Namespace:     "maas-system",
 			Phase:         "Active",
+			IsDeleting:    true,
 			StatusMessage: "successfully reconciled",
 			ModelRefs: []models.ModelRef{
 				{Name: "flan-t5-small", Namespace: "maas-models"},

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -83,7 +83,7 @@ type MaaSSubscription struct {
 	ModelRefs         []ModelSubscriptionRef `json:"modelRefs"`
 	TokenMetadata     *TokenMetadata         `json:"tokenMetadata,omitempty"`
 	CreationTimestamp *time.Time             `json:"creationTimestamp,omitempty"`
-	IsDeleting        bool                   `json:"isDeleting,omitempty"`
+	DeletionTimestamp *time.Time             `json:"deletionTimestamp,omitempty"`
 }
 
 // SubjectSpec defines subjects (groups) that have access.
@@ -109,7 +109,7 @@ type MaaSAuthPolicy struct {
 	ModelRefs         []ModelRef     `json:"modelRefs"`
 	Subjects          SubjectSpec    `json:"subjects"`
 	MeteringMetadata  *TokenMetadata `json:"meteringMetadata,omitempty"`
-	IsDeleting        bool           `json:"isDeleting,omitempty"`
+	DeletionTimestamp *time.Time     `json:"deletionTimestamp,omitempty"`
 }
 
 // ModelReference references a model endpoint.

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -83,6 +83,7 @@ type MaaSSubscription struct {
 	ModelRefs         []ModelSubscriptionRef `json:"modelRefs"`
 	TokenMetadata     *TokenMetadata         `json:"tokenMetadata,omitempty"`
 	CreationTimestamp *time.Time             `json:"creationTimestamp,omitempty"`
+	IsDeleting        bool                   `json:"isDeleting,omitempty"`
 }
 
 // SubjectSpec defines subjects (groups) that have access.
@@ -108,6 +109,7 @@ type MaaSAuthPolicy struct {
 	ModelRefs         []ModelRef     `json:"modelRefs"`
 	Subjects          SubjectSpec    `json:"subjects"`
 	MeteringMetadata  *TokenMetadata `json:"meteringMetadata,omitempty"`
+	IsDeleting        bool           `json:"isDeleting,omitempty"`
 }
 
 // ModelReference references a model endpoint.

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -429,11 +429,9 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 		}
 		sub.TokenMetadata = tokenMeta
 	}
-	deleting, _, _ := unstructured.NestedBool(content, "metadata", "deletionTimestamp")
-	if deleting {
-		sub.IsDeleting = true
-	} else {
-		sub.IsDeleting = false
+	if dt := obj.GetDeletionTimestamp(); dt != nil {
+		t := dt.Time
+		sub.DeletionTimestamp = &t
 	}
 
 	ct := obj.GetCreationTimestamp()
@@ -513,11 +511,9 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 		policy.CreationTimestamp = &t
 	}
 
-	deleting, _, _ := unstructured.NestedBool(content, "metadata", "deletionTimestamp")
-	if deleting {
-		policy.IsDeleting = true
-	} else {
-		policy.IsDeleting = false
+	if dt := obj.GetDeletionTimestamp(); dt != nil {
+		t := dt.Time
+		policy.DeletionTimestamp = &t
 	}
 
 	return policy, nil

--- a/packages/maas/bff/internal/repositories/subscriptions.go
+++ b/packages/maas/bff/internal/repositories/subscriptions.go
@@ -429,6 +429,12 @@ func convertUnstructuredToSubscription(obj *unstructured.Unstructured) (*models.
 		}
 		sub.TokenMetadata = tokenMeta
 	}
+	deleting, _, _ := unstructured.NestedBool(content, "metadata", "deletionTimestamp")
+	if deleting {
+		sub.IsDeleting = true
+	} else {
+		sub.IsDeleting = false
+	}
 
 	ct := obj.GetCreationTimestamp()
 	if !ct.IsZero() {
@@ -505,6 +511,13 @@ func convertUnstructuredToAuthPolicy(obj *unstructured.Unstructured) (*models.Ma
 	if !ct.IsZero() {
 		t := ct.Time
 		policy.CreationTimestamp = &t
+	}
+
+	deleting, _, _ := unstructured.NestedBool(content, "metadata", "deletionTimestamp")
+	if deleting {
+		policy.IsDeleting = true
+	} else {
+		policy.IsDeleting = false
 	}
 
 	return policy, nil

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1913,6 +1913,10 @@ components:
           type: string
           format: date-time
           description: When the resource was created
+        isDeleting:
+          type: boolean
+          description: Whether the subscription is in the process of being deleted
+          example: false
       required:
         - name
         - namespace
@@ -1988,6 +1992,10 @@ components:
           $ref: '#/components/schemas/SubjectSpec'
         meteringMetadata:
           $ref: '#/components/schemas/TokenMetadata'
+        isDeleting:
+          type: boolean
+          description: Whether the policy is in the process of being deleted
+          example: false
       required:
         - name
         - namespace

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -1913,10 +1913,10 @@ components:
           type: string
           format: date-time
           description: When the resource was created
-        isDeleting:
-          type: boolean
-          description: Whether the subscription is in the process of being deleted
-          example: false
+        deletionTimestamp:
+          type: string
+          format: date-time
+          description: When set, the subscription is marked for deletion (Kubernetes metadata.deletionTimestamp)
       required:
         - name
         - namespace
@@ -1992,10 +1992,10 @@ components:
           $ref: '#/components/schemas/SubjectSpec'
         meteringMetadata:
           $ref: '#/components/schemas/TokenMetadata'
-        isDeleting:
-          type: boolean
-          description: Whether the policy is in the process of being deleted
-          example: false
+        deletionTimestamp:
+          type: string
+          format: date-time
+          description: When set, the policy is marked for deletion (Kubernetes metadata.deletionTimestamp)
       required:
         - name
         - namespace

--- a/packages/maas/frontend/src/app/api/subscriptions.ts
+++ b/packages/maas/frontend/src/app/api/subscriptions.ts
@@ -72,7 +72,8 @@ const isMaaSSubscription = (v: unknown): v is MaaSSubscription =>
   Array.isArray(v.modelRefs) &&
   v.modelRefs.every(isMaaSSubscriptionRef) &&
   (v.tokenMetadata === undefined || typeof v.tokenMetadata === 'object') &&
-  (v.creationTimestamp === undefined || typeof v.creationTimestamp === 'string');
+  (v.creationTimestamp === undefined || typeof v.creationTimestamp === 'string') &&
+  (v.deletionTimestamp === undefined || typeof v.deletionTimestamp === 'string');
 
 export const isMaaSModelRefSummary = (v: unknown): v is MaaSModelRefSummary =>
   isRecord(v) &&
@@ -98,7 +99,8 @@ export const isMaaSAuthPolicy = (v: unknown): v is MaaSAuthPolicy =>
   Array.isArray(v.modelRefs) &&
   v.modelRefs.every(isModelRef) &&
   isSubjectSpec(v.subjects) &&
-  (v.meteringMetadata === undefined || isTokenMetadata(v.meteringMetadata));
+  (v.meteringMetadata === undefined || isTokenMetadata(v.meteringMetadata)) &&
+  (v.deletionTimestamp === undefined || typeof v.deletionTimestamp === 'string');
 
 /** Coerce null tokenRateLimits (Go nil slice → JSON null) to empty arrays. */
 const normalizeSubscription = (sub: MaaSSubscription): MaaSSubscription => ({

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -36,14 +36,14 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
             label: 'Edit',
             onClick: () =>
               navigate(`${URL_PREFIX}/auth-policies/edit/${encodeURIComponent(policy.name)}`),
-            isDisabled: policy.isDeleting,
+            isDisabled: !!policy.deletionTimestamp,
           },
           { isSpacer: true },
           {
             key: 'delete',
             label: 'Delete',
             onClick: () => setIsDeleteOpen(true),
-            isDisabled: policy.isDeleting,
+            isDisabled: !!policy.deletionTimestamp,
           },
         ]}
       />

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -36,12 +36,14 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
             label: 'Edit',
             onClick: () =>
               navigate(`${URL_PREFIX}/auth-policies/edit/${encodeURIComponent(policy.name)}`),
+            isDisabled: policy.isDeleting,
           },
           { isSpacer: true },
           {
             key: 'delete',
             label: 'Delete',
             onClick: () => setIsDeleteOpen(true),
+            isDisabled: policy.isDeleting,
           },
         ]}
       />

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -60,6 +60,7 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
       <Td isActionCell>
         <ActionsColumn
           data-testid="auth-policy-actions"
+          isDisabled={authPolicy.isDeleting}
           items={[
             {
               title: 'View details',

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -1,9 +1,11 @@
+import * as React from 'react';
 import { TableRowTitleDescription } from '@odh-dashboard/internal/components/table/index';
 import { SortableData } from '@odh-dashboard/internal/components/table/types';
-import { Tr, Td, ActionsColumn } from '@patternfly/react-table';
+import { Td, ActionsColumn } from '@patternfly/react-table';
 import { Label } from '@patternfly/react-core';
-import * as React from 'react';
+import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import { Link, useNavigate } from 'react-router-dom';
+import type { K8sResourceCommon } from '@odh-dashboard/internal/k8sTypes';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import PhaseLabel from '~/app/shared/PhaseLabel';
@@ -39,14 +41,29 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
     ? authPolicy.subjects.groups.length
     : 0;
   const modelsCount = Array.isArray(authPolicy.modelRefs) ? authPolicy.modelRefs.length : 0;
+  const policyResource: K8sResourceCommon = {
+    apiVersion: 'maas.opendatahub.io/v1alpha1',
+    kind: 'MaaSAuthPolicy',
+    metadata: {
+      name: authPolicy.name,
+      namespace: authPolicy.namespace,
+      ...(authPolicy.deletionTimestamp ? { deletionTimestamp: authPolicy.deletionTimestamp } : {}),
+    },
+  };
   return (
-    <Tr>
+    <ResourceTr resource={policyResource}>
       <Td dataLabel={columns[0].label}>
         <TableRowTitleDescription
           title={
-            <Link to={`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicy.name)}`}>
-              {authPolicy.displayName ?? authPolicy.name}
-            </Link>
+            authPolicy.deletionTimestamp ? (
+              <span data-testid="auth-policy-name">
+                {authPolicy.displayName ?? authPolicy.name}
+              </span>
+            ) : (
+              <Link to={`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicy.name)}`}>
+                {authPolicy.displayName ?? authPolicy.name}
+              </Link>
+            )
           }
           description={authPolicy.description ?? ''}
           truncateDescriptionLines={2}
@@ -60,7 +77,7 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
       <Td isActionCell>
         <ActionsColumn
           data-testid="auth-policy-actions"
-          isDisabled={authPolicy.isDeleting}
+          isDisabled={!!authPolicy.deletionTimestamp}
           items={[
             {
               title: 'View details',
@@ -78,7 +95,7 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
           ]}
         />
       </Td>
-    </Tr>
+    </ResourceTr>
   );
 };
 

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -39,14 +39,14 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription 
             key: 'edit',
             label: 'Edit',
             onClick: () => navigate(`${URL_PREFIX}/subscriptions/edit/${subscription.name}`),
-            isDisabled: subscription.isDeleting,
+            isDisabled: !!subscription.deletionTimestamp,
           },
           { isSpacer: true },
           {
             key: 'delete',
             label: 'Delete',
             onClick: () => setIsDeleteOpen(true),
-            isDisabled: subscription.isDeleting,
+            isDisabled: !!subscription.deletionTimestamp,
           },
         ]}
       />

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -39,12 +39,14 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription 
             key: 'edit',
             label: 'Edit',
             onClick: () => navigate(`${URL_PREFIX}/subscriptions/edit/${subscription.name}`),
+            isDisabled: subscription.isDeleting,
           },
           { isSpacer: true },
           {
             key: 'delete',
             label: 'Delete',
             onClick: () => setIsDeleteOpen(true),
+            isDisabled: subscription.isDeleting,
           },
         ]}
       />

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -61,6 +61,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
       <Td isActionCell>
         <ActionsColumn
           data-testid="subscription-actions"
+          isDisabled={subscription.isDeleting}
           items={[
             {
               title: 'View details',

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Td } from '@patternfly/react-table';
+import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
 import { Content, Label } from '@patternfly/react-core';
 import { Link, useNavigate } from 'react-router-dom';
+import type { K8sResourceCommon } from '@odh-dashboard/internal/k8sTypes';
 import { MaaSSubscription } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import PhaseLabel from '~/app/shared/PhaseLabel';
@@ -31,14 +33,31 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
     setDeleteSubscription(subscriptionToDelete);
   };
 
+  const subscriptionResource: K8sResourceCommon = {
+    apiVersion: 'maas.opendatahub.io/v1alpha1',
+    kind: 'MaaSSubscription',
+    metadata: {
+      name: subscription.name,
+      namespace: subscription.namespace,
+      ...(subscription.deletionTimestamp
+        ? { deletionTimestamp: subscription.deletionTimestamp }
+        : {}),
+    },
+  };
   return (
-    <Tr key={key}>
+    <ResourceTr resource={subscriptionResource} key={key}>
       <Td dataLabel={subscriptionsColumns[0].label}>
         <TableRowTitleDescription
           title={
-            <Link to={`${URL_PREFIX}/subscriptions/view/${subscription.name}`}>
-              {subscription.displayName ?? subscription.name}
-            </Link>
+            subscription.deletionTimestamp ? (
+              <span data-testid="subscription-name">
+                {subscription.displayName ?? subscription.name}
+              </span>
+            ) : (
+              <Link to={`${URL_PREFIX}/subscriptions/view/${subscription.name}`}>
+                {subscription.displayName ?? subscription.name}
+              </Link>
+            )
           }
           description={subscription.description ?? ''}
           truncateDescriptionLines={2}
@@ -61,7 +80,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
       <Td isActionCell>
         <ActionsColumn
           data-testid="subscription-actions"
-          isDisabled={subscription.isDeleting}
+          isDisabled={!!subscription.deletionTimestamp}
           items={[
             {
               title: 'View details',
@@ -79,7 +98,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
           ]}
         />
       </Td>
-    </Tr>
+    </ResourceTr>
   );
 };
 

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -10,6 +10,7 @@ export type MaaSSubscription = {
   modelRefs: ModelSubscriptionRef[];
   tokenMetadata?: TokenMetadata;
   creationTimestamp?: string;
+  isDeleting?: boolean;
 };
 
 export type ModelSubscriptionRef = {
@@ -113,6 +114,7 @@ export type MaaSAuthPolicy = {
   modelRefs: ModelRef[];
   subjects: SubjectSpec;
   meteringMetadata?: TokenMetadata;
+  isDeleting?: boolean;
 };
 
 export type SubscriptionInfoResponse = {

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -10,7 +10,7 @@ export type MaaSSubscription = {
   modelRefs: ModelSubscriptionRef[];
   tokenMetadata?: TokenMetadata;
   creationTimestamp?: string;
-  isDeleting?: boolean;
+  deletionTimestamp?: string;
 };
 
 export type ModelSubscriptionRef = {
@@ -114,7 +114,7 @@ export type MaaSAuthPolicy = {
   modelRefs: ModelRef[];
   subjects: SubjectSpec;
   meteringMetadata?: TokenMetadata;
-  isDeleting?: boolean;
+  deletionTimestamp?: string;
 };
 
 export type SubscriptionInfoResponse = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-58617](https://redhat.atlassian.net/browse/RHOAIENG-58617)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The whole row disables when the subscription is marked for deletion and if you do navigate directly to the view page of the sub or policy the actions there are disabled as well

I hope I added everything to the openapi spec I needed to lmk


https://github.com/user-attachments/assets/18eec018-ff8c-4aeb-816c-dbd7c684d6a7





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

To test:
- I updated the mocks so you can see some with `isDeleting = true` so you can see how they would look

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added some mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - UI now treats subscriptions and auth policies with a deletion timestamp as "deleting": row actions and title links are disabled, and Edit/Delete on detail pages are non-interactive.

* **Tests**
  - Updated and added end-to-end tests to cover deleting-state rows and detail pages; adjusted table row-count expectations for new mock entries.

* **Chores**
  - Added test helpers and mock fixtures and extended types/schemas to represent a deletion-in-progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->