### PR TITLE
[RHOAIENG-58958] Upgrade mlflow BFF Go version from 1.24 to 1.25

### DIFF
--- a/.github/workflows/mlflow-bff-tests.yml
+++ b/.github/workflows/mlflow-bff-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.6'
+          go-version: '1.25.0'
 
       - name: Lint
         working-directory: packages/mlflow/bff

--- a/packages/mlflow/AGENTS.md
+++ b/packages/mlflow/AGENTS.md
@@ -99,7 +99,7 @@ mlflow/
 
 ### BFF
 
-- **Go**: >= 1.24.3
+- **Go**: >= 1.25.0
 
 ---
 
@@ -361,7 +361,7 @@ make test   # Run tests
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.24+** for the BFF and **Node 22+** for the frontend
+1. Use **Go 1.25+** for the BFF and **Node 22+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Use **PatternFly components** for all federated-mode UI
 4. Run tests before pushing:

--- a/packages/mlflow/Dockerfile
+++ b/packages/mlflow/Dockerfile
@@ -4,7 +4,7 @@ ARG BFF_SOURCE_CODE=./bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=node:22
-ARG GOLANG_BASE_IMAGE=golang:1.24.3
+ARG GOLANG_BASE_IMAGE=golang:1.25.7
 ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # UI build stage

--- a/packages/mlflow/Dockerfile.workspace
+++ b/packages/mlflow/Dockerfile.workspace
@@ -9,7 +9,7 @@ ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
 
 # UI build stage

--- a/packages/mlflow/bff/README.md
+++ b/packages/mlflow/bff/README.md
@@ -4,7 +4,7 @@ Minimal backend-for-frontend providing only core endpoints required by the MLflo
 
 ## Dependencies
 
-- Go >= 1.25.7
+- Go >= 1.25.0
 
 ## Scope
 

--- a/packages/mlflow/bff/README.md
+++ b/packages/mlflow/bff/README.md
@@ -4,7 +4,7 @@ Minimal backend-for-frontend providing only core endpoints required by the MLflo
 
 ## Dependencies
 
-- Go >= 1.24.3
+- Go >= 1.25.7
 
 ## Scope
 

--- a/packages/mlflow/bff/go.mod
+++ b/packages/mlflow/bff/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/mlflow/bff
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58958

## Description

Upgrade the mlflow BFF module from Go 1.24 to Go 1.25, following the same pattern used for model-registry in PR #6286.

Prod Sec recommended upgrading Go from 1.24 to 1.25 for security improvements. This PR covers the upstream (ODH) changes for the `mlflow` module.

**Files changed:**

| # | File | Change |
|---|------|--------|
| 1 | `packages/mlflow/bff/go.mod` | `go 1.24.3` → `go 1.25.0` |
| 2 | `packages/mlflow/bff/go.sum` | Regenerated via `go mod tidy` |
| 3 | `packages/mlflow/Dockerfile.workspace` | `go-toolset:1.24` → `go-toolset:1.25` |
| 4 | `packages/mlflow/Dockerfile` | `golang:1.24.3` → `golang:1.25.7` |
| 5 | `.github/workflows/mlflow-bff-tests.yml` | `go-version: '1.24.6'` → `go-version: '1.25.0'` |
| 6 | `packages/mlflow/AGENTS.md` | Go version references updated to 1.25 |
| 7 | `packages/mlflow/bff/README.md` | `Go >= 1.24.3` → `Go >= 1.25.7` |

## How Has This Been Tested?

- `cd packages/mlflow/bff && make test` — all packages pass (`cmd`, `internal/api`, `internal/helpers`, `internal/integrations/mlflow`, `internal/repositories`)
- `go mod tidy` ran cleanly with no dependency changes
- Version alignment verified against the model-registry reference pattern (PR #6286)

## Test Impact

No new tests added or modified — this is a pure toolchain version bump with no functional changes. Existing BFF test suite validates the build compiles and runs correctly under Go 1.25.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement to 1.25+ across documentation and build configurations.
  * Updated Docker base images to use Go 1.25 and 1.25.7 toolchain versions for building the backend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->