### PR TITLE
Add agent rule to use PR template when creating pull requests

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,10 @@
+# Pull Request Creation
+
+When creating a pull request targeting `opendatahub-io/odh-dashboard`, you **MUST** use the PR template at `.github/pull_request_template.md` as the PR body structure. Read the template, fill in every section following the HTML comment instructions within it, and include the full checklist. This rule does not apply to PRs targeting other repositories.
+
+## Agent-Specific Guidance
+
+- **Honesty over completeness.** Only check `[x]` checklist items you can substantiate. If you didn't add tests, leave that box unchecked and explain why in the Test Impact section. If you only ran automated checks (lint, type-check), do not check "manually tested."
+- **Post-merge items stay unchecked.** The "After the PR is posted & before it merges" items are human tasks — leave them as `[ ]`.
+- **UI section is conditional.** If the change has no UI impact, omit the "If you have UI changes" checklist items entirely rather than leaving them unchecked.
+- **No bare summaries.** Never skip the template and use a plain paragraph as the PR body. Reviewers expect the full structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Rules live in `.claude/rules/`. Read the relevant rule file before starting the 
 | **Modular Architecture**    | `modular-architecture.md`     | When working on the plugin/extension system or package integration              |
 | **Module Federation**       | `module-federation.md`        | When configuring Module Federation, webpack remotes, or shared dependencies    |
 | **Module Onboarding**       | `module-onboarding.md`        | When creating a new package/module in the monorepo                             |
+| **Pull Requests**           | `pull-requests.md`            | When creating a pull request — must follow `.github/pull_request_template.md`  |
 | **React**                   | `react.md`                    | When writing React components, hooks, or pages                                 |
 | **Security**                | `security.md`                 | When working on auth, secrets, input validation, or K8s API interactions        |
 | **Testing Standards**       | `testing-standards.md`        | When working across multiple test types or choosing a testing strategy          |


### PR DESCRIPTION
This is a non-code change — agent configuration only.

## Description

Adds an agent rule (`.claude/rules/pull-requests.md`) that instructs AI agents to use the repository's existing PR template at `.github/pull_request_template.md` when creating pull requests. The rule includes agent-specific guidance on:

- Only checking checklist items the agent can substantiate
- Leaving post-merge items unchecked (human tasks)
- Omitting the UI checklist section when the change has no UI impact
- Never submitting a bare summary instead of the full template

Also registers the new rule in the `AGENTS.md` rules table.

## How Has This Been Tested?

This is an agent configuration change (markdown files only). No runtime behavior is affected. Verified that:
- The new rule file is consistent in structure with existing rules in `.claude/rules/`
- The `AGENTS.md` table entry is alphabetically ordered correctly
- The rule content aligns with the actual PR template at `.github/pull_request_template.md`

## Test Impact

No tests are applicable — this change adds agent guidance documentation only.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`