### PR TITLE
fix(network): simplify NetworkPolicy egress to unrestricted in-cluster

### DIFF
--- a/manifests/modular-architecture/networkpolicy.yaml
+++ b/manifests/modular-architecture/networkpolicy.yaml
@@ -36,52 +36,19 @@ spec:
         # Allow traffic from pods in the same namespace
         - podSelector: {}
   egress:
-    # Allow DNS resolution (RHOAIENG-49013)
-    # Ports 53 (service) and 5353 (CoreDNS pod target port after DNAT)
+    # Allow all in-cluster egress (DNS, inter-BFF communication, Prometheus, Perses, etc.)
+    # No port restrictions: the dashboard communicates with many in-cluster services
+    # on various ports; enumerating them creates fragile maintenance burden (RHOAIENG-59861).
     - to:
         - namespaceSelector: {}
-      ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-        - port: 5353
-          protocol: UDP
-        - port: 5353
-          protocol: TCP
-    # Allow inter-BFF communication within same namespace
-    - to:
-        - podSelector:
-            matchLabels:
-              deployment: odh-dashboard
-      ports:
-        - port: 8043
-          protocol: TCP
-        - port: 8143
-          protocol: TCP
-        - port: 8243
-          protocol: TCP
-        - port: 8343
-          protocol: TCP
-    # Allow egress to Kubernetes API server (runs on host network, port 6443)
+    # Allow egress to Kubernetes API server (runs on host network, not matched by namespaceSelector)
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
       ports:
         - port: 6443
           protocol: TCP
-    # Allow egress to in-cluster services (any namespace) on common ports
-    - to:
-        - namespaceSelector: {}
-      ports:
-        - port: 443
-          protocol: TCP
-        - port: 80
-          protocol: TCP
-        - port: 8321
-          protocol: TCP
     # Allow egress to external services (off-cluster backends like MaaS, MLflow, LlamaStack)
-    # ipBlock with 0.0.0.0/0 matches all external IPs; namespaceSelector only matches in-cluster pods
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59861

## Description

The granular egress port enumeration introduced in #6404 caused two issues in RHOAI deployments ([RHOAIENG-59861](https://issues.redhat.com/browse/RHOAIENG-59861), [RHOAIENG-59862](https://issues.redhat.com/browse/RHOAIENG-59862)):

1. **Missing RHOAI pod selector label in egress** — The inter-BFF egress rule targeted `podSelector: {matchLabels: {deployment: odh-dashboard}}`, but RHOAI pods have `deployment: rhods-dashboard`. The RHOAI kustomize patch only fixes `spec.podSelector` (which pod the policy applies TO), not the egress destination selector. This broke inter-BFF and module federation proxy traffic in RHOAI.

2. **Egress port enumeration too restrictive** — The in-cluster egress only allowed ports 443, 80, 8321, blocking dashboard access to Perses (port 8080) and Thanos/Prometheus (port 9092). The inter-BFF egress also missed newer module ports: 8543 (eval-hub), 8643 (automl), 8743 (autorag). Every new module or service integration would require a NetworkPolicy update.

**Fix**: Replace the 5 egress rules with 3 simplified rules:
- **Unrestricted in-cluster** (`namespaceSelector: {}`, no port restrictions) — covers DNS, inter-BFF, Perses, Prometheus, and any future in-cluster service
- **K8s API server** (`ipBlock`, port 6443) — host-network API server not matched by namespaceSelector
- **External services** (`ipBlock`, ports 443/80) — off-cluster backends like MaaS, MLflow, LlamaStack

This eliminates both bugs at once and is forward-compatible — no NetworkPolicy update needed when adding new modules or in-cluster service integrations. The RHOAI kustomize overlay requires no changes since the removed inter-BFF `podSelector` rule (which had the label bug) is subsumed by the unrestricted in-cluster rule.

## How Has This Been Tested?

### 1. Kustomize Build Verification

