### PR TITLE
fix(gen-ai): add HuggingFace offline env vars to LlamaStackDistribution

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1376,6 +1376,22 @@ func (kc *TokenKubernetesClient) InstallLlamaStackDistribution(ctx context.Conte
 			Name:  "VLLM_MAX_TOKENS",
 			Value: "4096",
 		},
+		{
+			Name:  "SENTENCE_TRANSFORMERS_HOME",
+			Value: "/opt/app-root/src/.cache/huggingface/hub",
+		},
+		{
+			Name:  "HF_HUB_OFFLINE",
+			Value: "1",
+		},
+		{
+			Name:  "TRANSFORMERS_OFFLINE",
+			Value: "1",
+		},
+		{
+			Name:  "HF_DATASETS_OFFLINE",
+			Value: "1",
+		},
 	}
 
 	// Add token environment variables from existing secrets


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-50523

## Description

On disconnected clusters, RAG document upload stalls because llama-stack attempts to pull the `ibm-granite/granite-embedding-125m-english` embedding model from `huggingface.co` at runtime, even though the model is already bundled in the LlamaStack Distribution image.

This PR adds the four environment variables required to force llama-stack to use the locally cached model:

| Variable | Value |
|---|---|
| `SENTENCE_TRANSFORMERS_HOME` | `/opt/app-root/src/.cache/huggingface/hub` |
| `HF_HUB_OFFLINE` | `1` |
| `TRANSFORMERS_OFFLINE` | `1` |
| `HF_DATASETS_OFFLINE` | `1` |

These are injected into the `LlamaStackDistribution` pod's `ContainerSpec.Env` during installation via the BFF's `InstallLlamaStackDistribution` in `token_k8s_client.go`.

## How Has This Been Tested?

Tested on a connected cluster by installing the Gen AI Playground and uploading a RAG document. Two pod logs were captured to show the difference:

**Without the fix** ([lsd-genai-playground-online.log](https://github.com/user-attachments/files/27262395/lsd-genai-playground-online.log)) — uploading a document triggers the sentence-transformer to load and contact HuggingFace:

```
INFO  llama_stack.providers.utils.inference.embedding_mixin:98 Loading sentence
      transformer for ibm-granite/granite-embedding-125m-english...  category=providers::utils
...
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN
         to enable higher rate limits and faster downloads.
```

On a disconnected cluster this results in `Network is unreachable` and the upload never completes.

**With the fix** ([lsd-genai-playground-offline.log](https://github.com/user-attachments/files/27262394/lsd-genai-playground-offline.log)) — the env vars cause the model to be loaded from the local cache. The HuggingFace contact attempt and warning are absent entirely. Document upload succeeds.

## Test Impact

No new tests added. The change is a static env var addition to the K8s resource spec created by the BFF — there is no conditional logic to test. The behaviour was validated by comparing pod logs before and after the change on a live cluster (see above).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes pod configuration to support offline mode for AI model caching. Environment variables now configure the system to use local Hugging Face model caches and operate without requiring external model downloads during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->