### PR TITLE
chore: gitignore .claude/mlflow/ runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ contract-test-results
 # Claude
 CLAUDE.md
 .claude/settings.local.json
+.claude/mlflow/
 
 # Playwright MCP
 .playwright-mcp/


### PR DESCRIPTION
## Description

MLflow's Claude Code tracing integration (`mlflow autolog claude`) creates a `.claude/mlflow/` directory containing runtime trace logs (`claude_tracing.log`). These are local artifacts that shouldn't be committed.

## How Has This Been Tested?

Verified the `.gitignore` pattern correctly matches the `.claude/mlflow/` directory.

## Test Impact

No tests needed — gitignore change only.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version control ignores to exclude an additional local directory.

* **New Features**
  * Preflight/status summary now presents a structured multi-field overview (remote, branch, commit, PR or no-PR, Jira key, synced state, affected packages) for clearer traceability and MLflow emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->