### PR TITLE
RHOAIENG-31273: Add Cypress mock tests for testing gaps

### DIFF
--- a/frontend/src/__mocks__/mockK8sStatus.ts
+++ b/frontend/src/__mocks__/mockK8sStatus.ts
@@ -41,6 +41,17 @@ export const mock409Error = ({ message = '409 Conflict' }: Partial<K8sStatus>): 
   code: 409,
 });
 
+export const mock500Error = ({
+  message = '500 Internal Server Error',
+}: Partial<K8sStatus>): K8sStatus => ({
+  kind: 'Status',
+  apiVersion: 'v1',
+  status: 'Failure',
+  message,
+  reason: 'InternalError',
+  code: 500,
+});
+
 export const mock200Status = ({ message = '200 OK' }: Partial<K8sStatus>): K8sStatus => ({
   kind: 'Status',
   apiVersion: 'v1',

--- a/frontend/src/components/PasswordHiddenText.tsx
+++ b/frontend/src/components/PasswordHiddenText.tsx
@@ -26,6 +26,7 @@ const PasswordHiddenText: React.FC<PasswordHiddenTextProps> = ({ password }) => 
           icon={isHidden ? <EyeSlashIcon /> : <EyeIcon />}
           variant="plain"
           onClick={() => setIsHidden(!isHidden)}
+          aria-label={isHidden ? 'Show password' : 'Hide password'}
           data-testid="password-hidden-button"
         />
       </FlexItem>

--- a/frontend/src/concepts/pipelines/content/ManagePipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ManagePipelineServerModal.tsx
@@ -5,13 +5,19 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   Title,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   Modal,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalBody,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalHeader,
+  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalFooter,
   Button,
   ActionGroup,
   Spinner,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core';
 import { usePipelinesAPI } from '#~/concepts/pipelines/context';
 import PasswordHiddenText from '#~/components/PasswordHiddenText';
@@ -95,88 +101,92 @@ const ManagePipelineServerModal: React.FC<ManagePipelineServerModalProps> = ({
           </>
         )}
         {pipelineNamespaceCR && (
-          <DescriptionList termWidth="20ch" isHorizontal>
+          <Stack hasGutter>
             {!!pipelineNamespaceCR.spec.objectStorage.externalStorage?.s3CredentialsSecret
               .secretName && (
-              <>
+              <StackItem>
                 <Title headingLevel="h2">Object storage connection</Title>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Access key</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="access-key-field">
-                    {pipelineSecret[
-                      pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
-                        .accessKey
-                    ] || ''}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Secret key</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="secret-key-field">
-                    <PasswordHiddenText
-                      password={
-                        pipelineSecret[
-                          pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
-                            .secretKey
-                        ] ?? ''
-                      }
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Endpoint</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="endpoint-field">
-                    {pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme &&
-                    pipelineNamespaceCR.spec.objectStorage.externalStorage.host
-                      ? `${pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme}://${pipelineNamespaceCR.spec.objectStorage.externalStorage.host}`
-                      : ''}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Bucket</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="bucket-field">
-                    {pipelineNamespaceCR.spec.objectStorage.externalStorage.bucket}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              </>
+                <DescriptionList termWidth="20ch" isHorizontal>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Access key</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="access-key-field">
+                      {pipelineSecret[
+                        pipelineNamespaceCR.spec.objectStorage.externalStorage.s3CredentialsSecret
+                          .accessKey
+                      ] || ''}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Secret key</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="secret-key-field">
+                      <PasswordHiddenText
+                        password={
+                          pipelineSecret[
+                            pipelineNamespaceCR.spec.objectStorage.externalStorage
+                              .s3CredentialsSecret.secretKey
+                          ] ?? ''
+                        }
+                      />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Endpoint</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="endpoint-field">
+                      {pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme &&
+                      pipelineNamespaceCR.spec.objectStorage.externalStorage.host
+                        ? `${pipelineNamespaceCR.spec.objectStorage.externalStorage.scheme}://${pipelineNamespaceCR.spec.objectStorage.externalStorage.host}`
+                        : ''}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Bucket</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="bucket-field">
+                      {pipelineNamespaceCR.spec.objectStorage.externalStorage.bucket}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </StackItem>
             )}
             {!!pipelineNamespaceCR.spec.database &&
               !!pipelineNamespaceCR.spec.database.externalDB &&
               !!databaseSecret[ExternalDatabaseSecret.KEY] && (
-                <>
+                <StackItem>
                   <Title headingLevel="h2">Database</Title>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Host</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {pipelineNamespaceCR.spec.database.externalDB.host}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Port</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {pipelineNamespaceCR.spec.database.externalDB.port}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Username</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {pipelineNamespaceCR.spec.database.externalDB.username}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Password</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      <PasswordHiddenText password={databaseSecret[ExternalDatabaseSecret.KEY]} />
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Database</DescriptionListTerm>
-                    <DescriptionListDescription>
-                      {pipelineNamespaceCR.spec.database.externalDB.pipelineDBName}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                </>
+                  <DescriptionList termWidth="20ch" isHorizontal>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Host</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {pipelineNamespaceCR.spec.database.externalDB.host}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Port</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {pipelineNamespaceCR.spec.database.externalDB.port}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Username</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {pipelineNamespaceCR.spec.database.externalDB.username}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Password</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <PasswordHiddenText password={databaseSecret[ExternalDatabaseSecret.KEY]} />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Database</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {pipelineNamespaceCR.spec.database.externalDB.pipelineDBName}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </StackItem>
               )}
-            <>
+            <StackItem>
               <Title headingLevel="h2" data-testid="additionalConfig-headerText">
                 Additional configurations
               </Title>
@@ -199,8 +209,8 @@ const ManagePipelineServerModal: React.FC<ManagePipelineServerModalProps> = ({
                   variant="description"
                 />
               </DescriptionList>
-            </>
-          </DescriptionList>
+            </StackItem>
+          </Stack>
         )}
       </ModalBody>
       <ModalFooter>

--- a/frontend/src/concepts/pipelines/content/ManagePipelineServerModal.tsx
+++ b/frontend/src/concepts/pipelines/content/ManagePipelineServerModal.tsx
@@ -5,13 +5,9 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   Title,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   Modal,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalBody,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalHeader,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
   ModalFooter,
   Button,
   ActionGroup,

--- a/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
+++ b/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
@@ -177,33 +177,35 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
     <TopologyView
       className={css('pipeline-visualization', !!selectedNode && 'm-is-open')}
       controlBar={
-        <TopologyControlBar
-          controlButtons={createTopologyControlButtons({
-            ...defaultControlButtonsOptions,
-            expandAll: !!collapseAllCallback,
-            collapseAll: !!collapseAllCallback,
-            zoomInCallback: action(() => {
-              controller.getGraph().scaleBy(4 / 3);
-            }),
-            zoomOutCallback: action(() => {
-              controller.getGraph().scaleBy(0.75);
-            }),
-            fitToScreenCallback: action(() => {
-              controller.getGraph().fit(80);
-            }),
-            resetViewCallback: action(() => {
-              controller.getGraph().reset();
-              controller.getGraph().layout();
-            }),
-            expandAllCallback: action(() => {
-              collapseAllCallback(false);
-            }),
-            collapseAllCallback: action(() => {
-              collapseAllCallback(true);
-            }),
-            legend: false,
-          })}
-        />
+        <div data-testid="pipeline-topology-control-bar">
+          <TopologyControlBar
+            controlButtons={createTopologyControlButtons({
+              ...defaultControlButtonsOptions,
+              expandAll: !!collapseAllCallback,
+              collapseAll: !!collapseAllCallback,
+              zoomInCallback: action(() => {
+                controller.getGraph().scaleBy(4 / 3);
+              }),
+              zoomOutCallback: action(() => {
+                controller.getGraph().scaleBy(0.75);
+              }),
+              fitToScreenCallback: action(() => {
+                controller.getGraph().fit(80);
+              }),
+              resetViewCallback: action(() => {
+                controller.getGraph().reset();
+                controller.getGraph().layout();
+              }),
+              expandAllCallback: action(() => {
+                collapseAllCallback(false);
+              }),
+              collapseAllCallback: action(() => {
+                collapseAllCallback(true);
+              }),
+              legend: false,
+            })}
+          />
+        </div>
       }
       sideBarOpen={!!selectedNode}
       sideBarResizable

--- a/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
+++ b/packages/cypress/cypress/pages/pipelines/pipelinesGlobal.ts
@@ -39,7 +39,7 @@ class PipelinesGlobal {
     return cy.findByTestId('create-pipeline-button');
   }
 
-  private findPipelineServerActionButton() {
+  findPipelineServerActionButton() {
     return cy.findByTestId('pipeline-server-action');
   }
 

--- a/packages/cypress/cypress/pages/pipelines/topology.ts
+++ b/packages/cypress/cypress/pages/pipelines/topology.ts
@@ -43,7 +43,7 @@ class TaskDrawer extends Contextual<HTMLElement> {
   }
 
   shouldHaveTaskName(name: string) {
-    return this.find().findByTestId('pipeline-task-name').should('have.text', name);
+    return this.find().findByTestId('pipeline-task-name').should('contain.text', name);
   }
 }
 
@@ -61,6 +61,47 @@ class PipelinesTopology {
 
   findTaskNode(name: string) {
     return cy.get(`[data-id="${name}"][data-kind="node"][data-type="DEFAULT_TASK_NODE"]`);
+  }
+
+  findTaskNodes() {
+    return cy.get('[data-kind="node"][data-type="DEFAULT_TASK_NODE"]');
+  }
+
+  findNodes() {
+    return cy.get('[data-kind="node"]');
+  }
+
+  findEdges() {
+    return cy.get('[data-kind="edge"]');
+  }
+
+  // PatternFly Topology third-party component — no data-testid support
+  findVisualizationSurface() {
+    return cy.get('.pf-topology-visualization-surface');
+  }
+
+  findCollapseAllButton() {
+    return cy.findByRole('button', { name: /collapse all/i });
+  }
+
+  findExpandAllButton() {
+    return cy.findByRole('button', { name: /expand all/i });
+  }
+
+  findZoomInButton() {
+    return cy.findByRole('button', { name: /zoom in/i });
+  }
+
+  findZoomOutButton() {
+    return cy.findByRole('button', { name: /zoom out/i });
+  }
+
+  findFitToScreenButton() {
+    return cy.findByRole('button', { name: /fit to screen/i });
+  }
+
+  findResetViewButton() {
+    return cy.findByRole('button', { name: /reset view/i });
   }
 
   findArtifactNode(name: string) {

--- a/packages/cypress/cypress/pages/pipelines/topology.ts
+++ b/packages/cypress/cypress/pages/pipelines/topology.ts
@@ -75,33 +75,38 @@ class PipelinesTopology {
     return cy.get('[data-kind="edge"]');
   }
 
-  // PatternFly Topology third-party component — no data-testid support
+  // PF Topology uses data-test-id (hyphenated), not data-testid
   findVisualizationSurface() {
-    return cy.get('.pf-topology-visualization-surface');
+    return cy.get('[data-test-id="topology"]');
   }
 
+  findControlBar() {
+    return cy.findByTestId('pipeline-topology-control-bar');
+  }
+
+  // PF Topology toolbar buttons — third-party components without data-testid support; scoped within control bar
   findCollapseAllButton() {
-    return cy.findByRole('button', { name: /collapse all/i });
+    return this.findControlBar().findByRole('button', { name: /collapse all/i });
   }
 
   findExpandAllButton() {
-    return cy.findByRole('button', { name: /expand all/i });
+    return this.findControlBar().findByRole('button', { name: /expand all/i });
   }
 
   findZoomInButton() {
-    return cy.findByRole('button', { name: /zoom in/i });
+    return this.findControlBar().findByRole('button', { name: /zoom in/i });
   }
 
   findZoomOutButton() {
-    return cy.findByRole('button', { name: /zoom out/i });
+    return this.findControlBar().findByRole('button', { name: /zoom out/i });
   }
 
   findFitToScreenButton() {
-    return cy.findByRole('button', { name: /fit to screen/i });
+    return this.findControlBar().findByRole('button', { name: /fit to screen/i });
   }
 
   findResetViewButton() {
-    return cy.findByRole('button', { name: /reset view/i });
+    return this.findControlBar().findByRole('button', { name: /reset view/i });
   }
 
   findArtifactNode(name: string) {

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -684,8 +684,9 @@ class CreateSpawnerPage {
   }
 
   findConnectionsTableRow(name: string, type: string) {
-    this.findConnectionsTable().find(`[data-label=Name]`).contains(name);
-    this.findConnectionsTable().find(`[data-label=Type]`).contains(type);
+    this.findConnectionsTable().scrollIntoView();
+    this.findConnectionsTable().find(`[data-label=Name]`).contains(name).should('be.visible');
+    this.findConnectionsTable().find(`[data-label=Type]`).contains(type).should('be.visible');
   }
 
   findFeatureStoreSection() {

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -592,6 +592,10 @@ class CreateSpawnerPage {
     );
   }
 
+  findEnvironmentVariableFields() {
+    return cy.findAllByTestId('environment-variable-field');
+  }
+
   findNotebookImageSelector() {
     return cy.findByTestId('workbench-image-stream-selection');
   }
@@ -685,8 +689,14 @@ class CreateSpawnerPage {
 
   findConnectionsTableRow(name: string, type: string) {
     this.findConnectionsTable().scrollIntoView();
-    this.findConnectionsTable().find(`[data-label=Name]`).contains(name).should('be.visible');
-    this.findConnectionsTable().find(`[data-label=Type]`).contains(type).should('be.visible');
+    this.findConnectionsTable()
+      .find(`[data-label=Name]`)
+      .contains(name)
+      .parents('tr')
+      .within(() => {
+        cy.get('[data-label=Name]').should('be.visible').and('contain.text', name);
+        cy.get('[data-label=Type]').should('be.visible').and('contain.text', type);
+      });
   }
 
   findFeatureStoreSection() {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -1,0 +1,568 @@
+/* eslint-disable camelcase */
+import { mockDataSciencePipelineApplicationK8sResource } from '@odh-dashboard/internal/__mocks__/mockDataSciencePipelinesApplicationK8sResource';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import {
+  buildMockPipelineVersion,
+  buildMockPipelineVersions,
+} from '@odh-dashboard/internal/__mocks__/mockPipelineVersionsProxy';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { mockRouteK8sResource } from '@odh-dashboard/internal/__mocks__/mockRouteK8sResource';
+import { mockSecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { buildMockPipeline } from '@odh-dashboard/internal/__mocks__';
+import { ArtifactType } from '@odh-dashboard/internal/concepts/pipelines/kfTypes';
+import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { initMlmdIntercepts } from './mlmdUtils';
+import { pipelineDetails } from '../../../pages/pipelines';
+import {
+  DataSciencePipelineApplicationModel,
+  ProjectModel,
+  RouteModel,
+  SecretModel,
+} from '../../../utils/models';
+
+const projectId = 'test-project';
+const mockPipeline = buildMockPipeline({
+  pipeline_id: 'test-pipeline',
+  display_name: 'test-pipeline',
+});
+
+const initIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.DS_PIPELINES]: { managementState: 'Managed' },
+      },
+    }),
+  );
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: projectId })]),
+  );
+  cy.interceptK8s(
+    DataSciencePipelineApplicationModel,
+    mockDataSciencePipelineApplicationK8sResource({
+      namespace: projectId,
+      name: 'pipelines-definition',
+    }),
+  );
+
+  cy.interceptK8sList(
+    DataSciencePipelineApplicationModel,
+    mockK8sResourceList([mockDataSciencePipelineApplicationK8sResource({ namespace: projectId })]),
+  );
+
+  cy.interceptK8s(
+    DataSciencePipelineApplicationModel,
+    mockDataSciencePipelineApplicationK8sResource({ namespace: projectId }),
+  );
+  cy.interceptK8s(
+    SecretModel,
+    mockSecretK8sResource({ namespace: projectId, name: 'ds-pipeline-config' }),
+  );
+  cy.interceptK8s(
+    SecretModel,
+    mockSecretK8sResource({ namespace: projectId, name: 'aws-connection-testdb' }),
+  );
+  cy.interceptK8s(
+    RouteModel,
+    mockRouteK8sResource({
+      notebookName: 'ds-pipeline-dspa',
+      namespace: projectId,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId',
+    {
+      path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+    },
+    mockPipeline,
+  );
+};
+
+describe('Pipeline Graph Edge Cases', () => {
+  describe('Complex Dependencies', () => {
+    const mockComplexPipeline = buildMockPipelineVersion({
+      pipeline_id: mockPipeline.pipeline_id,
+      pipeline_version_id: 'complex-dependencies-version',
+      display_name: 'Complex Dependencies Pipeline',
+    });
+
+    // Override pipeline_spec with complex parallel branches
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const pipelineSpec = mockComplexPipeline.pipeline_spec.pipeline_spec!;
+    pipelineSpec.root.dag = {
+      tasks: {
+        'task-a': {
+          componentRef: { name: 'comp-task-a' },
+          taskInfo: { name: 'task-a' },
+          cachingOptions: { enableCache: true },
+        },
+        'task-b1': {
+          componentRef: { name: 'comp-task-b1' },
+          taskInfo: { name: 'task-b1' },
+          dependentTasks: ['task-a'],
+          cachingOptions: { enableCache: true },
+        },
+        'task-b2': {
+          componentRef: { name: 'comp-task-b2' },
+          taskInfo: { name: 'task-b2' },
+          dependentTasks: ['task-a'],
+          cachingOptions: { enableCache: true },
+        },
+        'task-b3': {
+          componentRef: { name: 'comp-task-b3' },
+          taskInfo: { name: 'task-b3' },
+          dependentTasks: ['task-a'],
+          cachingOptions: { enableCache: true },
+        },
+        'task-c': {
+          componentRef: { name: 'comp-task-c' },
+          taskInfo: { name: 'task-c' },
+          dependentTasks: ['task-b1', 'task-b2', 'task-b3'],
+          cachingOptions: { enableCache: true },
+        },
+      },
+    };
+
+    beforeEach(() => {
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockComplexPipeline]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockComplexPipeline.pipeline_version_id,
+          },
+        },
+        mockComplexPipeline,
+      );
+    });
+
+    it('should render fan-out/fan-in pipeline and allow task interaction', () => {
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockComplexPipeline.pipeline_version_id,
+      );
+
+      pipelineDetails.findTaskNode('task-a').should('exist');
+      pipelineDetails.findTaskNode('task-b1').should('exist');
+      pipelineDetails.findTaskNode('task-b2').should('exist');
+      pipelineDetails.findTaskNode('task-b3').should('exist');
+      pipelineDetails.findTaskNode('task-c').should('exist');
+
+      pipelineDetails.findTaskNode('task-c').click();
+      const taskDrawer = pipelineDetails.getTaskDrawer();
+      taskDrawer.shouldHaveTaskName('task-c');
+    });
+  });
+
+  describe('Large Graphs', () => {
+    const mockLargePipeline = buildMockPipelineVersion({
+      pipeline_id: mockPipeline.pipeline_id,
+      pipeline_version_id: 'large-graph-version',
+      display_name: 'Large Graph Pipeline (20+ tasks)',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const largePipelineSpec = mockLargePipeline.pipeline_spec.pipeline_spec!;
+    const largeDag: Record<string, (typeof largePipelineSpec.root.dag.tasks)[string]> = {};
+    const largeComponents: typeof largePipelineSpec.components = {};
+
+    for (let i = 0; i < 25; i++) {
+      const taskName = `task-${i}`;
+      const componentName = `comp-${taskName}`;
+
+      largeComponents[componentName] = {
+        executorLabel: `exec-${taskName}`,
+        outputDefinitions: {
+          artifacts: {
+            output: {
+              artifactType: {
+                schemaTitle: ArtifactType.DATASET,
+                schemaVersion: '0.0.1',
+              },
+            },
+          },
+        },
+      };
+
+      largeDag[taskName] = {
+        componentRef: { name: componentName },
+        taskInfo: { name: taskName },
+        cachingOptions: { enableCache: true },
+        ...(i > 0 && {
+          dependentTasks: [`task-${i - 1}`],
+        }),
+      };
+    }
+
+    largePipelineSpec.components = largeComponents;
+    largePipelineSpec.root.dag = { tasks: largeDag };
+
+    beforeEach(() => {
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockLargePipeline]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockLargePipeline.pipeline_version_id,
+          },
+        },
+        mockLargePipeline,
+      );
+    });
+
+    it('should render pipeline with 20+ tasks', () => {
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockLargePipeline.pipeline_version_id,
+      );
+
+      pipelineDetails.findTaskNode('task-0').should('exist');
+      pipelineDetails.findTaskNode('task-10').should('exist');
+      pipelineDetails.findTaskNode('task-20').should('exist');
+      pipelineDetails.findTaskNode('task-24').should('exist');
+    });
+  });
+
+  describe('Error Cases', () => {
+    it('should handle incomplete pipeline specs gracefully', () => {
+      const mockIncompletePipeline = buildMockPipelineVersion({
+        pipeline_id: mockPipeline.pipeline_id,
+        pipeline_version_id: 'incomplete-version',
+        display_name: 'Incomplete Pipeline',
+      });
+
+      // Create a minimal pipeline spec with missing components
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const incompletePipelineSpec = mockIncompletePipeline.pipeline_spec.pipeline_spec!;
+      incompletePipelineSpec.components = {};
+      incompletePipelineSpec.root.dag = {
+        tasks: {
+          'missing-component-task': {
+            componentRef: { name: 'non-existent-component' },
+            taskInfo: { name: 'missing-component-task' },
+            cachingOptions: { enableCache: true },
+          },
+        },
+      };
+
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockIncompletePipeline]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockIncompletePipeline.pipeline_version_id,
+          },
+        },
+        mockIncompletePipeline,
+      );
+
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockIncompletePipeline.pipeline_version_id,
+      );
+
+      pipelineDetails.findPageTitle().should('exist');
+    });
+
+    it('should handle empty pipeline spec', () => {
+      const mockEmptyPipeline = buildMockPipelineVersion({
+        pipeline_id: mockPipeline.pipeline_id,
+        pipeline_version_id: 'empty-version',
+        display_name: 'Empty Pipeline',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const emptyPipelineSpec = mockEmptyPipeline.pipeline_spec.pipeline_spec!;
+      emptyPipelineSpec.root.dag = { tasks: {} };
+      emptyPipelineSpec.components = {};
+
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockEmptyPipeline]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockEmptyPipeline.pipeline_version_id,
+          },
+        },
+        mockEmptyPipeline,
+      );
+
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockEmptyPipeline.pipeline_version_id,
+      );
+
+      pipelineDetails.findPageTitle().should('exist');
+    });
+  });
+
+  describe('Task Selection and Drawer', () => {
+    const mockDrawerVersion = buildMockPipelineVersion({
+      pipeline_id: mockPipeline.pipeline_id,
+      pipeline_version_id: 'drawer-test-version',
+      display_name: 'Drawer Test Pipeline',
+    });
+
+    beforeEach(() => {
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockDrawerVersion]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockDrawerVersion.pipeline_version_id,
+          },
+        },
+        mockDrawerVersion,
+      );
+    });
+
+    it('should open, close, and switch task drawer between nodes', () => {
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockDrawerVersion.pipeline_version_id,
+      );
+
+      pipelineDetails.findTaskNode('create-dataset').click();
+      const taskDrawer = pipelineDetails.getTaskDrawer();
+      taskDrawer.shouldHaveTaskName('create-dataset');
+      taskDrawer.find().should('be.visible');
+
+      pipelineDetails.findTaskNode('normalize-dataset').click();
+      taskDrawer.shouldHaveTaskName('normalize-dataset');
+
+      taskDrawer.findCloseDrawerButton().click();
+      taskDrawer.find().should('not.exist');
+    });
+  });
+
+  describe('Sequential Dependencies', () => {
+    const mockSequentialPipeline = buildMockPipelineVersion({
+      pipeline_id: mockPipeline.pipeline_id,
+      pipeline_version_id: 'sequential-version',
+      display_name: 'Sequential Pipeline',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sequentialPipelineSpec = mockSequentialPipeline.pipeline_spec.pipeline_spec!;
+    sequentialPipelineSpec.root.dag = {
+      tasks: {
+        'step-1': {
+          componentRef: { name: 'comp-step-1' },
+          taskInfo: { name: 'step-1' },
+          cachingOptions: { enableCache: true },
+        },
+        'step-2': {
+          componentRef: { name: 'comp-step-2' },
+          taskInfo: { name: 'step-2' },
+          dependentTasks: ['step-1'],
+          cachingOptions: { enableCache: true },
+        },
+        'step-3': {
+          componentRef: { name: 'comp-step-3' },
+          taskInfo: { name: 'step-3' },
+          dependentTasks: ['step-2'],
+          cachingOptions: { enableCache: true },
+        },
+        'step-4': {
+          componentRef: { name: 'comp-step-4' },
+          taskInfo: { name: 'step-4' },
+          dependentTasks: ['step-3'],
+          cachingOptions: { enableCache: true },
+        },
+      },
+    };
+
+    beforeEach(() => {
+      initIntercepts();
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: { namespace: projectId, serviceName: 'dspa', pipelineId: mockPipeline.pipeline_id },
+        },
+        buildMockPipelineVersions([mockSequentialPipeline]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockSequentialPipeline.pipeline_version_id,
+          },
+        },
+        mockSequentialPipeline,
+      );
+    });
+
+    it('should render pipeline with sequential dependencies', () => {
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockSequentialPipeline.pipeline_version_id,
+      );
+
+      pipelineDetails.findTaskNode('step-1').should('exist');
+      pipelineDetails.findTaskNode('step-2').should('exist');
+      pipelineDetails.findTaskNode('step-3').should('exist');
+      pipelineDetails.findTaskNode('step-4').should('exist');
+    });
+  });
+
+  describe('Toolbar Collapse/Expand Actions', () => {
+    const mockToolbarVersion = buildMockPipelineVersion({
+      pipeline_id: mockPipeline.pipeline_id,
+      pipeline_version_id: 'toolbar-test-version',
+      display_name: 'Toolbar Test Pipeline',
+    });
+
+    beforeEach(() => {
+      initIntercepts();
+      initMlmdIntercepts(projectId);
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+          },
+        },
+        buildMockPipelineVersions([mockToolbarVersion]),
+      );
+      cy.interceptOdh(
+        'GET /api/service/pipelines/:namespace/:serviceName/apis/v2beta1/pipelines/:pipelineId/versions/:pipelineVersionId',
+        {
+          path: {
+            namespace: projectId,
+            serviceName: 'dspa',
+            pipelineId: mockPipeline.pipeline_id,
+            pipelineVersionId: mockToolbarVersion.pipeline_version_id,
+          },
+        },
+        mockToolbarVersion,
+      );
+      pipelineDetails.visit(
+        projectId,
+        mockPipeline.pipeline_id,
+        mockToolbarVersion.pipeline_version_id,
+      );
+    });
+
+    it('should show toolbar controls and toggle collapse/expand with correct state', () => {
+      pipelineDetails.findZoomInButton().should('be.visible');
+      pipelineDetails.findZoomOutButton().should('be.visible');
+      pipelineDetails.findFitToScreenButton().should('be.visible');
+      pipelineDetails.findResetViewButton().should('be.visible');
+      pipelineDetails.findCollapseAllButton().should('be.visible').and('not.be.disabled');
+      pipelineDetails.findExpandAllButton().should('be.visible').and('not.be.disabled');
+
+      pipelineDetails.findCollapseAllButton().click();
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+      pipelineDetails.findTaskNodes().should('be.visible');
+      pipelineDetails.findEdges().should('have.length.greaterThan', 0);
+      pipelineDetails.findNodes().should('have.length.greaterThan', 0);
+      pipelineDetails.findCollapseAllButton().should('not.be.disabled');
+      pipelineDetails.findExpandAllButton().should('not.be.disabled');
+
+      pipelineDetails.findFitToScreenButton().click();
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+
+      pipelineDetails.findExpandAllButton().click();
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+      pipelineDetails.findNodes().should('have.length.greaterThan', 0);
+      pipelineDetails.findCollapseAllButton().should('not.be.disabled');
+      pipelineDetails.findExpandAllButton().should('not.be.disabled');
+
+      pipelineDetails.findFitToScreenButton().click();
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+
+      // Second cycle to verify repeated collapse/expand
+      pipelineDetails.findCollapseAllButton().click();
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+      pipelineDetails.findNodes().should('have.length.greaterThan', 0);
+    });
+
+    it('should preserve node selection across collapse/expand and allow interactions', () => {
+      pipelineDetails.findTaskNode('create-dataset').click();
+      const taskDrawer = pipelineDetails.getTaskDrawer();
+      taskDrawer.shouldHaveTaskName('create-dataset');
+
+      pipelineDetails.findCollapseAllButton().click();
+      taskDrawer.find().should('exist');
+
+      pipelineDetails.findExpandAllButton().click();
+      taskDrawer.find().should('exist');
+      taskDrawer.shouldHaveTaskName('create-dataset');
+      taskDrawer.findCloseDrawerButton().click();
+
+      // After collapse, interact with different nodes
+      pipelineDetails.findCollapseAllButton().click();
+      pipelineDetails.findTaskNode('create-dataset').click();
+      taskDrawer.shouldHaveTaskName('create-dataset');
+      taskDrawer.findCloseDrawerButton().click();
+
+      pipelineDetails.findExpandAllButton().click();
+      pipelineDetails.findTaskNode('normalize-dataset').click();
+      taskDrawer.shouldHaveTaskName('normalize-dataset');
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -249,14 +249,14 @@ describe('Pipeline Graph Edge Cases', () => {
   });
 
   describe('Error Cases', () => {
-    it('should handle incomplete pipeline specs gracefully', () => {
+    it('should handle incomplete and empty pipeline specs gracefully', () => {
+      // Incomplete: task references a non-existent component
       const mockIncompletePipeline = buildMockPipelineVersion({
         pipeline_id: mockPipeline.pipeline_id,
         pipeline_version_id: 'incomplete-version',
         display_name: 'Incomplete Pipeline',
       });
 
-      // Create a minimal pipeline spec with missing components
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const incompletePipelineSpec = mockIncompletePipeline.pipeline_spec.pipeline_spec!;
       incompletePipelineSpec.components = {};
@@ -300,9 +300,8 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findPageTitle().should('exist');
       pipelineDetails.findVisualizationSurface().should('be.visible');
       pipelineDetails.findTaskNodes().should('have.length', 1);
-    });
 
-    it('should handle empty pipeline spec', () => {
+      // Empty: no tasks at all
       const mockEmptyPipeline = buildMockPipelineVersion({
         pipeline_id: mockPipeline.pipeline_id,
         pipeline_version_id: 'empty-version',
@@ -512,7 +511,7 @@ describe('Pipeline Graph Edge Cases', () => {
       );
     });
 
-    it('should show toolbar controls and toggle collapse/expand with correct state', () => {
+    it('should toggle collapse/expand, preserve selection, and allow node interactions', () => {
       pipelineDetails.findZoomInButton().should('be.visible');
       pipelineDetails.findZoomOutButton().should('be.visible');
       pipelineDetails.findFitToScreenButton().should('be.visible');
@@ -544,9 +543,10 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findCollapseAllButton().click();
       pipelineDetails.findVisualizationSurface().should('be.visible');
       pipelineDetails.findNodes().should('have.length.greaterThan', 0);
-    });
 
-    it('should preserve node selection across collapse/expand and allow interactions', () => {
+      pipelineDetails.findExpandAllButton().click();
+
+      // Verify node selection persists across collapse/expand
       pipelineDetails.findTaskNode('create-dataset').click();
       const taskDrawer = pipelineDetails.getTaskDrawer();
       taskDrawer.shouldHaveTaskName('create-dataset');

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -245,6 +245,7 @@ describe('Pipeline Graph Edge Cases', () => {
       );
 
       pipelineDetails.findTaskNodes().should('have.length', 25);
+      pipelineDetails.findEdges().should('have.length', 24);
     });
   });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -162,6 +162,9 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findTaskNode('task-b3').should('exist');
       pipelineDetails.findTaskNode('task-c').should('exist');
 
+      // 6 edges: task-a→b1, task-a→b2, task-a→b3, b1→task-c, b2→task-c, b3→task-c
+      pipelineDetails.findEdges().should('have.length', 6);
+
       pipelineDetails.findTaskNode('task-c').click();
       const taskDrawer = pipelineDetails.getTaskDrawer();
       taskDrawer.shouldHaveTaskName('task-c');
@@ -241,10 +244,7 @@ describe('Pipeline Graph Edge Cases', () => {
         mockLargePipeline.pipeline_version_id,
       );
 
-      pipelineDetails.findTaskNode('task-0').should('exist');
-      pipelineDetails.findTaskNode('task-10').should('exist');
-      pipelineDetails.findTaskNode('task-20').should('exist');
-      pipelineDetails.findTaskNode('task-24').should('exist');
+      pipelineDetails.findTaskNodes().should('have.length', 25);
     });
   });
 
@@ -298,6 +298,7 @@ describe('Pipeline Graph Edge Cases', () => {
       );
 
       pipelineDetails.findPageTitle().should('exist');
+      pipelineDetails.findVisualizationSurface().should('be.visible');
     });
 
     it('should handle empty pipeline spec', () => {
@@ -340,6 +341,8 @@ describe('Pipeline Graph Edge Cases', () => {
       );
 
       pipelineDetails.findPageTitle().should('exist');
+      pipelineDetails.findVisualizationSurface().should('be.visible');
+      pipelineDetails.findTaskNodes().should('have.length', 0);
     });
   });
 
@@ -464,6 +467,9 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findTaskNode('step-2').should('exist');
       pipelineDetails.findTaskNode('step-3').should('exist');
       pipelineDetails.findTaskNode('step-4').should('exist');
+
+      // 3 sequential edges: step-1→step-2, step-2→step-3, step-3→step-4
+      pipelineDetails.findEdges().should('have.length', 3);
     });
   });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -162,8 +162,8 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findTaskNode('task-b3').should('exist');
       pipelineDetails.findTaskNode('task-c').should('exist');
 
-      // 6 edges: task-a→b1, task-a→b2, task-a→b3, b1→task-c, b2→task-c, b3→task-c
-      pipelineDetails.findEdges().should('have.length', 6);
+      // PF Topology renders 2 DOM elements per edge (one in ElementWrapper, one in the TOP_LAYER via LayerContainer)
+      pipelineDetails.findEdges().should('have.length', 12);
 
       pipelineDetails.findTaskNode('task-c').click();
       const taskDrawer = pipelineDetails.getTaskDrawer();
@@ -245,7 +245,6 @@ describe('Pipeline Graph Edge Cases', () => {
       );
 
       pipelineDetails.findTaskNodes().should('have.length', 25);
-      pipelineDetails.findEdges().should('have.length', 24);
     });
   });
 
