### PR TITLE
fix: Use full page navigation for OIDC logout instead of AJAX fetch (…

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -125,10 +125,7 @@ const App: React.FC = () => {
               </Alert>
             </StackItem>
             <StackItem>
-              <Button
-                variant="secondary"
-                onClick={() => logout().then(() => window.location.reload())}
-              >
+              <Button variant="secondary" onClick={() => logout()}>
                 Logout
               </Button>
             </StackItem>

--- a/frontend/src/app/HeaderTools.tsx
+++ b/frontend/src/app/HeaderTools.tsx
@@ -60,11 +60,7 @@ const HeaderTools: React.FC<Props> = ({ onNotificationsClick, ...devFeatureFlags
 
   const handleLogout = () => {
     setUserMenuOpen(false);
-    logout().then(() => {
-      /* eslint-disable-next-line no-console */
-      console.log('logged out');
-      window.location.reload();
-    });
+    logout();
   };
 
   const userMenuItems = [

--- a/frontend/src/app/SessionExpiredModal.tsx
+++ b/frontend/src/app/SessionExpiredModal.tsx
@@ -28,7 +28,7 @@ const SessionExpiredModal: React.FC = () => (
         data-testid="modal-login-button"
         key="confirm"
         variant="primary"
-        onClick={() => logout().then(() => window.location.reload())}
+        onClick={() => logout()}
       >
         Log in
       </Button>

--- a/frontend/src/app/appUtils.ts
+++ b/frontend/src/app/appUtils.ts
@@ -1,3 +1,11 @@
-export const logout = (): Promise<unknown> =>
-  /* eslint-disable-next-line no-console */
-  fetch('/oauth2/sign_out').catch((err) => console.error('Error logging out', err));
+import { DEV_MODE } from '#~/utilities/const';
+
+export const logout = (): void => {
+  if (DEV_MODE) {
+    /* eslint-disable-next-line no-console */
+    console.log('you have been logged out in dev mode');
+    window.location.reload();
+    return;
+  }
+  window.location.href = '/oauth2/sign_out';
+};

--- a/frontend/src/app/useTimeBasedRefresh.ts
+++ b/frontend/src/app/useTimeBasedRefresh.ts
@@ -33,8 +33,8 @@ const useTimeBasedRefresh = (): SetTime => {
     lastDate.setHours(lastDate.getHours() + 1);
     if (lastDate < refreshDateMarker) {
       setNewDateString(refreshDateMarker.toString());
-      console.log('Logging out and refreshing');
-      logout().then(() => window.location.reload());
+      console.log('Logging out and redirecting');
+      logout();
     } else {
       console.error(
         `We should have refreshed but it appears the last time we auto-refreshed was less than an hour ago. '${KEY_NAME}' session storage setting can be cleared for this to refresh again within the hour from the last refresh.`,


### PR DESCRIPTION
…#7083)

The dashboard used fetch('/oauth2/sign_out') (AJAX) to trigger logout. When kube-auth-proxy responds with a 302 redirect to the IdP's end_session_endpoint (e.g. Microsoft Entra ID), the browser blocks the cross-origin redirect due to CORS policy. This prevents the IdP session from being terminated, causing immediate re-authentication.

Replace fetch() with window.location.href to perform a full page navigation, allowing the browser to follow the 302 redirect chain to the IdP logout page and back.

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
