### PR TITLE
fix(autorag): warn when no compatible vector I/O providers found

### DIFF
--- a/packages/autorag/frontend/src/__mocks__/mockVectorStore.ts
+++ b/packages/autorag/frontend/src/__mocks__/mockVectorStore.ts
@@ -16,6 +16,10 @@ export const mockVectorStoreProvider = ({
 
 export const mockVectorStoreProvidersResponse = (
   providers?: LlamaStackVectorStoreProvider[],
-): LlamaStackVectorStoreProvidersResponse => ({
-  vector_store_providers: providers ?? [mockVectorStoreProvider()],
-});
+): LlamaStackVectorStoreProvidersResponse & { totalProviderCount: number } => {
+  const list = providers ?? [mockVectorStoreProvider()];
+  return {
+    vector_store_providers: list,
+    totalProviderCount: list.length,
+  };
+};

--- a/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
@@ -59,7 +59,17 @@ const AutoragVectorStoreSelector: React.FC = () => {
     SUPPORTED_VECTOR_STORE_PROVIDER_TYPES,
   );
 
+  // TODO: Re-enable in 3.5 when DEFAULT_IN_MEMORY_PROVIDER is available.
+  // Inject the default in-memory provider at the beginning of the list.
+  // const providers = [DEFAULT_IN_MEMORY_PROVIDER, ...apiProviders];
+  const apiProviders = providersData?.vector_store_providers ?? [];
+  const providers = apiProviders;
+  const totalProviderCount = providersData?.totalProviderCount ?? 0;
+
   useEffect(() => {
+    if (isLoading) {
+      return;
+    }
     if (isError) {
       notification.error(
         'Failed to load vector I/O providers.',
@@ -68,14 +78,16 @@ const AutoragVectorStoreSelector: React.FC = () => {
           not expired.
         </>,
       );
+    } else if (totalProviderCount > 0 && providers.length === 0) {
+      notification.warning(
+        'No compatible vector I/O providers found.',
+        <>
+          Vector I/O providers were found on the Llama Stack server, but none are compatible with
+          AutoRAG. Ensure a remote Milvus provider is configured on your Llama Stack server.
+        </>,
+      );
     }
-  }, [isError, notification]);
-
-  // TODO: Re-enable in 3.5 when DEFAULT_IN_MEMORY_PROVIDER is available.
-  // Inject the default in-memory provider at the beginning of the list.
-  // const providers = [DEFAULT_IN_MEMORY_PROVIDER, ...apiProviders];
-  const apiProviders = providersData?.vector_store_providers ?? [];
-  const providers = apiProviders;
+  }, [isLoading, isError, totalProviderCount, providers.length, notification]);
   const selectedProvider = providers.find((p) => p.provider_id === field.value);
 
   // Clear stale selection when the provider list changes and no longer includes

--- a/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/AutoragVectorStoreSelector.tsx
@@ -43,7 +43,9 @@ const AutoragVectorStoreSelector: React.FC = () => {
     control,
   } = useFormContext<ConfigureSchema>();
 
-  const { field } = useController<ConfigureSchema, 'llama_stack_vector_io_provider_id'>({
+  const {
+    field: { value: fieldValue, onChange: fieldOnChange },
+  } = useController<ConfigureSchema, 'llama_stack_vector_io_provider_id'>({
     name: 'llama_stack_vector_io_provider_id',
   });
 
@@ -88,16 +90,16 @@ const AutoragVectorStoreSelector: React.FC = () => {
       );
     }
   }, [isLoading, isError, totalProviderCount, providers.length, notification]);
