### PR TITLE
[3.3 backport] add default cache-control headers for module web files

### DIFF
--- a/backend/src/__tests__/routes/module-federation.spec.ts
+++ b/backend/src/__tests__/routes/module-federation.spec.ts
@@ -1,0 +1,22 @@
+import { IncomingHttpHeaders } from 'http';
+import { addDefaultCacheControl } from '../../utils/proxy';
+
+describe('addDefaultCacheControl', () => {
+  it('should set Cache-Control to no-cache when not present', () => {
+    const result = addDefaultCacheControl({});
+    expect(result['cache-control']).toBe('no-cache');
+  });
+
+  it.each(['public, max-age=31536000, immutable', 'no-store', 'public, max-age=0', 'no-cache'])(
+    'should preserve existing Cache-Control: %s',
+    (value) => {
+      const headers: IncomingHttpHeaders = { 'cache-control': value };
+      expect(addDefaultCacheControl(headers)['cache-control']).toBe(value);
+    },
+  );
+
+  it('should mutate and return the same headers object', () => {
+    const headers: IncomingHttpHeaders = {};
+    expect(addDefaultCacheControl(headers)).toBe(headers);
+  });
+});

--- a/backend/src/routes/module-federation.ts
+++ b/backend/src/routes/module-federation.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { getModuleFederationConfigs, type ModuleFederationConfig } from '@odh-dashboard/app-config';
-import { registerProxy } from '../utils/proxy';
+import { addDefaultCacheControl, registerProxy } from '../utils/proxy';
 import { KubeFastifyInstance } from '../types';
 import { DEV_MODE } from '../utils/constants';
 import { errorHandler } from '../utils';
@@ -28,6 +28,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             namespace: backend.service.namespace ?? process.env.OC_PROJECT,
           },
           local: backend.localService,
+          rewriteHeaders: addDefaultCacheControl,
           onError: (reply, error) => {
             if (
               'code' in error.error &&

--- a/backend/src/utils/proxy.ts
+++ b/backend/src/utils/proxy.ts
@@ -6,7 +6,15 @@ import { DEV_MODE } from './constants';
 import { createCustomError } from './requestUtils';
 import { getAccessToken, getDirectCallOptions } from './directCallUtils';
 import { EitherNotBoth } from '../typeHelpers';
+import { IncomingHttpHeaders } from 'http';
 import { V1Service } from '@kubernetes/client-node';
+
+export const addDefaultCacheControl = (headers: IncomingHttpHeaders): IncomingHttpHeaders => {
+  if (!headers['cache-control']) {
+    headers['cache-control'] = 'no-cache';
+  }
+  return headers;
+};
 
 export const getParam = <F extends FastifyRequest<any, any>>(req: F, name: string): string =>
   (req.params as { [key: string]: string })[name];
@@ -200,6 +208,7 @@ export const registerProxy = async (
     authorize,
     tls,
     onError,
+    rewriteHeaders,
   }: {
     prefix: string;
     rewritePrefix?: string;
@@ -215,6 +224,7 @@ export const registerProxy = async (
       port?: number | string;
     };
     onError?: FastifyHttpProxyOptions['replyOptions']['onError'];
+    rewriteHeaders?: FastifyHttpProxyOptions['replyOptions']['rewriteHeaders'];
   },
 ): Promise<void> => {
   const scheme = tls === false ? 'http' : 'https';
@@ -229,6 +239,7 @@ export const registerProxy = async (
     replyOptions: {
       getUpstream: () => upstream,
       onError,
+      rewriteHeaders,
     },
     preHandler: async (request, reply) => {
       if (checkRequestLimitExceeded(request, fastify, reply)) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58983

Backport of #6632 to `v3.3.0-fixes` (backend changes only).

## Description

After a redeployment of a federated remote module, users may encounter a `ChunkLoadError` due to the browser serving stale cached files from the upstream module service. All static files for remote modules — including `remoteEntry.js`, JavaScript chunks, CSS, and other build artifacts — are served through the dashboard backend's `/_mf/` proxy endpoint.

Upstream module services do not return `Cache-Control` or `ETag` response headers for these files, and the proxy passes upstream headers through unchanged. Without a `Cache-Control` header, the browser falls back to **heuristic caching** per RFC 7234. Using the `Last-Modified` header returned by Go's `http.FileServer`, browsers typically calculate a heuristic freshness lifetime of 10% of the age of the resource — for a file last modified 11 days ago, the browser may consider it fresh for over 26 hours, serving it from cache without revalidating with the server.

### Changes

- **`backend/src/utils/proxy.ts`**: Added `addDefaultCacheControl` utility that sets `Cache-Control: no-cache` on response headers when the upstream does not provide one. Added `rewriteHeaders` as an optional parameter to `registerProxy`, passing it through to `@fastify/http-proxy`'s `replyOptions`.
- **`backend/src/routes/module-federation.ts`**: Applied `addDefaultCacheControl` as the `rewriteHeaders` callback for `/_mf/` backend proxy registrations. Non-`/_mf/` proxy service registrations (API proxies) are unaffected.
- **`backend/src/__tests__/routes/module-federation.spec.ts`**: Added 6 unit tests covering the cache header rewrite behavior.

### Conflict resolution

The `headers` property on `registerProxy` was removed on `v3.3.0-fixes` (not present in this branch). The cherry-pick added only `rewriteHeaders` without `headers`.

## How Has This Been Tested?

- All 6 unit tests for `addDefaultCacheControl` pass
- Type-check passes across all packages
- Lint passes

## Test Impact

Added `backend/src/__tests__/routes/module-federation.spec.ts` with 6 unit tests covering:
- `Cache-Control: no-cache` is added when upstream omits the header
- Existing upstream `Cache-Control` values are preserved (`max-age`, `no-store`, `public, max-age=0`, `no-cache`)
- The function mutates and returns the same headers object

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`