### PR TITLE
Replace MCP deployment Phase with Conditions-based status model

### DIFF
--- a/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mcpCatalog/mcpDeployments.cy.ts
@@ -88,7 +88,7 @@ describe('MCP Deployments', () => {
     initIntercepts();
     visitDeployments();
     mcpDeploymentsPage.findTable().should('be.visible');
-    mcpDeploymentsPage.findTableRows().should('have.length', 3);
+    mcpDeploymentsPage.findTableRows().should('have.length', 6);
 
     const runningRow = mcpDeploymentsPage.getRow('kubernetes-mcp');
     runningRow.findServer().should('contain.text', 'Kubernetes');
@@ -106,6 +106,21 @@ describe('MCP Deployments', () => {
     failedRow.findStatusLabel().should('contain.text', 'Unavailable');
     failedRow.findServiceUnavailable().should('exist').and('have.text', '\u2013');
     failedRow.findServiceViewButton().should('not.exist');
+
+    const initRow = mcpDeploymentsPage.getRow('init-mcp');
+    initRow.findStatusLabel().should('contain.text', 'Initializing');
+    initRow.findServiceUnavailable().should('exist').and('have.text', '\u2013');
+    initRow.findServiceViewButton().should('not.exist');
+
+    const invalidRow = mcpDeploymentsPage.getRow('invalid-mcp');
+    invalidRow.findStatusLabel().should('contain.text', 'Configuration invalid');
+    invalidRow.findServiceUnavailable().should('exist').and('have.text', '\u2013');
+    invalidRow.findServiceViewButton().should('not.exist');
+
+    const scaledRow = mcpDeploymentsPage.getRow('scaled-mcp');
+    scaledRow.findStatusLabel().should('contain.text', 'Scaled to zero');
+    scaledRow.findServiceUnavailable().should('exist').and('have.text', '\u2013');
+    scaledRow.findServiceViewButton().should('not.exist');
   });
 
   it('should default-sort rows by Created with newest first', () => {

--- a/packages/cypress/cypress/utils/mcpDeploymentUtils.ts
+++ b/packages/cypress/cypress/utils/mcpDeploymentUtils.ts
@@ -1,8 +1,29 @@
 import {
   type McpDeployment,
+  type McpDeploymentCondition,
   type MCPServerCR,
-  McpDeploymentPhase,
+  McpConditionType,
+  McpConditionStatus,
+  McpAcceptedReason,
+  McpReadyReason,
 } from '@odh-dashboard/model-registry/types/mcpDeploymentTypes';
+
+const acceptedValid = (): McpDeploymentCondition => ({
+  type: McpConditionType.ACCEPTED,
+  status: McpConditionStatus.TRUE,
+  reason: McpAcceptedReason.VALID,
+});
+
+const readyCondition = (
+  status: McpConditionStatus,
+  reason: string,
+  message?: string,
+): McpDeploymentCondition => ({
+  type: McpConditionType.READY,
+  status,
+  reason,
+  message,
+});
 
 export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeployment => ({
   name: 'kubernetes-mcp',
@@ -12,7 +33,7 @@ export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeploy
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
-  phase: McpDeploymentPhase.RUNNING,
+  conditions: [acceptedValid(), readyCondition(McpConditionStatus.TRUE, McpReadyReason.AVAILABLE)],
   address: { url: 'http://kubernetes-mcp.test-project.svc:8080/sse' },
   ...overrides,
 });
@@ -35,7 +56,7 @@ export const mockPendingDeployment = (overrides?: Partial<McpDeployment>): McpDe
     uid: 'uid-2',
     creationTimestamp: '2026-03-11T10:00:00Z',
     image: 'quay.io/mcp-servers/github:2.1.0',
-    phase: McpDeploymentPhase.PENDING,
+    conditions: [],
     address: undefined,
     ...overrides,
   });
@@ -48,7 +69,62 @@ export const mockFailedDeployment = (overrides?: Partial<McpDeployment>): McpDep
     uid: 'uid-3',
     creationTimestamp: '2026-03-12T08:00:00Z',
     image: 'quay.io/mcp-servers/slack:1.0.0',
-    phase: McpDeploymentPhase.FAILED,
+    conditions: [
+      acceptedValid(),
+      readyCondition(McpConditionStatus.FALSE, McpReadyReason.DEPLOYMENT_UNAVAILABLE),
+    ],
+    address: undefined,
+    ...overrides,
+  });
+
+export const mockInitializingDeployment = (overrides?: Partial<McpDeployment>): McpDeployment =>
+  mockMcpDeployment({
+    name: 'init-mcp',
+    displayName: 'Init MCP',
+    serverName: 'Init',
+    uid: 'uid-4',
+    creationTimestamp: '2026-03-13T09:00:00Z',
+    image: 'quay.io/mcp-servers/init:1.0.0',
+    conditions: [
+      acceptedValid(),
+      readyCondition(McpConditionStatus.FALSE, McpReadyReason.INITIALIZING),
+    ],
+    address: undefined,
+    ...overrides,
+  });
+
+export const mockConfigInvalidDeployment = (overrides?: Partial<McpDeployment>): McpDeployment =>
+  mockMcpDeployment({
+    name: 'invalid-mcp',
+    displayName: 'Invalid MCP',
+    serverName: 'Invalid',
+    uid: 'uid-5',
+    creationTimestamp: '2026-03-14T09:00:00Z',
+    image: 'quay.io/mcp-servers/invalid:1.0.0',
+    conditions: [
+      {
+        type: McpConditionType.ACCEPTED,
+        status: McpConditionStatus.FALSE,
+        reason: McpAcceptedReason.INVALID,
+        message: 'Invalid port configuration.',
+      },
+    ],
+    address: undefined,
+    ...overrides,
+  });
+
+export const mockScaledToZeroDeployment = (overrides?: Partial<McpDeployment>): McpDeployment =>
+  mockMcpDeployment({
+    name: 'scaled-mcp',
+    displayName: 'Scaled MCP',
+    serverName: 'Scaled',
+    uid: 'uid-6',
+    creationTimestamp: '2026-03-15T09:00:00Z',
+    image: 'quay.io/mcp-servers/scaled:1.0.0',
+    conditions: [
+      acceptedValid(),
+      readyCondition(McpConditionStatus.TRUE, McpReadyReason.SCALED_TO_ZERO),
+    ],
     address: undefined,
     ...overrides,
   });
