### PR TITLE
fix: remove .github exclusion from CodeRabbit path filters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,6 @@ reviews:
     # Baseline already excludes: vendor, node_modules, bin, __pycache__,
     #   *.sum, *.pb.go, *.generated.go, synced security configs
     - "!package-lock.json"
-    - "!.github/**"
     - "!.tekton/**"
     - "!**/@mf-types/**"
     - "!**/dist/**"


### PR DESCRIPTION
## Description

Removes the `!.github/**` exclusion from CodeRabbit's path filters in `.coderabbit.yaml`.

This was discovered on [#7284](https://github.com/opendatahub-io/odh-dashboard/pull/7284) where CodeRabbit [skipped review entirely](https://github.com/opendatahub-io/odh-dashboard/pull/7284#issuecomment-4262774020) because all four changed files (`.github/dependabot.yml`, `.github/workflows/dependabot-auto-merge.yml`, `.github/workflows/dependency-validation.yml`, `.github/workflows/stale.yml`) fell under the `.github/**` exclusion. Workflow and CI config changes should be reviewed.

## How Has This Been Tested?

Config-only change — verified the YAML is valid and the remaining path filters are unchanged.

## Test Impact

No tests needed — this is a CodeRabbit configuration change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)