### PR TITLE
fix(cypress): stabilize flaky project selector test in distributedwor…

### DIFF
--- a/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/distributedWorkloads/globalDistributedWorkloads.cy.ts
@@ -238,10 +238,11 @@ describe('Distributed Workload Metrics root page', () => {
   it('Changing the project and navigating between tabs or to the root of the page retains the new project', () => {
     initIntercepts({});
     globalDistributedWorkloads.visit();
-    cy.url().should('include', '/workload-status/test-project');
+    cy.url().should('match', /\/workload-status\/test-project(?!\w|-)/);
 
     globalDistributedWorkloads.projectDropdown.openAndSelectItem('Test Project 2', true);
     cy.url().should('include', '/workload-status/test-project-2');
+    globalDistributedWorkloads.findProjectSelect().should('contain.text', 'Test Project 2');
 
     cy.findByLabelText('Project metrics tab').click();
     cy.url().should('include', '/project-metrics/test-project-2');


### PR DESCRIPTION

Summary
  - Fix ambiguous URL assertion (`test-project` was matching `test-project-2`) using regex with negative lookahead
  - Add UI state stabilization check to wait for project selector to reflect the new selection before proceeding

The mock test `globalDistributedWorkloads.cy.ts` was flaky because `cy.url().should('include', '/workload-status/test-project')` would pass even when the URL contained `test-project-2`. 

This allowed subsequent actions to execute before the page state had fully settled, causing the project selection to revert on tab switch.
  
  
<img width="2547" height="1287" alt="image" src="https://github.com/user-attachments/assets/8ddc0613-8ef0-47f4-878e-40d7ccfab255" />


## Test plan
  - [x] Ran locally 5+ times — all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for distributed workloads functionality with enhanced route matching and project selection verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->