### PR TITLE
feat(nim-serving): add extension to exclude NIM-owned InferenceServices from KServe listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35983,7 +35983,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@odh-dashboard/internal": "*",
-        "@odh-dashboard/model-serving": "*"
+        "@odh-dashboard/model-serving": "*",
+        "@odh-dashboard/plugin-core": "*"
       },
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
@@ -20,33 +20,33 @@ import {
 } from '../../../utils/models';
 import { asClusterAdminUser } from '../../../utils/mockUsers';
 
-const mockNIMOwnedInferenceService = (): InferenceServiceKind => ({
-  ...mockInferenceServiceK8sResource({
+const mockNIMOwnedInferenceService = (): InferenceServiceKind => {
+  const base = mockInferenceServiceK8sResource({
     name: 'nim-managed-is',
     displayName: 'NIM Managed Model',
     namespace: 'test-project',
-  }),
-  metadata: {
-    ...mockInferenceServiceK8sResource({
-      name: 'nim-managed-is',
-      namespace: 'test-project',
-    }).metadata,
-    ownerReferences: [
-      {
-        apiVersion: 'apps.nvidia.com/v1alpha1',
-        kind: 'NIMService',
-        name: 'my-nim-service',
-        uid: '046c2db8-68cf-449e-b7cb-45ee7b2de60a',
-        blockOwnerDeletion: true,
-        controller: true,
+  });
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      ownerReferences: [
+        {
+          apiVersion: 'apps.nvidia.com/v1alpha1',
+          kind: 'NIMService',
+          name: 'my-nim-service',
+          uid: '046c2db8-68cf-449e-b7cb-45ee7b2de60a',
+          blockOwnerDeletion: true,
+          controller: true,
+        },
+      ],
+      labels: {
+        ...base.metadata.labels,
+        'app.kubernetes.io/managed-by': 'k8s-nim-operator',
       },
-    ],
-    labels: {
-      'opendatahub.io/dashboard': 'true',
-      'app.kubernetes.io/managed-by': 'k8s-nim-operator',
     },
-  },
-});
+  };
+};
 
 describe('NIM InferenceService Exclusion from KServe', () => {
   beforeEach(() => {

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
@@ -1,0 +1,113 @@
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockInferenceServiceK8sResource } from '@odh-dashboard/internal/__mocks__/mockInferenceServiceK8sResource';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { mockSecretK8sResource } from '@odh-dashboard/internal/__mocks__/mockSecretK8sResource';
+import { mockServingRuntimeK8sResource } from '@odh-dashboard/internal/__mocks__/mockServingRuntimeK8sResource';
+import type { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
+import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import {
+  mockConnectionTypeConfigMap,
+  mockModelServingFields,
+} from '@odh-dashboard/internal/__mocks__/mockConnectionType';
+import { modelServingGlobal, modelServingSection } from '../../../pages/modelServing';
+import {
+  InferenceServiceModel,
+  ProjectModel,
+  SecretModel,
+  ServingRuntimeModel,
+} from '../../../utils/models';
+import { asClusterAdminUser } from '../../../utils/mockUsers';
+
+const mockNIMOwnedInferenceService = (): InferenceServiceKind => ({
+  ...mockInferenceServiceK8sResource({
+    name: 'nim-managed-is',
+    displayName: 'NIM Managed Model',
+    namespace: 'test-project',
+  }),
+  metadata: {
+    ...mockInferenceServiceK8sResource({
+      name: 'nim-managed-is',
+      namespace: 'test-project',
+    }).metadata,
+    ownerReferences: [
+      {
+        apiVersion: 'apps.nvidia.com/v1alpha1',
+        kind: 'NIMService',
+        name: 'my-nim-service',
+        uid: '046c2db8-68cf-449e-b7cb-45ee7b2de60a',
+        blockOwnerDeletion: true,
+        controller: true,
+      },
+    ],
+    labels: {
+      'opendatahub.io/dashboard': 'true',
+      'app.kubernetes.io/managed-by': 'k8s-nim-operator',
+    },
+  },
+});
+
+describe('NIM InferenceService Exclusion from KServe', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+
+    cy.interceptOdh(
+      'GET /api/dsc/status',
+      mockDscStatus({
+        components: {
+          [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
+        },
+      }),
+    );
+    cy.interceptOdh(
+      'GET /api/config',
+      mockDashboardConfig({
+        disableKServe: false,
+        disableNIMModelServing: false,
+      }),
+    );
+    cy.interceptK8sList(
+      ProjectModel,
+      mockK8sResourceList([
+        mockProjectK8sResource({
+          k8sName: 'test-project',
+          displayName: 'Test Project',
+          enableKServe: true,
+        }),
+      ]),
+    );
+    cy.interceptK8sList(SecretModel, mockK8sResourceList([mockSecretK8sResource({})]));
+    cy.interceptOdh('GET /api/connection-types', [
+      mockConnectionTypeConfigMap({
+        name: 's3',
+        displayName: 'S3 compatible object storage - v1',
+        fields: mockModelServingFields,
+      }),
+    ]);
+  });
+
+  it('should not show NIM-owned InferenceServices in the KServe deployments table', () => {
+    const kserveIS = mockInferenceServiceK8sResource({
+      name: 'kserve-model',
+      displayName: 'KServe Model',
+      namespace: 'test-project',
+    });
+    const nimOwnedIS = mockNIMOwnedInferenceService();
+
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([kserveIS, nimOwnedIS]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([mockServingRuntimeK8sResource({})]),
+    );
+
+    modelServingGlobal.visit('test-project');
+
+    modelServingSection.findDeploymentsTable().should('exist');
+    modelServingSection.getDeploymentRow('KServe Model').should('exist');
+    modelServingSection.findDeploymentsTable().find('tr').should('have.length', 2); // header + 1 data row (KServe only)
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
@@ -65,6 +65,7 @@ describe('NIM InferenceService Exclusion from KServe', () => {
       mockDashboardConfig({
         disableKServe: false,
         disableNIMModelServing: false,
+        nimWizard: true,
       }),
     );
     cy.interceptK8sList(

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingNimExclusion.cy.ts
@@ -107,7 +107,7 @@ describe('NIM InferenceService Exclusion from KServe', () => {
     modelServingGlobal.visit('test-project');
 
     modelServingSection.findDeploymentsTable().should('exist');
-    modelServingSection.getDeploymentRow('KServe Model').should('exist');
-    modelServingSection.findDeploymentsTable().find('tr').should('have.length', 2); // header + 1 data row (KServe only)
+    modelServingSection.getDeploymentRow('KServe Model').find().should('exist');
+    cy.findByTestId('deployments-table').find('tbody tr').should('have.length', 1);
   });
 });

--- a/packages/kserve/package.json
+++ b/packages/kserve/package.json
@@ -13,7 +13,8 @@
   },
   "exports": {
     "./extensions": "./extensions.ts",
-    "./deployUtils": "./src/deployUtils.ts"
+    "./deployUtils": "./src/deployUtils.ts",
+    "./deploymentEndpoints": "./src/deploymentEndpoints.ts"
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",

--- a/packages/kserve/package.json
+++ b/packages/kserve/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",
-    "@odh-dashboard/model-serving": "*"
+    "@odh-dashboard/model-serving": "*",
+    "@odh-dashboard/plugin-core": "*"
   },
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",

--- a/packages/kserve/package.json
+++ b/packages/kserve/package.json
@@ -13,8 +13,7 @@
   },
   "exports": {
     "./extensions": "./extensions.ts",
-    "./deployUtils": "./src/deployUtils.ts",
-    "./deploymentEndpoints": "./src/deploymentEndpoints.ts"
+    "./deployUtils": "./src/deployUtils.ts"
   },
   "dependencies": {
     "@odh-dashboard/internal": "*",

--- a/packages/kserve/src/__tests__/deployments.spec.ts
+++ b/packages/kserve/src/__tests__/deployments.spec.ts
@@ -15,6 +15,11 @@ import * as watchModule from '../api/watch';
 // Mock the watch module
 jest.mock('../api/watch');
 
+// Mock plugin-core - [resolvedExtensions, resolved, errors]
+jest.mock('@odh-dashboard/plugin-core', () => ({
+  useResolvedExtensions: jest.fn(() => [[], true, []]),
+}));
+
 const mockUseWatchInferenceServices = watchModule.useWatchInferenceServices as jest.Mock;
 const mockUseWatchServingRuntimes = watchModule.useWatchServingRuntimes as jest.Mock;
 const mockUseWatchDeploymentPods = watchModule.useWatchDeploymentPods as jest.Mock;
@@ -331,5 +336,52 @@ describe('useWatchDeployments', () => {
 
     expect(deployments).toHaveLength(1);
     expect(deployments?.[0].model.metadata.name).toBe('model-1');
+  });
+
+  it('should exclude InferenceServices matched by exclusion extensions', () => {
+    const { useResolvedExtensions } = jest.requireMock('@odh-dashboard/plugin-core');
+    (useResolvedExtensions as jest.Mock).mockReturnValue([
+      [
+        {
+          properties: {
+            platform: 'nvidia-nim',
+            excludeFromPlatform: 'kserve',
+            filter: (is: InferenceServiceKind) =>
+              is.metadata.ownerReferences?.some(
+                (ref: { kind: string }) => ref.kind === 'NIMService',
+              ) ?? false,
+          },
+        },
+      ],
+      true,
+      [],
+    ]);
+
+    const nimOwnedIS = mockInferenceServiceK8sResource({
+      name: 'nim-model',
+      namespace: 'test-project',
+    });
+    nimOwnedIS.metadata.ownerReferences = [
+      {
+        apiVersion: 'apps.nvidia.com/v1alpha1',
+        kind: 'NIMService',
+        name: 'my-nim',
+        uid: 'abc-123',
+      },
+    ];
+
+    mockUseWatchInferenceServices.mockReturnValue([
+      [...mockInferenceServices, nimOwnedIS],
+      true,
+      undefined,
+    ]);
+
+    const renderResult = testHook(useWatchDeployments)(mockProject, undefined, undefined);
+
+    const [deployments, loaded] = renderResult.result.current as DeploymentHookResult;
+
+    expect(loaded).toBe(true);
+    expect(deployments).toHaveLength(3);
+    expect(deployments?.find((d) => d.model.metadata.name === 'nim-model')).toBeUndefined();
   });
 });

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -5,7 +5,8 @@ import {
   ProjectKind,
   ServingRuntimeKind,
 } from '@odh-dashboard/internal/k8sTypes';
-import { Deployment } from '@odh-dashboard/model-serving/extension-points';
+import { Deployment, isModelServingExcludeDeployment } from '@odh-dashboard/model-serving/extension-points';
+import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import {
   deleteInferenceService,
   deleteServingRuntime,
@@ -43,12 +44,30 @@ export const useWatchDeployments = (
     opts,
   );
 
+  const [exclusionExtensions, exclusionsResolved] = useResolvedExtensions(
+    isModelServingExcludeDeployment,
+  );
+
+  const kserveExclusions = React.useMemo(
+    () => exclusionExtensions.filter((ext) => ext.properties.excludeFromPlatform === KSERVE_ID),
+    [exclusionExtensions],
+  );
+
   const filteredInferenceServices = React.useMemo(() => {
-    if (!filterFn) {
-      return inferenceServices;
+    let services = inferenceServices;
+
+    if (kserveExclusions.length > 0) {
+      services = services.filter(
+        (is) => !kserveExclusions.some((ext) => ext.properties.filter(is)),
+      );
     }
-    return inferenceServices.filter(filterFn);
-  }, [inferenceServices, filterFn]);
+
+    if (filterFn) {
+      services = services.filter(filterFn);
+    }
+
+    return services;
+  }, [inferenceServices, kserveExclusions, filterFn]);
 
   const deployments: KServeDeployment[] = React.useMemo(
     () =>
@@ -73,7 +92,8 @@ export const useWatchDeployments = (
   const effectivelyLoaded = Boolean(
     (inferenceServiceLoaded || inferenceServiceError) &&
       (servingRuntimeLoaded || servingRuntimeError) &&
-      (deploymentPodsLoaded || deploymentPodsError),
+      (deploymentPodsLoaded || deploymentPodsError) &&
+      exclusionsResolved,
   );
 
   const errors = React.useMemo(() => {

--- a/packages/kserve/src/deployments.ts
+++ b/packages/kserve/src/deployments.ts
@@ -5,7 +5,10 @@ import {
   ProjectKind,
   ServingRuntimeKind,
 } from '@odh-dashboard/internal/k8sTypes';
-import { Deployment, isModelServingExcludeDeployment } from '@odh-dashboard/model-serving/extension-points';
+import {
+  Deployment,
+  isModelServingExcludeDeployment,
+} from '@odh-dashboard/model-serving/extension-points';
 import { useResolvedExtensions } from '@odh-dashboard/plugin-core';
 import {
   deleteInferenceService,

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -508,3 +508,28 @@ export const isWizardFieldDeploymentFunctionsExtension = <
   extension: Extension,
 ): extension is WizardFieldDeploymentFunctionsExtension<T, D> =>
   extension.type === 'model-serving.deployment/wizard-field-deployment-functions';
+
+/**
+ * Extension point for platforms to declare resources that should be excluded from
+ * another platform's deployment listings. This prevents duplicate entries when a
+ * platform's operator creates child resources that another platform would also list.
+ *
+ * `platform` identifies the source platform registering the exclusion.
+ * `excludeFromPlatform` identifies which platform should apply this filter.
+ * `filter` returns true for resources that belong to this platform and should NOT
+ * appear in the target platform's deployment table.
+ */
+export type ModelServingExcludeDeploymentExtension = Extension<
+  'model-serving.platform/exclude-deployment',
+  {
+    platform: string;
+    excludeFromPlatform: string;
+    filter: CodeRef<(resource: K8sResourceCommon) => boolean>;
+  }
+>;
+export type ResolvedModelServingExcludeDeployment =
+  ResolvedExtension<ModelServingExcludeDeploymentExtension>;
+export const isModelServingExcludeDeployment = (
+  extension: Extension,
+): extension is ModelServingExcludeDeploymentExtension =>
+  extension.type === 'model-serving.platform/exclude-deployment';

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -69,7 +69,7 @@ const extensions: (
       filter: () => import('./src/nimOwnership').then((m) => m.isNIMOwned),
     },
     flags: {
-      required: [SupportedArea.NIM_MODEL],
+      required: [SupportedArea.NIM_WIZARD],
     },
   },
 ];

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -37,7 +37,7 @@ const extensions: (
       component: () => import('./src/pages/projectSettings/NIMSettingsCard'),
     },
     flags: {
-      required: [SupportedArea.NIM_MODEL],
+      required: [SupportedArea.NIM_WIZARD],
     },
   },
   {

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -37,7 +37,7 @@ const extensions: (
       component: () => import('./src/pages/projectSettings/NIMSettingsCard'),
     },
     flags: {
-      required: [SupportedArea.NIM_WIZARD],
+      required: [SupportedArea.NIM_MODEL],
     },
   },
   {

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -7,6 +7,7 @@ import type {
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import type {
   DeployedModelServingDetails,
+  ModelServingExcludeDeploymentExtension,
   ModelServingPlatformWatchDeploymentsExtension,
 } from '@odh-dashboard/model-serving/extension-points';
 import type { NIMDeployment } from './src/api/deployments/useWatchDeployments';
@@ -18,6 +19,7 @@ const extensions: (
   | ProjectDetailsSettingsCardExtension
   | ModelServingPlatformWatchDeploymentsExtension<NIMDeployment>
   | DeployedModelServingDetails<NIMDeployment>
+  | ModelServingExcludeDeploymentExtension
 )[] = [
   {
     type: 'app.area',
@@ -57,6 +59,17 @@ const extensions: (
     },
     flags: {
       required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.platform/exclude-deployment',
+    properties: {
+      platform: NIM_ID,
+      excludeFromPlatform: 'kserve',
+      filter: () => import('./src/nimOwnership').then((m) => m.isNIMOwned),
+    },
+    flags: {
+      required: [SupportedArea.NIM_MODEL],
     },
   },
 ];

--- a/packages/nim-serving/src/__tests__/nimOwnership.spec.ts
+++ b/packages/nim-serving/src/__tests__/nimOwnership.spec.ts
@@ -1,0 +1,105 @@
+import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { isNIMOwned } from '../nimOwnership';
+
+describe('isNIMOwned', () => {
+  it('should return true when resource has NIMService ownerReference', () => {
+    const resource: K8sResourceCommon = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: {
+        name: 'test-is',
+        ownerReferences: [
+          {
+            apiVersion: 'apps.nvidia.com/v1alpha1',
+            kind: 'NIMService',
+            name: 'my-nim',
+            uid: 'abc-123',
+          },
+        ],
+      },
+    };
+    expect(isNIMOwned(resource)).toBe(true);
+  });
+
+  it('should return false when resource has no ownerReferences', () => {
+    const resource: K8sResourceCommon = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: {
+        name: 'test-is',
+      },
+    };
+    expect(isNIMOwned(resource)).toBe(false);
+  });
+
+  it('should return false when ownerReferences exist but none are NIMService', () => {
+    const resource: K8sResourceCommon = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: {
+        name: 'test-is',
+        ownerReferences: [
+          {
+            apiVersion: 'serving.kserve.io/v1alpha1',
+            kind: 'ServingRuntime',
+            name: 'some-runtime',
+            uid: 'xyz-789',
+          },
+        ],
+      },
+    };
+    expect(isNIMOwned(resource)).toBe(false);
+  });
+
+  it('should return false when kind is NIMService but apiVersion is wrong', () => {
+    const resource: K8sResourceCommon = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: {
+        name: 'test-is',
+        ownerReferences: [
+          {
+            apiVersion: 'other.group/v1',
+            kind: 'NIMService',
+            name: 'my-nim',
+            uid: 'abc-123',
+          },
+        ],
+      },
+    };
+    expect(isNIMOwned(resource)).toBe(false);
+  });
+
+  it('should handle multiple ownerReferences and find the NIMService one', () => {
+    const resource: K8sResourceCommon = {
+      apiVersion: 'serving.kserve.io/v1beta1',
+      kind: 'InferenceService',
+      metadata: {
+        name: 'test-is',
+        ownerReferences: [
+          {
+            apiVersion: 'serving.kserve.io/v1beta1',
+            kind: 'ServingRuntime',
+            name: 'some-runtime',
+            uid: 'xyz-789',
+          },
+          {
+            apiVersion: 'apps.nvidia.com/v1alpha1',
+            kind: 'NIMService',
+            name: 'my-nim',
+            uid: 'abc-123',
+          },
+        ],
+      },
+    };
+    expect(isNIMOwned(resource)).toBe(true);
+  });
+
+  it('should return false when metadata is undefined', () => {
+    const resource = {
+      apiVersion: 'v1',
+      kind: 'InferenceService',
+    } as K8sResourceCommon;
+    expect(isNIMOwned(resource)).toBe(false);
+  });
+});

--- a/packages/nim-serving/src/nimOwnership.ts
+++ b/packages/nim-serving/src/nimOwnership.ts
@@ -1,0 +1,11 @@
+import type { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+/**
+ * Check if a K8s resource (typically InferenceService) is owned by a NIMService
+ * by inspecting its ownerReferences. The NIM Operator sets controller ownerReferences
+ * on the InferenceService it creates for each NIMService.
+ */
+export const isNIMOwned = (resource: K8sResourceCommon): boolean =>
+  resource.metadata?.ownerReferences?.some(
+    (ref) => ref.kind === 'NIMService' && ref.apiVersion.startsWith('apps.nvidia.com/'),
+  ) ?? false;


### PR DESCRIPTION
<!--- Reference related issues; see example below -->

https://issues.redhat.com/browse/RHOAIENG-60275

## Description

When the NIM Operator creates a `NIMService`, it reconciles a companion `InferenceService` as a child resource (with `ownerReferences`). Because KServe's `useWatchDeployments` watches all InferenceServices in a namespace, this NIM-owned IS appears as a duplicate entry in the deployments table alongside the NIM deployment itself.

This PR introduces a new extension-based mechanism to solve this without coupling KServe to NIM-specific logic:

1. **New extension type** (`model-serving.platform/exclude-deployment`) in `@odh-dashboard/model-serving` — allows any platform to declare a filter predicate for InferenceServices that belong to it and should be excluded from other platforms' listings.

2. **KServe consumes the extension** — `useWatchDeployments` in `@odh-dashboard/kserve` resolves all registered exclusion extensions via `useResolvedExtensions` and applies them before listing IS deployments. KServe has no NIM-specific knowledge — it generically applies whatever exclusion filters other platforms register.

3. **NIM registers the extension** — `@odh-dashboard/nim-serving` registers a `model-serving.platform/exclude-deployment` extension with `isNIMOwned` as the filter predicate. This checks `ownerReferences` for `kind: NIMService` with `apiVersion: apps.nvidia.com/*` — the exact signature the NIM Operator sets on child InferenceServices.

## How Has This Been Tested?
<img width="2940" height="908" alt="Screenshot 2026-05-06 at 1 32 23 PM" src="https://github.com/user-attachments/assets/5ad787cd-a92d-43b3-9f7e-ce517865bf3a" />

- Unit tests: 6 new tests for `isNIMOwned` (nim-serving), 29 existing kserve tests still pass with plugin-core mock
- Cypress test created to verify NIM-owned IS is excluded from KServe deployments table

## Test Impact

- **Added:** `packages/nim-serving/src/__tests__/nimOwnership.spec.ts` — 6 unit tests covering `isNIMOwned` (valid ownerRef, no ownerRef, wrong kind, wrong apiVersion, multiple refs, undefined metadata)
- **Modified:** `packages/kserve/src/__tests__/deployments.spec.ts` — added mock for `@odh-dashboard/plugin-core`
- **Added:** `packages/cypress/.../modelServingNimExclusion.cy.ts` — mocked Cypress test asserting NIM-owned IS does not appear in KServe table

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platforms can register exclusion filters so Nim-managed models are omitted from KServe deployment listings; users see only applicable deployments.
  * New platform extension to declare exclusions targeting specific platforms.

* **Tests**
  * Added end-to-end and unit tests validating exclusion behavior and ownership detection for Nim-managed resources.

* **Chores**
  * Updated platform extension setup and test mocks; deployment listings now wait for exclusions to resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->