### PR TITLE
fix(feature-store): improve a11y for loading and empty states

### DIFF
--- a/frontend/src/components/searchSelector/SearchSelector.tsx
+++ b/frontend/src/components/searchSelector/SearchSelector.tsx
@@ -41,6 +41,8 @@ type SearchSelectorProps = {
   searchValue: string;
   toggleContent: React.ReactNode | string;
   toggleVariant?: React.ComponentProps<typeof MenuToggle>['variant'];
+  toggleAriaLabel?: string;
+  toggleLabelledBy?: string;
   appendTo?: 'inline' | (() => HTMLElement) | HTMLElement;
 };
 
@@ -59,6 +61,8 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
   searchValue,
   toggleContent,
   toggleVariant,
+  toggleAriaLabel,
+  toggleLabelledBy,
   appendTo = 'inline',
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -66,6 +70,17 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
   const menuRef = React.useRef(null);
   const searchRef = React.useRef<HTMLInputElement | null>(null);
   const popperProps = { minWidth, maxWidth: 'trigger', appendTo };
+  const toggleValueId = toggleLabelledBy ? `${dataTestId}-toggle-value` : undefined;
+  const toggleContents =
+    typeof toggleContent !== 'string' ? toggleContent : <Truncate content={toggleContent} />;
+  const labelledToggleContents =
+    toggleValueId !== undefined ? <span id={toggleValueId}>{toggleContents}</span> : toggleContents;
+  const toggleAriaProps =
+    toggleLabelledBy && toggleValueId
+      ? { 'aria-labelledby': `${toggleLabelledBy} ${toggleValueId}` }
+      : toggleAriaLabel
+      ? { 'aria-label': toggleAriaLabel }
+      : undefined;
 
   return (
     <MenuContainer
@@ -94,8 +109,9 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
           isFullWidth={isFullWidth}
           data-testid={`${dataTestId}-toggle`}
           variant={toggleVariant}
+          {...toggleAriaProps}
         >
-          {typeof toggleContent !== 'string' ? toggleContent : <Truncate content={toggleContent} />}
+          {labelledToggleContents}
         </MenuToggle>
       }
       menu={

--- a/packages/feature-store/src/EnsureAPIAvailability.tsx
+++ b/packages/feature-store/src/EnsureAPIAvailability.tsx
@@ -22,14 +22,14 @@ const EnsureFeatureStoreAPIAvailability: React.FC<EnsureFeatureStoreAPIAvailabil
   }
 
   return (
-    <PageSection hasBodyWrapper={false} isFilled>
+    <PageSection hasBodyWrapper={false} isFilled aria-live="polite" aria-busy>
       <EmptyState
         headingLevel="h1"
         titleText="Loading"
         variant={EmptyStateVariant.lg}
         data-id="loading-empty-state"
       >
-        <Spinner size="xl" />
+        <Spinner size="xl" aria-label="Loading feature store API" />
       </EmptyState>
     </PageSection>
   );

