### PR TITLE
Fix auth policy view page when model refs do not exist

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1255,11 +1255,11 @@ class ViewAuthPolicyPage {
   }
 
   findModelsSection(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('subscription-models-section');
+    return cy.findByTestId('authorization-policy-models-section');
   }
 
   findModelsTable(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('subscription-models-table');
+    return cy.findByTestId('authorization-policy-models-table');
   }
 
   findActionsToggle(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -13,6 +13,7 @@ import {
   mockCreatePolicyResponse,
   mockPolicyInfo,
   mockSubscriptionFormData,
+  mockPolicyInfoMissingModelSummaries,
 } from '../../../utils/maasUtils';
 
 const setupAuthPoliciesCommon = () => {
@@ -264,6 +265,21 @@ describe('View Auth Policy Page', () => {
 
     viewAuthPolicyPage.findBreadcrumbPoliciesLink().click();
     cy.url().should('include', '/maas/auth-policies');
+  });
+
+  it("should list models from the policy when model ref doesn't exist", () => {
+    const orphanPolicyName = 'missing-model-summary-policy';
+    cy.interceptOdh(
+      'GET /maas/api/v1/view-policy/:name',
+      { path: { name: orphanPolicyName } },
+      { data: mockPolicyInfoMissingModelSummaries() },
+    );
+    viewAuthPolicyPage.visit(orphanPolicyName);
+    viewAuthPolicyPage.findModelsSection().should('exist');
+    viewAuthPolicyPage
+      .findModelsTable()
+      .should('contain.text', 'deleted-model-ref')
+      .and('contain.text', 'maas-models');
   });
 
   it('should show error state when the view-policy API fails', () => {

--- a/packages/cypress/cypress/utils/maasUtils.ts
+++ b/packages/cypress/cypress/utils/maasUtils.ts
@@ -474,3 +474,26 @@ export const mockPolicyInfo = (name = 'premium-team-policy'): PolicyInfoResponse
     })),
   };
 };
+
+export const mockPolicyInfoMissingModelSummaries = (): PolicyInfoResponse => {
+  const policy: MaaSAuthPolicy = {
+    name: 'missing-model-summary-policy',
+    displayName: "Policy with model refs that don't exist",
+    namespace: 'maas-system',
+    phase: 'Active',
+    statusMessage: 'successfully reconciled',
+    modelRefs: [
+      {
+        name: 'deleted-model-ref',
+        namespace: 'maas-models',
+      },
+    ],
+    subjects: { groups: [{ name: 'premium-users' }] },
+    creationTimestamp: '2025-03-01T10:00:00Z',
+  };
+
+  return {
+    policy,
+    modelRefs: [],
+  };
+};

--- a/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
@@ -425,6 +425,7 @@ const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({ onClose }) => {
                         hideColumns={['project']}
                         titleHeadingLevel="h3"
                         titleSize="md"
+                        resourceType="subscription"
                       />
                     </FormGroup>
                   </>

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -11,7 +11,8 @@ import {
 } from '@patternfly/react-core';
 import SimpleMenuActions from '@odh-dashboard/internal/components/SimpleMenuActions';
 import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
-import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+import { MaaSAuthPolicy, MaaSModelRefSummary } from '~/app/types/subscriptions';
+import { PolicyInfoResponse } from '~/app/types/auth-policies';
 import { URL_PREFIX } from '~/app/utilities/const';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteAuthPolicyModal from './DeleteAuthPolicyModal';
@@ -20,6 +21,24 @@ import PolicyGroupsSection from './viewAuthPolicy/PolicyGroupsSection';
 
 type PolicyActionsProps = {
   policy: MaaSAuthPolicy;
+};
+
+const viewModelRefSummaries = (info: PolicyInfoResponse): MaaSModelRefSummary[] => {
+  const policyRefs = Array.isArray(info.policy.modelRefs) ? info.policy.modelRefs : [];
+  const modelRefSummaries = Array.isArray(info.modelRefs) ? info.modelRefs : [];
+
+  return policyRefs.map((ref) => {
+    const summary = modelRefSummaries.find(
+      (s) => s.name === ref.name && s.namespace === ref.namespace,
+    );
+    return (
+      summary ?? {
+        name: ref.name,
+        namespace: ref.namespace,
+        modelRef: { kind: '', name: '' },
+      }
+    );
+  });
 };
 
 const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
@@ -109,8 +128,9 @@ const ViewAuthPoliciesPage: React.FC = () => {
             </PageSection>
             <PageSection hasBodyWrapper={false} className="pf-v6-u-pb-xl">
               <MaasModelsSection
-                modelRefSummaries={policyInfo.modelRefs}
+                modelRefSummaries={viewModelRefSummaries(policyInfo)}
                 hideColumns={['tokenLimits']}
+                resourceType="authorization policy"
               />
             </PageSection>
           </Tab>

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -35,7 +35,7 @@ const viewModelRefSummaries = (info: PolicyInfoResponse): MaaSModelRefSummary[] 
       summary ?? {
         name: ref.name,
         namespace: ref.namespace,
-        modelRef: { kind: '', name: '' },
+        modelRef: { kind: '', name: ref.name },
       }
     );
   });

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -171,7 +171,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
             data-testid="policy-no-models-warning"
           >
             There are no model endpoints available on the cluster. Deploy a model and create a
