### PR TITLE
fix: add preflight early-exit guard for empty branches

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -70,6 +70,29 @@ Optional tools (check but don't block):
 - `coderabbit` — needed only if user selects CodeRabbit review
 - `npm` / `npx` — needed only for local lint/type-check/test runs
 
+## Step 0.5: Early exit — nothing to check
+
+After prerequisites pass, before doing any work, check if there's actually something to preflight:
+
+```bash
+branch=$(git branch --show-current)
+base_branch="main"
+diff_count=$(git diff --name-only origin/$base_branch 2>/dev/null | wc -l | tr -d ' ')
+uncommitted=$(git status --porcelain | grep -v '^??' | wc -l | tr -d ' ')
+```
+
+If ALL of these are true:
+- Branch is the default branch (`main` or `master`)
+- No diff vs `origin/$base_branch` (`diff_count == 0`)
+- No uncommitted tracked changes (`uncommitted == 0`)
+- No PR number was explicitly passed as an argument
+
+Then **stop immediately** and tell the user:
+
+> Nothing to preflight. You're on `$branch` with no changes vs `origin/$branch`. Preflight checks a branch or PR that has work to review.
+
+Do not run the full check ceremony. Do not produce a table of ➖s. That's noise.
+
 ## Step 1: Gather context
 
 Try to find a PR (unless `--local`):


### PR DESCRIPTION
Non-code change — AI skill improvement only.

## Description

The preflight skill (`/preflight`) previously ran its full check ceremony when invoked on `main` with zero diff, producing a useless table of N/A results. This adds a Step 0.5 early-exit guard that detects when there's nothing to check and stops immediately.

**Root cause:** During a session, the agent ran `/preflight` on `main` after fixing a local-only issue (`npm install` for stale `node_modules`). The skill had no guard against this, so it ran every check and produced noise.

**Fix:** After prerequisites pass, check if branch is default + no diff + no uncommitted changes + no explicit PR arg. If all true, exit with a clear message instead of running the full protocol.

## How Has This Been Tested?

Metacognitive trace — the failure that motivated this fix occurred in this session. The guard logic was verified against the exact scenario that triggered it.

## Test Impact

Not applicable — this is an AI skill definition (`.claude/skills/`), not application code. No unit or cypress tests apply.

---

*This PR was authored by an AI assistant (Anthropic claude-sonnet-4-20250514) on behalf of @bgregor.*

Co-authored-by: darachcawley <dcawley@redhat.com>