@@ -57,6 +133,9 @@ export const mockAllDeployments = (): McpDeployment[] => [
   mockRunningDeployment(),
   mockPendingDeployment(),
   mockFailedDeployment(),
+  mockInitializingDeployment(),
+  mockConfigInvalidDeployment(),
+  mockScaledToZeroDeployment(),
 ];
 
 export const mockDeploymentListResponse = (

--- a/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
@@ -3251,10 +3251,9 @@ func GetMcpDeploymentMocks() []models.McpDeployment {
 			UID:               "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 			CreationTimestamp: "2026-03-10T14:30:00Z",
 			Image:             "quay.io/mcp-servers/kubernetes:1.0.0",
-			Phase:             models.McpDeploymentPhaseRunning,
 			Conditions: []models.McpDeploymentCondition{
-				{Type: "Available", Status: "True", LastTransitionTime: "2026-03-10T14:32:00Z", Reason: "DeploymentAvailable"},
-				{Type: "Progressing", Status: "True", LastTransitionTime: "2026-03-10T14:31:00Z", Reason: "NewReplicaSetAvailable"},
+				{Type: "Accepted", Status: "True", LastTransitionTime: "2026-03-10T14:31:00Z", Reason: "Valid"},
+				{Type: "Ready", Status: "True", LastTransitionTime: "2026-03-10T14:32:00Z", Reason: "Available"},
 			},
 		},
 		{
@@ -3264,10 +3263,9 @@ func GetMcpDeploymentMocks() []models.McpDeployment {
 			UID:               "b2c3d4e5-f6a7-8901-bcde-f12345678901",
 			CreationTimestamp: "2026-03-14T11:00:00Z",
 			Image:             "quay.io/mcp-servers/slack:0.5.0",
-			Phase:             models.McpDeploymentPhasePending,
 			Conditions: []models.McpDeploymentCondition{
-				{Type: "Available", Status: "False", LastTransitionTime: "2026-03-14T11:00:00Z", Reason: "MinimumReplicasUnavailable"},
-				{Type: "Progressing", Status: "True", LastTransitionTime: "2026-03-14T11:00:00Z", Reason: "ReplicaSetUpdated"},
+				{Type: "Accepted", Status: "True", LastTransitionTime: "2026-03-14T11:00:00Z", Reason: "Valid"},
+				{Type: "Ready", Status: "False", LastTransitionTime: "2026-03-14T11:00:00Z", Reason: "Initializing", Message: "Waiting for pods to become ready."},
 			},
 		},
 		{
@@ -3277,10 +3275,9 @@ func GetMcpDeploymentMocks() []models.McpDeployment {
 			UID:               "c3d4e5f6-a7b8-9012-cdef-123456789012",
 			CreationTimestamp: "2026-03-08T16:45:00Z",
 			Image:             "quay.io/mcp-servers/jira:1.2.0",
-			Phase:             models.McpDeploymentPhaseFailed,
 			Conditions: []models.McpDeploymentCondition{
-				{Type: "Available", Status: "False", LastTransitionTime: "2026-03-08T16:50:00Z", Reason: "MinimumReplicasUnavailable"},
-				{Type: "Progressing", Status: "False", LastTransitionTime: "2026-03-08T16:55:00Z", Reason: "ProgressDeadlineExceeded"},
+				{Type: "Accepted", Status: "True", LastTransitionTime: "2026-03-08T16:46:00Z", Reason: "Valid"},
+				{Type: "Ready", Status: "False", LastTransitionTime: "2026-03-08T16:55:00Z", Reason: "DeploymentUnavailable", Message: "Pod crashed."},
 			},
 		},
 	}

--- a/packages/model-registry/upstream/bff/internal/models/mcp_deployment.go
+++ b/packages/model-registry/upstream/bff/internal/models/mcp_deployment.go
@@ -1,13 +1,5 @@
 package models
 
-type McpDeploymentPhase string
-
-const (
-	McpDeploymentPhasePending McpDeploymentPhase = "Pending"
-	McpDeploymentPhaseRunning McpDeploymentPhase = "Running"
-	McpDeploymentPhaseFailed  McpDeploymentPhase = "Failed"
-)
-
 type McpDeploymentCondition struct {
 	Type               string `json:"type"`
 	Status             string `json:"status"`
@@ -31,8 +23,7 @@ type McpDeployment struct {
 	CreationTimestamp string                   `json:"creationTimestamp"`
 	Image             string                   `json:"image"`
 	YAML              string                   `json:"yaml,omitempty"`
-	Phase             McpDeploymentPhase       `json:"phase"`
-	Conditions        []McpDeploymentCondition `json:"conditions,omitempty"`
+	Conditions        []McpDeploymentCondition `json:"conditions"`
 	Address           *McpDeploymentAddress    `json:"address,omitempty"`
 }
 

--- a/packages/model-registry/upstream/bff/internal/redhat/handlers/mcp_deployments_test.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/handlers/mcp_deployments_test.go
@@ -86,8 +86,8 @@ func TestMcpDeploymentListReturnsDeployments(t *testing.T) {
 			}
 			return models.McpDeploymentList{
 				Items: []models.McpDeployment{
-					{Name: "kubernetes-mcp", Phase: models.McpDeploymentPhaseRunning},
-					{Name: "slack-mcp", Phase: models.McpDeploymentPhasePending},
+					{Name: "kubernetes-mcp", Conditions: []models.McpDeploymentCondition{{Type: "Ready", Status: "True", Reason: "Available"}}},
+					{Name: "slack-mcp", Conditions: []models.McpDeploymentCondition{{Type: "Ready", Status: "False", Reason: "Initializing"}}},
 				},
 				Size: 2,
 			}, nil
@@ -243,7 +243,7 @@ func TestMcpDeploymentCreateReturnsCreated(t *testing.T) {
 				Namespace:         namespace,
 				CreationTimestamp: "2026-03-26T10:00:00Z",
 				Image:             req.Image,
-				Phase:             models.McpDeploymentPhasePending,
+				Conditions:        []models.McpDeploymentCondition{},
 			}, nil
 		},
 	}
@@ -268,8 +268,8 @@ func TestMcpDeploymentCreateReturnsCreated(t *testing.T) {
 	if resp.Data.Name != "github-mcp" {
 		t.Fatalf("expected name 'github-mcp', got %q", resp.Data.Name)
 	}
-	if resp.Data.Phase != models.McpDeploymentPhasePending {
-		t.Fatalf("expected phase Pending, got %q", resp.Data.Phase)
+	if len(resp.Data.Conditions) != 0 {
+		t.Fatalf("expected empty conditions, got %+v", resp.Data.Conditions)
 	}
 }
 
@@ -421,7 +421,7 @@ func TestMcpDeploymentUpdateReturnsOK(t *testing.T) {
 				Namespace:         namespace,
 				CreationTimestamp: "2026-03-10T14:30:00Z",
 				Image:             *req.Image,
-				Phase:             models.McpDeploymentPhaseRunning,
+				Conditions:        []models.McpDeploymentCondition{{Type: "Ready", Status: "True", Reason: "Available"}},
 			}, nil
 		},
 	}
