### PR TITLE
fix: rename odh-u-spin to ai-u-spin from mod arch library

### DIFF
--- a/.claude/rules/css-patternfly.md
+++ b/.claude/rules/css-patternfly.md
@@ -89,10 +89,11 @@ Follow the project's BEM-like convention. Custom block-level classes must be nam
 
 | Type | Pattern | Example |
 |------|---------|---------|
-| Block | `{prefix}-{name}` | `odh-card`, `autorag-leaderboard` |
-| Element | `{prefix}-{block}__{element}` | `odh-card__footer`, `autorag-leaderboard__header` |
-| Modifier | `m-{modifier}` or `{prefix}-m-{modifier}` | `m-disabled`, `m-is-selected`, `odh-m-doc` |
-| Utility | `{prefix}-u-{name}` | `odh-u-spin`, `odh-u-scrollable` |
+| Block | `odh-{name}` | `odh-card`, `odh-list-item` |
+| Element | `odh-{block}__{element}` | `odh-card__footer`, `odh-list-item__doc-text` |
+| Modifier | `m-{modifier}` or `odh-m-{modifier}` | `m-disabled`, `m-is-selected`, `odh-m-doc` |
+| Utility | `odh-u-{name}` | `odh-u-scrollable` |
+| Shared utility | `ai-u-{name}` | `ai-u-spin` (from mod-arch-shared) |
 
 ## PF Component Overrides
 

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -23,7 +23,7 @@ body,
   }
 }
 
