### PR TITLE
test: prevent false-positive duplicate-name check in argo workflow version test

### DIFF
--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -1099,6 +1099,18 @@ describe('Pipelines', () => {
 
   it('uploads fails with argo workflow', () => {
     initIntercepts({});
+
+    // Return empty results for filtered version requests (duplicate-name check)
+    // so the generic initIntercepts mock doesn't cause a false-positive.
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: `/api/service/pipelines/${projectName}/dspa/apis/v2beta1/pipelines/${initialMockPipeline.pipeline_id}/versions`,
+        query: { filter: /.*/ },
+      },
+      { pipeline_versions: [], total_size: 0 },
+    );
+
     pipelinesGlobal.visit(projectName);
 
     // Wait for the pipelines table to load


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
https://redhat.atlassian.net/browse/RHOAIENG-58263

## Problem

The Cypress mock test **"uploads fails with argo workflow"** in `pipelines.cy.ts` is flaky. It intermittently fails with:
```
AssertionError: Timed out retrying after 10000ms: expected '<button.pf-v6-c-button.pf-m-primary.pf-m-progress>' to be 'enabled'
```


## Root Cause

The `initIntercepts` function registers a generic intercept for the pipeline versions endpoint (`GET .../pipelines/:pipelineId/versions`) that returns mock versions **regardless of query parameters**.

When the user types a version name, `PipelineImportBase` triggers a debounced (500ms) duplicate-name check that calls `listPipelineVersions` with a `?filter=display_name==...` query param. The generic intercept catches this filtered request and returns mock versions. The application code (non-kubernetes path) trusts the server-side filter and only checks `duplicateVersions.length` — since the mock returns a non-empty list, `hasDuplicateName` is set to `true`, permanently disabling the submit button.

The test is flaky rather than always broken because it's a race between the 500ms debounce completing and Cypress reaching the `should('be.enabled')` assertion:
- **Passes**: Cypress outruns the debounce and clicks submit before the check completes.
- **Fails**: The debounce resolves first, the false positive disables the button, and `should('be.enabled')` times out.

## Fix

Add a more-specific `cy.intercept` after `initIntercepts` that matches version-list requests containing a `filter` query param and returns an empty list. Since Cypress matches the most recently registered intercept first, this takes priority over the generic one for filtered requests, while the unfiltered table-population requests continue to work as before.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through CI runs.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
N/A

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for Argo workflow pipeline uploads by fixing version lookup handling in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->