### PR TITLE
Pass workspace context to external MLflow UI on launch

### DIFF
--- a/frontend/src/pages/projects/screens/detail/overview/trainModels/__tests__/MLflowCard.spec.ts
+++ b/frontend/src/pages/projects/screens/detail/overview/trainModels/__tests__/MLflowCard.spec.ts
@@ -2,6 +2,7 @@ import {
   setWorkspaceQueryParam,
   buildMLflowExperimentsWorkspaceHref,
 } from '#~/pages/projects/screens/detail/overview/trainModels/MLflowCard';
+import { mlflowLaunchRoute } from '#~/routes/pipelines/mlflow';
 
 describe('setWorkspaceQueryParam', () => {
   it('should add workspace param to a path without query string', () => {
@@ -40,6 +41,30 @@ describe('setWorkspaceQueryParam', () => {
   it('should handle workspace name with ampersand', () => {
     const result = setWorkspaceQueryParam('/experiments', 'a&b');
     expect(result).toBe('/experiments?workspace=a%26b');
+  });
+});
+
+describe('mlflowLaunchRoute', () => {
+  it('should return base path when no namespace is provided', () => {
+    expect(mlflowLaunchRoute()).toBe('/mlflow');
+  });
+
+  it('should return base path when namespace is undefined', () => {
+    expect(mlflowLaunchRoute(undefined)).toBe('/mlflow');
+  });
+
+  it('should append workspace in hash fragment when namespace is provided', () => {
+    expect(mlflowLaunchRoute('my-project')).toBe('/mlflow/#/?workspace=my-project');
+  });
+
+  it('should URL-encode special characters in namespace', () => {
+    expect(mlflowLaunchRoute('project with spaces')).toBe(
+      '/mlflow/#/?workspace=project%20with%20spaces',
+    );
+  });
+
+  it('should URL-encode ampersands in namespace', () => {
+    expect(mlflowLaunchRoute('a&b')).toBe('/mlflow/#/?workspace=a%26b');
   });
 });
 

--- a/frontend/src/routes/pipelines/mlflow.ts
+++ b/frontend/src/routes/pipelines/mlflow.ts
@@ -32,3 +32,10 @@ export const globPromptManagementAll = `${promptManagementPath}/*`;
 
 export const mlflowPromptManagementBaseRoute = (namespace?: string): string =>
   withWorkspace(promptManagementPath, namespace);
+
+export const mlflowLaunchRoute = (namespace?: string): string => {
+  if (!namespace) {
+    return MLFLOW_PROXY_BASE_PATH;
+  }
+  return `${MLFLOW_PROXY_BASE_PATH}/#/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(namespace)}`;
+};

--- a/packages/cypress/cypress/tests/mocked/mlflow/mlflowExperiments.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mlflow/mlflowExperiments.cy.ts
@@ -37,7 +37,7 @@ describe('MLflow Experiments page wrapper', () => {
       mlflowExperiments
         .findLaunchMlflowButton()
         .should('be.visible')
-        .should('have.attr', 'href', '/mlflow')
+        .should('have.attr', 'href', `/mlflow/#/?workspace=${PROJECT_A}`)
         .should('have.attr', 'target', '_blank');
     });
 

--- a/packages/cypress/cypress/tests/mocked/mlflow/promptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mlflow/promptManagement.cy.ts
@@ -40,7 +40,7 @@ describe('Prompt Management page wrapper', () => {
       promptManagement
         .findLaunchMlflowButton()
         .should('be.visible')
-        .should('have.attr', 'href', '/mlflow')
+        .should('have.attr', 'href', `/mlflow/#/?workspace=${PROJECT_A}`)
         .should('have.attr', 'target', '_blank');
     });
   });

--- a/packages/mlflow-embedded/experiments/MlflowExperimentsPage.tsx
+++ b/packages/mlflow-embedded/experiments/MlflowExperimentsPage.tsx
@@ -75,7 +75,11 @@ const MlflowExperimentsPage: React.FC = () => {
             />
           </FlexItem>
           <FlexItem>
-            <LaunchMlflowButton testId="mlflow-embedded-jump-link" section="experiments-page" />
+            <LaunchMlflowButton
+              testId="mlflow-embedded-jump-link"
+              section="experiments-page"
+              workspace={workspace}
+            />
           </FlexItem>
         </Flex>
       }

--- a/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
+++ b/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
@@ -77,7 +77,11 @@ const MlflowPromptManagementPage: React.FC = () => {
       }
       headerAction={
         isTopLevel ? (
-          <LaunchMlflowButton testId="mlflow-prompts-jump-link" section="prompt-management-page" />
+          <LaunchMlflowButton
+            testId="mlflow-prompts-jump-link"
+            section="prompt-management-page"
+            workspace={workspace}
+          />
         ) : undefined
       }
       keepBodyWrapper={false}

--- a/packages/mlflow-embedded/shared/LaunchMlflowButton.tsx
+++ b/packages/mlflow-embedded/shared/LaunchMlflowButton.tsx
@@ -2,33 +2,37 @@ import React from 'react';
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { fireLinkTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { MLFLOW_PROXY_BASE_PATH } from '@odh-dashboard/internal/routes/pipelines/mlflow';
+import { mlflowLaunchRoute } from '@odh-dashboard/internal/routes/pipelines/mlflow';
 
 const LaunchMlflowButton: React.FC<{
   testId: string;
   section: string;
-}> = ({ testId, section }) => (
-  <Button
-    component="a"
-    isInline
-    data-testid={testId}
-    href={MLFLOW_PROXY_BASE_PATH}
-    target="_blank"
-    rel="noopener noreferrer"
-    variant="link"
-    icon={<ExternalLinkAltIcon />}
-    iconPosition="end"
-    aria-label="Launch MLflow"
-    onClick={() =>
-      fireLinkTrackingEvent('Launch MLflow clicked', {
-        from: window.location.pathname,
-        href: MLFLOW_PROXY_BASE_PATH,
-        section,
-      })
-    }
-  >
-    Launch MLflow
-  </Button>
-);
+  workspace?: string;
+}> = ({ testId, section, workspace }) => {
+  const href = mlflowLaunchRoute(workspace);
+  return (
+    <Button
+      component="a"
+      isInline
+      data-testid={testId}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="end"
+      aria-label="Launch MLflow"
+      onClick={() =>
+        fireLinkTrackingEvent('Launch MLflow clicked', {
+          from: window.location.pathname,
+          href,
+          section,
+        })
+      }
+    >
+      Launch MLflow
+    </Button>
+  );
+};
 
 export default LaunchMlflowButton;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-60053

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Launching the external MLflow UI via the "Launch MLflow" button caused the user to lose their current project context. The button always opened a fixed `/mlflow` URL without any workspace information, so the external MLflow UI had no way to know which project the user was working in.
This PR passes the active workspace as a hash fragment query parameter so the external MLflow UI lands in the correct project.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified on cluster that clicking "Launch MLflow" from the Experiments and Prompts pages preserves workspace context.

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added unit tests.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MLflow launch button now generates workspace-specific URLs to provide proper context when launching MLflow from different workspaces.

* **Tests**
  * Added comprehensive tests covering workspace route generation, URL encoding, and edge cases for MLflow launch functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->