### PR TITLE
Upgrade MaaS go version to 1.25.9

### DIFF
--- a/.github/workflows/maas-bff-tests.yml
+++ b/.github/workflows/maas-bff-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.6"
+          go-version: "1.25.9"
 
       - name: Lint
         working-directory: packages/maas/bff

--- a/packages/maas/AGENTS.md
+++ b/packages/maas/AGENTS.md
@@ -105,7 +105,7 @@ maas/
 
 ### BFF
 
-- **Go**: >= 1.24
+- **Go**: >= 1.25
 
 ---
 
@@ -313,7 +313,7 @@ DEPLOYMENT_MODE=federated STYLE_THEME=patternfly-theme make dev-start
 
 ## Project-Wide Expectations
 
-1. Use **Go 1.24+** for the BFF and **Node 20+** for the frontend
+1. Use **Go 1.25+** for the BFF and **Node 20+** for the frontend
 2. Keep tooling in sync with `package.json` and `go.mod`
 3. Stick to **PatternFly components** and utilities; Material UI appears only when Kubeflow flavor
    explicitly requires it

--- a/packages/maas/Dockerfile
+++ b/packages/maas/Dockerfile
@@ -4,7 +4,7 @@ ARG BFF_SOURCE_CODE=./bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=node:22
-ARG GOLANG_BASE_IMAGE=golang:1.24.3
+ARG GOLANG_BASE_IMAGE=golang:1.25.9
 ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # UI build stage

--- a/packages/maas/Dockerfile.workspace
+++ b/packages/maas/Dockerfile.workspace
@@ -9,7 +9,7 @@ ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
 ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
-ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
 
 # UI build stage

--- a/packages/maas/bff/Makefile
+++ b/packages/maas/bff/Makefile
@@ -100,7 +100,7 @@ define go-install-tool
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) GOTOOLCHAIN=go1.24.3 go install $${package} ;\
+GOBIN=$(LOCALBIN) GOTOOLCHAIN=go1.25.9 go install $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef

--- a/packages/maas/bff/README.md
+++ b/packages/maas/bff/README.md
@@ -4,7 +4,7 @@ Minimal backend-for-frontend providing only core endpoints required by the start
 
 ## Dependencies
 
-- Go >= 1.24.3
+- Go >= 1.25.9
 
 ## Scope
 

--- a/packages/maas/bff/go.mod
+++ b/packages/maas/bff/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/maas-library/bff
 
-go 1.24.3
+go 1.25.9
 
 require (
 	github.com/google/uuid v1.6.0

--- a/packages/maas/docs/install.md
+++ b/packages/maas/docs/install.md
@@ -36,7 +36,7 @@ npx mod-arch-installer experiments-ui --flavor default
 ## After running the installer
 
 1. `cd <your-project>/frontend` and run `npm run start:dev` (or `npm run start:default` if you generated the default flavor).
-2. Run the Go BFF locally: `cd <your-project>/bff && make run` (requires Go 1.24+).
+2. Run the Go BFF locally: `cd <your-project>/bff && make run` (requires Go 1.25+).
 3. Update the OpenAPI spec inside `api/openapi/` to describe your module's contract.
 4. Customize namespaces, routes, and branding to match your feature.
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58954
## Description
Upgrades the `packages/maas` BFF from Go 1.24 to **Go 1.25.9** (latest stable patch, released 2026-04-07) across all toolchain configuration, container images, CI, and documentation.
**Files changed:**
| File | Change |
|---|---|
| `packages/maas/bff/go.mod` | `go 1.24.3` → `go 1.25.9` |
| `packages/maas/bff/go.sum` | Regenerated via `go mod tidy` |
| `packages/maas/Dockerfile` | `golang:1.24.3` → `golang:1.25.9` |
| `packages/maas/Dockerfile.workspace` | `go-toolset:1.24` → `go-toolset:1.25` |
| `.github/workflows/maas-bff-tests.yml` | `go-version: "1.24.6"` → `"1.25.9"` |
| `packages/maas/bff/Makefile` | `GOTOOLCHAIN=go1.24.3` → `go1.25.9` |
| `packages/maas/AGENTS.md` / `CLAUDE.md` | `Go 1.24+` / `>= 1.24` → `1.25+` / `>= 1.25` |
| `packages/maas/bff/README.md` | `Go >= 1.24.3` → `>= 1.25.9` |
| `packages/maas/docs/install.md` | `Go 1.24+` → `Go 1.25+` |
No Go source code changes were needed — this is a pure toolchain bump. The Go source is compatible with 1.25 without modification.
Note: the CI workflow previously pinned `go-version: "1.24.6"` while `go.mod` declared `go 1.24.3`; both are now aligned to `1.25.9`.
Reference: model-registry equivalent — [#6286](https://github.com/opendatahub-io/odh-dashboard/pull/6286).
## How Has This Been Tested?
Ran the full BFF test suite locally after upgrading to go 1.25.9:
```bash
cd packages/maas/bff && go mod tidy   # regenerated go.sum against Go 1.25.9
cd packages/maas/bff && make lint     # 0 issues
cd packages/maas && make test         # 71/71 tests passed
```
from root
```bash
docker build --file packages/maas/Dockerfile.workspace .
```

## Test Impact
No new tests were added. This is a toolchain-only change — the existing 71 BFF API unit tests provide coverage that the code continues to compile and function correctly under Go 1.25.9. No logic changed.
## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain requirement to 1.25.9 across build configurations and CI workflows

* **Documentation**
  * Updated Go version requirements in development and installation guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->