### PR TITLE
fix(cypress): extend sidebar poll timeout past defaultCommandTimeout

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -82,25 +82,30 @@ const waitForGenAiStudioFeatureFlag = (): Cypress.Chainable<Cypress.Exec> => {
 };
 
 /**
- * Check if the Gen AI Studio section exists in the sidebar.
- *
- * @returns A Cypress chainable resolving to true if the section exists, false otherwise.
- */
-/**
  * Retry-aware check for an element inside the sidebar.
  * See `findNavItemInSidebar` in mlflow.ts for rationale.
+ *
+ * After `dashboard-page-main` appears, extension nav items can render asynchronously.
+ * Poll the live `#page-sidebar` DOM (not only the initial command subject) until the
+ * selector matches or the settle window elapses.
+ *
+ * The inner poll can run up to `NAV_ITEM_SETTLE_MS`; `.then()` must use a longer timeout
+ * than `defaultCommandTimeout` (10s) or Cypress aborts while the Promise is still pending.
  */
 const SIDEBAR_SETTLE_TIMEOUT = 30000;
 const NAV_ITEM_SETTLE_MS = 15000;
 const NAV_ITEM_POLL_MS = 500;
+const NAV_ITEM_FIND_TIMEOUT_MS = NAV_ITEM_SETTLE_MS + 5000;
 
 const findInSidebar = (selector: string): Cypress.Chainable<boolean> =>
   appChrome.findSideBar().then(
-    ($sidebar) =>
+    { timeout: NAV_ITEM_FIND_TIMEOUT_MS },
+    () =>
       new Cypress.Promise<boolean>((resolve) => {
         const deadline = Date.now() + NAV_ITEM_SETTLE_MS;
         const poll = () => {
-          if ($sidebar.find(selector).length > 0) {
+          const $sidebar = Cypress.$('#page-sidebar');
+          if ($sidebar.length > 0 && $sidebar.find(selector).length > 0) {
             resolve(true);
           } else if (Date.now() >= deadline) {
             resolve(false);

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -237,19 +237,25 @@ const logSidebarDiagnostics = (): void => {
  * yet contain extension items. A one-shot jQuery `.find()` during that gap
  * always misses the item, making the outer reload loop retry needlessly.
  *
- * This helper polls the live jQuery element for up to `NAV_ITEM_SETTLE_MS`
+ * This helper polls the live `#page-sidebar` DOM for up to `NAV_ITEM_SETTLE_MS`
  * so that a single page load is enough once the extensions are ready.
+ *
+ * `.then()` must allow longer than `defaultCommandTimeout` (10s) while the inner
+ * `Cypress.Promise` polls for up to `NAV_ITEM_SETTLE_MS` (15s).
  */
 const NAV_ITEM_SETTLE_MS = 15000;
 const NAV_ITEM_POLL_MS = 500;
+const NAV_ITEM_FIND_TIMEOUT_MS = NAV_ITEM_SETTLE_MS + 5000;
 
-const findNavItemInSidebar = ($sidebar: JQuery, navLabel: string): Cypress.Chainable<boolean> =>
+const findNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =>
   cy.wrap(null, { log: false }).then(
+    { timeout: NAV_ITEM_FIND_TIMEOUT_MS },
     () =>
       new Cypress.Promise<boolean>((resolve) => {
         const deadline = Date.now() + NAV_ITEM_SETTLE_MS;
         const poll = () => {
-          if ($sidebar.find(`a:contains("${navLabel}")`).length > 0) {
+          const $sidebar = Cypress.$('#page-sidebar');
+          if ($sidebar.length > 0 && $sidebar.find(`a:contains("${navLabel}")`).length > 0) {
             resolve(true);
           } else if (Date.now() >= deadline) {
             resolve(false);
@@ -278,7 +284,7 @@ const waitForNavItemInSidebar = (navLabel: string): Cypress.Chainable<boolean> =
 
     return appChrome
       .findSideBar()
-      .then(($sidebar) => findNavItemInSidebar($sidebar, navLabel))
+      .then(() => findNavItemInSidebar(navLabel))
       .then((found) => {
         const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-60360

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
fix(cypress): extend sidebar poll timeout past defaultCommandTimeout
<img width="1167" height="666" alt="Screenshot 2026-04-29 at 12 38 27" src="https://github.com/user-attachments/assets/ec32b0a4-24f7-48be-9838-db6730727a69" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
