### PR TITLE
overhaul node_modules caching to eliminate excessive cache misses

### DIFF
--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -9,6 +9,9 @@ inputs:
   include-modules:
     required: false
     default: 'false'
+  force-install:
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -36,7 +39,7 @@ runs:
           ${{ runner.os }}-cypress-bin-
 
     - name: Install root dependencies
-      if: steps.root-cache.outputs.cache-hit != 'true'
+      if: inputs.force-install == 'true' || steps.root-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm install
 
@@ -50,7 +53,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-
 
     - name: Install automl dependencies
-      if: inputs.include-modules == 'true' && steps.automl-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.automl-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/automl/frontend
 
@@ -64,7 +67,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-
 
     - name: Install autorag dependencies
-      if: inputs.include-modules == 'true' && steps.autorag-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.autorag-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/autorag/frontend
 
@@ -78,7 +81,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-
 
     - name: Install eval-hub dependencies
-      if: inputs.include-modules == 'true' && steps.eval-hub-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.eval-hub-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/eval-hub/frontend
 
@@ -92,7 +95,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-
 
     - name: Install gen-ai dependencies
-      if: inputs.include-modules == 'true' && steps.gen-ai-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.gen-ai-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/gen-ai/frontend
 
@@ -106,7 +109,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-
 
     - name: Install maas dependencies
-      if: inputs.include-modules == 'true' && steps.maas-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.maas-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/maas/frontend
 
@@ -120,7 +123,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-
 
     - name: Install mlflow dependencies
-      if: inputs.include-modules == 'true' && steps.mlflow-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.mlflow-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/mlflow/frontend
 
@@ -134,7 +137,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-
 
     - name: Install model-registry dependencies
-      if: inputs.include-modules == 'true' && steps.model-registry-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.model-registry-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/model-registry/upstream/frontend
 
@@ -148,6 +151,6 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-
 
     - name: Install notebooks dependencies
-      if: inputs.include-modules == 'true' && steps.notebooks-cache.outputs.cache-hit != 'true'
+      if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.notebooks-cache.outputs.cache-hit != 'true')
       shell: bash
       run: npm install --prefix packages/notebooks/upstream/workspaces/frontend

