### PR TITLE
[WIP] Add agent-eval-harness evaluation infrastructure for skill testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ vendor/
 # Triage artifacts
 .artifacts/
 
+# Eval harness runs (generated results, logs, reports)
+eval/runs/
+
 # AgentReady reports
 .agentready/
 assessment-output.txt

--- a/eval/dataset/docs-create/cases/case-001/annotations.yaml
+++ b/eval/dataset/docs-create/cases/case-001/annotations.yaml
@@ -1,0 +1,9 @@
+doc_type: package
+expected_path: packages/model-serving/docs/overview.md
+expected_template: docs/templates/package-template.md
+key_sections:
+  - Overview
+  - Architecture
+  - Dependencies
+  - Interactions
+min_interactions: 1

--- a/eval/dataset/docs-create/cases/case-001/input.yaml
+++ b/eval/dataset/docs-create/cases/case-001/input.yaml
@@ -1,0 +1,4 @@
+prompt: >
+  Create documentation for the model-serving package. It provides the UI
+  for deploying and managing model serving endpoints in OpenShift AI,
+  including inference services, serving runtimes, and model deployments.

--- a/eval/dataset/docs-create/cases/case-002/annotations.yaml
+++ b/eval/dataset/docs-create/cases/case-002/annotations.yaml
@@ -1,0 +1,9 @@
+doc_type: frontend_area
+expected_path: frontend/docs/pipelines.md
+expected_template: docs/templates/frontend-template.md
+key_sections:
+  - Overview
+  - Pages
+  - Components
+  - Interactions
+min_interactions: 1

--- a/eval/dataset/docs-create/cases/case-002/input.yaml
+++ b/eval/dataset/docs-create/cases/case-002/input.yaml
@@ -1,0 +1,4 @@
+prompt: >
+  Create documentation for the pipelines frontend area. This area covers
+  the pipeline runs, experiments, and executions pages in the dashboard.
+  It is under frontend/src/pages/pipelines/ and frontend/src/concepts/pipelines/.

--- a/eval/dataset/docs-create/cases/case-003/annotations.yaml
+++ b/eval/dataset/docs-create/cases/case-003/annotations.yaml
@@ -1,0 +1,9 @@
+doc_type: backend_module
+expected_path: backend/docs/accelerator-profiles.md
+expected_template: docs/templates/backend-template.md
+key_sections:
+  - Overview
+  - API Routes
+  - K8s Resources
+  - Dependencies
+min_interactions: 1

--- a/eval/dataset/docs-create/cases/case-003/input.yaml
+++ b/eval/dataset/docs-create/cases/case-003/input.yaml
@@ -1,0 +1,4 @@
+prompt: >
+  Create documentation for the backend route handler that manages
+  accelerator profiles. The routes are in backend/src/routes/api/
+  and handle CRUD operations for AcceleratorProfile custom resources.

--- a/eval/dataset/docs-create/cases/case-004/annotations.yaml
+++ b/eval/dataset/docs-create/cases/case-004/annotations.yaml
@@ -1,0 +1,7 @@
+doc_type: guide
+expected_path_pattern: "docs/*.md or frontend/docs/*.md"
+key_sections:
+  - Overview
+  - How it works
+  - Usage
+min_interactions: 1

--- a/eval/dataset/docs-create/cases/case-004/input.yaml
+++ b/eval/dataset/docs-create/cases/case-004/input.yaml
@@ -1,0 +1,4 @@
+prompt: >
+  Create a brief guide on how connection types work in the dashboard.
+  Connection types define reusable templates for data connections
+  (S3, database, etc.) that users can instantiate in their projects.

--- a/eval/dataset/docs-create/cases/case-005/annotations.yaml
+++ b/eval/dataset/docs-create/cases/case-005/annotations.yaml
@@ -1,0 +1,10 @@
+doc_type: package
+expected_path: packages/gen-ai/docs/overview.md
+expected_template: docs/templates/package-template.md
+key_sections:
+  - Overview
+  - Architecture
+  - Features
+  - Dependencies
+  - Interactions
+min_interactions: 1

--- a/eval/dataset/docs-create/cases/case-005/input.yaml
+++ b/eval/dataset/docs-create/cases/case-005/input.yaml
@@ -1,0 +1,4 @@
+prompt: >
+  Create documentation for the gen-ai package. It provides the Gen AI
+  Studio experience including the playground, chatbot, guardrails
+  configuration, RAG/vector stores, and LlamaStack integration.

