### PR TITLE
fix(cypress): fix access mode verification in verifyStorageClassConfi…

### DIFF
--- a/packages/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/storageClasses/storageClasses.cy.ts
@@ -216,6 +216,7 @@ describe('An admin user can manage Storage Classes from Settings -> Storage clas
       verifyStorageClassConfig(scAccessModeName1, false, true, undefined, undefined, {
         ReadWriteOnce: true,
         ReadWriteMany: true,
+        ReadWriteOncePod: false,
         ReadOnlyMany: true,
       });
 

--- a/packages/cypress/cypress/utils/storageClass.ts
+++ b/packages/cypress/cypress/utils/storageClass.ts
@@ -287,7 +287,7 @@ export const verifyStorageClassConfig = (
     }
 
     if (expectedAccessModes !== undefined) {
-      cy.wrap(config.accessModeSettings).should('equal', expectedAccessModes);
+      cy.wrap(config.accessModeSettings).should('deep.equal', expectedAccessModes);
     }
     cy.log('Storage Class Config:', JSON.stringify(config));
     return cy.wrap(result);


### PR DESCRIPTION
…g (#7319)

The condition guard fix in #7184 exposed two bugs in the access mode assertion: `should('equal')` uses strict reference equality which always fails for objects, and the expected object was missing `ReadWriteOncePod: false`.

Made-with: Cursor

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
