### PR TITLE
fix(gen-ai): pin csstype to 3.1.3 to fix standalone type-check

### DIFF
--- a/packages/gen-ai/frontend/package-lock.json
+++ b/packages/gen-ai/frontend/package-lock.json
@@ -2390,6 +2390,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@emotion/serialize/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
@@ -4329,6 +4335,13 @@
         }
       }
     },
+    "node_modules/@mui/material/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@mui/material/node_modules/react-is": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
@@ -4399,6 +4412,13 @@
         }
       }
     },
+    "node_modules/@mui/styled-engine/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@mui/system": {
       "version": "7.3.10",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
@@ -4439,6 +4459,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/system/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@mui/types": {
       "version": "7.4.12",
@@ -6431,6 +6458,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
@@ -10937,12 +10970,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
     "node_modules/cyclist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.2.tgz",
@@ -11741,6 +11768,13 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dom-helpers/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",

--- a/packages/gen-ai/frontend/package.json
+++ b/packages/gen-ai/frontend/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "private": true,
   "overrides": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.0",
+    "csstype": "3.1.3"
   },
   "scripts": {
     "prebuild:standalone": "npm run test:type-check:standalone && npm run clean",

--- a/packages/notebooks/upstream/workspaces/frontend/package-lock.json
+++ b/packages/notebooks/upstream/workspaces/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "lodash-es": "^4.17.15",
         "mod-arch-core": "^1.10.2",
         "mod-arch-kubeflow": "^1.10.2",
-        "mod-arch-shared": "^1.10.2",
+        "mod-arch-shared": "^1.15.4",
         "react": "^18",
         "react-dom": "^18",
         "react-router": "^7.5.2",
@@ -12557,9 +12557,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -21154,12 +21155,12 @@
       }
     },
     "node_modules/mod-arch-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.11.0.tgz",
-      "integrity": "sha512-QFHobWbeiE69D/RFCfNmbug64xHt/2lyGBP0kV4FvgyIQ2slpNuB8fWcjpmI549cD2QukPvaxsVAlou307hFWw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-core/-/mod-arch-core-1.16.0.tgz",
+      "integrity": "sha512-Sx1imQU1NS0+XreHlV8fmFFHZUhXiFrEuEBWTTXmqv97nKTGUvTzaHVfMiUoD2oAaDQ1aRDmfnvBd4zbjrM3LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash-es": "^4.17.23",
+        "lodash-es": "^4.18.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21187,9 +21188,9 @@
       }
     },
     "node_modules/mod-arch-kubeflow": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.11.0.tgz",
-      "integrity": "sha512-NY6DEq9huV04z9X0chvkKkNl+4ZE3AKM9SG0XkaZQDTUst7xcYfPrCRlqbi3JYjEH66NCrb+T++UxkS2asGSPw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-kubeflow/-/mod-arch-kubeflow-1.16.0.tgz",
+      "integrity": "sha512-597RBSJanHPhtB4miAgyNKQOIotEwqvtry5X4tWk8NUEwXnmZtBKTmm5NXAbPqMYu0XoEPPD9m9peirXXbgWKw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -21217,16 +21218,16 @@
       }
     },
     "node_modules/mod-arch-shared": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.11.0.tgz",
-      "integrity": "sha512-iWlrba4Gd5WJdRP9L8gHcWu2c4xaNGRFkF+8uyu7a6Ajq99RIFRe5muBIN5u2lwo2ixE6ZGBQx9ex65Blep+fA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/mod-arch-shared/-/mod-arch-shared-1.16.0.tgz",
+      "integrity": "sha512-EOzCM4gbGFRMmEjUMjCbn3AGuEdtd8/+8jS1ssjvGAYbvoilHSqpV5kCNnJO5ICuWAljIGkQgHQbS/QBiugRNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.4.0",
         "@patternfly/react-drag-drop": "^6.4.0",
         "classnames": "^2.2.6",
-        "dompurify": "^3.2.4",
-        "lodash-es": "^4.17.23",
+        "dompurify": "^3.3.2",
+        "lodash-es": "^4.18.1",
         "showdown": "^2.1.0"
       },
       "engines": {
@@ -21249,8 +21250,8 @@
         "eslint-plugin-react-hooks": "^5.2.0"
       },
       "peerDependencies": {
-        "mod-arch-core": ">=1.11.0",
-        "mod-arch-kubeflow": ">=1.11.0",
+        "mod-arch-core": ">=1.16.0",
+        "mod-arch-kubeflow": ">=1.16.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=6.4.0"


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/RHOAIENG-60613

## Description

PR #7362 regenerated the gen-ai lockfile from scratch and pulled in `csstype@3.2.3` as a transitive dependency (via `mod-arch-shared@1.15.4` → `@types/react@18.3.24` → `csstype: ^3.0.2`). The root `node_modules` stays on `csstype@3.1.3`. Because gen-ai's standalone type-check (`tsc -p tsconfig-standalone.json`) follows imports into `frontend/src/` via `@odh-dashboard/internal`, TypeScript encounters two separate `csstype` module instances with incompatible types — causing `TS2322` errors in `MarkdownView.tsx`, `ScopedLabel.tsx`, `TruncatedText.tsx`, `ProjectScopedIcon.tsx`, `ProjectScopedSearchDropdown.tsx`, and `kueue/index.ts`.

**Changes:**
- Pins `csstype` to `3.1.3` via the existing `overrides` field in gen-ai's `package.json`, matching the pattern already used by other packages in the monorepo
- Updates the notebooks lockfile which was also stale after #7362 bumped `mod-arch-shared` across packages (just ran npm install)

## How Has This Been Tested?

Ran `npx tsc --noEmit -p tsconfig-standalone.json` in `packages/gen-ai/frontend` — no errors.

## Test Impact

No functional changes. This only affects the standalone TypeScript type-check used in CI and a stale lockfile.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)