### PR TITLE
Update maas create pages to use zod validation

### DIFF
--- a/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/CreateApiKeyModal.tsx
@@ -158,10 +158,7 @@ const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({ onClose }) => {
     createApiKeySchema,
   );
 
-  const isFormValid = () => {
-    const result = createApiKeySchema.safeParse(formData);
-    return result.success;
-  };
+  const isFormValid = getFieldValidation(undefined, true).length === 0;
 
   const selectedOption = EXPIRATION_OPTIONS.find((opt) => opt.value === formData.expirationOption);
 
@@ -539,7 +536,7 @@ const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({ onClose }) => {
                 key="create"
                 variant="primary"
                 onClick={handleSubmit}
-                isDisabled={!isFormValid() || isCreating || subscriptions.length === 0}
+                isDisabled={!isFormValid || isCreating || subscriptions.length === 0}
                 isLoading={isCreating}
                 data-testid="submit-create-api-key-button"
               >

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -36,8 +36,7 @@ import { URL_PREFIX } from '~/app/utilities/const';
 import { modelRefsToSummaries } from '~/app/utilities/authpolicies';
 
 const policyFormSchema = z.object({
-  groups: z.array(z.string()).min(1, 'At least one group must be selected'),
-  models: z.array(z.unknown()).min(1, 'At least one model must be added'),
+  groups: z.array(z.string()).min(1, 'One or more groups must be selected'),
 });
 
 export type PolicyFormProps = {
@@ -80,10 +79,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
 
   const selectedGroupNames = selectedGroups.filter((g) => g.selected).map((g) => String(g.id));
 
-  const zodFormData = React.useMemo(
-    () => ({ groups: selectedGroupNames, models: selectedModels }),
-    [selectedGroupNames, selectedModels],
-  );
+  const zodFormData = React.useMemo(() => ({ groups: selectedGroupNames }), [selectedGroupNames]);
 
   const { getFieldValidation } = useZodFormValidation(zodFormData, policyFormSchema);
 
@@ -93,7 +89,10 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
       : undefined;
 
   const canSubmit =
-    isValidK8sNameDescription && getFieldValidation(undefined, true).length === 0 && !isSubmitting;
+    isValidK8sNameDescription &&
+    getFieldValidation(undefined, true).length === 0 &&
+    selectedModels.length > 0 &&
+    !isSubmitting;
 
   const handleAddModels = (refs: MaaSModelRefSummary[]) => {
     const existingKeys = new Set(selectedModels.map((m) => `${m.namespace}/${m.name}`));
@@ -153,9 +152,8 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
         <FormGroup label="Groups" fieldId="policy-groups" isRequired>
           <FormHelperText>
             <HelperText>
-              <HelperTextItem variant={groupsValidationError ? 'error' : 'default'}>
-                {groupsValidationError ||
-                  'Select user groups that can access models in this authorization policy.'}
+              <HelperTextItem>
+                Select user groups that can access models in this authorization policy.
               </HelperTextItem>
             </HelperText>
           </FormHelperText>
@@ -170,9 +168,14 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
             isCreatable
             createOptionMessage={(value) => `Add group "${value}"`}
             placeholder="Select groups or type to add a new group"
-            selectionRequired={groupsTouched}
-            noSelectedOptionsMessage="One or more groups must be selected"
           />
+          {groupsValidationError && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">{groupsValidationError}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
 
         {formData.modelRefs.length === 0 ? (

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -20,7 +20,9 @@ import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { isK8sNameDescriptionDataValid } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
+import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { APIOptions } from 'mod-arch-core';
+import { z } from 'zod';
 import AddModelsModal from '~/app/shared/AddModelsModal';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import { createAuthPolicy, updateAuthPolicy } from '~/app/api/auth-policies';
@@ -32,6 +34,11 @@ import {
 } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import { modelRefsToSummaries } from '~/app/utilities/authpolicies';
+
+const policyFormSchema = z.object({
+  groups: z.array(z.string()).min(1, 'At least one group must be selected'),
+  models: z.array(z.unknown()).min(1, 'At least one model must be added'),
+});
 
 export type PolicyFormProps = {
   formData: SubscriptionPolicyFormDataResponse;
@@ -72,16 +79,21 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
   const isValidK8sNameDescription = isK8sNameDescriptionDataValid(nameDescData);
 
   const selectedGroupNames = selectedGroups.filter((g) => g.selected).map((g) => String(g.id));
+
+  const zodFormData = React.useMemo(
+    () => ({ groups: selectedGroupNames, models: selectedModels }),
+    [selectedGroupNames, selectedModels],
+  );
+
+  const { getFieldValidation } = useZodFormValidation(zodFormData, policyFormSchema);
+
   const groupsValidationError =
-    groupsTouched && selectedGroupNames.length === 0
-      ? 'At least one group must be selected'
+    groupsTouched && getFieldValidation(['groups'], true).length > 0
+      ? getFieldValidation(['groups'], true)[0].message
       : undefined;
 
   const canSubmit =
-    isValidK8sNameDescription &&
-    selectedGroupNames.length > 0 &&
-    selectedModels.length > 0 &&
-    !isSubmitting;
+    isValidK8sNameDescription && getFieldValidation(undefined, true).length === 0 && !isSubmitting;
 
   const handleAddModels = (refs: MaaSModelRefSummary[]) => {
     const existingKeys = new Set(selectedModels.map((m) => `${m.namespace}/${m.name}`));

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -37,6 +37,7 @@ import { modelRefsToSummaries } from '~/app/utilities/authpolicies';
 
 const policyFormSchema = z.object({
   groups: z.array(z.string()).min(1, 'One or more groups must be selected'),
+  models: z.array(z.unknown()).min(1, 'One or more models must be added'),
 });
 
 export type PolicyFormProps = {
@@ -68,6 +69,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
   });
 
   const [groupsTouched, setGroupsTouched] = React.useState(false);
+  const [modelsTouched, setModelsTouched] = React.useState(false);
   const [selectedModels, setSelectedModels] = React.useState<MaaSModelRefSummary[]>(() =>
     initialPolicy ? modelRefsToSummaries(initialPolicy.modelRefs, formData.modelRefs) : [],
   );
@@ -79,7 +81,10 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
 
   const selectedGroupNames = selectedGroups.filter((g) => g.selected).map((g) => String(g.id));
 
-  const zodFormData = React.useMemo(() => ({ groups: selectedGroupNames }), [selectedGroupNames]);
+  const zodFormData = React.useMemo(
+    () => ({ groups: selectedGroupNames, models: selectedModels }),
+    [selectedGroupNames, selectedModels],
+  );
 
   const { getFieldValidation } = useZodFormValidation(zodFormData, policyFormSchema);
 
@@ -89,10 +94,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
       : undefined;
 
   const canSubmit =
-    isValidK8sNameDescription &&
-    getFieldValidation(undefined, true).length === 0 &&
-    selectedModels.length > 0 &&
-    !isSubmitting;
+    isValidK8sNameDescription && getFieldValidation(undefined, true).length === 0 && !isSubmitting;
 
   const handleAddModels = (refs: MaaSModelRefSummary[]) => {
     const existingKeys = new Set(selectedModels.map((m) => `${m.namespace}/${m.name}`));
@@ -195,11 +197,19 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
               hideColumns={['tokenLimits']}
               editable
               onAddModels={() => setIsAddModelsModalOpen(true)}
-              onRemoveModel={handleRemoveModelAt}
+              onRemoveModel={(index) => {
+                setModelsTouched(true);
+                handleRemoveModelAt(index);
+              }}
               helperText={
                 <Content>
                   Add models that subjects of this authorization policy will be granted access to.
                 </Content>
+              }
+              validationError={
+                modelsTouched && getFieldValidation(['models'], true).length > 0
+                  ? getFieldValidation(['models'], true)[0].message
+                  : undefined
               }
               formGroupFieldId="policy-models"
               sectionTestId="policy-models-section"
@@ -216,8 +226,14 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
                 allSubscriptions={formData.subscriptions}
                 allPolicies={formData.policies}
                 currentModels={selectedModels.map((m) => ({ modelRefSummary: m }))}
-                onAdd={handleAddModels}
-                onRemove={handleRemoveModelsByRef}
+                onAdd={(refs) => {
+                  setModelsTouched(true);
+                  handleAddModels(refs);
+                }}
+                onRemove={(refs) => {
+                  setModelsTouched(true);
+                  handleRemoveModelsByRef(refs);
+                }}
                 onClose={() => setIsAddModelsModalOpen(false)}
                 ariaLabel="Add models to authorization policy"
                 title="Add models to authorization policy"

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -55,6 +55,7 @@ const subscriptionFormSchema = z.object({
     .min(MIN_PRIORITY, `Priority must be at least ${MIN_PRIORITY}`)
     .max(MAX_PRIORITY, `Priority must be at most ${MAX_PRIORITY}`),
   groups: z.array(z.string()).min(1, 'One or more groups must be selected'),
+  models: z.array(z.unknown()).min(1, 'One or more models must be added'),
 });
 
 type SubscriptionFormData = z.infer<typeof subscriptionFormSchema>;
@@ -107,6 +108,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     return [];
   });
   const [groupsTouched, setGroupsTouched] = React.useState(false);
+  const [modelsTouched, setModelsTouched] = React.useState(false);
   const [priority, setPriority] = React.useState<number | undefined>(
     subscription?.priority ?? undefined,
   );
@@ -211,8 +213,9 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     () => ({
       priority: priority == null || Number.isNaN(priority) ? Number.NaN : priority,
       groups: selectedGroupNames,
+      models,
     }),
-    [priority, selectedGroupNames],
+    [priority, selectedGroupNames, models],
   );
 
   const { getFieldValidation } = useZodFormValidation(zodFormData, subscriptionFormSchema);
@@ -226,7 +229,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   const canSubmit =
     isNameValid &&
     getFieldValidation(undefined, true).length === 0 &&
-    models.length > 0 &&
     allModelsHaveRateLimits &&
     !isSubmitting &&
     !priorityConflictError;
@@ -392,7 +394,15 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             editable
             onAddModels={canAddModels ? () => setIsAddModelsModalOpen(true) : undefined}
             onEditLimits={(index) => setEditLimitsTarget(index)}
-            onRemoveModel={handleRemoveModel}
+            onRemoveModel={(index) => {
+              setModelsTouched(true);
+              handleRemoveModel(index);
+            }}
+            validationError={
+              modelsTouched && getFieldValidation(['models'], true).length > 0
+                ? getFieldValidation(['models'], true)[0].message
+                : undefined
+            }
             resourceType="subscription"
           />
         )}
@@ -404,8 +414,14 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             allSubscriptions={subscriptionsForConflictCheck}
             allPolicies={formData.policies}
             currentModels={models}
-            onAdd={handleAddModels}
-            onRemove={handleRemoveModelsByRef}
+            onAdd={(refs) => {
+              setModelsTouched(true);
+              handleAddModels(refs);
+            }}
+            onRemove={(refs) => {
+              setModelsTouched(true);
+              handleRemoveModelsByRef(refs);
+            }}
             onClose={() => setIsAddModelsModalOpen(false)}
           />
         )}

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -54,8 +54,7 @@ const subscriptionFormSchema = z.object({
     .int('Priority must be a whole number')
     .min(MIN_PRIORITY, `Priority must be at least ${MIN_PRIORITY}`)
     .max(MAX_PRIORITY, `Priority must be at most ${MAX_PRIORITY}`),
-  groups: z.array(z.string()).min(1, 'At least one group must be selected'),
-  models: z.array(z.unknown()).min(1, 'At least one model must be added'),
+  groups: z.array(z.string()).min(1, 'One or more groups must be selected'),
 });
 
 type SubscriptionFormData = z.infer<typeof subscriptionFormSchema>;
@@ -212,9 +211,8 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     () => ({
       priority: priority == null || Number.isNaN(priority) ? Number.NaN : priority,
       groups: selectedGroupNames,
-      models,
     }),
-    [priority, selectedGroupNames, models],
+    [priority, selectedGroupNames],
   );
 
   const { getFieldValidation } = useZodFormValidation(zodFormData, subscriptionFormSchema);
