### PR TITLE
Fix MaaS Tiers TokenRateLimitPolicy and RateLimitPolicy Conflict Bug

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasTiers.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasTiers.cy.ts
@@ -80,18 +80,21 @@ describe('Tiers Page', () => {
   });
 
   it('should create a new tier', () => {
+    const createdTier = mockTier({
+      name: 'test-tier',
+      displayName: 'Test Tier',
+      description: 'Test tier description',
+      level: 5,
+      groups: ['premium-users'],
+      limits: {
+        tokensPerUnit: [{ count: 500, time: 5, unit: 'hour' }],
+        requestsPerUnit: [{ count: 200, time: 3, unit: 'second' }],
+      },
+    });
+    const tiersAfterCreate = mockTiers().concat(createdTier);
+
     cy.interceptOdh('POST /maas/api/v1/tier', {
-      data: mockTier({
-        name: 'test-tier',
-        displayName: 'Test Tier',
-        description: 'Test tier description',
-        level: 5,
-        groups: ['premium-users'],
-        limits: {
-          tokensPerUnit: [{ count: 500, time: 5, unit: 'hour' }],
-          requestsPerUnit: [{ count: 200, time: 3, unit: 'second' }],
-        },
-      }),
+      data: createdTier,
     }).as('createTier');
 
     tiersPage.findCreateTierButton().click();
@@ -144,20 +147,11 @@ describe('Tiers Page', () => {
       ]);
     });
     cy.interceptOdh('GET /maas/api/v1/tiers', {
-      data: mockTiers().concat(
-        mockTier({
-          name: 'test-tier',
-          displayName: 'Test Tier',
-          description: 'Test tier description',
-          level: 5,
-          groups: ['premium-users'],
-          limits: {
-            tokensPerUnit: [{ count: 500, time: 5, unit: 'hour' }],
-            requestsPerUnit: [{ count: 200, time: 3, unit: 'second' }],
-          },
-        }),
-      ),
+      data: tiersAfterCreate,
     });
+    cy.intercept('GET', '/api/tiers', tiersAfterCreate);
+
+    tiersPage.visit();
 
     tiersPage.findTable().should('exist');
     tiersPage.findRows().should('have.length', 4);
@@ -251,7 +245,7 @@ describe('Tiers Page', () => {
     createTierPage.selectGroupsOption('all-users');
     createTierPage.findTokenRateLimitCheckbox().should('be.checked');
     createTierPage.findTokenRateLimitCountInput(0).should('have.value', '1000000');
-    createTierPage.findTokenRateLimitCountInput(0).clear().type('2000000');
+    createTierPage.findTokenRateLimitCountInput(0).focus().type('{selectall}2000000');
     createTierPage.findTokenRateLimitTimeInput(0).should('have.value', '1');
     createTierPage.findTokenRateLimitTimeInput(0).clear().type('2');
     createTierPage.selectTokenRateLimitUnit(0, 'minute');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasTiers.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasTiers.cy.ts
@@ -149,7 +149,6 @@ describe('Tiers Page', () => {
     cy.interceptOdh('GET /maas/api/v1/tiers', {
       data: tiersAfterCreate,
     });
-    cy.intercept('GET', '/api/tiers', tiersAfterCreate);
 
     tiersPage.visit();
 

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")
 
 	// MaaS
-	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "maas-api"), "Namespace where the ConfigMap for tiers configuration is located")
+	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "redhat-ods-applications"), "Namespace where the ConfigMap for tiers configuration is located")
 	flag.StringVar(&cfg.TiersConfigMapName, "tiers-configmap-name", getEnvAsString("TIERS_CONFIGMAP_NAME", "tier-to-group-mapping"), "Name of the ConfigMap for tiers configuration")
 	flag.StringVar(&cfg.GatewayNamespace, "gateway-namespace", getEnvAsString("GATEWAY_NAMESPACE", "openshift-ingress"), "Namespace where the MaaS Gateway is deployed in")
 	flag.StringVar(&cfg.GatewayName, "gateway-name", getEnvAsString("GATEWAY_NAME", "maas-default-gateway"), "The names of the MaaS Gateway")

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -50,12 +50,22 @@ func main() {
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")
 
 	// MaaS
-	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "maas-api"), "Namespace where the ConfigMap for tiers configuration is located")
+	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "redhat-ods-applications"), "Namespace where the ConfigMap for tiers configuration is located")
 	flag.StringVar(&cfg.TiersConfigMapName, "tiers-configmap-name", getEnvAsString("TIERS_CONFIGMAP_NAME", "tier-to-group-mapping"), "Name of the ConfigMap for tiers configuration")
 	flag.StringVar(&cfg.GatewayNamespace, "gateway-namespace", getEnvAsString("GATEWAY_NAMESPACE", "openshift-ingress"), "Namespace where the MaaS Gateway is deployed in")
 	flag.StringVar(&cfg.GatewayName, "gateway-name", getEnvAsString("GATEWAY_NAME", "maas-default-gateway"), "The names of the MaaS Gateway")
+	flag.StringVar(&cfg.CombinedTokenRateLimitPolicyName, "combined-token-rate-limit-policy-name", getEnvAsString("MAAS_COMBINED_TOKEN_RATE_LIMIT_POLICY_NAME", ""), "Name of the single TokenRateLimitPolicy holding all tier token limits (default: {gateway-name}-token-rate-limits)")
+	flag.StringVar(&cfg.CombinedRequestRateLimitPolicyName, "combined-request-rate-limit-policy-name", getEnvAsString("MAAS_COMBINED_REQUEST_RATE_LIMIT_POLICY_NAME", ""), "Name of the single RateLimitPolicy holding all tier request limits (default: {gateway-name}-request-rate-limits)")
 
 	flag.Parse()
+
+	// Resolve combined policy names after flags/env so we can default from gateway name.
+	if cfg.CombinedTokenRateLimitPolicyName == "" {
+		cfg.CombinedTokenRateLimitPolicyName = cfg.GatewayName + "-token-rate-limits"
+	}
+	if cfg.CombinedRequestRateLimitPolicyName == "" {
+		cfg.CombinedRequestRateLimitPolicyName = cfg.GatewayName + "-request-rate-limits"
+	}
 
 	// Handle backward compatibility: if old flags are used, override deployment mode
 	if cfg.StandaloneMode {

--- a/packages/maas/bff/cmd/main.go
+++ b/packages/maas/bff/cmd/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")
 
 	// MaaS
-	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "redhat-ods-applications"), "Namespace where the ConfigMap for tiers configuration is located")
+	flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "maas-api"), "Namespace where the ConfigMap for tiers configuration is located")
 	flag.StringVar(&cfg.TiersConfigMapName, "tiers-configmap-name", getEnvAsString("TIERS_CONFIGMAP_NAME", "tier-to-group-mapping"), "Name of the ConfigMap for tiers configuration")
 	flag.StringVar(&cfg.GatewayNamespace, "gateway-namespace", getEnvAsString("GATEWAY_NAMESPACE", "openshift-ingress"), "Namespace where the MaaS Gateway is deployed in")
 	flag.StringVar(&cfg.GatewayName, "gateway-name", getEnvAsString("GATEWAY_NAME", "maas-default-gateway"), "The names of the MaaS Gateway")

--- a/packages/maas/bff/internal/config/environment.go
+++ b/packages/maas/bff/internal/config/environment.go
@@ -119,4 +119,8 @@ type EnvConfig struct {
 	TiersConfigMapName      string
 	GatewayNamespace        string
 	GatewayName             string
+	// CombinedTokenRateLimitPolicyName is the single TokenRateLimitPolicy CR name the BFF maintains (all tier token limits live under spec.limits).
+	CombinedTokenRateLimitPolicyName string
+	// CombinedRequestRateLimitPolicyName is the single RateLimitPolicy CR name for all tier request limits.
+	CombinedRequestRateLimitPolicyName string
 }

--- a/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/packages/maas/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -1,10 +1,8 @@
 package k8mocks
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -476,27 +474,20 @@ func createMaaSLimitPolicies(k8sClient dynamic.Interface, ctx context.Context, n
 		return err
 	}
 
-	// The token-limit-policy.yaml file is multi-document. Using Decoder instead of Unmarshall
+	// Single combined TokenRateLimitPolicy (all tier token limits under spec.limits).
 	tokenLimitYaml, err := os.ReadFile("internal/testdata/token-limit-policy.yaml")
 	if err != nil {
 		return err
 	}
 
-	decoder := yaml.NewDecoder(bytes.NewReader(tokenLimitYaml))
-	for {
-		var tokenLimit map[string]interface{}
-		err = decoder.Decode(&tokenLimit)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to decode token limit policy: %w", err)
-		}
+	var tokenLimit map[string]interface{}
+	if err = yaml.Unmarshal(tokenLimitYaml, &tokenLimit); err != nil {
+		return fmt.Errorf("failed to decode token limit policy: %w", err)
+	}
 
-		_, err = k8sClient.Resource(constants.TokenPolicyGvr).Namespace(namespace).Create(ctx, &unstructured.Unstructured{Object: tokenLimit}, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to create token limit policy: %w", err)
-		}
+	_, err = k8sClient.Resource(constants.TokenPolicyGvr).Namespace(namespace).Create(ctx, &unstructured.Unstructured{Object: tokenLimit}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create token limit policy: %w", err)
 	}
 
 	return nil

--- a/packages/maas/bff/internal/repositories/repositories.go
+++ b/packages/maas/bff/internal/repositories/repositories.go
@@ -27,7 +27,9 @@ func NewRepositories(logger *slog.Logger, k8sFactory kubernetes.KubernetesClient
 			config.TiersConfigMapNamespace,
 			config.TiersConfigMapName,
 			config.GatewayNamespace,
-			config.GatewayName),
+			config.GatewayName,
+			config.CombinedTokenRateLimitPolicyName,
+			config.CombinedRequestRateLimitPolicyName),
 		APIKeys: NewAPIKeysRepository(logger),
 	}
 }

