### PR TITLE
update jira triage to incorporate observability and perses

### DIFF
--- a/.claude/skills/jira-triage/jira-project-reference.md
+++ b/.claude/skills/jira-triage/jira-project-reference.md
@@ -416,6 +416,7 @@ Labels that categorize issues by functional area. Format: `dashboard-area-{area}
 | `dashboard-area-documentation` | Documentation |
 | `dashboard-area-automl` | AutoML |
 | `dashboard-area-autorag` | AutoRAG |
+| `dashboard-area-observability` | Observability |
 | `dashboard-area-applications` | Applications |
 
 ## Area Label Signal Mapping
@@ -462,6 +463,7 @@ Matched against issue summary, description text, and **Jira labels** (non-area l
 | `dashboard-area-documentation` | documentation, docs, README, ADR | |
 | `dashboard-area-automl` | AutoML, AutoX, automl experiment, tabular pipeline, timeseries pipeline, binary classification, multiclass classification, regression pipeline, AutoGluon, automl leaderboard, automl model details, confusion matrix, feature importance, prediction type, label column, automl configure, register model (in AutoML context), S3 file explorer (in AutoML context) | |
 | `dashboard-area-autorag` | AutoRAG, AutoX, autorag experiment, RAG pattern evaluation, autorag leaderboard, pattern details, optimization metric, faithfulness, answer correctness, context correctness, RAG patterns, vector store provider, Milvus (in AutoRAG context), chunking, embedding model, retrieval method, generation model, autorag configure, S3 file explorer (in AutoRAG context), Docling, text extraction (in AutoRAG context), test data file | |
+| `dashboard-area-observability` | observability, observability dashboard, Perses, PersesDashboard, PersesBoard, metrics dashboard, time range selector, Prometheus datasource | |
 | `dashboard-area-applications` | application, enabled application, explore application, ISV | |
 | `dashboard-area-consistencies` | consistency, shared pattern, common component, UX consistency | |
 
@@ -497,6 +499,7 @@ Matched against file paths from linked PRs, code references in descriptions, or 
 | `dashboard-area-cypress` | `packages/cypress/` |
 | `dashboard-area-automl` | `packages/automl/` |
 | `dashboard-area-autorag` | `packages/autorag/` |
+| `dashboard-area-observability` | `packages/observability/`, `manifests/observability/` |
 | `dashboard-area-applications` | `frontend/src/pages/enabledApplications/`, `frontend/src/pages/exploreApplication/` |
 | `dashboard-area-bff` | *(cross-cutting -- shared patterns span `packages/*/bff/`)* |
 | `dashboard-area-security` | *(cross-cutting -- no dedicated directory)* |
@@ -569,6 +572,7 @@ An area label can appear on issues belonging to any team. This mapping provides 
 | `dashboard-area-cluster-settings` | Monarch |
 | `dashboard-area-cypress` | Monarch |
 | `dashboard-area-applications` | Monarch |
+| `dashboard-area-observability` | Monarch |
 | `dashboard-area-workbenches` | Razzmatazz |
 | `dashboard-area-jupyter` | Razzmatazz |
 | `dashboard-area-notebooks` | Razzmatazz |
@@ -612,7 +616,7 @@ When an issue lacks area labels, these keywords and feature associations can hel
 
 | Team | Scrum label | Keywords / features | Reasoning |
 |---|---|---|---|
-| **Monarch** | `dashboard-monarch-scrum` | PatternFly, PF6, home page, projects page, navigation, infrastructure, cluster settings, shared UI, consistencies, BFF shared infrastructure (not feature-specific BFF), Go backend shared patterns, common middleware, shared auth, plugin-core, app-config, common libraries, cross-package utilities, applications, **generic `manifests/` / install-base / cross-cutting operator YAML** | Monarch owns app shell, shared infrastructure, cross-cutting UI foundations, cross-cutting BFF/Go backend patterns, and **default ownership of repo-wide manifest and install layout** when no feature-specific path dominates. "applications" refers to the enabled/explore applications pages (ISV integrations). |
+| **Monarch** | `dashboard-monarch-scrum` | PatternFly, PF6, home page, projects page, navigation, infrastructure, cluster settings, shared UI, consistencies, BFF shared infrastructure (not feature-specific BFF), Go backend shared patterns, common middleware, shared auth, plugin-core, app-config, common libraries, cross-package utilities, applications, observability, Perses, PersesDashboard, metrics dashboard, **generic `manifests/` / install-base / cross-cutting operator YAML** | Monarch owns app shell, shared infrastructure, cross-cutting UI foundations, cross-cutting BFF/Go backend patterns, the observability/Perses dashboard integration (`packages/observability/`), and **default ownership of repo-wide manifest and install layout** when no feature-specific path dominates. "applications" refers to the enabled/explore applications pages (ISV integrations). |
 | **Razzmatazz** | `dashboard-razzmatazz-scrum` | workbenches, spawner, notebook server, notebooks, BYON image, Jupyter, JupyterLab, pipelines, pipeline server, DSPA, pipeline run, hardware profiles, accelerator profiles, tolerations, node selector, storage classes, user management, RBAC, permissions, group settings | Razzmatazz owns the core DS project experience: workbenches, notebooks, pipelines, hardware profiles, storage classes, and user management. |
 | **Zaffre** | `dashboard-zaffre-scrum` | model serving, inference, KServe, ModelMesh, serving runtime, model deploy, NIM, vLLM, connections, connection types, MaaS admin (subscriptions, API keys, auth policies), operator bundles, kustomize overlays, OLM resources for serving, MaaS, and connection types | Zaffre owns model serving infrastructure, the MaaS admin package (`packages/maas/`, `dashboard-area-maas` — subscriptions, API keys, auth policies), connection types, and the operator and deployment layers that ship those capabilities. Gen AI Studio's consumption of MaaS models/tokens is Crimson (`dashboard-area-genai`). |
 | **Green** | `dashboard-green-scrum` | model catalog, catalog card, model registry, registered model, model version, model artifact, distributed workloads, Kueue, cluster queue, local queue, workload metrics, Ray (when related to DW queue management), MCP, MCP server, MCP catalog | Green owns model catalog, model registry, distributed workloads (queue management side), and MCP. |


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Updates the jira triage skill to include `dashboard-area-observability` for the observability package and perses related changes. Maps to the monarch scrum team.

Observed that an issue was mis classified as model serving when it was a generic observability / perses related issue.

## How Has This Been Tested?
Performed jira triage

## Test Impact
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new `dashboard-area-observability` area label to the triage reference system.
  * Updated default team assignment for observability dashboard issues to route to Monarch.
  * Extended keyword mappings to capture observability and Perses dashboard-related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->