### PR TITLE
Fix button order and standardize help icons in Deploy MCP Server modal

### DIFF
--- a/packages/cypress/cypress/pages/mcpCatalog.ts
+++ b/packages/cypress/cypress/pages/mcpCatalog.ts
@@ -71,7 +71,7 @@ class McpDeployModal {
   }
 
   findSubmitButton() {
-    return cy.findByTestId('modal-submit-button');
+    return this.find().findByTestId('modal-submit-button');
   }
 }
 

--- a/packages/cypress/cypress/pages/mcpCatalog.ts
+++ b/packages/cypress/cypress/pages/mcpCatalog.ts
@@ -71,7 +71,7 @@ class McpDeployModal {
   }
 
   findSubmitButton() {
-    return cy.findByTestId('mcp-deploy-submit-button');
+    return cy.findByTestId('modal-submit-button');
   }
 }
 

--- a/packages/cypress/cypress/pages/mcpDeployments.ts
+++ b/packages/cypress/cypress/pages/mcpDeployments.ts
@@ -171,19 +171,15 @@ class McpDeployModal {
   }
 
   findSubmitButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findModal().findByTestId('mcp-deploy-submit-button');
+    return this.findModal().findByTestId('modal-submit-button');
   }
 
   findCloseButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findModal().findByTestId('mcp-deploy-close-button');
