### PR TITLE
Fix: testAboutDialog e2e test retry

### DIFF
--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -53,9 +53,9 @@ describe('Verify RHODS About Dialog', () => {
           .invoke('text')
           .should('match', /\d/) // Wait until text contains at least one digit
           .then((uiVersion) => {
-            softTrue(
-              version.includes(uiVersion),
-              `${productName} version '${version}' is not similar to '${uiVersion}' in About dialog`,
+            expect(version).to.contain(
+              uiVersion,
+              `${productName} version '${version}' should be similar to '${uiVersion}' in About dialog`,
             );
           });
       });
@@ -77,8 +77,8 @@ describe('Verify RHODS About Dialog', () => {
                 return;
               }
               const text = texts.join(' ');
-              softTrue(
-                version.some((v) => text.includes(v)),
+              expect(version.some((v) => text.includes(v))).to.equal(
+                true,
                 `Version ${version} not found for component ${component}`,
               );
             });


### PR DESCRIPTION
## Description
testAboutDialog wasn't retrying when failing. It was happening this way because:
"""
Soft assertions and retries are fundamentally incompatible as used here. Soft assertions defer the failure to after(), which makes Cypress think the test passed, so it never retries. If it did retry, the soft assertion state would also need to be reset.
"""
_Claude dixit_ 

## How Has This Been Tested?
Forcing an error to happen and setting the retries to 2, we have now 3 attempts:
<img width="658" height="218" alt="Greenshot 2026-04-28 08 55 17" src="https://github.com/user-attachments/assets/0cb52797-5983-4ab3-9447-e15c6f8b0a1d" />

Then I've deleted the e
<img width="664" height="239" alt="Greenshot 2026-04-28 09 00 20" src="https://github.com/user-attachments/assets/fb314759-9015-4605-b3ff-9f05fa24e58c" />
rror I was forcing (and the retries when running locally) and the test was also passing properly:

## Test Impact
Test fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened version validation tests for the About dialog to improve test reliability and assertion accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->