### PR TITLE
RHOAIENG-38577: Can't stop a basic workbench on a cluster with custom OIDC provider

### DIFF
--- a/backend/src/utils/route-security.ts
+++ b/backend/src/utils/route-security.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { getOpenshiftUser, getUserInfo, usernameTranslate } from './userUtils';
+import { getUserInfo, usernameTranslate } from './userUtils';
 import { createCustomError } from './requestUtils';
 import { isUserAdmin } from './adminUtils';
 import { getNamespaces } from './notebookUtils';
@@ -38,25 +38,6 @@ const testAdmin = async (
   }
 
   return false; // Not admin, no bypassing
-};
-
-const requestSecurityGuardNotebook = async (
-  fastify: KubeFastifyInstance,
-  request: OauthFastifyRequest,
-  username: string,
-): Promise<void> => {
-  // Check first admin to not give away if a user does not exist to regular users
-  await testAdmin(fastify, request, true);
-
-  try {
-    await getOpenshiftUser(fastify, username);
-  } catch (e) {
-    throw createCustomError(
-      'Wrong username',
-      'Request invalid against a username that does not exist.',
-      403,
-    );
-  }
 };
 
 const requestSecurityGuard = async (
@@ -191,7 +172,7 @@ const handleSecurityOnRouteData = async (
       request.params.name,
     );
   } else if (isRequestNotebookAdmin(request)) {
-    await requestSecurityGuardNotebook(fastify, request, request.body.username ?? '');
+    await testAdmin(fastify, request, true);
   } else if (isRequestNotebookEndpoint(request)) {
     // Endpoint has self validation internal
   } else {

--- a/backend/src/utils/userUtils.ts
+++ b/backend/src/utils/userUtils.ts
@@ -44,23 +44,6 @@ export type OpenShiftUser = {
   groups: string[];
 };
 
-export const getOpenshiftUser = async (
-  fastify: KubeFastifyInstance,
-  username: string,
-): Promise<OpenShiftUser> => {
-  try {
-    const userResponse = await fastify.kube.customObjectsApi.getClusterCustomObject(
-      'user.openshift.io',
-      'v1',
-      'users',
-      username,
-    );
-    return userResponse.body as OpenShiftUser;
-  } catch (e) {
-    throw new Error(`Error retrieving user, ${errorHandler(e)}`);
-  }
-};
-
 export const getUser = async (
   fastify: KubeFastifyInstance,
   request: FastifyRequest,


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-38577

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
When an admin stops a basic workbench, the frontend sends `PATCH /api/notebooks` with `{ state: "stopped", username: "<oidc-user>" }`. The backend security guard `requestSecurityGuardNotebook` in `route-security.ts` calls `getOpenshiftUser()`, which fetches `user.openshift.io/v1/users/<username>`. On clusters with custom OIDC providers (Keycloak, Azure AD, etc.), this API has **no entries for BYOIDC users** -- they authenticate via the external IdP and OpenShift does not create `User` CRs for them. The call always fails, resulting in a **403 "Wrong username"** error.

This was introduced in PR #643 (Oct 2022) as a defense-in-depth check to validate that the target user exists before allowing an admin to operate on their notebook. At the time, all clusters used OpenShift's built-in OAuth, so every user had a `User` CR. BYOIDC support came later and this guard was never updated.

**Working screen recording:**

https://github.com/user-attachments/assets/7bbf6fc6-4696-4133-9ddd-523168e79da4

### Fix
Remove the `getOpenshiftUser` check from `requestSecurityGuardNotebook`. The `testAdmin()` check alone is sufficient security because:

- Only admins can reach this code path (enforced by `testAdmin(..., true)`)
- If no notebook exists for the given username, the K8s patch in `stopNotebook` will return a 404 from the API
- Admins already have cluster-wide access to all notebooks via other routes
- The fix is scoped to the notebook admin path only -- no other resources or guards are affected

Also removes the now-unused `getOpenshiftUser` function from `userUtils.ts`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a cluster with custom (keycloak) OIDC provider. Reach out to get access to the cluster for testing.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No test changes required. There are no unit, mock, or e2e tests covering the `requestSecurityGuardNotebook` function or the `getOpenshiftUser` call. The existing Cypress tests for notebook stop/start intercept `PATCH /api/notebooks` at the HTTP level and mock the response, so they do not exercise the backend security guard. Manual testing on a BYOIDC cluster is recommended to verify the fix end-to-end.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed redundant username validation from admin security checks.
  * Consolidated user identity retrieval into existing lookup flows.
  * No expected user-facing changes; admin access flow streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->