### PR TITLE
fix(feature-store): content review changes per UX feedback

### DIFF
--- a/packages/cypress/cypress/pages/featureStore/featureEntities.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureEntities.ts
@@ -12,7 +12,7 @@ class FeatureEntitiesTable extends Contextual<HTMLElement> {
 
   findRow(entityName: string) {
     return new FeatureEntityTableRow(() =>
-      this.findTable().find('[data-label="Entities"]').contains(entityName).parents('tr'),
+      this.findTable().find('[data-label="Name"]').contains(entityName).parents('tr'),
     );
   }
 
@@ -58,7 +58,7 @@ class FeatureEntityToolbar extends Contextual<HTMLElement> {
 
 class FeatureEntityTableRow extends TableRow {
   findEntityName() {
-    return this.find().find('[data-label="Entities"]');
+    return this.find().find('[data-label="Name"]');
   }
 
   findEntityLink() {

--- a/packages/cypress/cypress/pages/featureStore/featureService.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureService.ts
@@ -36,7 +36,7 @@ class FeatureServicesTable extends Contextual<HTMLElement> {
 
 class FeatureServiceTableRow extends TableRow {
   shouldHaveFeatureServiceName(name: string) {
-    this.find().find('[data-label="Name"]').should('contains.text', name);
+    this.find().find('[data-label="Name"]').should('contain.text', name);
     return this;
   }
 

--- a/packages/cypress/cypress/pages/featureStore/featureService.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureService.ts
@@ -12,10 +12,7 @@ class FeatureServicesTable extends Contextual<HTMLElement> {
 
   findRow(featureServiceName: string) {
     return new FeatureServiceTableRow(() =>
-      this.findTable()
-        .find('[data-label="Feature service"]')
-        .contains(featureServiceName)
-        .parents('tr'),
+      this.findTable().find('[data-label="Name"]').contains(featureServiceName).parents('tr'),
     );
   }
 
@@ -39,7 +36,7 @@ class FeatureServicesTable extends Contextual<HTMLElement> {
 
 class FeatureServiceTableRow extends TableRow {
   shouldHaveFeatureServiceName(name: string) {
-    this.find().find('[data-label="Feature service"]').should('contains.text', name);
+    this.find().find('[data-label="Name"]').should('contains.text', name);
     return this;
   }
 

--- a/packages/cypress/cypress/pages/featureStore/featureView.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureView.ts
@@ -12,7 +12,7 @@ class FeatureViewsTable extends Contextual<HTMLElement> {
 
   findRow(featureViewName: string) {
     return new FeatureViewTableRow(() =>
-      this.findTable().find('[data-label="Feature View"]').contains(featureViewName).parents('tr'),
+      this.findTable().find('[data-label="Name"]').contains(featureViewName).parents('tr'),
     );
   }
 
@@ -55,7 +55,7 @@ class FeatureViewToolbar extends Contextual<HTMLElement> {
 
 class FeatureViewTableRow extends TableRow {
   findFeatureViewName() {
-    return this.find().find('[data-label="Feature View"]');
+    return this.find().find('[data-label="Name"]');
   }
 
   findFeatureViewLink() {

--- a/packages/cypress/cypress/pages/featureStore/features.ts
+++ b/packages/cypress/cypress/pages/featureStore/features.ts
@@ -12,7 +12,7 @@ class FeaturesTable extends Contextual<HTMLElement> {
 
   findRow(featureName: string) {
     return new FeatureTableRow(() =>
-      this.findTable().find('[data-label="Feature"]').contains(featureName).parents('tr'),
+      this.findTable().find('[data-label="Name"]').contains(featureName).parents('tr'),
     );
   }
 
@@ -74,7 +74,7 @@ class FeatureToolbar extends Contextual<HTMLElement> {
 
 class FeatureTableRow extends TableRow {
   findFeatureName() {
-    return this.find().find('[data-label="Feature"]');
+    return this.find().find('[data-label="Name"]');
   }
 
   findFeatureLink() {

--- a/packages/feature-store/src/components/FeatureStoreCodeBlock.tsx
+++ b/packages/feature-store/src/components/FeatureStoreCodeBlock.tsx
@@ -49,9 +49,13 @@ const FeatureStoreCodeBlock: React.FC<FeatureStoreCodeBlockProps> = ({
         </Title>
         <Popover
           maxWidth="400px"
-          bodyContent={`This code shows the definition used to create the ${id} ${
-            featureStoreType ?? 'resource'
-          }. You can copy and modify it to define similar resources in code.`}
+          bodyContent={
+            <>
+              This code shows the definition used to create the <strong>{id}</strong>{' '}
+              {featureStoreType ?? 'resource'}. You can copy and modify it to define similar
+              resources in code.
+            </>
+          }
         >
           <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} />
         </Popover>

--- a/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
@@ -207,7 +207,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
         <MultiSelection
           value={getEntityOptions}
           setValue={(selections: SelectionOptions[]) => handleSelectionChange('entity', selections)}
-          placeholder={!lineageDataLoaded ? 'Loading lineage...' : 'Search entities...'}
+          placeholder={!lineageDataLoaded ? 'Loading lineage...' : 'Filter by entity name'}
           ariaLabel="Search entities"
           isDisabled={!lineageDataLoaded}
         />

--- a/packages/feature-store/src/components/FeatureStoreToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreToolbar.tsx
@@ -26,6 +26,40 @@ export type BaseFeatureStoreToolbarProps = {
 
 export type FeatureStoreToolbarProps = BaseFeatureStoreToolbarProps & Partial<TagFilterProps>;
 
+/** Placeholder for filters */
+export function getSearchFilterPlaceholder(
+  filterKey: string,
+  filterOptions: Record<string, string>,
+  explicitPlaceholder?: string,
+): string {
+  if (explicitPlaceholder) {
+    return explicitPlaceholder;
+  }
+  const label = filterOptions[filterKey];
+  if (filterKey === 'tags') {
+    return `Filter by tag`;
+  }
+  const labelLower = label.toLowerCase();
+  const excludedKeys = new Set([
+    'owner',
+    'type',
+    'created',
+    'updated',
+    'tag',
+    'storeType',
+    'valueType',
+    'joinKey',
+  ]);
+  if (excludedKeys.has(filterKey)) {
+    return `Filter by ${labelLower}`;
+  }
+  // Labels that already end with " name" (e.g. "Entity name") must not append another " name".
+  if (labelLower.endsWith(' name')) {
+    return `Filter by ${labelLower}`;
+  }
+  return `Filter by ${labelLower} name`;
+}
+
 const TagMultiInput: React.FC<{
   tagFilters?: string[];
   onTagFilterAdd?: (tag: string) => void;
@@ -60,7 +94,7 @@ const TagMultiInput: React.FC<{
       value={localValue}
       onChange={handleInputChange}
       onKeyDown={handleKeyDown}
-      placeholder="Filter tags or press enter to add tag"
+      placeholder="Filter by tag"
       aria-label="Search or add tag filter"
     />
   );
@@ -96,12 +130,12 @@ export function createDefaultFilterOptionRenders(
         />
       );
     } else {
-      result[key] = ({ onChange, value, ...props }) => (
+      result[key] = ({ onChange, value, placeholder, ...props }) => (
         <SearchInput
           {...props}
           value={value || ''}
           onChange={(_event, v) => onChange(v)}
-          placeholder={`Filter by ${filterOptions[key].toLowerCase()}`}
+          placeholder={getSearchFilterPlaceholder(key, filterOptions, placeholder)}
         />
       );
     }

--- a/packages/feature-store/src/components/FeatureStoreToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreToolbar.tsx
@@ -39,6 +39,9 @@ export function getSearchFilterPlaceholder(
   if (filterKey === 'tags') {
     return `Filter by tag`;
   }
+  if (!label) {
+    return `Filter by ${filterKey}`;
+  }
   const labelLower = label.toLowerCase();
   const excludedKeys = new Set([
     'owner',

--- a/packages/feature-store/src/components/IntegrationInstructionsPopover.tsx
+++ b/packages/feature-store/src/components/IntegrationInstructionsPopover.tsx
@@ -35,6 +35,10 @@ const IntegrationInstructionsPopover: React.FC<IntegrationInstructionsPopoverPro
           permission to access the feature store.
           <br />
           <br />
+          To see which projects have the required permissions, click{' '}
+          <strong>View connected workbenches</strong>.
+          <br />
+          <br />
           In a compatible project, create or edit a workbench and select the desired feature store
           in the <strong>Feature stores</strong> field.
         </p>

--- a/packages/feature-store/src/components/__tests__/FeatureStoreToolbar.spec.ts
+++ b/packages/feature-store/src/components/__tests__/FeatureStoreToolbar.spec.ts
@@ -1,0 +1,58 @@
+import { getSearchFilterPlaceholder } from '../FeatureStoreToolbar';
+import { entityTableFilterOptions } from '../../screens/entities/const';
+import { featureTableFilterOptions } from '../../screens/features/const';
+
+describe('getSearchFilterPlaceholder', () => {
+  it('should return the explicit placeholder when provided', () => {
+    expect(
+      getSearchFilterPlaceholder('entity', entityTableFilterOptions, 'Custom placeholder'),
+    ).toBe('Custom placeholder');
+  });
+
+  it('should return "Filter by tag" for the tags filter key', () => {
+    expect(getSearchFilterPlaceholder('tags', { tags: 'Tags' })).toBe('Filter by tag');
+  });
+
+  it('should return a fallback using the filter key when the label is missing', () => {
+    expect(getSearchFilterPlaceholder('unknownKey', {})).toBe('Filter by unknownKey');
+  });
+
+  it('should not append " name" for excluded filter keys', () => {
+    expect(getSearchFilterPlaceholder('owner', entityTableFilterOptions)).toBe('Filter by owner');
+    expect(getSearchFilterPlaceholder('created', entityTableFilterOptions)).toBe(
+      'Filter by created after',
+    );
+    expect(getSearchFilterPlaceholder('updated', entityTableFilterOptions)).toBe(
+      'Filter by updated after',
+    );
+    expect(getSearchFilterPlaceholder('tag', entityTableFilterOptions)).toBe('Filter by tags');
+    expect(getSearchFilterPlaceholder('valueType', entityTableFilterOptions)).toBe(
+      'Filter by value type',
+    );
+    expect(getSearchFilterPlaceholder('joinKey', entityTableFilterOptions)).toBe(
+      'Filter by join key',
+    );
+    expect(getSearchFilterPlaceholder('type', { type: 'Type' })).toBe('Filter by type');
+    expect(getSearchFilterPlaceholder('storeType', { storeType: 'Store type' })).toBe(
+      'Filter by store type',
+    );
+  });
+
+  it('should not append an extra " name" when the label already ends with " name"', () => {
+    expect(getSearchFilterPlaceholder('entity', { entity: 'Entity name' })).toBe(
+      'Filter by entity name',
+    );
+  });
+
+  it('should append " name" for standard searchable filters', () => {
+    expect(getSearchFilterPlaceholder('entity', entityTableFilterOptions)).toBe(
+      'Filter by entity name',
+    );
+    expect(getSearchFilterPlaceholder('feature', featureTableFilterOptions)).toBe(
+      'Filter by feature name',
+    );
+    expect(getSearchFilterPlaceholder('featureViews', entityTableFilterOptions)).toBe(
+      'Filter by feature views name',
+    );
+  });
+});

--- a/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsTabs.tsx
+++ b/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsTabs.tsx
@@ -59,7 +59,7 @@ const DataSetDetailsTabs: React.FC<DataSetDetailsTabsProps> = ({ dataSet }) => {
           <Table aria-label="Features table" data-testid="features-table" variant="compact">
             <Thead>
               <Tr>
-                <Th>Feature</Th>
+                <Th>Name</Th>
                 <Th
                   info={{
                     popover:

--- a/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsView.tsx
+++ b/packages/feature-store/src/screens/dataSets/DataSetDetails/DataSetDetailsView.tsx
@@ -176,7 +176,7 @@ const DataSetDetailsView: React.FC<DataSetDetailsViewProps> = ({ dataSet }) => {
                     dataSet.meta.lastUpdatedTimestamp ? (
                       <FeatureStoreTimestamp date={dataSet.meta.lastUpdatedTimestamp} />
                     ) : (
-                      'No last modified'
+                      '--'
                     )
                   }
                   testId="data-set-last-modified"

--- a/packages/feature-store/src/screens/dataSets/const.ts
+++ b/packages/feature-store/src/screens/dataSets/const.ts
@@ -45,7 +45,7 @@ export const columns: SortableData<DataSet>[] = [
 ];
 
 export const dataSetTableFilterOptions: Record<string, string> = {
-  dataSet: 'Datasets',
+  dataSet: 'Dataset',
   project: 'Feature store',
   tag: 'Tags',
   featureServiceName: 'Feature service',

--- a/packages/feature-store/src/screens/dataSources/const.ts
+++ b/packages/feature-store/src/screens/dataSources/const.ts
@@ -29,7 +29,7 @@ export const columns: SortableData<DataSource>[] = [
   },
   {
     field: 'featureViews',
-    label: 'Feature views',
+    label: 'Feature view',
     width: 10,
     sortable: false,
     info: {
@@ -73,10 +73,10 @@ export const dataSourceTableFilterKeyMapping = {
   owner: 'owner',
 };
 export const dataSourceTableFilterOptions: Record<string, string> = {
-  name: 'Name',
+  name: 'Resource',
   project: 'Feature store',
   type: 'Data source connector',
-  featureViews: 'Feature views',
+  featureViews: 'Feature view',
   updated: 'Modified after',
   created: 'Created after',
   owner: 'Owner',

--- a/packages/feature-store/src/screens/dataSources/const.ts
+++ b/packages/feature-store/src/screens/dataSources/const.ts
@@ -73,7 +73,7 @@ export const dataSourceTableFilterKeyMapping = {
   owner: 'owner',
 };
 export const dataSourceTableFilterOptions: Record<string, string> = {
-  name: 'Resource',
+  name: 'Name',
   project: 'Feature store',
   type: 'Data source connector',
   featureViews: 'Feature view',

--- a/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceDetailsView.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceDetailsView.tsx
@@ -103,7 +103,7 @@ const DataSourceDetailsView: React.FC<DataSourceDetailsViewProps> = ({ dataSourc
                 dataSource.meta.lastUpdatedTimestamp ? (
                   <FeatureStoreTimestamp date={new Date(dataSource.meta.lastUpdatedTimestamp)} />
                 ) : (
-                  'No last modified'
+                  '--'
                 )
               }
               testId="data-source-last-modified"
@@ -123,7 +123,7 @@ const DataSourceDetailsView: React.FC<DataSourceDetailsViewProps> = ({ dataSourc
             />
             <DetailsItem
               label="Owner"
-              value={getContentValue(dataSource.owner, 'No owner')}
+              value={getContentValue(dataSource.owner, '--')}
               testId="data-source-owner"
               className={getDisabledClassName(dataSource.owner)}
             />

--- a/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceDetails/DataSourceTabs.tsx
@@ -47,7 +47,7 @@ const FeatureViewsTabContent: React.FC<{
     >
       <Thead>
         <Tr>
-          <Th width={20}>Feature View</Th>
+          <Th width={20}>Name</Th>
           <Th width={20}>Feature service consumers</Th>
         </Tr>
       </Thead>

--- a/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceTableRow.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceTableRow.tsx
@@ -118,7 +118,7 @@ const FeatureStoreDataSourcesTableRow: React.FC<FeatureStoreDataSourcesTableRowT
         <FeatureStoreTimestamp date={dataSource.meta.createdTimestamp} />,
         'data-source-created',
       )}
-      {renderTableCell('Owner', dataSource.owner ?? '--', 'data-source-owner')}
+      {renderTableCell('Owner', dataSource.owner?.trim() || '--', 'data-source-owner')}
     </Tr>
   );
 };

--- a/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceTableRow.tsx
+++ b/packages/feature-store/src/screens/dataSources/dataSourceTable/FeatureStoreDataSourceTableRow.tsx
@@ -118,7 +118,7 @@ const FeatureStoreDataSourcesTableRow: React.FC<FeatureStoreDataSourcesTableRowT
         <FeatureStoreTimestamp date={dataSource.meta.createdTimestamp} />,
         'data-source-created',
       )}
-      {renderTableCell('Owner', dataSource.owner ?? '-', 'data-source-owner')}
+      {renderTableCell('Owner', dataSource.owner ?? '--', 'data-source-owner')}
     </Tr>
   );
 };

--- a/packages/feature-store/src/screens/entities/EntitiesDetails/EntityDetailsView.tsx
+++ b/packages/feature-store/src/screens/entities/EntitiesDetails/EntityDetailsView.tsx
@@ -71,7 +71,7 @@ const EntityDetailsView: React.FC<EntityDetailsViewProps> = ({ entity }) => (
           />
           <DetailsItem
             label="Value type"
-            value={getContentValue(entity.spec.valueType, 'No value type')}
+            value={getContentValue(entity.spec.valueType, '--')}
             testId="entity-value-type"
             className={getDisabledClassName(entity.spec.valueType)}
           />

--- a/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesTableRow.tsx
+++ b/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesTableRow.tsx
@@ -84,7 +84,7 @@ const FeatureStoreEntitiesTableRow: React.FC<FeatureStoreEntitiesTableRowType> =
 
   return (
     <Tr>
-      {renderTableCell('Entities', <EntityName entity={entity} currentProject={currentProject} />)}
+      {renderTableCell('Name', <EntityName entity={entity} currentProject={currentProject} />)}
       {renderTableCell('Project', entity.project, 'project-name')}
       {renderTableCell(
         'Tags',
@@ -94,10 +94,10 @@ const FeatureStoreEntitiesTableRow: React.FC<FeatureStoreEntitiesTableRowType> =
           onTagClick={onTagClick}
         />,
       )}
-      {renderTableCell('Join key', entity.spec.joinKey ?? '-', 'join-key')}
+      {renderTableCell('Join key', entity.spec.joinKey ?? '--', 'join-key')}
       {renderTableCell(
         'Value type',
-        entity.spec.valueType ?? '-',
+        entity.spec.valueType ?? '--',
         `value-type-${entity.spec.name}`,
       )}
       {renderTableCell(
@@ -118,7 +118,7 @@ const FeatureStoreEntitiesTableRow: React.FC<FeatureStoreEntitiesTableRowType> =
         <FeatureStoreTimestamp date={entity.meta.lastUpdatedTimestamp} />,
         'updated',
       )}
-      {renderTableCell('Owner', entity.spec.owner ?? '-', 'owner')}
+      {renderTableCell('Owner', entity.spec.owner ?? '--', 'owner')}
     </Tr>
   );
 };

--- a/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesTableRow.tsx
+++ b/packages/feature-store/src/screens/entities/EntitiesTable/FeatureStoreEntitiesTableRow.tsx
@@ -94,10 +94,10 @@ const FeatureStoreEntitiesTableRow: React.FC<FeatureStoreEntitiesTableRowType> =
           onTagClick={onTagClick}
         />,
       )}
-      {renderTableCell('Join key', entity.spec.joinKey ?? '--', 'join-key')}
+      {renderTableCell('Join key', entity.spec.joinKey?.trim() || '--', 'join-key')}
       {renderTableCell(
         'Value type',
-        entity.spec.valueType ?? '--',
+        entity.spec.valueType?.trim() || '--',
         `value-type-${entity.spec.name}`,
       )}
       {renderTableCell(
@@ -118,7 +118,7 @@ const FeatureStoreEntitiesTableRow: React.FC<FeatureStoreEntitiesTableRowType> =
         <FeatureStoreTimestamp date={entity.meta.lastUpdatedTimestamp} />,
         'updated',
       )}
-      {renderTableCell('Owner', entity.spec.owner ?? '--', 'owner')}
+      {renderTableCell('Owner', entity.spec.owner?.trim() || '--', 'owner')}
     </Tr>
   );
 };

--- a/packages/feature-store/src/screens/entities/FeatureStoreEntities.tsx
+++ b/packages/feature-store/src/screens/entities/FeatureStoreEntities.tsx
@@ -11,10 +11,13 @@ import { featureStoreRoute } from '../../routes';
 import FeatureStorePageTitle from '../../components/FeatureStorePageTitle';
 import FeatureStoreObjectIcon from '../../components/FeatureStoreObjectIcon';
 import FeatureStoreAccessDenied from '../../components/FeatureStoreAccessDenied';
+import { getFeatureStoreObjectDescription } from '../../utils';
+import { FeatureStoreObject } from '../../const';
 
 const title = 'Entities';
-const description =
-  'Select a feature store to view and manage its entities. Entities are collections of related features and can be mapped to your use case (for example, customers, products, transactions).';
+const description = `Select a feature store to view and manage its entities. ${getFeatureStoreObjectDescription(
+  FeatureStoreObject.ENTITIES,
+).trim()}`;
 
 const FeatureStoreEntities = (): React.ReactElement => {
   const { currentProject } = useFeatureStoreProject();

--- a/packages/feature-store/src/screens/entities/const.ts
+++ b/packages/feature-store/src/screens/entities/const.ts
@@ -4,7 +4,7 @@ import { Entity } from '../../types/entities';
 export const columns: SortableData<Entity>[] = [
   {
     field: 'spec.name',
-    label: 'Entity name',
+    label: 'Name',
     width: 60,
     sortable: (a, b): number => a.spec.name.localeCompare(b.spec.name),
   },
@@ -76,7 +76,7 @@ export const columns: SortableData<Entity>[] = [
 ];
 
 export const entityTableFilterOptions: Record<string, string> = {
-  entity: 'Entity name',
+  entity: 'Entity',
   project: 'Feature store',
   tag: 'Tags',
   joinKey: 'Join key',

--- a/packages/feature-store/src/screens/featureServices/FeatureServiceTableRow.tsx
+++ b/packages/feature-store/src/screens/featureServices/FeatureServiceTableRow.tsx
@@ -21,7 +21,7 @@ const FeatureServiceTableRow: React.FC<FeatureServiceTableRowType> = ({
   onTagClick,
 }) => (
   <Tr>
-    <Td dataLabel="Feature service">
+    <Td dataLabel="Name">
       <TableRowTitleDescription
         title={
           <Link

--- a/packages/feature-store/src/screens/featureServices/FeatureServices.tsx
+++ b/packages/feature-store/src/screens/featureServices/FeatureServices.tsx
@@ -11,10 +11,11 @@ import useFeatureServices from '../../apiHooks/useFeatureServices';
 import { featureStoreRoute } from '../../routes';
 import FeatureStoreObjectIcon from '../../components/FeatureStoreObjectIcon';
 import FeatureStoreAccessDenied from '../../components/FeatureStoreAccessDenied';
+import { getFeatureStoreObjectDescription } from '../../utils';
+import { FeatureStoreObject } from '../../const';
 
 const title = 'Feature services';
-const description =
-  'Select a feature store to view its feature services. Feature services are groups of related features from one or more feature views that are designed to be retrieved together for model training, online inference, or GenAI applications like RAG.';
+const description = getFeatureStoreObjectDescription(FeatureStoreObject.FEATURE_SERVICES);
 
 const FeatureServices = (): React.ReactElement => {
   const { currentProject } = useFeatureStoreProject();

--- a/packages/feature-store/src/screens/featureServices/const.ts
+++ b/packages/feature-store/src/screens/featureServices/const.ts
@@ -4,7 +4,7 @@ import { FeatureService } from '../../types/featureServices';
 export const columns: SortableData<FeatureService>[] = [
   {
     field: 'feature_service',
-    label: 'Feature service',
+    label: 'Name',
     width: 25,
     sortable: (a: FeatureService, b: FeatureService): number =>
       a.spec.name.localeCompare(b.spec.name),

--- a/packages/feature-store/src/screens/featureViews/FeatureViewTableRow.tsx
+++ b/packages/feature-store/src/screens/featureViews/FeatureViewTableRow.tsx
@@ -106,7 +106,7 @@ const FeatureViewTableRow: React.FC<FeatureViewTableRowType> = ({
     switch (column.field) {
       case 'feature_view':
         return (
-          <Td key="feature_view" dataLabel="Feature View">
+          <Td key="feature_view" dataLabel="Name">
             <TableRowTitleDescription
               title={
                 <Link

--- a/packages/feature-store/src/screens/featureViews/const.ts
+++ b/packages/feature-store/src/screens/featureViews/const.ts
@@ -18,7 +18,7 @@ export const featureViewTableFilterOptions: Record<string, string> = {
 export const columns: SortableData<FeatureView>[] = [
   {
     field: 'feature_view',
-    label: 'Feature View',
+    label: 'Name',
     width: 25,
     sortable: (a: FeatureView, b: FeatureView): number => a.spec.name.localeCompare(b.spec.name),
   },

--- a/packages/feature-store/src/screens/features/FeatureTableRow.tsx
+++ b/packages/feature-store/src/screens/features/FeatureTableRow.tsx
@@ -15,7 +15,7 @@ type FeatureTableRowType = {
 
 const FeatureTableRow: React.FC<FeatureTableRowType> = ({ features, fsProject, onTagClick }) => (
   <Tr>
-    <Td dataLabel="Feature">
+    <Td dataLabel="Name">
       <TableRowTitleDescription
         title={
           <Link

--- a/packages/feature-store/src/screens/features/const.ts
+++ b/packages/feature-store/src/screens/features/const.ts
@@ -14,7 +14,7 @@ export const featureTableFilterOptions: Record<string, string> = {
 export const baseColumns: SortableData<Features>[] = [
   {
     field: 'feature',
-    label: 'Feature',
+    label: 'Name',
     width: 25,
     sortable: (a: Features, b: Features): number => a.name.localeCompare(b.name),
   },

--- a/packages/feature-store/src/utils.ts
+++ b/packages/feature-store/src/utils.ts
@@ -151,7 +151,7 @@ export const getFeatureStoreObjectDescription = (
     case FeatureStoreObject.FEATURE_VIEWS:
       return 'Select a feature store to view and manage its feature views. A feature view defines how to retrieve a logical group of features from a specific data source. It binds a data source to one or more entities and contains the logic for transforming the raw data into feature values.';
     case FeatureStoreObject.FEATURE_SERVICES:
-      return 'Feature services are groups of related features from one or more feature views that are designed to be retrieved together for model training, online inference, or GenAI applications like RAG.';
+      return 'Select a feature store to view its feature services. Feature services are groups of related features from one or more feature views that are designed to be retrieved together for model training, online inference, or GenAI applications like RAG.';
     case FeatureStoreObject.DATA_SETS:
       return 'View and manage datasets generated from feature services. These datasets contain point-in-time-correct feature values to avoid leakage and support reliable training, validation, and offline analysis. You can add labels and apply additional preprocessing as needed.';
     case FeatureStoreObject.OVERVIEW:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-48982

## Description
Content review changes requested by the UX team according to doc.

## How Has This Been Tested?

No tests needed as these are text/label updates only


## Screenshots -

Attaching screenshots for easier review

<img width="1200" height="901" alt="02-integration-instructions-popover" src="https://github.com/user-attachments/assets/85a2bd44-9aa3-47fd-a1a6-f67711a44581" />


<img width="1728" height="945" alt="05-data-sources-filter-dropdown-feature-view-singular" src="https://github.com/user-attachments/assets/41312b44-0606-43e5-9dc0-1344a63dd343" />

<img width="1728" height="945" alt="07-tag-filter-placeholder-filter-by-tag" src="https://github.com/user-attachments/assets/2b8a3fc8-0352-4227-8dd0-0ac7c08565cf" />

<img width="1728" height="945" alt="08-feature-services-page-description-and-filter-placeholder" src="https://github.com/user-attachments/assets/8a10376e-dc06-46bc-a93f-bda96ef387ac" />

<img width="1728" height="945" alt="10-data-source-details-owner-and-definition-popover" src="https://github.com/user-attachments/assets/d251eb68-2f80-4553-80c3-7e6f80f5c9e4" />

<img width="1728" height="945" alt="11-data-source-details-feature-views-tab-name-column" src="https://github.com/user-attachments/assets/4f652e70-fd64-4cef-9585-6b3a61a23082" />

<img width="1728" height="945" alt="12-entity-details-value-type-em-dash" src="https://github.com/user-attachments/assets/d5eb4219-f76e-4fc1-9e56-8b3723413b9a" />

<img width="1728" height="945" alt="13-entities-page-description-and-placeholder-bug" src="https://github.com/user-attachments/assets/8c51abbe-cbd1-45ce-8de5-34a305328225" />


Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Join key" column to the entities table for improved metadata visibility.

* **Improvements**
  * Standardized many table column headers to "Name" for consistency.
  * More descriptive filter placeholders (e.g., "Filter by entity name", "Filter by tag").
  * Missing-data fallbacks now display "--" instead of "No ...".
  * Singularized labels (Dataset, Feature view); updated integration popover and service description text.

* **Tests**
  * Added unit tests for placeholder logic and updated end-to-end selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->