-.odh-u-spin {
+.ai-u-spin {
   animation: pf-v6-c-spinner-animation-rotate 3s linear infinite;
 }
 

--- a/frontend/src/concepts/kueue/__tests__/index.spec.ts
+++ b/frontend/src/concepts/kueue/__tests__/index.spec.ts
@@ -358,7 +358,7 @@ describe('getKueueStatusInfo', () => {
     const info = getKueueStatusInfo(KueueWorkloadStatus.Admitted);
     expect(info.label).toBe('Starting');
     expect(info.color).toBe('blue');
-    expect(info.iconClassName).toBe('odh-u-spin');
+    expect(info.iconClassName).toBe('ai-u-spin');
   });
 
   it('should return correct info for Complete', () => {

--- a/frontend/src/concepts/kueue/index.ts
+++ b/frontend/src/concepts/kueue/index.ts
@@ -149,7 +149,7 @@ export const getKueueStatusInfo = (status: KueueWorkloadStatus): KueueStatusInfo
         label: 'Starting',
         color: 'blue',
         IconComponent: InProgressIcon,
-        iconClassName: 'odh-u-spin',
+        iconClassName: 'ai-u-spin',
       };
     case KueueWorkloadStatus.Complete:
       return {

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -50,7 +50,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       return {
         label: 'Stopping',
         color: 'grey',
-        icon: <InProgressIcon className="odh-u-spin" />,
+        icon: <InProgressIcon className="ai-u-spin" />,
         message: 'Model deployment is stopping.',
       };
     }
@@ -63,7 +63,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       return {
         label: 'Starting',
         color: 'blue',
-        icon: <InProgressIcon className="odh-u-spin" />,
+        icon: <InProgressIcon className="ai-u-spin" />,
         message: 'Model deployment is starting.',
       };
     }
@@ -81,7 +81,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         return {
           label: 'Starting',
           color: 'blue',
-          icon: <InProgressIcon className="odh-u-spin" />,
+          icon: <InProgressIcon className="ai-u-spin" />,
           message: 'Model deployment is starting.',
         };
       case ModelDeploymentState.FAILED_TO_LOAD:

--- a/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
+++ b/frontend/src/concepts/notebooks/NotebookStatusLabel.tsx
@@ -54,7 +54,7 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
       return {
         label: 'Stopping',
         color: 'grey',
-        icon: <InProgressIcon className="odh-u-spin" />,
+        icon: <InProgressIcon className="ai-u-spin" />,
       };
     }
     if (kueueStatus?.status && KUEUE_STATUSES_OVERRIDE_WORKBENCH.includes(kueueStatus.status)) {
@@ -70,7 +70,7 @@ const NotebookStatusLabel: React.FC<NotebookStateStatusProps> = ({
       return {
         label: 'Starting',
         color: 'blue',
-        icon: <InProgressIcon className="odh-u-spin" />,
+        icon: <InProgressIcon className="ai-u-spin" />,
       };
     }
     if (isRunning) {

--- a/frontend/src/concepts/notebooks/StartNotebookModal.tsx
+++ b/frontend/src/concepts/notebooks/StartNotebookModal.tsx
@@ -203,7 +203,7 @@ const StartNotebookModal: React.FC<StartNotebookModalProps> = ({
         <Flex gap={{ default: 'gapSm' }}>
           {(!spawnStatus || spawnStatus.status === AlertVariant.info) && inProgress ? (
             <FlexItem>
-              <InProgressIcon style={{ color: BrandIconColor.var }} className="odh-u-spin" />
+              <InProgressIcon style={{ color: BrandIconColor.var }} className="ai-u-spin" />
             </FlexItem>
           ) : null}
           <FlexItem>

--- a/frontend/src/concepts/pipelines/content/PipelineComponentStatusIcon.tsx
+++ b/frontend/src/concepts/pipelines/content/PipelineComponentStatusIcon.tsx
@@ -28,7 +28,7 @@ const STATUS_CONFIG: Record<StatusType, StatusConfig> = {
   },
   [StatusType.IN_PROGRESS]: {
     icon: InProgressIcon,
-    className: 'odh-u-spin',
+    className: 'ai-u-spin',
   },
   [StatusType.SUCCESS]: {
     icon: CheckCircleIcon,

--- a/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
+++ b/frontend/src/pages/modelRegistrySettings/ModelRegistryTableRowStatus.tsx
@@ -76,7 +76,7 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     // Degrading
     else if (degradedCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Degrading;
-      icon = <InProgressIcon className="odh-u-spin" />;
+      icon = <InProgressIcon className="ai-u-spin" />;
       popoverTitle = 'Service is degrading';
     }
     // Available
@@ -88,7 +88,7 @@ export const ModelRegistryTableRowStatus: React.FC<ModelRegistryTableRowStatusPr
     // Progressing
     else if (progressCondition?.status === ConditionStatus.True) {
       statusLabel = ModelRegistryStatusLabel.Progressing;
-      icon = <InProgressIcon className="odh-u-spin" />;
+      icon = <InProgressIcon className="ai-u-spin" />;
       status = 'info';
     }
   }

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookImageDisplayName.tsx
@@ -320,7 +320,7 @@ export const NotebookImageDisplayName = ({
           <FlexItem>
             <Tooltip content="Updating version" data-testid="updating-image-icon-tooltip">
               <InProgressIcon
-                className="odh-u-spin"
+                className="ai-u-spin"
                 style={{ cursor: 'pointer' }}
                 data-testid="updating-image-icon"
               />

--- a/packages/automl/frontend/package-lock.json
+++ b/packages/automl/frontend/package-lock.json
@@ -25,8 +25,8 @@
         "dompurify": "^3.4.1",
         "es-toolkit": "^1.44.0",
         "lodash-es": "^4.17.15",
-        "mod-arch-core": "^1.6.0",
-        "mod-arch-shared": "^1.5.0",
+        "mod-arch-core": "^1.15.4",
+        "mod-arch-shared": "^1.15.4",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.71.1",
@@ -2333,7 +2333,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2346,7 +2345,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2362,7 +2360,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2377,7 +2374,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -2392,7 +2388,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -4377,7 +4372,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.5.tgz",
       "integrity": "sha512-kOLwlcDPnVz2QMhiBv0OQ8le8hTCqKM9cRXlfVPL91l3RGeOsxrIhNRsUt3Xb8wb+pTVUolW+JXKym93vRKxCw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4415,7 +4409,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.5.tgz",
       "integrity": "sha512-8VVxFmp1GIm9PpmnQoCoYo0UWHoOrdA57tDL62vkpzEgvb/d71Wsbv4FRg7r1Gyx7PuSo0tflH34cdl/NvfHNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4465,7 +4458,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.5.tgz",
       "integrity": "sha512-cTx584W2qrLonwhZLbEN7P5pAUu0nZblg8cLBlTrZQ4sIiw8Fbvg7GvuphQaSHxPxrCpa7FDwJKtXdbl2TSmrA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4493,7 +4485,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.5.tgz",
       "integrity": "sha512-zbsZ0uYYPndFCCPp2+V3RLcAN6+fv4C8pdwRx6OS3BwDkRCN8WBehqks7hWyF3vj1kdQLIWrpdv/5Y0jHRxYXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4528,7 +4519,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.5.tgz",
       "integrity": "sha512-yPaf5+gY3v80HNkJcPi6WT+r9ebeM4eJzrREXPxMt7pNTV/1eahyODO4fbH3Qvd8irNxDFYn5RQ3idHW55rA6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4569,7 +4559,6 @@
       "version": "7.4.8",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.8.tgz",
       "integrity": "sha512-ZNXLBjkPV6ftLCmmRCafak3XmSn8YV0tKE/ZOhzKys7TZXUiE0mZxlH8zKDo6j6TTUaDnuij68gIG+0Ucm7Xhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4"
@@ -4587,7 +4576,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.5.tgz",
       "integrity": "sha512-jisvFsEC3sgjUjcPnR4mYfhzjCDIudttSGSbe1o/IXFNu0kZuR+7vqQI0jg8qtcVZBHWrwTfvAZj9MNMumcq1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -5085,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-drag-drop/-/react-drag-drop-6.4.1.tgz",
       "integrity": "sha512-+zkN+6JO/6qPKb1srsKyC4OpeF/dgQvZ0U4soXeh/n22n2YVcrH9QAUGn1QBB7FmLiAoATHB9vr1awafF5HIYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -5275,7 +5262,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6538,7 +6524,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -6559,7 +6544,6 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6581,7 +6565,6 @@
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -9327,7 +9310,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11110,7 +11092,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -18366,9 +18347,9 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.15.3.tgz",
-      "integrity": "sha512-9DOdYqE7FFCciVJi2Ru9mL99/t87vVYFMAAHfLTfhmr1AS/JOPFpVFEn3NtTKAnKRxmOvUt8annx0o7YZkiFtQ==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.15.4.tgz",
+      "integrity": "sha512-FUsm9FIn0EyvwuoPvg6Dj3D54CejUblnAiSfwov9WPwAjDbJrV5DP6oqBReVfsrbV1QZHPjdA2Z5a0jmznTPqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.18.1",
@@ -18398,16 +18379,48 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/mod-arch-kubeflow": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.15.4.tgz",
+      "integrity": "sha512-P356bPOu5sVRcJV5EykKj6GpOoyNk0ya+LaUMpzSUAVHvEN1rrBij1/Cm7GdxIP1gkx4zhf3BkGDXVvdtQMv3A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.26.1",
+        "@typescript-eslint/parser": "^8.26.1",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-typescript": "^3.8.3",
+        "eslint-plugin-cypress": "^3.3.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-no-only-tests": "^3.1.0",
+        "eslint-plugin-no-relative-import-paths": "^1.6.1",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react-hooks": "^5.2.0"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.4",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0"
+      }
+    },
     "node_modules/mod-arch-shared": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.9.1.tgz",
-      "integrity": "sha512-6EiMY683gxYwanRmnmiFPJnalx9MWR8UGxO1DYW/GKypuF9gp4xiQiArcYmyRFYINSIctRDgJ41m9H1pLVLveg==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.15.4.tgz",
+      "integrity": "sha512-BJ3hB+4uf5pWV8vYuBAwGOz1Z1mbUV06BtgHPl3AVCgwNRbzWzb2vRpYagYsInsY1ugIR2gXH+xnpbrf0pzZeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.4.0",
+        "@patternfly/react-drag-drop": "^6.4.0",
         "classnames": "^2.2.6",
-        "dompurify": "^3.2.4",
-        "lodash-es": "^4.17.15",
+        "dompurify": "^3.3.2",
+        "lodash-es": "^4.18.1",
         "showdown": "^2.1.0"
       },
       "engines": {
@@ -18430,6 +18443,8 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
+        "mod-arch-core": ">=1.15.4",
+        "mod-arch-kubeflow": ">=1.15.4",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"
@@ -20972,7 +20987,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-jss": {
@@ -21064,7 +21078,6 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -21402,8 +21415,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/packages/automl/frontend/package.json
+++ b/packages/automl/frontend/package.json
@@ -113,7 +113,7 @@
     "es-toolkit": "^1.44.0",
     "lodash-es": "^4.17.15",
     "mod-arch-core": "^1.6.0",
-    "mod-arch-shared": "^1.5.0",
+    "mod-arch-shared": "^1.15.4",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.71.1",

--- a/packages/automl/frontend/package.json
+++ b/packages/automl/frontend/package.json
@@ -112,7 +112,7 @@
     "dompurify": "^3.4.1",
     "es-toolkit": "^1.44.0",
     "lodash-es": "^4.17.15",
-    "mod-arch-core": "^1.6.0",
+    "mod-arch-core": "^1.15.4",
     "mod-arch-shared": "^1.15.4",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/autorag/frontend/package-lock.json
+++ b/packages/autorag/frontend/package-lock.json
@@ -27,8 +27,8 @@
         "dompurify": "^3.4.0",
         "echarts": "^5.6.0",
         "es-toolkit": "^1.44.0",
-        "mod-arch-core": "^1.6.0",
-        "mod-arch-shared": "^1.5.0",
+        "mod-arch-core": "^1.15.4",
+        "mod-arch-shared": "^1.15.4",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.71.1",
@@ -18438,12 +18438,12 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.11.0.tgz",
-      "integrity": "sha512-QFHobWbeiE69D/RFCfNmbug64xHt/2lyGBP0kV4FvgyIQ2slpNuB8fWcjpmI549cD2QukPvaxsVAlou307hFWw==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.15.4.tgz",
+      "integrity": "sha512-FUsm9FIn0EyvwuoPvg6Dj3D54CejUblnAiSfwov9WPwAjDbJrV5DP6oqBReVfsrbV1QZHPjdA2Z5a0jmznTPqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.23",
+        "lodash-es": "^4.18.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18471,9 +18471,9 @@
       }
     },
     "node_modules/mod-arch-kubeflow": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.11.0.tgz",
-      "integrity": "sha512-NY6DEq9huV04z9X0chvkKkNl+4ZE3AKM9SG0XkaZQDTUst7xcYfPrCRlqbi3JYjEH66NCrb+T++UxkS2asGSPw==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.15.4.tgz",
+      "integrity": "sha512-P356bPOu5sVRcJV5EykKj6GpOoyNk0ya+LaUMpzSUAVHvEN1rrBij1/Cm7GdxIP1gkx4zhf3BkGDXVvdtQMv3A==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -18502,16 +18502,16 @@
       }
     },
     "node_modules/mod-arch-shared": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.11.0.tgz",
-      "integrity": "sha512-iWlrba4Gd5WJdRP9L8gHcWu2c4xaNGRFkF+8uyu7a6Ajq99RIFRe5muBIN5u2lwo2ixE6ZGBQx9ex65Blep+fA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.15.4.tgz",
+      "integrity": "sha512-BJ3hB+4uf5pWV8vYuBAwGOz1Z1mbUV06BtgHPl3AVCgwNRbzWzb2vRpYagYsInsY1ugIR2gXH+xnpbrf0pzZeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-drag-drop": "^6.4.0",
         "classnames": "^2.2.6",
-        "dompurify": "^3.2.4",
-        "lodash-es": "^4.17.23",
+        "dompurify": "^3.3.2",
+        "lodash-es": "^4.18.1",
         "showdown": "^2.1.0"
       },
       "engines": {
@@ -18534,8 +18534,8 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
-        "mod-arch-core": ">=1.11.0",
-        "mod-arch-kubeflow": ">=1.11.0",
+        "mod-arch-core": ">=1.15.4",
+        "mod-arch-kubeflow": ">=1.15.4",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"

--- a/packages/autorag/frontend/package.json
+++ b/packages/autorag/frontend/package.json
@@ -115,7 +115,7 @@
     "echarts": "^5.6.0",
     "es-toolkit": "^1.44.0",
     "mod-arch-core": "^1.6.0",
-    "mod-arch-shared": "^1.5.0",
+    "mod-arch-shared": "^1.15.4",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.71.1",

--- a/packages/autorag/frontend/package.json
+++ b/packages/autorag/frontend/package.json
@@ -114,7 +114,7 @@
     "dompurify": "^3.4.0",
     "echarts": "^5.6.0",
     "es-toolkit": "^1.44.0",
-    "mod-arch-core": "^1.6.0",
+    "mod-arch-core": "^1.15.4",
     "mod-arch-shared": "^1.15.4",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationStatusLabel.tsx
@@ -48,7 +48,7 @@ const statusMap: Record<EvaluationJobState, StatusConfig> = {
   stopping: {
     label: 'Canceling',
     color: 'grey',
-    icon: <InProgressIcon className="odh-u-spin" />,
+    icon: <InProgressIcon className="ai-u-spin" />,
   },
   stopped: {
     label: 'Stopped',

--- a/packages/gen-ai/frontend/package-lock.json
+++ b/packages/gen-ai/frontend/package-lock.json
@@ -19,8 +19,8 @@
         "@patternfly/react-templates": "^6.3.1",
         "@tanstack/react-query": "^5.62.0",
         "immer": "^11.1.3",
-        "mod-arch-core": "^1.2.0",
-        "mod-arch-shared": "^1.2.0",
+        "mod-arch-core": "^1.15.4",
+        "mod-arch-shared": "^1.15.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router": "^7.12.0",
@@ -1964,9 +1964,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2194,6 +2194,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4201,6 +4268,234 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.10.tgz",
+      "integrity": "sha512-vrOpWRmPJSuwLo23J62wggEm/jvGdzqctej+UOCtgDUz6nZJQuj3ByPccVyaa7eQmwAzUwKN56FQPMKkqbj1GA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz",
+      "integrity": "sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/core-downloads-tracker": "^7.3.10",
+        "@mui/system": "^7.3.10",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.10",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.3.10",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.10.tgz",
+      "integrity": "sha512-j3EZN+zOctxUISvJSmsEPo5o2F8zse4l5vRkBY+ps6UtnL6J7o14kUaI4w7gwo73id9e3cDNMVQK/9BVaMHVBw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "^7.3.10",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
+      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
+      "integrity": "sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/private-theming": "^7.3.10",
+        "@mui/styled-engine": "^7.3.10",
+        "@mui/types": "^7.4.12",
+        "@mui/utils": "^7.3.10",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.3.10",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz",
+      "integrity": "sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
@@ -4664,9 +4959,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.3.1.tgz",
-      "integrity": "sha512-O/lTo5EHKzer/HNzqMQOQEAMG7izDDkEHpAeJ5+sGaeQ/maB3RK7sQsOPS4DjrnMxt4/cC6LogK2mowlbf1j5Q==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.4.0.tgz",
+      "integrity": "sha512-4drFhg74sEc/fftark5wZevODIog17qR4pwLCdB3j5iK3Uu5oMA2SdLhsEeEQggalfnFzve/Km87MdVR0ghhvQ==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-code-editor": {
@@ -4688,14 +4983,14 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.3.1.tgz",
-      "integrity": "sha512-1qV20nU4M6PA28qnikH9fPLQlkteaZZToFlATjBNBw7aUI6zIvj7U0akkHz8raWcfHAI+tAzGV7dfKjiv035/g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.3.tgz",
+      "integrity": "sha512-CYf+DFmcV5LCTQh7ZNBhHgqaEbDKwKOxBB/3Si6xFn8fIH8h/Wj3ZHSm6rYslQS7dJUusqyv5gJ2dR9LixT3TA==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^6.3.1",
-        "@patternfly/react-styles": "^6.3.1",
-        "@patternfly/react-tokens": "^6.3.1",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-tokens": "^6.4.0",
         "focus-trap": "7.6.4",
         "react-dropzone": "^14.3.5",
         "tslib": "^2.8.1"
@@ -4705,10 +5000,29 @@
         "react-dom": "^17 || ^18 || ^19"
       }
     },
+    "node_modules/@patternfly/react-drag-drop": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-drag-drop/-/react-drag-drop-6.4.3.tgz",
+      "integrity": "sha512-O8W4KPc3AGIATXpDPirkSr5D25ajDikFvalOlIBCDmWG7CE4E+LLe+x/t2UmQFY59JeoALFMIzrNJtHlozBuTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@patternfly/react-core": "^6.4.3",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.1.tgz",
-      "integrity": "sha512-uiMounSIww1iZLM4pq+X8c3upzwl9iowXRPjR5CA8entb70lwgAXg3PqvypnuTAcilTq1Y3k5sFTqkhz7rgKcQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.4.0.tgz",
+      "integrity": "sha512-SPjzatm73NUYv/BL6A/cjRA5sFQ15NkiyPAcT8gmklI7HY+ptd6/eg49uBDFmxTQcSwbb5ISW/R6wwCQBY2M+Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
@@ -4716,9 +5030,9 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.1.tgz",
-      "integrity": "sha512-hyb+PlO8YITjKh2wBvjdeZhX6FyB3hlf4r6yG4rPOHk4SgneXHjNSdGwQ3szAxgGqtbENCYtOqwD/8ai72GrxQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
+      "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
@@ -4757,9 +5071,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.3.1.tgz",
-      "integrity": "sha512-wt/xKU1tGCDXUueFb+8/Cwxlm4vUD/Xl26O8MxbSLm6NZAHOUPwytJ7gugloGSPvc/zcsXxEgKANL8UZNO6DTw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.4.0.tgz",
+      "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4851,6 +5165,17 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@posthog/core": {
       "version": "1.0.2",
@@ -6095,6 +6420,16 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -10603,9 +10938,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/cyclist": {
@@ -11396,6 +11731,17 @@
         "utila": "~0.4"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
@@ -11477,9 +11823,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -18849,9 +19195,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeepwith": {
@@ -20859,16 +21205,16 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.2.0.tgz",
-      "integrity": "sha512-Nr1lmoLddboF9VFhCL8njwwJW87jQZPSsH81wiqHc5DMsBms+/eIp5Wxh3dkMRlK7aQK0mayw1DVrV+YgbvtNA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.15.4.tgz",
+      "integrity": "sha512-FUsm9FIn0EyvwuoPvg6Dj3D54CejUblnAiSfwov9WPwAjDbJrV5DP6oqBReVfsrbV1QZHPjdA2Z5a0jmznTPqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.15",
+        "lodash-es": "^4.18.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.26.1",
@@ -20939,20 +21285,14 @@
         }
       }
     },
