### PR TITLE
update jira triage rules to use code paths as hints

### DIFF
--- a/.claude/skills/jira-assign-scrum-team/SKILL.md
+++ b/.claude/skills/jira-assign-scrum-team/SKILL.md
@@ -71,8 +71,9 @@ Follow the resolution path that matches the issue's state:
 When the effective area set is empty (no existing or proposed area labels), attempt resolution via the Team keyword / feature associations table in `jira-project-reference.md`.
 
 1. Read the issue's summary and description.
-2. Match content against each team's keywords in the associations table.
-3. Evaluate the result:
+2. **Resolve file references.** If the summary or description mentions a file name (e.g., `*.cy.ts`, `*.test.ts`, `*.tsx`, `*.go`, or any identifiable source file), search the repository using workspace tools (e.g., `Glob` with `**/<filename>`) to find matching paths. Add each resolved path's intermediate directory names as additional keyword signals. If no matches are found, continue without path signals. This is the same resolution procedure documented in the validate-area-label skill § Signal Dimensions → Code paths. File resolution is especially valuable for test failure/flake issues where the spec file name is the primary content signal.
+3. Match content (including any resolved path signals from step 2) against each team's keywords in the associations table.
+4. Evaluate the result:
    - **One team matches clearly**: Produce an `ADD_LABEL` operation with the corresponding `dashboard-*-scrum` label.
    - **Multiple teams match** or **no match**: Skip the issue.
 

--- a/.claude/skills/jira-triage/SKILL.md
+++ b/.claude/skills/jira-triage/SKILL.md
@@ -1069,6 +1069,8 @@ See `jira-project-reference.md` § Project Constants for the Team field ID and v
 
 Run the analysis skills in order **only for issues that passed Step 2a**. Each skill reads the issue data already in session and produces operations. **Read each skill's SKILL.md** before executing it.
 
+**Workspace tools are available during analysis.** Some analysis skills (notably validate-area-label and assign-scrum-team) may use workspace tools like `Glob` to resolve file names mentioned in issues to their full repository paths. This is expected — the codebase is a signal source alongside Jira data, and is especially important for test failure/flake issues where the spec file name is the primary routing signal.
+
 If during Step 2b you determine the issue belongs to **another team** (not RHOAI Dashboard), **stop the pipeline for this issue**: do not run remaining analysis skills, do not run Step 2c or 2d, and **discard any operations already drafted for it in this run**. Produce a single `NO_OP` with reason (e.g., "Late team-gate: not a dashboard issue — {reason}") and write it to the file in Step 2e. Step 2a should prevent most cases; this catches late realizations.
 
 **Pipeline order:**

--- a/.claude/skills/jira-validate-area-label/SKILL.md
+++ b/.claude/skills/jira-validate-area-label/SKILL.md
@@ -43,7 +43,7 @@ The skill uses six signal dimensions to determine area labels. No single dimensi
 
 1. **Keywords** -- Feature names, UI text, and domain terms matched against issue summary and description. Source: Content Signals table in `jira-project-reference.md`.
 2. **K8s resource kinds** -- Kubernetes CRD/resource type names referenced in descriptions. Source: Content Signals table.
-3. **Code paths** -- Repository file/directory paths from linked PRs, stack traces, or description references. Source: Code Path Signals table.
+3. **Code paths** -- Repository file/directory paths from linked PRs, stack traces, or description references. **When a file name is mentioned without its full path** (common in test failure/flake issues that reference a spec like `someTest.cy.ts`), **resolve the file name to its full repository path** using workspace search tools (e.g., `Glob` with `**/<filename>`). The resolved full path is then matched against the Code Path Signals table. Intermediate directory names in the resolved path also contribute as keyword signals (e.g., resolving `featureDataSources.cy.ts` to `packages/cypress/cypress/tests/mocked/featureStore/featureDataSources.cy.ts` surfaces `featureStore` as a keyword hit). Source: Code Path Signals table in `jira-project-reference.md`.
 4. **Jira labels** -- Non-area labels already on the issue (e.g., `AutoML`, `AutoRAG`, `gen-ai`, `ai-pipelines`) that serve as product/feature identifiers. Source: Jira Label Signals table in `jira-project-reference.md`. Treated as keyword-equivalent signals with the same confidence as a keyword match in the summary.
 5. **Linked issues** -- Area labels on linked Jira issues (parent, blocks/blocked-by, relates-to). If linked issues already have `dashboard-area-*` labels, those are a confirming signal. Fetch linked issue labels via `issuelinks` field data (inward/outward issue keys and their labels).
 6. **Scrum team label** -- If the issue has a `dashboard-*-scrum` label, use the Area-to-Scrum Default Mapping in `jira-project-reference.md` in reverse as a **weak confirming signal**. Not definitive: a scrum team may pick up issues outside their default areas.
@@ -67,10 +67,11 @@ A single generic keyword match alone (e.g., "deployment", "connection", "storage
 Used by both modes:
 
 1. **Extract signals** from summary, description, Jira labels (non-area labels), linked issues, and scrum team labels. Check issue labels against the Jira Label Signals table in `jira-project-reference.md` to identify product/feature label matches.
-2. **Score each area** against the Content Signals, Jira Label Signals, and Code Path Signals tables in `jira-project-reference.md`. For each area, check all six dimensions and compute a match score.
-3. **Rank areas** by score. The top-scoring area(s) with sufficient confidence become candidates.
-4. **Apply disambiguation rules** (below) to resolve conflicts
-5. **Multiple area labels are expected.** An issue can genuinely span multiple areas. Produce an `ADD_LABEL` for each area that independently meets the confidence threshold. Do not cap at one.
+2. **Resolve file references.** Scan the summary and description for file names — look for patterns like `*.cy.ts`, `*.test.ts`, `*.spec.ts`, `*.tsx`, `*.ts`, `*.go`, or any identifiable source file name. For each file name found, search the repository using workspace tools (e.g., `Glob` with `**/<filename>`) to locate matching paths. Add every resolved path as a Code Path signal and treat each path's intermediate directory names as keyword signals. If no matches are found, continue without a Code Path signal. This step is critical for test failure and flake issues where the spec file name is often the strongest — or only — content signal pointing to a feature area.
+3. **Score each area** against the Content Signals, Jira Label Signals, and Code Path Signals tables in `jira-project-reference.md`. For each area, check all six dimensions (including any resolved file paths from step 2) and compute a match score.
+4. **Rank areas** by score. The top-scoring area(s) with sufficient confidence become candidates.
+5. **Apply disambiguation rules** (below) to resolve conflicts
+6. **Multiple area labels are expected.** An issue can genuinely span multiple areas. Produce an `ADD_LABEL` for each area that independently meets the confidence threshold. Do not cap at one.
 
 ### Disambiguation Rules
 


### PR DESCRIPTION
Enhances the jira triage rules to utilize code paths to help establish context to determine area and scrum team assignments.

Observed that a ticket which was clear that a specific test failure was at fault calling out the file in question, the tool failed to establish a relationship with the file and the associated area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Issue routing and classification now better resolve file references mentioned in descriptions, improving accuracy of team assignment and area label assignment through enhanced path analysis.

* **Documentation**
  * Updated analysis pipeline documentation to clarify tool availability and file path resolution capabilities during issue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->