### PR TITLE
Prevent subscriptions table from jumping

### DIFF
--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/columns.ts
@@ -11,19 +11,21 @@ export const subscriptionsColumns: SortableData<MaaSSubscription>[] = [
   {
     label: 'Phase',
     field: 'phase',
-    width: 10,
+    width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       (a.phase ?? '').localeCompare(b.phase ?? ''),
   },
   {
     label: 'Groups',
     field: 'owner.groups',
+    width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       a.owner.groups.length - b.owner.groups.length,
   },
   {
     label: 'Models',
     field: 'modelRefs',
+    width: 15,
     sortable: (a: MaaSSubscription, b: MaaSSubscription): number =>
       a.modelRefs.length - b.modelRefs.length,
   },


### PR DESCRIPTION
Closes: [RHOAIENG-58388](https://redhat.atlassian.net/browse/RHOAIENG-58388)

## Description
This fix adjusts the other columns to take up approximately 50% of the window space, and leaves the remaining space to the name column. This will hopefully keep the columns from jumping around, while also not having weird amounts of white space on small or large screens. 

## How Has This Been Tested?
Tested locally. 

- Create a subscription with a super long name or description. 
- Use the sorting at the top to hopefully sort your new subscription in and out of the current page. 
- The table should no longer hop around with the long subscription.

## Test Impact
No tests changed

## Screen grab
Before:

https://github.com/user-attachments/assets/ddb83d37-3fb0-4e8e-b228-74483695bef1


After:

https://github.com/user-attachments/assets/6db7e3c6-8dd2-46f8-9b4f-60192134cbc6



## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved subscriptions table display with optimized column widths and enhanced sorting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->