-    "node_modules/mod-arch-shared": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.2.0.tgz",
-      "integrity": "sha512-30y3WlcehWCwf+2Fn/m9WUHMXDYN6TJosqfQtpGSV6H4CsnNw1HSMidOH9zqh9IEybhUq0sp9VPLWnwNAHm1Jw==",
+    "node_modules/mod-arch-kubeflow": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.15.4.tgz",
+      "integrity": "sha512-P356bPOu5sVRcJV5EykKj6GpOoyNk0ya+LaUMpzSUAVHvEN1rrBij1/Cm7GdxIP1gkx4zhf3BkGDXVvdtQMv3A==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@patternfly/patternfly": "^6.2.0",
-        "classnames": "^2.2.6",
-        "dompurify": "^3.2.4",
-        "lodash-es": "^4.17.15",
-        "showdown": "^2.1.0"
-      },
+      "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.26.1",
@@ -20971,6 +21311,96 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
+        "@mui/material": "^7.3.4",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0"
+      }
+    },
+    "node_modules/mod-arch-kubeflow/node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/mod-arch-kubeflow/node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mod-arch-shared": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.15.4.tgz",
+      "integrity": "sha512-BJ3hB+4uf5pWV8vYuBAwGOz1Z1mbUV06BtgHPl3AVCgwNRbzWzb2vRpYagYsInsY1ugIR2gXH+xnpbrf0pzZeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@patternfly/patternfly": "^6.4.0",
+        "@patternfly/react-drag-drop": "^6.4.0",
+        "classnames": "^2.2.6",
+        "dompurify": "^3.3.2",
+        "lodash-es": "^4.18.1",
+        "showdown": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.26.1",
+        "@typescript-eslint/parser": "^8.26.1",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-typescript": "^3.8.3",
+        "eslint-plugin-cypress": "^3.3.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-no-only-tests": "^3.1.0",
+        "eslint-plugin-no-relative-import-paths": "^1.6.1",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react-hooks": "^5.2.0"
+      },
+      "peerDependencies": {
+        "mod-arch-core": ">=1.15.4",
+        "mod-arch-kubeflow": ">=1.15.4",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"
@@ -25153,6 +25583,23 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -25670,6 +26117,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -102,7 +102,7 @@
     "@patternfly/react-templates": "^6.3.1",
     "immer": "^11.1.3",
     "mod-arch-core": "^1.2.0",
-    "mod-arch-shared": "^1.2.0",
+    "mod-arch-shared": "^1.15.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.12.0",

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -101,7 +101,7 @@
     "@patternfly/react-styles": "^6.3.1",
     "@patternfly/react-templates": "^6.3.1",
     "immer": "^11.1.3",
-    "mod-arch-core": "^1.2.0",
+    "mod-arch-core": "^1.15.4",
     "mod-arch-shared": "^1.15.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/notebooks/upstream/workspaces/frontend/package.json
+++ b/packages/notebooks/upstream/workspaces/frontend/package.json
@@ -136,7 +136,7 @@
     "lodash-es": "^4.17.15",
     "mod-arch-core": "^1.10.2",
     "mod-arch-kubeflow": "^1.10.2",
-    "mod-arch-shared": "^1.10.2",
+    "mod-arch-shared": "^1.15.4",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^7.5.2",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-55746

## Description

Rename `odh-u-spin` → `ai-u-spin` to align with the shared utility class now provided by `mod-arch-shared`. Bump `mod-arch-shared` to `^1.15.4` in packages that use the class.

## How Has This Been Tested?

Verified inline spinners (workbench start/stop, model serving status) on a dev cluster. Rotation animation works as before.

## Test Impact

Updated existing kueue unit test for the renamed class. No new tests needed — class rename only.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised CSS/PatternFly naming guidance to use namespaced class patterns and document a new shared utility category (example: ai-u-spin).

* **Style**
  * Updated spinner class references across UI components to the new utility name; no visual or behavior changes.

* **Tests**
  * Adjusted unit test assertions to match the renamed spinner utility.

* **Chores**
  * Bumped shared frontend dependency version ranges across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->