### PR TITLE
Increase the project deletion timeout to 3 minutes

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/project.ts
+++ b/packages/cypress/cypress/utils/oc_commands/project.ts
@@ -52,7 +52,7 @@ export const deleteOpenShiftProject = (
   projectName: string,
   options: { timeout?: number; wait?: boolean; ignoreNotFound?: boolean } = {},
 ): Cypress.Chainable<CommandLineResult> => {
-  const { timeout, wait = true, ignoreNotFound = false } = options;
+  const { timeout = 180000, wait = true, ignoreNotFound = false } = options;
   const waitFlag = wait ? '--wait' : '--wait=false';
   const ignoreNotFoundFlag = ignoreNotFound ? '--ignore-not-found' : '';
   const ocCommand = `oc delete project ${projectName} ${waitFlag} ${ignoreNotFoundFlag}`.trim();
@@ -60,7 +60,7 @@ export const deleteOpenShiftProject = (
   // Only apply timeout if we're waiting for the deletion
   const execOptions = {
     failOnNonZeroExit: false,
-    ...(wait && timeout && { timeout }),
+    ...(wait && { timeout }),
   };
 
   return cy.exec(ocCommand, execOptions).then((result) => {


### PR DESCRIPTION
## Description
Increase the default timeout for deleteOpenShiftProject from Cypress's default (60s) to 180 seconds (3 minutes), giving slow cluster project deletions more time to complete before the test fails.

## How Has This Been Tested?
dashboard-e2e-tests/515/

<img width="1176" height="158" alt="image" src="https://github.com/user-attachments/assets/4d29a185-3688-4498-a35c-532f662f1f38" />

(Just showing the failures as non of those were related to "oc delete project" timeouts)

## Test Impact
oc delete project now has a 3 mins timeout

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of project deletion by enforcing a default timeout when waiting for deletion; deletion requests now consistently apply the timeout so operations are less likely to fail due to missing or inconsistent timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->