### PR TITLE
Remove auth annotation when MaaS is selected in Wizard

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -219,6 +219,10 @@ describe('MaaS Deployment Wizard', () => {
           namespace: 'openshift-ingress',
         },
       ]);
+
+      expect(interception.request.body.metadata.annotations).to.not.have.property(
+        'security.opendatahub.io/enable-auth',
+      );
     });
 
     cy.wait('@createLLMInferenceService');

--- a/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maasDeploymentTransformer.ts
+++ b/packages/maas/frontend/src/odh/modelServingExtensions/modelDeploymentWizard/maasDeploymentTransformer.ts
@@ -25,15 +25,15 @@ export const applyMaaSEndpointData = (
   const filteredRefs = existingRefs.filter((ref) => !isMaaSGateway(ref));
 
   if (fieldData.isChecked) {
-    // Add the MaaS gateway
-    const newRefs = [...filteredRefs, MAAS_DEFAULT_GATEWAY];
+    // Add the MaaS gateway and remove the enable-auth annotation — MaaS manages auth externally
     result.model.spec.router = {
       ...result.model.spec.router,
       gateway: {
         ...result.model.spec.router?.gateway,
-        refs: newRefs,
+        refs: [...filteredRefs, MAAS_DEFAULT_GATEWAY],
       },
     };
+    delete result.model.metadata.annotations?.['security.opendatahub.io/enable-auth'];
   } else if (filteredRefs.length > 0) {
     // Keep other gateways if they exist
     result.model.spec.router = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-61103
## Description
When MaaS is enabled we need to disable the auth checkbox and not set the auth annotation to false. In the past we were letting the annotation `security.opendatahub.io/enable-auth: 'false'` get added when maas is selected which is causing a bug where the odh model controller creates auth policies that allow users to get around MaaS governance (MaaSAuthPolicy and MaaSSubscription)
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
1. Create an llminferenceservice through the wizard
2. De-select token auth
3. Deploy

See annotation `security.opendatahub.io/enable-auth: 'false'`
4. Update through the wizard to select maas checkbox

See annotation removed

Also try these again with a token auth model. I tested with vllm on MaaS flow as well as standard llmd
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added a jest test to cover the auth scenarios
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication configuration handling in the MaaS deployment wizard to ensure proper security settings are applied when enabling model serving services
  * Improved gateway reference management during MaaS deployment for better overall configuration handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->