- Verified `kustomize build manifests/rhoai/shared/base/` produces a valid NetworkPolicy with the correct RHOAI name (`rhods-dashboard-allow-ports`), pod selector (`deployment: rhods-dashboard`), and simplified egress rules (3 rules instead of 5)

### 2. Cluster Testing — RHOAI (dash-e2e-odh)

Applied the simplified NetworkPolicy to a live RHOAI cluster (`dash-e2e-odh.osp.rh-ods.com`) in namespace `redhat-ods-applications` and verified all traffic paths from both dashboard pods (`rhods-dashboard-58dd4d8f-fz57b`, `rhods-dashboard-58dd4d8f-z82fd`):

**BFF Healthchecks (all 7 sidecars):**

```
model-registry (8043): HTTP 200 ✅
gen-ai         (8143): HTTP 200 ✅
maas           (8243): HTTP 200 ✅
mlflow         (8343): HTTP 200 ✅
eval-hub       (8543): HTTP 200 ✅
automl         (8643): HTTP 200 ✅
autorag        (8743): HTTP 200 ✅
```

**Module Federation remoteEntry via K8s service DNS (all 7 modules):**

```
model-registry (8043): HTTP 200 (0.020s) ✅
gen-ai         (8143): HTTP 200 (0.015s) ✅
maas           (8243): HTTP 200 (0.019s) ✅
mlflow         (8343): HTTP 200 (0.015s) ✅
eval-hub       (8543): HTTP 200 (0.016s) ✅
automl         (8643): HTTP 200 (0.018s) ✅
autorag        (8743): HTTP 200 (0.017s) ✅
```

All remoteEntry files load in ~15-20ms — no NetworkPolicy-induced timeouts.

**Inter-BFF Communication (PR #6404 test suite):**

```bash
# MaaS token issuance (direct)
curl -sk -X POST https://localhost:8243/api/v1/tokens \
  -H "x-forwarded-access-token: $TOKEN" -d '{"expiration":"2h"}'
# → {"data":{"token":"eyJhbG...","expiresAt":1777315253}} ✅

# MaaS token issuance (via K8s service DNS)
curl -sk -X POST https://rhods-dashboard.<ns>.svc.cluster.local:8243/api/v1/tokens \
  -H "x-forwarded-access-token: $TOKEN" -d '{"expiration":"2h"}'
# → {"data":{"token":"eyJhbG...","expiresAt":1777315284}} ✅

# Token revocation
curl -sk -X DELETE https://rhods-dashboard.<ns>.svc.cluster.local:8243/api/v1/tokens \
  -H "x-forwarded-access-token: $TOKEN"
# → HTTP 204 ✅
```

Verified on both pods — both work identically.

**Cross-namespace services (previously blocked by port enumeration):**

```
Perses    (8080): HTTP 200 (0.010s) ✅  — data-science-perses.redhat-ods-monitoring
Thanos    (9092): Reachable (0.019s) ✅  — thanos-querier.openshift-monitoring
```

Both services were blocked before this fix and are now accessible.

**K8s API and external egress:**

```
K8s API   (6443): HTTP 200 (0.022s) ✅  — kubernetes.default.svc
External  (443):  Reachable (0.046s) ✅  — registry.redhat.io
```

### 3. Known Issue Found (pre-existing, not related to this PR)

The gen-ai BFF has `BFF_MAAS_SERVICE_NAME=odh-dashboard` hardcoded in the base deployment manifest. In RHOAI the service is `rhods-dashboard`, so inter-BFF calls routed through the Gen-AI BFF proxy endpoint (`/gen-ai/api/v1/bff/maas/tokens`) fail with DNS resolution errors. Direct calls to MaaS via the correct service name succeed, confirming this is a service name env var issue, not a NetworkPolicy issue. Filed as [RHOAIENG-60050](https://issues.redhat.com/browse/RHOAIENG-60050).

## Test Impact

This is a manifest-only change (Kubernetes NetworkPolicy YAML). No application code or tests are affected. The change simplifies network rules — no new test coverage is applicable. Cluster-level verification is documented above.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`