@@ -577,7 +577,7 @@ func TestMcpDeploymentGetReturnsDeployment(t *testing.T) {
 				UID:               "abc-123",
 				CreationTimestamp: "2026-03-10T14:30:00Z",
 				Image:             "quay.io/mcp-servers/kubernetes:1.0.0",
-				Phase:             models.McpDeploymentPhaseRunning,
+				Conditions:        []models.McpDeploymentCondition{{Type: "Ready", Status: "True", Reason: "Available"}},
 			}, nil
 		},
 	}

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository.go
@@ -331,7 +331,6 @@ func convertUnstructuredToMcpDeployment(obj unstructured.Unstructured) (models.M
 		Namespace:         server.Metadata.Namespace,
 		UID:               string(obj.GetUID()),
 		CreationTimestamp: obj.GetCreationTimestamp().UTC().Format("2006-01-02T15:04:05Z"),
-		Phase:             models.McpDeploymentPhasePending,
 	}
 
 	if server.Metadata.Annotations != nil {
@@ -349,7 +348,7 @@ func convertUnstructuredToMcpDeployment(obj unstructured.Unstructured) (models.M
 	}
 	deployment.YAML = marshalSpecToYAML(specBody)
 
-	deployment.Phase, deployment.Conditions = extractMcpServerStatus(obj)
+	deployment.Conditions = extractMcpServerConditions(obj)
 	deployment.Address = extractMcpServerAddress(obj)
 
 	return deployment, nil
@@ -467,25 +466,18 @@ func marshalSpecToYAML(spec models.McpSpecBody) string {
 	return string(yamlBytes)
 }
 
-func extractMcpServerStatus(obj unstructured.Unstructured) (models.McpDeploymentPhase, []models.McpDeploymentCondition) {
-	phase := models.McpDeploymentPhasePending
-	var conditions []models.McpDeploymentCondition
-
+func extractMcpServerConditions(obj unstructured.Unstructured) []models.McpDeploymentCondition {
 	status, ok := obj.Object["status"].(map[string]interface{})
 	if !ok {
-		return phase, conditions
-	}
-
-	if p, ok := status["phase"].(string); ok && p != "" {
-		phase = models.McpDeploymentPhase(p)
+		return []models.McpDeploymentCondition{}
 	}
 
 	condList, ok := status["conditions"].([]interface{})
 	if !ok {
-		return phase, conditions
+		return []models.McpDeploymentCondition{}
 	}
 
-	conditions = make([]models.McpDeploymentCondition, 0, len(condList))
+	conditions := make([]models.McpDeploymentCondition, 0, len(condList))
 	for _, item := range condList {
 		c, ok := item.(map[string]interface{})
 		if !ok {
@@ -500,7 +492,7 @@ func extractMcpServerStatus(obj unstructured.Unstructured) (models.McpDeployment
 		})
 	}
 
-	return phase, conditions
+	return conditions
 }
 
 func extractMcpServerAddress(obj unstructured.Unstructured) *models.McpDeploymentAddress {

--- a/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
+++ b/packages/model-registry/upstream/bff/internal/redhat/repositories/mcp_deployment_repository_test.go
@@ -412,77 +412,74 @@ func TestConvertUnstructuredToMcpDeployment_NoAnnotations(t *testing.T) {
 	}
 }
 
-// extractMcpServerStatus
-func TestExtractMcpServerStatus_NoStatus(t *testing.T) {
+// extractMcpServerConditions
+func TestExtractMcpServerConditions_NoStatus(t *testing.T) {
 	obj := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{"name": "test"},
 		},
 	}
 
-	phase, conditions := extractMcpServerStatus(obj)
-	if phase != models.McpDeploymentPhasePending {
-		t.Fatalf("expected phase Pending, got %q", phase)
-	}
-	if conditions != nil {
-		t.Fatalf("expected nil conditions, got %+v", conditions)
+	conditions := extractMcpServerConditions(obj)
+	if len(conditions) != 0 {
+		t.Fatalf("expected empty conditions, got %+v", conditions)
 	}
 }
 
-func TestExtractMcpServerStatus_WithPhase(t *testing.T) {
+func TestExtractMcpServerConditions_NoConditions(t *testing.T) {
 	obj := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{"name": "test"},
-			"status": map[string]interface{}{
-				"phase": "Running",
-			},
+			"status":   map[string]interface{}{},
 		},
 	}
 
-	phase, _ := extractMcpServerStatus(obj)
-	if phase != models.McpDeploymentPhaseRunning {
-		t.Fatalf("expected phase Running, got %q", phase)
+	conditions := extractMcpServerConditions(obj)
+	if len(conditions) != 0 {
+		t.Fatalf("expected empty conditions, got %+v", conditions)
 	}
 }
 
-func TestExtractMcpServerStatus_WithConditions(t *testing.T) {
+func TestExtractMcpServerConditions_WithConditions(t *testing.T) {
 	obj := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{"name": "test"},
 			"status": map[string]interface{}{
-				"phase": "Running",
 				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":               "Accepted",
+						"status":             "True",
+						"lastTransitionTime": "2026-03-30T10:00:00Z",
+						"reason":             "Valid",
+						"message":            "Configuration is valid",
+					},
 					map[string]interface{}{
 						"type":               "Ready",
 						"status":             "True",
-						"lastTransitionTime": "2026-03-30T10:00:00Z",
-						"reason":             "AllGood",
+						"lastTransitionTime": "2026-03-30T10:01:00Z",
+						"reason":             "Available",
 						"message":            "Server is running",
-					},
-					map[string]interface{}{
-						"type":   "Available",
-						"status": "True",
 					},
 				},
 			},
 		},
 	}
 
-	phase, conditions := extractMcpServerStatus(obj)
-	if phase != models.McpDeploymentPhaseRunning {
-		t.Fatalf("expected phase Running, got %q", phase)
-	}
+	conditions := extractMcpServerConditions(obj)
 	if len(conditions) != 2 {
 		t.Fatalf("expected 2 conditions, got %d", len(conditions))
 	}
