### PR TITLE
RHOAIENG-58577: Replace rest.CopyConfig with rest.AnonymousClientConfig in gen-ai BFF

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -200,8 +200,8 @@ func newTokenKubernetesClient(token string, logger *slog.Logger, envConfig confi
 		return nil, fmt.Errorf("failed to get kube config: %w", err)
 	}
 
-	// Use CopyConfig for explicit, clean copying
-	cfg := rest.CopyConfig(baseConfig)
+	// Start with an anonymous config to avoid preloaded auth
+	cfg := rest.AnonymousClientConfig(baseConfig)
 	cfg.BearerToken = token
 
 	// Explicitly clear all other auth mechanisms
@@ -249,7 +249,7 @@ func (kc *TokenKubernetesClient) GetNamespaces(ctx context.Context, identity *in
 	}
 
 	// Create a dynamic client with user token
-	userConfig := rest.CopyConfig(kc.Config)
+	userConfig := rest.AnonymousClientConfig(kc.Config)
 	userConfig.BearerToken = identity.Token
 	userConfig.BearerTokenFile = ""
 
@@ -330,7 +330,7 @@ func (kc *TokenKubernetesClient) CanListNamespaces(ctx context.Context, identity
 	}
 
 	// Create a new config with the token from the request identity
-	config := rest.CopyConfig(kc.Config)
+	config := rest.AnonymousClientConfig(kc.Config)
 	config.BearerToken = identity.Token
 	config.BearerTokenFile = ""
 
@@ -374,7 +374,7 @@ func (kc *TokenKubernetesClient) CanListLlamaStackDistributions(ctx context.Cont
 	}
 
 	// Create a new config with the token from the request identity
-	config := rest.CopyConfig(kc.Config)
+	config := rest.AnonymousClientConfig(kc.Config)
 	config.BearerToken = identity.Token
 	config.BearerTokenFile = ""
 
@@ -418,7 +418,7 @@ func (kc *TokenKubernetesClient) CanListGuardrailsOrchestrator(ctx context.Conte
 	}
 
 	// Create a new config with the token from the request identity
-	config := rest.CopyConfig(kc.Config)
+	config := rest.AnonymousClientConfig(kc.Config)
 	config.BearerToken = identity.Token
 	config.BearerTokenFile = ""
 
@@ -513,7 +513,7 @@ func (kc *TokenKubernetesClient) GetUser(ctx context.Context, identity *integrat
 	defer cancel()
 
 	// Create a new config with the token from the request identity
-	config := rest.CopyConfig(kc.Config)
+	config := rest.AnonymousClientConfig(kc.Config)
 	config.BearerToken = identity.Token
 	config.BearerTokenFile = ""
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -1305,3 +1305,81 @@ func TestGetSecretValue(t *testing.T) {
 		assert.Contains(t, err.Error(), "key 'wrong_key' not found in Secret")
 	})
 }