--- a/eval/dataset/jira-validate-area-label/cases/case-001/annotations.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-001/annotations.yaml
@@ -1,0 +1,6 @@
+expected_areas:
+  - dashboard-area-model-serving
+confidence: high
+signal_dimensions:
+  - K8s kind (InferenceService, ServingRuntime)
+  - keyword (serving runtime, inference, model deploy)

--- a/eval/dataset/jira-validate-area-label/cases/case-001/input.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-001/input.yaml
@@ -1,0 +1,22 @@
+prompt: >
+  Validate area labels on this issue. The issue has no existing area labels.
+  Analyze the content and assign appropriate dashboard-area-* labels.
+
+issue_key: "RHOAIENG-99001"
+summary: "InferenceService returns 500 after deploying model with custom serving runtime"
+description: >
+  When deploying a model using a custom ServingRuntime on RHOAI 2.19,
+  the InferenceService returns HTTP 500 errors. The model deploys
+  successfully but inference calls fail with "Internal Server Error".
+  Logs show a timeout connecting to the model mesh backend.
+
+  Steps to reproduce:
+  1. Create a custom ServingRuntime
+  2. Deploy a model using that runtime
+  3. Send an inference request
+
+  Expected: 200 OK with prediction result
+  Actual: 500 Internal Server Error
+labels: []
+issuetype: Bug
+issuelinks: []

--- a/eval/dataset/jira-validate-area-label/cases/case-002/annotations.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-002/annotations.yaml
@@ -1,0 +1,8 @@
+expected_areas:
+  - dashboard-area-pipelines
+  - dashboard-area-hardware-profiles
+confidence: high
+signal_dimensions:
+  - keyword (pipeline run, hardware profile, GPU)
+  - linked issue (RHOAIENG-98500 has dashboard-area-pipelines)
+  - code path (packages/hardware-profiles/)

--- a/eval/dataset/jira-validate-area-label/cases/case-002/input.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-002/input.yaml
@@ -1,0 +1,21 @@
+prompt: >
+  Validate area labels on this issue. The issue has no existing area labels.
+  Analyze the content and assign appropriate dashboard-area-* labels.
+
+issue_key: "RHOAIENG-99002"
+summary: "Pipeline run fails when workbench notebook uses GPU hardware profile"
+description: >
+  When a pipeline references a notebook that uses a GPU hardware profile,
+  the pipeline run fails with a resource allocation error. The pipeline
+  definition in the pipeline server cannot resolve the hardware profile
+  reference for the notebook container.
+
+  This affects the pipeline runs page and the workbench spawner integration.
+  The GPU hardware profile is configured via packages/hardware-profiles/.
+
+labels: []
+issuetype: Bug
+issuelinks:
+  - key: "RHOAIENG-98500"
+    type: "is blocked by"
+    labels: ["dashboard-area-pipelines"]

--- a/eval/dataset/jira-validate-area-label/cases/case-003/annotations.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-003/annotations.yaml
@@ -1,0 +1,6 @@
+expected_areas:
+  - dashboard-area-model-catalog
+confidence: high
+signal_dimensions:
+  - keyword (model catalog, admin settings)
+  - contextual (model + catalog = model-catalog, not model-serving or model-registry)

--- a/eval/dataset/jira-validate-area-label/cases/case-003/input.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-003/input.yaml
@@ -1,0 +1,17 @@
+prompt: >
+  Validate area labels on this issue. The issue has no existing area labels.
+  Analyze the content and assign appropriate dashboard-area-* labels.
+
+issue_key: "RHOAIENG-99003"
+summary: "Add helper text for Allowed Org setting in model catalog admin"
+description: >
+  The Allowed Org field in the admin settings for Model Catalog does not
+  have helper text explaining what organizations are supported and what
+  format to use. Users are confused about whether to use the org name or
+  org ID.
+
+  This is a minor UX improvement to the existing model catalog admin
+  settings page.
+labels: []
+issuetype: Story
+issuelinks: []

--- a/eval/dataset/jira-validate-area-label/cases/case-004/annotations.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-004/annotations.yaml
@@ -1,0 +1,11 @@
+expected_areas:
+  - dashboard-area-performance
+confidence: medium
+signal_dimensions:
+  - keyword (performance, table, virtualization)
+notes: >
+  This is a cross-cutting performance issue. Although it mentions
+  model serving, pipelines, and model registry, the issue is specifically
+  about performance improvement, not about any one feature area.
+  Feature area beats cross-cutting only when the issue is *about*
+  that feature, not when it *mentions* it.

