### PR TITLE
fix(cypress): stabilize prompt management E2E test polling

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -99,6 +99,8 @@ const isGenAiStudioVisible = (): Cypress.Chainable<boolean> => {
  *
  * @returns A Cypress chainable that resolves when the section is visible.
  */
+const SIDEBAR_SETTLE_TIMEOUT = 30000;
+
 const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
   const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
   const startTime = Date.now();
@@ -112,34 +114,35 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
       cy.reload();
     }
 
-    // Wait for sidebar to render before checking
-    return cy.get('#page-sidebar', { timeout: 15000 }).then(() =>
-      isGenAiStudioVisible().then((isVisible) => {
-        const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
+    // Wait for the dashboard app to finish its loading sequence
+    // (#dashboard-page-main appears only after user, config, and DSC are fetched).
+    cy.get('#dashboard-page-main', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
-        if (isVisible) {
-          cy.log(`✅ Gen AI studio section found in sidebar (after ${elapsedTime}s)`);
-          return cy.wrap(true);
-        }
+    return isGenAiStudioVisible().then((isVisible) => {
+      const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
-        if (attemptNumber >= maxAttempts) {
-          throw new Error(
-            `Gen AI studio section not found in sidebar after ${maxAttempts} attempts (${elapsedTime}s)`,
-          );
-        }
+      if (isVisible) {
+        cy.log(`Gen AI studio section found in sidebar (after ${elapsedTime}s)`);
+        return cy.wrap(true);
+      }
 
-        cy.log(
-          `⏳ Gen AI studio not yet visible (attempt ${attemptNumber}/${maxAttempts}, elapsed: ${elapsedTime}s)`,
+      if (attemptNumber >= maxAttempts) {
+        throw new Error(
+          `Gen AI studio section not found in sidebar after ${maxAttempts} attempts (${elapsedTime}s)`,
         );
+      }
 
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        return cy.wait(pollIntervalMs).then(() => checkForSection(attemptNumber + 1));
-      }),
-    );
+      cy.log(
+        `Gen AI studio not yet visible (attempt ${attemptNumber}/${maxAttempts}, elapsed: ${elapsedTime}s)`,
+      );
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      return cy.wait(pollIntervalMs).then(() => checkForSection(attemptNumber + 1));
+    });
   };
 
   const totalTimeout = (maxAttempts * pollIntervalMs) / 1000;
-  cy.log(`🔍 Polling for Gen AI studio in sidebar (max ${totalTimeout}s)`);
+  cy.log(`Polling for Gen AI studio in sidebar (max ${totalTimeout}s)`);
   return checkForSection();
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -86,20 +86,31 @@ const waitForGenAiStudioFeatureFlag = (): Cypress.Chainable<Cypress.Exec> => {
  *
  * @returns A Cypress chainable resolving to true if the section exists, false otherwise.
  */
-const isGenAiStudioVisible = (): Cypress.Chainable<boolean> => {
-  return appChrome
-    .findSideBar()
-    .then(($sidebar) => $sidebar.find('button:contains("Gen AI studio")').length > 0);
-};
-
 /**
- * Poll until the Gen AI Studio section appears in the sidebar.
- * Uses visitWithLogin for the first attempt to establish a session,
- * then cy.reload() for subsequent attempts to avoid repeated OAuth overhead.
- *
- * @returns A Cypress chainable that resolves when the section is visible.
+ * Retry-aware check for an element inside the sidebar.
+ * See `findNavItemInSidebar` in mlflow.ts for rationale.
  */
 const SIDEBAR_SETTLE_TIMEOUT = 30000;
+const NAV_ITEM_SETTLE_MS = 15000;
+const NAV_ITEM_POLL_MS = 500;
+
+const findInSidebar = (selector: string): Cypress.Chainable<boolean> =>
+  appChrome.findSideBar().then(
+    ($sidebar) =>
+      new Cypress.Promise<boolean>((resolve) => {
+        const deadline = Date.now() + NAV_ITEM_SETTLE_MS;
+        const poll = () => {
+          if ($sidebar.find(selector).length > 0) {
+            resolve(true);
+          } else if (Date.now() >= deadline) {
+            resolve(false);
+          } else {
+            setTimeout(poll, NAV_ITEM_POLL_MS);
+          }
+        };
+        poll();
+      }),
+  );
 
 const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
   const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
@@ -114,12 +125,9 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
       cy.reload();
     }
 
-    // Wait for the app to finish loading (user, config, DSC). The main
-    // content container is only rendered after those complete, so its
-    // presence confirms area flags and extensions are evaluated.
     cy.get('[data-testid="dashboard-page-main"]', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
-    return isGenAiStudioVisible().then((isVisible) => {
+    return findInSidebar('button:contains("Gen AI studio")').then((isVisible) => {
       const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
       if (isVisible) {

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -114,9 +114,10 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
       cy.reload();
     }
 
-    // Wait for the dashboard app to finish its loading sequence
-    // (#dashboard-page-main appears only after user, config, and DSC are fetched).
-    cy.get('#dashboard-page-main', { timeout: SIDEBAR_SETTLE_TIMEOUT });
+    // Wait for the app to finish loading (user, config, DSC). The main
+    // content container is only rendered after those complete, so its
+    // presence confirms area flags and extensions are evaluated.
+    cy.get('[data-testid="dashboard-page-main"]', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
     return isGenAiStudioVisible().then((isVisible) => {
       const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -10,9 +10,8 @@ const DASHBOARD_CONFIG = 'odhdashboardconfig odh-dashboard-config';
 
 // Polling configuration for UI visibility (slower, requires page reload)
 const UI_POLL_CONFIG = {
-  maxAttempts: 15,
-  pollIntervalMs: 10000, // 10 seconds between attempts
-  pageLoadWaitMs: 5000,
+  maxAttempts: 20,
+  pollIntervalMs: 5000,
 } as const;
 
 /**
@@ -95,24 +94,27 @@ const isGenAiStudioVisible = (): Cypress.Chainable<boolean> => {
 
 /**
  * Poll until the Gen AI Studio section appears in the sidebar.
- * Refreshes the page and checks for the nav section on each attempt.
+ * Uses visitWithLogin for the first attempt to establish a session,
+ * then cy.reload() for subsequent attempts to avoid repeated OAuth overhead.
  *
  * @returns A Cypress chainable that resolves when the section is visible.
  */
 const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
-  const { maxAttempts, pollIntervalMs, pageLoadWaitMs } = UI_POLL_CONFIG;
+  const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
   const startTime = Date.now();
 
   const checkForSection = (attemptNumber = 1): Cypress.Chainable<boolean> => {
     cy.step(`Attempt ${attemptNumber}/${maxAttempts} - Checking for Gen AI studio in sidebar...`);
 
-    // Visit/reload the dashboard to get fresh sidebar state
-    cy.visitWithLogin('/');
+    if (attemptNumber === 1) {
+      cy.visitWithLogin('/');
+    } else {
+      cy.reload();
+    }
 
-    // Wait for page to fully load, then check for the section
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    return cy.wait(pageLoadWaitMs).then(() => {
-      return isGenAiStudioVisible().then((isVisible) => {
+    // Wait for sidebar to render before checking
+    return cy.get('#page-sidebar', { timeout: 15000 }).then(() =>
+      isGenAiStudioVisible().then((isVisible) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
         if (isVisible) {
@@ -132,8 +134,8 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         return cy.wait(pollIntervalMs).then(() => checkForSection(attemptNumber + 1));
-      });
-    });
+      }),
+    );
   };
 
   const totalTimeout = (maxAttempts * pollIntervalMs) / 1000;
@@ -142,14 +144,13 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
 };
 
 /**
- * Enable Gen AI features by patching the DataScienceCluster and ODHDashboardConfig resources.
- * Sets LlamaStack operator to Managed, waits for the operator to be ready,
- * waits for the namespace, enables Gen AI Studio, polls for the feature flag,
- * and finally polls until it appears in the sidebar.
+ * Enable Gen AI backend resources without waiting for sidebar visibility.
+ * Sets LlamaStack operator to Managed, waits for readiness, namespace,
+ * enables Gen AI Studio flag, and polls for the feature flag.
  *
- * @returns A Cypress chainable that resolves when Gen AI Studio is visible in the sidebar.
+ * Useful for composition when a caller will perform its own sidebar check.
  */
-export const enableGenAiFeatures = (): Cypress.Chainable<boolean> => {
+export const enableGenAiBackend = (): Cypress.Chainable<Cypress.Exec> => {
   const namespace = getApplicationsNamespace();
 
   cy.step('Set LlamaStack to Managed');
@@ -169,6 +170,33 @@ export const enableGenAiFeatures = (): Cypress.Chainable<boolean> => {
     .then(() => {
       cy.step('Wait for genAiStudio feature flag to be set');
       return waitForGenAiStudioFeatureFlag();
+    });
+};
+
+/**
+ * Poll until the DSC status reports llamastackoperator as Managed.
+ * The dashboard frontend reads DSC status to evaluate the plugin-gen-ai area flag.
+ */
+const waitForDSCLlamaStackManaged = (): Cypress.Chainable<Cypress.Exec> =>
+  pollUntilSuccess(
+    `oc get ${DSC_RESOURCE} -o json | jq -e '.status.components.llamastackoperator.managementState == "Managed"'`,
+    'DSC status to reflect llamastackoperator as Managed',
+    { maxAttempts: 60, pollIntervalMs: 5000 },
+  );
+
+/**
+ * Enable Gen AI features by patching the DataScienceCluster and ODHDashboardConfig resources.
+ * Sets LlamaStack operator to Managed, waits for the operator to be ready,
+ * waits for the namespace, enables Gen AI Studio, polls for the feature flag,
+ * verifies DSC status, and finally polls until it appears in the sidebar.
+ *
+ * @returns A Cypress chainable that resolves when Gen AI Studio is visible in the sidebar.
+ */
+export const enableGenAiFeatures = (): Cypress.Chainable<boolean> => {
+  return enableGenAiBackend()
+    .then(() => {
+      cy.step('Verify DSC status reflects llamastackoperator as Managed');
+      return waitForDSCLlamaStackManaged();
     })
     .then(() => {
       cy.step('Wait for Gen AI Studio to appear in sidebar');

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -264,6 +264,55 @@ const waitForMlflowTrackingPodReady = (namespace: string): Cypress.Chainable<Cyp
 };
 
 /**
+ * Poll via cy.request() until the mlflowEmbedded module federation remote entry
+ * returns HTTP 200. The dashboard proxies this through /_mf/mlflowEmbedded/*.
+ *
+ * The k8s deployment can report "Available" before the MLflow web server is
+ * ready to serve the federated JavaScript bundle. Without this check the
+ * sidebar poll would start while loadRemote() still fails silently, so the
+ * nav item never appears.
+ *
+ * Requires an active browser session (call after cy.visitWithLogin).
+ */
+const waitForMlflowRemoteEntry = (): Cypress.Chainable<boolean> => {
+  const remoteEntryPath = '/_mf/mlflowEmbedded/mlflow/static-files/federated/remoteEntry.js';
+  const maxAttempts = 60;
+  const pollIntervalMs = 5000;
+  const startTime = Date.now();
+
+  const check = (attempt = 1): Cypress.Chainable<boolean> => {
+    cy.step(`Attempt ${attempt}/${maxAttempts} - Polling mlflowEmbedded remote entry...`);
+
+    return cy
+      .request({ url: remoteEntryPath, failOnStatusCode: false, timeout: 10000 })
+      .then((resp) => {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+        if (resp.status === 200) {
+          cy.log(`mlflowEmbedded remote entry reachable (after ${elapsed}s)`);
+          return cy.wrap(true);
+        }
+
+        if (attempt >= maxAttempts) {
+          throw new Error(
+            `mlflowEmbedded remote entry not reachable after ${maxAttempts} attempts ` +
+              `(${elapsed}s, last status=${resp.status})`,
+          );
+        }
+
+        cy.log(
+          `remote entry returned ${resp.status} (attempt ${attempt}/${maxAttempts}, ${elapsed}s)`,
+        );
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        return cy.wait(pollIntervalMs).then(() => check(attempt + 1));
+      });
+  };
+
+  cy.log(`Polling mlflowEmbedded remote entry (max ${(maxAttempts * pollIntervalMs) / 1000}s)`);
+  return check();
+};
+
+/**
  * Enable MLflow backend resources without waiting for sidebar visibility.
  * Sets MLflow operator to Managed, waits for it, creates MLflow CR,
  * waits for CR readiness and tracking server pod availability.
@@ -298,13 +347,23 @@ const enableMlflowBackend = (): Cypress.Chainable<Cypress.Exec> => {
  * 1. Set mlflowoperator to Managed and wait for it
  * 2. Create an MLflow CR and wait for it to be ready
  * 3. Verify DSC status reflects mlflowoperator as Managed
- * 4. Wait for Experiments (MLflow) nav item in the sidebar
+ * 4. Establish browser session and verify federated remote is loadable
+ * 5. Wait for Experiments (MLflow) nav item in the sidebar
  */
 export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
   return enableMlflowBackend()
     .then(() => {
       cy.step('Verify DSC status reflects mlflowoperator as Managed');
       return waitForDSCComponentsManaged(['mlflowoperator']);
+    })
+    .then(() => {
+      cy.step('Establish browser session for remote entry check');
+      cy.visitWithLogin('/');
+      return cy.get('#page-sidebar', { timeout: 15000 });
+    })
+    .then(() => {
+      cy.step('Wait for mlflowEmbedded module federation remote to be loadable');
+      return waitForMlflowRemoteEntry();
     })
     .then(() => {
       cy.step('Wait for Experiments (MLflow) nav item in sidebar');
@@ -359,6 +418,15 @@ export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => 
     .then(() => {
       cy.step('Verify DSC status reflects both operators as Managed');
       return waitForDSCComponentsManaged(['llamastackoperator', 'mlflowoperator']);
+    })
+    .then(() => {
+      cy.step('Establish browser session for remote entry check');
+      cy.visitWithLogin('/');
+      return cy.get('#page-sidebar', { timeout: 15000 });
+    })
+    .then(() => {
+      cy.step('Wait for mlflowEmbedded module federation remote to be loadable');
+      return waitForMlflowRemoteEntry();
     })
     .then(() => {
       cy.step('Wait for Prompts nav item in sidebar');

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -185,14 +185,11 @@ const waitForMlflowCRReady = (namespace: string): Cypress.Chainable<Cypress.Exec
  * Uses visitWithLogin for the first attempt to establish a session,
  * then cy.reload() for subsequent attempts to avoid repeated OAuth overhead.
  */
+const SIDEBAR_SETTLE_TIMEOUT = 30000;
+
 const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> => {
   const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
   const startTime = Date.now();
-
-  const isVisible = (): Cypress.Chainable<boolean> =>
-    appChrome
-      .findSideBar()
-      .then(($sidebar) => $sidebar.find(`a:contains("${navLabel}")`).length > 0);
 
   const check = (attemptNumber = 1): Cypress.Chainable<boolean> => {
     cy.step(`Attempt ${attemptNumber}/${maxAttempts} - Checking for ${navLabel} in sidebar...`);
@@ -203,8 +200,14 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
       cy.reload();
     }
 
-    return cy.get('#page-sidebar', { timeout: 15000 }).then(() =>
-      isVisible().then((found) => {
+    // Wait for the dashboard app to finish its loading sequence
+    // (#dashboard-page-main appears only after user, config, and DSC are fetched).
+    cy.get('#dashboard-page-main', { timeout: SIDEBAR_SETTLE_TIMEOUT });
+
+    return appChrome
+      .findSideBar()
+      .then(($sidebar) => $sidebar.find(`a:contains("${navLabel}")`).length > 0)
+      .then((found) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
         if (found) {
@@ -224,8 +227,7 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         return cy.wait(pollIntervalMs).then(() => check(attemptNumber + 1));
-      }),
-    );
+      });
   };
 
   const totalTimeout = (maxAttempts * pollIntervalMs) / 1000;

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -267,6 +267,66 @@ const waitForMlflowTrackingPodReady = (namespace: string): Cypress.Chainable<Cyp
 };
 
 /**
+ * Poll the dashboard backend's /api/dsc/status until it reflects the expected
+ * component management states.
+ *
+ * The backend uses a ResourceWatcher that caches DSC status with a 2-minute
+ * (active) or 30-minute (inactive) polling interval. After patching the DSC
+ * on the cluster, the cached response can be stale. Polling this endpoint:
+ *  - activates the watcher (switches from 30 min to 2 min interval)
+ *  - waits for the cache to refresh before the frontend evaluates area flags
+ *
+ * Requires an active browser session (call after cy.visitWithLogin).
+ */
+const waitForDashboardDSCStatus = (
+  components: Record<string, string>,
+): Cypress.Chainable<boolean> => {
+  const maxAttempts = 60;
+  const pollIntervalMs = 5000;
+  const startTime = Date.now();
+  const label = Object.entries(components)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(', ');
+
+  const check = (attempt = 1): Cypress.Chainable<boolean> => {
+    cy.step(`Attempt ${attempt}/${maxAttempts} - Polling /api/dsc/status for ${label}...`);
+
+    return cy
+      .request({ url: '/api/dsc/status', failOnStatusCode: false, timeout: 10000 })
+      .then((resp) => {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+        if (resp.status === 200 && resp.body?.components) {
+          const allMatch = Object.entries(components).every(
+            ([comp, expected]) => resp.body.components[comp]?.managementState === expected,
+          );
+          if (allMatch) {
+            cy.log(`Dashboard DSC status matches (after ${elapsed}s)`);
+            return cy.wrap(true);
+          }
+        }
+
+        if (attempt >= maxAttempts) {
+          throw new Error(
+            `Dashboard /api/dsc/status did not reflect ${label} after ${maxAttempts} ` +
+              `attempts (${elapsed}s)`,
+          );
+        }
+
+        cy.log(
+          `Dashboard DSC status not yet updated (attempt ${attempt}/${maxAttempts}, ${elapsed}s)`,
+        );
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        return cy.wait(pollIntervalMs).then(() => check(attempt + 1));
+      });
+  };
+
+  const totalTimeout = (maxAttempts * pollIntervalMs) / 1000;
+  cy.log(`Polling dashboard /api/dsc/status for ${label} (max ${totalTimeout}s)`);
+  return check();
+};
+
+/**
  * Poll via cy.request() until the mlflowEmbedded module federation remote entry
  * returns HTTP 200. The dashboard proxies this through /_mf/mlflowEmbedded/*.
  *
@@ -369,6 +429,10 @@ export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
       return waitForMlflowRemoteEntry();
     })
     .then(() => {
+      cy.step('Wait for dashboard backend to reflect mlflowoperator as Managed');
+      return waitForDashboardDSCStatus({ mlflowoperator: 'Managed' });
+    })
+    .then(() => {
       cy.step('Wait for Experiments (MLflow) nav item in sidebar');
       return waitForNavItemInSidebar('Experiments (MLflow)');
     });
@@ -430,6 +494,13 @@ export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => 
     .then(() => {
       cy.step('Wait for mlflowEmbedded module federation remote to be loadable');
       return waitForMlflowRemoteEntry();
+    })
+    .then(() => {
+      cy.step('Wait for dashboard backend to reflect both operators as Managed');
+      return waitForDashboardDSCStatus({
+        llamastackoperator: 'Managed',
+        mlflowoperator: 'Managed',
+      });
     })
     .then(() => {
       cy.step('Wait for Prompts nav item in sidebar');

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -1,5 +1,5 @@
 import { pollUntilSuccess } from './baseCommands';
-import { enableGenAiFeatures, disableGenAiFeatures } from './genAi';
+import { enableGenAiBackend, disableGenAiFeatures } from './genAi';
 import { appChrome } from '../../pages/appChrome';
 import type { CommandLineResult, MlflowExperimentRunData } from '../../types';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
@@ -9,8 +9,7 @@ const K8S_NAMESPACE_RE = /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
 
 const UI_POLL_CONFIG = {
   maxAttempts: 20,
-  pollIntervalMs: 10000,
-  pageLoadWaitMs: 5000,
+  pollIntervalMs: 5000,
 } as const;
 
 const assertNamespace = (namespace: string): string => {
@@ -183,9 +182,11 @@ const waitForMlflowCRReady = (namespace: string): Cypress.Chainable<Cypress.Exec
 
 /**
  * Poll until a nav item with the given label appears in the sidebar.
+ * Uses visitWithLogin for the first attempt to establish a session,
+ * then cy.reload() for subsequent attempts to avoid repeated OAuth overhead.
  */
 const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> => {
-  const { maxAttempts, pollIntervalMs, pageLoadWaitMs } = UI_POLL_CONFIG;
+  const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
   const startTime = Date.now();
 
   const isVisible = (): Cypress.Chainable<boolean> =>
@@ -196,10 +197,13 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
   const check = (attemptNumber = 1): Cypress.Chainable<boolean> => {
     cy.step(`Attempt ${attemptNumber}/${maxAttempts} - Checking for ${navLabel} in sidebar...`);
 
-    cy.visitWithLogin('/');
+    if (attemptNumber === 1) {
+      cy.visitWithLogin('/');
+    } else {
+      cy.reload();
+    }
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    return cy.wait(pageLoadWaitMs).then(() =>
+    return cy.get('#page-sidebar', { timeout: 15000 }).then(() =>
       isVisible().then((found) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
@@ -230,12 +234,43 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
 };
 
 /**
- * Enable MLflow operator and tracking server (no Gen AI):
- * 1. Set mlflowoperator to Managed and wait for it
- * 2. Create an MLflow CR and wait for it to be ready
- * 3. Wait for Experiments (MLflow) nav item in the sidebar
+ * Poll until the DSC status reports given components as Managed.
+ * The dashboard frontend reads DSC status to evaluate area flags, so these
+ * must be reflected in the cluster status before the nav items will appear.
  */
-export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
+const waitForDSCComponentsManaged = (components: string[]): Cypress.Chainable<Cypress.Exec> => {
+  const jqChecks = components
+    .map((c) => `.components.${c}.managementState == "Managed"`)
+    .join(' and ');
+  const command = `oc get datasciencecluster default-dsc -o json | jq -e '.status | ${jqChecks}'`;
+  return pollUntilSuccess(command, `DSC components [${components.join(', ')}] to be Managed`, {
+    maxAttempts: 60,
+    pollIntervalMs: 5000,
+  });
+};
+
+/**
+ * Poll until the MLflow tracking server pod is Ready (not just Running).
+ * The CR status.address.url can be set before the pod passes readiness probes,
+ * which means the BFF may still return 503 until the pod is fully ready.
+ */
+const waitForMlflowTrackingPodReady = (namespace: string): Cypress.Chainable<Cypress.Exec> => {
+  const ns = assertNamespace(namespace);
+  return pollUntilSuccess(
+    `oc wait --for=condition=Available deployment/mlflow -n ${ns} --timeout=0`,
+    'MLflow tracking server deployment to be Available',
+    { maxAttempts: 60, pollIntervalMs: 5000 },
+  );
+};
+
+/**
+ * Enable MLflow backend resources without waiting for sidebar visibility.
+ * Sets MLflow operator to Managed, waits for it, creates MLflow CR,
+ * waits for CR readiness and tracking server pod availability.
+ *
+ * Useful for composition when a caller will perform its own sidebar check.
+ */
+const enableMlflowBackend = (): Cypress.Chainable<Cypress.Exec> => {
   const namespace = getApplicationsNamespace();
 
   cy.step('Set MLflow operator to Managed');
@@ -251,6 +286,25 @@ export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
     .then(() => {
       cy.step('Wait for MLflow CR to be ready');
       return waitForMlflowCRReady(namespace);
+    })
+    .then(() => {
+      cy.step('Wait for MLflow tracking server deployment to be available');
+      return waitForMlflowTrackingPodReady(namespace);
+    });
+};
+
+/**
+ * Enable MLflow operator and tracking server (no Gen AI):
+ * 1. Set mlflowoperator to Managed and wait for it
+ * 2. Create an MLflow CR and wait for it to be ready
+ * 3. Verify DSC status reflects mlflowoperator as Managed
+ * 4. Wait for Experiments (MLflow) nav item in the sidebar
+ */
+export const enableMlflowFeatures = (): Cypress.Chainable<boolean> => {
+  return enableMlflowBackend()
+    .then(() => {
+      cy.step('Verify DSC status reflects mlflowoperator as Managed');
+      return waitForDSCComponentsManaged(['mlflowoperator']);
     })
     .then(() => {
       cy.step('Wait for Experiments (MLflow) nav item in sidebar');
@@ -287,14 +341,25 @@ export const disableMlflowFeatures = (
 
 /**
  * Enable all features required for Prompt Management:
- * 1. Enable Gen AI features (LlamaStack operator, genAiStudio flag, sidebar)
- * 2. Enable MLflow features (operator, CR)
- * 3. Wait for Prompts nav item in the sidebar
+ * 1. Enable Gen AI backend (LlamaStack operator, genAiStudio flag)
+ * 2. Enable MLflow backend (operator, CR, tracking pod readiness)
+ * 3. Verify DSC status reflects both operators as Managed
+ * 4. Single sidebar poll for "Prompts" nav item (confirms frontend picked up the state)
+ *
+ * Polls backend resources first so the sidebar check is a quick confirmation,
+ * not a long discovery loop.
  */
 export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => {
-  cy.step('Enable Gen AI features (required for Prompts nav)');
-  return enableGenAiFeatures()
-    .then(() => enableMlflowFeatures())
+  cy.step('Enable Gen AI backend (required for Prompts nav)');
+  return enableGenAiBackend()
+    .then(() => {
+      cy.step('Enable MLflow backend (required for Prompts nav)');
+      return enableMlflowBackend();
+    })
+    .then(() => {
+      cy.step('Verify DSC status reflects both operators as Managed');
+      return waitForDSCComponentsManaged(['llamastackoperator', 'mlflowoperator']);
+    })
     .then(() => {
       cy.step('Wait for Prompts nav item in sidebar');
       return waitForNavItemInSidebar('Prompts');

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -187,6 +187,80 @@ const waitForMlflowCRReady = (namespace: string): Cypress.Chainable<Cypress.Exec
  */
 const SIDEBAR_SETTLE_TIMEOUT = 30000;
 
+const logSidebarDiagnostics = (): void => {
+  cy.window({ log: false }).then((win) => {
+    const mfEl = win.document.getElementById('mf-remotes-json');
+    const mfContent = mfEl?.textContent ?? '(element not found)';
+    cy.log(`[DIAG] mf-remotes-json: ${mfContent}`);
+  });
+
+  appChrome.findSideBar().then(($sidebar) => {
+    const links: string[] = [];
+    $sidebar.find('a').each((_i, el) => {
+      const text = el.textContent;
+      if (text && text.trim()) {
+        links.push(text.trim());
+      }
+    });
+    cy.log(`[DIAG] Sidebar links (${links.length}): ${links.join(' | ')}`);
+
+    const sections: string[] = [];
+    $sidebar.find('button').each((_i, el) => {
+      const text = el.textContent;
+      if (text && text.trim()) {
+        sections.push(text.trim());
+      }
+    });
+    cy.log(`[DIAG] Sidebar sections (${sections.length}): ${sections.join(' | ')}`);
+  });
+
+  cy.request({ url: '/api/dsc/status', failOnStatusCode: false, timeout: 10000, log: false }).then(
+    (resp) => {
+      if (resp.status === 200 && resp.body?.components) {
+        const mlflow = resp.body.components.mlflowoperator?.managementState ?? '(missing)';
+        const llama = resp.body.components.llamastackoperator?.managementState ?? '(missing)';
+        cy.log(`[DIAG] /api/dsc/status: mlflowoperator=${mlflow}, llamastackoperator=${llama}`);
+      } else {
+        cy.log(`[DIAG] /api/dsc/status: HTTP ${resp.status}`);
+      }
+    },
+  );
+};
+
+/**
+ * Retry-aware check for a nav item inside the sidebar element.
+ *
+ * After `dashboard-page-main` appears, area flags are set via a React
+ * useEffect that runs asynchronously. Extension-provided nav items only
+ * render once the PluginStore has evaluated those flags. This creates a
+ * short gap (typically < 1 s) during which the sidebar exists but doesn't
+ * yet contain extension items. A one-shot jQuery `.find()` during that gap
+ * always misses the item, making the outer reload loop retry needlessly.
+ *
+ * This helper polls the live jQuery element for up to `NAV_ITEM_SETTLE_MS`
+ * so that a single page load is enough once the extensions are ready.
+ */
+const NAV_ITEM_SETTLE_MS = 15000;
+const NAV_ITEM_POLL_MS = 500;
+
+const findNavItemInSidebar = ($sidebar: JQuery, navLabel: string): Cypress.Chainable<boolean> =>
+  cy.wrap(null, { log: false }).then(
+    () =>
+      new Cypress.Promise<boolean>((resolve) => {
+        const deadline = Date.now() + NAV_ITEM_SETTLE_MS;
+        const poll = () => {
+          if ($sidebar.find(`a:contains("${navLabel}")`).length > 0) {
+            resolve(true);
+          } else if (Date.now() >= deadline) {
+            resolve(false);
+          } else {
+            setTimeout(poll, NAV_ITEM_POLL_MS);
+          }
+        };
+        poll();
+      }),
+  );
+
 const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> => {
   const { maxAttempts, pollIntervalMs } = UI_POLL_CONFIG;
   const startTime = Date.now();
@@ -200,14 +274,11 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
       cy.reload();
     }
 
-    // Wait for the app to finish loading (user, config, DSC). The main
-    // content container is only rendered after those complete, so its
-    // presence confirms area flags and extensions are evaluated.
     cy.get('[data-testid="dashboard-page-main"]', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
     return appChrome
       .findSideBar()
-      .then(($sidebar) => $sidebar.find(`a:contains("${navLabel}")`).length > 0)
+      .then(($sidebar) => findNavItemInSidebar($sidebar, navLabel))
       .then((found) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
@@ -216,7 +287,12 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
           return cy.wrap(true);
         }
 
+        if (attemptNumber === 1) {
+          logSidebarDiagnostics();
+        }
+
         if (attemptNumber >= maxAttempts) {
+          logSidebarDiagnostics();
           throw new Error(
             `${navLabel} nav item not found in sidebar after ${maxAttempts} attempts (${elapsedTime}s)`,
           );

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -200,9 +200,10 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
       cy.reload();
     }
 
-    // Wait for the dashboard app to finish its loading sequence
-    // (#dashboard-page-main appears only after user, config, and DSC are fetched).
-    cy.get('#dashboard-page-main', { timeout: SIDEBAR_SETTLE_TIMEOUT });
+    // Wait for the app to finish loading (user, config, DSC). The main
+    // content container is only rendered after those complete, so its
+    // presence confirms area flags and extensions are evaluated.
+    cy.get('[data-testid="dashboard-page-main"]', { timeout: SIDEBAR_SETTLE_TIMEOUT });
 
     return appChrome
       .findSideBar()


### PR DESCRIPTION
## Description
The test was flaking because UI sidebar polls used cy.visitWithLogin on every retry, incurring full OAuth + page-load overhead (~15s per attempt). Combined with non-deterministic operator leader-election delays (~83s for MLflow), the polling budget was exhausted before the nav items appeared.

Changes:
- Use cy.reload() for retry attempts after the initial visitWithLogin
- Poll backend resources (DSC component status, deployment readiness) before checking the sidebar, so the UI poll is a quick confirmation
- Extract enableGenAiBackend / enableMlflowBackend for composition so enablePromptManagementFeatures does one sidebar poll instead of three
- Reduce poll interval from 10s to 5s (viable now that retries are cheap)

## How Has This Been Tested?
- Validated with 7 consecutive passes at retries=0.
- Jenkins - passed twice in a row
<img width="321" height="272" alt="image" src="https://github.com/user-attachments/assets/60bbc87d-f259-4605-9887-7c6c6cf5b8b5" />


## Test Impact
- None 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked UI polling to visit once per session then reload on retries, wait for page readiness, and emit richer diagnostics on failures
  * Split backend enablement from UI checks so GenAI, MLflow, and Prompt flows enable backend resources first, then verify readiness
  * Added operator/deployment readiness and remote-entry HTTP checks before confirming sidebar features

* **Bug Fixes**
  * Improved reliability of sidebar detection and reduced repeated logins during setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->