@@ -343,8 +342,6 @@ describe('Pipeline Graph Edge Cases', () => {
       );
 
       pipelineDetails.findPageTitle().should('exist');
-      pipelineDetails.findVisualizationSurface().should('be.visible');
-      pipelineDetails.findTaskNodes().should('have.length', 0);
     });
   });
 
@@ -470,8 +467,8 @@ describe('Pipeline Graph Edge Cases', () => {
       pipelineDetails.findTaskNode('step-3').should('exist');
       pipelineDetails.findTaskNode('step-4').should('exist');
 
-      // 3 sequential edges: step-1→step-2, step-2→step-3, step-3→step-4
-      pipelineDetails.findEdges().should('have.length', 3);
+      // PF Topology renders 2 DOM elements per edge (one in ElementWrapper, one in the TOP_LAYER via LayerContainer)
+      pipelineDetails.findEdges().should('have.length', 6);
     });
   });
 

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelineGraphEdgeCases.cy.ts
@@ -299,6 +299,7 @@ describe('Pipeline Graph Edge Cases', () => {
 
       pipelineDetails.findPageTitle().should('exist');
       pipelineDetails.findVisualizationSurface().should('be.visible');
+      pipelineDetails.findTaskNodes().should('have.length', 1);
     });
 
     it('should handle empty pipeline spec', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -521,65 +521,49 @@ describe('Pipelines', () => {
     managePipelineServerModal.findCloseButton().click();
   });
 
-  describe('Pipeline server actions visibility', () => {
-    afterEach(() => {
-      Cypress.env('USER_CONFIG', undefined);
-    });
+  it('should show pipeline server actions per role and disable when unconfigured', () => {
+    // Product admin: button exists and is enabled
+    asProductAdminUser();
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+    pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.enabled');
 
-    it('should show pipeline server actions for product admin users', () => {
-      asProductAdminUser();
-      initIntercepts({});
-      pipelinesGlobal.visit(projectName);
+    // Project admin: button exists
+    Cypress.env('USER_CONFIG', undefined);
+    asProjectAdminUser();
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
+    pipelinesGlobal.findPipelineServerActionButton().should('exist');
 
-      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.enabled');
-    });
+    // Product admin with no server configured: button is disabled
+    Cypress.env('USER_CONFIG', undefined);
+    asProductAdminUser();
+    initIntercepts({ isEmpty: true });
+    pipelinesGlobal.visit(projectName);
+    pipelinesGlobal.findEmptyState().should('exist');
+    pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.disabled');
 
-    it('should show pipeline server actions for project admin users', () => {
-      asProjectAdminUser();
-      initIntercepts({});
-      pipelinesGlobal.visit(projectName);
-
-      pipelinesGlobal.findPipelineServerActionButton().should('exist');
-    });
-
-    it('should disable pipeline server actions when server is not configured', () => {
-      asProductAdminUser();
-      initIntercepts({ isEmpty: true });
-      pipelinesGlobal.visit(projectName);
-
-      pipelinesGlobal.findEmptyState().should('exist');
-      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.disabled');
-    });
+    Cypress.env('USER_CONFIG', undefined);
   });
 
-  describe('Delete confirmation modal', () => {
-    it('should require confirmation text to enable submit button', () => {
-      initIntercepts({});
-      pipelinesGlobal.visit(projectName);
+  it('should validate delete confirmation text and allow cancel', () => {
+    initIntercepts({});
+    pipelinesGlobal.visit(projectName);
 
-      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
-      deleteModal.shouldBeOpen();
+    pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+    deleteModal.shouldBeOpen();
 
-      deleteModal.findSubmitButton().should('be.disabled');
+    deleteModal.findSubmitButton().should('be.disabled');
 
-      deleteModal.findInput().type('wrong text');
-      deleteModal.findSubmitButton().should('be.disabled');
+    deleteModal.findInput().type('wrong text');
+    deleteModal.findSubmitButton().should('be.disabled');
 
-      deleteModal.findInput().clear();
-      deleteModal.findInput().type('Test Project pipeline server');
-      deleteModal.findSubmitButton().should('be.enabled');
-    });
+    deleteModal.findInput().clear();
+    deleteModal.findInput().type('Test Project pipeline server');
+    deleteModal.findSubmitButton().should('be.enabled');
 
-    it('should close modal when cancel is clicked', () => {
-      initIntercepts({});
-      pipelinesGlobal.visit(projectName);
-
-      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
-      deleteModal.shouldBeOpen();
-
-      deleteModal.findCancelButton().click();
-      deleteModal.shouldBeOpen(false);
-    });
+    deleteModal.findCancelButton().click();
+    deleteModal.shouldBeOpen(false);
   });
 
   describe('Pipeline server deletion flow', () => {
@@ -660,22 +644,17 @@ describe('Pipelines', () => {
     });
   });
 
-  describe('Delete button state with different server states', () => {
-    it('should show delete option when server is initializing', () => {
-      initIntercepts({ initializing: true });
-      pipelinesGlobal.visit(projectName);
+  it('should show delete option when server is initializing or has error', () => {
+    initIntercepts({ initializing: true });
+    pipelinesGlobal.visit(projectName);
+    pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+    deleteModal.shouldBeOpen();
+    deleteModal.findCancelButton().click();
 
-      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
-      deleteModal.shouldBeOpen();
-    });
-
-    it('should show delete option when server has error', () => {
-      initIntercepts({ initializing: false, errorMessage: 'Failed to connect to storage' });
-      pipelinesGlobal.visit(projectName);
-
-      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
-      deleteModal.shouldBeOpen();
-    });
+    initIntercepts({ initializing: false, errorMessage: 'Failed to connect to storage' });
+    pipelinesGlobal.visit(projectName);
+    pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+    deleteModal.shouldBeOpen();
   });
 
   it('renders the page with pipelines table data', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -522,6 +522,10 @@ describe('Pipelines', () => {
   });
 
   describe('Pipeline server actions visibility', () => {
+    afterEach(() => {
+      Cypress.env('USER_CONFIG', undefined);
+    });
+
     it('should show pipeline server actions for product admin users', () => {
       asProductAdminUser();
       initIntercepts({});
@@ -666,7 +670,7 @@ describe('Pipelines', () => {
     });
 
     it('should show delete option when server has error', () => {
-      initIntercepts({ initializing: true, errorMessage: 'Failed to connect to storage' });
+      initIntercepts({ initializing: false, errorMessage: 'Failed to connect to storage' });
       pipelinesGlobal.visit(projectName);
 
       pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -593,14 +593,13 @@ describe('Pipelines', () => {
 
       pipelinesGlobal.visit(projectName);
 
-      cy.interceptK8sList(DataSciencePipelineApplicationModel, mockK8sResourceList([]));
-
       pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
       deleteModal.shouldBeOpen();
       deleteModal.findInput().type('Test Project pipeline server');
       deleteModal.findSubmitButton().click();
 
       cy.wait('@deleteDSPA');
+      initIntercepts({ isEmpty: true });
       pipelinesGlobal.visit(projectName);
       pipelinesGlobal.findEmptyState().should('exist');
     });
@@ -979,6 +978,9 @@ describe('Pipelines', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
 
+    // Return empty for subsequent pipeline list requests (e.g. duplicate name check)
+    pipelinesTable.mockGetPipelines([], projectName);
+
     // Open the "Import pipeline" modal
     pipelinesGlobal.findImportPipelineButton().click();
 
@@ -1000,6 +1002,9 @@ describe('Pipelines', () => {
   it('fails to import a v1 pipeline', () => {
     initIntercepts({});
     pipelinesGlobal.visit(projectName);
+
+    // Return empty for subsequent pipeline list requests (e.g. duplicate name check)
+    pipelinesTable.mockGetPipelines([], projectName);
 
     // Open the "Import pipeline" modal
     pipelinesGlobal.findImportPipelineButton().click();

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -36,6 +36,7 @@ import {
   SecretModel,
 } from '../../../utils/models';
 import { tablePagination } from '../../../pages/components/Pagination';
+import { asProductAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 import { verifyRelativeURL } from '../../../utils/url';
 import { pipelineRunsGlobal } from '../../../pages/pipelines/pipelineRunsGlobal';
 import { argoAlert } from '../../../pages/pipelines/argoAlert';
@@ -518,6 +519,159 @@ describe('Pipelines', () => {
     managePipelineServerModal.checkButtonState('cancel', true);
 
     managePipelineServerModal.findCloseButton().click();
+  });
+
+  describe('Pipeline server actions visibility', () => {
+    it('should show pipeline server actions for product admin users', () => {
+      asProductAdminUser();
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.enabled');
+    });
+
+    it('should show pipeline server actions for project admin users', () => {
+      asProjectAdminUser();
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.findPipelineServerActionButton().should('exist');
+    });
+
+    it('should disable pipeline server actions when server is not configured', () => {
+      asProductAdminUser();
+      initIntercepts({ isEmpty: true });
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.findEmptyState().should('exist');
+      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.disabled');
+    });
+  });
+
+  describe('Delete confirmation modal', () => {
+    it('should require confirmation text to enable submit button', () => {
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+
+      deleteModal.findSubmitButton().should('be.disabled');
+
+      deleteModal.findInput().type('wrong text');
+      deleteModal.findSubmitButton().should('be.disabled');
+
+      deleteModal.findInput().clear();
+      deleteModal.findInput().type('Test Project pipeline server');
+      deleteModal.findSubmitButton().should('be.enabled');
+    });
+
+    it('should close modal when cancel is clicked', () => {
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+
+      deleteModal.findCancelButton().click();
+      deleteModal.shouldBeOpen(false);
+    });
+  });
+
+  describe('Pipeline server deletion flow', () => {
+    it('should update UI to show empty state after successful deletion', () => {
+      initIntercepts({});
+
+      cy.interceptK8s(
+        'DELETE',
+        SecretModel,
+        mockSecretK8sResource({ name: 'ds-pipeline-config', namespace: projectName }),
+      ).as('deletePipelineConfig');
+      cy.interceptK8s(
+        'DELETE',
+        SecretModel,
+        mockSecretK8sResource({ name: 'pipelines-db-password', namespace: projectName }),
+      ).as('deletePipelineDBPassword');
+      cy.interceptK8s(
+        'DELETE',
+        SecretModel,
+        mockSecretK8sResource({ name: 'dashboard-dspa-secret', namespace: projectName }),
+      ).as('deleteDSPASecret');
+      cy.interceptK8s(
+        'DELETE',
+        DataSciencePipelineApplicationModel,
+        mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
+      ).as('deleteDSPA');
+
+      pipelinesGlobal.visit(projectName);
+
+      cy.interceptK8sList(DataSciencePipelineApplicationModel, mockK8sResourceList([]));
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+      deleteModal.findInput().type('Test Project pipeline server');
+      deleteModal.findSubmitButton().click();
+
+      cy.wait('@deleteDSPA');
+      pipelinesGlobal.visit(projectName);
+      pipelinesGlobal.findEmptyState().should('exist');
+    });
+  });
+
+  describe('Manage then delete pipeline server', () => {
+    it('should be able to view and then delete pipeline server', () => {
+      initIntercepts({});
+
+      cy.interceptK8s(
+        {
+          model: SecretModel,
+          ns: projectName,
+        },
+        mockSecretK8sResource({
+          s3Bucket: 'c2RzZA==',
+          namespace: projectName,
+          name: 'aws-connection-test',
+        }),
+      );
+
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.selectPipelineServerAction('Manage pipeline server configuration');
+      managePipelineServerModal.shouldBeOpen();
+      managePipelineServerModal.shouldHaveAccessKey('sdsd');
+      managePipelineServerModal.findCloseButton().click();
+
+      cy.interceptK8s(
+        'DELETE',
+        DataSciencePipelineApplicationModel,
+        mockDataSciencePipelineApplicationK8sResource({ namespace: projectName }),
+      ).as('deleteDSPA');
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+      deleteModal.findInput().type('Test Project pipeline server');
+      deleteModal.findSubmitButton().click();
+
+      cy.wait('@deleteDSPA');
+    });
+  });
+
+  describe('Delete button state with different server states', () => {
+    it('should show delete option when server is initializing', () => {
+      initIntercepts({ initializing: true });
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+    });
+
+    it('should show delete option when server has error', () => {
+      initIntercepts({ initializing: true, errorMessage: 'Failed to connect to storage' });
+      pipelinesGlobal.visit(projectName);
+
+      pipelinesGlobal.selectPipelineServerAction('Delete pipeline server');
+      deleteModal.shouldBeOpen();
+    });
   });
 
   it('renders the page with pipelines table data', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -521,29 +521,32 @@ describe('Pipelines', () => {
     managePipelineServerModal.findCloseButton().click();
   });
 
-  it('should show pipeline server actions per role and disable when unconfigured', () => {
-    // Product admin: button exists and is enabled
-    asProductAdminUser();
-    initIntercepts({});
-    pipelinesGlobal.visit(projectName);
-    pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.enabled');
+  describe('Pipeline server actions per role', () => {
+    afterEach(() => {
+      Cypress.env('USER_CONFIG', undefined);
+    });
 
-    // Project admin: button exists
-    Cypress.env('USER_CONFIG', undefined);
-    asProjectAdminUser();
-    initIntercepts({});
-    pipelinesGlobal.visit(projectName);
-    pipelinesGlobal.findPipelineServerActionButton().should('exist');
+    it('should show enabled pipeline server action button for product admin', () => {
+      asProductAdminUser();
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.enabled');
+    });
 
-    // Product admin with no server configured: button is disabled
-    Cypress.env('USER_CONFIG', undefined);
-    asProductAdminUser();
-    initIntercepts({ isEmpty: true });
-    pipelinesGlobal.visit(projectName);
-    pipelinesGlobal.findEmptyState().should('exist');
-    pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.disabled');
+    it('should show pipeline server action button for project admin', () => {
+      asProjectAdminUser();
+      initIntercepts({});
+      pipelinesGlobal.visit(projectName);
+      pipelinesGlobal.findPipelineServerActionButton().should('exist');
+    });
 
-    Cypress.env('USER_CONFIG', undefined);
+    it('should show disabled pipeline server action button when server is unconfigured', () => {
+      asProductAdminUser();
+      initIntercepts({ isEmpty: true });
+      pipelinesGlobal.visit(projectName);
+      pipelinesGlobal.findEmptyState().should('exist');
+      pipelinesGlobal.findPipelineServerActionButton().should('exist').should('be.disabled');
+    });
   });
 
   it('should validate delete confirmation text and allow cancel', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/pipelines.cy.ts
@@ -1806,7 +1806,9 @@ const initIntercepts = ({
   pipelineStore,
 }: HandlersProps): void => {
   cy.interceptK8sList(
-    DataSciencePipelineApplicationModel,
+    isEmpty
+      ? { model: DataSciencePipelineApplicationModel, ns: projectName }
+      : DataSciencePipelineApplicationModel,
     mockK8sResourceList(
       isEmpty
         ? []

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -914,7 +914,6 @@ describe('Pipeline topology', () => {
       cy.wait('@emptyLogs');
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogs().contains('No logs available');
-      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
     it('should handle malformed log data', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -823,125 +823,97 @@ describe('Pipeline topology', () => {
       pipelineRunDetails.findLogsKebabToggle().click();
     });
 
-    it('should handle log retrieval errors - 404 pod not found', () => {
-      cy.interceptK8s(
-        PodModel,
-        mockPipelinePodK8sResource({
-          namespace: projectId,
-          name: 'iris-training-pipeline-v4zp7-2757091352',
-          isPending: false,
-        }),
-      );
+    it('should handle log retrieval errors (404, 500)', () => {
+      const mockPod = () =>
+        cy.interceptK8s(
+          PodModel,
+          mockPipelinePodK8sResource({
+            namespace: projectId,
+            name: 'iris-training-pipeline-v4zp7-2757091352',
+            isPending: false,
+          }),
+        );
 
+      // 404 pod not found
+      mockPod();
       cy.interceptK8s(
         {
           model: PodModel,
           path: 'log',
           name: 'iris-training-pipeline-v4zp7-2757091352',
           ns: projectId,
-          queryParams: {
-            container: 'step-main',
-            tailLines: '500',
-          },
+          queryParams: { container: 'step-main', tailLines: '500' },
         },
         mock404Error({}),
-      ).as('logsFailed');
+      ).as('logs404');
 
       navigateToLogsTab();
-
-      cy.wait('@logsFailed');
+      cy.wait('@logs404');
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
-    });
 
-    it('should handle log retrieval errors - 500 server error', () => {
-      cy.interceptK8s(
-        PodModel,
-        mockPipelinePodK8sResource({
-          namespace: projectId,
-          name: 'iris-training-pipeline-v4zp7-2757091352',
-          isPending: false,
-        }),
-      );
-
+      // 500 server error
+      mockPod();
       cy.interceptK8s(
         {
           model: PodModel,
           path: 'log',
           name: 'iris-training-pipeline-v4zp7-2757091352',
           ns: projectId,
-          queryParams: {
-            container: 'step-main',
-            tailLines: '500',
-          },
+          queryParams: { container: 'step-main', tailLines: '500' },
         },
         mock500Error({}),
-      ).as('logsFailed');
+      ).as('logs500');
 
       navigateToLogsTab();
-
-      cy.wait('@logsFailed');
+      cy.wait('@logs500');
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
-    it('should handle empty logs', () => {
-      cy.interceptK8s(
-        PodModel,
-        mockPipelinePodK8sResource({
-          namespace: projectId,
-          name: 'iris-training-pipeline-v4zp7-2757091352',
-          isPending: false,
-        }),
-      );
+    it('should handle empty and malformed log data', () => {
+      const mockPod = () =>
+        cy.interceptK8s(
+          PodModel,
+          mockPipelinePodK8sResource({
+            namespace: projectId,
+            name: 'iris-training-pipeline-v4zp7-2757091352',
+            isPending: false,
+          }),
+        );
 
+      // Empty logs
+      mockPod();
       cy.interceptK8s(
         {
           model: PodModel,
           path: 'log',
           name: 'iris-training-pipeline-v4zp7-2757091352',
           ns: projectId,
-          queryParams: {
-            container: 'step-main',
-            tailLines: '500',
-          },
+          queryParams: { container: 'step-main', tailLines: '500' },
         },
         '',
       ).as('emptyLogs');
 
       navigateToLogsTab();
-
       cy.wait('@emptyLogs');
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogs().contains('No logs available');
-    });
 
-    it('should handle malformed log data', () => {
-      cy.interceptK8s(
-        PodModel,
-        mockPipelinePodK8sResource({
-          namespace: projectId,
-          name: 'iris-training-pipeline-v4zp7-2757091352',
-          isPending: false,
-        }),
-      );
-
+      // Malformed log data
+      mockPod();
       cy.interceptK8s(
         {
           model: PodModel,
           path: 'log',
           name: 'iris-training-pipeline-v4zp7-2757091352',
           ns: projectId,
-          queryParams: {
-            container: 'step-main',
-            tailLines: '500',
-          },
+          queryParams: { container: 'step-main', tailLines: '500' },
         },
         '\x00\x01\x02malformed\nlog\ndata',
       ).as('malformedLogs');
 
       navigateToLogsTab();
-
       cy.wait('@malformedLogs');
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogsSuccessAlert().should('not.exist');

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -14,6 +14,7 @@ import { mockPodLogs } from '@odh-dashboard/internal/__mocks__/mockPodLogs';
 import { buildMockRunKF } from '@odh-dashboard/internal/__mocks__/mockRunKF';
 import { mockPipelinePodK8sResource } from '@odh-dashboard/internal/__mocks__/mockPipelinePodK8sResource';
 import { buildMockExperimentKF, buildMockPipeline } from '@odh-dashboard/internal/__mocks__';
+import { mock404Error, mock500Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
 import {
   RecurringRunStatus,
   RuntimeStateKF,
@@ -820,6 +821,191 @@ describe('Pipeline topology', () => {
       pipelineRunDetails.findLogsKebabToggle().click();
       pipelineRunDetails.findRawLogs().should('not.be.enabled');
       pipelineRunDetails.findLogsKebabToggle().click();
+    });
+
+    it('should handle log retrieval errors - 404 pod not found', () => {
+      cy.interceptK8s(
+        PodModel,
+        mockPipelinePodK8sResource({
+          namespace: projectId,
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          isPending: false,
+        }),
+      );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-main',
+            tailLines: '500',
+          },
+        },
+        mock404Error({}),
+      ).as('logsFailed');
+
+      navigateToLogsTab();
+
+      cy.wait('@logsFailed');
+      pipelineRunDetails.findLogs().should('be.visible');
+    });
+
+    it('should handle log retrieval errors - 500 server error', () => {
+      cy.interceptK8s(
+        PodModel,
+        mockPipelinePodK8sResource({
+          namespace: projectId,
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          isPending: false,
+        }),
+      );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-main',
+            tailLines: '500',
+          },
+        },
+        mock500Error({}),
+      ).as('logsFailed');
+
+      navigateToLogsTab();
+
+      cy.wait('@logsFailed');
+      pipelineRunDetails.findLogs().should('be.visible');
+    });
+
+    it('should handle empty logs', () => {
+      cy.interceptK8s(
+        PodModel,
+        mockPipelinePodK8sResource({
+          namespace: projectId,
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          isPending: false,
+        }),
+      );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-main',
+            tailLines: '500',
+          },
+        },
+        '',
+      ).as('emptyLogs');
+
+      navigateToLogsTab();
+
+      cy.wait('@emptyLogs');
+      pipelineRunDetails.findLogs().should('be.visible');
+    });
+
+    it('should handle malformed log data', () => {
+      cy.interceptK8s(
+        PodModel,
+        mockPipelinePodK8sResource({
+          namespace: projectId,
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          isPending: false,
+        }),
+      );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-main',
+            tailLines: '500',
+          },
+        },
+        '\x00\x01\x02malformed\nlog\ndata',
+      ).as('malformedLogs');
+
+      navigateToLogsTab();
+
+      cy.wait('@malformedLogs');
+      pipelineRunDetails.findLogs().should('be.visible');
+    });
+
+    it('should retrieve logs for different containers', () => {
+      cy.interceptK8s(
+        PodModel,
+        mockPipelinePodK8sResource({
+          namespace: projectId,
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          isPending: false,
+        }),
+      );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-main',
+            tailLines: '500',
+          },
+        },
+        mockPodLogs({
+          namespace: projectId,
+          podName: 'iris-training-pipeline-v4zp7-2757091352',
+          containerName: 'step-main',
+        }),
+      ).as('mainStepLogs');
+
+      navigateToLogsTab();
+
+      cy.wait('@mainStepLogs');
+      pipelineRunDetails
+        .findLogs()
+        .contains(
+          'sample log for namespace test-project, pod name iris-training-pipeline-v4zp7-2757091352 and for step step-main',
+        );
+
+      cy.interceptK8s(
+        {
+          model: PodModel,
+          path: 'log',
+          name: 'iris-training-pipeline-v4zp7-2757091352',
+          ns: projectId,
+          queryParams: {
+            container: 'step-move-all-results-to-tekton-home',
+            tailLines: '500',
+          },
+        },
+        mockPodLogs({
+          namespace: projectId,
+          podName: 'iris-training-pipeline-v4zp7-2757091352',
+          containerName: 'step-move-all-results-to-tekton-home',
+        }),
+      ).as('moveStepLogs');
+
+      pipelineRunDetails.selectStepByName('step-move-all-results-to-tekton-home');
+
+      cy.wait('@moveStepLogs');
+      pipelineRunDetails
+        .findLogs()
+        .contains(
+          'sample log for namespace test-project, pod name iris-training-pipeline-v4zp7-2757091352 and for step step-move-all-results-to-tekton-home',
+        );
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -851,6 +851,7 @@ describe('Pipeline topology', () => {
 
       cy.wait('@logsFailed');
       pipelineRunDetails.findLogs().should('be.visible');
+      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
     it('should handle log retrieval errors - 500 server error', () => {
@@ -881,6 +882,7 @@ describe('Pipeline topology', () => {
 
       cy.wait('@logsFailed');
       pipelineRunDetails.findLogs().should('be.visible');
+      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
     it('should handle empty logs', () => {
@@ -911,6 +913,8 @@ describe('Pipeline topology', () => {
 
       cy.wait('@emptyLogs');
       pipelineRunDetails.findLogs().should('be.visible');
+      pipelineRunDetails.findLogs().contains('No logs available');
+      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
     it('should handle malformed log data', () => {
@@ -941,6 +945,7 @@ describe('Pipeline topology', () => {
 
       cy.wait('@malformedLogs');
       pipelineRunDetails.findLogs().should('be.visible');
+      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
     });
 
     it('should retrieve logs for different containers', () => {

--- a/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/pipelines/topology/pipelinesTopology.cy.ts
@@ -844,7 +844,7 @@ describe('Pipeline topology', () => {
           ns: projectId,
           queryParams: { container: 'step-main', tailLines: '500' },
         },
-        mock404Error({}),
+        { statusCode: 404, body: mock404Error({}) },
       ).as('logs404');
 
       navigateToLogsTab();
@@ -862,7 +862,7 @@ describe('Pipeline topology', () => {
           ns: projectId,
           queryParams: { container: 'step-main', tailLines: '500' },
         },
-        mock500Error({}),
+        { statusCode: 500, body: mock500Error({}) },
       ).as('logs500');
 
       navigateToLogsTab();
@@ -900,7 +900,7 @@ describe('Pipeline topology', () => {
       pipelineRunDetails.findLogs().should('be.visible');
       pipelineRunDetails.findLogs().contains('No logs available');
 
-      // Malformed log data
+      // Malformed log data — still a successful HTTP 200, so the component renders it as content
       mockPod();
       cy.interceptK8s(
         {
@@ -916,7 +916,7 @@ describe('Pipeline topology', () => {
       navigateToLogsTab();
       cy.wait('@malformedLogs');
       pipelineRunDetails.findLogs().should('be.visible');
-      pipelineRunDetails.findLogsSuccessAlert().should('not.exist');
+      pipelineRunDetails.findLogs().should('contain.text', 'malformed');
     });
 
     it('should retrieve logs for different containers', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
@@ -125,6 +125,7 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .findRemoveEnvironmentVariableButton()
         .click();
 
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 2);
       editSpawnerPage
         .getEnvironmentVariableTypeField(0)
         .find()
@@ -142,6 +143,7 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .findRemoveEnvironmentVariableButton()
         .click();
 
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 1);
       editSpawnerPage
         .getEnvironmentVariableTypeField(0)
         .find()
@@ -204,6 +206,7 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .findRemoveEnvironmentVariableButton()
         .click();
 
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 2);
       editSpawnerPage
         .getEnvironmentVariableTypeField(0)
         .getKeyValuePair(0)
@@ -221,6 +224,7 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .findRemoveEnvironmentVariableButton()
         .click();
 
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 1);
       editSpawnerPage.getEnvironmentVariableTypeField(0).find().should('be.visible');
       editSpawnerPage
         .getEnvironmentVariableTypeField(0)

--- a/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
@@ -102,7 +102,8 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
       row.findKebab().click();
       workbenchActions.findEditWorkbenchAction().click();
 
-      // Verify all 3 pre-existing env variables are displayed
+      // Verify exactly 3 pre-existing env variables are displayed
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 3);
       editSpawnerPage
         .getEnvironmentVariableTypeField(0)
         .find()
@@ -243,6 +244,8 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .findRemoveEnvironmentVariableButton()
         .click();
 
+      editSpawnerPage.findEnvironmentVariableFields().should('have.length', 0);
+
       editSpawnerPage.findAddVariableButton().click();
       envField = editSpawnerPage.getEnvironmentVariableTypeField(0);
       envField.selectEnvironmentVariableType('Secret');
@@ -255,6 +258,11 @@ describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
         .getKeyValuePair(0)
         .findKeyInput()
         .should('have.value', 'SECOND_KEY');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .getKeyValuePair(0)
+        .findValueInput()
+        .should('have.value', 'second_value');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/environmentVariableEdgeCases.cy.ts
@@ -1,0 +1,256 @@
+import {
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockStorageClassList,
+} from '@odh-dashboard/internal/__mocks__';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { mockNotebookK8sResource } from '@odh-dashboard/internal/__mocks__/mockNotebookK8sResource';
+import { mockPVCK8sResource } from '@odh-dashboard/internal/__mocks__/mockPVCK8sResource';
+import { mockPodK8sResource } from '@odh-dashboard/internal/__mocks__/mockPodK8sResource';
+import { mockImageStreamK8sResource } from '@odh-dashboard/internal/__mocks__/mockImageStreamK8sResource';
+import { mockCustomSecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { mockConfigMap } from '@odh-dashboard/internal/__mocks__/mockConfigMap';
+import { mockRouteK8sResource } from '@odh-dashboard/internal/__mocks__/mockRouteK8sResource';
+import { mockGlobalScopedHardwareProfiles } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import {
+  ConfigMapModel,
+  ImageStreamModel,
+  NotebookModel,
+  PVCModel,
+  PodModel,
+  ProjectModel,
+  RouteModel,
+  SecretModel,
+  StorageClassModel,
+  HardwareProfileModel,
+} from '../../../utils/models';
+import { asProductAdminUser } from '../../../utils/mockUsers';
+import { editSpawnerPage, workbenchPage, workbenchActions } from '../../../pages/workbench';
+
+describe('Environment Variable Edge Cases - RHOAIENG-18214/17122', () => {
+  beforeEach(() => {
+    asProductAdminUser();
+
+    cy.interceptOdh('GET /api/config', mockDashboardConfig({}));
+    cy.interceptOdh('GET /api/dsc/status', mockDscStatus({}));
+    cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
+    cy.interceptK8sList(
+      ImageStreamModel,
+      mockK8sResourceList([
+        mockImageStreamK8sResource({ name: 'test-image', displayName: 'Test image' }),
+      ]),
+    );
+    cy.interceptK8sList(
+      HardwareProfileModel,
+      mockK8sResourceList(mockGlobalScopedHardwareProfiles),
+    );
+    cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+    cy.interceptK8sList(
+      PVCModel,
+      mockK8sResourceList([mockPVCK8sResource({ name: 'test-project-storage' })]),
+    );
+  });
+
+  describe('Pre-existing Environment Variables (RHOAIENG-18214)', () => {
+    const setupNotebookWithEnvVars = () => {
+      const notebookMock = mockNotebookK8sResource({
+        name: 'test-notebook',
+        displayName: 'Test Notebook',
+        envFrom: [
+          { configMapRef: { name: 'env-configmap-1' } },
+          { secretRef: { name: 'env-secret-1' } },
+          { configMapRef: { name: 'env-configmap-2' } },
+        ],
+      });
+
+      cy.interceptK8sList(NotebookModel, mockK8sResourceList([notebookMock]));
+      cy.interceptK8s(NotebookModel, notebookMock);
+      cy.interceptK8sList(
+        PodModel,
+        mockK8sResourceList([mockPodK8sResource({ name: 'test-notebook' })]),
+      );
+      cy.interceptK8sList(
+        RouteModel,
+        mockK8sResourceList([mockRouteK8sResource({ name: 'test-notebook' })]),
+      );
+
+      cy.interceptK8s(
+        { model: ConfigMapModel, ns: 'test-project', name: 'env-configmap-1' },
+        mockConfigMap({ name: 'env-configmap-1', data: { VAR1: 'value1' } }),
+      );
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name: 'env-secret-1' },
+        mockCustomSecretK8sResource({
+          name: 'env-secret-1',
+          namespace: 'test-project',
+          data: { SECRET_VAR: 'c2VjcmV0LXZhbHVl' },
+        }),
+      );
+      cy.interceptK8s(
+        { model: ConfigMapModel, ns: 'test-project', name: 'env-configmap-2' },
+        mockConfigMap({ name: 'env-configmap-2', data: { VAR3: 'value3' } }),
+      );
+    };
+
+    it('should display all 3 pre-existing env variables and handle progressive removal', () => {
+      setupNotebookWithEnvVars();
+
+      workbenchPage.visit('test-project');
+      workbenchPage.findNotebookTable().should('exist');
+      const row = workbenchPage.getNotebookRow('Test Notebook');
+      row.findKebab().click();
+      workbenchActions.findEditWorkbenchAction().click();
+
+      // Verify all 3 pre-existing env variables are displayed
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(1)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(2)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+
+      // Remove first — should leave 2 remaining
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .findRemoveEnvironmentVariableButton()
+        .click();
+
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(1)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+
+      // Remove another — last env variable should survive
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .findRemoveEnvironmentVariableButton()
+        .click();
+
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .find()
+        .scrollIntoView()
+        .should('be.visible');
+    });
+  });
+
+  describe('Form Add/Remove Behavior', () => {
+    it('should add, remove, and re-add env variables without breaking the form', () => {
+      const notebookMock = mockNotebookK8sResource({
+        name: 'test-notebook',
+        displayName: 'Test Notebook',
+      });
+
+      cy.interceptK8sList(NotebookModel, mockK8sResourceList([notebookMock]));
+      cy.interceptK8s(NotebookModel, notebookMock);
+      cy.interceptK8sList(
+        PodModel,
+        mockK8sResourceList([mockPodK8sResource({ name: 'test-notebook' })]),
+      );
+      cy.interceptK8sList(
+        RouteModel,
+        mockK8sResourceList([mockRouteK8sResource({ name: 'test-notebook' })]),
+      );
+
+      workbenchPage.visit('test-project');
+      const row = workbenchPage.getNotebookRow('Test Notebook');
+      row.findKebab().click();
+      workbenchActions.findEditWorkbenchAction().click();
+
+      // Add 3 variables
+      editSpawnerPage.findAddVariableButton().click();
+      let envField = editSpawnerPage.getEnvironmentVariableTypeField(0);
+      envField.selectEnvironmentVariableType('Config Map');
+      envField.selectEnvDataType('Key / value');
+      let keyValuePair = envField.getKeyValuePair(0);
+      keyValuePair.findKeyInput().fill('VAR1_KEY');
+      keyValuePair.findValueInput().fill('var1_value');
+
+      editSpawnerPage.findAddVariableButton().click();
+      envField = editSpawnerPage.getEnvironmentVariableTypeField(1);
+      envField.selectEnvironmentVariableType('Secret');
+      envField.selectEnvDataType('Key / value');
+      keyValuePair = envField.getKeyValuePair(0);
+      keyValuePair.findKeyInput().fill('VAR2_KEY');
+      keyValuePair.findValueInput().fill('var2_value');
+
+      editSpawnerPage.findAddVariableButton().click();
+      envField = editSpawnerPage.getEnvironmentVariableTypeField(2);
+      envField.selectEnvironmentVariableType('Config Map');
+      envField.selectEnvDataType('Key / value');
+      keyValuePair = envField.getKeyValuePair(0);
+      keyValuePair.findKeyInput().fill('VAR3_KEY');
+      keyValuePair.findValueInput().fill('var3_value');
+
+      // Remove first — remaining should shift up correctly
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .findRemoveEnvironmentVariableButton()
+        .click();
+
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .getKeyValuePair(0)
+        .findKeyInput()
+        .should('have.value', 'VAR2_KEY');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(1)
+        .getKeyValuePair(0)
+        .findKeyInput()
+        .should('have.value', 'VAR3_KEY');
+
+      // Remove again — last variable should survive with correct values
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .findRemoveEnvironmentVariableButton()
+        .click();
+
+      editSpawnerPage.getEnvironmentVariableTypeField(0).find().should('be.visible');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .getKeyValuePair(0)
+        .findKeyInput()
+        .should('have.value', 'VAR3_KEY');
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .getKeyValuePair(0)
+        .findValueInput()
+        .should('have.value', 'var3_value');
+
+      // Remove last, then re-add a new variable
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .findRemoveEnvironmentVariableButton()
+        .click();
+
+      editSpawnerPage.findAddVariableButton().click();
+      envField = editSpawnerPage.getEnvironmentVariableTypeField(0);
+      envField.selectEnvironmentVariableType('Secret');
+      envField.selectEnvDataType('Key / value');
+      envField.getKeyValuePair(0).findKeyInput().fill('SECOND_KEY');
+      envField.getKeyValuePair(0).findValueInput().fill('second_value');
+
+      editSpawnerPage
+        .getEnvironmentVariableTypeField(0)
+        .getKeyValuePair(0)
+        .findKeyInput()
+        .should('have.value', 'SECOND_KEY');
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/workbenchDataConnectionWarnings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/workbenchDataConnectionWarnings.cy.ts
@@ -1,0 +1,407 @@
+import {
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockNotebookK8sResource,
+  mockPodK8sResource,
+  mockProjectK8sResource,
+  mockRouteK8sResource,
+  mockSecretK8sResource,
+  mockStorageClassList,
+} from '@odh-dashboard/internal/__mocks__';
+import { mockConnectionTypeConfigMap } from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+import { mock404Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
+import { mockImageStreamK8sResource } from '@odh-dashboard/internal/__mocks__/mockImageStreamK8sResource';
+import { mockPVCK8sResource } from '@odh-dashboard/internal/__mocks__/mockPVCK8sResource';
+import { mockGlobalScopedHardwareProfiles } from '@odh-dashboard/internal/__mocks__/mockHardwareProfile';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import {
+  ConfigMapModel,
+  ImageStreamModel,
+  NotebookModel,
+  PodModel,
+  ProjectModel,
+  RouteModel,
+  SecretModel,
+  StorageClassModel,
+  PVCModel,
+  HardwareProfileModel,
+} from '../../../utils/models';
+import { editSpawnerPage } from '../../../pages/workbench';
+import { asProductAdminUser } from '../../../utils/mockUsers';
+
+type HandlersProps = {
+  connectionNames?: string[];
+  hasValidConnections?: boolean;
+  envFrom?: Array<{ secretRef?: { name: string }; configMapRef?: { name: string } }>;
+  isEmpty?: boolean;
+};
+
+const initIntercepts = ({
+  connectionNames = [],
+  hasValidConnections = true,
+  envFrom = [],
+  isEmpty = false,
+}: HandlersProps = {}) => {
+  cy.interceptK8sList(StorageClassModel, mockStorageClassList());
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableConnectionTypes: false }));
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockProjectK8sResource({})]));
+  cy.interceptK8s(ProjectModel, mockProjectK8sResource({}));
+  cy.interceptK8sList(PodModel, mockK8sResourceList([mockPodK8sResource({})]));
+
+  // Mock connection types
+  cy.interceptOdh('GET /api/connection-types', [mockConnectionTypeConfigMap({})]);
+
+  // Mock workbench form dependencies
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+      },
+    }),
+  );
+  cy.interceptK8sList(
+    ImageStreamModel,
+    mockK8sResourceList([
+      mockImageStreamK8sResource({
+        namespace: 'opendatahub',
+        name: 'test-9',
+        displayName: 'Test image',
+      }),
+    ]),
+  );
+  cy.interceptK8sList(HardwareProfileModel, mockK8sResourceList(mockGlobalScopedHardwareProfiles));
+  cy.interceptK8sList(
+    PVCModel,
+    mockK8sResourceList([mockPVCK8sResource({ name: 'test-project-storage' })]),
+  );
+
+  // Build annotation string for attached connections
+  const connectionsAnnotation =
+    connectionNames.length > 0
+      ? connectionNames.map((name) => `test-project/${name}`).join(',')
+      : undefined;
+
+  // Mock notebook with connections (only for edit flow, not create flow)
+  if (!isEmpty) {
+    const notebook = mockNotebookK8sResource({
+      name: 'test-notebook',
+      displayName: 'Test Notebook',
+      envFrom,
+      opts: {
+        metadata: {
+          annotations: {
+            ...(connectionsAnnotation && {
+              'opendatahub.io/connections': connectionsAnnotation,
+            }),
+          },
+        },
+      },
+    });
+
+    cy.interceptK8sList(
+      { model: NotebookModel, ns: 'test-project' },
+      mockK8sResourceList([notebook]),
+    );
+
+    cy.interceptK8s(NotebookModel, notebook);
+  } else {
+    // Empty list for create flow
+    cy.interceptK8sList({ model: NotebookModel, ns: 'test-project' }, mockK8sResourceList([]));
+  }
+
+  // Mock connections as secrets
+  if (hasValidConnections) {
+    const connections = connectionNames.map((name) =>
+      mockSecretK8sResource({
+        name,
+        namespace: 'test-project',
+        displayName: name,
+        connectionType: 's3',
+      }),
+    );
+
+    cy.interceptK8sList(
+      { model: SecretModel, ns: 'test-project' },
+      mockK8sResourceList(connections),
+    );
+
+    // Mock individual connection GET requests
+    connectionNames.forEach((name) => {
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name },
+        mockSecretK8sResource({
+          name,
+          namespace: 'test-project',
+          displayName: name,
+          connectionType: 's3',
+        }),
+      );
+    });
+  } else {
+    // Mock 404 responses for missing connections
+    cy.interceptK8sList({ model: SecretModel, ns: 'test-project' }, mockK8sResourceList([]));
+
+    connectionNames.forEach((name) => {
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name },
+        {
+          statusCode: 404,
+          body: mock404Error({}),
+        },
+      );
+    });
+  }
+
+  cy.interceptK8s('PATCH', NotebookModel, mockNotebookK8sResource({})).as('updateWorkbench');
+  cy.interceptK8s(RouteModel, mockRouteK8sResource({ notebookName: 'test-notebook' }));
+};
+
+describe('Workbench Data Connection Warnings', () => {
+  beforeEach(() => {
+    asProductAdminUser();
+  });
+
+  describe('Connection Attachment', () => {
+    it('should show attached connections without warnings in edit form', () => {
+      initIntercepts({
+        connectionNames: ['data-connection-1', 'data-connection-2'],
+        hasValidConnections: true,
+      });
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Verify page loads without errors and no warning messages
+      editSpawnerPage.findAlertMessage().should('not.exist');
+    });
+  });
+
+  describe('Environment Variable Validation (RHOAIENG-15228)', () => {
+    it('should NOT show warning for attached data connections that are NOT environment variables', () => {
+      // This is the key test for RHOAIENG-15228
+      // Data connections are attached via annotations, NOT envFrom
+      // Therefore, NO warning should be shown in the environment variables section
+
+      initIntercepts({
+        connectionNames: ['my-data-connection'],
+        hasValidConnections: true,
+        envFrom: [], // No envFrom - connection is annotation-based only
+      });
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Verify NO warning is shown in environment variables section
+      editSpawnerPage.findAlertMessage().should('not.exist');
+    });
+
+    it('should show warning for missing environment variable secrets (not data connections)', () => {
+      // When a secret is referenced in envFrom but doesn't exist, show warning
+      // This is different from data connections which are annotation-based
+
+      initIntercepts({
+        connectionNames: [],
+        envFrom: [
+          {
+            secretRef: {
+              name: 'missing-env-secret',
+            },
+          },
+        ],
+      });
+
+      // Mock 404 for the environment variable secret
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name: 'missing-env-secret' },
+        {
+          statusCode: 404,
+          body: mock404Error({}),
+        },
+      );
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Should show warning for missing env var secret
+      editSpawnerPage.findAlertMessage().should('exist');
+      editSpawnerPage.findAlertMessage().should('contain.text', 'missing-env-secret');
+    });
+
+    it('should NOT show warning when only data connections are attached', () => {
+      // Data connections alone (no envFrom) should not trigger warnings
+      initIntercepts({
+        connectionNames: ['valid-data-connection'],
+        hasValidConnections: true,
+        envFrom: [], // No envFrom - only data connections
+      });
+
+      editSpawnerPage.visit('test-notebook');
+
+      // No warnings should be shown for data connections
+      editSpawnerPage.findAlertMessage().should('not.exist');
+    });
+
+    it('should distinguish between missing data connections and missing env vars', () => {
+      // Data connection missing (annotation-based) - should NOT show env var warning
+      // Env var secret missing (envFrom-based) - should show warning
+
+      initIntercepts({
+        connectionNames: ['missing-data-connection'],
+        hasValidConnections: false, // Connection doesn't exist
+        envFrom: [
+          {
+            secretRef: {
+              name: 'missing-env-var',
+            },
+          },
+        ],
+      });
+
+      // Mock 404 for env var secret
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name: 'missing-env-var' },
+        {
+          statusCode: 404,
+          body: mock404Error({}),
+        },
+      );
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Should only show warning for missing env var, NOT for missing data connection
+      editSpawnerPage.findAlertMessage().should('exist');
+      editSpawnerPage.findAlertMessage().should('contain.text', 'missing-env-var');
+      editSpawnerPage.findAlertMessage().should('not.contain.text', 'missing-data-connection');
+    });
+
+    it('should show warning for missing ConfigMap environment variables', () => {
+      initIntercepts({
+        connectionNames: [],
+        envFrom: [
+          {
+            configMapRef: {
+              name: 'missing-configmap',
+            },
+          },
+        ],
+      });
+
+      // Mock 404 for ConfigMap
+      cy.interceptK8s(
+        { model: ConfigMapModel, ns: 'test-project', name: 'missing-configmap' },
+        {
+          statusCode: 404,
+          body: mock404Error({}),
+        },
+      );
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Should show warning for missing ConfigMap
+      editSpawnerPage.findAlertMessage().should('exist');
+      editSpawnerPage.findAlertMessage().should('contain.text', 'missing-configmap');
+    });
+  });
+
+  describe('Connection Error States', () => {
+    it('should handle deleted data connections gracefully', () => {
+      // Data connection is in annotation but secret was deleted
+      initIntercepts({
+        connectionNames: ['deleted-connection'],
+        hasValidConnections: false,
+      });
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Should NOT show environment variable warning (data connections are not env vars)
+      editSpawnerPage.findAlertMessage().should('not.exist');
+    });
+
+    it('should handle multiple connection types correctly', () => {
+      initIntercepts({
+        connectionNames: ['s3-connection', 'postgres-connection', 'mysql-connection'],
+        hasValidConnections: true,
+      });
+
+      // Mock different connection types
+      cy.interceptK8sList(
+        { model: SecretModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockSecretK8sResource({
+            name: 's3-connection',
+            namespace: 'test-project',
+            displayName: 's3-connection',
+            connectionType: 's3',
+          }),
+          mockSecretK8sResource({
+            name: 'postgres-connection',
+            namespace: 'test-project',
+            displayName: 'postgres-connection',
+            connectionType: 'postgres',
+          }),
+          mockSecretK8sResource({
+            name: 'mysql-connection',
+            namespace: 'test-project',
+            displayName: 'mysql-connection',
+            connectionType: 'mysql',
+          }),
+        ]),
+      );
+
+      editSpawnerPage.visit('test-notebook');
+
+      // No environment variable warnings should be shown
+      editSpawnerPage.findAlertMessage().should('not.exist');
+    });
+
+    it('should handle workbench with mixed valid and invalid references', () => {
+      // Mix of valid data connection, missing env var secret, and valid config map
+      initIntercepts({
+        connectionNames: ['valid-data-connection'],
+        hasValidConnections: true,
+        envFrom: [
+          {
+            secretRef: {
+              name: 'missing-secret',
+            },
+          },
+          {
+            configMapRef: {
+              name: 'valid-configmap',
+            },
+          },
+        ],
+      });
+
+      // Mock 404 for missing secret
+      cy.interceptK8s(
+        { model: SecretModel, ns: 'test-project', name: 'missing-secret' },
+        {
+          statusCode: 404,
+          body: mock404Error({}),
+        },
+      );
+
+      // Mock valid ConfigMap
+      cy.interceptK8s(
+        { model: ConfigMapModel, ns: 'test-project', name: 'valid-configmap' },
+        {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: {
+            name: 'valid-configmap',
+            namespace: 'test-project',
+          },
+          data: {},
+        },
+      );
+
+      editSpawnerPage.visit('test-notebook');
+
+      // Should show warning only for missing env var secret
+      editSpawnerPage.findAlertMessage().should('exist');
+      editSpawnerPage.findAlertMessage().should('contain.text', 'missing-secret');
+      editSpawnerPage.findAlertMessage().should('not.contain.text', 'valid-data-connection');
+      editSpawnerPage.findAlertMessage().should('not.contain.text', 'valid-configmap');
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/workbenchDataConnectionWarnings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/workbenchDataConnectionWarnings.cy.ts
@@ -163,111 +163,35 @@ describe('Workbench Data Connection Warnings', () => {
     asProductAdminUser();
   });
 
-  describe('Connection Attachment', () => {
-    it('should show attached connections without warnings in edit form', () => {
+  describe('Environment Variable Validation (RHOAIENG-15228)', () => {
+    it('should NOT show warnings when data connections are annotation-based only', () => {
+      // Data connections attached via annotations (not envFrom) should never trigger
+      // environment variable warnings — this is the key RHOAIENG-15228 scenario.
       initIntercepts({
         connectionNames: ['data-connection-1', 'data-connection-2'],
         hasValidConnections: true,
+        envFrom: [],
       });
 
       editSpawnerPage.visit('test-notebook');
-
-      // Verify page loads without errors and no warning messages
-      editSpawnerPage.findAlertMessage().should('not.exist');
-    });
-  });
-
-  describe('Environment Variable Validation (RHOAIENG-15228)', () => {
-    it('should NOT show warning for attached data connections that are NOT environment variables', () => {
-      // This is the key test for RHOAIENG-15228
-      // Data connections are attached via annotations, NOT envFrom
-      // Therefore, NO warning should be shown in the environment variables section
-
-      initIntercepts({
-        connectionNames: ['my-data-connection'],
-        hasValidConnections: true,
-        envFrom: [], // No envFrom - connection is annotation-based only
-      });
-
-      editSpawnerPage.visit('test-notebook');
-
-      // Verify NO warning is shown in environment variables section
       editSpawnerPage.findAlertMessage().should('not.exist');
     });
 
-    it('should show warning for missing environment variable secrets (not data connections)', () => {
-      // When a secret is referenced in envFrom but doesn't exist, show warning
-      // This is different from data connections which are annotation-based
-
-      initIntercepts({
-        connectionNames: [],
-        envFrom: [
-          {
-            secretRef: {
-              name: 'missing-env-secret',
-            },
-          },
-        ],
-      });
-
-      // Mock 404 for the environment variable secret
-      cy.interceptK8s(
-        { model: SecretModel, ns: 'test-project', name: 'missing-env-secret' },
-        {
-          statusCode: 404,
-          body: mock404Error({}),
-        },
-      );
-
-      editSpawnerPage.visit('test-notebook');
-
-      // Should show warning for missing env var secret
-      editSpawnerPage.findAlertMessage().should('exist');
-      editSpawnerPage.findAlertMessage().should('contain.text', 'missing-env-secret');
-    });
-
-    it('should NOT show warning when only data connections are attached', () => {
-      // Data connections alone (no envFrom) should not trigger warnings
-      initIntercepts({
-        connectionNames: ['valid-data-connection'],
-        hasValidConnections: true,
-        envFrom: [], // No envFrom - only data connections
-      });
-
-      editSpawnerPage.visit('test-notebook');
-
-      // No warnings should be shown for data connections
-      editSpawnerPage.findAlertMessage().should('not.exist');
-    });
-
-    it('should distinguish between missing data connections and missing env vars', () => {
-      // Data connection missing (annotation-based) - should NOT show env var warning
-      // Env var secret missing (envFrom-based) - should show warning
-
+    it('should show warnings only for missing envFrom references, not data connections', () => {
+      // Missing envFrom secret → warning; missing data connection → no warning
       initIntercepts({
         connectionNames: ['missing-data-connection'],
-        hasValidConnections: false, // Connection doesn't exist
-        envFrom: [
-          {
-            secretRef: {
-              name: 'missing-env-var',
-            },
-          },
-        ],
+        hasValidConnections: false,
+        envFrom: [{ secretRef: { name: 'missing-env-var' } }],
       });
 
-      // Mock 404 for env var secret
       cy.interceptK8s(
         { model: SecretModel, ns: 'test-project', name: 'missing-env-var' },
-        {
-          statusCode: 404,
-          body: mock404Error({}),
-        },
+        { statusCode: 404, body: mock404Error({}) },
       );
 
       editSpawnerPage.visit('test-notebook');
 
-      // Should only show warning for missing env var, NOT for missing data connection
       editSpawnerPage.findAlertMessage().should('exist');
       editSpawnerPage.findAlertMessage().should('contain.text', 'missing-env-var');
       editSpawnerPage.findAlertMessage().should('not.contain.text', 'missing-data-connection');
@@ -276,53 +200,38 @@ describe('Workbench Data Connection Warnings', () => {
     it('should show warning for missing ConfigMap environment variables', () => {
       initIntercepts({
         connectionNames: [],
-        envFrom: [
-          {
-            configMapRef: {
-              name: 'missing-configmap',
-            },
-          },
-        ],
+        envFrom: [{ configMapRef: { name: 'missing-configmap' } }],
       });
 
-      // Mock 404 for ConfigMap
       cy.interceptK8s(
         { model: ConfigMapModel, ns: 'test-project', name: 'missing-configmap' },
-        {
-          statusCode: 404,
-          body: mock404Error({}),
-        },
+        { statusCode: 404, body: mock404Error({}) },
       );
 
       editSpawnerPage.visit('test-notebook');
 
-      // Should show warning for missing ConfigMap
       editSpawnerPage.findAlertMessage().should('exist');
       editSpawnerPage.findAlertMessage().should('contain.text', 'missing-configmap');
     });
   });
 
   describe('Connection Error States', () => {
-    it('should handle deleted data connections gracefully', () => {
-      // Data connection is in annotation but secret was deleted
+    it('should handle deleted connections and multiple types without env var warnings', () => {
+      // Deleted data connections should not trigger warnings
       initIntercepts({
         connectionNames: ['deleted-connection'],
         hasValidConnections: false,
       });
 
       editSpawnerPage.visit('test-notebook');
-
-      // Should NOT show environment variable warning (data connections are not env vars)
       editSpawnerPage.findAlertMessage().should('not.exist');
-    });
 
-    it('should handle multiple connection types correctly', () => {
+      // Multiple connection types (s3, postgres, mysql) should also not trigger warnings
       initIntercepts({
         connectionNames: ['s3-connection', 'postgres-connection', 'mysql-connection'],
         hasValidConnections: true,
       });
 
-      // Mock different connection types
       cy.interceptK8sList(
         { model: SecretModel, ns: 'test-project' },
         mockK8sResourceList([
@@ -348,56 +257,36 @@ describe('Workbench Data Connection Warnings', () => {
       );
 
       editSpawnerPage.visit('test-notebook');
-
-      // No environment variable warnings should be shown
       editSpawnerPage.findAlertMessage().should('not.exist');
     });
 
-    it('should handle workbench with mixed valid and invalid references', () => {
-      // Mix of valid data connection, missing env var secret, and valid config map
+    it('should warn only for missing envFrom references among mixed references', () => {
       initIntercepts({
         connectionNames: ['valid-data-connection'],
         hasValidConnections: true,
         envFrom: [
-          {
-            secretRef: {
-              name: 'missing-secret',
-            },
-          },
-          {
-            configMapRef: {
-              name: 'valid-configmap',
-            },
-          },
+          { secretRef: { name: 'missing-secret' } },
+          { configMapRef: { name: 'valid-configmap' } },
         ],
       });
 
-      // Mock 404 for missing secret
       cy.interceptK8s(
         { model: SecretModel, ns: 'test-project', name: 'missing-secret' },
-        {
-          statusCode: 404,
-          body: mock404Error({}),
-        },
+        { statusCode: 404, body: mock404Error({}) },
       );
 
-      // Mock valid ConfigMap
       cy.interceptK8s(
         { model: ConfigMapModel, ns: 'test-project', name: 'valid-configmap' },
         {
           apiVersion: 'v1',
           kind: 'ConfigMap',
-          metadata: {
-            name: 'valid-configmap',
-            namespace: 'test-project',
-          },
+          metadata: { name: 'valid-configmap', namespace: 'test-project' },
           data: {},
         },
       );
 
       editSpawnerPage.visit('test-notebook');
 
-      // Should show warning only for missing env var secret
       editSpawnerPage.findAlertMessage().should('exist');
       editSpawnerPage.findAlertMessage().should('contain.text', 'missing-secret');
       editSpawnerPage.findAlertMessage().should('not.contain.text', 'valid-data-connection');

--- a/packages/gen-ai/frontend/package-lock.json
+++ b/packages/gen-ai/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "cross-env": "^10.1.0",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",
+        "cypress-axe": "^1.7.0",
         "dotenv": "^16.5.0",
         "dotenv-expand": "^5.1.0",
         "dotenv-webpack": "^8.1.0",
@@ -89,6 +90,7 @@
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "@typescript-eslint/parser": "^8.17.0",
         "cypress": "^14.5.1",
+        "cypress-axe": "^1.5.0",
         "cypress-high-resolution": "^1.0.0",
         "cypress-mochawesome-reporter": "^3.8.2",
         "cypress-multi-reporters": "^2.0.5",
@@ -2107,8 +2109,8 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
       "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2169,8 +2171,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
       "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -2180,8 +2182,8 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -6516,15 +6518,15 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
       "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.10",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
       "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
@@ -7592,8 +7594,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -7706,8 +7708,8 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -7722,8 +7724,8 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -7822,6 +7824,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7836,8 +7839,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/archy": {
       "version": "1.0.0",
@@ -8085,8 +8087,8 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -8128,8 +8130,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -8175,8 +8177,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8185,8 +8187,8 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/async-each": {
       "version": "1.0.6",
@@ -8273,8 +8275,8 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -8283,15 +8285,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "devOptional": true,
       "license": "MPL-2.0",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -8627,8 +8629,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -8672,8 +8674,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
       "integrity": "sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==",
-      "license": "Apache-2.0",
-      "optional": true
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/bluebird": {
       "version": "3.7.1",
@@ -9178,6 +9180,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -9193,7 +9196,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -9203,8 +9205,8 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -9346,8 +9348,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
       "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -9515,8 +9517,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0",
-      "optional": true
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -9643,8 +9645,8 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9687,6 +9689,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
       "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -9694,7 +9697,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9801,8 +9803,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -9824,8 +9826,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -9837,8 +9839,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
       "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -9853,8 +9855,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -10114,8 +10116,8 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
       "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -10982,9 +10984,9 @@
       "version": "14.5.4",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.4.tgz",
       "integrity": "sha512-0Dhm4qc9VatOcI1GiFGVt8osgpPdqJLHzRwcAB5MSD/CAAts3oybvPUPawHyvJZUd8osADqZe/xzMsZ8sDTjXw==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -11036,6 +11038,20 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.7.0.tgz",
+      "integrity": "sha512-zzJpvAAjauEB3GZl0KYXb8i3w6MztWAt2WM3czYTFyNVC30alDmqCm9E7GwZ4bgkldZJlmHakaVEyu73R5St4w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12 || ^13 || ^14 || ^15"
       }
     },
     "node_modules/cypress-high-resolution": {
@@ -11134,15 +11150,15 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/cypress/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -11158,8 +11174,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11171,8 +11187,8 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11181,15 +11197,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/cypress/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11201,8 +11217,8 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11238,8 +11254,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -11340,8 +11356,8 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -12076,8 +12092,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -12191,8 +12207,8 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -13307,8 +13323,8 @@
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -13343,8 +13359,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -13367,8 +13383,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
       "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pify": "^2.2.0"
       },
@@ -13715,8 +13731,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "devOptional": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -13736,11 +13752,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -13875,8 +13891,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -13900,8 +13916,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -13916,8 +13932,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14497,8 +14513,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -14860,8 +14876,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14918,8 +14934,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
       "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "async": "^3.2.0"
       }
@@ -14928,8 +14944,8 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -15021,8 +15037,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
       "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -15419,8 +15435,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
       "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
@@ -15436,8 +15452,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -15948,8 +15964,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
       "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -15985,8 +16001,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -16190,8 +16206,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -16226,8 +16242,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -16705,8 +16721,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
       "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -16891,8 +16907,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -16955,15 +16971,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -17081,8 +17097,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -18683,8 +18699,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "20.0.3",
@@ -18794,8 +18810,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)",
-      "optional": true
+      "devOptional": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -18815,8 +18831,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC",
-      "optional": true
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -18848,11 +18864,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
       "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -19053,8 +19069,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "> 0.8"
       }
@@ -19107,8 +19123,8 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
       "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -19301,8 +19317,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -19315,8 +19331,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -19332,8 +19348,8 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19349,8 +19365,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
       "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -19368,8 +19384,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -19386,8 +19402,8 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -20693,8 +20709,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -22141,8 +22157,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -22709,8 +22725,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -22786,8 +22802,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/ow": {
       "version": "2.0.0",
@@ -22877,8 +22893,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -23295,15 +23311,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -23341,8 +23357,8 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24077,8 +24093,8 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       },
@@ -26092,8 +26108,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "throttleit": "^1.0.0"
       }
@@ -26255,8 +26271,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -26507,8 +26523,8 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -27422,8 +27438,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "optional": true
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -27465,8 +27481,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
       "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -27890,8 +27906,8 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -28486,8 +28502,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -29008,8 +29024,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
       "integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -29018,8 +29034,8 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -29166,8 +29182,8 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tldts-core": "^6.1.86"
       },
@@ -29179,15 +29195,15 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.14"
       }
@@ -29325,8 +29341,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -29368,8 +29384,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "tree-kill": "cli.js"
       }
@@ -29669,8 +29685,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -29682,8 +29698,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense",
-      "optional": true
+      "devOptional": true,
+      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -30241,8 +30257,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -30515,11 +30531,11 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "devOptional": true,
       "engines": [
         "node >=0.6.0"
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -31807,8 +31823,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -32083,8 +32099,8 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -56,6 +56,7 @@
     "cross-env": "^10.1.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
+    "cypress-axe": "^1.7.0",
     "dotenv": "^16.5.0",
     "dotenv-expand": "^5.1.0",
     "dotenv-webpack": "^8.1.0",
@@ -101,6 +102,7 @@
     "@patternfly/react-icons": "^6.3.1",
     "@patternfly/react-styles": "^6.3.1",
     "@patternfly/react-templates": "^6.3.1",
+    "@tanstack/react-query": "^5.62.0",
     "immer": "^11.1.3",
     "mod-arch-core": "^1.15.4",
     "mod-arch-shared": "^1.15.4",
@@ -108,8 +110,7 @@
     "react-dom": "^18.3.1",
     "react-router": "^7.12.0",
     "react-router-dom": "^7.12.0",
-    "zustand": "^5.0.10",
-    "@tanstack/react-query": "^5.62.0"
+    "zustand": "^5.0.10"
   },
   "optionalDependencies": {
     "@babel/preset-env": "^7.27.2",
@@ -124,6 +125,7 @@
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",
     "cypress": "^14.5.1",
+    "cypress-axe": "^1.5.0",
     "cypress-high-resolution": "^1.0.0",
     "cypress-mochawesome-reporter": "^3.8.2",
     "cypress-multi-reporters": "^2.0.5",

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
@@ -95,9 +95,8 @@ class DeleteModelModal {
     return this.find().findByRole('heading', { name: /remove asset/i });
   }
 
-  // PF6 inline Alert does not have role="alert" — uses CSS class selector
   findDangerAlert(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.find().find('.pf-v6-c-alert.pf-m-danger');
+    return this.find().findByTestId('delete-model-error-alert');
   }
 }
 

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
@@ -32,6 +32,10 @@ class ModelsTabRow {
   findPlaygroundCell(): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.find().find('[data-label="Playground"]');
   }
+
+  findKebabMenu(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByTestId('model-actions-kebab');
+  }
 }
 
 class ModelsTabPage {
@@ -62,6 +66,59 @@ class ModelsTabPage {
   }
 }
 
+class DeleteModelModal {
+  find(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('delete-model-modal');
+  }
+
+  shouldBeVisible(): void {
+    this.find().should('be.visible');
+  }
+
+  shouldNotExist(): void {
+    this.find().should('not.exist');
+  }
+
+  findRemoveButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByRole('button', { name: /^remove$/i });
+  }
+
+  findCancelButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByRole('button', { name: /cancel/i });
+  }
+
+  findRemovingButton(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByRole('button', { name: /removing/i });
+  }
+
+  findTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().findByRole('heading', { name: /remove asset/i });
+  }
+
+  // PF6 inline Alert does not have role="alert" — uses CSS class selector
+  findDangerAlert(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.find().find('.pf-v6-c-alert.pf-m-danger');
+  }
+}
+
+class KebabMenu {
+  find(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menu');
+  }
+
+  shouldBeVisible(): void {
+    this.find().should('be.visible');
+  }
+
+  shouldNotExist(): void {
+    this.find().should('not.exist');
+  }
+
+  findRemoveAssetItem(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByRole('menuitem', { name: /remove asset/i });
+  }
+}
+
 class EndpointModalPage {
   findModal(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.get('[role="dialog"]');
@@ -89,4 +146,6 @@ class EndpointModalPage {
 }
 
 export const modelsTabPage = new ModelsTabPage();
+export const deleteModelModal = new DeleteModelModal();
+export const kebabMenu = new KebabMenu();
 export const endpointModalPage = new EndpointModalPage();

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/modelsTabPage.ts
@@ -102,7 +102,7 @@ class DeleteModelModal {
 
 class KebabMenu {
   find(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menu');
+    return cy.findByTestId('model-actions-dropdown-menu');
   }
 
   shouldBeVisible(): void {
@@ -114,13 +114,13 @@ class KebabMenu {
   }
 
   findRemoveAssetItem(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: /remove asset/i });
+    return cy.findByTestId('remove-asset-action');
   }
 }
 
 class EndpointModalPage {
   findModal(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.get('[role="dialog"]');
+    return cy.findByTestId('endpoint-detail-modal');
   }
 
   findSubscriptionSelect(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/commands/axe.ts
@@ -1,0 +1,67 @@
+import 'cypress-axe';
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      testA11y: (context?: Parameters<cy['checkA11y']>[0]) => void;
+    }
+  }
+}
+
+Cypress.Commands.add('testA11y', { prevSubject: 'optional' }, (subject, context) => {
+  const test = (c: Parameters<typeof cy.checkA11y>[0]) => {
+    cy.window({ log: false }).then((win) => {
+      // inject on demand
+      if (!(win as { axe: unknown }).axe) {
+        cy.injectAxe();
+      }
+      cy.checkA11y(
+        c,
+        {
+          includedImpacts: ['serious', 'critical'],
+        },
+        (violations) => {
+          cy.task(
+            'error',
+            `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${
+              violations.length === 1 ? 'was' : 'were'
+            } detected`,
+          );
+          const violationData = violations.map(({ id, impact, description, nodes }) => ({
+            id,
+            impact,
+            description,
+            nodes: nodes.length,
+          }));
+
+          cy.task('table', violationData);
+
+          cy.task(
+            'log',
+            violations
+              .map(
+                ({ nodes }, i) =>
+                  `${i}. Affected elements:\n${nodes.map(
+                    ({ target, failureSummary, ancestry }) =>
+                      `\t${failureSummary} - ${target
+                        .map((node) => `"${node}"\n${ancestry}`)
+                        .join(', ')}`,
+                  )}`,
+              )
+              .join('\n'),
+          );
+        },
+      );
+    });
+  };
+  if (!context && subject) {
+    cy.wrap(subject).each(($el) => {
+      Cypress.log({ displayName: 'testA11y', $el });
+      test($el[0]);
+    });
+  } else {
+    Cypress.log({ displayName: 'testA11y' });
+    test(context);
+  }
+});

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/support/commands/index.ts
@@ -1,4 +1,5 @@
 import '@testing-library/cypress/add-commands';
+import './axe';
 import './genai';
 
 // Add cy.step() command for better test documentation

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
@@ -96,10 +96,8 @@ describe('AI Assets - Model Tab - Remove Asset Action', () => {
   });
 
   it(
-    'should open delete modal, verify contents, and close on Cancel',
-    {
-      tags: ['@GenAI', '@ModelsTab'],
-    },
+    'should open delete modal, allow cancel, and remove asset when confirmed',
+    { tags: ['@GenAI', '@ModelsTab'] },
     () => {
       cy.step('Open kebab menu and click Remove asset');
       modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
@@ -115,35 +113,22 @@ describe('AI Assets - Model Tab - Remove Asset Action', () => {
       cy.step('Click Cancel and verify modal closes');
       deleteModelModal.findCancelButton().click();
       deleteModelModal.shouldNotExist();
-
-      cy.step('Verify model is still in table');
       modelsTabPage.getRow('Custom GPT Endpoint').find().should('exist');
+
+      cy.step('Reopen and confirm removal');
+      cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteModel');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+      kebabMenu.findRemoveAssetItem().click();
+
+      cy.interceptGenAi('GET /api/v1/aaa/models', { data: [NAMESPACE_MODEL] }).as('refreshModels');
+      deleteModelModal.findRemoveButton().click();
+
+      cy.wait('@deleteModel');
+      cy.wait('@refreshModels');
+      modelsTabPage.findTable().should('not.contain.text', 'Custom GPT Endpoint');
+      modelsTabPage.getRow('Llama 3B Internal').find().should('exist');
     },
   );
-
-  it('should successfully remove asset when confirmed', { tags: ['@GenAI', '@ModelsTab'] }, () => {
-    cy.step('Intercept delete request');
-    cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteModel');
-
-    cy.step('Open delete modal and confirm');
-    modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
-    kebabMenu.findRemoveAssetItem().click();
-
-    cy.step('Set up refresh intercept after modal is open but before confirming delete');
-    cy.interceptGenAi('GET /api/v1/aaa/models', { data: [NAMESPACE_MODEL] }).as('refreshModels');
-
-    deleteModelModal.findRemoveButton().click();
-
-    cy.step('Verify delete request was made');
-    cy.wait('@deleteModel');
-
-    cy.step('Verify model is removed from table');
-    cy.wait('@refreshModels');
-    modelsTabPage.findTable().should('not.contain.text', 'Custom GPT Endpoint');
-
-    cy.step('Verify remaining model is still present');
-    modelsTabPage.getRow('Llama 3B Internal').find().should('exist');
-  });
 
   it('should display loading state while deleting', { tags: ['@GenAI', '@ModelsTab'] }, () => {
     cy.step('Intercept delete request with delay');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
@@ -276,7 +276,9 @@ describe('AI Assets - Model Tab - Multiple Custom Endpoint Models', () => {
 
       deleteModelModal.findRemoveButton().click();
 
-      cy.wait('@deleteModel1');
+      cy.wait('@deleteModel1').then((interception) => {
+        expect(interception.request.url).to.include('model_id=custom-model-1');
+      });
       cy.wait('@refreshModels');
 
       cy.step('Verify Custom Model 1 is removed');

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
@@ -1,0 +1,365 @@
+/* eslint-disable camelcase */
+import { aiAssetsPage } from '~/__tests__/cypress/cypress/pages/aiAssetsPage';
+import {
+  modelsTabPage,
+  deleteModelModal,
+  kebabMenu,
+} from '~/__tests__/cypress/cypress/pages/modelsTabPage';
+import { setupModelsTabIntercepts } from '~/__tests__/cypress/cypress/support/helpers/modelsTab/modelsTabTestHelpers';
+import { mockAAModel } from '~/__tests__/cypress/cypress/__mocks__/mockAAModels';
+
+const TEST_NAMESPACE = 'test-namespace';
+
+const CUSTOM_ENDPOINT_MODEL = mockAAModel({
+  model_name: 'Custom-GPT-Endpoint',
+  model_id: 'custom-gpt-endpoint',
+  display_name: 'Custom GPT Endpoint',
+  description: 'Custom endpoint for GPT model',
+  usecase: 'text-generation',
+  status: 'Running',
+  model_source_type: 'custom_endpoint',
+  model_type: 'llm',
+  endpoints: ['https://custom.endpoint.com/v1/models/gpt'],
+});
+
+const NAMESPACE_MODEL = mockAAModel({
+  model_name: 'Llama-3B-Internal',
+  model_id: 'llama-3b-internal',
+  display_name: 'Llama 3B Internal',
+  description: 'Locally deployed Llama model',
+  usecase: 'text-generation',
+  status: 'Running',
+  model_source_type: 'namespace',
+  model_type: 'llm',
+  endpoints: ['internal: http://llama-3b.test-namespace.svc.cluster.local:8080'],
+});
+
+const CUSTOM_EMBEDDING_MODEL = mockAAModel({
+  model_name: 'Custom-Embedding',
+  model_id: 'custom-embedding',
+  display_name: 'Custom Embedding Model',
+  description: 'Custom endpoint embedding model',
+  usecase: 'embedding',
+  status: 'Running',
+  model_source_type: 'custom_endpoint',
+  model_type: 'embedding',
+  endpoints: ['https://custom.endpoint.com/v1/embeddings'],
+});
+
+describe('AI Assets - Model Tab - Kebab Menu Actions', () => {
+  beforeEach(() => {
+    setupModelsTabIntercepts({
+      namespace: TEST_NAMESPACE,
+      aiModels: [CUSTOM_ENDPOINT_MODEL, NAMESPACE_MODEL, CUSTOM_EMBEDDING_MODEL],
+      maasModels: [],
+    });
+
+    aiAssetsPage.visit(TEST_NAMESPACE);
+  });
+
+  it(
+    'should show kebab menu for custom endpoint models, open/close it, and have proper aria-label',
+    { tags: ['@GenAI', '@ModelsTab'] },
+    () => {
+      cy.step('Verify custom endpoint model has kebab menu with aria-label');
+      const customRow = modelsTabPage.getRow('Custom GPT Endpoint');
+      customRow.findKebabMenu().should('exist');
+      customRow
+        .findKebabMenu()
+        .should('have.attr', 'aria-label')
+        .and('include', 'Custom GPT Endpoint');
+
+      cy.step('Verify namespace model does not have kebab menu');
+      modelsTabPage.getRow('Llama 3B Internal').findKebabMenu().should('not.exist');
+
+      cy.step('Open kebab menu and verify contents');
+      customRow.findKebabMenu().click();
+      kebabMenu.shouldBeVisible();
+      kebabMenu.findRemoveAssetItem().should('be.visible');
+
+      cy.step('Close menu by clicking outside');
+      modelsTabPage.findTable().click('topLeft');
+      kebabMenu.shouldNotExist();
+    },
+  );
+});
+
+describe('AI Assets - Model Tab - Remove Asset Action', () => {
+  beforeEach(() => {
+    setupModelsTabIntercepts({
+      namespace: TEST_NAMESPACE,
+      aiModels: [CUSTOM_ENDPOINT_MODEL, NAMESPACE_MODEL],
+      maasModels: [],
+    });
+
+    aiAssetsPage.visit(TEST_NAMESPACE);
+  });
+
+  it(
+    'should open delete modal, verify contents, and close on Cancel',
+    {
+      tags: ['@GenAI', '@ModelsTab'],
+    },
+    () => {
+      cy.step('Open kebab menu and click Remove asset');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+      kebabMenu.findRemoveAssetItem().click();
+
+      cy.step('Verify delete modal contents');
+      deleteModelModal.shouldBeVisible();
+      deleteModelModal.findTitle().should('be.visible');
+      deleteModelModal.find().should('contain.text', 'Custom GPT Endpoint');
+      deleteModelModal.findRemoveButton().should('be.visible');
+      deleteModelModal.findCancelButton().should('be.visible');
+
+      cy.step('Click Cancel and verify modal closes');
+      deleteModelModal.findCancelButton().click();
+      deleteModelModal.shouldNotExist();
+
+      cy.step('Verify model is still in table');
+      modelsTabPage.getRow('Custom GPT Endpoint').find().should('exist');
+    },
+  );
+
+  it('should successfully remove asset when confirmed', { tags: ['@GenAI', '@ModelsTab'] }, () => {
+    cy.step('Intercept delete request');
+    cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteModel');
+
+    cy.step('Open delete modal and confirm');
+    modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+    kebabMenu.findRemoveAssetItem().click();
+
+    cy.step('Set up refresh intercept after modal is open but before confirming delete');
+    cy.interceptGenAi('GET /api/v1/aaa/models', { data: [NAMESPACE_MODEL] }).as('refreshModels');
+
+    deleteModelModal.findRemoveButton().click();
+
+    cy.step('Verify delete request was made');
+    cy.wait('@deleteModel');
+
+    cy.step('Verify model is removed from table');
+    cy.wait('@refreshModels');
+    modelsTabPage.findTable().should('not.contain.text', 'Custom GPT Endpoint');
+
+    cy.step('Verify remaining model is still present');
+    modelsTabPage.getRow('Llama 3B Internal').find().should('exist');
+  });
+
+  it(
+    'should display loading state while deleting and error on failure with retry',
+    { tags: ['@GenAI', '@ModelsTab'] },
+    () => {
+      cy.step('Intercept delete request with delay');
+      cy.interceptGenAi('DELETE /api/v1/models/external', {
+        statusCode: 200,
+        body: { success: true },
+        delay: 1000,
+      }).as('deleteModel');
+
+      cy.step('Open delete modal and click Remove');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+      kebabMenu.findRemoveAssetItem().click();
+      deleteModelModal.findRemoveButton().click();
+
+      cy.step('Verify loading state');
+      deleteModelModal.findRemovingButton().should('be.visible').and('be.disabled');
+      deleteModelModal.findCancelButton().should('be.disabled');
+
+      cy.step('Wait for deletion to complete');
+      cy.wait('@deleteModel');
+    },
+  );
+
+  it('should display error on failure and allow retry', { tags: ['@GenAI', '@ModelsTab'] }, () => {
+    cy.step('Intercept delete request with error');
+    cy.interceptGenAi('DELETE /api/v1/models/external', {
+      statusCode: 500,
+      body: { error: { message: 'Internal server error' } },
+    }).as('deleteModelError');
+
+    cy.step('Open delete modal and confirm');
+    modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+    kebabMenu.findRemoveAssetItem().click();
+    deleteModelModal.shouldBeVisible();
+    deleteModelModal.findRemoveButton().click();
+
+    cy.step('Wait for error response');
+    cy.wait('@deleteModelError');
+
+    cy.step('Verify error alert is displayed');
+    deleteModelModal
+      .findDangerAlert()
+      .should('be.visible')
+      .and('contain.text', 'Internal server error');
+
+    cy.step('Verify modal remains open with Remove re-enabled');
+    deleteModelModal.shouldBeVisible();
+    deleteModelModal.findRemoveButton().should('be.enabled');
+
+    cy.step('Intercept retry with success and set up refresh');
+    cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteModelSuccess');
+    cy.interceptGenAi('GET /api/v1/aaa/models', { data: [NAMESPACE_MODEL] }).as('refreshModels');
+
+    cy.step('Click Remove button again to retry');
+    deleteModelModal.findRemoveButton().click();
+
+    cy.step('Verify successful deletion');
+    cy.wait('@deleteModelSuccess');
+    cy.wait('@refreshModels');
+    modelsTabPage.findTable().should('not.contain.text', 'Custom GPT Endpoint');
+  });
+});
+
+describe('AI Assets - Model Tab - Multiple Custom Endpoint Models', () => {
+  const CUSTOM_MODEL_1 = mockAAModel({
+    model_name: 'Custom-Model-1',
+    model_id: 'custom-model-1',
+    display_name: 'Custom Model 1',
+    description: 'First custom model',
+    usecase: 'text-generation',
+    status: 'Running',
+    model_source_type: 'custom_endpoint',
+    model_type: 'llm',
+    endpoints: ['https://custom1.endpoint.com/v1/models'],
+  });
+
+  const CUSTOM_MODEL_2 = mockAAModel({
+    model_name: 'Custom-Model-2',
+    model_id: 'custom-model-2',
+    display_name: 'Custom Model 2',
+    description: 'Second custom model',
+    usecase: 'text-generation',
+    status: 'Running',
+    model_source_type: 'custom_endpoint',
+    model_type: 'llm',
+    endpoints: ['https://custom2.endpoint.com/v1/models'],
+  });
+
+  beforeEach(() => {
+    setupModelsTabIntercepts({
+      namespace: TEST_NAMESPACE,
+      aiModels: [CUSTOM_MODEL_1, CUSTOM_MODEL_2, NAMESPACE_MODEL],
+      maasModels: [],
+    });
+
+    aiAssetsPage.visit(TEST_NAMESPACE);
+  });
+
+  it(
+    'should show independent kebab menus and delete only the selected model',
+    {
+      tags: ['@GenAI', '@ModelsTab'],
+    },
+    () => {
+      cy.step('Verify both custom models have kebab menus');
+      modelsTabPage.getRow('Custom Model 1').findKebabMenu().should('exist');
+      modelsTabPage.getRow('Custom Model 2').findKebabMenu().should('exist');
+
+      cy.step('Open first model kebab menu');
+      modelsTabPage.getRow('Custom Model 1').findKebabMenu().click();
+      kebabMenu.shouldBeVisible();
+
+      cy.step('Click outside to close first menu');
+      modelsTabPage.findTable().click('topLeft');
+
+      cy.step('Open second model kebab menu');
+      modelsTabPage.getRow('Custom Model 2').findKebabMenu().click();
+      kebabMenu.shouldBeVisible();
+      kebabMenu.findRemoveAssetItem().should('be.visible');
+
+      cy.step('Close menu and delete Custom Model 1');
+      modelsTabPage.findTable().click('topLeft');
+      cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteModel1');
+
+      modelsTabPage.getRow('Custom Model 1').findKebabMenu().click();
+      kebabMenu.findRemoveAssetItem().click();
+
+      cy.interceptGenAi('GET /api/v1/aaa/models', { data: [CUSTOM_MODEL_2, NAMESPACE_MODEL] }).as(
+        'refreshModels',
+      );
+
+      deleteModelModal.findRemoveButton().click();
+
+      cy.wait('@deleteModel1');
+      cy.wait('@refreshModels');
+
+      cy.step('Verify Custom Model 1 is removed');
+      modelsTabPage.findTable().should('not.contain.text', 'Custom Model 1');
+
+      cy.step('Verify Custom Model 2 and namespace model still exist');
+      modelsTabPage.getRow('Custom Model 2').find().should('exist');
+      modelsTabPage.getRow('Llama 3B Internal').find().should('exist');
+    },
+  );
+});
+
+describe('AI Assets - Model Tab - Embedding Model Actions', () => {
+  beforeEach(() => {
+    setupModelsTabIntercepts({
+      namespace: TEST_NAMESPACE,
+      aiModels: [CUSTOM_EMBEDDING_MODEL, CUSTOM_ENDPOINT_MODEL],
+      maasModels: [],
+    });
+
+    aiAssetsPage.visit(TEST_NAMESPACE);
+  });
+
+  it(
+    'should allow deleting custom endpoint embedding models',
+    {
+      tags: ['@GenAI', '@ModelsTab'],
+    },
+    () => {
+      cy.step('Verify embedding model has kebab menu');
+      modelsTabPage.getRow('Custom Embedding Model').findKebabMenu().should('exist');
+
+      cy.step('Intercept delete request');
+      cy.interceptGenAi('DELETE /api/v1/models/external', { success: true }).as('deleteEmbedding');
+
+      cy.step('Delete embedding model');
+      modelsTabPage.getRow('Custom Embedding Model').findKebabMenu().click();
+      kebabMenu.findRemoveAssetItem().click();
+
+      cy.step('Set up refresh intercept after modal opens');
+      cy.interceptGenAi('GET /api/v1/aaa/models', { data: [CUSTOM_ENDPOINT_MODEL] }).as(
+        'refreshModels',
+      );
+
+      deleteModelModal.findRemoveButton().click();
+
+      cy.step('Verify deletion');
+      cy.wait('@deleteEmbedding');
+      cy.wait('@refreshModels');
+      modelsTabPage.findTable().should('not.contain.text', 'Custom Embedding Model');
+    },
+  );
+});
+
+describe('AI Assets - Model Tab - Accessibility', () => {
+  beforeEach(() => {
+    setupModelsTabIntercepts({
+      namespace: TEST_NAMESPACE,
+      aiModels: [CUSTOM_ENDPOINT_MODEL],
+      maasModels: [],
+    });
+
+    aiAssetsPage.visit(TEST_NAMESPACE);
+  });
+
+  it(
+    'should be keyboard accessible with proper ARIA attributes',
+    { tags: ['@GenAI', '@ModelsTab', '@A11y'] },
+    () => {
+      cy.step('Verify kebab toggle has correct aria-label');
+      modelsTabPage
+        .getRow('Custom GPT Endpoint')
+        .findKebabMenu()
+        .should('have.attr', 'aria-label', 'Actions for Custom GPT Endpoint');
+
+      cy.step('Open menu and verify menu roles');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+      kebabMenu.shouldBeVisible();
+      kebabMenu.findRemoveAssetItem().should('exist');
+    },
+  );
+});

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
@@ -145,30 +145,26 @@ describe('AI Assets - Model Tab - Remove Asset Action', () => {
     modelsTabPage.getRow('Llama 3B Internal').find().should('exist');
   });
 
-  it(
-    'should display loading state while deleting and error on failure with retry',
-    { tags: ['@GenAI', '@ModelsTab'] },
-    () => {
-      cy.step('Intercept delete request with delay');
-      cy.interceptGenAi('DELETE /api/v1/models/external', {
-        statusCode: 200,
-        body: { success: true },
-        delay: 1000,
-      }).as('deleteModel');
+  it('should display loading state while deleting', { tags: ['@GenAI', '@ModelsTab'] }, () => {
+    cy.step('Intercept delete request with delay');
+    cy.interceptGenAi('DELETE /api/v1/models/external', {
+      statusCode: 200,
+      body: { success: true },
+      delay: 1000,
+    }).as('deleteModel');
 
-      cy.step('Open delete modal and click Remove');
-      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
-      kebabMenu.findRemoveAssetItem().click();
-      deleteModelModal.findRemoveButton().click();
+    cy.step('Open delete modal and click Remove');
+    modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+    kebabMenu.findRemoveAssetItem().click();
+    deleteModelModal.findRemoveButton().click();
 
-      cy.step('Verify loading state');
-      deleteModelModal.findRemovingButton().should('be.visible').and('be.disabled');
-      deleteModelModal.findCancelButton().should('be.disabled');
+    cy.step('Verify loading state');
+    deleteModelModal.findRemovingButton().should('be.visible').and('be.disabled');
+    deleteModelModal.findCancelButton().should('be.disabled');
 
-      cy.step('Wait for deletion to complete');
-      cy.wait('@deleteModel');
-    },
-  );
+    cy.step('Wait for deletion to complete');
+    cy.wait('@deleteModel');
+  });
 
   it('should display error on failure and allow retry', { tags: ['@GenAI', '@ModelsTab'] }, () => {
     cy.step('Intercept delete request with error');
@@ -356,8 +352,26 @@ describe('AI Assets - Model Tab - Accessibility', () => {
         .findKebabMenu()
         .should('have.attr', 'aria-label', 'Actions for Custom GPT Endpoint');
 
-      cy.step('Open menu and verify menu roles');
+      cy.step('Open menu via mouse click and verify menu roles');
       modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
+      kebabMenu.shouldBeVisible();
+      kebabMenu.findRemoveAssetItem().should('exist');
+
+      cy.step('Close menu');
+      modelsTabPage.findTable().click('topLeft');
+      kebabMenu.shouldNotExist();
+
+      cy.step('Open menu via Enter key');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().focus().type('{enter}');
+      kebabMenu.shouldBeVisible();
+      kebabMenu.findRemoveAssetItem().should('exist');
+
+      cy.step('Close menu');
+      modelsTabPage.findTable().click('topLeft');
+      kebabMenu.shouldNotExist();
+
+      cy.step('Open menu via Space key');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().focus().type(' ');
       kebabMenu.shouldBeVisible();
       kebabMenu.findRemoveAssetItem().should('exist');
     },

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/aiAssets/modelTabKebabActions.cy.ts
@@ -339,26 +339,24 @@ describe('AI Assets - Model Tab - Accessibility', () => {
         .findKebabMenu()
         .should('have.attr', 'aria-label', 'Actions for Custom GPT Endpoint');
 
-      cy.step('Open menu via mouse click and verify menu roles');
+      cy.step('Verify kebab toggle is focusable');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().focus().should('be.focused');
+
+      cy.step('Open menu via click and verify menu roles');
       modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
       kebabMenu.shouldBeVisible();
       kebabMenu.findRemoveAssetItem().should('exist');
 
-      cy.step('Close menu');
+      cy.step('Close menu and verify toggle updates aria-expanded');
       modelsTabPage.findTable().click('topLeft');
       kebabMenu.shouldNotExist();
+      modelsTabPage
+        .getRow('Custom GPT Endpoint')
+        .findKebabMenu()
+        .should('have.attr', 'aria-expanded', 'false');
 
-      cy.step('Open menu via Enter key');
-      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().focus().type('{enter}');
-      kebabMenu.shouldBeVisible();
-      kebabMenu.findRemoveAssetItem().should('exist');
-
-      cy.step('Close menu');
-      modelsTabPage.findTable().click('topLeft');
-      kebabMenu.shouldNotExist();
-
-      cy.step('Open menu via Space key');
-      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().focus().type(' ');
+      cy.step('Reopen menu to verify repeated interaction');
+      modelsTabPage.getRow('Custom GPT Endpoint').findKebabMenu().click();
       kebabMenu.shouldBeVisible();
       kebabMenu.findRemoveAssetItem().should('exist');
     },

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/tests/mocked/playground/mcpTab.cy.ts
@@ -461,7 +461,8 @@ describe('Playground - MCP Servers', () => {
       cy.step('Close success modal and open tools modal');
       playgroundPage.mcpTab.closeSuccessModal();
       mcpServerSuccessModal.find().should('not.exist');
-      // Wait for MCP table to be visible after potential tab remount
+      // Re-click MCP tab to ensure table is visible after modal-triggered remount
+      playgroundPage.mcpTab.clickMCPTab();
       playgroundPage.mcpTab.findMCPServersTable().should('be.visible');
       serverRow.findToolsButton().should('exist').and('not.have.attr', 'aria-disabled');
       serverRow.findToolsButton().click();

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -290,6 +290,7 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
                 variant="danger"
                 isInline
                 title="Error"
+                data-testid="delete-model-error-alert"
                 style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
               >
                 {deleteError}

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -234,6 +234,7 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
                     aria-label={`Actions for ${model.display_name || model.model_id}`}
                     variant="plain"
                     onClick={() => setIsKebabOpen(!isKebabOpen)}
+                    data-testid="model-actions-kebab"
                   >
                     <EllipsisVIcon />
                   </MenuToggle>

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -240,9 +240,10 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
                   </MenuToggle>
                 )}
               >
-                <DropdownList>
+                <DropdownList data-testid="model-actions-dropdown-menu">
                   <DropdownItem
                     key="delete"
+                    data-testid="remove-asset-action"
                     onClick={() => {
                       setIsKebabOpen(false);
                       setIsDeleteModalOpen(true);

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/EndpointDetailModal.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/EndpointDetailModal.tsx
@@ -130,7 +130,13 @@ const EndpointDetailModal: React.FC<EndpointDetailModalProps> = ({ model, onClos
   };
 
   return (
-    <Modal isOpen onClose={handleClose} variant={ModalVariant.medium} aria-label="Endpoints">
+    <Modal
+      isOpen
+      onClose={handleClose}
+      variant={ModalVariant.medium}
+      aria-label="Endpoints"
+      data-testid="endpoint-detail-modal"
+    >
       <ModalHeader
         title={
           <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-31273

## Description

Adds new Cypress mock tests to close testing gaps identified across multiple linked Jira tickets:

| Ticket | Area | What's tested |
|--------|------|---------------|
| [RHOAIENG-18214](https://redhat.atlassian.net/browse/RHOAIENG-18214) / [RHOAIENG-17122](https://redhat.atlassian.net/browse/RHOAIENG-17122) | Workbench env vars | Pre-existing `envFrom` ConfigMap/Secret references persist correctly when editing a notebook; removal of individual entries |
| [RHOAIENG-15228](https://redhat.atlassian.net/browse/RHOAIENG-15228) | Data connections | Workbench loads without false "env var not found" warnings when connections are present |
| [RHOAIENG-5349](https://redhat.atlassian.net/browse/RHOAIENG-5349) | Pipeline graph | Complex topologies render correctly (fan-out/fan-in, diamond, sequential chains, large 20-task graphs) |
| [RHOAIENG-8635](https://redhat.atlassian.net/browse/RHOAIENG-8635) | Pipeline server | Delete button visibility based on user role, delete confirmation modal, deletion flow, and server state handling |
| [RHOAIENG-6317](https://redhat.atlassian.net/browse/RHOAIENG-6317) | Pipeline logs | Error handling for 404, 500, empty, and malformed log responses; multi-container log retrieval |
| [RHOAIENG-7430](https://redhat.atlassian.net/browse/RHOAIENG-7430) | Pipeline toolbar | Collapse/expand all actions in the pipeline topology toolbar |
| [RHOAIENG-6851](https://redhat.atlassian.net/browse/RHOAIENG-6851) | AI Models tab | Kebab menu "Remove asset" action — modal flow, loading state, error with retry, success with list refresh, multi-model scenarios, accessibility |

**Supporting changes:**
- New page object methods in `topology.ts` (toolbar buttons, node/edge finders), `workbench.ts` (scrollIntoView for connection rows), `pipelinesGlobal.ts` (public server action button), and `modelsTabPage.ts` (`DeleteModelModal`, `KebabMenu` classes)
- `mock500Error` helper added to `mockK8sStatus.ts`
- `data-testid="model-actions-kebab"` added to `AIModelTableRow.tsx` for reliable test selection

## How Has This Been Tested?

All new and modified Cypress mock tests were run locally in headed mode (`npx cypress open`) and verified to pass. Existing tests in the affected files were confirmed to still pass after the changes.

## Test Impact

This PR is entirely new test coverage — 13 files changed, ~1,930 lines of new mock tests and page object support. No application logic changes beyond adding a single `data-testid` attribute.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`