### PR TITLE
fix(gen-ai): reset toolsLoaded before each MCP server tools fetch

### DIFF
--- a/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useMCPServerTools.ts
@@ -32,6 +32,7 @@ export const useMCPServerTools = (
     }
 
     setIsLoading(true);
+    setToolsLoaded(false);
     setToolsLoadError(null);
 
     try {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58729

## Description

In the Playground MCP tab, the loading spinner for an MCP server's tools only appeared on the first open. Subsequent opens showed a blank modal body until the fetch completed.

**Root cause:** When the modal closed, `enabled` (`isOpen`) became `false`, causing `fetchTools` to take its early-return branch, which set `toolsLoaded = true` without ever calling `setIsLoading(true)`. On the next open, `setIsLoading(true)` ran — but `toolsLoaded` was still `true` from the close path, so the spinner condition `isLoading && !toolsLoaded` evaluated to `false` and no spinner was shown.

**Fix:** Add `setToolsLoaded(false)` at the start of the actual fetch path in `useMCPServerTools.ts`, so `toolsLoaded` is always reset before each new load begins.

## How Has This Been Tested?

Manually tested in the Playground MCP tab:
1. Opened the tools modal for an MCP server — spinner appeared ✓
2. Closed and reopened the modal — spinner appeared again on each subsequent open ✓

## Test Impact

The fix is a one-line change to hook state initialization. No new tests added; the existing behaviour is straightforward and the fix is self-contained.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`