### PR TITLE
Forward impersonation token to BFF modules in federated dev mode

### DIFF
--- a/packages/automl/frontend/config/webpack.dev.js
+++ b/packages/automl/frontend/config/webpack.dev.js
@@ -88,7 +88,19 @@ module.exports = smp.wrap(
             context: ['/api', '/automl/api'],
             target: `${PROXY_PROTOCOL}://${PROXY_HOST}:${PROXY_PORT}`,
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
         ],
         devMiddleware: {

--- a/packages/autorag/frontend/config/webpack.dev.js
+++ b/packages/autorag/frontend/config/webpack.dev.js
@@ -92,7 +92,19 @@ module.exports = smp.wrap(
               port: PROXY_PORT,
             },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
         ],
         devMiddleware: {

--- a/packages/eval-hub/frontend/config/webpack.dev.js
+++ b/packages/eval-hub/frontend/config/webpack.dev.js
@@ -93,7 +93,19 @@ module.exports = smp.wrap(
               port: PROXY_PORT,
             },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
           {
             context: ['/mlflow'],
@@ -103,7 +115,19 @@ module.exports = smp.wrap(
               port: MLFLOW_PROXY_PORT,
             },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
         ],
         devMiddleware: {

--- a/packages/gen-ai/frontend/config/webpack.dev.js
+++ b/packages/gen-ai/frontend/config/webpack.dev.js
@@ -82,7 +82,19 @@ module.exports = merge(
             protocol: PROXY_PROTOCOL,
           },
           changeOrigin: true,
-          headers: getProxyHeaders(),
+          onProxyReq: (proxyReq, req) => {
+            const upstreamAuth = req.headers.authorization;
+            if (upstreamAuth && AUTH_METHOD === 'user_token') {
+              // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+              const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+              proxyReq.setHeader('x-forwarded-access-token', token);
+            } else {
+              const headers = getProxyHeaders();
+              Object.entries(headers).forEach(([key, value]) => {
+                proxyReq.setHeader(key, value);
+              });
+            }
+          },
         },
       ],
     },

