### PR TITLE
Fix(RHOAIENG-58940) :Added fix for pause to be disabled for clusterselector ray job

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelTraining/modelTrainingRayJobs.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelTraining/modelTrainingRayJobs.cy.ts
@@ -1088,6 +1088,17 @@ describe('RayJob Pause/Resume - Table Toggle', () => {
     trainingJobTable.getTableRow('ray-completed-job').findPauseResumeToggle().should('not.exist');
     trainingJobTable.getTableRow('ray-failed-job').findPauseResumeToggle().should('not.exist');
   });
+
+  it('should disable Pause toggle and kebab action for clusterSelector RayJob', () => {
+    modelTrainingGlobal.visit(projectName);
+    trainingJobTable.filterByName('ray-workspace-job');
+
+    const row = trainingJobTable.getTableRow('ray-workspace-job');
+    row.findPauseResumeToggle().should('be.disabled');
+
+    row.findKebabButton().click();
+    row.findKebabMenuItem('Pause job').should('have.attr', 'aria-disabled', 'true');
+  });
 });
 
 describe('RayJob Pause/Resume - Pause Modal', () => {
@@ -1259,6 +1270,18 @@ describe('RayJob Pause/Resume - Drawer Kebab Menu', () => {
     rayJobDetailsDrawer.findKebabMenuItem('Pause job').click();
 
     pauseRayJobModal.shouldBeOpen();
+  });
+
+  it('should show Pause job as aria-disabled in drawer kebab for clusterSelector RayJob', () => {
+    modelTrainingGlobal.visit(projectName);
+    trainingJobTable.filterByName('ray-workspace-job');
+
+    const row = trainingJobTable.getTableRow('ray-workspace-job');
+    row.findNameLink().click();
+
+    rayJobDetailsDrawer.shouldBeOpen();
+    rayJobDetailsDrawer.clickKebabMenu();
+    rayJobDetailsDrawer.findKebabMenuItem('Pause job').should('have.attr', 'aria-disabled', 'true');
   });
 });
 

--- a/packages/model-training/src/const.ts
+++ b/packages/model-training/src/const.ts
@@ -3,4 +3,4 @@ export const TRAINER_STATUS_ANNOTATION = 'trainer.opendatahub.io/trainerStatus';
 export const KUEUE_QUEUE_LABEL = 'kueue.x-k8s.io/queue-name';
 export const RAY_CLUSTER_SELECTOR_LABEL = 'ray.io/cluster';
 export const PAUSE_RAY_JOB_TOOLTIP_CONTENT =
-  'Pause is not available for Ray jobs without a dedicated cluster';
+  'Pause is only available for Ray jobs with a dedicated Ray cluster.';

--- a/packages/model-training/src/const.ts
+++ b/packages/model-training/src/const.ts
@@ -1,3 +1,6 @@
 export const KUEUE_MANAGED_LABEL = 'kueue.openshift.io/managed';
 export const TRAINER_STATUS_ANNOTATION = 'trainer.opendatahub.io/trainerStatus';
 export const KUEUE_QUEUE_LABEL = 'kueue.x-k8s.io/queue-name';
+export const RAY_CLUSTER_SELECTOR_LABEL = 'ray.io/cluster';
+export const PAUSE_RAY_JOB_TOOLTIP_CONTENT =
+  'Pause is not available for Ray jobs without a dedicated cluster';

--- a/packages/model-training/src/global/rayJobDetailsDrawer/RayJobDetailsDrawer.tsx
+++ b/packages/model-training/src/global/rayJobDetailsDrawer/RayJobDetailsDrawer.tsx
@@ -28,6 +28,7 @@ import { getStatusFlags, getRayJobStatusSync } from '../trainingJobList/utils';
 import { useRayJobNodeScaling } from '../../hooks/useRayJobNodeScaling';
 import { RayJobKind } from '../../k8sTypes';
 import { JobDisplayState, RayJobState, TrainingJobState } from '../../types';