--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -1,0 +1,79 @@
+name: Module caches
+description: Restores and saves root, per-module node_modules, and Cypress binary caches
+inputs:
+  node-version:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Root node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-root-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.node-version }}-modules-root-
+
+    - name: Cypress binary cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/Cypress
+        key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-cypress-bin-
+
+    - name: automl node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/automl/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-${{ hashFiles('packages/automl/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-
+
+    - name: autorag node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/autorag/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-${{ hashFiles('packages/autorag/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-
+
+    - name: eval-hub node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/eval-hub/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-
+
+    - name: gen-ai node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/gen-ai/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-
+
+    - name: maas node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/maas/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-${{ hashFiles('packages/maas/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-
+
+    - name: mlflow node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/mlflow/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-${{ hashFiles('packages/mlflow/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-
+
+    - name: model-registry node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/model-registry/upstream/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-
+
+    - name: notebooks node_modules cache
+      uses: actions/cache@v4
+      with:
+        path: packages/notebooks/upstream/workspaces/frontend/node_modules
+        key: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-${{ hashFiles('packages/notebooks/upstream/workspaces/frontend/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-

--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -3,6 +3,9 @@ description: Restores and saves root, per-module node_modules, and Cypress binar
 inputs:
   node-version:
     required: true
+  include-cypress:
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -15,6 +18,7 @@ runs:
           ${{ runner.os }}-${{ inputs.node-version }}-modules-root-
 
     - name: Cypress binary cache
+      if: inputs.include-cypress == 'true'
       uses: actions/cache@v4
       with:
         path: ~/.cache/Cypress

--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -6,13 +6,21 @@ inputs:
   include-cypress:
     required: false
     default: 'false'
+  include-modules:
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
     - name: Root node_modules cache
       uses: actions/cache@v4
       with:
-        path: node_modules
+        path: |
+          node_modules
+          backend/node_modules
+          frontend/node_modules
+          frontend/src/node_modules
+          packages/*/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-root-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.node-version }}-modules-root-
@@ -27,6 +35,7 @@ runs:
           ${{ runner.os }}-cypress-bin-
 
     - name: automl node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/automl/frontend/node_modules
@@ -34,6 +43,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-
 
     - name: autorag node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/autorag/frontend/node_modules
@@ -41,6 +51,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-
 
     - name: eval-hub node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/eval-hub/frontend/node_modules
@@ -48,6 +59,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-
 
     - name: gen-ai node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/gen-ai/frontend/node_modules
@@ -55,6 +67,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-
 
     - name: maas node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/maas/frontend/node_modules
@@ -62,6 +75,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-
 
     - name: mlflow node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/mlflow/frontend/node_modules
@@ -69,6 +83,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-
 
     - name: model-registry node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/model-registry/upstream/frontend/node_modules
@@ -76,6 +91,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-
 
     - name: notebooks node_modules cache
+      if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/notebooks/upstream/workspaces/frontend/node_modules

--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -1,5 +1,5 @@
 name: Module caches
-description: Restores and saves root, per-module node_modules, and Cypress binary caches
+description: Restores and saves root, per-module node_modules, and Cypress binary caches. Runs npm install when cache is not an exact hit.
 inputs:
   node-version:
     required: true
@@ -13,6 +13,7 @@ runs:
   using: composite
   steps:
     - name: Root node_modules cache
+      id: root-cache
       uses: actions/cache@v4
       with:
         path: |
@@ -34,7 +35,13 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cypress-bin-
 
+    - name: Install root dependencies
+      if: steps.root-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install
+
     - name: automl node_modules cache
+      id: automl-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -42,7 +49,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-${{ hashFiles('packages/automl/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-
 
+    - name: Install automl dependencies
+      if: inputs.include-modules == 'true' && steps.automl-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/automl/frontend
+
     - name: autorag node_modules cache
+      id: autorag-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -50,7 +63,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-${{ hashFiles('packages/autorag/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-
 
+    - name: Install autorag dependencies
+      if: inputs.include-modules == 'true' && steps.autorag-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/autorag/frontend
+
     - name: eval-hub node_modules cache
+      id: eval-hub-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -58,7 +77,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-
 
+    - name: Install eval-hub dependencies
+      if: inputs.include-modules == 'true' && steps.eval-hub-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/eval-hub/frontend
+
     - name: gen-ai node_modules cache
+      id: gen-ai-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -66,7 +91,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-
 
+    - name: Install gen-ai dependencies
+      if: inputs.include-modules == 'true' && steps.gen-ai-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/gen-ai/frontend
+
     - name: maas node_modules cache
+      id: maas-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -74,7 +105,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-${{ hashFiles('packages/maas/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-
 
+    - name: Install maas dependencies
+      if: inputs.include-modules == 'true' && steps.maas-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/maas/frontend
+
     - name: mlflow node_modules cache
+      id: mlflow-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -82,7 +119,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-${{ hashFiles('packages/mlflow/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-
 
+    - name: Install mlflow dependencies
+      if: inputs.include-modules == 'true' && steps.mlflow-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/mlflow/frontend
+
     - name: model-registry node_modules cache
+      id: model-registry-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
@@ -90,10 +133,21 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-
 
+    - name: Install model-registry dependencies
+      if: inputs.include-modules == 'true' && steps.model-registry-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/model-registry/upstream/frontend
+
     - name: notebooks node_modules cache
+      id: notebooks-cache
       if: inputs.include-modules == 'true'
       uses: actions/cache@v4
       with:
         path: packages/notebooks/upstream/workspaces/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-${{ hashFiles('packages/notebooks/upstream/workspaces/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-
+
+    - name: Install notebooks dependencies
+      if: inputs.include-modules == 'true' && steps.notebooks-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install --prefix packages/notebooks/upstream/workspaces/frontend

--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -28,8 +28,13 @@ runs:
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-root-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.node-version }}-modules-root-
+    - name: Install root dependencies
+      if: inputs.force-install == 'true' || steps.root-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install
 
     - name: Cypress binary cache
+      id: cypress-cache
       if: inputs.include-cypress == 'true'
       uses: actions/cache@v4
       with:
@@ -37,11 +42,10 @@ runs:
         key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-cypress-bin-
-
-    - name: Install root dependencies
-      if: inputs.force-install == 'true' || steps.root-cache.outputs.cache-hit != 'true'
+    - name: Install Cypress binaries
+      if: inputs.include-cypress == 'true' && (inputs.force-install == 'true' || steps.cypress-cache.outputs.cache-hit != 'true')
       shell: bash
-      run: npm install
+      run: npx cypress install
 
     - name: automl node_modules cache
       id: automl-cache
@@ -51,7 +55,6 @@ runs:
         path: packages/automl/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-${{ hashFiles('packages/automl/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-
-
     - name: Install automl dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.automl-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -65,7 +68,6 @@ runs:
         path: packages/autorag/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-${{ hashFiles('packages/autorag/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-
-
     - name: Install autorag dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.autorag-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -79,7 +81,6 @@ runs:
         path: packages/eval-hub/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-
-
     - name: Install eval-hub dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.eval-hub-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -93,7 +94,6 @@ runs:
         path: packages/gen-ai/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-
-
     - name: Install gen-ai dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.gen-ai-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -107,7 +107,6 @@ runs:
         path: packages/maas/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-${{ hashFiles('packages/maas/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-
-
     - name: Install maas dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.maas-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -121,7 +120,6 @@ runs:
         path: packages/mlflow/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-${{ hashFiles('packages/mlflow/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-
-
     - name: Install mlflow dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.mlflow-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -135,7 +133,6 @@ runs:
         path: packages/model-registry/upstream/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-
-
     - name: Install model-registry dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.model-registry-cache.outputs.cache-hit != 'true')
       shell: bash
@@ -149,7 +146,6 @@ runs:
         path: packages/notebooks/upstream/workspaces/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-${{ hashFiles('packages/notebooks/upstream/workspaces/frontend/package-lock.json') }}
         restore-keys: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-
-
     - name: Install notebooks dependencies
       if: inputs.include-modules == 'true' && (inputs.force-install == 'true' || steps.notebooks-cache.outputs.cache-hit != 'true')
       shell: bash

--- a/.github/workflows/automl-bff-tests.yml
+++ b/.github/workflows/automl-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "packages/automl/**"
-      - ".github/workflows/**"
+      - ".github/workflows/automl-bff-tests.yml"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/autorag-bff-tests.yml
+++ b/.github/workflows/autorag-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "packages/autorag/**"
-      - ".github/workflows/**"
+      - ".github/workflows/autorag-bff-tests.yml"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -873,6 +873,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.3.0

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -873,6 +873,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
           include-cypress: 'true'
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -881,12 +881,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install dependencies
-        run: npm install
-
-      - name: Install standalone module dependencies
-        run: npm run install:modules
-
       - name: Restore OpenShift CLI tarball cache
         uses: actions/cache/restore@v4
         id: oc-cache

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -81,7 +81,7 @@ permissions:
   statuses: write
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 22
   DO_NOT_TRACK: 1
 
 # =============================================================================
@@ -869,34 +869,21 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - name: Restore npm dependencies cache
-        uses: actions/cache/restore@v4
-        id: npm-cache
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-all-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-all-modules-
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        if: steps.npm-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install dependencies
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm install
 
-      - name: Restore turbo build artifacts cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/.turbo
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-e2e
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
+      - name: Install standalone module dependencies
+        run: npm run install:modules
 
       - name: Restore OpenShift CLI tarball cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/eval-hub-bff-tests.yml
+++ b/.github/workflows/eval-hub-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "packages/eval-hub/**"
-      - ".github/workflows/**"
+      - ".github/workflows/eval-hub-bff-tests.yml"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/eval-hub-frontend-tests.yml
+++ b/.github/workflows/eval-hub-frontend-tests.yml
@@ -47,10 +47,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-eval-hub-
 
-      - name: Install root level dependencies
-        run: npm install
-
-      - name: Install dependencies
+      - name: Install eval-hub dependencies
         working-directory: packages/eval-hub/frontend
         run: npm install
 

--- a/.github/workflows/eval-hub-frontend-tests.yml
+++ b/.github/workflows/eval-hub-frontend-tests.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - 'packages/eval-hub/**'
+      - '.github/workflows/eval-hub-frontend-tests.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'
@@ -11,6 +13,8 @@ on:
   pull_request:
     paths:
       - 'packages/eval-hub/**'
+      - '.github/workflows/eval-hub-frontend-tests.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'

--- a/.github/workflows/eval-hub-frontend-tests.yml
+++ b/.github/workflows/eval-hub-frontend-tests.yml
@@ -30,16 +30,27 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Cache npm dependencies
+      - name: Root node_modules cache
         uses: actions/cache@v4
         with:
-          path: |
-            **/node_modules
-            ~/.npm
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-${{ hashFiles('package-lock.json', 'packages/eval-hub/frontend/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+      - name: Cypress binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-bin-
+      - name: eval-hub node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: packages/eval-hub/frontend/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-eval-hub-
 
       - name: Install root level dependencies
         run: npm install

--- a/.github/workflows/eval-hub-frontend-tests.yml
+++ b/.github/workflows/eval-hub-frontend-tests.yml
@@ -30,20 +30,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Root node_modules cache
-        uses: actions/cache@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
-      - name: Cypress binary cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-bin-
+          node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: eval-hub node_modules cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -34,20 +34,11 @@ jobs:
           go-version-file: 'packages/gen-ai/bff/go.mod'
           cache-dependency-path: 'packages/gen-ai/bff/go.sum'
 
-      - name: Root node_modules cache
-        uses: actions/cache@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
-      - name: Cypress binary cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-bin-
+          node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: gen-ai node_modules cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -51,10 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-gen-ai-
 
-      - name: Install root level dependencies
-        run: npm install
-
-      - name: Install dependencies
+      - name: Install gen-ai dependencies
         working-directory: packages/gen-ai/frontend
         run: npm install
 

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -34,16 +34,27 @@ jobs:
           go-version-file: 'packages/gen-ai/bff/go.mod'
           cache-dependency-path: 'packages/gen-ai/bff/go.sum'
 
-      - name: Cache npm dependencies
+      - name: Root node_modules cache
         uses: actions/cache@v4
         with:
-          path: |
-            **/node_modules
-            ~/.npm
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-${{ hashFiles('package-lock.json', 'packages/gen-ai/frontend/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+      - name: Cypress binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-bin-
+      - name: gen-ai node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: packages/gen-ai/frontend/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-gen-ai-
 
       - name: Install root level dependencies
         run: npm install

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - 'packages/gen-ai/**'
+      - '.github/workflows/gen-ai-frontend-build.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'
@@ -11,6 +13,8 @@ on:
   pull_request:
     paths:
       - 'packages/gen-ai/**'
+      - '.github/workflows/gen-ai-frontend-build.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'

--- a/.github/workflows/maas-bff-tests.yml
+++ b/.github/workflows/maas-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "packages/maas/**"
-      - ".github/workflows/**"
+      - ".github/workflows/maas-bff-tests.yml"
       - "!LICENSE*"
       - "!DOCKERFILE*"
       - "!**.gitignore"

--- a/.github/workflows/mlflow-bff-tests.yml
+++ b/.github/workflows/mlflow-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - 'packages/mlflow/**'
-      - '.github/workflows/**'
+      - '.github/workflows/mlflow-bff-tests.yml'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'

--- a/.github/workflows/model-registry-bff-tests.yml
+++ b/.github/workflows/model-registry-bff-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - 'packages/model-registry/**'
-      - '.github/workflows/**'
+      - '.github/workflows/model-registry-bff-tests.yml'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'

--- a/.github/workflows/model-registry-frontend-tests.yml
+++ b/.github/workflows/model-registry-frontend-tests.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - 'packages/model-registry/**'
+      - '.github/workflows/model-registry-frontend-tests.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'
@@ -11,6 +13,8 @@ on:
   pull_request:
     paths:
       - 'packages/model-registry/**'
+      - '.github/workflows/model-registry-frontend-tests.yml'
+      - '.github/actions/module-caches/**'
       - '!LICENSE*'
       - '!DOCKERFILE*'
       - '!**.gitignore'

--- a/.github/workflows/model-registry-frontend-tests.yml
+++ b/.github/workflows/model-registry-frontend-tests.yml
@@ -30,20 +30,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Root node_modules cache
-        uses: actions/cache@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
-      - name: Cypress binary cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-bin-
+          node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: model-registry node_modules cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/model-registry-frontend-tests.yml
+++ b/.github/workflows/model-registry-frontend-tests.yml
@@ -30,16 +30,27 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Cache npm dependencies
+      - name: Root node_modules cache
         uses: actions/cache@v4
         with:
-          path: |
-            **/node_modules
-            ~/.npm
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-${{ hashFiles('package-lock.json', 'packages/model-registry/upstream/frontend/package-lock.json') }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-npm-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+      - name: Cypress binary cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-bin-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-bin-
+      - name: model-registry node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: packages/model-registry/upstream/frontend/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-model-registry-
 
       - name: Install root level dependencies
         run: npm install

--- a/.github/workflows/model-registry-frontend-tests.yml
+++ b/.github/workflows/model-registry-frontend-tests.yml
@@ -47,10 +47,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-model-registry-
 
-      - name: Install root level dependencies
-        run: npm install
-
-      - name: Install dependencies
+      - name: Install model-registry dependencies
         working-directory: packages/model-registry/upstream/frontend
         run: npm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,6 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install dependencies
-        run: npm install
-      - name: Install standalone module dependencies
-        run: npm run install:modules
 
       - name: Validate module federation ports
         run: npm run validate:ports
@@ -269,12 +265,6 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install dependencies
-        if: steps.cypress-build-cache.outputs.cache-hit != 'true'
-        run: npm install
-      - name: Install standalone module dependencies
-        if: steps.cypress-build-cache.outputs.cache-hit != 'true'
-        run: npm run install:modules
       - name: Build for cypress
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         run: npm run cypress:server:build:coverage -- --concurrency=4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.3.0
         with:
@@ -257,6 +258,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4.3.0
@@ -286,6 +288,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-cypress: 'true'
       - name: Restore Cypress build cache
         id: cypress-build-cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,30 +8,22 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 22.x
+  NODE_VERSION: 22
   DO_NOT_TRACK: 1
-  NODE_MODULES_CACHE_VERSION: 1
 jobs:
   Setup:
     runs-on: ubuntu-latest
-    outputs:
-      modules-cache-key: ${{ steps.key.outputs.modules-cache-key }}
     steps:
       - uses: actions/checkout@v4
       - name: Validate all package-lock.json files
         run: ./scripts/check-package-lock.sh --all
-      - name: Generate modules cache key
-        id: key
-        run: |
-          echo "modules-cache-key=${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ env.NODE_MODULES_CACHE_VERSION }}-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
-      - name: Node.js modules cache
+      - name: Root node_modules cache
         uses: actions/cache@v4
-        id: modules-cache
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ steps.key.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.3.0
         with:
@@ -54,21 +46,21 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore cache
+      - name: Restore root node_modules
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - name: Cache turbo
         uses: actions/cache@v4
         with:
           path: |
             **/.turbo
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-type-check
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-type-check-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-type-check-
       - name: Run type checks
         run: npm run type-check
 
@@ -81,21 +73,21 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore cache
+      - name: Restore root node_modules
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - name: Cache turbo
         uses: actions/cache@v4
         with:
           path: |
             **/.turbo
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-lint
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-lint-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-lint-
       - name: Run linting and formatting checks
         run: NODE_OPTIONS="--max-old-space-size=8192" npm run lint
 
@@ -108,21 +100,21 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore cache
+      - name: Restore root node_modules
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - name: Cache turbo
         uses: actions/cache@v4
         with:
           path: |
             **/.turbo
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-${{ github.sha }}-unit-tests
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-unit-tests-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-turbo-unit-tests-
       - name: Unit tests with coverage
         run: |
           npm run test-unit-coverage
@@ -144,13 +136,13 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore cache
+      - name: Restore root node_modules
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - id: set-groups
         shell: bash
         run: |
@@ -224,13 +216,13 @@ jobs:
             packages/model-registry/upstream/bff/go.sum
             packages/gen-ai/bff/go.sum
             packages/mlflow/bff/go.sum
-      - name: Restore cache
+      - name: Restore root node_modules
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
       - name: Run contract tests
         run: |
           export GITHUB_RUN_ID="$GITHUB_RUN_ID"
@@ -276,19 +268,19 @@ jobs:
           path: |
             **/public-cypress
           key: ${{ steps.key.outputs.cypress-cache-key }}
-      - name: Restore cache
+      - name: Module caches
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v4
+        uses: ./.github/actions/module-caches
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Install standalone module dependencies
+        if: steps.cypress-build-cache.outputs.cache-hit != 'true'
+        run: npm run install:modules
       - name: Build for cypress
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         run: npm run cypress:server:build:coverage -- --concurrency=4
@@ -306,13 +298,10 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore cache
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: |
-            ~/.cache/Cypress
-            **/node_modules
-          key: ${{ needs.Setup.outputs.modules-cache-key }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Restore Cypress build cache
         id: cypress-build-cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
           include-cypress: 'true'
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.3.0
@@ -258,6 +259,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
           include-cypress: 'true'
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
@@ -288,6 +290,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
           include-cypress: 'true'
       - name: Restore Cypress build cache
         id: cypress-build-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,19 +17,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate all package-lock.json files
         run: ./scripts/check-package-lock.sh --all
-      - name: Root node_modules cache
-        uses: actions/cache@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
         run: npm install
+      - name: Install standalone module dependencies
+        run: npm run install:modules
 
       - name: Validate module federation ports
         run: npm run validate:ports
@@ -46,13 +45,10 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore root node_modules
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -73,13 +69,10 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore root node_modules
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -100,13 +93,10 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore root node_modules
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -136,13 +126,10 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Restore root node_modules
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - id: set-groups
         shell: bash
         run: |
@@ -216,13 +203,10 @@ jobs:
             packages/model-registry/upstream/bff/go.sum
             packages/gen-ai/bff/go.sum
             packages/mlflow/bff/go.sum
-      - name: Restore root node_modules
-        uses: actions/cache/restore@v4
+      - name: Module caches
+        uses: ./.github/actions/module-caches
         with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-root-
+          node-version: ${{ env.NODE_VERSION }}
       - name: Run contract tests
         run: |
           export GITHUB_RUN_ID="$GITHUB_RUN_ID"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate all package-lock.json files
         run: ./scripts/check-package-lock.sh --all
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
           include-modules: 'true'
           include-cypress: 'true'
-      - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+          force-install: 'true'
 
       - name: Validate module federation ports
         run: npm run validate:ports
@@ -47,7 +48,6 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
-          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -97,7 +97,6 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
-          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -268,6 +269,9 @@ jobs:
         uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Install dependencies
+        if: steps.cypress-build-cache.outputs.cache-hit != 'true'
+        run: npm install
       - name: Install standalone module dependencies
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
         run: npm run install:modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:
@@ -75,6 +76,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         uses: ./.github/actions/module-caches
         with:
           node-version: ${{ env.NODE_VERSION }}
+          include-modules: 'true'
       - name: Cache turbo
         uses: actions/cache@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "odh-dashboard",
       "version": "2.0.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cypress:server:dev": "turbo run cypress:server:dev",
     "cypress:server:build": "turbo run cypress:server:build",
     "cypress:server:build:coverage": "turbo run cypress:server:build:coverage",
-    "postinstall": "turbo run install:module --ui=stream",
+    "install:modules": "turbo run install:module --ui=stream",
     "test-e2e:dev": "concurrently --hide=0 -k -s first \"turbo run start:dev\" \"turbo run start:dev:wait && npm run test:cypress:e2e --prefix frontend\"",
     "start:dev": "turbo run start:dev",
     "start:dev:ext": "turbo run start:dev:ext"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-60448

## Description

Overhauls the CI caching strategy for `node_modules` to eliminate excessive cache misses and reduce storage bloat.

**Problems solved:**
- Monolithic cache keyed on all 10 `package-lock.json` files was invalidated by almost every commit, causing full cold installs (~3-5 min) on nearly every CI run
- `postinstall` installed all 8 standalone frontend modules on every `npm install`, even for jobs that don't need them
- Turbo cache restore-keys were too broad, causing tasks to restore wrong-task caches
- Standalone module workflows used incompatible cache keys, preventing cross-workflow sharing
- `~/.cache/Cypress` was bundled with root `node_modules`, forcing non-Cypress jobs to download it
- Root cache only stored top-level `node_modules/`, missing workspace package `node_modules/` directories
- BFF workflow `paths` triggers used `.github/workflows/**`, causing all 6 BFF workflows to run on any workflow file change
- `NODE_VERSION` mismatch (`22.x` vs `22`) between workflows prevented cross-workflow cache sharing
- E2E workflow used `npm ci` (destructive) and had a dead turbo cache restore step

**Changes:**

Cache architecture:
- Split monolithic cache into per-module caches (root + 8 module frontends + Cypress binary), each keyed on its own lockfile with `restore-keys` for warm fallbacks
- Root cache covers all workspace `node_modules` paths (`node_modules`, `backend/node_modules`, `frontend/node_modules`, `frontend/src/node_modules`, `packages/*/node_modules`)
- Separated `~/.cache/Cypress` into its own cache with `npx cypress install` to ensure all binaries are present
- Extracted cache + install logic into `.github/actions/module-caches/action.yml` composite action with `include-modules`, `include-cypress`, and `force-install` parameters
- Composite action handles `npm install` on cache miss for each scope, eliminating redundant install steps in workflows

Install optimization:
- Renamed `postinstall` to explicit `install:modules` script
- Setup job uses `force-install` to always run installs; downstream jobs only install on cache miss
- E2E workflow uses `npm install` (incremental) instead of `npm ci` (destructive)

Turbo caches:
- Key order changed from `turbo-{sha}-{task}` to `turbo-{task}-{sha}` so restore-keys are task-specific
- Removed dead turbo cache restore from E2E workflow

Workflow hygiene:
- Aligned `NODE_VERSION` to `22` across all workflows
- Removed `NODE_MODULES_CACHE_VERSION` env var
- BFF workflows reference only their own file in `paths` instead of `.github/workflows/**`
- Frontend module workflows trigger on changes to their own workflow file and the composite action

> **Note:** Removing `postinstall` means developers who want to work with standalone modules locally need to run `npm run install:modules`.

## How Has This Been Tested?

CI workflow changes -- verified by reviewing cache key generation logic, restore-key prefix matching, and job dependency graph. CI runs confirmed cache hits and installs work correctly.

## Test Impact

No application test changes. This PR modifies CI workflow configuration and `package.json` scripts only. Existing tests run identically; only the caching and install layer changes.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflows with refined caching strategy for faster build times, splitting broad dependency caches into targeted segments for root modules, frontend packages, and Cypress binaries.
  * Added new composite GitHub Action for consistent module caching across workflows.
  * Refactored module installation script from automatic to manual invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->