+
+func TestAnonymousClientConfigStripsServiceAccountCredentials(t *testing.T) {
+	t.Run("should strip TLS client cert fields from base config", func(t *testing.T) {
+		baseConfig := &rest.Config{
+			Host: "https://test-cluster.example.com",
+			TLSClientConfig: rest.TLSClientConfig{
+				CertData: []byte("fake-cert-data"),
+				CertFile: "/var/run/secrets/kubernetes.io/serviceaccount/cert.pem",
+				KeyData:  []byte("fake-key-data"),
+				KeyFile:  "/var/run/secrets/kubernetes.io/serviceaccount/key.pem",
+				CAData:   []byte("fake-ca-data"),
+				CAFile:   "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+			},
+			BearerToken:     "sa-token-should-be-stripped",
+			BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			Username:        "system:serviceaccount:test:default",
+			Password:        "sa-password",
+		}
+
+		cfg := rest.AnonymousClientConfig(baseConfig)
+		cfg.BearerToken = "user-token"
+
+		assert.Equal(t, "https://test-cluster.example.com", cfg.Host,
+			"server URL must be preserved")
+		assert.Equal(t, []byte("fake-ca-data"), cfg.CAData,
+			"CA data must be preserved for TLS verification")
+		assert.Equal(t, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", cfg.CAFile,
+			"CA file must be preserved for TLS verification")
+
+		assert.Empty(t, cfg.CertData,
+			"client cert data must be stripped to prevent SA auth")
+		assert.Empty(t, cfg.CertFile,
+			"client cert file must be stripped to prevent SA auth")
+		assert.Empty(t, cfg.KeyData,
+			"client key data must be stripped to prevent SA auth")
+		assert.Empty(t, cfg.KeyFile,
+			"client key file must be stripped to prevent SA auth")
+
+		assert.Equal(t, "user-token", cfg.BearerToken,
+			"user bearer token must be the only auth credential")
+		assert.Empty(t, cfg.BearerTokenFile,
+			"bearer token file must be stripped")
+		assert.Empty(t, cfg.Username,
+			"username must be stripped")
+		assert.Empty(t, cfg.Password,
+			"password must be stripped")
+	})
+
+	t.Run("user-scoped client config should not inherit SA credentials", func(t *testing.T) {
+		baseConfig := &rest.Config{
+			Host: "https://test-cluster.example.com",
+			TLSClientConfig: rest.TLSClientConfig{
+				CertData: []byte("sa-cert"),
+				KeyData:  []byte("sa-key"),
+				CAData:   []byte("cluster-ca"),
+			},
+			BearerToken: "sa-bearer-token",
+		}
+
+		kc := &TokenKubernetesClient{
+			Config: baseConfig,
+			Logger: slog.Default(),
+		}
+
+		userConfig := rest.AnonymousClientConfig(kc.Config)
+		userConfig.BearerToken = "user-token-123"
+		userConfig.BearerTokenFile = ""
+
+		assert.Equal(t, "user-token-123", userConfig.BearerToken)
+		assert.Empty(t, userConfig.CertData,
+			"user config must not carry SA client cert")
+		assert.Empty(t, userConfig.KeyData,
+			"user config must not carry SA client key")
+		assert.Equal(t, []byte("cluster-ca"), userConfig.CAData,
+			"user config must keep cluster CA for TLS verification")
+		assert.Equal(t, "https://test-cluster.example.com", userConfig.Host)
+	})
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58577

## Description

The gen-ai BFF creates user-scoped Kubernetes clients using `rest.CopyConfig(baseConfig)` instead of `rest.AnonymousClientConfig(baseConfig)`. `CopyConfig` preserves TLS client certificate fields (`CertData`, `CertFile`, `KeyData`, `KeyFile`) from the service account's in-cluster config, which means the resulting "user-scoped" client silently authenticates as the service account even when a user bearer token is explicitly set.

This PR replaces all 6 user-scoped `rest.CopyConfig` calls with `rest.AnonymousClientConfig` in `token_k8s_client.go`, matching the pattern already used by the maas, automl, and autorag BFFs.

The SA-scoped call in `GetClusterDomainUsingServiceAccount` (line 162) is left unchanged since it intentionally uses the service account for cluster infrastructure discovery.

### Changes
- **`token_k8s_client.go`**: Replace `rest.CopyConfig` → `rest.AnonymousClientConfig` in 6 user-scoped functions: `newTokenKubernetesClient`, `GetNamespaces`, `CanListNamespaces`, `CanListLlamaStackDistributions`, `CanListGuardrailsOrchestrator`, `GetUser`
- **`token_k8s_client_test.go`**: Add `TestAnonymousClientConfigStripsServiceAccountCredentials` with 2 subtests verifying TLS client cert fields are stripped and CA is preserved

## How Has This Been Tested?

- New unit tests verify that `rest.AnonymousClientConfig` strips TLS client cert fields while preserving CA and server URL
- Full existing test suite passes: `go test ./internal/integrations/kubernetes/...`
- `go vet ./...` clean

## Test Impact

Added 2 new test cases in `TestAnonymousClientConfigStripsServiceAccountCredentials`:
1. Verifies all TLS client cert fields, bearer token file, username, and password are stripped from the base config
2. Verifies user-scoped client config does not inherit SA credentials while preserving cluster CA

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes authentication handling to ensure bearer tokens are properly isolated and not inadvertently mixed with other authentication credentials.

* **Tests**
  * Added validation tests for authentication credential stripping to ensure service account credentials are properly excluded from token-scoped client configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->