### PR TITLE
fix: Show connected resources for URI-v1 connections

### DIFF
--- a/frontend/src/pages/projects/__tests__/useInferenceServicesForConnection.spec.ts
+++ b/frontend/src/pages/projects/__tests__/useInferenceServicesForConnection.spec.ts
@@ -46,4 +46,44 @@ describe('useInferenceServicesForConnection', () => {
     const renderResult = testHook(useInferenceServicesForConnection)(connection);
     expect(renderResult.result.current).toHaveLength(1);
   });
+
+  it('should match connections via the opendatahub.io/connections annotation', () => {
+    const uriConnection = mockConnection({
+      name: 'uri-connection',
+      displayName: 'URI Connection',
+      connectionType: 'uri-v1',
+      data: { URI: btoa('https://example.com/model') },
+    });
+
+    const uriInferenceServices = [
+      mockInferenceServiceK8sResource({
+        name: 'uri-model',
+        displayName: 'URI Model',
+        secretName: 'uri-connection',
+        storageUri: 'https://example.com/model',
+      }),
+      mockInferenceServiceK8sResource({
+        name: 'other-model',
+        displayName: 'Other Model',
+        secretName: 'other-connection',
+      }),
+    ];
+
+    useContextMock.mockReturnValue({
+      inferenceServices: {
+        data: { items: uriInferenceServices, hasNonDashboardItems: false },
+        loaded: true,
+        refresh: jest.fn(),
+      },
+    } satisfies Pick<ProjectDetailsContextType, 'inferenceServices'>);
+
+    const renderResult = testHook(useInferenceServicesForConnection)(uriConnection);
+    expect(renderResult.result.current).toHaveLength(1);
+    expect(renderResult.result.current[0].metadata.name).toBe('uri-model');
+  });
+
+  it('should return empty array when no connection is provided', () => {
+    const renderResult = testHook(useInferenceServicesForConnection)(undefined);
+    expect(renderResult.result.current).toHaveLength(0);
+  });
 });

--- a/frontend/src/pages/projects/useInferenceServicesForConnection.ts
+++ b/frontend/src/pages/projects/useInferenceServicesForConnection.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InferenceServiceKind, PersistentVolumeClaimKind } from '#~/k8sTypes';
+import { InferenceServiceKind, MetadataAnnotation, PersistentVolumeClaimKind } from '#~/k8sTypes';
 import { Connection } from '#~/concepts/connectionTypes/types';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { getPVCNameFromURI } from '#~/pages/modelServing/screens/projects/utils';
@@ -19,7 +19,8 @@ export const useInferenceServicesForConnection = (
 
   return inferenceServices.filter(
     (inferenceService) =>
-      // Known issue: this only works for OCI, S3, and PVC connections
+      inferenceService.metadata.annotations?.[MetadataAnnotation.ConnectionName] ===
+        connectionName ||
       inferenceService.spec.predictor.model?.storage?.key === connectionName ||
       inferenceService.spec.predictor.imagePullSecrets?.[0]?.name === connectionName ||
       getPVCNameFromURI(inferenceService.spec.predictor.model?.storageUri ?? '') ===


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-59657

## Description

URI-v1 connections always show `--` in the **Connected Resources** column of the Connections table, even when deployed models are actively using them.

**Root cause:** `useInferenceServicesForConnection` only matched connections to InferenceServices via `storage.key` (S3), `imagePullSecrets` (OCI), or PVC URI hostname. When a model is deployed with a URI-v1 connection, `assembleInferenceService` sets `model.storageUri` directly and **deletes** `model.storage` — so `storage.key` is never present, and none of the existing matchers apply to URI connections.

**Fix:** Added two new matching strategies to `useInferenceServicesForConnection`:
1. **Annotation match** — checks the `opendatahub.io/connections` annotation (`MetadataAnnotation.ConnectionName`) on the InferenceService, which the kserve package deploy flow sets.
2. **URI value match** — decodes the connection's `data.URI` (base64) and compares it to the InferenceService's `storageUri`. This handles the `ManageKServeModal` deploy flow which doesn't set the annotation. Follows the same pattern used in `useLabeledConnections.ts` and `useRegistryConnections.ts`.

A new `isConnectionWithUri` type guard was introduced to safely narrow `Connection | PersistentVolumeClaimKind` without relying on `isSecretKind` (which fails on listed K8s items because the list API omits `kind` from individual items).

## How Has This Been Tested?

https://github.com/user-attachments/assets/11b56c4e-4452-493f-8b98-bd5e56c4a914


- Manually tested on a live cluster (ODH Dashboard local dev, `npm run start:dev:ext`) against a project with URI-v1 connections and deployed InferenceServices — Connected Resources column correctly shows the model name.
- Added 3 new unit tests covering URI storageUri comparison, annotation-based matching, and the undefined connection edge case.
- Existing `ConnectionsTable` tests continue to pass.

## Test Impact

Added 3 unit tests to `frontend/src/pages/projects/__tests__/useInferenceServicesForConnection.spec.ts`:
- `should match URI-v1 connections via storageUri value comparison`
- `should match connections via the opendatahub.io/connections annotation`
- `should return empty array when no connection is provided`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced inference service matching for connections by adding metadata annotation-based matching criteria alongside existing storage and pull secrets matching, improving service discovery accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->