--- a/packages/maas/bff/internal/repositories/tiers.go
+++ b/packages/maas/bff/internal/repositories/tiers.go
@@ -3,8 +3,10 @@ package repositories
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -34,6 +36,9 @@ type TiersRepository struct {
 	tiersConfigMapName      string
 	gatewayNamespace        string
 	gatewayName             string
+	// combinedTokenPolicyName / combinedRatePolicyName are the single CR names holding all tier limits (Kuadrant enforces one per kind per Gateway).
+	combinedTokenPolicyName string
+	combinedRatePolicyName  string
 }
 
 var (
@@ -44,7 +49,19 @@ var (
 
 // TODO: In general, there is no protection around edits from multiple users
 
-func NewTiersRepository(logger *slog.Logger, k8sFactory kubernetes.KubernetesClientFactory, configMapNamespace, configMapName, gatewayNamespace, gatewayName string) *TiersRepository {
+func NewTiersRepository(
+	logger *slog.Logger,
+	k8sFactory kubernetes.KubernetesClientFactory,
+	configMapNamespace, configMapName, gatewayNamespace, gatewayName string,
+	combinedTokenPolicyName, combinedRatePolicyName string,
+) *TiersRepository {
+	// Tests may pass empty policy names; default from gateway so Get/List behaviour stays deterministic.
+	if combinedTokenPolicyName == "" {
+		combinedTokenPolicyName = gatewayName + "-token-rate-limits"
+	}
+	if combinedRatePolicyName == "" {
+		combinedRatePolicyName = gatewayName + "-request-rate-limits"
+	}
 	return &TiersRepository{
 		logger:                  logger,
 		k8sFactory:              k8sFactory,
@@ -52,6 +69,8 @@ func NewTiersRepository(logger *slog.Logger, k8sFactory kubernetes.KubernetesCli
 		tiersConfigMapName:      configMapName,
 		gatewayNamespace:        gatewayNamespace,
 		gatewayName:             gatewayName,
+		combinedTokenPolicyName: combinedTokenPolicyName,
+		combinedRatePolicyName:  combinedRatePolicyName,
 	}
 }
 
@@ -126,31 +145,54 @@ func (t *TiersRepository) updateTiersConfigMap(ctx context.Context, tiersConfigM
 	return nil
 }
 
-func (t *TiersRepository) fetchTierLimits(ctx context.Context, tiers models.TiersList) error {
-	tokenPolicies, ratePolicies, err := t.fetchPolicyResources(ctx)
+// attachTierRateLimits fills each tier's Limits from the single combined TokenRateLimitPolicy / RateLimitPolicy.
+// Step A: GET combined policies by fixed names (CLI can use the same names without the dashboard label).
+// Step B: read spec.limits["<tier>-tokens"] / ["<tier>-requests"].
+// Step C: if a tier has no data in the combined object, fall back to legacy per-tier CRs (pre-migration clusters).
+func (t *TiersRepository) attachTierRateLimits(ctx context.Context, tiers models.TiersList) error {
+	combinedToken, err := t.getPolicyByName(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName)
+	if err != nil {
+		return err
+	}
+	combinedRate, err := t.getPolicyByName(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName)
+	if err != nil {
+		return err
+	}
+
+	legacyTokenPolicies, legacyRatePolicies, err := t.fetchPolicyResources(ctx)
 	if err != nil {
 		return err
 	}
 
 	for idx := range tiers {
 		tierName := tiers[idx].Name
+		tokenLimitKey := managedTokenLimitKey(tierName)
+		rateLimitKey := managedRequestLimitKey(tierName)
 
-		// Token rate limits
-		tokenPolicyName := "tier-" + tierName + "-token-rate-limits"
-		tokenLimitKey := tierName + "-tokens"
-		tokenPolicy := t.findPolicyByName(tokenPolicyName, tokenPolicies)
+		tokenPolicy := combinedToken
 		tiers[idx].Limits.TokensPerUnit, err = convertPolicyToRateLimits(tokenPolicy, tokenLimitKey)
 		if err != nil {
 			return err
 		}
+		if len(tiers[idx].Limits.TokensPerUnit) == 0 {
+			legacy := t.findPolicyByName(legacyPerTierTokenPolicyName(tierName), legacyTokenPolicies)
+			tiers[idx].Limits.TokensPerUnit, err = convertPolicyToRateLimits(legacy, tokenLimitKey)
+			if err != nil {
+				return err
+			}
+		}
 
-		// Request rate limits
-		ratePolicyName := "tier-" + tierName + "-rate-limits"
-		rateLimitKey := tierName + "-requests"
-		ratePolicy := t.findPolicyByName(ratePolicyName, ratePolicies)
+		ratePolicy := combinedRate
 		tiers[idx].Limits.RequestsPerUnit, err = convertPolicyToRateLimits(ratePolicy, rateLimitKey)
 		if err != nil {
 			return err
+		}
+		if len(tiers[idx].Limits.RequestsPerUnit) == 0 {
+			legacy := t.findPolicyByName(legacyPerTierRatePolicyName(tierName), legacyRatePolicies)
+			tiers[idx].Limits.RequestsPerUnit, err = convertPolicyToRateLimits(legacy, rateLimitKey)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -170,12 +212,14 @@ func (t *TiersRepository) GetTiersList(ctx context.Context) (models.TiersList, e
 		tiersList[idx].Description = tier.Description
 		tiersList[idx].Groups = tier.Groups
 		tiersList[idx].Level = tier.Level
-		if err = t.fetchTierLimits(ctx, tiersList); err != nil {
-			return nil, err
-		}
 
 		// TODO: Remove fake data
 		tiersList[idx].Models = []string{"ns1-llama", "n2-granite"}
+	}
+
+	// One cluster round-trip for all tiers (previously this ran inside the loop and re-fetched every iteration).
+	if err = t.attachTierRateLimits(ctx, tiersList); err != nil {
+		return nil, err
 	}
 
 	return tiersList, nil
@@ -223,11 +267,8 @@ func (t *TiersRepository) CreateTier(ctx context.Context, tier models.Tier) (*mo
 		return nil, err
 	}
 
-	if !t.isEmptyLimits(tier.Limits) {
-		err = t.createOrUpdateRateLimitPolicies(ctx, tier.Name, tier.Limits)
-	}
-
-	if err != nil {
+	// Reconcile the two combined Kuadrant policies: merge this tier's limits with every other tier's limits from the live CRs.
+	if err := t.syncCombinedPoliciesFromDirtyTier(ctx, parsedTiers, tier.Name, tier.Limits, nil); err != nil {
 		return nil, err
 	}
 
@@ -263,11 +304,9 @@ func (t *TiersRepository) UpdateTier(ctx context.Context, tier models.Tier) (*mo
 		return nil, err
 	}
 
-	if !t.isEmptyLimits(tier.Limits) {
-		err = t.createOrUpdateRateLimitPolicies(ctx, tier.Name, tier.Limits)
-		if err != nil {
-			return nil, err
-		}
+	// Always sync: clearing limits must delete managed keys; non-empty limits must upsert without wiping other tiers.
+	if err := t.syncCombinedPoliciesFromDirtyTier(ctx, parsedTiers, tier.Name, tier.Limits, nil); err != nil {
+		return nil, err
 	}
 
 	return &tier, nil
@@ -293,60 +332,17 @@ func (t *TiersRepository) DeleteTierByName(ctx context.Context, name string) err
 
 	// TODO: Delete side effects? (e.g. models belonging to the tier)
 
-	// Clean up rate limit policy resources associated with this tier
-	if err := t.deleteTierRateLimitPolicies(ctx, name); err != nil {
-		t.logger.Warn("Failed to cleanup tier rate limit policies", "tier", name, "error", err)
+	remainingTiers := slices.Delete(slices.Clone(parsedTiers), tierIdx, tierIdx+1)
+	if err := t.updateTiersConfigMap(ctx, tierConfigMap, remainingTiers); err != nil {
 		return err
 	}
 
-	return t.updateTiersConfigMap(ctx, tierConfigMap, slices.Delete(parsedTiers, tierIdx, tierIdx+1))
-}
-
-// deleteTierRateLimitPolicies removes all rate limit policy resources associated with a tier
-func (t *TiersRepository) deleteTierRateLimitPolicies(ctx context.Context, tierName string) error {
-	var errs []error
-
-	client, err := t.k8sFactory.GetClient(ctx)
-	if err != nil {
+	// Strip removed tier's managed keys from the combined policies and delete legacy per-tier CRs for all affected names.
+	if err := t.syncCombinedPoliciesFromDirtyTier(ctx, remainingTiers, "", models.TierLimits{}, []string{name}); err != nil {
 		return err
-	}
-
-	kubeClient := client.GetDynamicClient()
-
-	// Delete RateLimitPolicy if it exists
-	ratePolicyName := "tier-" + tierName + "-rate-limits"
-	err = kubeClient.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, ratePolicyName, metav1.DeleteOptions{})
-	if err != nil {
-		if !k8sErrors.IsNotFound(err) {
-			t.logger.Warn("Failed to delete RateLimitPolicy", "tier", tierName, "policy", ratePolicyName, "error", err)
-			errs = append(errs, err)
-		}
-	} else {
-		t.logger.Info("Deleted RateLimitPolicy", "tier", tierName, "policy", ratePolicyName)
-	}
-
-	// Delete TokenRateLimitPolicy if it exists
-	tokenPolicyName := "tier-" + tierName + "-token-rate-limits"
-	err = kubeClient.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, tokenPolicyName, metav1.DeleteOptions{})
-	if err != nil {
-		if !k8sErrors.IsNotFound(err) {
-			t.logger.Warn("Failed to delete TokenRateLimitPolicy", "tier", tierName, "policy", tokenPolicyName, "error", err)
-			errs = append(errs, err)
-		}
-	} else {
-		t.logger.Info("Deleted TokenRateLimitPolicy", "tier", tierName, "policy", tokenPolicyName)
-	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
 	}
 
 	return nil
-}
-
-// isEmptyLimits checks if the provided TierLimits structure contains any rate limits
-func (t *TiersRepository) isEmptyLimits(limits models.TierLimits) bool {
-	return len(limits.TokensPerUnit) == 0 && len(limits.RequestsPerUnit) == 0
 }
 
 // convertPolicyToRateLimits extracts rate limits from a policy resource
@@ -367,9 +363,22 @@ func convertPolicyToRateLimits(policy *unstructured.Unstructured, limitKey strin
 	}
 
 	for _, rate := range rates {
-		rateMap := rate.(map[string]interface{})
-		count := rateMap["limit"].(int64)
-		window := rateMap["window"].(string)
+		rateMap, ok := rate.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("rates entry: expected map[string]interface{}, got %T", rate)
+		}
+		count, err := kubernetesNumericToInt64(rateMap["limit"])
+		if err != nil {
+			return nil, fmt.Errorf("rates entry limit: %w", err)
+		}
+		windowVal, hasWindow := rateMap["window"]
+		if !hasWindow {
+			return nil, fmt.Errorf("rates entry: missing window")
+		}
+		window, ok := windowVal.(string)
+		if !ok {
+			return nil, fmt.Errorf("rates window: expected string, got %T", windowVal)
+		}
 		parsedWindow, parseWindowErr := time.ParseDuration(window)
 		if parseWindowErr != nil {
 			return nil, parseWindowErr
@@ -403,9 +412,11 @@ func convertPolicyToRateLimits(policy *unstructured.Unstructured, limitKey strin
 	return rateLimits, nil
 }
 
-// convertRateLimitToKubernetesFormat converts models.RateLimit slice to Kubernetes policy rates format
-func convertRateLimitToKubernetesFormat(rateLimits []models.RateLimit) []map[string]interface{} {
-	var rates []map[string]interface{}
+// convertRateLimitToKubernetesFormat converts models.RateLimit slice to the JSON shape Kubernetes
+// expects inside unstructured objects. Slices must be []interface{}, not []map[string]interface{} —
+// otherwise unstructured.SetNestedMap panics with "cannot deep copy []map[string]interface {}".
+func convertRateLimitToKubernetesFormat(rateLimits []models.RateLimit) []interface{} {
+	rates := make([]interface{}, 0, len(rateLimits))
 
 	for _, rateLimit := range rateLimits {
 		var duration time.Duration
@@ -423,172 +434,68 @@ func convertRateLimitToKubernetesFormat(rateLimits []models.RateLimit) []map[str
 			duration = time.Duration(rateLimit.Time) * time.Second
 		}
 
-		rate := map[string]interface{}{
+		rates = append(rates, map[string]interface{}{
 			"limit":  rateLimit.Count,
-			"window": duration.String(),
-		}
-		rates = append(rates, rate)
+			"window": formatKuadrantDurationWindow(duration),
+		})
 	}
 
 	return rates
 }
 
-// buildRateLimitPolicy creates a Kubernetes RateLimitPolicy resource for request-based rate limiting
-func buildRateLimitPolicy(tierName, gatewayNamespace, gatewayName string, rateLimits []models.RateLimit) *unstructured.Unstructured {
-	policyName := "tier-" + tierName + "-rate-limits"
-	limitKey := tierName + "-requests"
-
-	policy := &unstructured.Unstructured{}
-	policy.SetAPIVersion("kuadrant.io/v1")
-	policy.SetKind("RateLimitPolicy")
-	policy.SetName(policyName)
-	policy.SetNamespace(gatewayNamespace)
-	policy.SetLabels(map[string]string{
-		"opendatahub.io/dashboard": "true",
-	})
-
-	// Build the policy specification
-	spec := map[string]interface{}{
-		"targetRef": map[string]interface{}{
-			"group": "gateway.networking.k8s.io",
-			"kind":  "Gateway",
-			"name":  gatewayName,
-		},
-		"limits": map[string]interface{}{
-			limitKey: map[string]interface{}{
-				"rates": convertRateLimitToKubernetesFormat(rateLimits),
-				"when": []map[string]interface{}{
-					{
-						"predicate": "auth.identity.tier == \"" + tierName + "\" && !request.path.endsWith(\"/v1/models\")",
-					},
-				},
-				"counters": []map[string]interface{}{
-					{
-						"expression": "auth.identity.userid",
-					},
-				},
-			},
-		},
+// formatKuadrantDurationWindow formats a duration for Kuadrant's window field
+// (pattern ^([0-9]{1,5}(h|m|s|ms)){1,4}$ in the bundled CRD). Go's duration.String()
+// can emit values like "1h0m0s" or sub-nanosecond forms that fail validation.
+func formatKuadrantDurationWindow(d time.Duration) string {
+	if d <= 0 {
+		return "1s"
 	}
+	h := int(d / time.Hour)
+	d %= time.Hour
+	m := int(d / time.Minute)
+	d %= time.Minute
+	s := int(d / time.Second)
+	d %= time.Second
+	ms := int(d / time.Millisecond)
 
-	policy.Object["spec"] = spec
-	return policy
+	var parts []string
+	if h > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", min(h, 99999)))
+	}
+	if m > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", min(m, 99999)))
+	}
+	if s > 0 {
+		parts = append(parts, fmt.Sprintf("%ds", min(s, 99999)))
+	}
+	if ms > 0 {
+		parts = append(parts, fmt.Sprintf("%dms", min(ms, 99999)))
+	}
+	if len(parts) == 0 {
+		return "1s"
+	}
+	if len(parts) > 4 {
+		parts = parts[:4]
+	}
+	return strings.Join(parts, "")
 }
 
-// buildTokenRateLimitPolicy creates a Kubernetes TokenRateLimitPolicy resource for token-based rate limiting
-func buildTokenRateLimitPolicy(tierName, gatewayNamespace, gatewayName string, rateLimits []models.RateLimit) *unstructured.Unstructured {
-	policyName := "tier-" + tierName + "-token-rate-limits"
-	limitKey := tierName + "-tokens"
-
-	policy := &unstructured.Unstructured{}
-	policy.SetAPIVersion("kuadrant.io/v1alpha1")
-	policy.SetKind("TokenRateLimitPolicy")
-	policy.SetName(policyName)
-	policy.SetNamespace(gatewayNamespace)
-	policy.SetLabels(map[string]string{
-		"opendatahub.io/dashboard": "true",
-	})
-
-	// Build the policy specification
-	spec := map[string]interface{}{
-		"targetRef": map[string]interface{}{
-			"group": "gateway.networking.k8s.io",
-			"kind":  "Gateway",
-			"name":  gatewayName,
-		},
-		"limits": map[string]interface{}{
-			limitKey: map[string]interface{}{
-				"rates": convertRateLimitToKubernetesFormat(rateLimits),
-				"when": []map[string]interface{}{
-					{
-						"predicate": "auth.identity.tier == \"" + tierName + "\" && !request.path.endsWith(\"/v1/models\")",
-					},
-				},
-				"counters": []map[string]interface{}{
-					{
-						"expression": "auth.identity.userid",
-					},
-				},
-			},
-		},
+// kubernetesNumericToInt64 normalizes JSON / unstructured numeric shapes (int64 vs float64) from the API server.
+func kubernetesNumericToInt64(v interface{}) (int64, error) {
+	switch x := v.(type) {
+	case int64:
+		return x, nil
+	case int32:
+		return int64(x), nil
+	case int:
+		return int64(x), nil
+	case float64:
+		return int64(x), nil
+	case float32:
+		return int64(x), nil
+	default:
+		return 0, fmt.Errorf("unsupported numeric type %T", v)
 	}
-
-	policy.Object["spec"] = spec
-	return policy
-}
-
-// createOrUpdateRateLimitPolicies creates or updates Kubernetes rate limit policy resources for a tier
-func (t *TiersRepository) createOrUpdateRateLimitPolicies(ctx context.Context, tierName string, limits models.TierLimits) error {
-	var errs []error
-
-	client, err := t.k8sFactory.GetClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	kubeClient := client.GetDynamicClient()
-
-	// Create/update RateLimitPolicy for RequestsPerUnit if present
-	if len(limits.RequestsPerUnit) > 0 {
-		rateLimitPolicy := buildRateLimitPolicy(tierName, t.gatewayNamespace, t.gatewayName, limits.RequestsPerUnit)
-
-		_, createErr := kubeClient.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Create(ctx, rateLimitPolicy, metav1.CreateOptions{})
-		if createErr != nil {
-			if k8sErrors.IsAlreadyExists(createErr) {
-				existingPolicy, getErr := kubeClient.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Get(ctx, rateLimitPolicy.GetName(), metav1.GetOptions{})
-				if getErr != nil {
-					t.logger.Warn("Failed to get RateLimitPolicy for update", "tier", tierName, "error", getErr)
-					errs = append(errs, getErr)
-				} else {
-					existingPolicy.Object["spec"] = rateLimitPolicy.Object["spec"]
-					_, updateErr := kubeClient.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Update(ctx, existingPolicy, metav1.UpdateOptions{})
-					if updateErr != nil {
-						t.logger.Warn("Failed to update RateLimitPolicy", "tier", tierName, "error", updateErr)
-						errs = append(errs, updateErr)
-					} else {
-						t.logger.Debug("Updated RateLimitPolicy", "tier", tierName, "policy", rateLimitPolicy.GetName())
-					}
-				}
-			} else {
-				t.logger.Warn("Failed to create RateLimitPolicy", "tier", tierName, "error", createErr)
-				errs = append(errs, createErr)
-			}
-		} else {
-			t.logger.Debug("Created RateLimitPolicy", "tier", tierName, "policy", rateLimitPolicy.GetName())
-		}
-	}
-
-	// Create/update TokenRateLimitPolicy for TokensPerUnit if present
-	if len(limits.TokensPerUnit) > 0 {
-		tokenRateLimitPolicy := buildTokenRateLimitPolicy(tierName, t.gatewayNamespace, t.gatewayName, limits.TokensPerUnit)
-
-		_, createErr := kubeClient.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Create(ctx, tokenRateLimitPolicy, metav1.CreateOptions{})
-		if createErr != nil {
-			if k8sErrors.IsAlreadyExists(createErr) {
-				existingPolicy, getErr := kubeClient.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Get(ctx, tokenRateLimitPolicy.GetName(), metav1.GetOptions{})
-				if getErr != nil {
-					t.logger.Warn("Failed to get TokenRateLimitPolicy for update", "tier", tierName, "error", getErr)
-					errs = append(errs, getErr)
-				} else {
-					existingPolicy.Object["spec"] = tokenRateLimitPolicy.Object["spec"]
-					_, updateErr := kubeClient.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Update(ctx, existingPolicy, metav1.UpdateOptions{})
-					if updateErr != nil {
-						t.logger.Warn("Failed to update TokenRateLimitPolicy", "tier", tierName, "error", updateErr)
-						errs = append(errs, updateErr)
-					} else {
-						t.logger.Debug("Updated TokenRateLimitPolicy", "tier", tierName, "policy", tokenRateLimitPolicy.GetName())
-					}
-				}
-			} else {
-				t.logger.Warn("Failed to create TokenRateLimitPolicy", "tier", tierName, "error", createErr)
-				errs = append(errs, createErr)
-			}
-		} else {
-			t.logger.Debug("Created TokenRateLimitPolicy", "tier", tierName, "policy", tokenRateLimitPolicy.GetName())
-		}
-	}
-
-	return errors.Join(errs...)
 }
 
 // findPolicyByName finds a policy resource by its name

--- a/packages/maas/bff/internal/repositories/tiers.go
+++ b/packages/maas/bff/internal/repositories/tiers.go
@@ -145,19 +145,20 @@ func (t *TiersRepository) updateTiersConfigMap(ctx context.Context, tiersConfigM
 	return nil
 }
 
-// attachTierRateLimits fills each tier's Limits from the single combined TokenRateLimitPolicy / RateLimitPolicy.
-// Step A: GET combined policies by fixed names (CLI can use the same names without the dashboard label).
-// Step B: read spec.limits["<tier>-tokens"] / ["<tier>-requests"].
-// Step C: if a tier has no data in the combined object, fall back to legacy per-tier CRs (pre-migration clusters).
+// attachTierRateLimits fills each tier's Limits from TokenRateLimitPolicy / RateLimitPolicy objects that target
+// this repository's Gateway. Discovery order: canonical combined names first, then other gateway-scoped policies
+// (CLI layout: arbitrary limit keys with tier predicates), then legacy per-tier CRs that may not targetRef the Gateway.
 func (t *TiersRepository) attachTierRateLimits(ctx context.Context, tiers models.TiersList) error {
-	combinedToken, err := t.getPolicyByName(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName)
+	allTRLP, err := t.listPoliciesForGateway(ctx, constants.TokenPolicyGvr)
 	if err != nil {
 		return err
 	}
-	combinedRate, err := t.getPolicyByName(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName)
+	allRLP, err := t.listPoliciesForGateway(ctx, constants.RatePolicyGvr)
 	if err != nil {
 		return err
 	}
+	sortedTR := sortPoliciesCanonicalFirst(allTRLP, t.combinedTokenPolicyName)
+	sortedRL := sortPoliciesCanonicalFirst(allRLP, t.combinedRatePolicyName)
 
 	legacyTokenPolicies, legacyRatePolicies, err := t.fetchPolicyResources(ctx)
 	if err != nil {
@@ -169,8 +170,7 @@ func (t *TiersRepository) attachTierRateLimits(ctx context.Context, tiers models
 		tokenLimitKey := managedTokenLimitKey(tierName)
 		rateLimitKey := managedRequestLimitKey(tierName)
 
-		tokenPolicy := combinedToken
-		tiers[idx].Limits.TokensPerUnit, err = convertPolicyToRateLimits(tokenPolicy, tokenLimitKey)
+		tiers[idx].Limits.TokensPerUnit, err = discoverTokenRateLimitsForTier(tierName, sortedTR)
 		if err != nil {
 			return err
 		}
@@ -182,8 +182,7 @@ func (t *TiersRepository) attachTierRateLimits(ctx context.Context, tiers models
 			}
 		}
 
-		ratePolicy := combinedRate
-		tiers[idx].Limits.RequestsPerUnit, err = convertPolicyToRateLimits(ratePolicy, rateLimitKey)
+		tiers[idx].Limits.RequestsPerUnit, err = discoverRequestRateLimitsForTier(tierName, sortedRL)
 		if err != nil {
 			return err
 		}

--- a/packages/maas/bff/internal/repositories/tiers.go
+++ b/packages/maas/bff/internal/repositories/tiers.go
@@ -332,12 +332,13 @@ func (t *TiersRepository) DeleteTierByName(ctx context.Context, name string) err
 	// TODO: Delete side effects? (e.g. models belonging to the tier)
 
 	remainingTiers := slices.Delete(slices.Clone(parsedTiers), tierIdx, tierIdx+1)
-	if err := t.updateTiersConfigMap(ctx, tierConfigMap, remainingTiers); err != nil {
+
+	// Sync the policies before updating the ConfigMap so a failed policy update leaves the tier row in place
+	// If the ConfigMap update fails after this, the tier still shows up in the UI while limits are already stripped
+	if err := t.syncCombinedPoliciesFromDirtyTier(ctx, remainingTiers, "", models.TierLimits{}, []string{name}); err != nil {
 		return err
 	}
-
-	// Strip removed tier's managed keys from the combined policies and delete legacy per-tier CRs for all affected names.
-	if err := t.syncCombinedPoliciesFromDirtyTier(ctx, remainingTiers, "", models.TierLimits{}, []string{name}); err != nil {
+	if err := t.updateTiersConfigMap(ctx, tierConfigMap, remainingTiers); err != nil {
 		return err
 	}
 

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -1,0 +1,468 @@
+// File tiers_combined_policies.go implements the single-CR Kuadrant model for MaaS tiers.
+//
+// Background: Kuadrant enforces at most one TokenRateLimitPolicy and one RateLimitPolicy per Gateway
+// target. The dashboard used to create tier-<name>-token-rate-limits per tier, so only one tier was
+// actually enforced. We now maintain exactly two cluster objects (names configurable, defaulting to
+// "<gatewayName>-token-rate-limits" and "<gatewayName>-request-rate-limits") and store every tier
+// under spec.limits using keys "<tier>-tokens" and "<tier>-requests".
+//
+// Read path (see attachTierRateLimits in tiers.go):
+//
+//	Step 1 — GET the two combined policies by fixed metadata.name (no label selector required).
+//	Step 2 — For each tier row from the ConfigMap, read rates from spec.limits using the managed keys.
+//	Step 3 — If a tier has no data in the combined object, GET legacy per-tier CRs (pre-upgrade clusters).
+//
+// Write path (CreateTier / UpdateTier / DeleteTier in tiers.go):
+//
+//	Step 1 — Persist tier metadata in the tier-to-group-mapping ConfigMap as before.
+//	Step 2 — buildLimitsByTierForSync merges live cluster limits with the one tier changed in this request.
+//	Step 3 — mergeManagedTokenKeysOnly / mergeManagedRequestKeysOnly copy existing spec.limits and
+//	         upsert or delete only the managed keys for tiers still in the ConfigMap (CLI-only keys stay).
+//	Step 4 — upsert combined CRs; Update uses mergeGatewayPolicySpec so unknown spec fields survive.
+//	Step 5 — delete legacy per-tier policy objects for tiers we touched + tiers just removed.
+//
+// DeleteTier ordering: ConfigMap row is removed first, then sync runs with tiersRemoved so managed keys
+// for the deleted tier are stripped from spec.limits even though that tier no longer appears in the loop.
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/constants"
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// --- Legacy naming (one Kuadrant policy per tier) -----------------------------------------------
+// Kuadrant only enforces one RateLimitPolicy / TokenRateLimitPolicy per Gateway target, so these
+// per-tier objects conflict. We still read them as a fallback until migration deletes them.
+
+func legacyPerTierTokenPolicyName(tier string) string {
+	return "tier-" + tier + "-token-rate-limits"
+}
+
+func legacyPerTierRatePolicyName(tier string) string {
+	return "tier-" + tier + "-rate-limits"
+}
+
+// --- Managed limit keys inside the combined policies --------------------------------------------
+// The dashboard reserves spec.limits keys shaped like "<tierName>-tokens" and "<tierName>-requests".
+// Extra keys (e.g. from CLI) are preserved on merge.
+
+func managedTokenLimitKey(tierName string) string {
+	return tierName + "-tokens"
+}
+
+func managedRequestLimitKey(tierName string) string {
+	return tierName + "-requests"
+}
+
+func dashboardManagedLabels() map[string]string {
+	return map[string]string{
+		"opendatahub.io/dashboard": "true",
+	}
+}
+
+// tierPredicateWhen returns the same auth/path predicate the dashboard has always used for tier rows.
+// Must be []interface{} (not []map[string]interface{}) for unstructured.SetNested* deep-copy.
+func tierPredicateWhen(tierName string) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"predicate": "auth.identity.tier == \"" + tierName + "\" && !request.path.endsWith(\"/v1/models\")",
+		},
+	}
+}
+
+func tierCountersWhen() []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"expression": "auth.identity.userid",
+		},
+	}
+}
+
+// buildManagedTokenLimitEntry builds one spec.limits entry for token limits for a single tier.
+func buildManagedTokenLimitEntry(tierName, gatewayName string, rateLimits []models.RateLimit) map[string]interface{} {
+	return map[string]interface{}{
+		"rates":    convertRateLimitToKubernetesFormat(rateLimits),
+		"when":     tierPredicateWhen(tierName),
+		"counters": tierCountersWhen(),
+	}
+}
+
+// buildManagedRequestLimitEntry builds one spec.limits entry for request limits for a single tier.
+func buildManagedRequestLimitEntry(tierName, gatewayName string, rateLimits []models.RateLimit) map[string]interface{} {
+	return map[string]interface{}{
+		"rates":    convertRateLimitToKubernetesFormat(rateLimits),
+		"when":     tierPredicateWhen(tierName),
+		"counters": tierCountersWhen(),
+	}
+}
+
+// cloneLimitsShallowTopLevel copies the top-level spec.limits map so we can add/remove keys without
+// mutating the object returned from the API server cache.
+func cloneLimitsShallowTopLevel(src map[string]interface{}) map[string]interface{} {
+	if len(src) == 0 {
+		return map[string]interface{}{}
+	}
+	out := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+// mergeManagedTokenKeysOnly updates only "<tier>-tokens" keys on the TokenRateLimitPolicy limits map.
+// Request keys must never be written onto a TRLP; that is a separate CR (RateLimitPolicy).
+func mergeManagedTokenKeysOnly(
+	existingLimits map[string]interface{},
+	tierNames []string,
+	limitsByTier map[string]models.TierLimits,
+	gatewayName string,
+) map[string]interface{} {
+	merged := cloneLimitsShallowTopLevel(existingLimits)
+	for _, tierName := range tierNames {
+		lim := limitsByTier[tierName]
+		key := managedTokenLimitKey(tierName)
+		if len(lim.TokensPerUnit) > 0 {
+			merged[key] = buildManagedTokenLimitEntry(tierName, gatewayName, lim.TokensPerUnit)
+		} else {
+			delete(merged, key)
+		}
+	}
+	return merged
+}
+
+// mergeManagedRequestKeysOnly updates only "<tier>-requests" keys on the RateLimitPolicy limits map.
+func mergeManagedRequestKeysOnly(
+	existingLimits map[string]interface{},
+	tierNames []string,
+	limitsByTier map[string]models.TierLimits,
+	gatewayName string,
+) map[string]interface{} {
+	merged := cloneLimitsShallowTopLevel(existingLimits)
+	for _, tierName := range tierNames {
+		lim := limitsByTier[tierName]
+		key := managedRequestLimitKey(tierName)
+		if len(lim.RequestsPerUnit) > 0 {
+			merged[key] = buildManagedRequestLimitEntry(tierName, gatewayName, lim.RequestsPerUnit)
+		} else {
+			delete(merged, key)
+		}
+	}
+	return merged
+}
+
+// getPolicyByName loads one namespaced dynamic object; returns (nil, nil) if NotFound.
+func (t *TiersRepository) getPolicyByName(ctx context.Context, gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error) {
+	client, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	kube := client.GetDynamicClient()
+	obj, err := kube.Resource(gvr).Namespace(t.gatewayNamespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return obj, nil
+}
+
+// extractLimitsMap returns spec.limits as a map, or empty map if missing/malformed.
+func extractLimitsMap(policy *unstructured.Unstructured) map[string]interface{} {
+	if policy == nil {
+		return map[string]interface{}{}
+	}
+	limits, found, err := unstructured.NestedMap(policy.Object, "spec", "limits")
+	if err != nil || !found || limits == nil {
+		return map[string]interface{}{}
+	}
+	return limits
+}
+
+// buildLimitsByTierForSync builds per-tier TierLimits used for the next combined policy write.
+// Step 1: load the current combined TRLP/RLP (if any).
+// Step 2: for each tier in parsedTiers, if tier name matches dirtyTierName use dirtyLimits from the API request;
+// otherwise copy limits from the combined policies (with legacy per-tier GET fallback when combined is missing a key).
+func (t *TiersRepository) buildLimitsByTierForSync(
+	ctx context.Context,
+	parsedTiers []tierConfigMapData,
+	dirtyTierName string,
+	dirtyLimits models.TierLimits,
+) (map[string]models.TierLimits, error) {
+	combinedToken, err := t.getPolicyByName(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName)
+	if err != nil {
+		return nil, err
+	}
+	combinedRate, err := t.getPolicyByName(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]models.TierLimits, len(parsedTiers))
+	kube, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dyn := kube.GetDynamicClient()
+
+	for _, row := range parsedTiers {
+		name := row.Name
+		if name == dirtyTierName {
+			out[name] = dirtyLimits
+			continue
+		}
+
+		tok, tokErr := convertPolicyToRateLimits(combinedToken, managedTokenLimitKey(name))
+		if tokErr != nil {
+			return nil, tokErr
+		}
+		req, reqErr := convertPolicyToRateLimits(combinedRate, managedRequestLimitKey(name))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+
+		// Legacy fallback: old clusters had one TokenRateLimitPolicy / RateLimitPolicy per tier.
+		if len(tok) == 0 {
+			legacyTokObj, legacyErr := dyn.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Get(ctx, legacyPerTierTokenPolicyName(name), metav1.GetOptions{})
+			if legacyErr == nil && legacyTokObj != nil {
+				tok, tokErr = convertPolicyToRateLimits(legacyTokObj, managedTokenLimitKey(name))
+				if tokErr != nil {
+					return nil, tokErr
+				}
+			} else if legacyErr != nil && !k8sErrors.IsNotFound(legacyErr) {
+				return nil, legacyErr
+			}
+		}
+		if len(req) == 0 {
+			legacyRateObj, legacyErr := dyn.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Get(ctx, legacyPerTierRatePolicyName(name), metav1.GetOptions{})
+			if legacyErr == nil && legacyRateObj != nil {
+				req, reqErr = convertPolicyToRateLimits(legacyRateObj, managedRequestLimitKey(name))
+				if reqErr != nil {
+					return nil, reqErr
+				}
+			} else if legacyErr != nil && !k8sErrors.IsNotFound(legacyErr) {
+				return nil, legacyErr
+			}
+		}
+
+		out[name] = models.TierLimits{
+			TokensPerUnit:   tok,
+			RequestsPerUnit: req,
+		}
+	}
+
+	return out, nil
+}
+
+// syncCombinedPolicies writes the two combined policies from limitsByTier for every tier name in tierNames.
+// Step 1: GET each combined policy (if exists) to recover spec.limits for merge.
+// Step 2: merge token keys and request keys into their respective CRs (never cross-contaminate).
+// Step 3: Create or Update; on Update we merge into existing spec so unknown Kuadrant fields are preserved.
+// tiersRemoved lists tier names just deleted from the ConfigMap so we strip their managed limit keys
+// from the combined policies (mergeManaged* only touches tiers still present in parsedTiers).
+func (t *TiersRepository) syncCombinedPolicies(ctx context.Context, parsedTiers []tierConfigMapData, limitsByTier map[string]models.TierLimits, tiersRemoved []string) error {
+	tierNames := make([]string, 0, len(parsedTiers))
+	for _, row := range parsedTiers {
+		tierNames = append(tierNames, row.Name)
+	}
+
+	client, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	dyn := client.GetDynamicClient()
+
+	existingToken, err := t.getPolicyByName(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName)
+	if err != nil {
+		return err
+	}
+	existingRate, err := t.getPolicyByName(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName)
+	if err != nil {
+		return err
+	}
+
+	tokenLimitsMap := mergeManagedTokenKeysOnly(
+		extractLimitsMap(existingToken),
+		tierNames,
+		limitsByTier,
+		t.gatewayName,
+	)
+	rateLimitsMap := mergeManagedRequestKeysOnly(
+		extractLimitsMap(existingRate),
+		tierNames,
+		limitsByTier,
+		t.gatewayName,
+	)
+
+	// Tiers removed from the ConfigMap are no longer in tierNames — merge would not delete their keys, so strip explicitly.
+	for _, gone := range tiersRemoved {
+		delete(tokenLimitsMap, managedTokenLimitKey(gone))
+		delete(rateLimitsMap, managedRequestLimitKey(gone))
+	}
+
+	if err := t.upsertCombinedTokenPolicy(ctx, dyn, existingToken, tokenLimitsMap); err != nil {
+		return fmt.Errorf("TokenRateLimitPolicy %s/%s: %w", t.gatewayNamespace, t.combinedTokenPolicyName, err)
+	}
+	if err := t.upsertCombinedRatePolicy(ctx, dyn, existingRate, rateLimitsMap); err != nil {
+		return fmt.Errorf("RateLimitPolicy %s/%s: %w", t.gatewayNamespace, t.combinedRatePolicyName, err)
+	}
+
+	// After a successful combined write, remove legacy per-tier objects so Kuadrant stops seeing conflicts.
+	// Include tiersRemoved so we delete tier-<gone>-* legacy CRs for the tier just deleted from the ConfigMap.
+	legacyCleanupNames := append(slices.Clone(tierNames), tiersRemoved...)
+	if err := t.deleteLegacyPerTierPoliciesForTiers(ctx, legacyCleanupNames); err != nil {
+		if t.logger != nil {
+			t.logger.Warn("legacy per-tier policy cleanup failed (combined policies are still correct)", "error", err)
+		}
+	}
+
+	return nil
+}
+
+// syncCombinedPoliciesFromDirtyTier builds limits from cluster + one dirty tier row, then writes combined policies.
+func (t *TiersRepository) syncCombinedPoliciesFromDirtyTier(
+	ctx context.Context,
+	parsedTiers []tierConfigMapData,
+	dirtyTierName string,
+	dirtyLimits models.TierLimits,
+	tiersRemoved []string,
+) error {
+	limitsByTier, err := t.buildLimitsByTierForSync(ctx, parsedTiers, dirtyTierName, dirtyLimits)
+	if err != nil {
+		return err
+	}
+	return t.syncCombinedPolicies(ctx, parsedTiers, limitsByTier, tiersRemoved)
+}
+
+func (t *TiersRepository) upsertCombinedTokenPolicy(ctx context.Context, dyn dynamic.Interface, existing *unstructured.Unstructured, limits map[string]interface{}) error {
+	if existing == nil {
+		// Unstructured.Object must be non-nil before SetNestedMap; a zero Unstructured has Object == nil and would panic.
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		obj.SetAPIVersion("kuadrant.io/v1alpha1")
+		obj.SetKind("TokenRateLimitPolicy")
+		obj.SetName(t.combinedTokenPolicyName)
+		obj.SetNamespace(t.gatewayNamespace)
+		obj.SetLabels(dashboardManagedLabels())
+		spec := combinedTokenPolicySpec(t.gatewayName, limits)
+		if err := unstructured.SetNestedMap(obj.Object, spec, "spec"); err != nil {
+			return err
+		}
+		_, err := dyn.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Create(ctx, obj, metav1.CreateOptions{})
+		return err
+	}
+
+	// Preserve any Kuadrant-only spec keys we do not know about: merge into existing spec map, then set limits + targetRef.
+	if err := mergeGatewayPolicySpec(existing, t.gatewayName, limits); err != nil {
+		return err
+	}
+	_, err := dyn.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+func (t *TiersRepository) upsertCombinedRatePolicy(ctx context.Context, dyn dynamic.Interface, existing *unstructured.Unstructured, limits map[string]interface{}) error {
+	if existing == nil {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		obj.SetAPIVersion("kuadrant.io/v1")
+		obj.SetKind("RateLimitPolicy")
+		obj.SetName(t.combinedRatePolicyName)
+		obj.SetNamespace(t.gatewayNamespace)
+		obj.SetLabels(dashboardManagedLabels())
+		spec := combinedRatePolicySpec(t.gatewayName, limits)
+		if err := unstructured.SetNestedMap(obj.Object, spec, "spec"); err != nil {
+			return err
+		}
+		_, err := dyn.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Create(ctx, obj, metav1.CreateOptions{})
+		return err
+	}
+	if err := mergeGatewayPolicySpec(existing, t.gatewayName, limits); err != nil {
+		return err
+	}
+	_, err := dyn.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// mergeGatewayPolicySpec writes limits + targetRef onto unstructured.Object["spec"],
+// keeping any other sibling keys already present under spec.
+//
+// Important: Kuadrant TokenRateLimitPolicy and RateLimitPolicy CRDs do NOT allow spec.strategy
+// alongside top-level spec.limits (strategy exists only under spec.defaults / spec.overrides).
+// A root-level strategy causes strict CRD validation to reject Create/Update — seen as HTTP 500
+// from the BFF while the ConfigMap write had already succeeded.
+func mergeGatewayPolicySpec(existing *unstructured.Unstructured, gatewayName string, limits map[string]interface{}) error {
+	if existing.Object == nil {
+		existing.Object = map[string]interface{}{}
+	}
+	spec, found, err := unstructured.NestedMap(existing.Object, "spec")
+	if err != nil {
+		return err
+	}
+	if !found || spec == nil {
+		spec = map[string]interface{}{}
+	}
+	spec["limits"] = limits
+	spec["targetRef"] = map[string]interface{}{
+		"group": "gateway.networking.k8s.io",
+		"kind":  "Gateway",
+		"name":  gatewayName,
+	}
+	delete(spec, "strategy")
+	return unstructured.SetNestedMap(existing.Object, spec, "spec")
+}
+
+func combinedTokenPolicySpec(gatewayName string, limits map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"targetRef": map[string]interface{}{
+			"group": "gateway.networking.k8s.io",
+			"kind":  "Gateway",
+			"name":  gatewayName,
+		},
+		"limits": limits,
+	}
+}
+
+func combinedRatePolicySpec(gatewayName string, limits map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"targetRef": map[string]interface{}{
+			"group": "gateway.networking.k8s.io",
+			"kind":  "Gateway",
+			"name":  gatewayName,
+		},
+		"limits": limits,
+	}
+}
+
+func (t *TiersRepository) deleteLegacyPerTierPoliciesForTiers(ctx context.Context, tierNames []string) error {
+	client, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	dyn := client.GetDynamicClient()
+	var errs []error
+	for _, tierName := range tierNames {
+		tokenName := legacyPerTierTokenPolicyName(tierName)
+		rateName := legacyPerTierRatePolicyName(tierName)
+		if err := dyn.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, tokenName, metav1.DeleteOptions{}); err != nil && !k8sErrors.IsNotFound(err) {
+			errs = append(errs, err)
+		}
+		if err := dyn.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, rateName, metav1.DeleteOptions{}); err != nil && !k8sErrors.IsNotFound(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// deleteLegacyPoliciesForSingleTier removes old per-tier policy names for one tier (used after DeleteTier).
+func (t *TiersRepository) deleteLegacyPoliciesForSingleTier(ctx context.Context, tierName string) error {
+	return t.deleteLegacyPerTierPoliciesForTiers(ctx, []string{tierName})
+}

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -434,7 +434,9 @@ func mergeGatewayPolicySpec(existing *unstructured.Unstructured, gatewayName str
 		"kind":  "Gateway",
 		"name":  gatewayName,
 	}
-	delete(spec, "strategy")
+	if defaults, ok := spec["defaults"].(map[string]interface{}); ok && defaults != nil {
+		delete(defaults, "strategy")
+	}
 	return unstructured.SetNestedMap(existing.Object, spec, "spec")
 }
 
@@ -478,9 +480,4 @@ func (t *TiersRepository) deleteLegacyPerTierPoliciesForTiers(ctx context.Contex
 		}
 	}
 	return errors.Join(errs...)
-}
-
-// deleteLegacyPoliciesForSingleTier removes old per-tier policy names for one tier (used after DeleteTier).
-func (t *TiersRepository) deleteLegacyPoliciesForSingleTier(ctx context.Context, tierName string) error {
-	return t.deleteLegacyPerTierPoliciesForTiers(ctx, []string{tierName})
 }

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -8,9 +8,12 @@
 //
 // Read path (see attachTierRateLimits in tiers.go):
 //
-//	Step 1 — GET the two combined policies by fixed metadata.name (no label selector required).
-//	Step 2 — For each tier row from the ConfigMap, read rates from spec.limits using the managed keys.
-//	Step 3 — If a tier has no data in the combined object, GET legacy per-tier CRs (pre-upgrade clusters).
+//	Step 1 — LIST TokenRateLimitPolicy / RateLimitPolicy in the gateway namespace whose spec.targetRef
+//	         matches this Gateway (see tiers_gateway_discovery.go).
+//	Step 2 — For each tier, discover limits: managed keys, tier-named keys, then arbitrary keys whose
+//	         when predicates reference auth.identity.tier == "<tier>" (CLI layout). Canonical combined
+//	         names are tried first.
+//	Step 3 — If still empty, GET legacy per-tier CRs (pre-upgrade clusters that may not set targetRef).
 //
 // Write path (CreateTier / UpdateTier / DeleteTier in tiers.go):
 //
@@ -20,6 +23,7 @@
 //	         upsert or delete only the managed keys for tiers still in the ConfigMap (CLI-only keys stay).
 //	Step 4 — upsert combined CRs; Update uses mergeGatewayPolicySpec so unknown spec fields survive.
 //	Step 5 — delete legacy per-tier policy objects for tiers we touched + tiers just removed.
+//	Step 6 — delete any other gateway-scoped TRLP/RLP (non-canonical names) so limits live in one object.
 //
 // DeleteTier ordering: ConfigMap row is removed first, then sync runs with tiersRemoved so managed keys
 // for the deleted tier are stripped from spec.limits even though that tier no longer appears in the loop.
@@ -191,23 +195,25 @@ func extractLimitsMap(policy *unstructured.Unstructured) map[string]interface{} 
 }
 
 // buildLimitsByTierForSync builds per-tier TierLimits used for the next combined policy write.
-// Step 1: load the current combined TRLP/RLP (if any).
+// Step 1: list all gateway-scoped TRLP/RLP (same targetRef as this Gateway).
 // Step 2: for each tier in parsedTiers, if tier name matches dirtyTierName use dirtyLimits from the API request;
-// otherwise copy limits from the combined policies (with legacy per-tier GET fallback when combined is missing a key).
+// otherwise copy limits via discovery (canonical keys, tier-named keys, predicate match), then legacy per-tier GET.
 func (t *TiersRepository) buildLimitsByTierForSync(
 	ctx context.Context,
 	parsedTiers []tierConfigMapData,
 	dirtyTierName string,
 	dirtyLimits models.TierLimits,
 ) (map[string]models.TierLimits, error) {
-	combinedToken, err := t.getPolicyByName(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName)
+	allTRLP, err := t.listPoliciesForGateway(ctx, constants.TokenPolicyGvr)
 	if err != nil {
 		return nil, err
 	}
-	combinedRate, err := t.getPolicyByName(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName)
+	allRLP, err := t.listPoliciesForGateway(ctx, constants.RatePolicyGvr)
 	if err != nil {
 		return nil, err
 	}
+	sortedTR := sortPoliciesCanonicalFirst(allTRLP, t.combinedTokenPolicyName)
+	sortedRL := sortPoliciesCanonicalFirst(allRLP, t.combinedRatePolicyName)
 
 	out := make(map[string]models.TierLimits, len(parsedTiers))
 	kube, err := t.k8sFactory.GetClient(ctx)
@@ -223,11 +229,11 @@ func (t *TiersRepository) buildLimitsByTierForSync(
 			continue
 		}
 
-		tok, tokErr := convertPolicyToRateLimits(combinedToken, managedTokenLimitKey(name))
+		tok, tokErr := discoverTokenRateLimitsForTier(name, sortedTR)
 		if tokErr != nil {
 			return nil, tokErr
 		}
-		req, reqErr := convertPolicyToRateLimits(combinedRate, managedRequestLimitKey(name))
+		req, reqErr := discoverRequestRateLimitsForTier(name, sortedRL)
 		if reqErr != nil {
 			return nil, reqErr
 		}
@@ -324,6 +330,18 @@ func (t *TiersRepository) syncCombinedPolicies(ctx context.Context, parsedTiers 
 	if err := t.deleteLegacyPerTierPoliciesForTiers(ctx, legacyCleanupNames); err != nil {
 		if t.logger != nil {
 			t.logger.Warn("legacy per-tier policy cleanup failed (combined policies are still correct)", "error", err)
+		}
+	}
+
+	// Remove any other TRLP/RLP that target the same Gateway so limits are not split across objects (Kuadrant "Overridden").
+	if err := t.deleteNonCanonicalGatewayPolicies(ctx, constants.TokenPolicyGvr, t.combinedTokenPolicyName); err != nil {
+		if t.logger != nil {
+			t.logger.Warn("non-canonical TokenRateLimitPolicy cleanup failed (combined policy is still correct)", "error", err)
+		}
+	}
+	if err := t.deleteNonCanonicalGatewayPolicies(ctx, constants.RatePolicyGvr, t.combinedRatePolicyName); err != nil {
+		if t.logger != nil {
+			t.logger.Warn("non-canonical RateLimitPolicy cleanup failed (combined policy is still correct)", "error", err)
 		}
 	}
 

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -22,6 +22,8 @@
 //	Step 3 — mergeManagedTokenKeysOnly / mergeManagedRequestKeysOnly copy existing spec.limits and
 //	         upsert or delete only the managed keys for tiers still in the ConfigMap (CLI-only keys stay).
 //	Step 4 — upsert combined CRs; Update uses mergeGatewayPolicySpec so unknown spec fields survive.
+//	         If merged spec.limits would be empty (e.g. last tier deleted), the combined TRLP/RLP is deleted
+//	         instead — Kuadrant rejects empty limits; CreateTier recreates the CR when limits return.
 //	Step 5 — delete legacy per-tier policy objects for tiers we touched + tiers just removed.
 //	Step 6 — delete any other gateway-scoped TRLP/RLP (non-canonical names) so limits live in one object.
 //
@@ -264,7 +266,7 @@ func (t *TiersRepository) buildLimitsByTierForSync(
 // syncCombinedPolicies writes the two combined policies from limitsByTier for every tier name in tierNames.
 // Step 1: GET each combined policy (if exists) to recover spec.limits for merge.
 // Step 2: merge token keys and request keys into their respective CRs (never cross-contaminate).
-// Step 3: Create or Update; on Update we merge into existing spec so unknown Kuadrant fields are preserved.
+// Step 3: Create, Update, or Delete when limits map is empty (see upsertCombined*Policy).
 // tiersRemoved lists tier names just deleted from the ConfigMap so we strip their managed limit keys
 // from the combined policies (mergeManaged* only touches tiers still present in parsedTiers).
 func (t *TiersRepository) syncCombinedPolicies(ctx context.Context, parsedTiers []tierConfigMapData, limitsByTier map[string]models.TierLimits, tiersRemoved []string) error {
@@ -344,6 +346,16 @@ func (t *TiersRepository) syncCombinedPoliciesFromDirtyTier(
 }
 
 func (t *TiersRepository) upsertCombinedTokenPolicy(ctx context.Context, dyn dynamic.Interface, existing *unstructured.Unstructured, limits map[string]interface{}) error {
+	if len(limits) == 0 {
+		if existing == nil {
+			return nil
+		}
+		if err := dyn.Resource(constants.TokenPolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, t.combinedTokenPolicyName, metav1.DeleteOptions{}); err != nil && !k8sErrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
 	if existing == nil {
 		// Unstructured.Object must be non-nil before SetNestedMap; a zero Unstructured has Object == nil and would panic.
 		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
@@ -369,6 +381,16 @@ func (t *TiersRepository) upsertCombinedTokenPolicy(ctx context.Context, dyn dyn
 }
 
 func (t *TiersRepository) upsertCombinedRatePolicy(ctx context.Context, dyn dynamic.Interface, existing *unstructured.Unstructured, limits map[string]interface{}) error {
+	if len(limits) == 0 {
+		if existing == nil {
+			return nil
+		}
+		if err := dyn.Resource(constants.RatePolicyGvr).Namespace(t.gatewayNamespace).Delete(ctx, t.combinedRatePolicyName, metav1.DeleteOptions{}); err != nil && !k8sErrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
 	if existing == nil {
 		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 		obj.SetAPIVersion("kuadrant.io/v1")

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -94,7 +94,7 @@ func tierCountersWhen() []interface{} {
 }
 
 // buildManagedTokenLimitEntry builds one spec.limits entry for token limits for a single tier.
-func buildManagedTokenLimitEntry(tierName, gatewayName string, rateLimits []models.RateLimit) map[string]interface{} {
+func buildManagedTokenLimitEntry(tierName string, rateLimits []models.RateLimit) map[string]interface{} {
 	return map[string]interface{}{
 		"rates":    convertRateLimitToKubernetesFormat(rateLimits),
 		"when":     tierPredicateWhen(tierName),
@@ -103,7 +103,7 @@ func buildManagedTokenLimitEntry(tierName, gatewayName string, rateLimits []mode
 }
 
 // buildManagedRequestLimitEntry builds one spec.limits entry for request limits for a single tier.
-func buildManagedRequestLimitEntry(tierName, gatewayName string, rateLimits []models.RateLimit) map[string]interface{} {
+func buildManagedRequestLimitEntry(tierName string, rateLimits []models.RateLimit) map[string]interface{} {
 	return map[string]interface{}{
 		"rates":    convertRateLimitToKubernetesFormat(rateLimits),
 		"when":     tierPredicateWhen(tierName),
@@ -126,18 +126,13 @@ func cloneLimitsShallowTopLevel(src map[string]interface{}) map[string]interface
 
 // mergeManagedTokenKeysOnly updates only "<tier>-tokens" keys on the TokenRateLimitPolicy limits map.
 // Request keys must never be written onto a TRLP; that is a separate CR (RateLimitPolicy).
-func mergeManagedTokenKeysOnly(
-	existingLimits map[string]interface{},
-	tierNames []string,
-	limitsByTier map[string]models.TierLimits,
-	gatewayName string,
-) map[string]interface{} {
+func mergeManagedTokenKeysOnly(existingLimits map[string]interface{}, tierNames []string, limitsByTier map[string]models.TierLimits) map[string]interface{} {
 	merged := cloneLimitsShallowTopLevel(existingLimits)
 	for _, tierName := range tierNames {
 		lim := limitsByTier[tierName]
 		key := managedTokenLimitKey(tierName)
 		if len(lim.TokensPerUnit) > 0 {
-			merged[key] = buildManagedTokenLimitEntry(tierName, gatewayName, lim.TokensPerUnit)
+			merged[key] = buildManagedTokenLimitEntry(tierName, lim.TokensPerUnit)
 		} else {
 			delete(merged, key)
 		}
@@ -146,18 +141,13 @@ func mergeManagedTokenKeysOnly(
 }
 
 // mergeManagedRequestKeysOnly updates only "<tier>-requests" keys on the RateLimitPolicy limits map.
-func mergeManagedRequestKeysOnly(
-	existingLimits map[string]interface{},
-	tierNames []string,
-	limitsByTier map[string]models.TierLimits,
-	gatewayName string,
-) map[string]interface{} {
+func mergeManagedRequestKeysOnly(existingLimits map[string]interface{}, tierNames []string, limitsByTier map[string]models.TierLimits) map[string]interface{} {
 	merged := cloneLimitsShallowTopLevel(existingLimits)
 	for _, tierName := range tierNames {
 		lim := limitsByTier[tierName]
 		key := managedRequestLimitKey(tierName)
 		if len(lim.RequestsPerUnit) > 0 {
-			merged[key] = buildManagedRequestLimitEntry(tierName, gatewayName, lim.RequestsPerUnit)
+			merged[key] = buildManagedRequestLimitEntry(tierName, lim.RequestsPerUnit)
 		} else {
 			delete(merged, key)
 		}
@@ -298,18 +288,8 @@ func (t *TiersRepository) syncCombinedPolicies(ctx context.Context, parsedTiers 
 		return err
 	}
 
-	tokenLimitsMap := mergeManagedTokenKeysOnly(
-		extractLimitsMap(existingToken),
-		tierNames,
-		limitsByTier,
-		t.gatewayName,
-	)
-	rateLimitsMap := mergeManagedRequestKeysOnly(
-		extractLimitsMap(existingRate),
-		tierNames,
-		limitsByTier,
-		t.gatewayName,
-	)
+	tokenLimitsMap := mergeManagedTokenKeysOnly(extractLimitsMap(existingToken), tierNames, limitsByTier)
+	rateLimitsMap := mergeManagedRequestKeysOnly(extractLimitsMap(existingRate), tierNames, limitsByTier)
 
 	// Tiers removed from the ConfigMap are no longer in tierNames — merge would not delete their keys, so strip explicitly.
 	for _, gone := range tiersRemoved {
@@ -433,9 +413,6 @@ func mergeGatewayPolicySpec(existing *unstructured.Unstructured, gatewayName str
 		"group": "gateway.networking.k8s.io",
 		"kind":  "Gateway",
 		"name":  gatewayName,
-	}
-	if defaults, ok := spec["defaults"].(map[string]interface{}); ok && defaults != nil {
-		delete(defaults, "strategy")
 	}
 	return unstructured.SetNestedMap(existing.Object, spec, "spec")
 }

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies.go
@@ -392,11 +392,6 @@ func (t *TiersRepository) upsertCombinedRatePolicy(ctx context.Context, dyn dyna
 
 // mergeGatewayPolicySpec writes limits + targetRef onto unstructured.Object["spec"],
 // keeping any other sibling keys already present under spec.
-//
-// Important: Kuadrant TokenRateLimitPolicy and RateLimitPolicy CRDs do NOT allow spec.strategy
-// alongside top-level spec.limits (strategy exists only under spec.defaults / spec.overrides).
-// A root-level strategy causes strict CRD validation to reject Create/Update — seen as HTTP 500
-// from the BFF while the ConfigMap write had already succeeded.
 func mergeGatewayPolicySpec(existing *unstructured.Unstructured, gatewayName string, limits map[string]interface{}) error {
 	if existing.Object == nil {
 		existing.Object = map[string]interface{}{}

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies_test.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies_test.go
@@ -1,0 +1,66 @@
+package repositories
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// TestMergeManagedTokenKeysOnly_preservesCLIKeys ensures we do not wipe unrelated spec.limits entries when syncing token limits.
+func TestMergeManagedTokenKeysOnly_preservesCLIKeys(t *testing.T) {
+	t.Parallel()
+	existing := map[string]interface{}{
+		"operator-custom-limit": map[string]interface{}{"rates": []interface{}{map[string]interface{}{"limit": int64(1), "window": "1s"}}},
+		"tier0-tokens":          map[string]interface{}{"stale": true},
+	}
+	limits := map[string]models.TierLimits{
+		"tier0": {TokensPerUnit: []models.RateLimit{{Count: 42, Time: 2, Unit: models.GEP_2257_HOUR}}},
+	}
+	out := mergeManagedTokenKeysOnly(existing, []string{"tier0"}, limits, "maas-default-gateway")
+	if _, ok := out["operator-custom-limit"]; !ok {
+		t.Fatal("expected CLI / operator limit key to be preserved")
+	}
+	tok := out["tier0-tokens"]
+	m, ok := tok.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tier0-tokens to be a map, got %T", tok)
+	}
+	if _, has := m["stale"]; has {
+		t.Fatal("expected stale tier0-tokens entry to be replaced by dashboard-managed shape")
+	}
+}
+
+// TestMergeManagedRequestKeysOnly_removesEmptyRequestTier verifies clearing request limits deletes only the managed request key.
+// TestBuildManagedTokenLimitEntry_unstructuredSetDoesNotPanic guards against []map[string]interface{}
+// in rates/when/counters, which causes runtime.DeepCopyJSONValue to panic inside SetNestedMap.
+func TestBuildManagedTokenLimitEntry_unstructuredSetDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	limits := map[string]interface{}{
+		"tier-x-tokens": buildManagedTokenLimitEntry("tier-x", "gw", []models.RateLimit{
+			{Count: 10, Time: 1, Unit: models.GEP_2257_HOUR},
+		}),
+	}
+	spec := map[string]interface{}{
+		"limits": limits,
+	}
+	if err := unstructured.SetNestedMap(obj.Object, spec, "spec"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeManagedRequestKeysOnly_removesEmptyRequestTier(t *testing.T) {
+	t.Parallel()
+	existing := map[string]interface{}{
+		"tier0-requests": map[string]interface{}{"rates": []interface{}{map[string]interface{}{"limit": int64(5), "window": "1m"}}},
+	}
+	limits := map[string]models.TierLimits{
+		"tier0": {RequestsPerUnit: nil},
+	}
+	out := mergeManagedRequestKeysOnly(existing, []string{"tier0"}, limits, "gw")
+	if _, ok := out["tier0-requests"]; ok {
+		t.Fatal("expected tier0-requests to be removed when RequestsPerUnit is empty")
+	}
+}

--- a/packages/maas/bff/internal/repositories/tiers_combined_policies_test.go
+++ b/packages/maas/bff/internal/repositories/tiers_combined_policies_test.go
@@ -18,7 +18,7 @@ func TestMergeManagedTokenKeysOnly_preservesCLIKeys(t *testing.T) {
 	limits := map[string]models.TierLimits{
 		"tier0": {TokensPerUnit: []models.RateLimit{{Count: 42, Time: 2, Unit: models.GEP_2257_HOUR}}},
 	}
-	out := mergeManagedTokenKeysOnly(existing, []string{"tier0"}, limits, "maas-default-gateway")
+	out := mergeManagedTokenKeysOnly(existing, []string{"tier0"}, limits)
 	if _, ok := out["operator-custom-limit"]; !ok {
 		t.Fatal("expected CLI / operator limit key to be preserved")
 	}
@@ -39,9 +39,7 @@ func TestBuildManagedTokenLimitEntry_unstructuredSetDoesNotPanic(t *testing.T) {
 	t.Parallel()
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	limits := map[string]interface{}{
-		"tier-x-tokens": buildManagedTokenLimitEntry("tier-x", "gw", []models.RateLimit{
-			{Count: 10, Time: 1, Unit: models.GEP_2257_HOUR},
-		}),
+		"tier-x-tokens": buildManagedTokenLimitEntry("tier-x", []models.RateLimit{{Count: 10, Time: 1, Unit: models.GEP_2257_HOUR}}),
 	}
 	spec := map[string]interface{}{
 		"limits": limits,
@@ -59,7 +57,7 @@ func TestMergeManagedRequestKeysOnly_removesEmptyRequestTier(t *testing.T) {
 	limits := map[string]models.TierLimits{
 		"tier0": {RequestsPerUnit: nil},
 	}
-	out := mergeManagedRequestKeysOnly(existing, []string{"tier0"}, limits, "gw")
+	out := mergeManagedRequestKeysOnly(existing, []string{"tier0"}, limits)
 	if _, ok := out["tier0-requests"]; ok {
 		t.Fatal("expected tier0-requests to be removed when RequestsPerUnit is empty")
 	}

--- a/packages/maas/bff/internal/repositories/tiers_format_test.go
+++ b/packages/maas/bff/internal/repositories/tiers_format_test.go
@@ -1,0 +1,26 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatKuadrantDurationWindow(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{time.Hour, "1h"},
+		{2 * time.Hour, "2h"},
+		{time.Minute, "1m"},
+		{90 * time.Minute, "1h30m"},
+		{time.Second, "1s"},
+		{500 * time.Millisecond, "500ms"},
+	}
+	for _, tc := range cases {
+		if got := formatKuadrantDurationWindow(tc.d); got != tc.want {
+			t.Fatalf("formatKuadrantDurationWindow(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}

--- a/packages/maas/bff/internal/repositories/tiers_gateway_discovery.go
+++ b/packages/maas/bff/internal/repositories/tiers_gateway_discovery.go
@@ -1,0 +1,222 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"slices"
+	"strings"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+// listPoliciesForGateway returns all Kuadrant TokenRateLimitPolicy or RateLimitPolicy objects in the
+// gateway namespace whose spec.targetRef points at this repository's Gateway (same group/kind/name).
+func (t *TiersRepository) listPoliciesForGateway(ctx context.Context, gvr schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	client, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	list, err := client.GetDynamicClient().Resource(gvr).Namespace(t.gatewayNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var out []unstructured.Unstructured
+	for i := range list.Items {
+		if policyTargetRefMatchesGateway(&list.Items[i], t.gatewayName) {
+			out = append(out, list.Items[i])
+		}
+	}
+	return out, nil
+}
+
+func policyTargetRefMatchesGateway(obj *unstructured.Unstructured, gatewayName string) bool {
+	if obj == nil {
+		return false
+	}
+	g, gOK, gErr := unstructured.NestedString(obj.Object, "spec", "targetRef", "group")
+	if gErr != nil || !gOK {
+		return false
+	}
+	kind, kOK, kErr := unstructured.NestedString(obj.Object, "spec", "targetRef", "kind")
+	if kErr != nil || !kOK {
+		return false
+	}
+	name, nOK, nErr := unstructured.NestedString(obj.Object, "spec", "targetRef", "name")
+	if nErr != nil || !nOK {
+		return false
+	}
+	return g == "gateway.networking.k8s.io" && kind == "Gateway" && name == gatewayName
+}
+
+// sortPoliciesCanonicalFirst returns a copy of items with the named policy first (if present), then others sorted by name.
+func sortPoliciesCanonicalFirst(items []unstructured.Unstructured, canonicalName string) []unstructured.Unstructured {
+	var first []unstructured.Unstructured
+	var rest []unstructured.Unstructured
+	for i := range items {
+		if items[i].GetName() == canonicalName {
+			first = append(first, items[i])
+		} else {
+			rest = append(rest, items[i])
+		}
+	}
+	slices.SortFunc(rest, func(a, b unstructured.Unstructured) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+	return append(first, rest...)
+}
+
+// discoverTokenRateLimitsForTier finds token rates for a tier across all TRLPs targeting the gateway.
+// Resolution order (first hit wins):
+//  1. spec.limits["<tier>-tokens"] on any policy (canonical first)
+//  2. spec.limits["<tier>"] when the value looks like a token limit block (rates / when)
+//  3. any other limits entry whose when predicates include auth.identity.tier == "<tier>" (CLI layout)
+func discoverTokenRateLimitsForTier(tierName string, policies []unstructured.Unstructured) ([]models.RateLimit, error) {
+	for _, pol := range policies {
+		for _, key := range []string{managedTokenLimitKey(tierName), tierName} {
+			rates, err := convertPolicyToRateLimits(&pol, key)
+			if err != nil {
+				return nil, err
+			}
+			if len(rates) > 0 {
+				return rates, nil
+			}
+		}
+		limits := extractLimitsMap(&pol)
+		for key, raw := range limits {
+			if key == managedTokenLimitKey(tierName) || key == tierName {
+				continue
+			}
+			val, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if !limitBlockMentionsTierInPredicates(val, tierName) {
+				continue
+			}
+			rates, err := convertPolicyToRateLimits(&pol, key)
+			if err != nil {
+				return nil, err
+			}
+			if len(rates) > 0 {
+				return rates, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// discoverRequestRateLimitsForTier is the RateLimitPolicy analogue of discoverTokenRateLimitsForTier.
+func discoverRequestRateLimitsForTier(tierName string, policies []unstructured.Unstructured) ([]models.RateLimit, error) {
+	for _, pol := range policies {
+		for _, key := range []string{managedRequestLimitKey(tierName), tierName} {
+			rates, err := convertPolicyToRateLimits(&pol, key)
+			if err != nil {
+				return nil, err
+			}
+			if len(rates) > 0 {
+				return rates, nil
+			}
+		}
+		limits := extractLimitsMap(&pol)
+		for key, raw := range limits {
+			if key == managedRequestLimitKey(tierName) || key == tierName {
+				continue
+			}
+			val, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if !limitBlockMentionsTierInPredicates(val, tierName) {
+				continue
+			}
+			rates, err := convertPolicyToRateLimits(&pol, key)
+			if err != nil {
+				return nil, err
+			}
+			if len(rates) > 0 {
+				return rates, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+var (
+	tierPredDoubleQuote = regexp.MustCompile(`auth\.identity\.tier\s*==\s*"([^"]+)"`)
+	tierPredSingleQuote = regexp.MustCompile(`auth\.identity\.tier\s*==\s*'([^']+)'`)
+)
+
+func limitBlockMentionsTierInPredicates(limitBlock map[string]interface{}, tierName string) bool {
+	whenRaw, ok := limitBlock["when"]
+	if !ok || whenRaw == nil {
+		return false
+	}
+	whenSlice, ok := whenRaw.([]interface{})
+	if !ok {
+		return false
+	}
+	var b strings.Builder
+	for _, w := range whenSlice {
+		m, ok := w.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		p, _ := m["predicate"].(string)
+		b.WriteString(p)
+		b.WriteByte(' ')
+	}
+	joined := strings.ReplaceAll(b.String(), `\"`, `"`)
+	for _, re := range []*regexp.Regexp{tierPredDoubleQuote, tierPredSingleQuote} {
+		for _, sm := range re.FindAllStringSubmatch(joined, -1) {
+			if len(sm) > 1 && sm[1] == tierName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// deleteNonCanonicalGatewayPolicies removes every policy of this GVR in the gateway namespace that targets
+// the same Gateway but is not the canonical combined object name. This rolls CLI-created duplicate TRLP/RLP
+// objects into the single resource the dashboard manages so Kuadrant stops reporting Overridden policies.
+func (t *TiersRepository) deleteNonCanonicalGatewayPolicies(ctx context.Context, gvr schema.GroupVersionResource, canonicalName string) error {
+	items, err := t.listPoliciesForGateway(ctx, gvr)
+	if err != nil {
+		return err
+	}
+	client, err := t.k8sFactory.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	dyn := client.GetDynamicClient()
+	var errs []error
+	for i := range items {
+		n := items[i].GetName()
+		if n == canonicalName {
+			continue
+		}
+		if err := dyn.Resource(gvr).Namespace(t.gatewayNamespace).Delete(ctx, n, metav1.DeleteOptions{}); err != nil {
+			if !k8sErrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("delete %s %s/%s: %w", gvr.Resource, t.gatewayNamespace, n, err))
+			}
+			continue
+		}
+		if t.logger != nil {
+			t.logger.Info("removed duplicate gateway-scoped policy after consolidating limits",
+				slog.String("resource", gvr.Resource),
+				slog.String("namespace", t.gatewayNamespace),
+				slog.String("name", n),
+				slog.String("canonical", canonicalName),
+			)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/packages/maas/bff/internal/repositories/tiers_gateway_discovery_test.go
+++ b/packages/maas/bff/internal/repositories/tiers_gateway_discovery_test.go
@@ -1,0 +1,124 @@
+package repositories
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/models"
+)
+
+func TestSortPoliciesCanonicalFirst(t *testing.T) {
+	t.Parallel()
+	a := unstructured.Unstructured{}
+	a.SetName("alpha")
+	b := unstructured.Unstructured{}
+	b.SetName("beta")
+	c := unstructured.Unstructured{}
+	c.SetName("canonical")
+	out := sortPoliciesCanonicalFirst([]unstructured.Unstructured{b, c, a}, "canonical")
+	if len(out) != 3 || out[0].GetName() != "canonical" {
+		t.Fatalf("expected canonical first, got %#v", namesOf(out))
+	}
+	if out[1].GetName() != "alpha" || out[2].GetName() != "beta" {
+		t.Fatalf("expected alphabetical tail, got %#v", namesOf(out))
+	}
+}
+
+func namesOf(items []unstructured.Unstructured) []string {
+	s := make([]string, len(items))
+	for i := range items {
+		s[i] = items[i].GetName()
+	}
+	return s
+}
+
+func TestLimitBlockMentionsTierInPredicates(t *testing.T) {
+	t.Parallel()
+	block := map[string]interface{}{
+		"when": []interface{}{
+			map[string]interface{}{"predicate": `auth.identity.tier == "enterprise"`},
+		},
+	}
+	if !limitBlockMentionsTierInPredicates(block, "enterprise") {
+		t.Fatal("expected match for double-quoted tier")
+	}
+	if limitBlockMentionsTierInPredicates(block, "free") {
+		t.Fatal("expected no match for different tier")
+	}
+	blockSingle := map[string]interface{}{
+		"when": []interface{}{
+			map[string]interface{}{"predicate": `auth.identity.tier == 'gold'`},
+		},
+	}
+	if !limitBlockMentionsTierInPredicates(blockSingle, "gold") {
+		t.Fatal("expected match for single-quoted tier")
+	}
+}
+
+func TestDiscoverTokenRateLimitsForTier_arbitraryKeyWithPredicate(t *testing.T) {
+	t.Parallel()
+	pol := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"limits": map[string]interface{}{
+					"cli-custom": map[string]interface{}{
+						"when": []interface{}{
+							map[string]interface{}{"predicate": `auth.identity.tier == "mytier"`},
+						},
+						"rates": []interface{}{
+							map[string]interface{}{"limit": int64(7), "window": "1h"},
+						},
+					},
+				},
+			},
+		},
+	}
+	pol.SetName("orphan-trlp")
+	rates, err := discoverTokenRateLimitsForTier("mytier", []unstructured.Unstructured{pol})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rates) != 1 || rates[0].Count != 7 || rates[0].Unit != models.GEP_2257_HOUR {
+		t.Fatalf("unexpected rates: %#v", rates)
+	}
+}
+
+func TestDiscoverTokenRateLimitsForTier_prefersCanonicalFirst(t *testing.T) {
+	t.Parallel()
+	orphan := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"limits": map[string]interface{}{
+					"tier-a-tokens": map[string]interface{}{
+						"rates": []interface{}{
+							map[string]interface{}{"limit": int64(1), "window": "1m"},
+						},
+					},
+				},
+			},
+		},
+	}
+	orphan.SetName("orphan")
+	canonical := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"limits": map[string]interface{}{
+					"tier-a-tokens": map[string]interface{}{
+						"rates": []interface{}{
+							map[string]interface{}{"limit": int64(99), "window": "1h"},
+						},
+					},
+				},
+			},
+		},
+	}
+	canonical.SetName("gw-token-rate-limits")
+	rates, err := discoverTokenRateLimitsForTier("tier-a", sortPoliciesCanonicalFirst([]unstructured.Unstructured{orphan, canonical}, "gw-token-rate-limits"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rates) != 1 || rates[0].Count != 99 {
+		t.Fatalf("expected canonical limit, got %#v", rates)
+	}
+}

--- a/packages/maas/bff/internal/testdata/rate-limit-policy.yaml
+++ b/packages/maas/bff/internal/testdata/rate-limit-policy.yaml
@@ -1,7 +1,8 @@
+# Single RateLimitPolicy: name must match {gatewayName}-request-rate-limits (see NewTiersRepository defaults).
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
-  name: tier-tier0-rate-limits
+  name: maas-default-gateway-request-rate-limits
   labels:
     opendatahub.io/dashboard: "true"
 spec:
@@ -17,5 +18,14 @@ spec:
       when:
         - predicate: |
             auth.identity.tier == "tier0"
+      counters:
+        - expression: auth.identity.userid
+    tier1-requests:
+      rates:
+        - limit: 10
+          window: 1m
+      when:
+        - predicate: |
+            auth.identity.tier == "tier1"
       counters:
         - expression: auth.identity.userid

--- a/packages/maas/bff/internal/testdata/token-limit-policy.yaml
+++ b/packages/maas/bff/internal/testdata/token-limit-policy.yaml
@@ -1,7 +1,8 @@
+# Single TokenRateLimitPolicy for the test gateway: name must match {gatewayName}-token-rate-limits (default gateway maas-default-gateway).
 apiVersion: kuadrant.io/v1alpha1
 kind: TokenRateLimitPolicy
 metadata:
-  name: tier-tier0-token-rate-limits
+  name: maas-default-gateway-token-rate-limits
   labels:
     opendatahub.io/dashboard: "true"
 spec:
@@ -19,19 +20,6 @@ spec:
             auth.identity.tier == "tier0"
       counters:
         - expression: auth.identity.userid
----
-apiVersion: kuadrant.io/v1alpha1
-kind: TokenRateLimitPolicy
-metadata:
-  name: tier-tier1-token-rate-limits
-  labels:
-    opendatahub.io/dashboard: "true"
-spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: Gateway
-    name: maas-default-gateway
-  limits:
     tier1-tokens:
       rates:
         - limit: 50000
@@ -39,27 +27,5 @@ spec:
       when:
         - predicate: |
             auth.identity.tier == "tier1"
-      counters:
-        - expression: auth.identity.userid
----
-apiVersion: kuadrant.io/v1alpha1
-kind: TokenRateLimitPolicy
-metadata:
-  name: tier-enterprise-token-rate-limits
-  labels:
-    opendatahub.io/dashboard: "true"
-spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: Gateway
-    name: maas-default-gateway
-  limits:
-    enterprise-tokens:
-      rates:
-        - limit: 100000
-          window: 1m
-      when:
-        - predicate: |
-            auth.identity.tier == "enterprise"
       counters:
         - expression: auth.identity.userid


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-53865](https://redhat.atlassian.net/browse/RHOAIENG-53865)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
We were making a `TokenRateLimitPolicy` and a `RateLimitPolicy` for each tier created, but Kuadrant will only enforce one policy, the rest are overridden

## Issue 1:
Here it will create a singular `TokenRateLimitPolicy` and `RateLimitPolicy` combining all the limits into one resource that Kuadrant will enforce

If you have old tiers with the old per-tier-policy-situation or create new ones with the CLI -> as soon as you create or edit **any** tier, all outstanding policies will be rolled into its respective singular policy 

create, edit, and delete works -> adding to, editing, or deleting the relevant info from the singular policies

## Issue 2:
If you have a combined policy the limits won't show in the UI bc it reads from the `tier-to-group-mapping` resource instead of the policy

So that got changed to read from the policies pointing at the `maas-default-gateway`

## Issue 3:
If you apply a combined rate limit policy from the cli, then edit it, it overwrites it and just creates a new policy for each tier

The fix: 
If you have multiple `TokenRateLimitPolicy` and `RateLimitPolicy` and edit or create ANY tier it will roll any outstanding policies into the central policy `maas-default-gateway-token-rate-limits` and/or `maas-default-gateway-request-rate-limits`

CLI testing: Creating a new tier merges the policies

https://github.com/user-attachments/assets/16428aff-42b1-4a9d-9805-b3910abfb964


CLI testing: Editing one of the tiers in a while it's still in a separate policy still works and it still merges policies



https://github.com/user-attachments/assets/a30ad842-1b6f-4708-ace8-1f405ed80cc2


Using old tiers with the one-policy-per-tier-system:


https://github.com/user-attachments/assets/f3a3c556-b8d9-40be-9d2b-712f4daa5a96



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

I tested:
- Making tiers the old way (policy per tier) -> doing CRUD on them -> policies merge
- Making tiers and limits via CLI -> UI shows limits correctly -> CRUD works -> policies merge
- Making tiers the new way (1 policy)

Here's some yaml to import to do CLI testing:
add this to the `tier-to-group-mapping` resource:
```
    - name: cli-testing
      displayName: cli testing
      groups:
        - system:authenticated
      level: 111
    - name: cli-testing2
      displayName: cli testing2
      groups:
        - system:authenticated
      level: 222
```
then apply this:
```
apiVersion: kuadrant.io/v1
kind: RateLimitPolicy
metadata:
  name: maas-gateway-rate-limits-cli
  namespace: openshift-ingress
spec:
  limits:
    cli-testing:
      rates:
        - limit: 11111
          window: 1h
      when:
        - predicate: auth.identity.tier == "cli-testing" && !request.path.endsWith("/v1/models")
    cli-testing2:
      rates:
        - limit: 22222
          window: 2h
      when:
        - predicate: auth.identity.tier == "cli-testing" && !request.path.endsWith("/v1/models")
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: maas-default-gateway
---
apiVersion: kuadrant.io/v1alpha1
kind: TokenRateLimitPolicy
metadata:
  name: maas-gateway-rate-limits-cli
  namespace: openshift-ingress
spec:
  limits:
    cli-testing:
      rates:
        - limit: 11111
          window: 1h
      when:
        - predicate: auth.identity.tier == "cli-testing" && !request.path.endsWith("/v1/models")
    cli-testing2:
      rates:
        - limit: 22222
          window: 2h
      when:
        - predicate: auth.identity.tier == "cli-testing" && !request.path.endsWith("/v1/models")
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: maas-default-gateway

```



To test:
- I have a 3.3 cluster going, dm me for the link and login
- You'll need to go to `packages/maas/bff/cmd/main.go` and update this:
```
flag.StringVar(&cfg.TiersConfigMapNamespace, "tiers-configmap-namespace", getEnvAsString("TIERS_CONFIGMAP_NS", "maas-api"), "Namespace where the ConfigMap for tiers configuration is located")
```
to use `redhat-ods-applications` instead of `maas-api` ^
- and update your `env.local` to use `OC_PROJECT=redhat-ods-applications` instead of `OC_PROJECT=opendatahub` bc the cluster is a RHOAI cluster
- Open the dashboard via the cluster and make a few tiers -> also note you can see the rate limits in the table etc
- Go see the `TokenRateLimitPolicy` and `RateLimitPolicy` resources and see there's one for each tier and that most of them will say they're overridden
- Run the dashboard locally 
- Then either create or edit any tier -> make sure that goes through
- Go back to the console and see all your old tiers `TokenRateLimitPolicy` and `RateLimitPolicy` rolled into one singular policy -> also check out the `tier-to-group-mapping` resource, that should be updating as well
- Do some CRUD actions, make sure the singular policy and such gets updated correctly
- Go back to the console and apply the yaml I listed above ^ to make some cli tiers and limits
- The tiers should show in the table and list the rate limits correctly
- Either edit or create one of the new tiers or literally any tier -> the extra policies will get rolled into the singular mega policy
- Do some CRUD actions -> all should work


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated some mock tests that were failing

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limit policies are now managed as consolidated Gateway-level resources instead of individual tier policies, improving system scalability and policy management.
  * Configuration now supports dedicated settings for token and request rate limit policy names.

* **Bug Fixes**
  * Enhanced numeric parsing and error handling for rate limit policy conversion.

* **Tests**
  * Updated test fixtures and suite to reflect consolidated policy model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->