-  const selectedProvider = providers.find((p) => p.provider_id === field.value);
+  const selectedProvider = providers.find((p) => p.provider_id === fieldValue);
 
   // Clear stale selection when the provider list changes and no longer includes
   // the previously selected provider (e.g., LlamaStack secret was changed or
   // providers became empty).
   useEffect(() => {
-    if (field.value && !providers.some((p) => p.provider_id === field.value)) {
-      field.onChange('');
+    if (fieldValue && !providers.some((p) => p.provider_id === fieldValue)) {
+      fieldOnChange('');
     }
-  }, [providers, field]);
+  }, [providers, fieldValue, fieldOnChange]);
 
   if (isLoading) {
     return <Skeleton width="200px" height="36px" />;
@@ -112,10 +114,10 @@ const AutoragVectorStoreSelector: React.FC = () => {
       onOpenChange={setIsOpen}
       onSelect={(_e, selectedProviderId) => {
         const provider = providers.find((p) => p.provider_id === selectedProviderId);
-        field.onChange(provider ? provider.provider_id : '');
+        fieldOnChange(provider ? provider.provider_id : '');
         setIsOpen(false);
       }}
-      selected={selectedProvider?.provider_id}
+      selected={fieldValue}
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
+++ b/packages/autorag/frontend/src/app/components/configure/__tests__/AutoragVectorStoreSelector.spec.tsx
@@ -21,12 +21,13 @@ jest.mock('~/app/hooks/queries', () => ({
 }));
 
 const mockNotificationError = jest.fn();
+const mockNotificationWarning = jest.fn();
 jest.mock('~/app/hooks/useNotification', () => ({
   useNotification: jest.fn(() => ({
     success: jest.fn(),
     error: mockNotificationError,
     info: jest.fn(),
-    warning: jest.fn(),
+    warning: mockNotificationWarning,
     remove: jest.fn(),
   })),
 }));
@@ -134,7 +135,7 @@ describe('AutoragVectorStoreSelector', () => {
 
   it('should disable the toggle when no providers are available', () => {
     mockUseLlamaStackVectorStoreProvidersQuery.mockReturnValue({
-      data: { vector_store_providers: [] }, // eslint-disable-line camelcase
+      data: { vector_store_providers: [], totalProviderCount: 0 }, // eslint-disable-line camelcase
       isLoading: false,
     } as unknown as ReturnType<typeof useLlamaStackVectorStoreProvidersQuery>);
 
@@ -160,6 +161,31 @@ describe('AutoragVectorStoreSelector', () => {
       'Failed to load vector I/O providers.',
       expect.anything(), // Error message may include details from lls BFF in the future.
     );
+  });
+
+  it('should show warning notification when providers exist but none are supported', () => {
+    mockUseLlamaStackVectorStoreProvidersQuery.mockReturnValue({
+      data: { vector_store_providers: [], totalProviderCount: 2 }, // eslint-disable-line camelcase
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLlamaStackVectorStoreProvidersQuery>);
+
+    renderWithProviders(<AutoragVectorStoreSelector />);
+
+    expect(mockNotificationWarning).toHaveBeenCalledWith(
+      'No compatible vector I/O providers found.',
+      expect.anything(),
+    );
+  });
+
+  it('should not show warning notification when no providers exist at all', () => {
+    mockUseLlamaStackVectorStoreProvidersQuery.mockReturnValue({
+      data: { vector_store_providers: [], totalProviderCount: 0 }, // eslint-disable-line camelcase
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLlamaStackVectorStoreProvidersQuery>);
+
+    renderWithProviders(<AutoragVectorStoreSelector />);
+
+    expect(mockNotificationWarning).not.toHaveBeenCalled();
   });
 
   it('should show a loading skeleton when providers are loading', () => {

--- a/packages/autorag/frontend/src/app/hooks/queries.ts
+++ b/packages/autorag/frontend/src/app/hooks/queries.ts
@@ -6,7 +6,7 @@ import { getFiles as getS3Files } from '~/app/api/s3';
 import {
   LlamaStackModelsResponse,
   LlamaStackModelType,
-  LlamaStackVectorStoreProvidersResponse,
+  LlamaStackFilteredVectorStoreProvidersResponse,
   PipelineRun,
   S3ListObjectsResponse,
   SecretListItem,
@@ -124,7 +124,7 @@ export function useLlamaStackVectorStoreProvidersQuery(
   namespace: string,
   secretName: string,
   providerTypes?: string[],
-): UseQueryResult<LlamaStackVectorStoreProvidersResponse, Error> {
+): UseQueryResult<LlamaStackFilteredVectorStoreProvidersResponse, Error> {
   return useQuery({
     enabled: !!namespace && !!secretName,
     // providerTypes is intentionally excluded: select transforms cached data without
@@ -153,11 +153,14 @@ export function useLlamaStackVectorStoreProvidersQuery(
       }
     },
     // Filter by provider_type when a non-empty providerTypes array is given.
+    // totalProviderCount preserves the unfiltered count so the UI can distinguish
+    // "no providers at all" from "providers exist but none are supported".
     select: (data) => ({
       // eslint-disable-next-line camelcase
       vector_store_providers: data.vector_store_providers.filter(
         (p) => !providerTypes?.length || providerTypes.includes(p.provider_type),
       ),
+      totalProviderCount: data.vector_store_providers.length,
     }),
   });
 }

--- a/packages/autorag/frontend/src/app/types.ts
+++ b/packages/autorag/frontend/src/app/types.ts
@@ -131,6 +131,11 @@ export type LlamaStackVectorStoreProvidersResponse = {
   vector_store_providers: LlamaStackVectorStoreProvider[];
 };
 
+export type LlamaStackFilteredVectorStoreProvidersResponse =
+  LlamaStackVectorStoreProvidersResponse & {
+    totalProviderCount: number;
+  };
+
 export type SecretListItem = {
   uuid: string;
   name: string;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-60578

## Description

When the Llama Stack server returns vector I/O providers but none match the supported types (e.g., `remote::milvus`), the user previously saw no feedback — the dropdown was simply empty with no explanation.

This PR adds a warning notification that distinguishes between two cases:
- **No providers at all** — no notification (the dropdown already shows "No vector I/O providers available")
- **Providers exist but none are compatible** — shows a warning: _"No compatible vector I/O providers found."_ with guidance to configure a remote Milvus provider

### Implementation details
- Added `totalProviderCount` to the `select` transform in `useLlamaStackVectorStoreProvidersQuery`, preserving the unfiltered count so the UI can distinguish the two cases
- Added `LlamaStackFilteredVectorStoreProvidersResponse` type extending the base response with `totalProviderCount`
- Added `isLoading` guard in the notification `useEffect` to prevent spurious notifications during initial render

Before
<img width="1181" height="738" alt="Screenshot 2026-05-01 at 2 28 48 PM" src="https://github.com/user-attachments/assets/115d57d8-b9d8-4fee-b7e0-5cf46ad4e62f" />

After
<img width="2557" height="1293" alt="Screenshot 2026-04-30 at 2 28 31 PM" src="https://github.com/user-attachments/assets/f4f6d215-de93-42d2-bb8e-32d5abb259f2" />

## How Has This Been Tested?

- Unit tests: 12/12 passing (2 new tests added)
- Lint: passing
- Type-check: passing
- BFF tests: passing
- Contract tests: passing

## Test Impact

Added two new unit tests in `AutoragVectorStoreSelector.spec.tsx`:
- `should show warning notification when providers exist but none are supported` — verifies warning fires when `totalProviderCount > 0` but filtered list is empty
- `should not show warning notification when no providers exist at all` — verifies no warning when `totalProviderCount === 0`

Updated existing test mock data to include `totalProviderCount` for consistency.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning behavior in the vector store selector: it now distinguishes “no providers exist” from “providers exist but none are compatible,” and avoids spurious warnings while loading.

* **New Features**
  * Provider query now returns an overall provider count so the UI can tell the difference between zero providers and zero compatible providers.

* **Tests**
  * Updated tests to assert the new warning conditions and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->