-  }
-
-  findResetButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findModal().findByTestId('mcp-deploy-reset-button');
+    return this.findModal().findByTestId('modal-cancel-button');
   }
 
   findSubmitError(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findModal().findByTestId('mcp-deploy-submit-error');
+    return this.findModal().findByTestId('error-message-alert');
   }
 
   findLoadError(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
+++ b/packages/model-registry/src/projectSelector/ProjectSelectorField.tsx
@@ -1,9 +1,8 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   Alert,
   Button,
   FormGroup,
-  FormGroupLabelHelp,
   HelperText,
   HelperTextItem,
   Popover,
@@ -12,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
 import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import FieldGroupHelpLabelIcon from '@odh-dashboard/internal/components/FieldGroupHelpLabelIcon';
 import type { NamespaceSelectorFieldProps } from '@mf/modelRegistry/extension-points';
 
 const SELECTOR_TOOLTIP =
@@ -52,17 +52,12 @@ const ProjectSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
   registryName,
   selectorOnly,
 }) => {
-  const labelHelpRef = useRef<HTMLSpanElement>(null);
   const { projects, loaded: projectsLoaded } = React.useContext(ProjectsContext);
   const noProjects = projectsLoaded && projects.length === 0;
 
   const showNoAccessAlert = selectedNamespace && !isLoading && hasAccess === false;
 
-  const labelHelp = (
-    <Popover triggerRef={labelHelpRef} bodyContent={SELECTOR_TOOLTIP} aria-label={SELECTOR_TOOLTIP}>
-      <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for project field" />
-    </Popover>
-  );
+  const labelHelp = <FieldGroupHelpLabelIcon content={SELECTOR_TOOLTIP} />;
 
   const helperTextNode = (
     <>

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   Alert,
   Button,
+  FormGroupLabelHelp,
   HelperText,
   HelperTextItem,
   Popover,
@@ -9,7 +10,7 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
-import { FieldGroupHelpLabelIcon, SimpleSelect } from 'mod-arch-shared';
+import { SimpleSelect } from 'mod-arch-shared';
 import { SimpleSelectOption } from 'mod-arch-shared/dist/components/SimpleSelect';
 import { useNamespaces } from '~/app/hooks/useNamespaces';
 import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
@@ -58,6 +59,7 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
   registryName,
   selectorOnly,
 }) => {
+  const labelHelpRef = useRef<HTMLSpanElement>(null);
   const [namespaces, namespacesLoaded, namespacesLoadError] = useNamespaces();
   const [textInputValue, setTextInputValue] = React.useState(selectedNamespace);
   const debounceTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
@@ -144,7 +146,11 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
     ? NamespaceSelectorMessages.TEXT_INPUT_TOOLTIP
     : NamespaceSelectorMessages.SELECTOR_TOOLTIP;
 
-  const labelHelp = <FieldGroupHelpLabelIcon content={tooltipContent} />;
+  const labelHelp = (
+    <Popover triggerRef={labelHelpRef} bodyContent={tooltipContent} aria-label={tooltipContent}>
+      <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for namespace field" />
+    </Popover>
+  );
 
   const helperTextNode = (
     <>

--- a/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
+++ b/packages/model-registry/upstream/frontend/src/concepts/k8s/NamespaceSelectorField/NamespaceSelectorField.tsx
@@ -1,8 +1,7 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import {
   Alert,
   Button,
-  FormGroupLabelHelp,
   HelperText,
   HelperTextItem,
   Popover,
@@ -10,7 +9,7 @@ import {
   StackItem,
   TextInput,
 } from '@patternfly/react-core';
-import { SimpleSelect } from 'mod-arch-shared';
+import { FieldGroupHelpLabelIcon, SimpleSelect } from 'mod-arch-shared';
 import { SimpleSelectOption } from 'mod-arch-shared/dist/components/SimpleSelect';
 import { useNamespaces } from '~/app/hooks/useNamespaces';
 import ThemeAwareFormGroupWrapper from '~/app/pages/settings/components/ThemeAwareFormGroupWrapper';
@@ -59,7 +58,6 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
   registryName,
   selectorOnly,
 }) => {
-  const labelHelpRef = useRef<HTMLSpanElement>(null);
   const [namespaces, namespacesLoaded, namespacesLoadError] = useNamespaces();
   const [textInputValue, setTextInputValue] = React.useState(selectedNamespace);
   const debounceTimerRef = React.useRef<ReturnType<typeof setTimeout>>();
@@ -146,11 +144,7 @@ const NamespaceSelectorField: React.FC<NamespaceSelectorFieldProps> = ({
     ? NamespaceSelectorMessages.TEXT_INPUT_TOOLTIP
     : NamespaceSelectorMessages.SELECTOR_TOOLTIP;
 
-  const labelHelp = (
-    <Popover triggerRef={labelHelpRef} bodyContent={tooltipContent} aria-label={tooltipContent}>
-      <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for namespace field" />
-    </Popover>
-  );
+  const labelHelp = <FieldGroupHelpLabelIcon content={tooltipContent} />;
 
   const helperTextNode = (
     <>

--- a/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/components/McpDeployModal.tsx
@@ -2,25 +2,19 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router';
 import {
   Alert,
-  Button,
   Content,
   Form,
   FormGroup,
-  FormGroupLabelHelp,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
-  Popover,
   Spinner,
-  Split,
-  SplitItem,
-  Stack,
-  StackItem,
   TextInput,
 } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { APIOptions, useQueryParamNamespaces } from 'mod-arch-core';
+import { DashboardModalFooter, FieldGroupHelpLabelIcon } from 'mod-arch-shared';
 import { useThemeContext } from '@odh-dashboard/internal/app/ThemeContext';
 import NamespaceSelectorFieldWrapper from '~/odh/components/NamespaceSelectorFieldWrapper';
 import useMcpServerConverter from '~/app/hooks/mcpCatalogDeployment/useMcpServerConverter';
@@ -69,8 +63,6 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
   const [submitError, setSubmitError] = React.useState<Error>();
   const abortControllerRef = React.useRef<AbortController>();
   const crInitializedRef = React.useRef(false);
-  const ociImageLabelHelpRef = React.useRef<HTMLSpanElement>(null);
-  const configLabelHelpRef = React.useRef<HTMLSpanElement>(null);
 
   React.useEffect(() => {
     if (!existingDeployment && crData && !crInitializedRef.current) {
@@ -219,16 +211,7 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
             isRequired
             fieldId="mcp-deploy-oci-image"
             labelHelp={
-              <Popover
-                triggerRef={ociImageLabelHelpRef}
-                bodyContent="This is the container image associated with the MCP server that you selected from the catalog. This cannot be edited."
-                aria-label="OCI image help"
-              >
-                <FormGroupLabelHelp
-                  ref={ociImageLabelHelpRef}
-                  aria-label="More info for OCI image field"
-                />
-              </Popover>
+              <FieldGroupHelpLabelIcon content="This is the container image associated with the MCP server that you selected from the catalog. This cannot be edited." />
             }
           >
             <TextInput
@@ -259,16 +242,7 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
             label="YAML configuration"
             fieldId="mcp-deploy-yaml"
             labelHelp={
-              <Popover
-                triggerRef={configLabelHelpRef}
-                bodyContent="For more information about the prefilled YAML configuration, check the details page of the selected server."
-                aria-label="Configuration help"
-              >
-                <FormGroupLabelHelp
-                  ref={configLabelHelpRef}
-                  aria-label="More info for configuration field"
-                />
-              </Popover>
+              <FieldGroupHelpLabelIcon content="For more information about the prefilled YAML configuration, check the details page of the selected server." />
             }
           >
             <Content component="small" className="pf-v6-u-mb-sm">
@@ -288,45 +262,15 @@ const McpDeployModal: React.FC<McpDeployModalProps> = ({
         </Form>
       </ModalBody>
       <ModalFooter>
-        <Stack hasGutter style={{ flex: 'auto' }}>
-          {submitError && (
-            <StackItem>
-              <Alert
-                variant="danger"
-                isInline
-                title="Deployment failed"
-                data-testid="mcp-deploy-submit-error"
-              >
-                {submitError.message}
-              </Alert>
-            </StackItem>
-          )}
-          <StackItem>
-            <Split hasGutter className="pf-v6-u-w-100">
-              <SplitItem>
-                <Button
-                  variant="link"
-                  onClick={() => onClose()}
-                  data-testid="mcp-deploy-close-button"
-                >
-                  Close
-                </Button>
-              </SplitItem>
-              <SplitItem isFilled />
-              <SplitItem>
-                <Button
-                  variant="primary"
-                  onClick={handleDeploy}
-                  isDisabled={isDeployDisabled}
-                  isLoading={isSubmitting}
-                  data-testid="mcp-deploy-submit-button"
-                >
-                  {existingDeployment ? 'Save' : 'Deploy'}
-                </Button>
-              </SplitItem>
-            </Split>
-          </StackItem>
-        </Stack>
+        <DashboardModalFooter
+          submitLabel={existingDeployment ? 'Save' : 'Deploy'}
+          onSubmit={handleDeploy}
+          onCancel={() => onClose()}
+          isSubmitDisabled={isDeployDisabled}
+          isSubmitLoading={isSubmitting}
+          error={submitError}
+          alertTitle="Deployment failed"
+        />
       </ModalFooter>
     </Modal>
   );


### PR DESCRIPTION
Resolves [RHOAIENG-57708](https://redhat.atlassian.net/browse/RHOAIENG-57708)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The modal footer buttons were right-aligned with Close on the left and Deploy on the right. Replaced the manual footer with DashboardModalFooter to follow PatternFly conventions (primary action first, left-aligned). Also switched FormGroupLabelHelp icons on OCI image, Namespace, and YAML configuration fields to FieldGroupHelpLabelIcon for consistency with the existing Deployment name tooltip icon.

Made-with: Cursor

<img width="547" height="590" alt="Screenshot 2026-04-20 at 8 54 00 PM" src="https://github.com/user-attachments/assets/25e456e0-6191-4d65-946a-db3d1ed5187d" />

Cypress tests adjusted according to shared test IDs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Try deploying an MCP server - after `mcpCatalog` feature flag is on

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility / UX**
  * Replaced the label-help icon with an updated tooltip component to improve internal accessibility handling; tooltip content and visual behavior remain unchanged.

* **Other**
  * No additional user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->