### PR TITLE
feat(nim-serving): add nimWizard temp dev feature flag and nim-serving package

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -58,6 +58,7 @@ export type MockDashboardConfigType = {
   vLLMDeploymentOnMaaS?: boolean;
   llmGatewayField?: boolean;
   promptManagement?: boolean;
+  nimWizard?: boolean;
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
       externalProviders?: boolean;
@@ -115,6 +116,7 @@ export const mockDashboardConfig = ({
   vLLMDeploymentOnMaaS = false,
   llmGatewayField = false,
   promptManagement = false,
+  nimWizard = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   genAiStudioConfig = {
     aiAssetCustomEndpoints: {
@@ -295,6 +297,7 @@ export const mockDashboardConfig = ({
       vLLMDeploymentOnMaaS,
       llmGatewayField,
       promptManagement,
+      nimWizard,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -22,6 +22,7 @@ export const devTemporaryFeatureFlags = {
   disableKueue: true,
   disableProjectScoped: true,
   mlflowPipelines: false,
+  nimWizard: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -57,6 +57,7 @@ export enum SupportedArea {
   PERFORMANCE_METRICS = 'performance-metrics',
   TRUSTY_AI = 'trusty-ai',
   NIM_MODEL = 'nim-model',
+  NIM_WIZARD = 'nim-wizard',
   SERVING_RUNTIME_PARAMS = 'serving-runtime-params',
   MODEL_AS_SERVICE = 'model-as-service',
   MAAS_AUTH_POLICIES = 'maas-auth-policies',

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1333,6 +1333,7 @@ export type DashboardCommonConfig = {
   vLLMDeploymentOnMaaS?: boolean;
   llmGatewayField?: boolean;
   promptManagement?: boolean;
+  nimWizard?: boolean;
 };
 
 // [1] Intentionally disjointed fields from the CRD in this type definition

--- a/package-lock.json
+++ b/package-lock.json
@@ -5680,6 +5680,10 @@
       "resolved": "packages/model-training",
       "link": true
     },
+    "node_modules/@odh-dashboard/nim-serving": {
+      "resolved": "packages/nim-serving",
+      "link": true
+    },
     "node_modules/@odh-dashboard/notebooks": {
       "resolved": "packages/notebooks",
       "link": true
@@ -35818,6 +35822,18 @@
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*"
+      }
+    },
+    "packages/nim-serving": {
+      "name": "@odh-dashboard/nim-serving",
+      "version": "0.0.0",
+      "dependencies": {
+        "@odh-dashboard/plugin-core": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/jest-config": "*",
         "@odh-dashboard/tsconfig": "*"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35829,6 +35829,7 @@
       "name": "@odh-dashboard/nim-serving",
       "version": "0.0.0",
       "dependencies": {
+        "@odh-dashboard/internal": "*",
         "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { z } from 'zod';
-import { Form, FormSection, Spinner } from '@patternfly/react-core';
+import { Alert, Form, FormSection, Spinner } from '@patternfly/react-core';
 import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
+import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
 import { modelTypeSelectFieldSchema, ModelTypeSelectField } from '../fields/ModelTypeSelectField';
 import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import { ModelLocationSelectField } from '../fields/ModelLocationSelectField';
@@ -33,12 +34,17 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
   wizardState,
   validation,
 }) => {
+  const isNimWizardEnabled = useIsAreaAvailable(SupportedArea.NIM_WIZARD).status;
+
   if (!wizardState.loaded.modelSourceLoaded) {
     return <Spinner data-testid="spinner" />;
   }
 
   return (
     <Form>
+      {isNimWizardEnabled && (
+        <Alert variant="info" isInline title="(TODO replace me) NIM serving extension is enabled" />
+      )}
       <FormSection title="Model details">
         <p style={{ marginTop: '-8px' }}>Provide information about the model you want to deploy.</p>
         <ModelLocationSelectField

--- a/packages/nim-serving/.eslintrc.js
+++ b/packages/nim-serving/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@odh-dashboard/eslint-config').recommendedReactTypescript(__dirname);

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -1,4 +1,7 @@
 import type { AreaExtension } from '@odh-dashboard/plugin-core/extension-points';
+// Allow this import as it consists of types and enums only.
+// eslint-disable-next-line no-restricted-syntax
+import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 
 const extensions: AreaExtension[] = [
   {
@@ -6,7 +9,7 @@ const extensions: AreaExtension[] = [
     properties: {
       id: 'nim-wizard',
       featureFlags: ['nimWizard'],
-      reliantAreas: ['nim-model'],
+      reliantAreas: [SupportedArea.NIM_MODEL],
     },
   },
 ];

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -1,0 +1,14 @@
+import type { AreaExtension } from '@odh-dashboard/plugin-core/extension-points';
+
+const extensions: AreaExtension[] = [
+  {
+    type: 'app.area',
+    properties: {
+      id: 'nim-wizard',
+      featureFlags: ['nimWizard'],
+      reliantAreas: ['nim-model'],
+    },
+  },
+];
+
+export default extensions;

--- a/packages/nim-serving/jest.config.ts
+++ b/packages/nim-serving/jest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@odh-dashboard/jest-config';

--- a/packages/nim-serving/package.json
+++ b/packages/nim-serving/package.json
@@ -14,6 +14,7 @@
     "./extensions": "./extensions.ts"
   },
   "dependencies": {
+    "@odh-dashboard/internal": "*",
     "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {

--- a/packages/nim-serving/package.json
+++ b/packages/nim-serving/package.json
@@ -5,8 +5,9 @@
   "version": "0.0.0",
   "scripts": {
     "lint": "eslint .",
-    "test-unit": "jest --silent",
-    "test-unit-coverage": "jest --silent --coverage",
+    "lint:fix": "eslint . --fix",
+    "test-unit": "jest --silent --passWithNoTests",
+    "test-unit-coverage": "jest --silent --coverage --passWithNoTests",
     "type-check": "tsc --noEmit"
   },
   "exports": {

--- a/packages/nim-serving/package.json
+++ b/packages/nim-serving/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "@odh-dashboard/nim-serving",
+  "description": "NIM serving extensions for the model deployment wizard.",
+  "version": "0.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "test-unit": "jest --silent",
+    "test-unit-coverage": "jest --silent --coverage",
+    "type-check": "tsc --noEmit"
+  },
+  "exports": {
+    "./extensions": "./extensions.ts"
+  },
+  "dependencies": {
+    "@odh-dashboard/plugin-core": "*"
+  },
+  "devDependencies": {
+    "@odh-dashboard/eslint-config": "*",
+    "@odh-dashboard/jest-config": "*",
+    "@odh-dashboard/tsconfig": "*"
+  }
+}

--- a/packages/nim-serving/tsconfig.json
+++ b/packages/nim-serving/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@odh-dashboard/tsconfig/tsconfig.json"
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-60270

## Description
Adds a temporary developer feature flag `nimWizard` for NIM wizard development. This flag will gate future NIM serving extensions to the existing model deployment wizard.

Changes:
- Add `nimWizard?: boolean` to `DashboardCommonConfig` type
- Add `nimWizard: false` to `devTemporaryFeatureFlags` (disabled by default)
- Add `NIM_WIZARD = 'nim-wizard'` to `SupportedArea` enum
- Create `packages/nim-serving/` plugin package that registers an `app.area` extension with `featureFlags: ['nimWizard']` and `reliantAreas: [SupportedArea.NIM_MODEL]`
- Add placeholder `Alert` in the model source step of the deployment wizard when the flag is enabled
- Add `nimWizard` to the mock dashboard config for tests

The `nim-serving` package is a simple plugin package (no BFF, no Module Federation, no Dockerfile) that will serve as the home for future NIM serving extension code.

**Note:** This PR does not gate the feature flag on the NIM operator being installed. The existing hooks (`useIsNIMAvailable`, `useIsComponentIntegrationEnabled('nvidia-nim')`) check whether NIM is *enabled/configured*, not just *installed*, so they aren't suitable here. Gating on operator installation will require further investigation — tracked in [RHOAIENG-60439](https://redhat.atlassian.net/browse/RHOAIENG-60439).

Flag:
<img width="1045" height="143" alt="Screenshot 2026-04-29 at 1 12 12 PM" src="https://github.com/user-attachments/assets/d6ba676f-e7e1-4520-9fb3-b0876ebd8960" />

Placeholder consuming the flag in the wizard:
<img width="900" height="300" alt="Screenshot 2026-04-29 at 1 12 21 PM" src="https://github.com/user-attachments/assets/1ccd9e59-7eb2-42c4-bdc1-2c8da071ba54" />

## How Has This Been Tested?
- `npm install` — picks up new workspace package
- `npm run type-check` — passes for frontend, model-serving, and nim-serving packages
- `npm run lint` — passes for all modified files
- Port validation hook passes (no MF config in this package)

## Test Impact
No new tests added. This is a feature flag scaffold with a placeholder alert — tests will be added alongside the actual NIM wizard implementation.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIM Wizard feature flag support with conditional info alert in the model deployment workflow when enabled.

* **Chores**
  * Created new NIM Serving package with configuration scaffolding (ESLint, Jest, TypeScript, package exports).
  * Extended dashboard configuration to support NIM Wizard feature enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->