### PR TITLE
feat(backend): support DEV_IMPERSONATE_TOKEN for OAuth/IDP users

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,3 +20,14 @@ OC_URL=replace-with-url
 OC_USER=replace-with-username
 OC_PASSWORD=replace-with-password
 # OC_TOKEN=replace-with-token
+
+# Dev Impersonation (optional) — test as a different user without disabling backend functionality.
+# Set DEV_IMPERSONATE_USER along with EITHER a password OR a token:
+#   - Password: for users with local cluster credentials (htpasswd, etc.)
+#   - Token: for OAuth/IDP users (Google, LDAP, etc.) who don't have a cluster password.
+#     Obtain a token via: oc login --web && oc whoami -t
+#     Note: tokens expire (typically 24h) and must be refreshed.
+# If on ROSA, also set DEV_OAUTH_PREFIX=oauth
+# DEV_IMPERSONATE_USER=replace-with-username
+# DEV_IMPERSONATE_PASSWORD=replace-with-password
+# DEV_IMPERSONATE_TOKEN=replace-with-token

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -5,6 +5,7 @@ import { setImpersonateAccessToken } from '../../../devFlags';
 import { KubeFastifyInstance } from '../../../types';
 import {
   DEV_IMPERSONATE_PASSWORD,
+  DEV_IMPERSONATE_TOKEN,
   DEV_IMPERSONATE_USER,
   DEV_OAUTH_PREFIX,
 } from '../../../utils/constants';
@@ -18,6 +19,12 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       return new Promise<{ code: number; response: string }>((resolve, reject) => {
         const doImpersonate = request.body.impersonate;
         if (doImpersonate) {
+          // If a pre-obtained token is provided, use it directly without the OAuth flow
+          if (DEV_IMPERSONATE_TOKEN) {
+            setImpersonateAccessToken(DEV_IMPERSONATE_TOKEN);
+            resolve({ code: 200, response: DEV_IMPERSONATE_TOKEN });
+            return;
+          }
           const apiPath = fastify.kube.config.getCurrentCluster().server;
           const namedHost = apiPath.slice('https://api.'.length).split(':')[0];
           const url = `https://${DEV_OAUTH_PREFIX}.${namedHost}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -10,6 +10,8 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const DEV_IMPERSONATE_PASSWORD = DEV_MODE ? process.env.DEV_IMPERSONATE_PASSWORD : undefined;
+/** Allows providing a pre-obtained bearer token directly, bypassing the OAuth Basic Auth flow. Useful for OAuth/IDP users without a password. */
+export const DEV_IMPERSONATE_TOKEN = DEV_MODE ? process.env.DEV_IMPERSONATE_TOKEN : undefined;
 export const DEV_OAUTH_PREFIX = process.env.DEV_OAUTH_PREFIX || 'oauth-openshift.apps';
 export const APP_ENV = process.env.APP_ENV;
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -46,9 +46,20 @@ See the [k8s pass through API] here.
 
 ### Pass Through Impersonate User Dev Mode
 
-In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add the `DEV_IMPERSONATE_USER` and `DEV_IMPERSONATE_PASSWORD` environment variables to your local setup with valid k8s username and password in your cluster. This will bypass the regular pass-through flow and will add that specific headers to the calls. The steps to impersonate another user are listed as follows:
+In order to check regular user permissions without disabling the rest of the backend functionality in `dev mode`, you can add impersonation environment variables to your `.env.local` file. This will bypass the regular pass-through flow and will add that specific headers to the calls.
 
-1. Create a new env variable in your `.env.local` file with this format `DEV_IMPERSONATE_USER=<username>` and `DEV_IMPERSONATE_PASSWORD=<password>`. If you're on ROSA make sure you set `DEV_OAUTH_PREFIX=oauth`.
+Set `DEV_IMPERSONATE_USER` to the username you want to impersonate, along with **either** a password or a token:
+
+- **Password** (`DEV_IMPERSONATE_PASSWORD`): For users with local cluster credentials (htpasswd, etc.). Uses HTTP Basic Auth against the cluster's OAuth endpoint.
+- **Token** (`DEV_IMPERSONATE_TOKEN`): For OAuth/IDP users (Google, LDAP, etc.) who don't have a cluster password. Provide a pre-obtained bearer token directly, bypassing the OAuth flow entirely.
+
+The steps to impersonate another user are listed as follows:
+
+1. Add the following to your `.env.local` file:
+   - `DEV_IMPERSONATE_USER=<username>`
+   - **Option A** (password): `DEV_IMPERSONATE_PASSWORD=<password>`
+   - **Option B** (token): `DEV_IMPERSONATE_TOKEN=<token>` — obtain via `oc login --web && oc whoami -t`. Note: tokens expire (typically 24h) and must be refreshed.
+   - If you're on ROSA, also set `DEV_OAUTH_PREFIX=oauth`.
 2. Run the dev server for ODH dashboard. If you don't know how to run a local dev server, please refer to [CONTRIBUTING]
 3. Click on the username on the top right corner to open the dropdown menu, and choose `Start impersonate`, then the page will refresh and you will be impersonating as the user you set up in step 1
 4. To stop impersonating, click on the `Stop impersonate` button in the header toolbar


### PR DESCRIPTION
## Description
Adds a new `DEV_IMPERSONATE_TOKEN` env var that allows providing a pre-obtained bearer token directly, bypassing the OAuth Basic Auth flow in dev mode.

The existing `DEV_IMPERSONATE_USER` / `DEV_IMPERSONATE_PASSWORD` mechanism uses HTTP Basic Auth against the cluster's OAuth challenging-client endpoint. This doesn't work for OAuth/IDP users (e.g. Google IDP) who don't have a cluster password.

With this change, developers can:
1. Log in via `oc login --web` (browser-based OAuth)
2. Get their token via `oc whoami -t`
3. Set `DEV_IMPERSONATE_TOKEN=<token>` in `.env.local` instead of `DEV_IMPERSONATE_PASSWORD`
4. Toggle impersonation in the UI as normal

When `DEV_IMPERSONATE_TOKEN` is set, the `/api/dev-impersonate` endpoint skips the OAuth flow entirely and uses the provided token directly. `DEV_IMPERSONATE_USER` should also be set, as it is used for username resolution.

**Note:** OpenShift tokens expire (typically 24h), so the token needs periodic refresh.

### Documentation updates
- `.env.local.example` — added impersonation env vars with usage guidance
- `docs/SDK.md` — updated "Pass Through Impersonate User Dev Mode" section to cover both password and token options

## How Has This Been Tested?
- Verified the backend starts successfully with `DEV_IMPERSONATE_TOKEN` set
- Confirmed the impersonation toggle uses the provided token without attempting Basic Auth

## Test Impact
No new tests added. This is a dev-only feature (`DEV_MODE` gated) that adds an alternative code path alongside the existing Basic Auth flow. The existing flow is unchanged when `DEV_IMPERSONATE_TOKEN` is not set.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-based authentication option for developer impersonation mode, allowing use of pre-obtained OAuth/IDP tokens as an alternative to password credentials.

* **Documentation**
  * Updated configuration examples and SDK documentation with instructions for obtaining tokens, setting up impersonation variables, and handling token expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->