-            MaaSModelRef before creating a policy.
+            MaaSModelRef before creating an authorization policy.
           </Alert>
         ) : (
           <>
@@ -183,7 +183,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
               onRemoveModel={handleRemoveModelAt}
               helperText={
                 <Content>
-                  Add models that subjects of this policy will be granted access to.
+                  Add models that subjects of this authorization policy will be granted access to.
                 </Content>
               }
               formGroupFieldId="policy-models"
@@ -191,7 +191,8 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
               tableTestId="policy-models-table"
               tableAriaLabel="Policy models"
               addModelsButtonTestId="policy-add-models-button"
-              addModelsButtonAriaLabel="Add models to policy"
+              addModelsButtonAriaLabel="Add models to authorization policy"
+              resourceType="authorization policy"
             />
             {isAddModelsModalOpen && (
               <AddModelsModal
@@ -203,16 +204,16 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
                 onAdd={handleAddModels}
                 onRemove={handleRemoveModelsByRef}
                 onClose={() => setIsAddModelsModalOpen(false)}
-                ariaLabel="Add models to policy"
-                title="Add models to policy"
-                description="Select model endpoints to grant access to through this policy."
+                ariaLabel="Add models to authorization policy"
+                title="Add models to authorization policy"
+                description="Select model endpoints to grant access to through this authorization policy."
               />
             )}
           </>
         )}
 
         {submitError && (
-          <Alert variant="danger" isInline title="Failed to save policy">
+          <Alert variant="danger" isInline title="Failed to save authorization policy">
             {submitError}
           </Alert>
         )}

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -138,6 +138,7 @@ const ViewSubscriptionPage: React.FC = () => {
               <MaasModelsSection
                 modelRefSummaries={viewModelRefSummaries(subscriptionInfo)}
                 modelRefsWithRateLimits={subscriptionInfo.subscription.modelRefs}
+                resourceType="subscription"
               />
             </PageSection>
           </Tab>

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -371,6 +371,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             onAddModels={canAddModels ? () => setIsAddModelsModalOpen(true) : undefined}
             onEditLimits={(index) => setEditLimitsTarget(index)}
             onRemoveModel={handleRemoveModel}
+            resourceType="subscription"
           />
         )}
 

--- a/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
+++ b/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
@@ -49,6 +49,7 @@ export type MaasModelsSectionProps = {
   tableAriaLabel?: string;
   addModelsButtonTestId?: string;
   addModelsButtonAriaLabel?: string;
+  resourceType?: string;
 };
 
 const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
@@ -62,10 +63,11 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
   onEditLimits,
   onRemoveModel,
   helperText,