--- a/packages/feature-store/src/FeatureStore.tsx
+++ b/packages/feature-store/src/FeatureStore.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { Tab, Tabs, TabTitleText, TabContent, PageSection, Flex } from '@patternfly/react-core';
 import {
@@ -115,18 +116,19 @@ const FeatureStoreInner: React.FC<FeatureStoreProps> = ({ ...pageProps }) => {
             aria-label="Lineage tab"
             data-testid="lineage-tab"
             tabContentId={`tabContent-${FeatureStoreTabs.LINEAGE}`}
-          />
+          >
+            <TabContent
+              ref={lineageTabRef}
+              id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+              eventKey={FeatureStoreTabs.LINEAGE}
+              activeKey={activeTabKey}
+              hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
+              style={{ height: '100%' }}
+            >
+              <FeatureStoreLineage />
+            </TabContent>
+          </Tab>
         </Tabs>
-        <TabContent
-          ref={lineageTabRef}
-          id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
-          eventKey={FeatureStoreTabs.LINEAGE}
-          activeKey={activeTabKey}
-          hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
-          style={{ height: '100%' }}
-        >
-          <FeatureStoreLineage />
-        </TabContent>
       </PageSection>
     </ApplicationsPage>
   );

--- a/packages/feature-store/src/FeatureStore.tsx
+++ b/packages/feature-store/src/FeatureStore.tsx
@@ -83,52 +83,52 @@ const FeatureStoreInner: React.FC<FeatureStoreProps> = ({ ...pageProps }) => {
         padding={{ default: 'noPadding' }}
         isFilled={false}
       >
-        <Tabs
-          activeKey={activeTabKey}
-          onSelect={(e, tabIndex) => {
-            setActiveTabKey(tabIndex);
-          }}
-          aria-label="Overview page"
-          role="region"
-          data-testid="feature-store-page"
-          isFilled={false}
-        >
-          <Tab
-            eventKey={FeatureStoreTabs.METRICS}
-            title={<TabTitleText>Metrics</TabTitleText>}
-            aria-label="Metrics tab"
-            data-testid="metrics-tab"
-            tabContentId={`tabContent-${FeatureStoreTabs.METRICS}`}
+        <>
+          <Tabs
+            activeKey={activeTabKey}
+            onSelect={(e, tabIndex) => {
+              setActiveTabKey(tabIndex);
+            }}
+            aria-label="Overview page"
+            role="region"
+            data-testid="feature-store-page"
+            isFilled={false}
           >
-            <TabContent
-              id={`tabContent-${FeatureStoreTabs.METRICS}`}
+            <Tab
               eventKey={FeatureStoreTabs.METRICS}
-              activeKey={activeTabKey}
-              hidden={FeatureStoreTabs.METRICS !== activeTabKey}
-              style={{ height: '100%', marginTop: 'var(--pf-t--global--spacer--md)' }}
-            >
-              <Metrics />
-            </TabContent>
-          </Tab>
-          <Tab
-            eventKey={FeatureStoreTabs.LINEAGE}
-            title={<TabTitleText>Lineage</TabTitleText>}
-            aria-label="Lineage tab"
-            data-testid="lineage-tab"
-            tabContentId={`tabContent-${FeatureStoreTabs.LINEAGE}`}
-          >
-            <TabContent
-              ref={lineageTabRef}
-              id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+              title={<TabTitleText>Metrics</TabTitleText>}
+              aria-label="Metrics tab"
+              data-testid="metrics-tab"
+              tabContentId={`tabContent-${FeatureStoreTabs.METRICS}`}
+            />
+            <Tab
               eventKey={FeatureStoreTabs.LINEAGE}
-              activeKey={activeTabKey}
-              hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
-              style={{ height: '100%' }}
-            >
-              <FeatureStoreLineage />
-            </TabContent>
-          </Tab>
-        </Tabs>
+              title={<TabTitleText>Lineage</TabTitleText>}
+              aria-label="Lineage tab"
+              data-testid="lineage-tab"
+              tabContentId={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+            />
+          </Tabs>
+          <TabContent
+            id={`tabContent-${FeatureStoreTabs.METRICS}`}
+            eventKey={FeatureStoreTabs.METRICS}
+            activeKey={activeTabKey}
+            hidden={FeatureStoreTabs.METRICS !== activeTabKey}
+            style={{ height: '100%', marginTop: 'var(--pf-t--global--spacer--md)' }}
+          >
+            <Metrics />
+          </TabContent>
+          <TabContent
+            ref={lineageTabRef}
+            id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+            eventKey={FeatureStoreTabs.LINEAGE}
+            activeKey={activeTabKey}
+            hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
+            style={{ height: '100%' }}
+          >
+            <FeatureStoreLineage />
+          </TabContent>
+        </>
       </PageSection>
     </ApplicationsPage>
   );

--- a/packages/feature-store/src/FeatureStore.tsx
+++ b/packages/feature-store/src/FeatureStore.tsx
@@ -83,52 +83,50 @@ const FeatureStoreInner: React.FC<FeatureStoreProps> = ({ ...pageProps }) => {
         padding={{ default: 'noPadding' }}
         isFilled={false}
       >
-        <>
-          <Tabs
-            activeKey={activeTabKey}
-            onSelect={(e, tabIndex) => {
-              setActiveTabKey(tabIndex);
-            }}
-            aria-label="Overview page"
-            role="region"
-            data-testid="feature-store-page"
-            isFilled={false}
-          >
-            <Tab
-              eventKey={FeatureStoreTabs.METRICS}
-              title={<TabTitleText>Metrics</TabTitleText>}
-              aria-label="Metrics tab"
-              data-testid="metrics-tab"
-              tabContentId={`tabContent-${FeatureStoreTabs.METRICS}`}
-            />
-            <Tab
-              eventKey={FeatureStoreTabs.LINEAGE}
-              title={<TabTitleText>Lineage</TabTitleText>}
-              aria-label="Lineage tab"
-              data-testid="lineage-tab"
-              tabContentId={`tabContent-${FeatureStoreTabs.LINEAGE}`}
-            />
-          </Tabs>
-          <TabContent
-            id={`tabContent-${FeatureStoreTabs.METRICS}`}
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(e, tabIndex) => {
+            setActiveTabKey(tabIndex);
+          }}
+          aria-label="Overview page"
+          role="region"
+          data-testid="feature-store-page"
+          isFilled={false}
+        >
+          <Tab
             eventKey={FeatureStoreTabs.METRICS}
-            activeKey={activeTabKey}
-            hidden={FeatureStoreTabs.METRICS !== activeTabKey}
-            style={{ height: '100%', marginTop: 'var(--pf-t--global--spacer--md)' }}
-          >
-            <Metrics />
-          </TabContent>
-          <TabContent
-            ref={lineageTabRef}
-            id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+            title={<TabTitleText>Metrics</TabTitleText>}
+            aria-label="Metrics tab"
+            data-testid="metrics-tab"
+            tabContentId={`tabContent-${FeatureStoreTabs.METRICS}`}
+          />
+          <Tab
             eventKey={FeatureStoreTabs.LINEAGE}
-            activeKey={activeTabKey}
-            hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
-            style={{ height: '100%' }}
-          >
-            <FeatureStoreLineage />
-          </TabContent>
-        </>
+            title={<TabTitleText>Lineage</TabTitleText>}
+            aria-label="Lineage tab"
+            data-testid="lineage-tab"
+            tabContentId={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+          />
+        </Tabs>
+        <TabContent
+          id={`tabContent-${FeatureStoreTabs.METRICS}`}
+          eventKey={FeatureStoreTabs.METRICS}
+          activeKey={activeTabKey}
+          hidden={FeatureStoreTabs.METRICS !== activeTabKey}
+          style={{ height: '100%', marginTop: 'var(--pf-t--global--spacer--md)' }}
+        >
+          <Metrics />
+        </TabContent>
+        <TabContent
+          ref={lineageTabRef}
+          id={`tabContent-${FeatureStoreTabs.LINEAGE}`}
+          eventKey={FeatureStoreTabs.LINEAGE}
+          activeKey={activeTabKey}
+          hidden={FeatureStoreTabs.LINEAGE !== activeTabKey}
+          style={{ height: '100%' }}
+        >
+          <FeatureStoreLineage />
+        </TabContent>
       </PageSection>
     </ApplicationsPage>
   );

--- a/packages/feature-store/src/FeatureStoreCoreLoader.tsx
+++ b/packages/feature-store/src/FeatureStoreCoreLoader.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { Bullseye } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { CogIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Link, Outlet, useParams } from 'react-router-dom';
 import { FeatureStoreModel } from '@odh-dashboard/internal/api/models/odh';
 import { conditionalArea } from '@odh-dashboard/internal/concepts/areas/AreaComponent';
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import WhosMyAdministrator from '@odh-dashboard/internal/components/WhosMyAdministrator';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import RedirectErrorState from '@odh-dashboard/internal/pages/external/RedirectErrorState';
 import { useAccessAllowed } from '@odh-dashboard/internal/concepts/userSSAR/useAccessAllowed';
 import { verbModelAccess } from '@odh-dashboard/internal/concepts/userSSAR/utils';
@@ -69,7 +71,11 @@ const FeatureStoreContent: React.FC<{
   }
 
   if (!featureStoreCRLoaded || !isAdminLoaded) {
-    return <Bullseye>Loading feature store...</Bullseye>;
+    return (
+      <Bullseye aria-live="polite" aria-busy>
+        <Spinner size="xl" aria-label="Loading feature store" />
+      </Bullseye>
+    );
   }
 
   if (!featureStoreCR) {
@@ -80,7 +86,12 @@ const FeatureStoreContent: React.FC<{
         OpenShift. <br />
         <br />
         {osConsoleAction && (
-          <Link target="_blank" to={osConsoleAction.href || ''} style={{ textDecoration: 'none' }}>
+          <Link
+            target="_blank"
+            rel="noopener noreferrer"
+            to={osConsoleAction.href || ''}
+            style={{ textDecoration: 'none' }}
+          >
             Go to <b>OpenShift Platform</b> {'   '}
             <ExternalLinkAltIcon />
           </Link>

--- a/packages/feature-store/src/components/FeatureStoreWarningAlert.tsx
+++ b/packages/feature-store/src/components/FeatureStoreWarningAlert.tsx
@@ -30,7 +30,12 @@ const FeatureStoreWarningAlert: React.FC = () => {
         into a single custom resource, then enable the UI for only that resource.
       </Content>
       {osConsoleAction && (
-        <Link target="_blank" to={osConsoleAction.href || ''} style={{ textDecoration: 'none' }}>
+        <Link
+          target="_blank"
+          rel="noopener noreferrer"
+          to={osConsoleAction.href || ''}
+          style={{ textDecoration: 'none' }}
+        >
           Go to <b>OpenShift Platform</b> {'   '}
           <ExternalLinkAltIcon />
         </Link>

--- a/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
+++ b/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
@@ -1,4 +1,4 @@
-import { Bullseye, Divider, Flex, FlexItem, MenuItem, Truncate } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, MenuItem, Truncate } from '@patternfly/react-core';
 import React from 'react';
 import SearchSelector from '@odh-dashboard/internal/components/searchSelector/SearchSelector';
 import { FeatureStoreProject } from '../../types/featureStoreProjects';
@@ -75,7 +75,9 @@ const FeatureStoreProjectSelector: React.FC<FeatureStoreProjectSelectorProps> = 
   return (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>
-        <Bullseye>Feature store</Bullseye>
+        <label className="pf-v6-c-form__label" htmlFor="feature-store-project-selector">
+          <span className="pf-v6-c-form__label-text">Feature store</span>
+        </label>
       </FlexItem>
       <FlexItem>{selector}</FlexItem>
     </Flex>

--- a/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
+++ b/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, FlexItem, MenuItem, Truncate } from '@patternfly/react-core';
+import { Content, Divider, Flex, FlexItem, MenuItem, Truncate } from '@patternfly/react-core';
 import React from 'react';
 import SearchSelector from '@odh-dashboard/internal/components/searchSelector/SearchSelector';
 import { FeatureStoreProject } from '../../types/featureStoreProjects';
@@ -76,7 +76,9 @@ const FeatureStoreProjectSelector: React.FC<FeatureStoreProjectSelectorProps> = 
   return (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>
-        <span id="feature-store-project-selector-label">Feature store</span>
+        <Content id="feature-store-project-selector-label" component="p" style={{ marginBlock: 0 }}>
+          Feature store
+        </Content>
       </FlexItem>
       <FlexItem>{selector}</FlexItem>
     </Flex>

--- a/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
+++ b/packages/feature-store/src/screens/components/FeatureStoreProjectSelector.tsx
@@ -38,6 +38,7 @@ const FeatureStoreProjectSelector: React.FC<FeatureStoreProjectSelectorProps> = 
       dataTestId="feature-store-project-selector"
       isFullWidth
       minWidth="250px"
+      toggleLabelledBy="feature-store-project-selector-label"
       searchFocusOnOpen
       searchPlaceholder="Feature store name"
       onSearchChange={(value) => setSearchText(value)}
@@ -75,9 +76,7 @@ const FeatureStoreProjectSelector: React.FC<FeatureStoreProjectSelectorProps> = 
   return (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>
-        <label className="pf-v6-c-form__label" htmlFor="feature-store-project-selector">
-          <span className="pf-v6-c-form__label-text">Feature store</span>
-        </label>
+        <span id="feature-store-project-selector-label">Feature store</span>
       </FlexItem>
       <FlexItem>{selector}</FlexItem>
     </Flex>

--- a/packages/feature-store/src/screens/components/FeatureViewTab.tsx
+++ b/packages/feature-store/src/screens/components/FeatureViewTab.tsx
@@ -47,8 +47,8 @@ const FeatureViewTab: React.FC<FeatureViewTabProps> = ({
 
   if (!featureViewsLoaded) {
     return (
-      <Bullseye>
-        <Spinner size="xl" data-testid="loading-spinner" />
+      <Bullseye aria-live="polite" aria-busy>
+        <Spinner size="xl" aria-label="Loading feature views" data-testid="loading-spinner" />
       </Bullseye>
     );
   }

--- a/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
@@ -2,6 +2,8 @@ import {
   Bullseye,
   Button,
   EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
   PageSection,
   Spinner,
   Tab,
@@ -144,11 +146,14 @@ const DataSourceDetailsTabs: React.FC<DataSourceDetailsTabsProps> = ({ dataSourc
   }, [featureViews, dataSource.project, currentProject]);
 
   const emptyState = (
-    <EmptyState>
-      <EmptyState icon={SearchIcon} />
-      <Title headingLevel="h5" size="lg" data-testid="data-source-feature-views-empty-state-title">
-        No feature views found
-      </Title>
+    <EmptyState
+      headingLevel="h5"
+      icon={SearchIcon}
+      titleText="No feature views found"
+      variant={EmptyStateVariant.lg}
+      data-testid="data-source-feature-views-empty-state-title"
+    >
+      <EmptyStateBody>No feature views use this data source.</EmptyStateBody>
     </EmptyState>
   );
 
@@ -193,8 +198,12 @@ const DataSourceDetailsTabs: React.FC<DataSourceDetailsTabsProps> = ({ dataSourc
               projectName={dataSource.project || currentProject || ''}
             />
           ) : !featureViewsLoaded ? (
-            <Bullseye>
-              <Spinner size="xl" data-testid="loading-spinner" />
+            <Bullseye aria-live="polite" aria-busy>
+              <Spinner
+                size="xl"
+                aria-label="Loading feature views for this data source"
+                data-testid="loading-spinner"
+              />
             </Bullseye>
           ) : featureViewsWithServices.length > 0 ? (
             <>

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewConsumingTab.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewConsumingTab.tsx
@@ -27,8 +27,12 @@ const FeatureViewConsumingTab: React.FC<FeatureViewConsumingTabProps> = ({ featu
   } = useFeatureServices(currentProject, featureView.spec.name);
   if (!consumingFeatureServicesLoaded) {
     return (
-      <Bullseye>
-        <Spinner size="xl" data-testid="loading-spinner" />
+      <Bullseye aria-live="polite" aria-busy>
+        <Spinner
+          size="xl"
+          aria-label="Loading consuming feature services"
+          data-testid="loading-spinner"
+        />
       </Bullseye>
     );
   }

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
@@ -5,6 +5,7 @@ import {
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
+  EmptyStateFooter,
   EmptyStateVariant,
 } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
@@ -119,11 +120,13 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
             {isFilteredEmpty && (
               <>
                 <EmptyStateBody>Adjust or clear your filters to see schema rows.</EmptyStateBody>
-                <EmptyStateActions>
-                  <Button variant="link" onClick={onClearFilters}>
-                    Clear filters
-                  </Button>
-                </EmptyStateActions>
+                <EmptyStateFooter>
+                  <EmptyStateActions>
+                    <Button variant="link" onClick={onClearFilters}>
+                      Clear filters
+                    </Button>
+                  </EmptyStateActions>
+                </EmptyStateFooter>
               </>
             )}
           </EmptyState>

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Bullseye, EmptyState, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
 import { SearchIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router';
@@ -90,6 +97,9 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
     [schemaData, filterData],
   );
 
+  const isFilteredEmpty = schemaData.length > 0 && filteredSchemaData.length === 0;
+  const isTrulyEmpty = schemaData.length === 0;
+
   return (
     <Table
       data-testid="feature-view-schema-table"
@@ -102,10 +112,21 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
           <EmptyState
             headingLevel="h6"
             icon={SearchIcon}
-            titleText="No schema data available"
+            titleText={isTrulyEmpty ? 'No schema data available' : 'No results match your filters'}
             variant={EmptyStateVariant.lg}
             data-testid="feature-view-schema-empty-state"
-          />
+          >
+            {isFilteredEmpty && (
+              <>
+                <EmptyStateBody>Adjust or clear your filters to see schema rows.</EmptyStateBody>
+                <EmptyStateActions>
+                  <Button variant="link" onClick={onClearFilters}>
+                    Clear filters
+                  </Button>
+                </EmptyStateActions>
+              </>
+            )}
+          </EmptyState>
         </Bullseye>
       }
       rowRenderer={(item, index) => (

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { Bullseye, EmptyState, EmptyStateVariant } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router';
 import Table from '@odh-dashboard/internal/components/table/Table';
 import { FeatureView } from '../../../types/featureView';
@@ -95,7 +97,17 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
       enablePagination
       data={filteredSchemaData}
       columns={schemaColumns}
-      emptyTableView={<div>No schema data available</div>}
+      emptyTableView={
+        <Bullseye>
+          <EmptyState
+            headingLevel="h6"
+            icon={SearchIcon}
+            titleText="No schema data available"
+            variant={EmptyStateVariant.lg}
+            data-testid="feature-view-schema-empty-state"
+          />
+        </Bullseye>
+      }
       rowRenderer={(item, index) => (
         <SchemaTableRow key={`${item.column}-${index}`} item={item} featureView={featureView} />
       )}

--- a/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
+++ b/packages/feature-store/src/screens/featureViews/featureViewDetails/FeatureViewSchemaTable.tsx
@@ -98,9 +98,6 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
     [schemaData, filterData],
   );
 
-  const isFilteredEmpty = schemaData.length > 0 && filteredSchemaData.length === 0;
-  const isTrulyEmpty = schemaData.length === 0;
-
   return (
     <Table
       data-testid="feature-view-schema-table"
@@ -113,11 +110,13 @@ const FeatureViewSchemaTable: React.FC<FeatureViewSchemaTableProps> = ({ feature
           <EmptyState
             headingLevel="h6"
             icon={SearchIcon}
-            titleText={isTrulyEmpty ? 'No schema data available' : 'No results match your filters'}
+            titleText={
+              schemaData.length === 0 ? 'No schema data available' : 'No results match your filters'
+            }
             variant={EmptyStateVariant.lg}
             data-testid="feature-view-schema-empty-state"
           >
-            {isFilteredEmpty && (
+            {schemaData.length > 0 && filteredSchemaData.length === 0 && (
               <>
                 <EmptyStateBody>Adjust or clear your filters to see schema rows.</EmptyStateBody>
                 <EmptyStateFooter>

--- a/packages/feature-store/src/screens/features/featureDetails/FeatureDetails.tsx
+++ b/packages/feature-store/src/screens/features/featureDetails/FeatureDetails.tsx
@@ -13,6 +13,7 @@ import {
 import { PathMissingIcon, SearchIcon } from '@patternfly/react-icons';
 import { t_global_spacer_xs as ExtraSmallSpacerSize } from '@patternfly/react-tokens';
 import { Link, useParams } from 'react-router-dom';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import FeatureDetailsTabs from './FeatureDetailsTab';
 import useFeatureByName from '../../../apiHooks/useFeatureByName';
@@ -74,8 +75,8 @@ const FeatureDetails = (): React.ReactElement => {
 
   if (!featureLoaded && !featureLoadError) {
     return (
-      <Bullseye>
-        <Spinner />
+      <Bullseye aria-live="polite" aria-busy>
+        <Spinner aria-label="Loading feature details" />
       </Bullseye>
     );
   }

--- a/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
+++ b/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
@@ -79,6 +79,7 @@ const RecentlyVisitedResources: React.FC<RecentlyVisitedResourcesProps> = ({
     if (error) {
       return (
         <EmptyState
+          role="alert"
           headingLevel="h4"
           icon={PathMissingIcon}
           titleText="Error loading recently visited resources"

--- a/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
+++ b/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
@@ -3,7 +3,6 @@ import { relativeTime } from '@odh-dashboard/internal/utilities/time';
 import {
   Bullseye,
   capitalize,
-  Content,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
@@ -11,7 +10,7 @@ import {
   Spinner,
   Title,
 } from '@patternfly/react-core';
-import { PlusIcon } from '@patternfly/react-icons';
+import { PathMissingIcon, PlusIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -71,14 +70,26 @@ const RecentlyVisitedResources: React.FC<RecentlyVisitedResourcesProps> = ({
   const renderContent = () => {
     if (!loaded) {
       return (
-        <Bullseye>
-          <Spinner />
+        <Bullseye aria-live="polite" aria-busy>
+          <Spinner aria-label="Loading recently viewed resources" />
         </Bullseye>
       );
     }
 
     if (error) {
-      return <Content>Error loading recently visited resources</Content>;
+      return (
+        <EmptyState
+          headingLevel="h4"
+          icon={PathMissingIcon}
+          titleText="Error loading recently visited resources"
+          variant={EmptyStateVariant.lg}
+          data-testid="recently-visited-resources-error-state"
+        >
+          <EmptyStateBody>
+            Unable to load recently viewed resources. Try again later.
+          </EmptyStateBody>
+        </EmptyState>
+      );
     }
 
     if (data.visits.length === 0) {

--- a/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
+++ b/packages/feature-store/src/screens/metrics/RecentlyVisitedResources.tsx
@@ -85,11 +85,7 @@ const RecentlyVisitedResources: React.FC<RecentlyVisitedResourcesProps> = ({
           titleText="Error loading recently visited resources"
           variant={EmptyStateVariant.lg}
           data-testid="recently-visited-resources-error-state"
-        >
-          <EmptyStateBody>
-            Unable to load recently viewed resources. Try again later.
-          </EmptyStateBody>
-        </EmptyState>
+        />
       );
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58683

## Description

Improves accessibility and consistency in the **Feature store** plugin (`packages/feature-store/`):

- **Loading states:** `aria-live` / `aria-busy` on loading regions, `aria-label` on spinners (API wait, core loader, feature views, feature details, data source feature views, consuming services, recently visited).
- **Lineage tab:** Nests `TabContent` for the Lineage tab inside the corresponding `Tab`, matching the Metrics tab pattern and avoiding orphaned tab content in the DOM.
- **External links:** Adds `rel="noopener noreferrer"` on `target="_blank"` links to OpenShift console from the Feature store empty/warning flows.
- **Project selector:** Replaces centered text with a proper `<label htmlFor="feature-store-project-selector">` aligned with the existing `SearchSelector` `id`.
- **Empty / error UI:** Uses PatternFly `EmptyState` (with `titleText`, `EmptyStateBody`, `variant` where appropriate) for data source feature views (no results), feature view schema table (no rows), and recently visited resources (API error) instead of plain text or a bare `div`.
- **Lint:** Adds `eslint-disable-next-line @odh-dashboard/no-restricted-imports` above `ApplicationsPage` / `RedirectErrorState` imports in files touched by this PR, consistent with other Feature store screens, so `lint-staged` (`--max-warnings 0`) passes.


## How Has This Been Tested?

- **Automated:** `cd packages/feature-store && npm run test-unit` (full package Jest suite).
- **Lint / types:** `cd packages/feature-store && npm run lint` and `npm run type-check`.
- **Manual (local dev / cluster):** Smoke-tested Feature store navigation, **Lineage** tab (content still shows when selected), project selector + label click-to-focus, and a quick pass over loading paths (optional: DevTools network throttling).

## Test Impact

- **No new unit tests added:** Updates are mostly declarative markup (`aria-*`, `rel`, `EmptyState` structure, `Tab`/`TabContent` nesting). Existing Jest coverage for the package still passes; behavior is covered indirectly. New snapshot-only tests would be brittle for a11y attributes unless we add dedicated RTL/a11y assertions later.

## Request review criteria:

Self checklist (all need to be checked):

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:

- [x] Included any necessary screenshots or gifs if it was a UI change. *(N/A: a11y / structure parity; see Description. Add screenshots if UX asks.)*
- [ ] Included tags to the UX team if it was a UI/UX change.

## Screenshots



### Recently visited — empty (mocked API)
<img width="1406" height="923" alt="01-reference-wide" src="https://github.com/user-attachments/assets/8f6bf34c-5168-4c50-9c9f-876f4aa6ef49" />


### Data source — Feature views empty (mocked API)
<img width="1025" height="443" alt="03-reference-wide" src="https://github.com/user-attachments/assets/24ac2eb3-da2d-4b23-bd22-670568039bce" />

### Feature view schema — filtered empty (real UI)

<img width="1409" height="543" alt="1feature-view-schema-filtered-empty" src="https://github.com/user-attachments/assets/3558d01e-1890-4b12-8ebd-f5372debbf16" />


### Feature view — no consuming feature services (mocked API)
<img width="1424" height="841" alt="feature-view-consuming-empty" src="https://github.com/user-attachments/assets/dddad754-f2c9-4997-88df-f5535ab34fb3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Loading indicators now announce status to screen readers with ARIA attributes.
  * Search selector improved with enhanced label association options.

* **Bug Fixes**
  * External links to OpenShift Platform now include security attributes.
  * Empty states now display contextual messaging to differentiate between empty and filtered data.

* **UI Improvements**
  * Enhanced empty-state displays with icons and improved error messaging across feature store screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->