### PR TITLE
fix for Flaky Cypress test: Pipelines - uploads a new pipeline version

### DIFF
--- a/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineImportModal.ts
@@ -94,7 +94,7 @@ class PipelineImportModal extends Modal {
   }
 
   submit(): void {
-    this.findSubmitButton().click();
+    this.findSubmitButton().should('be.enabled').click();
   }
 }
 

--- a/packages/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelineVersionImportModal.ts
@@ -89,7 +89,7 @@ class PipelineImportModal extends Modal {
   }
 
   submit(): void {
-    this.findSubmitButton().click();
+    this.findSubmitButton().should('be.enabled').click();
   }
 
   mockCreatePipelineVersion(params: CreatePipelineVersionKFData, namespace: string) {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -1128,7 +1128,6 @@ describe('Pipelines', () => {
     // client-side argo detection is bypassed due to a stale-closure race.
     pipelineVersionImportModal.mockUploadVersion({}, projectName);
     pipelineVersionImportModal.uploadPipelineYaml(argoWorkflowPipeline);
-    pipelineVersionImportModal.findSubmitButton().should('be.enabled');
     pipelineVersionImportModal.submit();
 
     pipelineVersionImportModal.findImportModalError().should('exist');


### PR DESCRIPTION
fixes - https://redhat.atlassian.net/browse/RHOAIENG-59146

What was the main issue - 
-  `modal-submit-button` was disabled (or loading) when Cypress test clicked immediately after `uploadPipelineYaml()`. 

How it was fixed?
-  Chained `should('be.enabled')` before  `.click();`, so that the button loads completely before it is clicked
- Removed the redundant `findSubmitButton().should('be.enabled')` before `submit()` in the “uploads fails with argo workflow” test.



## How tested
- `npm run test:cypress-ci` with spec `pipelines.cy.ts` multiple times (>5) and passed every time

<img width="1715" height="960" alt="SCR-20260428-mxok" src="https://github.com/user-attachments/assets/1755985e-817b-44f6-891f-120212c2f6be" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced pipeline import modal tests to improve reliability by ensuring the submit button is ready before interaction, reducing potential timing issues in automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->