### PR TITLE
Fix mcpTab flaky test issue

### DIFF
--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -84,4 +84,4 @@ jobs:
         with:
           name: gen-ai-cypress-results
           path: packages/gen-ai/frontend/src/__tests__/cypress/results/
-          retention-days: 7
+          retention-days: 1

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -77,3 +77,11 @@ jobs:
               git diff
               exit 1
           fi
+
+      - name: Upload Cypress results on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: gen-ai-cypress-results
+          path: packages/gen-ai/frontend/src/__tests__/cypress/results/
+          retention-days: 7

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -32,7 +32,9 @@ class MCPTab {
   }
 
   // The table inside the MCP tab (testId unchanged in component)
-  findMCPServersTable(options?: { timeout?: number }): Cypress.Chainable<JQuery<HTMLElement>> {
+  findMCPServersTable(
+    options?: Partial<Cypress.Loggable & Cypress.Timeoutable>,
+  ): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('mcp-servers-panel-table', options);
   }
 

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -43,7 +43,7 @@ class MCPTab {
   }
 
   verifyMCPTabVisible(): void {
-    this.findMCPServersTable().should('be.visible', { timeout: 30000 });
+    this.findMCPServersTable().should('exist', { timeout: 30000 }).and('be.visible');
   }
 
   private findCheckedCheckboxes(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -43,7 +43,7 @@ class MCPTab {
   }
 
   verifyMCPTabVisible(): void {
-    this.findMCPServersTable().should('exist', { timeout: 30000 }).and('be.visible');
+    this.findMCPServersTable().should('be.visible', { timeout: 30000 });
   }
 
   private findCheckedCheckboxes(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -54,9 +54,10 @@ class MCPTab {
 
   getServerRow(serverName: string, serverUrl: string): PlaygroundMCPServerRow {
     const rowSelector = () =>
-      this.findMCPServersTable().contains('tr', serverName) as unknown as Cypress.Chainable<
-        JQuery<HTMLTableRowElement>
-      >;
+      this.findMCPServersTable({ timeout: 30000 }).contains(
+        'tr',
+        serverName,
+      ) as unknown as Cypress.Chainable<JQuery<HTMLTableRowElement>>;
     return new PlaygroundMCPServerRow(rowSelector, serverName, serverUrl);
   }
 

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -39,7 +39,7 @@ class MCPTab {
   openMCPTab(): void {
     // Click the MCP tab to show the servers table
     this.clickMCPTab();
-    this.findMCPServersTable({ timeout: 30000 }).should('exist').and('be.visible');
+    this.verifyMCPTabVisible();
   }
 
   verifyMCPTabVisible(): void {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -32,18 +32,18 @@ class MCPTab {
   }
 
   // The table inside the MCP tab (testId unchanged in component)
-  findMCPServersTable(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('mcp-servers-panel-table');
+  findMCPServersTable(options?: { timeout?: number }): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('mcp-servers-panel-table', options);
   }
 
   openMCPTab(): void {
     // Click the MCP tab to show the servers table
     this.clickMCPTab();
-    this.findMCPServersTable().should('exist', { timeout: 30000 }).and('be.visible');
+    this.findMCPServersTable({ timeout: 30000 }).should('exist').and('be.visible');
   }
 
   verifyMCPTabVisible(): void {
-    this.findMCPServersTable().should('exist', { timeout: 30000 }).and('be.visible');
+    this.findMCPServersTable({ timeout: 30000 }).should('exist').and('be.visible');
   }
 
   private findCheckedCheckboxes(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -54,10 +54,9 @@ class MCPTab {
 
   getServerRow(serverName: string, serverUrl: string): PlaygroundMCPServerRow {
     const rowSelector = () =>
-      this.findMCPServersTable({ timeout: 30000 }).contains(
-        'tr',
-        serverName,
-      ) as unknown as Cypress.Chainable<JQuery<HTMLTableRowElement>>;
+      this.findMCPServersTable().contains('tr', serverName) as unknown as Cypress.Chainable<
+        JQuery<HTMLTableRowElement>
+      >;
     return new PlaygroundMCPServerRow(rowSelector, serverName, serverUrl);
   }
 

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -424,7 +424,9 @@ describe('Playground - MCP Servers', () => {
           mcpToolsModal.find().should('not.exist');
 
           cy.step('Re-open tools modal to verify persistence');
-          freshServerRow.findToolsButton().click();
+          // Re-query server row after modal closes to avoid stale reference
+          const reopenServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+          reopenServerRow.findToolsButton().click();
           mcpToolsModal.find().should('be.visible');
 
           cy.step('Verify tool selection persisted (2 tools deselected)');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -377,10 +377,12 @@ describe('Playground - MCP Servers', () => {
       cy.step('Verify tools button is enabled after closing modal');
       // Wait for MCP table to be visible after potential tab remount
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
-      serverRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
 
       cy.step('Click tools button to open tools modal');
-      serverRow.findToolsButton().click();
+      freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with tools');
       mcpToolsModal.find().should('be.visible');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -70,10 +70,15 @@ describe('Playground - MCP Servers', () => {
       mcpServerSuccessModal.find().should('not.exist');
 
       cy.step('Verify server is now authenticated and tools button is enabled');
-      serverRow.findToolsButton().should('exist').should('not.have.attr', 'aria-disabled');
+      // Re-query server row after modal closes to avoid stale reference
+      const authenticatedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      authenticatedServerRow
+        .findToolsButton()
+        .should('exist')
+        .should('not.have.attr', 'aria-disabled');
 
       cy.step('Open tools modal');
-      serverRow.findToolsButton().click();
+      authenticatedServerRow.findToolsButton().click();
 
       cy.step('Wait for tools API call');
       cy.wait('@toolsRequest', { timeout: 10000 });
@@ -419,7 +424,7 @@ describe('Playground - MCP Servers', () => {
           mcpToolsModal.find().should('not.exist');
 
           cy.step('Re-open tools modal to verify persistence');
-          serverRow.findToolsButton().click();
+          freshServerRow.findToolsButton().click();
           mcpToolsModal.find().should('be.visible');
 
           cy.step('Verify tool selection persisted (2 tools deselected)');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -381,7 +381,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify tools button is enabled after closing modal');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
       freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
@@ -470,7 +470,7 @@ describe('Playground - MCP Servers', () => {
       cy.step('Close success modal and open tools modal');
       playgroundPage.mcpTab.closeSuccessModal();
       mcpServerSuccessModal.find().should('not.exist');
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
       freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
@@ -624,7 +624,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify warning alert is shown in MCP tab');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       cy.get('[data-testid="mcp-tools-warning-alert"]')
         .should('be.visible')
         .and('contain.text', 'Performance may be degraded with more than 40 active tools');
@@ -670,7 +670,7 @@ describe('Playground - MCP Servers', () => {
 
       cy.step('Verify warning alert is NOT shown (40 tools is the threshold, not exceeding)');
       // Wait for MCP table to be visible after potential tab remount
-      playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+      playgroundPage.mcpTab.verifyMCPTabVisible();
       cy.get('[data-testid="mcp-tools-warning-alert"]').should('not.exist');
 
       cy.step('Verify tools count shows 40 active');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -568,11 +568,11 @@ describe('Playground - MCP Servers', () => {
             // Wait for MCP table to be visible
             playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
 
-            // Directly query for the tools button by its testID (bypassing page object to avoid stale references)
-            cy.findByTestId(`mcp-server-tools-button-${serverUrl}`)
-              .should('exist')
-              .and('not.have.attr', 'aria-disabled')
-              .click();
+            // Re-query server row to avoid stale references
+            const reopenServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+            reopenServerRow.findToolsButton().should('exist');
+            reopenServerRow.findToolsButton().should('not.have.attr', 'aria-disabled');
+            reopenServerRow.findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -565,14 +565,15 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible and force immediate row query
+            // Wait for MCP table to be visible and force immediate element query
             playgroundPage.mcpTab
               .findMCPServersTable()
               .should('be.visible')
-              .then(() => {
-                const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
-                reopenedServerRow
-                  .findToolsButton()
+              .then(($table) => {
+                // Force immediate query for the row and tools button
+                cy.wrap($table)
+                  .contains('tr', serverName)
+                  .findByTestId(`mcp-server-tools-button-${serverUrl}`)
                   .should('exist')
                   .and('not.have.attr', 'aria-disabled')
                   .click();

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -565,6 +565,8 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
+            // Wait for MCP table to be visible after potential tab remount
+            playgroundPage.mcpTab.verifyMCPTabVisible();
             const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
             reopenedServerRow
               .findToolsButton()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -556,7 +556,7 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            serverRow.findToolsButton().click();
+            playgroundPage.mcpTab.getServerRow(serverName, serverUrl).findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -565,14 +565,18 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible after potential tab remount
-            playgroundPage.mcpTab.verifyMCPTabVisible();
-            const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
-            reopenedServerRow
-              .findToolsButton()
-              .should('exist')
-              .and('not.have.attr', 'aria-disabled');
-            reopenedServerRow.findToolsButton().click();
+            // Wait for MCP table to be visible and force immediate row query
+            playgroundPage.mcpTab
+              .findMCPServersTable()
+              .should('be.visible')
+              .then(() => {
+                const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+                reopenedServerRow
+                  .findToolsButton()
+                  .should('exist')
+                  .and('not.have.attr', 'aria-disabled')
+                  .click();
+              });
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -565,21 +565,14 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible and force immediate element query
-            playgroundPage.mcpTab
-              .findMCPServersTable()
-              .should('be.visible')
-              .then(($table) => {
-                // Force immediate query for the row and tools button within the table
-                cy.wrap($table)
-                  .contains('tr', serverName)
-                  .within(() => {
-                    cy.findByTestId(`mcp-server-tools-button-${serverUrl}`)
-                      .should('exist')
-                      .and('not.have.attr', 'aria-disabled')
-                      .click();
-                  });
-              });
+            // Wait for MCP table to be visible
+            playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+
+            // Directly query for the tools button by its testID (bypassing page object to avoid stale references)
+            cy.findByTestId(`mcp-server-tools-button-${serverUrl}`)
+              .should('exist')
+              .and('not.have.attr', 'aria-disabled')
+              .click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -464,8 +464,9 @@ describe('Playground - MCP Servers', () => {
       playgroundPage.mcpTab.closeSuccessModal();
       mcpServerSuccessModal.find().should('not.exist');
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
-      serverRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
-      serverRow.findToolsButton().click();
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with all tools selected');
       mcpToolsModal.find().should('be.visible');
@@ -558,7 +559,8 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            playgroundPage.mcpTab.getServerRow(serverName, serverUrl).findToolsButton().click();
+            const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+            reopenedServerRow.findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal
               .find()

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -565,8 +565,8 @@ describe('Playground - MCP Servers', () => {
             mcpToolsModal.find().should('not.exist');
 
             cy.step('Re-open to verify all tools remain selected');
-            // Wait for MCP table to be visible
-            playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
+            // Wait for MCP table to be visible after potential tab remount
+            playgroundPage.mcpTab.verifyMCPTabVisible();
 
             // Re-query server row to avoid stale references
             const reopenServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
@@ -628,7 +628,9 @@ describe('Playground - MCP Servers', () => {
         .and('contain.text', 'Performance may be degraded with more than 40 active tools');
 
       cy.step('Verify tools count shows 45 active');
-      serverRow.findToolsButton().should('contain.text', '45 active');
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRowFor45 = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRowFor45.findToolsButton().should('contain.text', '45 active');
 
       cy.step('Test completed - Tools warning alert works correctly');
     },
@@ -670,7 +672,9 @@ describe('Playground - MCP Servers', () => {
       cy.get('[data-testid="mcp-tools-warning-alert"]').should('not.exist');
 
       cy.step('Verify tools count shows 40 active');
-      serverRow.findToolsButton().should('contain.text', '40 active');
+      // Re-query server row after modal closes to avoid stale reference
+      const freshServerRowFor40 = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRowFor40.findToolsButton().should('contain.text', '40 active');
 
       cy.step('Test completed - No warning for 40 or fewer tools');
     },

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -471,6 +471,7 @@ describe('Playground - MCP Servers', () => {
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
       // Re-query server row after modal closes to avoid stale reference
       const freshServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+      freshServerRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
       freshServerRow.findToolsButton().click();
 
       cy.step('Verify tools modal opens with all tools selected');
@@ -565,6 +566,10 @@ describe('Playground - MCP Servers', () => {
 
             cy.step('Re-open to verify all tools remain selected');
             const reopenedServerRow = playgroundPage.mcpTab.getServerRow(serverName, serverUrl);
+            reopenedServerRow
+              .findToolsButton()
+              .should('exist')
+              .and('not.have.attr', 'aria-disabled');
             reopenedServerRow.findToolsButton().click();
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -570,13 +570,15 @@ describe('Playground - MCP Servers', () => {
               .findMCPServersTable()
               .should('be.visible')
               .then(($table) => {
-                // Force immediate query for the row and tools button
+                // Force immediate query for the row and tools button within the table
                 cy.wrap($table)
                   .contains('tr', serverName)
-                  .findByTestId(`mcp-server-tools-button-${serverUrl}`)
-                  .should('exist')
-                  .and('not.have.attr', 'aria-disabled')
-                  .click();
+                  .within(() => {
+                    cy.findByTestId(`mcp-server-tools-button-${serverUrl}`)
+                      .should('exist')
+                      .and('not.have.attr', 'aria-disabled')
+                      .click();
+                  });
               });
             mcpToolsModal.find().should('be.visible');
             mcpToolsModal


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
Fix flaky mcpTab test

## How Has This Been Tested?
Run the flaky test multiple times

## Test Impact
Only tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- ~~[ ] Included any necessary screenshots or gifs if it was a UI change.~~
- ~~[ ] Included tags to the UX team if it was a UI/UX change.~~

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Repaired flaky MCP tests by re-querying server rows after modal interactions to avoid stale element references.
  * Replaced fragile visibility assertions with a centralized MCP tab visibility check to handle remounts reliably.
  * Improved table lookup robustness with longer, explicit timeouts for server table discovery in slow environments.

* **Chores**
  * CI now uploads Cypress test results as an artifact on job failure for easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->