### PR TITLE
fix: correct gen-ai Tekton pipeline triggers

### DIFF
--- a/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-pull-request.yaml
@@ -8,9 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( " packages/gen-ai/**".pathChanged()
-      || ".tekton/odh-mod-arch-gen-ai-pull-request.yaml".pathChanged() || "Dockerfile.workspace".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      (
+        "packages/gen-ai/**".pathChanged() ||
+        ".tekton/odh-mod-arch-gen-ai-pull-request.yaml".pathChanged() ||
+        "Dockerfile.workspace".pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/odh-mod-arch-gen-ai-push.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-push.yaml
@@ -5,11 +5,15 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( " packages/gen-ai/**".pathChanged()
-      || ".tekton/odh-mod-arch-gen-ai-push.yaml".pathChanged() || "Dockerfile.workspace".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      (
+        "packages/gen-ai/**".pathChanged() ||
+        ".tekton/odh-mod-arch-gen-ai-push.yaml".pathChanged() ||
+        "Dockerfile.workspace".pathChanged()
       )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Description

The gen-ai Tekton pipeline files had a leading space in the `pathChanged()` CEL expression (`" packages/gen-ai/**"` instead of `"packages/gen-ai/**"`), which prevented the pipelines from ever triggering on gen-ai source changes.

Also aligns `cancel-in-progress` and CEL expression formatting with the conventions used by the other mod-arch packages.

Changes:
- Remove leading space in `pathChanged()` glob so the filter actually matches gen-ai file changes
- Set `cancel-in-progress` to `"false"` on push / `"true"` on pull-request (was `"true"` for both)
- Reformat CEL expression as a literal block scalar (`|`) for readability

## How Has This Been Tested?

Verified the YAML is valid and the CEL expressions match the pattern used by the other working Tekton pipeline files (mlflow, eval-hub, modular-architecture).

## Test Impact

No tests applicable — CI/CD configuration only.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`