### PR TITLE
fix(gen-ai): return empty slice instead of nil from extractEndpointsFromLLMInferenceService

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1184,7 +1184,7 @@ func (kc *TokenKubernetesClient) extractEndpointsFromLLMInferenceService(llmSvc 
 		}
 	}
 
-	var endpoints []string
+	endpoints := []string{}
 	if internalURL != "" {
 		endpoints = append(endpoints, fmt.Sprintf("internal: %s", internalURL))
 	}

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -544,12 +544,16 @@ func TestExtractEndpointsFromLLMInferenceService(t *testing.T) {
 
 	t.Run("nil LLMInferenceService returns empty endpoints", func(t *testing.T) {
 		endpoints := client.extractEndpointsFromLLMInferenceService(nil)
+		assert.NotNil(t, endpoints)
 		assert.Empty(t, endpoints)
 	})
 
 	t.Run("empty status returns empty endpoints", func(t *testing.T) {
+		// Simulates a stopped llm-d deployment where the address is removed from the CR.
+		// Must return [] (not nil) so the JSON response contains [] instead of null.
 		llmSvc := &kservev1alpha1.LLMInferenceService{}
 		endpoints := client.extractEndpointsFromLLMInferenceService(llmSvc)
+		assert.NotNil(t, endpoints)
 		assert.Empty(t, endpoints)
 	})
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58758

## Description

When a stopped llm-d deployment is registered as an AI Asset, opening the GenAI Playground crashed the UI.

**Root cause:** `extractEndpointsFromLLMInferenceService` declared `var endpoints []string`, which is a nil slice in Go. When the deployment is stopped and its address is removed from the CR status, no endpoints are appended and the function returns `nil`. A nil slice JSON-encodes as `null`, and the UI crashed when it tried to iterate over `null` endpoints.

**Fix:** Initialize `endpoints` as `[]string{}` so it always JSON-encodes as `[]` regardless of whether any endpoints are found. This matches the pattern already used by `extractEndpoints` for `InferenceService`.

## How Has This Been Tested?

Manually tested with a stopped llm-d deployment registered as an AI Asset — the Playground no longer crashes and correctly shows an empty endpoints list.

## Test Impact

Updated `token_k8s_client_test.go`:
- Added `assert.NotNil` to "nil LLMInferenceService returns empty endpoints" test case
- Added `assert.NotNil` to "empty status returns empty endpoints" test case (this case directly simulates a stopped deployment)

No new test cases were required — the existing "empty status" case already covered the stopped-deployment scenario; it just didn't assert the nil/empty distinction.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`