### PR TITLE
Bind backend to loopback, fix probes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,15 @@ RUN rm -rf node_modules/esbuild node_modules/@esbuild node_modules/.bin/esbuild
 
 FROM ${BASE_IMAGE} as runtime
 
+# The curl binary is required in the final image, as it's used for
+# liveness and readiness probes
+USER root
+RUN dnf install -y curl-minimal && dnf clean all && curl --version
+USER 1001:0
+
 WORKDIR /usr/src/app
 
 RUN mkdir /usr/src/app/logs && chmod 775 /usr/src/app/logs
-
-USER 1001:0
 
 COPY --chown=default:root --from=builder /usr/src/app/frontend/public /usr/src/app/frontend/public
 COPY --chown=default:root --from=builder /usr/src/app/backend/package.json /usr/src/app/backend/package.json

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
   "main": "src/server.ts",
   "scripts": {
     "clean": "rimraf ../logs/adminActivity.log",
-    "start": "NODE_ENV=production node ./dist/server.js",
+    "start": "NODE_ENV=production IP=127.0.0.1 node ./dist/server.js",
     "start:dev": "npm run clean && cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=development nodemon src/server.ts",
     "debug": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=development nodemon --exec 'node --inspect --require ts-node/register' src/server.ts",
     "start:dev:wait": "npx wait-on -i 1000 http://localhost:4000",

--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -42,18 +42,28 @@ spec:
               cpu: 1000m
               memory: 2Gi
           livenessProbe:
-            tcpSocket:
-              port: 8080
+            exec:
+              command:
+                - curl
+                - -f
+                - -s
+                - --max-time
+                - "10"
+                - http://127.0.0.1:8080/api/health
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /api/health
-              port: 8080
-              scheme: HTTP
+            exec:
+              command:
+                - curl
+                - -f
+                - -s
+                - --max-time
+                - "10"
+                - http://127.0.0.1:8080/api/health
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30

--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -42,18 +42,28 @@ spec:
             limits:
               memory: 1Gi
           livenessProbe:
-            tcpSocket:
-              port: 8080
+            exec:
+              command:
+                - curl
+                - -f
+                - -s
+                - --max-time
+                - "10"
+                - http://127.0.0.1:8080/api/health
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /api/health
-              port: 8080
-              scheme: HTTP
+            exec:
+              command:
+                - curl
+                - -f
+                - -s
+                - --max-time
+                - "10"
+                - http://127.0.0.1:8080/api/health
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30

--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -49,7 +49,7 @@ spec:
                 - -s
                 - --max-time
                 - "10"
-                - http://127.0.0.1:8080/api/health
+                - http://127.0.0.1:8080/
             initialDelaySeconds: 30
             timeoutSeconds: 15
             periodSeconds: 30


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
https://redhat.atlassian.net/browse/RHOAIENG-11892

Bind the production backend to 127.0.0.1 so port 8080 is only reachable by the in-pod kube-rbac-proxy sidecar, preventing direct unauthenticated access from other pods.

Convert liveness and readiness probes from tcpSocket/httpGet to exec-based curl since the kubelet can no longer reach the pod IP on port 8080.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production server startup now explicitly binds to the local loopback address for tighter network isolation.
  * Container health checks switched from HTTP probes to command-based checks that query the application health endpoints with an enforced timeout for more reliable monitoring.
  * Runtime image now includes a minimal HTTP client to support the new health checks; image setup privileges were temporarily elevated and then reverted to apply this safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->