--- a/packages/maas/frontend/config/webpack.dev.js
+++ b/packages/maas/frontend/config/webpack.dev.js
@@ -91,7 +91,19 @@ module.exports = smp.wrap(
               port: PROXY_PORT,
             },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
         ],
         devMiddleware: {

--- a/packages/mlflow/frontend/config/webpack.dev.js
+++ b/packages/mlflow/frontend/config/webpack.dev.js
@@ -87,7 +87,19 @@ module.exports = smp.wrap(
             },
             pathRewrite: { '^/_bff/mlflow/api': '/api' },
             changeOrigin: true,
-            headers: getProxyHeaders(),
+            onProxyReq: (proxyReq, req) => {
+              const upstreamAuth = req.headers.authorization;
+              if (upstreamAuth && AUTH_METHOD === 'user_token') {
+                // Federated mode: forward the upstream token (may be impersonated) as x-forwarded-access-token
+                const token = upstreamAuth.replace(/^Bearer\s+/i, '');
+                proxyReq.setHeader('x-forwarded-access-token', token);
+              } else {
+                const headers = getProxyHeaders();
+                Object.entries(headers).forEach(([key, value]) => {
+                  proxyReq.setHeader(key, value);
+                });
+              }
+            },
           },
         ],
         devMiddleware: {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59422

## Description

In federated dev mode (`make dev-start-federated`), module API calls flow through a double proxy chain:

```
Browser → Main webpack → Main backend → Module webpack → BFF
```

The main dashboard backend sets the `authorization` header on proxied requests — this can carry either the developer's kubectl token or an impersonated user's token (via the dev impersonation toggle). However, each module's webpack dev proxy used a static `headers: getProxyHeaders()` option that always overwrites `x-forwarded-access-token` with the developer's kubectl token (resolved once at startup), effectively discarding any impersonation.

**Fix**: Replace the static `headers:` with an `onProxyReq` callback in all module webpack.dev.js files. When the incoming request has an `authorization` header and `AUTH_METHOD === 'user_token'` (federated mode), the callback extracts the token and forwards it as `x-forwarded-access-token` — matching the production convention BFFs already use. In standalone or internal auth modes, it falls back to `getProxyHeaders()`.

### Modules changed

| Module | File | Notes |
|---|---|---|
| maas | `packages/maas/frontend/config/webpack.dev.js` | Single proxy entry |
| gen-ai | `packages/gen-ai/frontend/config/webpack.dev.js` | Single proxy entry |
| automl | `packages/automl/frontend/config/webpack.dev.js` | Single proxy entry |
| autorag | `packages/autorag/frontend/config/webpack.dev.js` | Single proxy entry |
| mlflow | `packages/mlflow/frontend/config/webpack.dev.js` | Single proxy entry; `pathRewrite` preserved |
| eval-hub | `packages/eval-hub/frontend/config/webpack.dev.js` | Two proxy entries (main API + MLflow) |

> **Note:** `model-registry` is excluded from this PR — its webpack config lives upstream at `kubeflow/model-registry`. The same fix is being addressed via https://github.com/kubeflow/model-registry/pull/2544, where we've suggested aligning with this approach.

No Makefile or `getProxyHeaders()` changes — only the proxy wiring in webpack.dev.js.

### Behavior per mode

| Mode | Result |
|---|---|
| Federated + impersonating | BFF receives impersonated token via `x-forwarded-access-token` |
| Federated + no impersonation | BFF receives kubectl token (same as before) |
| Standalone (`user_token`) | Falls back to `getProxyHeaders()` (same as before) |
| Mock federated (`internal`) | Falls back to `getProxyHeaders()` / `kubeflow-userid` (same as before) |

## How Has This Been Tested?

Tested on a live cluster with temporary debug logging added to the BFF `ExtractRequestIdentity` method (logging the first 8 and last 4 chars of the received token). Validated with both **maas** and **model-registry** BFFs in federated mode.

### Test setup

1. Main dashboard: `npm run dev`
2. MaaS BFF (federated): `cd packages/maas && make dev-start-federated`
3. Model Registry BFF (federated): `cd packages/model-registry && make dev-start-federated`

### Results — Admin (no impersonation)

Both BFFs receive the admin kubectl token (`sha256~m...6wd8`):

**Model Registry:**
```
time=2026-04-23T16:34:50.043+02:00 level=INFO msg="DEBUG ExtractRequestIdentity" header=x-forwarded-access-token tokenStart=sha256~m tokenEnd=6wd8
time=2026-04-23T16:34:54.736+02:00 level=INFO msg="user is cluster-admin"
```

**MaaS:**
```
time=2026-04-23T17:00:06.539+02:00 level=INFO msg="DEBUG ExtractRequestIdentity" header=x-forwarded-access-token tokenStart=sha256~m tokenEnd=6wd8
```

### Results — Impersonating dev user

Both BFFs receive a different token (`sha256~D...7l94`) — the impersonated user's token:

**Model Registry:**
```
time=2026-04-23T17:01:06.622+02:00 level=INFO msg="DEBUG ExtractRequestIdentity" header=x-forwarded-access-token tokenStart=sha256~D tokenEnd=7l94
time=2026-04-23T17:01:06.972+02:00 level=INFO msg="user is NOT cluster-admin"
```

**MaaS:**
```
time=2026-04-23T17:01:33.767+02:00 level=INFO msg="DEBUG ExtractRequestIdentity" header=x-forwarded-access-token tokenStart=sha256~D tokenEnd=7l94
time=2026-04-23T17:01:33.893+02:00 level=INFO msg="user is NOT cluster-admin"
time=2026-04-23T17:01:34.512+02:00 level=ERROR msg="failed to list MaaSAuthPolicies: maasauthpolicies.maas.opendatahub.io is forbidden: User \"regularuser1\" cannot list resource \"maasauthpolicies\" in API group \"maas.opendatahub.io\" in the namespace \"models-as-a-service\""
```

RBAC works end-to-end: the impersonated user is correctly identified as non-admin, and permission-gated resources are properly denied.

## Test Impact

This is a dev-only change (webpack dev server proxy configuration). No production code is affected. No new tests needed — the change is verified through manual testing of the dev impersonation flow.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`