### PR TITLE
feat(automl): unify model schema to support 3.5 format alongside legacy 3.4

### DIFF
--- a/packages/automl/frontend/src/app/context/AutomlResultsContext.ts
+++ b/packages/automl/frontend/src/app/context/AutomlResultsContext.ts
@@ -6,40 +6,20 @@ import { getTaskType } from '~/app/utilities/utils';
 
 const configureSchema = createConfigureSchema();
 
-// Normalized model types after rewriting relative S3 paths to absolute paths.
-// Tabular and timeseries models have different shapes; downstream code should
-// use the `AutomlModel` union and narrow via `isTimeseriesModel()` when needed.
-
-export type AutomlTabularModel = {
+/* eslint-disable camelcase */
+export type AutomlModel = {
   name: string;
   location: {
     model_directory: string;
     predictor: string;
     notebook: string;
+    metrics?: string;
   };
   metrics: {
     test_data: Record<string, number>;
   };
 };
-
-export type AutomlTimeseriesModel = {
-  name: string;
-  base_model: string;
-  location: {
-    model_directory: string;
-    predictor: string;
-    notebook: string;
-    metrics: string;
-  };
-  metrics: {
-    test_data: Record<string, number>;
-  };
-};
-
-export type AutomlModel = AutomlTabularModel | AutomlTimeseriesModel;
-
-export const isTimeseriesModel = (model: AutomlModel): model is AutomlTimeseriesModel =>
-  'base_model' in model;
+/* eslint-enable camelcase */
 
 export type AutomlResultsContextProps = {
   pipelineRun?: PipelineRun;

--- a/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
+++ b/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
@@ -13,6 +13,7 @@ import type {
   AutomlRawTabularModelV34,
   AutomlRawTimeseriesModelV34,
   AutomlRawModelV35,
+  AutomlRawModel,
 } from '~/app/hooks/queries';
 
 // Mock fetch globally
@@ -511,6 +512,15 @@ describe('AutomlModelSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('should parse a v3.4 tabular model with extra metrics in location as v3.5', () => {
+    const ambiguous = {
+      ...validTabularModelV34,
+      location: { ...validTabularModelV34.location, metrics: 'metrics' },
+    };
+    const result = AutomlModelSchema.safeParse(ambiguous);
+    expect(result.success).toBe(true);
+  });
+
   it('should reject non-numeric metric values', () => {
     const invalid = {
       ...validUnifiedModel,
@@ -588,6 +598,20 @@ describe('isRawModelV35', () => {
       metrics: { test_data: { mase: 1.2 } },
     };
     expect(isRawModelV35(model)).toBe(false);
+  });
+
+  it('should return false when notebook + metrics present but base_model also exists', () => {
+    const model = {
+      name: 'WeightedEnsemble_L5_FULL',
+      base_model: 'some-base',
+      location: {
+        predictor: 'predictor.pkl',
+        notebook: 'notebook.ipynb',
+        metrics: 'metrics',
+      },
+      metrics: { test_data: { accuracy: 0.95 } },
+    };
+    expect(isRawModelV35(model as AutomlRawModel)).toBe(false);
   });
 
   it('should return false for a legacy tabular model without metrics in location', () => {

--- a/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
+++ b/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
@@ -502,6 +502,15 @@ describe('AutomlModelSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('should reject a unified 3.5 model that includes base_model', () => {
+    const invalid = {
+      ...validUnifiedModel,
+      base_model: 'gpt-4',
+    };
+    const result = AutomlModelSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
   it('should reject non-numeric metric values', () => {
     const invalid = {
       ...validUnifiedModel,

--- a/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
+++ b/packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx
@@ -6,9 +6,14 @@ import {
   useModelEvaluationArtifactsQuery,
   fetchS3File,
   AutomlModelSchema,
-  isRawTimeseriesModel,
+  isRawTimeseriesModelV34,
+  isRawModelV35,
 } from '~/app/hooks/queries';
-import type { AutomlRawTabularModel, AutomlRawTimeseriesModel } from '~/app/hooks/queries';
+import type {
+  AutomlRawTabularModelV34,
+  AutomlRawTimeseriesModelV34,
+  AutomlRawModelV35,
+} from '~/app/hooks/queries';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -421,7 +426,19 @@ describe('fetchS3File', () => {
 
 /* eslint-disable camelcase */
 describe('AutomlModelSchema', () => {
-  const validTabularModel: AutomlRawTabularModel = {
+  const validUnifiedModel: AutomlRawModelV35 = {
+    name: 'WeightedEnsemble_L5_FULL',
+    location: {
+      predictor: 'WeightedEnsemble_L5_FULL/predictor.pkl',
+      notebook: 'WeightedEnsemble_L5_FULL/notebooks/automl_predictor_notebook.ipynb',
+      metrics: 'WeightedEnsemble_L5_FULL/metrics',
+    },
+    metrics: {
+      test_data: { accuracy: 0.95, f1: 0.93 },
+    },
+  };
+
+  const validTabularModelV34: AutomlRawTabularModelV34 = {
     name: 'WeightedEnsemble_L5_FULL',
     location: {
       predictor: 'WeightedEnsemble_L5_FULL/predictor.pkl',
@@ -432,7 +449,7 @@ describe('AutomlModelSchema', () => {
     },
   };
 
-  const validTimeseriesModel: AutomlRawTimeseriesModel = {
+  const validTimeseriesModelV34: AutomlRawTimeseriesModelV34 = {
     name: 'TemporalFusionTransformer_FULL',
     base_model: 'TemporalFusionTransformer',
     location: {
@@ -445,26 +462,36 @@ describe('AutomlModelSchema', () => {
     },
   };
 
-  it('should validate a tabular model', () => {
-    const result = AutomlModelSchema.safeParse(validTabularModel);
+  it('should validate a unified 3.5 model', () => {
+    const result = AutomlModelSchema.safeParse(validUnifiedModel);
     expect(result.success).toBe(true);
   });
 
-  it('should validate a timeseries model', () => {
-    const result = AutomlModelSchema.safeParse(validTimeseriesModel);
+  it('should validate a legacy tabular 3.4 model', () => {
+    const result = AutomlModelSchema.safeParse(validTabularModelV34);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a legacy timeseries 3.4 model', () => {
+    const result = AutomlModelSchema.safeParse(validTimeseriesModelV34);
     expect(result.success).toBe(true);
   });
 
   it('should accept optional model_directory', () => {
+    const unifiedWithDir = {
+      ...validUnifiedModel,
+      location: { ...validUnifiedModel.location, model_directory: 'some/dir/' },
+    };
     const tabularWithDir = {
-      ...validTabularModel,
-      location: { ...validTabularModel.location, model_directory: 'some/dir/' },
+      ...validTabularModelV34,
+      location: { ...validTabularModelV34.location, model_directory: 'some/dir/' },
     };
     const timeseriesWithDir = {
-      ...validTimeseriesModel,
-      location: { ...validTimeseriesModel.location, model_directory: 'some/dir/' },
+      ...validTimeseriesModelV34,
+      location: { ...validTimeseriesModelV34.location, model_directory: 'some/dir/' },
     };
 
+    expect(AutomlModelSchema.safeParse(unifiedWithDir).success).toBe(true);
     expect(AutomlModelSchema.safeParse(tabularWithDir).success).toBe(true);
     expect(AutomlModelSchema.safeParse(timeseriesWithDir).success).toBe(true);
   });
@@ -477,7 +504,7 @@ describe('AutomlModelSchema', () => {
 
   it('should reject non-numeric metric values', () => {
     const invalid = {
-      ...validTabularModel,
+      ...validUnifiedModel,
       metrics: { test_data: { accuracy: 'high' } },
     };
     const result = AutomlModelSchema.safeParse(invalid);
@@ -485,9 +512,9 @@ describe('AutomlModelSchema', () => {
   });
 });
 
-describe('isRawTimeseriesModel', () => {
-  it('should return true for a timeseries model with base_model', () => {
-    const model: AutomlRawTimeseriesModel = {
+describe('isRawTimeseriesModelV34', () => {
+  it('should return true for a legacy timeseries model with notebooks plural', () => {
+    const model: AutomlRawTimeseriesModelV34 = {
       name: 'TemporalFusionTransformer_FULL',
       base_model: 'TemporalFusionTransformer',
       location: {
@@ -497,11 +524,24 @@ describe('isRawTimeseriesModel', () => {
       },
       metrics: { test_data: { mase: 1.2 } },
     };
-    expect(isRawTimeseriesModel(model)).toBe(true);
+    expect(isRawTimeseriesModelV34(model)).toBe(true);
   });
 
-  it('should return false for a tabular model without base_model', () => {
-    const model: AutomlRawTabularModel = {
+  it('should return false for a unified 3.5 model', () => {
+    const model: AutomlRawModelV35 = {
+      name: 'WeightedEnsemble_L5_FULL',
+      location: {
+        predictor: 'predictor.pkl',
+        notebook: 'notebook.ipynb',
+        metrics: 'metrics',
+      },
+      metrics: { test_data: { accuracy: 0.95 } },
+    };
+    expect(isRawTimeseriesModelV34(model)).toBe(false);
+  });
+
+  it('should return false for a legacy tabular model', () => {
+    const model: AutomlRawTabularModelV34 = {
       name: 'WeightedEnsemble_L5_FULL',
       location: {
         predictor: 'predictor.pkl',
@@ -509,7 +549,48 @@ describe('isRawTimeseriesModel', () => {
       },
       metrics: { test_data: { accuracy: 0.95 } },
     };
-    expect(isRawTimeseriesModel(model)).toBe(false);
+    expect(isRawTimeseriesModelV34(model)).toBe(false);
+  });
+});
+
+describe('isRawModelV35', () => {
+  it('should return true for a unified 3.5 model', () => {
+    const model: AutomlRawModelV35 = {
+      name: 'WeightedEnsemble_L5_FULL',
+      location: {
+        predictor: 'predictor.pkl',
+        notebook: 'notebook.ipynb',
+        metrics: 'metrics',
+      },
+      metrics: { test_data: { accuracy: 0.95 } },
+    };
+    expect(isRawModelV35(model)).toBe(true);
+  });
+
+  it('should return false for a legacy timeseries model', () => {
+    const model: AutomlRawTimeseriesModelV34 = {
+      name: 'TemporalFusionTransformer_FULL',
+      base_model: 'TemporalFusionTransformer',
+      location: {
+        predictor: 'predictor.pkl',
+        notebooks: 'notebooks',
+        metrics: 'metrics',
+      },
+      metrics: { test_data: { mase: 1.2 } },
+    };
+    expect(isRawModelV35(model)).toBe(false);
+  });
+
+  it('should return false for a legacy tabular model without metrics in location', () => {
+    const model: AutomlRawTabularModelV34 = {
+      name: 'WeightedEnsemble_L5_FULL',
+      location: {
+        predictor: 'predictor.pkl',
+        notebook: 'notebook.ipynb',
+      },
+      metrics: { test_data: { accuracy: 0.95 } },
+    };
+    expect(isRawModelV35(model)).toBe(false);
   });
 });
 /* eslint-enable camelcase */

--- a/packages/automl/frontend/src/app/hooks/queries.ts
+++ b/packages/automl/frontend/src/app/hooks/queries.ts
@@ -333,7 +333,8 @@ const AutomlModelSchemaV35 = AutomlModelBaseSchema.extend({
   }),
 }).strict();
 
-// Try 3.5 first, then fall back to legacy schemas for backwards compatibility
+// Try 3.5 first, then fall back to legacy schemas for backwards compatibility.
+// strict() on each schema is what disambiguates V35 from V34 tabular (both have `notebook`).
 export const AutomlModelSchema = z.union([
   AutomlModelSchemaV35,
   AutomlTimeseriesModelSchemaV34,

--- a/packages/automl/frontend/src/app/hooks/queries.ts
+++ b/packages/automl/frontend/src/app/hooks/queries.ts
@@ -298,13 +298,13 @@ export async function fetchS3Json<T>(
  */
 /* eslint-disable camelcase */
 
-const AutomlModelBaseSchema = z.object({
+const AutomlModelBaseSchema = z.strictObject({
   name: z.string(),
-  location: z.object({
+  location: z.strictObject({
     model_directory: z.string().optional(),
     predictor: z.string(),
   }),
-  metrics: z.object({
+  metrics: z.strictObject({
     test_data: z.record(z.string(), z.number()),
   }),
 });
@@ -314,7 +314,7 @@ const AutomlTabularModelSchemaV34 = AutomlModelBaseSchema.extend({
   location: AutomlModelBaseSchema.shape.location.extend({
     notebook: z.string(),
   }),
-});
+}).strict();
 
 // Legacy timeseries schema (pre-3.5): notebooks plural (directory), base_model, metrics in location
 const AutomlTimeseriesModelSchemaV34 = AutomlModelBaseSchema.extend({
@@ -323,7 +323,7 @@ const AutomlTimeseriesModelSchemaV34 = AutomlModelBaseSchema.extend({
     notebooks: z.string(),
     metrics: z.string(),
   }),
-});
+}).strict();
 
 // Unified schema (3.5+): notebook singular (file path), metrics in location, no base_model
 const AutomlModelSchemaV35 = AutomlModelBaseSchema.extend({
@@ -331,7 +331,7 @@ const AutomlModelSchemaV35 = AutomlModelBaseSchema.extend({
     notebook: z.string(),
     metrics: z.string(),
   }),
-});
+}).strict();
 
 // Try 3.5 first, then fall back to legacy schemas for backwards compatibility
 export const AutomlModelSchema = z.union([

--- a/packages/automl/frontend/src/app/hooks/queries.ts
+++ b/packages/automl/frontend/src/app/hooks/queries.ts
@@ -288,46 +288,72 @@ export async function fetchS3Json<T>(
 
 /**
  * Zod schemas to validate AutomlModel shape from model.json files.
- * Tabular and timeseries models have different location structures:
- *   - Tabular:     location.notebook  (singular, full path to notebook file)
- *   - Timeseries:  location.notebooks (plural, directory containing notebooks)
+ *
+ * Three schemas cover the evolution of the model.json format:
+ *   - 3.4 Tabular:     location.notebook (singular, file path), no location.metrics
+ *   - 3.4 Timeseries:  location.notebooks (plural, directory), location.metrics, base_model
+ *   - 3.5 Unified:     location.notebook (file path), location.metrics, no base_model
+ *
  * model_directory is optional in the raw file since it gets rewritten after parsing.
  */
 /* eslint-disable camelcase */
-const AutomlTabularModelSchema = z.object({
+
+const AutomlModelBaseSchema = z.object({
   name: z.string(),
   location: z.object({
     model_directory: z.string().optional(),
     predictor: z.string(),
-    notebook: z.string(),
   }),
   metrics: z.object({
     test_data: z.record(z.string(), z.number()),
   }),
 });
 
-const AutomlTimeseriesModelSchema = z.object({
-  name: z.string(),
+// Legacy tabular schema (pre-3.5): notebook singular, no metrics in location
+const AutomlTabularModelSchemaV34 = AutomlModelBaseSchema.extend({
+  location: AutomlModelBaseSchema.shape.location.extend({
+    notebook: z.string(),
+  }),
+});
+
+// Legacy timeseries schema (pre-3.5): notebooks plural (directory), base_model, metrics in location
+const AutomlTimeseriesModelSchemaV34 = AutomlModelBaseSchema.extend({
   base_model: z.string(),
-  location: z.object({
-    model_directory: z.string().optional(),
-    predictor: z.string(),
+  location: AutomlModelBaseSchema.shape.location.extend({
     notebooks: z.string(),
     metrics: z.string(),
   }),
-  metrics: z.object({
-    test_data: z.record(z.string(), z.number()),
+});
+
+// Unified schema (3.5+): notebook singular (file path), metrics in location, no base_model
+const AutomlModelSchemaV35 = AutomlModelBaseSchema.extend({
+  location: AutomlModelBaseSchema.shape.location.extend({
+    notebook: z.string(),
+    metrics: z.string(),
   }),
 });
 
-export const AutomlModelSchema = z.union([AutomlTabularModelSchema, AutomlTimeseriesModelSchema]);
+// Try 3.5 first, then fall back to legacy schemas for backwards compatibility
+export const AutomlModelSchema = z.union([
+  AutomlModelSchemaV35,
+  AutomlTimeseriesModelSchemaV34,
+  AutomlTabularModelSchemaV34,
+]);
 
-export type AutomlRawTabularModel = z.infer<typeof AutomlTabularModelSchema>;
-export type AutomlRawTimeseriesModel = z.infer<typeof AutomlTimeseriesModelSchema>;
-export type AutomlRawModel = AutomlRawTabularModel | AutomlRawTimeseriesModel;
+export type AutomlRawTabularModelV34 = z.infer<typeof AutomlTabularModelSchemaV34>;
+export type AutomlRawTimeseriesModelV34 = z.infer<typeof AutomlTimeseriesModelSchemaV34>;
+export type AutomlRawModelV35 = z.infer<typeof AutomlModelSchemaV35>;
+export type AutomlRawModel =
+  | AutomlRawModelV35
+  | AutomlRawTabularModelV34
+  | AutomlRawTimeseriesModelV34;
 
-export const isRawTimeseriesModel = (model: AutomlRawModel): model is AutomlRawTimeseriesModel =>
-  'base_model' in model;
+export const isRawTimeseriesModelV34 = (
+  model: AutomlRawModel,
+): model is AutomlRawTimeseriesModelV34 => 'notebooks' in model.location;
+
+export const isRawModelV35 = (model: AutomlRawModel): model is AutomlRawModelV35 =>
+  'notebook' in model.location && 'metrics' in model.location && !('base_model' in model);
 /* eslint-enable camelcase */
 
 export function useModelEvaluationArtifactsQuery(

--- a/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
@@ -4,7 +4,6 @@ import {
   useS3ListFilesQuery,
   fetchS3Json,
   AutomlModelSchema,
-  isRawModelV35,
   isRawTimeseriesModelV34,
 } from '~/app/hooks/queries';
 import { getFiles as getS3Files } from '~/app/api/s3.ts';
@@ -180,50 +179,28 @@ export function useAutomlResults(
           });
 
           // Rewrite relative location paths to absolute S3 paths.
-          // Handles three schema versions:
-          //   3.5+:         notebook (file path) + metrics
-          //   3.4 timeseries: notebooks (directory) + metrics + base_model
-          //   3.4 tabular:    notebook (file path), no metrics
-          let model: AutomlModel;
-          if (isRawTimeseriesModelV34(validated)) {
-            model = {
-              name: validated.name,
-              location: {
-                // eslint-disable-next-line camelcase
-                model_directory: directory,
-                predictor: `${artifactDirectory}${validated.location.predictor}`,
-                notebook: `${artifactDirectory}${validated.location.notebooks}/automl_predictor_notebook.ipynb`,
-                metrics: `${artifactDirectory}${validated.location.metrics}`,
-              },
-              metrics: validated.metrics,
-            };
-          } else if (isRawModelV35(validated)) {
-            // Unified 3.5 schema: notebook (file path) + metrics in location
-            const { metrics: locationMetrics } = validated.location;
-            model = {
-              name: validated.name,
-              location: {
-                // eslint-disable-next-line camelcase
-                model_directory: directory,
-                predictor: `${artifactDirectory}${validated.location.predictor}`,
-                notebook: `${artifactDirectory}${validated.location.notebook}`,
-                metrics: `${artifactDirectory}${locationMetrics}`,
-              },
-              metrics: validated.metrics,
-            };
-          } else {
-            // Legacy tabular (3.4): no metrics in location
-            model = {
-              name: validated.name,
-              location: {
-                // eslint-disable-next-line camelcase
-                model_directory: directory,
-                predictor: `${artifactDirectory}${validated.location.predictor}`,
-                notebook: `${artifactDirectory}${validated.location.notebook}`,
-              },
-              metrics: validated.metrics,
-            };
-          }
+          // Timeseries (3.4) uses `notebooks` (plural, directory); all others use `notebook` (file).
+          // V35 and timeseries have `location.metrics`; legacy tabular does not.
+          const notebook = isRawTimeseriesModelV34(validated)
+            ? `${artifactDirectory}${validated.location.notebooks}/automl_predictor_notebook.ipynb`
+            : `${artifactDirectory}${validated.location.notebook}`;
+
+          const locationMetrics =
+            'metrics' in validated.location
+              ? `${artifactDirectory}${validated.location.metrics}`
+              : undefined;
+
+          const model: AutomlModel = {
+            name: validated.name,
+            location: {
+              // eslint-disable-next-line camelcase
+              model_directory: directory,
+              predictor: `${artifactDirectory}${validated.location.predictor}`,
+              notebook,
+              ...(locationMetrics != null && { metrics: locationMetrics }),
+            },
+            metrics: validated.metrics,
+          };
 
           return { name, model };
         },

--- a/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
@@ -4,7 +4,7 @@ import {
   useS3ListFilesQuery,
   fetchS3Json,
   AutomlModelSchema,
-  isRawTimeseriesModel,
+  isRawTimeseriesModelV34,
 } from '~/app/hooks/queries';
 import { getFiles as getS3Files } from '~/app/api/s3.ts';
 import type { AutomlModel } from '~/app/context/AutomlResultsContext';
@@ -179,13 +179,14 @@ export function useAutomlResults(
           });
 
           // Rewrite relative location paths to absolute S3 paths.
-          // Timeseries has `notebooks` (directory) + `metrics`; tabular has `notebook` (file path).
+          // Handles three schema versions:
+          //   3.5+:         notebook (file path) + metrics
+          //   3.4 timeseries: notebooks (directory) + metrics + base_model
+          //   3.4 tabular:    notebook (file path), no metrics
           let model: AutomlModel;
-          if (isRawTimeseriesModel(validated)) {
+          if (isRawTimeseriesModelV34(validated)) {
             model = {
               name: validated.name,
-              // eslint-disable-next-line camelcase
-              base_model: validated.base_model,
               location: {
                 // eslint-disable-next-line camelcase
                 model_directory: directory,
@@ -195,7 +196,25 @@ export function useAutomlResults(
               },
               metrics: validated.metrics,
             };
+          } else if (
+            'metrics' in validated.location &&
+            typeof validated.location.metrics === 'string'
+          ) {
+            // Unified 3.5 schema: notebook (file path) + metrics in location
+            const { metrics: locationMetrics } = validated.location;
+            model = {
+              name: validated.name,
+              location: {
+                // eslint-disable-next-line camelcase
+                model_directory: directory,
+                predictor: `${artifactDirectory}${validated.location.predictor}`,
+                notebook: `${artifactDirectory}${validated.location.notebook}`,
+                metrics: `${artifactDirectory}${locationMetrics}`,
+              },
+              metrics: validated.metrics,
+            };
           } else {
+            // Legacy tabular (3.4): no metrics in location
             model = {
               name: validated.name,
               location: {

--- a/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
@@ -4,6 +4,7 @@ import {
   useS3ListFilesQuery,
   fetchS3Json,
   AutomlModelSchema,
+  isRawModelV35,
   isRawTimeseriesModelV34,
 } from '~/app/hooks/queries';
 import { getFiles as getS3Files } from '~/app/api/s3.ts';
@@ -196,10 +197,7 @@ export function useAutomlResults(
               },
               metrics: validated.metrics,
             };
-          } else if (
-            'metrics' in validated.location &&
-            typeof validated.location.metrics === 'string'
-          ) {
+          } else if (isRawModelV35(validated)) {
             // Unified 3.5 schema: notebook (file path) + metrics in location
             const { metrics: locationMetrics } = validated.location;
             model = {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59743
https://redhat.atlassian.net/browse/RHOAIENG-57634

## Description

AutoML 3.5 introduces a unified `model.json` format that differs from both legacy 3.4 schemas:
- **3.5 Unified**: `location.notebook` (file path) + `location.metrics`, no `base_model`
- **3.4 Timeseries**: `location.notebooks` (plural, directory) + `location.metrics` + `base_model`
- **3.4 Tabular**: `location.notebook` (file path), no `location.metrics`

The previous code only handled the two 3.4 variants, so 3.5 model.json files would fail validation.

**Changes:**
- Added a new `AutomlModelSchemaV35` Zod schema and reordered the union to try 3.5 first
- Simplified `AutomlModel` type in `AutomlResultsContext` into a single type (removed `AutomlTabularModel` / `AutomlTimeseriesModel` / `isTimeseriesModel` discriminator) since 3.5 unifies the shape
- Updated `useAutomlResults` path-rewriting logic to handle all three schema variants
- Renamed type guards and types to include version suffixes (`V34`, `V35`) for clarity

## How Has This Been Tested?

Unit tests in `queries.spec.tsx` were updated and expanded to cover all three schema variants:
- Added validation tests for the new 3.5 unified model schema
- Updated existing tabular/timeseries tests to use versioned naming (`V34`)
- Added `isRawModelV35` type guard tests (positive and negative cases)
- Updated `isRawTimeseriesModelV34` tests with additional negative cases for 3.5 and legacy tabular models

## Test Impact

- Modified: `packages/automl/frontend/src/app/hooks/__tests__/queries.spec.tsx` — expanded from ~590 to ~590+ lines with new describe blocks for `isRawModelV35` and `isRawTimeseriesModelV34`, plus validation tests for the unified 3.5 schema

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified AutoML model type structure with consolidated schema definitions.
  * Enhanced support for multiple model versions (v3.4 and v3.5) with versioned validation schemas.
  * Simplified internal model type definitions and improved data transformation logic for compatibility across model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->