### PR TITLE
[Cypress-e2e] add polling step for validated model cards

### DIFF
--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
@@ -6,6 +6,7 @@ import {
   ensureModelCatalogSourceEnabled,
   waitForModelCatalogCards,
   waitForModelCatalogDeployment,
+  waitForValidatedModelCards,
 } from '../../../utils/oc_commands/modelCatalog';
 import { retryableBefore } from '../../../utils/retryableHooks';
 import { getCustomResource } from '../../../utils/oc_commands/customResources';
@@ -100,6 +101,9 @@ describe('Verify Performance Filters are available on RHOAI', () => {
       modelCatalog.findWorkloadTypeFilter().should('be.visible');
       modelCatalog.findLatencyFilter().should('be.visible');
       modelCatalog.findMaxRpsFilter().should('be.visible');
+
+      cy.step('Wait for validated model cards with performance data to appear');
+      waitForValidatedModelCards();
 
       cy.step('Find a validated model card and verify it shows metrics');
       modelCatalog.findValidatedModelCard().should('have.length.at.least', 1);

--- a/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
@@ -422,6 +422,67 @@ export const waitForModelCatalogCards = (
 };
 
 /**
+ * Poll until at least one model catalog card with validated performance data is visible,
+ * reloading the page between attempts.
+ * Required after enabling the performance view toggle on a fresh RHOAI install, where
+ * the model-catalog pod may be ready but the BFF has not yet served validated model metrics.
+ * @param maxAttempts Maximum number of attempts (default: 10)
+ * @param pollIntervalMs Interval between attempts in milliseconds (default: 5000)
+ * @returns A Cypress chainable that resolves when at least one validated model card is visible.
+ */
+export const waitForValidatedModelCards = (
+  maxAttempts = UI_POLL_CONFIG.maxAttempts,
+  pollIntervalMs = 10000,
+): Cypress.Chainable<undefined> => {
+  const startTime = Date.now();
+
+  const checkForValidatedCards = (attempt: number): void => {
+    const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
+
+    // Wait for the page content to stabilize after reload
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(UI_POLL_CONFIG.pageLoadWaitMs);
+    cy.get('body').then(($body) => {
+      const validatedCardCount = $body.find(
+        '[data-testid="model-catalog-card"]:has([data-testid="validated-model-hardware"])',
+      ).length;
+
+      cy.log(
+        `Attempt ${attempt}/${maxAttempts}: validatedCards=${validatedCardCount}, elapsed=${elapsedTime}s`,
+      );
+
+      if (validatedCardCount > 0) {
+        cy.log(
+          `✅ Found ${validatedCardCount} validated model card(s) with performance data (after ${elapsedTime}s)`,
+        );
+        return;
+      }
+
+      if (attempt >= maxAttempts) {
+        throw new Error(
+          `Validated model cards with performance data did not appear after ${maxAttempts} attempts (${elapsedTime}s). ` +
+            `Ensure the model-catalog BFF has fully loaded validated model metrics.`,
+        );
+      }
+
+      // Reload and retry — re-enable the performance toggle after reload as it resets to OFF
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(pollIntervalMs);
+      cy.reload();
+      cy.findByTestId('model-performance-view-toggle').then(($toggle) => {
+        if ($toggle.attr('aria-checked') !== 'true') {
+          cy.wrap($toggle).click({ force: true });
+        }
+      });
+      checkForValidatedCards(attempt + 1);
+    });
+  };
+
+  cy.step(`Polling for validated model cards with performance data (max ${maxAttempts} attempts)`);
+  return cy.then(() => checkForValidatedCards(1));
+};
+
+/**
  * Poll until model catalog shows empty state, reloading the page between attempts.
  * Useful after disabling all sources to wait for the UI to reflect the change.
  * @param maxAttempts Maximum number of attempts (default: 20)


### PR DESCRIPTION
## Description

On fresh RHOAI installations the model-catalog pod can be ready but the BFF has not yet finished loading validated model performance metrics, causing the performance filter test to fail at the "find validated model card" assertion.

- Adds waitForValidatedModelCards() — a polling utility that waits for at least one model card with validated-model-hardware data to appear, reloading the page and re-enabling the performance toggle between attempts (up to 10 attempts, 10s poll interval)

- Calls waitForValidatedModelCards() in the test after enabling the toggle, before asserting on validated cards

## How Has This Been Tested?
Jenkins job: dashboard/job/dashboard-e2e-tests/376/

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