-	if conditions[0].Type != "Ready" {
-		t.Fatalf("expected first condition type 'Ready', got %q", conditions[0].Type)
+	if conditions[0].Type != "Accepted" {
+		t.Fatalf("expected first condition type 'Accepted', got %q", conditions[0].Type)
 	}
-	if conditions[0].Reason != "AllGood" {
-		t.Fatalf("expected reason 'AllGood', got %q", conditions[0].Reason)
+	if conditions[0].Reason != "Valid" {
+		t.Fatalf("expected reason 'Valid', got %q", conditions[0].Reason)
 	}
-	if conditions[1].Type != "Available" {
-		t.Fatalf("expected second condition type 'Available', got %q", conditions[1].Type)
+	if conditions[1].Type != "Ready" {
+		t.Fatalf("expected second condition type 'Ready', got %q", conditions[1].Type)
+	}
+	if conditions[1].Reason != "Available" {
+		t.Fatalf("expected reason 'Available', got %q", conditions[1].Reason)
 	}
 }
 
@@ -559,13 +556,19 @@ func TestExtractMcpServerAddress_WithURL(t *testing.T) {
 func TestConvertUnstructuredToMcpDeployment_WithStatusAndAddress(t *testing.T) {
 	obj := newTestUnstructured("k8s-mcp", "test-ns", "quay.io/mcp/k8s:1.0", 8080)
 	obj.Object["status"] = map[string]interface{}{
-		"phase": "Running",
 		"conditions": []interface{}{
+			map[string]interface{}{
+				"type":               "Accepted",
+				"status":             "True",
+				"lastTransitionTime": "2026-03-30T10:04:00Z",
+				"reason":             "Valid",
+				"message":            "Configuration is valid",
+			},
 			map[string]interface{}{
 				"type":               "Ready",
 				"status":             "True",
 				"lastTransitionTime": "2026-03-30T10:05:00Z",
-				"reason":             "DeploymentAvailable",
+				"reason":             "Available",
 				"message":            "Deployment is available and ready",
 			},
 		},
@@ -579,14 +582,14 @@ func TestConvertUnstructuredToMcpDeployment_WithStatusAndAddress(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if deployment.Phase != models.McpDeploymentPhaseRunning {
-		t.Fatalf("expected phase Running, got %q", deployment.Phase)
+	if len(deployment.Conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(deployment.Conditions))
 	}
-	if len(deployment.Conditions) != 1 {
-		t.Fatalf("expected 1 condition, got %d", len(deployment.Conditions))
+	if deployment.Conditions[0].Type != "Accepted" {
+		t.Fatalf("expected first condition type 'Accepted', got %q", deployment.Conditions[0].Type)
 	}
-	if deployment.Conditions[0].Reason != "DeploymentAvailable" {
-		t.Fatalf("expected reason 'DeploymentAvailable', got %q", deployment.Conditions[0].Reason)
+	if deployment.Conditions[1].Reason != "Available" {
+		t.Fatalf("expected reason 'Available', got %q", deployment.Conditions[1].Reason)
 	}
 	if deployment.Address == nil {
 		t.Fatal("expected address to be populated")
@@ -599,12 +602,11 @@ func TestConvertUnstructuredToMcpDeployment_WithStatusAndAddress(t *testing.T) {
 func TestConvertUnstructuredToMcpDeployment_FailedNoAddress(t *testing.T) {
 	obj := newTestUnstructured("broken-mcp", "test-ns", "quay.io/fake:bad", 8080)
 	obj.Object["status"] = map[string]interface{}{
-		"phase": "Failed",
 		"conditions": []interface{}{
 			map[string]interface{}{
 				"type":   "Ready",
 				"status": "False",
-				"reason": "DeploymentFailed",
+				"reason": "DeploymentUnavailable",
 			},
 		},
 	}
@@ -614,8 +616,11 @@ func TestConvertUnstructuredToMcpDeployment_FailedNoAddress(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if deployment.Phase != models.McpDeploymentPhaseFailed {
-		t.Fatalf("expected phase Failed, got %q", deployment.Phase)
+	if len(deployment.Conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(deployment.Conditions))
+	}
+	if deployment.Conditions[0].Reason != "DeploymentUnavailable" {
+		t.Fatalf("expected reason 'DeploymentUnavailable', got %q", deployment.Conditions[0].Reason)
 	}
 	if deployment.Address != nil {
 		t.Fatalf("expected nil address for failed deployment without address, got %+v", deployment.Address)

--- a/packages/model-registry/upstream/frontend/src/__mocks__/mockMcpDeployment.ts
+++ b/packages/model-registry/upstream/frontend/src/__mocks__/mockMcpDeployment.ts
@@ -2,9 +2,39 @@
 import {
   McpDeployment,
   McpDeploymentList,
-  McpDeploymentPhase,
+  McpDeploymentCondition,
+  McpConditionType,
+  McpConditionStatus,
+  McpAcceptedReason,
+  McpReadyReason,
   MCPServerCR,
 } from '../odh/types/mcpDeploymentTypes';
+
+export const mockMcpCondition = (
+  overrides?: Partial<McpDeploymentCondition>,
+): McpDeploymentCondition => ({
+  type: McpConditionType.READY,
+  status: McpConditionStatus.TRUE,
+  lastTransitionTime: '2026-03-10T14:31:00Z',
+  reason: McpReadyReason.AVAILABLE,
+  message: 'The MCP server is ready and serving requests.',
+  ...overrides,
+});
+
+export const mockReadyConditions = (): McpDeploymentCondition[] => [
+  mockMcpCondition({
+    type: McpConditionType.ACCEPTED,
+    status: McpConditionStatus.TRUE,
+    reason: McpAcceptedReason.VALID,
+    message: 'Configuration is valid.',
+  }),
+  mockMcpCondition({
+    type: McpConditionType.READY,
+    status: McpConditionStatus.TRUE,
+    reason: McpReadyReason.AVAILABLE,
+    message: 'The MCP server is ready and serving requests.',
+  }),
+];
 
 export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeployment => ({
   name: 'kubernetes-mcp',
@@ -14,7 +44,7 @@ export const mockMcpDeployment = (overrides?: Partial<McpDeployment>): McpDeploy
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
-  phase: McpDeploymentPhase.RUNNING,
+  conditions: mockReadyConditions(),
   address: { url: 'http://kubernetes-mcp.test-project.svc:8080/sse' },
   ...overrides,
 });

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentStatusLabel.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentStatusLabel.tsx
@@ -1,25 +1,31 @@
 import * as React from 'react';
 import { Label, Popover } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
-import { McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
-import { getStatusInfo } from './utils';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InProgressIcon,
+} from '@patternfly/react-icons';
+import { McpDeploymentCondition } from '~/odh/types/mcpDeploymentTypes';
+import { getStatusInfo, McpDeploymentStatusInfo } from './utils';
 
 type McpDeploymentStatusLabelProps = {
-  phase: McpDeploymentPhase;
+  conditions: McpDeploymentCondition[];
 };
 
-const statusIconMap: Record<McpDeploymentPhase, React.ReactNode> = {
-  [McpDeploymentPhase.RUNNING]: <CheckCircleIcon />,
-  [McpDeploymentPhase.FAILED]: <ExclamationCircleIcon />,
-  [McpDeploymentPhase.PENDING]: <InProgressIcon />,
+const statusIconMap: Record<McpDeploymentStatusInfo['status'], React.ReactNode> = {
+  success: <CheckCircleIcon />,
+  danger: <ExclamationCircleIcon />,
+  warning: <ExclamationTriangleIcon />,
+  info: <InProgressIcon />,
 };
 
-const McpDeploymentStatusLabel: React.FC<McpDeploymentStatusLabelProps> = ({ phase }) => {
-  const { label, status, popoverBody } = getStatusInfo(phase);
+const McpDeploymentStatusLabel: React.FC<McpDeploymentStatusLabelProps> = ({ conditions }) => {
+  const { label, status, popoverBody } = getStatusInfo(conditions);
 
   return (
     <Popover bodyContent={popoverBody} data-testid="mcp-deployment-status-popover">
-      <Label status={status} icon={statusIconMap[phase]} data-testid="mcp-deployment-status-label">
+      <Label status={status} icon={statusIconMap[status]} data-testid="mcp-deployment-status-label">
         {label}
       </Label>
     </Popover>

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentsTableColumns.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentsTableColumns.ts
@@ -1,12 +1,6 @@
 import { SortableData } from 'mod-arch-shared';
-import { McpDeployment, McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
-import { getDeploymentDisplayName } from './utils';
-
-const phaseOrder: Record<McpDeploymentPhase, number> = {
-  [McpDeploymentPhase.RUNNING]: 0,
-  [McpDeploymentPhase.PENDING]: 1,
-  [McpDeploymentPhase.FAILED]: 2,
-};
+import { McpDeployment } from '~/odh/types/mcpDeploymentTypes';
+import { getDeploymentDisplayName, getStatusSortWeight } from './utils';
 
 export const mcpDeploymentColumns: SortableData<McpDeployment>[] = [
   {
@@ -31,7 +25,7 @@ export const mcpDeploymentColumns: SortableData<McpDeployment>[] = [
   {
     field: 'status',
     label: 'Status',
-    sortable: (a, b) => phaseOrder[a.phase] - phaseOrder[b.phase],
+    sortable: (a, b) => getStatusSortWeight(a.conditions) - getStatusSortWeight(b.conditions),
     width: 15,
   },
   {

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentsTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/McpDeploymentsTableRow.tsx
@@ -46,7 +46,7 @@ const McpDeploymentsTableRow: React.FC<McpDeploymentsTableRowProps> = ({
         />
       </Td>
       <Td dataLabel="Status" data-testid="mcp-deployment-status">
-        <McpDeploymentStatusLabel phase={deployment.phase} />
+        <McpDeploymentStatusLabel conditions={deployment.conditions} />
       </Td>
       <Td dataLabel="Service" data-testid="mcp-deployment-service">
         <McpDeploymentServicePopover deployment={deployment} />

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/McpDeploymentsTable.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/McpDeploymentsTable.spec.tsx
@@ -3,34 +3,35 @@ import * as React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { McpDeployment, McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
+import { McpDeployment } from '~/odh/types/mcpDeploymentTypes';
 import McpDeploymentsTable from '~/odh/pages/mcpDeployments/McpDeploymentsTable';
+import {
+  createMockDeployment,
+  createReadyConditions,
+  createInitializingConditions,
+  createFailedConditions,
+} from './mcpDeploymentTestUtils';
 
 const mockDeployments: McpDeployment[] = [
-  {
+  createMockDeployment({
     name: 'kubernetes-mcp',
-    namespace: 'mcp-servers',
     uid: 'uid-1',
-    creationTimestamp: '2026-03-10T14:30:00Z',
-    image: 'quay.io/mcp-servers/kubernetes:1.0.0',
-    phase: McpDeploymentPhase.RUNNING,
-  },
-  {
+    conditions: createReadyConditions(),
+  }),
+  createMockDeployment({
     name: 'slack-mcp',
-    namespace: 'mcp-servers',
     uid: 'uid-2',
     creationTimestamp: '2026-03-14T11:00:00Z',
     image: 'quay.io/mcp-servers/slack:0.5.0',
-    phase: McpDeploymentPhase.PENDING,
-  },
-  {
+    conditions: createInitializingConditions(),
+  }),
+  createMockDeployment({
     name: 'jira-mcp',
-    namespace: 'mcp-servers',
     uid: 'uid-3',
     creationTimestamp: '2026-03-08T16:45:00Z',
     image: 'quay.io/mcp-servers/jira:1.2.0',
-    phase: McpDeploymentPhase.FAILED,
-  },
+    conditions: createFailedConditions(),
+  }),
 ];
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/McpDeploymentsTableRow.spec.tsx
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/McpDeploymentsTableRow.spec.tsx
@@ -3,9 +3,14 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Table as PfTable, Tbody } from '@patternfly/react-table';
-import { McpDeployment, McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
+import { McpDeployment } from '~/odh/types/mcpDeploymentTypes';
 import McpDeploymentsTableRow from '~/odh/pages/mcpDeployments/McpDeploymentsTableRow';
-import { createMockDeployment } from './mcpDeploymentTestUtils';
+import {
+  createMockDeployment,
+  createReadyConditions,
+  createInitializingConditions,
+  createFailedConditions,
+} from './mcpDeploymentTestUtils';
 
 const renderRow = (deployment: McpDeployment, onDeleteClick = jest.fn(), onEditClick = jest.fn()) =>
   render(
@@ -49,16 +54,26 @@ describe('McpDeploymentsTableRow', () => {
     );
   });
 
-  it('should render status label that maps phase to display label', () => {
-    renderRow(createMockDeployment({ phase: McpDeploymentPhase.RUNNING }));
+  it('should render Available status label when Ready condition is True', () => {
+    renderRow(createMockDeployment({ conditions: createReadyConditions() }));
     expect(screen.getByTestId('mcp-deployment-status-label')).toHaveTextContent('Available');
   });
 
-  it('should render View link for Running deployment and show connection URL in popover', async () => {
+  it('should render Initializing status label when Ready is False with Initializing reason', () => {
+    renderRow(createMockDeployment({ conditions: createInitializingConditions() }));
+    expect(screen.getByTestId('mcp-deployment-status-label')).toHaveTextContent('Initializing');
+  });
+
+  it('should render Unavailable status label when Ready is False with DeploymentUnavailable reason', () => {
+    renderRow(createMockDeployment({ conditions: createFailedConditions() }));
+    expect(screen.getByTestId('mcp-deployment-status-label')).toHaveTextContent('Unavailable');
+  });
+
+  it('should render View link for Ready deployment and show connection URL in popover', async () => {
     const user = userEvent.setup();
     renderRow(
       createMockDeployment({
-        phase: McpDeploymentPhase.RUNNING,
+        conditions: createReadyConditions(),
         address: { url: 'kubernetes-test:8080' },
       }),
     );
@@ -71,11 +86,8 @@ describe('McpDeploymentsTableRow', () => {
     expect(popover).toHaveTextContent('kubernetes-test:8080');
   });
 
-  it.each([McpDeploymentPhase.FAILED, McpDeploymentPhase.PENDING])(
-    'should render dash for %s deployment without address',
-    (phase) => {
-      renderRow(createMockDeployment({ phase }));
-      expect(screen.getByTestId('mcp-deployment-service-unavailable')).toBeInTheDocument();
-    },
-  );
+  it('should render dash when deployment is not ready', () => {
+    renderRow(createMockDeployment({ conditions: createFailedConditions() }));
+    expect(screen.getByTestId('mcp-deployment-service-unavailable')).toBeInTheDocument();
+  });
 });

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/mcpDeploymentTestUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/mcpDeploymentTestUtils.ts
@@ -1,4 +1,44 @@
-import { McpDeployment, McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
+import {
+  McpDeployment,
+  McpDeploymentCondition,
+  McpConditionType,
+  McpConditionStatus,
+  McpAcceptedReason,
+  McpReadyReason,
+} from '~/odh/types/mcpDeploymentTypes';
+import { mockMcpCondition, mockReadyConditions } from '~/__mocks__/mockMcpDeployment';
+
+export { mockReadyConditions as createReadyConditions };
+
+export const createInitializingConditions = (): McpDeploymentCondition[] => [
+  mockMcpCondition({
+    type: McpConditionType.ACCEPTED,
+    status: McpConditionStatus.TRUE,
+    reason: McpAcceptedReason.VALID,
+    message: 'Configuration is valid.',
+  }),
+  mockMcpCondition({
+    type: McpConditionType.READY,
+    status: McpConditionStatus.FALSE,
+    reason: McpReadyReason.INITIALIZING,
+    message: 'Waiting for pods to become ready.',
+  }),
+];
+
+export const createFailedConditions = (): McpDeploymentCondition[] => [
+  mockMcpCondition({
+    type: McpConditionType.ACCEPTED,
+    status: McpConditionStatus.TRUE,
+    reason: McpAcceptedReason.VALID,
+    message: 'Configuration is valid.',
+  }),
+  mockMcpCondition({
+    type: McpConditionType.READY,
+    status: McpConditionStatus.FALSE,
+    reason: McpReadyReason.DEPLOYMENT_UNAVAILABLE,
+    message: 'The server deployment is unavailable.',
+  }),
+];
 
 export const createMockDeployment = (overrides: Partial<McpDeployment> = {}): McpDeployment => ({
   name: 'kubernetes-mcp',
@@ -6,6 +46,6 @@ export const createMockDeployment = (overrides: Partial<McpDeployment> = {}): Mc
   uid: 'test-uid-1234',
   creationTimestamp: '2026-03-10T14:30:00Z',
   image: 'quay.io/mcp-servers/kubernetes:1.0.0',
-  phase: McpDeploymentPhase.RUNNING,
+  conditions: mockReadyConditions(),
   ...overrides,
 });

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/utils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/__tests__/utils.spec.ts
@@ -1,10 +1,54 @@
-import { McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
 import {
+  McpConditionType,
+  McpConditionStatus,
+  McpAcceptedReason,
+  McpReadyReason,
+  McpDeploymentCondition,
+} from '~/odh/types/mcpDeploymentTypes';
+import {
+  getCondition,
+  isConditionTrue,
   getConnectionUrl,
   getDeploymentDisplayName,
   getStatusInfo,
+  getStatusSortWeight,
 } from '~/odh/pages/mcpDeployments/utils';
-import { createMockDeployment } from './mcpDeploymentTestUtils';
+import {
+  createMockDeployment,
+  createReadyConditions,
+  createInitializingConditions,
+  createFailedConditions,
+} from './mcpDeploymentTestUtils';
+
+describe('getCondition', () => {
+  it('should return matching condition or undefined', () => {
+    const conditions = createReadyConditions();
+    expect(getCondition(conditions, McpConditionType.READY)).toBeDefined();
+    expect(getCondition([], McpConditionType.READY)).toBeUndefined();
+  });
+});
+
+describe('isConditionTrue', () => {
+  it('should return true when condition status is True', () => {
+    const condition: McpDeploymentCondition = {
+      type: McpConditionType.READY,
+      status: McpConditionStatus.TRUE,
+    };
+    expect(isConditionTrue(condition)).toBe(true);
+  });
+
+  it('should return false when condition status is False', () => {
+    const condition: McpDeploymentCondition = {
+      type: McpConditionType.READY,
+      status: McpConditionStatus.FALSE,
+    };
+    expect(isConditionTrue(condition)).toBe(false);
+  });
+
+  it('should return false when condition is undefined', () => {
+    expect(isConditionTrue(undefined)).toBe(false);
+  });
+});
 
 describe('getDeploymentDisplayName', () => {
   it('should return displayName when set', () => {
@@ -29,9 +73,9 @@ describe('getDeploymentDisplayName', () => {
 });
 
 describe('getConnectionUrl', () => {
-  it('should return address URL when provided', () => {
+  it('should return address URL when Ready condition is True', () => {
     const deployment = createMockDeployment({
-      phase: McpDeploymentPhase.RUNNING,
+      conditions: createReadyConditions(),
       address: { url: 'https://kubernetes-mcp.example.com:8080' },
     });
     expect(getConnectionUrl(deployment)).toBe('https://kubernetes-mcp.example.com:8080');
@@ -39,52 +83,149 @@ describe('getConnectionUrl', () => {
 
   it('should return undefined when no address URL is set', () => {
     const deployment = createMockDeployment({
-      phase: McpDeploymentPhase.RUNNING,
+      conditions: createReadyConditions(),
     });
     expect(getConnectionUrl(deployment)).toBeUndefined();
   });
 
-  it.each([McpDeploymentPhase.PENDING, McpDeploymentPhase.FAILED])(
-    'should return undefined for %s deployment without address',
-    (phase) => {
-      const deployment = createMockDeployment({ phase });
-      expect(getConnectionUrl(deployment)).toBeUndefined();
-    },
-  );
-
-  it.each([McpDeploymentPhase.PENDING, McpDeploymentPhase.FAILED])(
-    'should return undefined for %s deployment even with address',
-    (phase) => {
-      const deployment = createMockDeployment({
-        phase,
-        address: { url: 'https://stale-url.example.com:8080' },
-      });
-      expect(getConnectionUrl(deployment)).toBeUndefined();
-    },
-  );
+  it('should return undefined when Ready condition is not True', () => {
+    expect(
+      getConnectionUrl(
+        createMockDeployment({
+          conditions: createFailedConditions(),
+          address: { url: 'https://stale-url.example.com:8080' },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(getConnectionUrl(createMockDeployment({ conditions: [] }))).toBeUndefined();
+  });
 });
 
 describe('getStatusInfo', () => {
-  it('should return available status for Running phase', () => {
-    const result = getStatusInfo(McpDeploymentPhase.RUNNING);
+  it('should return Available for Ready=True', () => {
+    const result = getStatusInfo(createReadyConditions());
     expect(result.label).toBe('Available');
     expect(result.status).toBe('success');
-    expect(result.popoverBody).toBe('The pod and its containers are healthy and running.');
   });
 
-  it('should return unavailable status for Failed phase', () => {
-    const result = getStatusInfo(McpDeploymentPhase.FAILED);
+  it('should return Initializing for Ready=False with Initializing reason', () => {
+    const result = getStatusInfo(createInitializingConditions());
+    expect(result.label).toBe('Initializing');
+    expect(result.status).toBe('info');
+  });
+
+  it('should return Unavailable for Ready=False with DeploymentUnavailable reason', () => {
+    const result = getStatusInfo(createFailedConditions());
     expect(result.label).toBe('Unavailable');
     expect(result.status).toBe('danger');
-    expect(result.popoverBody).toBe('At least 1 container in the pod failed.');
   });
 
-  it('should return pending status for Pending phase', () => {
-    const result = getStatusInfo(McpDeploymentPhase.PENDING);
+  it('should return Configuration invalid for Accepted=False with Invalid reason', () => {
+    const conditions: McpDeploymentCondition[] = [
+      {
+        type: McpConditionType.ACCEPTED,
+        status: McpConditionStatus.FALSE,
+        reason: McpAcceptedReason.INVALID,
+        message: 'Invalid port configuration.',
+      },
+    ];
+    const result = getStatusInfo(conditions);
+    expect(result.label).toBe('Configuration invalid');
+    expect(result.status).toBe('danger');
+    expect(result.popoverBody).toBe('Invalid port configuration.');
+  });
+
+  it('should return Configuration invalid for Ready=False with ConfigurationInvalid reason', () => {
+    const conditions: McpDeploymentCondition[] = [
+      {
+        type: McpConditionType.ACCEPTED,
+        status: McpConditionStatus.TRUE,
+        reason: McpAcceptedReason.VALID,
+      },
+      {
+        type: McpConditionType.READY,
+        status: McpConditionStatus.FALSE,
+        reason: McpReadyReason.CONFIGURATION_INVALID,
+        message: 'Container image pull failed.',
+      },
+    ];
+    const result = getStatusInfo(conditions);
+    expect(result.label).toBe('Configuration invalid');
+    expect(result.status).toBe('danger');
+    expect(result.popoverBody).toBe('Container image pull failed.');
+  });
+
+  it('should return Scaled to zero for Ready=True with ScaledToZero reason', () => {
+    const conditions: McpDeploymentCondition[] = [
+      {
+        type: McpConditionType.ACCEPTED,
+        status: McpConditionStatus.TRUE,
+        reason: McpAcceptedReason.VALID,
+      },
+      {
+        type: McpConditionType.READY,
+        status: McpConditionStatus.TRUE,
+        reason: McpReadyReason.SCALED_TO_ZERO,
+        message: 'Server is ready (scaled to 0 replicas)',
+      },
+    ];
+    const result = getStatusInfo(conditions);
+    expect(result.label).toBe('Scaled to zero');
+    expect(result.status).toBe('info');
+  });
+
+  it('should return Pending when there are no conditions', () => {
+    const result = getStatusInfo([]);
     expect(result.label).toBe('Pending');
     expect(result.status).toBe('info');
-    expect(result.popoverBody).toBe(
-      'This MCP server is starting up and will be available shortly.',
-    );
+  });
+
+  it('should return Not ready for unknown Ready=False reason', () => {
+    const conditions: McpDeploymentCondition[] = [
+      {
+        type: McpConditionType.READY,
+        status: McpConditionStatus.FALSE,
+        reason: 'SomeOtherReason',
+        message: 'Something happened.',
+      },
+    ];
+    const result = getStatusInfo(conditions);
+    expect(result.label).toBe('Not ready');
+    expect(result.status).toBe('warning');
+    expect(result.popoverBody).toBe('Something happened.');
+  });
+
+  it('should prioritize Accepted=False over Ready condition', () => {
+    const conditions: McpDeploymentCondition[] = [
+      {
+        type: McpConditionType.ACCEPTED,
+        status: McpConditionStatus.FALSE,
+        reason: McpAcceptedReason.INVALID,
+        message: 'Bad config.',
+      },
+      {
+        type: McpConditionType.READY,
+        status: McpConditionStatus.FALSE,
+        reason: McpReadyReason.DEPLOYMENT_UNAVAILABLE,
+        message: 'Deploy failed.',
+      },
+    ];
+    const result = getStatusInfo(conditions);
+    expect(result.label).toBe('Configuration invalid');
+    expect(result.popoverBody).toBe('Bad config.');
+  });
+});
+
+describe('getStatusSortWeight', () => {
+  it('should give lowest weight (first) to danger statuses', () => {
+    expect(getStatusSortWeight(createFailedConditions())).toBe(0);
+  });
+
+  it('should give highest weight (last) to success statuses', () => {
+    expect(getStatusSortWeight(createReadyConditions())).toBe(3);
+  });
+
+  it('should place info statuses in the middle', () => {
+    expect(getStatusSortWeight(createInitializingConditions())).toBe(2);
   });
 });

--- a/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/utils.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/pages/mcpDeployments/utils.ts
@@ -1,7 +1,22 @@
-import { McpDeployment, McpDeploymentPhase } from '~/odh/types/mcpDeploymentTypes';
+import {
+  McpDeployment,
+  McpDeploymentCondition,
+  McpConditionType,
+  McpConditionStatus,
+  McpReadyReason,
+} from '~/odh/types/mcpDeploymentTypes';
+
+export const getCondition = (
+  conditions: McpDeploymentCondition[],
+  type: McpConditionType,
+): McpDeploymentCondition | undefined => conditions.find((c) => c.type === type);
+
+export const isConditionTrue = (condition: McpDeploymentCondition | undefined): boolean =>
+  condition?.status === McpConditionStatus.TRUE;
 
 export const getConnectionUrl = (deployment: McpDeployment): string | undefined => {
-  if (deployment.phase !== McpDeploymentPhase.RUNNING) {
+  const ready = getCondition(deployment.conditions, McpConditionType.READY);
+  if (!isConditionTrue(ready)) {
     return undefined;
   }
   return deployment.address?.url;
@@ -12,35 +27,89 @@ export const getDeploymentDisplayName = (deployment: McpDeployment): string =>
 
 export type McpDeploymentStatusInfo = {
   label: string;
-  status: 'success' | 'danger' | 'info';
+  status: 'success' | 'danger' | 'warning' | 'info';
   popoverBody: string;
 };
 
-export const getStatusInfo = (phase: McpDeploymentPhase): McpDeploymentStatusInfo => {
-  switch (phase) {
-    case McpDeploymentPhase.RUNNING:
-      return {
-        label: 'Available',
-        status: 'success',
-        popoverBody: 'The pod and its containers are healthy and running.',
-      };
-    case McpDeploymentPhase.FAILED:
-      return {
-        label: 'Unavailable',
-        status: 'danger',
-        popoverBody: 'At least 1 container in the pod failed.',
-      };
-    case McpDeploymentPhase.PENDING:
-      return {
-        label: 'Pending',
-        status: 'info',
-        popoverBody: 'This MCP server is starting up and will be available shortly.',
-      };
-    default:
-      return {
-        label: 'Unknown',
-        status: 'info',
-        popoverBody: 'The status of this MCP server is unknown.',
-      };
+export const getStatusInfo = (conditions: McpDeploymentCondition[]): McpDeploymentStatusInfo => {
+  const accepted = getCondition(conditions, McpConditionType.ACCEPTED);
+  const ready = getCondition(conditions, McpConditionType.READY);
+
+  if (accepted && !isConditionTrue(accepted)) {
+    return {
+      label: 'Configuration invalid',
+      status: 'danger',
+      popoverBody: accepted.message || 'The server configuration is invalid.',
+    };
   }
+
+  if (ready?.reason === McpReadyReason.SCALED_TO_ZERO) {
+    return {
+      label: 'Scaled to zero',
+      status: 'info',
+      popoverBody: ready.message || 'This MCP server has been scaled to zero replicas.',
+    };
+  }
+
+  if (ready && isConditionTrue(ready)) {
+    return {
+      label: 'Available',
+      status: 'success',
+      popoverBody: ready.message || 'The MCP server is ready and serving requests.',
+    };
+  }
+
+  if (ready) {
+    switch (ready.reason) {
+      case McpReadyReason.INITIALIZING:
+        return {
+          label: 'Initializing',
+          status: 'info',
+          popoverBody:
+            ready.message || 'This MCP server is starting up and will be available shortly.',
+        };
+      case McpReadyReason.CONFIGURATION_INVALID:
+        return {
+          label: 'Configuration invalid',
+          status: 'danger',
+          popoverBody: ready.message || 'The server configuration is invalid.',
+        };
+      case McpReadyReason.DEPLOYMENT_UNAVAILABLE:
+        return {
+          label: 'Unavailable',
+          status: 'danger',
+          popoverBody: ready.message || 'The server deployment is unavailable.',
+        };
+      default:
+        return {
+          label: 'Not ready',
+          status: 'warning',
+          popoverBody: ready.message || 'The MCP server is not ready.',
+        };
+    }
+  }
+
+  if (conditions.length === 0) {
+    return {
+      label: 'Pending',
+      status: 'info',
+      popoverBody: 'This MCP server is starting up and will be available shortly.',
+    };
+  }
+
+  return {
+    label: 'Unknown',
+    status: 'info',
+    popoverBody: 'The status of this MCP server is unknown.',
+  };
 };
+
+const STATUS_SORT_WEIGHTS: Record<McpDeploymentStatusInfo['status'], number> = {
+  danger: 0,
+  warning: 1,
+  info: 2,
+  success: 3,
+};
+
+export const getStatusSortWeight = (conditions: McpDeploymentCondition[]): number =>
+  STATUS_SORT_WEIGHTS[getStatusInfo(conditions).status];

--- a/packages/model-registry/upstream/frontend/src/odh/types/mcpDeploymentTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/types/mcpDeploymentTypes.ts
@@ -59,10 +59,27 @@ export type MCPServerCR = {
   };
 };
 
-export enum McpDeploymentPhase {
-  PENDING = 'Pending',
-  RUNNING = 'Running',
-  FAILED = 'Failed',
+export enum McpConditionType {
+  ACCEPTED = 'Accepted',
+  READY = 'Ready',
+}
+
+export enum McpConditionStatus {
+  TRUE = 'True',
+  FALSE = 'False',
+}
+
+export enum McpAcceptedReason {
+  VALID = 'Valid',
+  INVALID = 'Invalid',
+}
+
+export enum McpReadyReason {
+  AVAILABLE = 'Available',
+  CONFIGURATION_INVALID = 'ConfigurationInvalid',
+  DEPLOYMENT_UNAVAILABLE = 'DeploymentUnavailable',
+  SCALED_TO_ZERO = 'ScaledToZero',
+  INITIALIZING = 'Initializing',
 }
 
 export type McpDeploymentCondition = {
@@ -86,8 +103,7 @@ export type McpDeployment = {
   creationTimestamp: string;
   image: string;
   yaml?: string;
-  phase: McpDeploymentPhase;
-  conditions?: McpDeploymentCondition[];
+  conditions: McpDeploymentCondition[];
   address?: McpDeploymentAddress;
 };
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Migrate from the simple Phase enum (`Pending`/`Running`/`Failed`) to a Kubernetes-style Conditions model (Accepted + Ready) with granular reasons (`Available`, `Initializing`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ScaledToZero`). Updates BFF Go models and extraction logic, frontend types/enums, status derivation utils, UI components, mock data, unit tests, and Cypress mock tests.

Closes: [RHOAIENG-59053](https://redhat.atlassian.net/browse/RHOAIENG-59053)

<img width="1098" height="397" alt="Screenshot 2026-04-30 at 4 17 32 PM" src="https://github.com/user-attachments/assets/6a75e6c6-fb74-4b18-9055-844d112fdec2" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Install the new `MCPServer` CRD (`green-3` already has it now) and try to deploy an MCPServer after fulfilling/partially fulfilling prerequisites - check whether all statuses are visible - not just `Pending`/`Running`/`Failed`.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added Cypress test case covering all statuses

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded MCP Deployments table test coverage to include additional deployment status scenarios.
  * Enhanced test assertions to validate status labels and service availability information across six deployment rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->