### PR TITLE
Fix auto select llmd option if no configs available

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/llmInferenceServiceConfig.ts
+++ b/packages/cypress/cypress/utils/oc_commands/llmInferenceServiceConfig.ts
@@ -19,7 +19,7 @@ export const cleanupLLMInferenceServiceConfig = (
   configName: string,
 ): Cypress.Chainable<CommandLineResult> => {
   const sanitizedName = configName.replace(/[^a-zA-Z0-9_-]/g, '');
-  const ocCommand = `oc get llminferenceserviceconfig -ojson -n ${applicationNamespace} | jq '.items[] | select(.metadata.name | contains("${sanitizedName}")) | .metadata.name' | tr -d '"'`;
+  const ocCommand = `oc get llminferenceserviceconfig -o json -n ${applicationNamespace} | jq '.items[] | select(.metadata.name | contains("${sanitizedName}")) | .metadata.name' | tr -d '"'`;
   cy.log(`Executing delete LLMInferenceServiceConfig command: ${ocCommand}`);
 
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -9,6 +9,7 @@ import ModelServerTemplateSelectField, {
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import { HardwareProfileKind } from '@odh-dashboard/internal/k8sTypes';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
 import { useModelServingClusterSettings } from '@odh-dashboard/model-serving/concepts/useModelServingClusterSettings';
 import { useFetchLLMInferenceServiceConfigs } from '../api/LLMInferenceServiceConfigs';
@@ -186,6 +187,8 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
         return {
           data: {
             selection: options[0],
+            autoSelect: true,
+            suggestion: options[0],
           },
         };
       }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