-  formGroupFieldId = 'subscription-models',
-  sectionTestId = 'subscription-models-section',
-  tableTestId = 'subscription-models-table',
-  tableAriaLabel = 'Subscription models',
+  resourceType = 'subscription',
+  formGroupFieldId = `${resourceType.toLowerCase().replace(' ', '-')}-models`,
+  sectionTestId = `${resourceType.toLowerCase().replace(' ', '-')}-models-section`,
+  tableTestId = `${resourceType.toLowerCase().replace(' ', '-')}-models-table`,
+  tableAriaLabel = `${resourceType} models`,
   addModelsButtonTestId = 'add-models-button',
   addModelsButtonAriaLabel,
 }) => {
@@ -214,7 +216,7 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
           <StackItem>
             {helperText ?? (
               <Content>
-                Select models to make available to members of this subscription, then set token
+                Select models to make available to members of this {resourceType}, then set token
                 limits for each one.
               </Content>
             )}
@@ -246,14 +248,14 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
             </Title>
           </FlexItem>
           <FlexItem>
-            <Content component="p">Models available to members of this subscription</Content>
+            <Content component="p">Models available to members of this {resourceType}</Content>
           </FlexItem>
         </Flex>
       </StackItem>
       <StackItem>
         {modelRefSummaries.length === 0 ? (
           <Bullseye>
-            <Content component="p">No models assigned to this subscription.</Content>
+            <Content component="p">No models assigned to this {resourceType}.</Content>
           </Bullseye>
         ) : (
           table

--- a/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
+++ b/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
@@ -64,9 +64,9 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
   onRemoveModel,
   helperText,
   resourceType = 'subscription',
-  formGroupFieldId = `${resourceType.toLowerCase().replace(' ', '-')}-models`,
-  sectionTestId = `${resourceType.toLowerCase().replace(' ', '-')}-models-section`,
-  tableTestId = `${resourceType.toLowerCase().replace(' ', '-')}-models-table`,
+  formGroupFieldId = `${resourceType.trim().toLowerCase().replace(/\s+/g, '-')}-models`,
+  sectionTestId = `${resourceType.trim().toLowerCase().replace(/\s+/g, '-')}-models-section`,
+  tableTestId = `${resourceType.trim().toLowerCase().replace(/\s+/g, '-')}-models-table`,
   tableAriaLabel = `${resourceType} models`,
   addModelsButtonTestId = 'add-models-button',
   addModelsButtonAriaLabel,
@@ -248,7 +248,7 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
             </Title>
           </FlexItem>
           <FlexItem>
-            <Content component="p">Models available to members of this {resourceType}</Content>
+            <Content component="p">Models available to members of this {resourceType}.</Content>
           </FlexItem>
         </Flex>
       </StackItem>


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-59343](https://redhat.atlassian.net/browse/RHOAIENG-59343)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Fixes where the models table on the view policy page gets it's info, so even if the ref itself is deleted you can still see the model in the table, just like I did with the twin of this ticket for subscriptions 

I made the `MaasModelsSection` generic so you pass in the resource type to determine the microcopy and test-ids

and updated a couple places where it was  still `policies` instead of `authorization policies`

Before (model ref has been deleted):
<img width="1223" height="833" alt="Screenshot 2026-04-30 at 11 25 34 AM" src="https://github.com/user-attachments/assets/1e762b30-a7e7-4c2a-afda-34a948c23d28" />


After:
<img width="1598" height="798" alt="Screenshot 2026-04-30 at 11 43 24 AM" src="https://github.com/user-attachments/assets/742f23f0-6332-426f-8ddd-5e26025cb095" />


Updated microcopy if there truly is no models:
<img width="1594" height="840" alt="Screenshot 2026-04-30 at 11 43 59 AM" src="https://github.com/user-attachments/assets/f649453f-d154-44fc-a3be-9dcd407f4a81" />


Video showing some microcopy changes:

https://github.com/user-attachments/assets/4c3eb48e-c0d0-40b5-944e-efff5a88a7e9




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

to test:
- find a policy using a model ref that doesn't exist anymore or make one
- you should still see the model listed in the table even if the ref is gone
- double check the microcopy changes

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added a mocked test

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Models section now displays policy-referenced models even when summary data is missing.

* **New Features**
  * Tests: Added coverage for authorization policies that reference deleted or missing models.
  * Mocks: Added a helper to simulate policies with missing model summaries.

* **Improvements**
  * UI text and accessibility labels updated to consistently use "authorization policy".
  * Models component enhanced to accept resource context (e.g., subscription vs. authorization policy) for dynamic labeling and IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->