--- a/eval/dataset/jira-validate-area-label/cases/case-004/input.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-004/input.yaml
@@ -1,0 +1,14 @@
+prompt: >
+  Validate area labels on this issue. The issue has no existing area labels.
+  Analyze the content and assign appropriate dashboard-area-* labels.
+
+issue_key: "RHOAIENG-99004"
+summary: "Improve table performance for large datasets"
+description: >
+  The data table component used across multiple pages is slow when
+  rendering more than 500 rows. This affects model serving endpoints
+  table, pipeline runs table, and the registered models list. Need
+  to implement virtualization or pagination to improve performance.
+labels: []
+issuetype: Task
+issuelinks: []

--- a/eval/dataset/jira-validate-area-label/cases/case-005/annotations.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-005/annotations.yaml
@@ -1,0 +1,13 @@
+expected_areas:
+  - dashboard-area-autorag
+confidence: high
+signal_dimensions:
+  - keyword (AutoRAG, faithfulness, answer correctness, pattern evaluation)
+  - Jira label (AutoRAG)
+  - code path (packages/autorag/)
+  - summary prefix ([AutoRAG])
+notes: >
+  Should NOT be assigned dashboard-area-automl despite sharing
+  leaderboard UI patterns. The [AutoRAG] prefix, AutoRAG Jira label,
+  and autorag-specific metrics (faithfulness, answer correctness)
+  all clearly point to autorag, not automl.

--- a/eval/dataset/jira-validate-area-label/cases/case-005/input.yaml
+++ b/eval/dataset/jira-validate-area-label/cases/case-005/input.yaml
@@ -1,0 +1,16 @@
+prompt: >
+  Validate area labels on this issue. The issue has no existing area labels.
+  Analyze the content and assign appropriate dashboard-area-* labels.
+
+issue_key: "RHOAIENG-99005"
+summary: "[AutoRAG] Experiment leaderboard shows wrong evaluation metrics"
+description: >
+  The AutoRAG experiment leaderboard page shows incorrect values for
+  faithfulness and answer correctness metrics. The pattern evaluation
+  scores are not being correctly parsed from the API response.
+
+  File: packages/autorag/frontend/src/pages/experiments/LeaderboardTable.tsx
+labels:
+  - AutoRAG
+issuetype: Bug
+issuelinks: []

--- a/eval/docs-create-eval.yaml
+++ b/eval/docs-create-eval.yaml
@@ -1,0 +1,118 @@
+name: docs-create-eval
+description: Evaluate the docs-create skill — generates documentation files from natural language descriptions
+skill: docs-create
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-7
+  judge: claude-opus-4-7
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__*"
+
+dataset:
+  path: eval/dataset/docs-create/cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file. The 'prompt' field is a natural language description
+      of what documentation to create. May reference specific packages, frontend
+      areas, or backend modules in the odh-dashboard monorepo.
+    - reference.md: Gold standard documentation output for comparison scoring.
+      Follows docs/guidelines.md conventions. Under 300 lines, no placeholder text.
+    - annotations.yaml: Expected doc type, output path, and quality signals.
+
+inputs:
+  tools:
+    - match: Questions asked to the user via AskUserQuestion.
+      prompt: |
+        Answer based on the test case context. If asked to confirm, say "yes".
+        If asked about scope, say "keep it focused on the specified area".
+
+outputs:
+  - path: .
+    schema: |
+      A single markdown documentation file created at the path determined by
+      the skill (frontend/docs/, backend/docs/, packages/<name>/docs/, or
+      .claude/rules/). The file follows docs/guidelines.md conventions.
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: file_created
+    description: |
+      Check that the skill created exactly one documentation file and it is
+      non-empty with at least 200 characters.
+    check: |
+      content = outputs.get("main_content", "")
+      if len(content.strip()) < 200:
+          return False, f"Output too short ({len(content.strip())} chars, need >=200)"
+      return True, f"Doc created with {len(content.strip())} chars"
+
+  - name: no_placeholders
+    description: |
+      Check that the generated doc has no placeholder text like [Description],
+      TODO, TBD, or "Not applicable" filler.
+    check: |
+      content = outputs.get("main_content", "")
+      placeholders = ["[Description]", "[TODO]", "TBD", "Not applicable",
+                       "[Add ", "[Insert ", "[Replace"]
+      found = [p for p in placeholders if p.lower() in content.lower()]
+      if found:
+          return False, f"Found placeholders: {', '.join(found)}"
+      return True, "No placeholder text found"
+
+  - name: under_line_limit
+    description: |
+      Check that the generated doc is under 300 lines (hard limit 500).
+    check: |
+      content = outputs.get("main_content", "")
+      lines = content.strip().split("\n")
+      if len(lines) > 500:
+          return False, f"Hard limit exceeded: {len(lines)} lines (max 500)"
+      if len(lines) > 300:
+          return False, f"Soft limit exceeded: {len(lines)} lines (target <300)"
+      return True, f"Doc is {len(lines)} lines"
+
+  - name: doc_quality
+    description: |
+      Evaluate the quality of the generated documentation compared to the
+      reference. Consider: accuracy, completeness, clarity, adherence to
+      docs/guidelines.md, and practical usefulness. Score 1-5.
+    prompt: |
+      Compare the generated documentation against the reference document.
+
+      Evaluation criteria:
+      1. **Accuracy** — Does the doc correctly describe the code/feature?
+      2. **Completeness** — Are all relevant sections covered?
+      3. **Clarity** — Is the writing clear and well-organized?
+      4. **Guidelines adherence** — Does it follow the project's doc conventions?
+      5. **Usefulness** — Would a developer find this doc helpful?
+
+      Score 1-5 where:
+      - 5: Excellent — matches or exceeds reference quality
+      - 4: Good — covers key points, minor gaps
+      - 3: Acceptable — usable but missing some important content
+      - 2: Below average — significant gaps or inaccuracies
+      - 1: Poor — largely incorrect or unhelpful
+
+thresholds:
+  file_created:
+    min_pass_rate: 1.0
+  no_placeholders:
+    min_pass_rate: 1.0
+  under_line_limit:
+    min_pass_rate: 1.0
+  doc_quality:
+    min_mean: 3.5

