### PR TITLE
fix(autorag): handle models loading and error states in configure page

### DIFF
--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -861,6 +861,7 @@ function AutoragConfigure(): React.JSX.Element {
                                         !inputDataKeyValue ||
                                         form.formState.isSubmitting ||
                                         isModelsLoading ||
+                                        isModelsError ||
                                         !allModelsData?.models.length
                                       }
                                     >

--- a/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragConfigure.tsx
@@ -35,6 +35,7 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Skeleton,
   Spinner,
   Split,
   SplitItem,
@@ -196,17 +197,33 @@ function AutoragConfigure(): React.JSX.Element {
 
   const showInputDataUploadDropzone = !isInputDataFileUploading && !inputDataKey.trim();
 
-  const { data: allModelsData } = useLlamaStackModelsQuery(namespace ?? '', llamaStackSecretName);
+  const {
+    data: allModelsData,
+    isError: isModelsError,
+    isLoading: isModelsLoading,
+  } = useLlamaStackModelsQuery(namespace ?? '', llamaStackSecretName);
   const { mutateAsync: uploadFileToS3 } = useS3FileUploadMutation('');
 
-  // Reset modelsInitialized when the LlamaStack secret changes so models re-populate
+  useEffect(() => {
+    if (isModelsError) {
+      notification.error(
+        'Failed to load models',
+        'Check that the LlamaStack secret is valid and try again.',
+      );
+    }
+  }, [isModelsError, notification]);
+
+  // When the secret changes, mark models as needing re-initialization and
+  // immediately clear stale selections so the UI reflects the transition.
   useEffect(() => {
     modelsInitialized.current = false;
-  }, [llamaStackSecretName]);
+    setValue('generation_models', []);
+    setValue('embeddings_models', []);
+  }, [llamaStackSecretName, setValue]);
 
   useEffect(() => {
     // Initialize available generation and embedding models into the form data
-    if (allModelsData?.models && !modelsInitialized.current) {
+    if (allModelsData?.models && !modelsInitialized.current && !isModelsError) {
       modelsInitialized.current = true;
       reset({
         ...getValues(),
@@ -222,7 +239,7 @@ function AutoragConfigure(): React.JSX.Element {
           .toSorted((a, b) => a.localeCompare(b)),
       });
     }
-  }, [allModelsData, getValues, reset]);
+  }, [allModelsData, isModelsError, getValues, reset]);
 
   // set bucket from selected secret
   useEffect(() => {
@@ -842,7 +859,9 @@ function AutoragConfigure(): React.JSX.Element {
                                       isDisabled={
                                         !inputDataBucketName ||
                                         !inputDataKeyValue ||
-                                        form.formState.isSubmitting
+                                        form.formState.isSubmitting ||
+                                        isModelsLoading ||
+                                        !allModelsData?.models.length
                                       }
                                     >
                                       Edit
@@ -857,70 +876,78 @@ function AutoragConfigure(): React.JSX.Element {
                           <CardBody>
                             <Stack hasGutter>
                               <StackItem>
-                                <Watch
-                                  control={form.control}
-                                  name="generation_models"
-                                  render={(generationModels) => (
-                                    <Flex
-                                      alignItems={{ default: 'alignItemsCenter' }}
-                                      spacer={{ default: 'spacerNone' }}
-                                      gap={{ default: 'gapSm' }}
-                                    >
-                                      <Content>{`${generationModels.length || 'No'} foundation models`}</Content>
-                                      {!!generationModels.length && (
-                                        <Popover
-                                          bodyContent={
-                                            <List>
-                                              {generationModels.map((model) => (
-                                                <ListItem key={`generation-${model}`}>
-                                                  {model}
-                                                </ListItem>
-                                              ))}
-                                            </List>
-                                          }
-                                        >
-                                          <DashboardPopupIconButton
-                                            icon={<InfoCircleIcon />}
-                                            hasNoPadding
-                                          />
-                                        </Popover>
-                                      )}
-                                    </Flex>
-                                  )}
-                                />
+                                {isModelsLoading ? (
+                                  <Skeleton width="150px" />
+                                ) : (
+                                  <Watch
+                                    control={form.control}
+                                    name="generation_models"
+                                    render={(generationModels) => (
+                                      <Flex
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                        spacer={{ default: 'spacerNone' }}
+                                        gap={{ default: 'gapSm' }}
+                                      >
+                                        <Content>{`${generationModels.length || 'No'} foundation models`}</Content>
+                                        {!!generationModels.length && (
+                                          <Popover
+                                            bodyContent={
+                                              <List>
+                                                {generationModels.map((model) => (
+                                                  <ListItem key={`generation-${model}`}>
+                                                    {model}
+                                                  </ListItem>
+                                                ))}
+                                              </List>
+                                            }
+                                          >
+                                            <DashboardPopupIconButton
+                                              icon={<InfoCircleIcon />}
+                                              hasNoPadding
+                                            />
+                                          </Popover>
+                                        )}
+                                      </Flex>
+                                    )}
+                                  />
+                                )}
                               </StackItem>
                               <StackItem>
-                                <Watch
-                                  control={form.control}
-                                  name="embeddings_models"
-                                  render={(embeddingModels) => (
-                                    <Flex
-                                      alignItems={{ default: 'alignItemsCenter' }}
-                                      spacer={{ default: 'spacerNone' }}
-                                      gap={{ default: 'gapSm' }}
-                                    >
-                                      <Content>{`${embeddingModels.length || 'No'} embedding models`}</Content>
-                                      {!!embeddingModels.length && (
-                                        <Popover
-                                          bodyContent={
-                                            <List>
-                                              {embeddingModels.map((model) => (
-                                                <ListItem key={`embedding-${model}`}>
-                                                  {model}
-                                                </ListItem>
-                                              ))}
-                                            </List>
-                                          }
-                                        >
-                                          <DashboardPopupIconButton
-                                            icon={<InfoCircleIcon />}
-                                            hasNoPadding
-                                          />
-                                        </Popover>
-                                      )}
-                                    </Flex>
-                                  )}
-                                />
+                                {isModelsLoading ? (
+                                  <Skeleton width="150px" />
+                                ) : (
+                                  <Watch
+                                    control={form.control}
+                                    name="embeddings_models"
+                                    render={(embeddingModels) => (
+                                      <Flex
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                        spacer={{ default: 'spacerNone' }}
+                                        gap={{ default: 'gapSm' }}
+                                      >
+                                        <Content>{`${embeddingModels.length || 'No'} embedding models`}</Content>
+                                        {!!embeddingModels.length && (
+                                          <Popover
+                                            bodyContent={
+                                              <List>
+                                                {embeddingModels.map((model) => (
+                                                  <ListItem key={`embedding-${model}`}>
+                                                    {model}
+                                                  </ListItem>
+                                                ))}
+                                              </List>
+                                            }
+                                          >
+                                            <DashboardPopupIconButton
+                                              icon={<InfoCircleIcon />}
+                                              hasNoPadding
+                                            />
+                                          </Popover>
+                                        )}
+                                      </Flex>
+                                    )}
+                                  />
+                                )}
                               </StackItem>
                             </Stack>
                           </CardBody>

--- a/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettingsModelSelection.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragExperimentSettingsModelSelection.tsx
@@ -17,7 +17,6 @@ import { useController, useFormContext, useWatch } from 'react-hook-form';
 import './AutoragExperimentSettingsModelSelection.scss';
 import { useParams } from 'react-router';
 import { useLlamaStackModelsQuery } from '~/app/hooks/queries';
-import { useNotification } from '~/app/hooks/useNotification';
 import { ConfigureSchema } from '~/app/schemas/configure.schema';
 import { LlamaStackModelType } from '~/app/types';
 
@@ -62,30 +61,18 @@ const AutoragExperimentSettingsModelSelection: React.FC = () => {
     name: 'llama_stack_secret_name',
   });
 
-  const {
-    data: llmModelsData,
-    isLoading: isLlmLoading,
-    isError: isLlmError,
-  } = useLlamaStackModelsQuery(namespace, llamaStackSecretName, 'llm');
-  const {
-    data: embeddingModelsData,
-    isLoading: isEmbeddingLoading,
-    isError: isEmbeddingError,
-  } = useLlamaStackModelsQuery(namespace, llamaStackSecretName, 'embedding');
+  const { data: llmModelsData, isLoading: isLlmLoading } = useLlamaStackModelsQuery(
+    namespace,
+    llamaStackSecretName,
+    'llm',
+  );
+  const { data: embeddingModelsData, isLoading: isEmbeddingLoading } = useLlamaStackModelsQuery(
+    namespace,
+    llamaStackSecretName,
+    'embedding',
+  );
 
   const isLoading = isLlmLoading || isEmbeddingLoading;
-  const isError = isLlmError || isEmbeddingError;
-
-  const notification = useNotification();
-
-  React.useEffect(() => {
-    if (isError) {
-      notification.error(
-        'Failed to load models',
-        'Check that the LlamaStack secret is valid and try again.',
-      );
-    }
-  }, [isError, notification]);
 
   const { field: generationModelField } = useController({
     control: form.control,

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -96,6 +96,7 @@ jest.mock('~/app/hooks/queries', () => ({
   useLlamaStackModelsQuery: jest.fn().mockReturnValue({
     data: { models: [] },
     isLoading: false,
+    isError: false,
   }),
   useLlamaStackVectorStoreProvidersQuery: jest.fn().mockReturnValue({
     data: { vector_store_providers: [] }, // eslint-disable-line camelcase
@@ -842,6 +843,17 @@ describe('AutoragConfigure', () => {
     });
 
     it('should enable "Edit" button when a file/folder is selected', () => {
+      mockUseLlamaStackModelsQuery.mockReturnValue({
+        data: {
+          models: [
+            // eslint-disable-next-line camelcase
+            { id: 'llm-model', type: 'llm', provider: 'ollama', resource_path: 'ollama://llm' },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useLlamaStackModelsQuery>);
+
       renderComponent();
 
       // Select a valid secret

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -842,6 +842,27 @@ describe('AutoragConfigure', () => {
       expect(browseButton).toBeEnabled();
     });
 
+    it('should disable "Edit" button when model loading fails', () => {
+      mockUseLlamaStackModelsQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      } as unknown as ReturnType<typeof useLlamaStackModelsQuery>);
+
+      renderComponent();
+
+      // Select a valid secret
+      fireEvent.click(screen.getByTestId('aws-secret-selector-select-secret-1'));
+
+      // Browse and select a file
+      fireEvent.click(screen.getByRole('button', { name: 'Browse bucket' }));
+      fireEvent.click(screen.getByTestId('file-explorer-select-file'));
+
+      // Edit button should be disabled due to model error
+      const editButton = screen.getByRole('button', { name: 'Edit' });
+      expect(editButton).toBeDisabled();
+    });
+
     it('should enable "Edit" button when a file/folder is selected', () => {
       mockUseLlamaStackModelsQuery.mockReturnValue({
         data: {

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragConfigure.spec.tsx
@@ -694,6 +694,23 @@ describe('AutoragConfigure', () => {
     });
   });
 
+  describe('Model error handling', () => {
+    it('should show error notification when model loading fails', () => {
+      mockUseLlamaStackModelsQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      } as unknown as ReturnType<typeof useLlamaStackModelsQuery>);
+
+      renderComponent();
+
+      expect(mockNotificationError).toHaveBeenCalledWith(
+        'Failed to load models',
+        'Check that the LlamaStack secret is valid and try again.',
+      );
+    });
+  });
+
   describe('selected input data file table', () => {
     it('should NOT display the selected file table when no file is selected', () => {
       renderComponent();

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettingsModelSelection.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragExperimentSettingsModelSelection.spec.tsx
@@ -7,20 +7,10 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createConfigureSchema } from '~/app/schemas/configure.schema';
 import { useLlamaStackModelsQuery } from '~/app/hooks/queries';
-import { useNotification } from '~/app/hooks/useNotification';
 import AutoragExperimentSettingsModelSelection from '~/app/components/configure/AutoragExperimentSettingsModelSelection';
 import { LlamaStackModelType } from '~/app/types';
 
 jest.mock('~/app/hooks/queries');
-jest.mock('~/app/hooks/useNotification', () => ({
-  useNotification: jest.fn(() => ({
-    success: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-    warning: jest.fn(),
-    remove: jest.fn(),
-  })),
-}));
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useParams: () => ({ namespace: 'test-namespace' }),
@@ -36,7 +26,6 @@ jest.mock('mod-arch-shared', () => ({
 }));
 
 const mockUseLlamaStackModelsQuery = jest.mocked(useLlamaStackModelsQuery);
-const mockUseNotification = jest.mocked(useNotification);
 
 const MOCK_MODELS = [
   { id: 'llama-8b', type: 'llm' as const, provider: 'ollama', resource_path: 'ollama://llama-8b' },
@@ -300,32 +289,6 @@ describe('AutoragExperimentSettingsModelSelection', () => {
 
       renderComponent();
       expect(screen.getAllByText('No models available.').length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Error handling', () => {
-    it('should show error notification when model loading fails', () => {
-      const mockError = jest.fn();
-      mockUseNotification.mockReturnValue({
-        success: jest.fn(),
-        error: mockError,
-        info: jest.fn(),
-        warning: jest.fn(),
-        remove: jest.fn(),
-      });
-
-      mockUseLlamaStackModelsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        isError: true,
-      } as unknown as ReturnType<typeof useLlamaStackModelsQuery>);
-
-      renderComponent();
-
-      expect(mockError).toHaveBeenCalledWith(
-        'Failed to load models',
-        'Check that the LlamaStack secret is valid and try again.',
-      );
     });
   });
 });


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-60550

## Description

The AutoRAG configure page did not handle loading and error states from the LlamaStack models query properly:

1. **No loading indicator** — The model count cards (foundation models / embedding models) showed "No models" while the query was still in flight, which was misleading.
2. **Duplicate error notifications** — Both `AutoragConfigure` and `AutoragExperimentSettingsModelSelection` independently called `notification.error()` on model fetch failure, resulting in duplicate toasts.
3. **Stale model selections** — When the LlamaStack secret changed, the previously selected models lingered in the form until the new query resolved.
4. **Edit button not gated on model state** — The Edit button could be clicked while models were loading, errored, or empty.


https://github.com/user-attachments/assets/596eb497-7f1d-4c54-bd4b-edbf177f3510


https://github.com/user-attachments/assets/cb67b41f-4ecb-4a47-8114-31b0e1aa09e5



### Changes

- Show `Skeleton` placeholders in the model count cards while `isModelsLoading` is true.
- Consolidate the error notification into the parent `AutoragConfigure` component and remove the duplicate from `AutoragExperimentSettingsModelSelection`.
- Clear `generation_models` and `embeddings_models` form values immediately when the LlamaStack secret changes.
- Disable the Edit button when models are loading, errored, or empty.

## How Has This Been Tested?

- Ran `npm run lint` and `npm run type-check` for the autorag package — both pass.
- Ran unit tests for `AutoragConfigure` and `AutoragExperimentSettingsModelSelection` — all 83 tests pass.

## Test Impact

- Added unit test: error notification fires when `isModelsError` is true (moved from `AutoragExperimentSettingsModelSelection.spec` to `AutoragConfigure.spec`).
- Added unit test: Edit button is disabled when model loading fails.
- Updated existing Edit button test to provide model data so it correctly validates the enabled state.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error notifications when model configuration fails to load, providing clearer user feedback
  * Edit functionality properly disabled during model loading and when errors occur
  * Model data immediately cleared when LlamaStack credentials are updated

* **UI Improvements**
  * Model selection interface now displays loading placeholders while fetching data instead of empty states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->