+import { PAUSE_RAY_JOB_TOOLTIP_CONTENT, RAY_CLUSTER_SELECTOR_LABEL } from '../../const';
 
 type RayJobDetailsDrawerProps = {
   job: RayJobKind | undefined;
@@ -55,6 +56,7 @@ const RayJobDetailsDrawer: React.FC<RayJobDetailsDrawerProps> = ({
 
   const status = job ? jobStatus || getRayJobStatusSync(job) : TrainingJobState.UNKNOWN;
   const { isPaused, canPauseResume } = getStatusFlags(status);
+  const isClusterSelectorJob = !!job?.spec.clusterSelector?.[RAY_CLUSTER_SELECTOR_LABEL];
 
   const {
     workerGroupReplicas,
@@ -131,8 +133,18 @@ const RayJobDetailsDrawer: React.FC<RayJobDetailsDrawerProps> = ({
                     {canPauseResume && (
                       <DropdownItem
                         key="pause-resume"
-                        isDisabled={isSubmitting}
+                        isAriaDisabled={isSubmitting || isClusterSelectorJob}
+                        tooltipProps={
+                          isClusterSelectorJob
+                            ? {
+                                content: PAUSE_RAY_JOB_TOOLTIP_CONTENT,
+                              }
+                            : undefined
+                        }
                         onClick={() => {
+                          if (isClusterSelectorJob) {
+                            return;
+                          }
                           setIsKebabOpen(false);
                           if (isPaused) {
                             void handleResume();

--- a/packages/model-training/src/global/trainingJobList/RayJobStatusModal.tsx
+++ b/packages/model-training/src/global/trainingJobList/RayJobStatusModal.tsx
@@ -15,6 +15,7 @@ type RayJobStatusModalProps = {
   onPauseClick?: () => void;
   onResumeClick?: () => void;
   isToggling?: boolean;
+  isPauseDisabled?: boolean;
 };
 
 const RayJobStatusModal: React.FC<RayJobStatusModalProps> = ({
@@ -25,6 +26,7 @@ const RayJobStatusModal: React.FC<RayJobStatusModalProps> = ({
   onPauseClick,
   onResumeClick,
   isToggling = false,
+  isPauseDisabled = false,
 }) => {
   const status = jobStatus ?? getRayJobStatusSync(job);
   const { isPaused, isComplete, isDeleting, canPauseResume } = getStatusFlags(status);
@@ -75,7 +77,7 @@ const RayJobStatusModal: React.FC<RayJobStatusModalProps> = ({
       onClick: (isPaused ? onResumeClick : onPauseClick) ?? onClose,
       variant: 'primary',
       dataTestId: isPaused ? 'resume-job-button' : 'pause-job-button',
-      isDisabled: isToggling,
+      isDisabled: isToggling || isPauseDisabled,
       isLoading: isToggling,
     });
   }

--- a/packages/model-training/src/global/trainingJobList/RayJobTableRow.tsx
+++ b/packages/model-training/src/global/trainingJobList/RayJobTableRow.tsx
@@ -19,7 +19,11 @@ import StateActionToggle from './StateActionToggle';
 import { getStatusFlags, getRayJobStatusSync } from './utils';
 import PauseRayJobModal from './PauseRayJobModal';
 import { useRayJobPauseResume } from './hooks/useRayJobPauseResume';
-import { KUEUE_QUEUE_LABEL } from '../../const';
+import {
+  KUEUE_QUEUE_LABEL,
+  PAUSE_RAY_JOB_TOOLTIP_CONTENT,
+  RAY_CLUSTER_SELECTOR_LABEL,
+} from '../../const';
 import { RayJobKind } from '../../k8sTypes';
 import { JobDisplayState, RayJobState } from '../../types';
 import { useRayClusterDashboardURL } from '../../hooks/useRayClusterDashboardURL';
@@ -50,6 +54,7 @@ const RayJobTableRow: React.FC<RayJobTableRowProps> = ({
   const displayName = job.metadata.name;
   const localQueueName = job.metadata.labels?.[KUEUE_QUEUE_LABEL];
   const { isPaused, canPauseResume } = getStatusFlags(jobStatus ?? getRayJobStatusSync(job));
+  const isClusterSelectorJob = !!job.spec.clusterSelector?.[RAY_CLUSTER_SELECTOR_LABEL];
   const [statusModalOpen, setStatusModalOpen] = React.useState(false);
 
   const {
@@ -94,7 +99,13 @@ const RayJobTableRow: React.FC<RayJobTableRowProps> = ({
       items.push({
         title: isPaused ? 'Resume job' : 'Pause job',
         isDisabled: isSubmitting || isExternallyToggling,
-        onClick: isPaused ? handleResume : onPauseClick,
+        isAriaDisabled: isClusterSelectorJob,
+        ...(isClusterSelectorJob && {
+          tooltipProps: {
+            content: PAUSE_RAY_JOB_TOOLTIP_CONTENT,
+          },
+        }),
+        onClick: isClusterSelectorJob ? undefined : isPaused ? handleResume : onPauseClick,
       });
     }
 
@@ -120,6 +131,7 @@ const RayJobTableRow: React.FC<RayJobTableRowProps> = ({
     onPauseClick,
     isSubmitting,
     isExternallyToggling,
+    isClusterSelectorJob,
     canEditNodes,
     setModalOpen,
     job,
@@ -228,12 +240,21 @@ const RayJobTableRow: React.FC<RayJobTableRowProps> = ({
         </Td>
         <Td>
           {canPauseResume && (
-            <StateActionToggle
-              isPaused={isPaused}
-              onPause={onPauseClick}
-              onResume={handleResume}
-              isLoading={isSubmitting || isExternallyToggling}
-            />
+            <Tooltip
+              content={PAUSE_RAY_JOB_TOOLTIP_CONTENT}
+              trigger={isClusterSelectorJob ? 'mouseenter focus' : ''}
+              aria={isClusterSelectorJob ? 'describedby' : 'none'}
+            >
+              <span>
+                <StateActionToggle
+                  isPaused={isPaused}
+                  onPause={onPauseClick}
+                  onResume={handleResume}
+                  isLoading={isSubmitting || isExternallyToggling}
+                  isDisabled={isClusterSelectorJob}
+                />
+              </span>
+            </Tooltip>
           )}
         </Td>
         <Td isActionCell>

--- a/packages/model-training/src/global/trainingJobList/RayJobTableRow.tsx
+++ b/packages/model-training/src/global/trainingJobList/RayJobTableRow.tsx
@@ -291,6 +291,7 @@ const RayJobTableRow: React.FC<RayJobTableRowProps> = ({
             handleResume();
           }}
           isToggling={isSubmitting}
+          isPauseDisabled={isClusterSelectorJob}
         />
       )}
 

--- a/packages/model-training/src/global/trainingJobList/StateActionToggle.tsx
+++ b/packages/model-training/src/global/trainingJobList/StateActionToggle.tsx
@@ -6,6 +6,7 @@ export type StateActionToggleProps = {
   onPause: () => void;
   onResume: () => void;
   isLoading?: boolean;
+  isDisabled?: boolean;
 };
 
 const StateActionToggle: React.FC<StateActionToggleProps> = ({
@@ -13,6 +14,7 @@ const StateActionToggle: React.FC<StateActionToggleProps> = ({
   onPause,
   onResume,
   isLoading = false,
+  isDisabled = false,
 }) => {
   return (
     <Button
@@ -20,7 +22,7 @@ const StateActionToggle: React.FC<StateActionToggleProps> = ({
       variant="link"
       onClick={isPaused ? onResume : onPause}
       isInline
-      isDisabled={isLoading}
+      isDisabled={isLoading || isDisabled}
       isLoading={isLoading}
     >
       {isPaused ? 'Resume' : 'Pause'}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-58940](https://redhat.atlassian.net/browse/RHOAIENG-58940)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="1591" height="941" alt="Screenshot 2026-04-22 at 4 23 03 PM" src="https://github.com/user-attachments/assets/993d3009-6825-429f-b64e-a45e5862caee" />
Fig : Pause disabled in the table 

<img width="1863" height="940" alt="Screenshot 2026-04-22 at 4 26 45 PM" src="https://github.com/user-attachments/assets/7e3ab816-e48f-499c-958d-ae2ba7cdb963" />

Fig : Pause disabled in the table kebab menu
 
<img width="1598" height="940" alt="Screenshot 2026-04-22 at 4 28 04 PM" src="https://github.com/user-attachments/assets/6ac40cce-c36c-4568-937f-6af83c7257e0" />

Fig : Pause disabled in the Drawer kebab menu 

<img width="1160" height="695" alt="image" src="https://github.com/user-attachments/assets/9ba4eec1-ded5-4e4b-acc7-b932e245f296" />

Fig : Disable pause in the status modal



Disables the Pause action for RayJobs that target a shared cluster via `clusterSelector`.
When a RayJob uses `clusterSelector`, setting `spec.suspend: true` is silently ignored by KubeRay as it cannot delete a cluster it doesn't own, so the job keeps running while the UI shows it as paused. This is a [known upstream limitation](https://github.com/ray-project/kuberay/pull/926).

 A fix has been proposed [here](https://github.com/ray-project/kuberay/issues/4740) 


RayJobs have two modes:
- **`rayClusterSpec`** — the job owns its cluster. Pause works: KubeRay deletes the cluster to stop the job.
- **`clusterSelector`** — the job targets an existing cluster. Pause has no effect.
We detect the second case by checking for the `ray.io/cluster` key inside `spec.clusterSelector` on the RayJob CR:
```yaml
# clusterSelector job — Pause is disabled
spec:
  clusterSelector:
    ray.io/cluster: my-shared-cluster
```
<img width="1253" height="824" alt="Screenshot 2026-04-22 at 4 30 16 PM" src="https://github.com/user-attachments/assets/de4607e1-272d-4f57-a446-8568628d0bbb" />
Fig : clusterSelector present for `rayjob-cluster-selector` on the cluster


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created two RayJobs to compare behaviour side by side:
| Job | Mode | Pause action |
|-----|------|-------------|
| `rayjob-inline-running` | `rayClusterSpec` (dedicated cluster) | Enabled — Pause/Resume works |
| `rayjob-cluster-selector` | `clusterSelector` (shared cluster) | Disabled — tooltip shown on hover |

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Added cypress test cases 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

@kywalker-rh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause/resume controls for Ray jobs without a dedicated cluster are disabled across table, row menu, and details drawer, with a tooltip explaining the limitation; related modals and toggles respect this disabled state.

* **Tests**
  * Added Cypress tests verifying pause is non-interactive for cluster-selector Ray jobs in both list and details views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->