--- a/eval/jira-validate-area-label-eval.yaml
+++ b/eval/jira-validate-area-label-eval.yaml
@@ -1,0 +1,123 @@
+name: jira-validate-area-label-eval
+description: Evaluate the jira-validate-area-label skill — assigns dashboard-area-* labels based on multi-signal content analysis
+skill: jira-validate-area-label
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+
+runner:
+  type: claude-code
+
+models:
+  skill: claude-sonnet-4-7
+  judge: claude-opus-4-7
+
+permissions:
+  allow: []
+  deny:
+    - "mcp__atlassian__*"
+    - "mcp__*"
+
+dataset:
+  path: eval/dataset/jira-validate-area-label/cases
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+        prompt: The instruction to run area label validation on a mock issue.
+        issue_key: Mock Jira issue key.
+        summary: Issue summary text.
+        description: Issue description text.
+        labels: Existing labels on the issue (list).
+        issuetype: Issue type (Bug, Story, Task).
+        issuelinks: Any linked issues (list, may be empty).
+    - reference.md: Expected operations output showing which dashboard-area-*
+      labels should be assigned and why.
+    - annotations.yaml: Expected area labels, confidence level, and signal
+      dimensions that should be cited.
+
+inputs:
+  tools:
+    - match: Questions asked to the user via AskUserQuestion.
+      prompt: |
+        Answer based on the test case context. Default to "yes" for
+        confirmations.
+    - match: Any interaction with Jira via MCP tools.
+      prompt: |
+        Block all Jira API calls. Return mock data from the test case
+        input.yaml instead.
+
+outputs:
+  - path: .artifacts/triage
+    schema: |
+      An operations JSON file following the jira-triage operations-schema.json
+      format. Contains ADD_LABEL operations for dashboard-area-* labels with
+      reasons citing the signal dimensions used.
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: correct_areas
+    description: |
+      Check that the skill assigned the expected area labels from annotations.
+    check: |
+      import json
+      annotations = outputs.get("annotations", {})
+      expected = set(annotations.get("expected_areas", []))
+      content = outputs.get("main_content", "")
+      if not expected:
+          return True, "No expected areas in annotations"
+      found = set()
+      for area in expected:
+          if area in content:
+              found.add(area)
+      missing = expected - found
+      extra_check = True
+      if missing:
+          return False, f"Missing areas: {', '.join(missing)}"
+      return True, f"All {len(expected)} expected areas found"
+
+  - name: has_reasons
+    description: |
+      Check that each ADD_LABEL operation includes a reason citing at least
+      one signal dimension.
+    check: |
+      content = outputs.get("main_content", "")
+      if "reason" not in content.lower():
+          return False, "No reasons found in output"
+      signal_terms = ["keyword", "K8s kind", "code path", "Jira label",
+                       "linked issue", "scrum team", "summary", "description"]
+      found_signals = [t for t in signal_terms if t.lower() in content.lower()]
+      if not found_signals:
+          return False, "Reasons don't cite any signal dimensions"
+      return True, f"Reasons cite signals: {', '.join(found_signals)}"
+
+  - name: area_quality
+    description: |
+      Evaluate the quality of area label assignments compared to the reference.
+      Score 1-5 based on accuracy, signal analysis depth, and reason quality.
+    prompt: |
+      Compare the skill's area label assignments against the reference.
+
+      Evaluation criteria:
+      1. **Correct labels** — Did it assign the right dashboard-area-* labels?
+      2. **No false positives** — Did it avoid assigning incorrect areas?
+      3. **Signal analysis** — Did it use multiple signal dimensions (keywords,
+         K8s kinds, code paths, Jira labels, linked issues)?
+      4. **Confidence threshold** — Did it correctly skip ambiguous cases?
+      5. **Reason quality** — Are reasons concise and cite specific signals?
+
+      Score 1-5 where 5 is perfect (correct labels, strong multi-signal
+      analysis, no false positives).
+
+thresholds:
+  correct_areas:
+    min_pass_rate: 0.8
+  has_reasons:
+    min_pass_rate: 1.0
+  area_quality:
+    min_mean: 3.5

