### PR TITLE
Fix federated mode theme defaulting to OS preference instead of odh default

### DIFF
--- a/frontend/src/app/ThemeContext.tsx
+++ b/frontend/src/app/ThemeContext.tsx
@@ -20,6 +20,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [odhTheme, setOdhTheme] = useBrowserStorage<string>('odh.dashboard.ui.theme', 'light');
   const [, setMlflowTheme] = useBrowserStorage<boolean>(MLFLOW_DARK_MODE_KEY, odhTheme === 'dark');
 
+  React.useEffect(() => {
+    setMlflowTheme(odhTheme === 'dark');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const setAllThemes = React.useCallback(
     (theme: string) => {
       setMlflowTheme(theme === 'dark');


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-59002

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
By default, ODH dashboard’s theme is set to light mode. If a user's OS theme preference is set to dark mode, MLflow renders in dark mode and persists this to localStorage (_mlflow_dark_mode_toggle_enabled: true). This causes a mismatch in federated mode. 

The fix adds a mount-time `useEffect` in `ThemeProvider` that explicitly writes `_mlflow_dark_mode_toggle_enabled` to localStorage to match ODH's theme. This ensures the key exists before the MLflow remote reads it via `loadRemote`. Subsequent theme changes are already handled by `setAllThemes`.

The change is idempotent for existing users since they already have the key in localStorage from prior `setAllThemes` calls.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Cleared all localStorage keys (`odh.dashboard.ui.theme` and `_mlflow_dark_mode_toggle_enabled`).
2. Set OS to dark mode.
3. Loaded the dashboard, verified both ODH and MLflow render in light mode (ODH's default).
4. Toggled the theme to dark, verified both ODH and MLflow switch to dark.
5. Refreshed, verified both stay in dark.
6. Toggled back to light, refreshed, both stay in light.


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