@@ -228,6 +226,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   const canSubmit =
     isNameValid &&
     getFieldValidation(undefined, true).length === 0 &&
+    models.length > 0 &&
     allModelsHaveRateLimits &&
     !isSubmitting &&
     !priorityConflictError;
@@ -359,14 +358,12 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             isCreatable
             createOptionMessage={(value) => `Add group "${value}"`}
             placeholder="Select groups"
-            selectionRequired={groupsTouched}
-            noSelectedOptionsMessage="One or more groups must be selected"
           />
-          {groupsTouched && getFieldValidation(['groups']).length > 0 && (
+          {groupsTouched && getFieldValidation(['groups'], true).length > 0 && (
             <FormHelperText>
               <HelperText>
                 <HelperTextItem variant="error">
-                  {getFieldValidation(['groups'])[0].message}
+                  {getFieldValidation(['groups'], true)[0].message}
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -22,8 +22,10 @@ import K8sNameDescriptionField, {
   useK8sNameDescriptionFieldData,
 } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { isK8sNameDescriptionDataValid } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
+import { useZodFormValidation } from '@odh-dashboard/internal/hooks/useZodFormValidation';
 import { APIOptions } from 'mod-arch-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { z } from 'zod';
 import { URL_PREFIX } from '~/app/utilities/const';
 import { getLowestAvailablePriority } from '~/app/utilities/subscriptions';
 import { createSubscription, updateSubscription } from '~/app/api/subscriptions';
@@ -45,6 +47,18 @@ type CreateSubscriptionFormProps = {
 };
 const MAX_PRIORITY = 1000000;
 const MIN_PRIORITY = -1000000;
+
+const subscriptionFormSchema = z.object({
+  priority: z
+    .number({ message: 'Priority is required' })
+    .int('Priority must be a whole number')
+    .min(MIN_PRIORITY, `Priority must be at least ${MIN_PRIORITY}`)
+    .max(MAX_PRIORITY, `Priority must be at most ${MAX_PRIORITY}`),
+  groups: z.array(z.string()).min(1, 'At least one group must be selected'),
+  models: z.array(z.unknown()).min(1, 'At least one model must be added'),
+});
+
+type SubscriptionFormData = z.infer<typeof subscriptionFormSchema>;
 
 const buildInitialModels = (info: SubscriptionInfoResponse): SubscriptionModelEntry[] =>
   info.subscription.modelRefs.map((ref) => {
@@ -143,10 +157,6 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   const isNameValid = isK8sNameDescriptionDataValid(nameDescData);
 
   const selectedGroupNames = selectedGroups.filter((g) => g.selected).map((g) => String(g.id));
-  const groupsValidationError =
-    groupsTouched && selectedGroupNames.length === 0
-      ? 'At least one group must be selected'
-      : undefined;
 
   const initialGroupNames = React.useMemo(
     () =>
@@ -194,23 +204,36 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
     return subscriptionsForConflictCheck.find((s) => (s.priority ?? 0) === priority);
   }, [priority, subscriptionsForConflictCheck]);
 
-  const priorityValidationError = conflictingSubscription
+  const priorityConflictError = conflictingSubscription
     ? `Priority ${conflictingSubscription.priority ?? 0} is already used by ${conflictingSubscription.displayName || conflictingSubscription.name}. The next available priority is ${getLowestAvailablePriority(subscriptionsForConflictCheck, (conflictingSubscription.priority ?? 0) + 1)}.`
     : undefined;
 
-  const isPriorityValid = priority != null && !Number.isNaN(priority);
+  const zodFormData: SubscriptionFormData = React.useMemo(
+    () => ({
+      priority: priority == null || Number.isNaN(priority) ? Number.NaN : priority,
+      groups: selectedGroupNames,
+      models,
+    }),
+    [priority, selectedGroupNames, models],
+  );
+
+  const { getFieldValidation } = useZodFormValidation(zodFormData, subscriptionFormSchema);
+
+  const priorityValidationError =
+    priorityConflictError ??
+    (getFieldValidation(['priority'], true).length > 0
+      ? getFieldValidation(['priority'], true)[0].message
+      : undefined);
 
   const canSubmit =
     isNameValid &&
-    selectedGroupNames.length > 0 &&
-    models.length > 0 &&
+    getFieldValidation(undefined, true).length === 0 &&
     allModelsHaveRateLimits &&
-    isPriorityValid &&
     !isSubmitting &&
-    !priorityValidationError;
+    !priorityConflictError;
 
   const handleSubmit = async () => {
-    if (!isPriorityValid) {
+    if (priority == null || Number.isNaN(priority)) {
       return;
     }
 
@@ -339,10 +362,12 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
             selectionRequired={groupsTouched}
             noSelectedOptionsMessage="One or more groups must be selected"
           />
-          {groupsValidationError && (
+          {groupsTouched && getFieldValidation(['groups']).length > 0 && (
             <FormHelperText>
               <HelperText>
-                <HelperTextItem>{groupsValidationError}</HelperTextItem>
+                <HelperTextItem variant="error">
+                  {getFieldValidation(['groups'])[0].message}
+                </HelperTextItem>
               </HelperText>
             </FormHelperText>
           )}

--- a/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
+++ b/packages/maas/frontend/src/app/shared/MaasModelsSection.tsx
@@ -43,6 +43,7 @@ export type MaasModelsSectionProps = {
   onEditLimits?: (index: number) => void;
   onRemoveModel?: (index: number) => void;
   helperText?: React.ReactNode;
+  validationError?: string;
   formGroupFieldId?: string;
   sectionTestId?: string;
   tableTestId?: string;
@@ -63,6 +64,7 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
   onEditLimits,
   onRemoveModel,
   helperText,
+  validationError,
   resourceType = 'subscription',
   formGroupFieldId = `${resourceType.trim().toLowerCase().replace(/\s+/g, '-')}-models`,
   sectionTestId = `${resourceType.trim().toLowerCase().replace(/\s+/g, '-')}-models-section`,
@@ -221,6 +223,15 @@ const MaasModelsSection: React.FC<MaasModelsSectionProps> = ({
               </Content>
             )}
           </StackItem>
+          {validationError && (
+            <StackItem>
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">{validationError}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </StackItem>
+          )}
           {table && <StackItem>{table}</StackItem>}
           <StackItem>
             <Button


### PR DESCRIPTION
Closes: [RHOAIENG-57520](https://redhat.atlassian.net/browse/RHOAIENG-57520)

## Description
Updates the MaaS create pages to use Zod. Mostly Subscriptions and Auth Policies. One small change in API keys, as it was already using zod

## How Has This Been Tested?
Tested locally, ensure that all the checks still work as they did previously, and not having any issues with submitting forms 

## Test Impact
No tests changed

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid submissions by improving submit enablement and adding early-return checks when required fields are missing or invalid.
  * Submission now disables when priority conflicts are detected.

* **Improvements**
  * Unified schema-driven validation across policy, subscription, and API-key forms for consistent inline error messages.
  * Model and group validation errors now display more appropriately (models show errors after interaction; model list shows validation messages).
* **New Features**
  * Model list component now surface explicit validation messages when editable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->