--- a/eval/prompts/docs-quality-judge.md
+++ b/eval/prompts/docs-quality-judge.md
@@ -1,0 +1,45 @@
+# Documentation Quality Judge
+
+Evaluate the generated documentation against the reference and the project's documentation guidelines.
+
+## Scoring Rubric
+
+### 5 — Excellent
+- All relevant sections present with accurate, detailed content
+- Follows docs/guidelines.md conventions precisely
+- No placeholder text, no filler sections
+- Under 300 lines
+- At least 1 concrete dependency in Interactions section
+- Would be useful to a new developer immediately
+
+### 4 — Good
+- Covers key sections with accurate content
+- Minor gaps (e.g., missing one optional section)
+- Follows conventions with minor deviations
+- Practical and useful
+
+### 3 — Acceptable
+- Core content is present but incomplete
+- Some sections lack depth or detail
+- Mostly follows conventions
+- Usable but would benefit from editing
+
+### 2 — Below Average
+- Significant gaps in content
+- Inaccurate descriptions of code or architecture
+- Convention violations
+- Limited practical usefulness
+
+### 1 — Poor
+- Mostly placeholder or generic content
+- Major inaccuracies
+- Does not follow project conventions
+- Not useful to a developer
+
+## Key Quality Signals
+
+- **Template adherence**: Did the skill select and follow the right template?
+- **Source research**: Does the content reflect actual code, not generic descriptions?
+- **Interactions section**: Names at least 1 concrete dependency
+- **No filler**: Every section has real content or is omitted entirely
+- **Line count**: Under 300 lines (hard limit 500)


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description

- **Eval configs** (`eval/*.yaml`) for two skills:
  - `docs-create` — tests documentation generation quality (file creation, placeholder detection, line limits, LLM quality scoring)
  - `jira-validate-area-label` — tests area label assignment accuracy (correct areas, signal dimension citations, disambiguation)
- **Test datasets** (`eval/dataset/`) with 5 cases per skill:
  - `docs-create`: package docs (model-serving, gen-ai), frontend area doc (pipelines), backend module doc (accelerator profiles), guide (connection types)
  - `jira-validate-area-label`: K8s kind signals, multi-area assignment, model-catalog disambiguation, cross-cutting vs feature area, AutoRAG vs AutoML disambiguation
- **Judge prompts** (`eval/prompts/`) with scoring rubrics for LLM-based quality evaluation
- **`.gitignore` update** to exclude `eval/runs/` (generated results, logs, reports)

### Not Included / Future Work

- Eval configs for remaining skills (jira-validate-issue-type, jira-validate-description, jira-validate-priority-severity, jira-evaluate-blockers, jira-assign-scrum-team, jira-triage orchestrator)
- Gold reference outputs (`reference.md` per case) — these get generated after the first successful runs using `--gold`
- MLflow tracking setup for persistent cross-run comparison
- Larger datasets with more edge cases (target 15-20 cases per skill)
- CI integration for automated skill regression detection on skill file changes
 
## How Has This Been Tested?

1. Launch Claude Code with the eval harness plugin:
   ```bash
   claude --plugin-dir ../agent-eval-harness
   ```
2. Run an eval:
```
/eval-run --config eval/docs-create-eval.yaml --model sonnet
/eval-run --config eval/jira-validate-area-label-eval.yaml --model sonnet
```
3. Review results:
```
/eval-review --run-id <run-id> --config eval/docs-create-eval.yaml
```

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added evaluation test cases and quality scoring criteria for documentation generation tasks
  * Added evaluation test cases and validation rules for Jira issue area label classification

* **Chores**
  * Updated configuration to exclude evaluation output directories
  * Added quality evaluation guidelines and scoring rubrics for documentation assessment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->