### PR TITLE
[RHOAIENG-44140] Fix User management infinite loading on BYOIDC clusters

### DIFF
--- a/frontend/src/api/k8s/__tests__/groups.spec.ts
+++ b/frontend/src/api/k8s/__tests__/groups.spec.ts
@@ -2,6 +2,8 @@ import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { groupVersionKind, useAccessReview, useGroups } from '#~/api';
 import { GroupModel } from '#~/api/models';
 import { mockGroup } from '#~/__mocks__/mockGroup';
+import { mock404Error, mock500Error } from '#~/__mocks__/mockK8sStatus';
+import { K8sStatusError } from '#~/api/errorUtils';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
 import { GroupKind } from '#~/k8sTypes';
 
@@ -18,69 +20,46 @@ const useAccessReviewMock = jest.mocked(useAccessReview);
 const useK8sWatchResourceListMock = jest.mocked(useK8sWatchResourceList<GroupKind[]>);
 
 describe('useGroups', () => {
-  it('should wrap useK8sWatchResource to watch groups', async () => {
+  it('should watch groups via useK8sWatchResourceList', async () => {
     const mockReturnValue: ReturnType<typeof useK8sWatchResourceListMock> = [[], false, undefined];
     useAccessReviewMock.mockReturnValue([true, true]);
     useK8sWatchResourceListMock.mockReturnValue(mockReturnValue);
     const { result } = testHook(useGroups)();
 
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledTimes(1);
     expect(useK8sWatchResourceListMock).toHaveBeenCalledWith(
-      {
-        isList: true,
-        groupVersionKind: groupVersionKind(GroupModel),
-      },
+      { isList: true, groupVersionKind: groupVersionKind(GroupModel) },
       GroupModel,
     );
     expect(result.current).toStrictEqual(mockReturnValue);
   });
 
   it('should render list of groups', () => {
-    const mockReturnValue: ReturnType<typeof useK8sWatchResourceListMock> = [
-      [mockGroup({})],
-      true,
-      undefined,
-    ];
     useAccessReviewMock.mockReturnValue([true, true]);
-    useK8sWatchResourceListMock.mockReturnValue(mockReturnValue);
+    useK8sWatchResourceListMock.mockReturnValue([[mockGroup({})], true, undefined]);
     const { result } = testHook(useGroups)();
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledTimes(1);
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledWith(
-      {
-        isList: true,
-        groupVersionKind: groupVersionKind(GroupModel),
-      },
-      GroupModel,
-    );
-    expect(result.current).toStrictEqual(mockReturnValue);
+    expect(result.current).toStrictEqual([[mockGroup({})], true, undefined]);
   });
 
-  it('should handle 403 error', () => {
+  it('should handle access review denial (403)', () => {
     useAccessReviewMock.mockReturnValue([false, true]);
     useK8sWatchResourceListMock.mockReturnValue([[], true, undefined]);
     const { result } = testHook(useGroups)();
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledTimes(1);
     expect(useK8sWatchResourceListMock).toHaveBeenCalledWith(null, GroupModel);
     expect(result.current).toStrictEqual([[], true, undefined]);
   });
 
-  it('should handle errors and rethrow', () => {
-    const mockReturnValue: ReturnType<typeof useK8sWatchResourceListMock> = [
-      [],
-      true,
-      new Error('Unknown error occured'),
-    ];
+  it('should return empty groups when the Group CRD does not exist (404 on BYOIDC clusters)', () => {
     useAccessReviewMock.mockReturnValue([true, true]);
-    useK8sWatchResourceListMock.mockReturnValue(mockReturnValue);
+    useK8sWatchResourceListMock.mockReturnValue([[], false, new K8sStatusError(mock404Error({}))]);
     const { result } = testHook(useGroups)();
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledTimes(1);
-    expect(useK8sWatchResourceListMock).toHaveBeenCalledWith(
-      {
-        isList: true,
-        groupVersionKind: groupVersionKind(GroupModel),
-      },
-      GroupModel,
-    );
-    expect(result.current).toStrictEqual(mockReturnValue);
+    expect(result.current).toStrictEqual([[], true, undefined]);
+  });
+
+  it('should propagate non-404 errors', () => {
+    const serverError = new K8sStatusError(mock500Error({}));
+    useAccessReviewMock.mockReturnValue([true, true]);
+    useK8sWatchResourceListMock.mockReturnValue([[], false, serverError]);
+    const { result } = testHook(useGroups)();
+    expect(result.current).toStrictEqual([[], false, serverError]);
   });
 });

--- a/frontend/src/api/k8s/groups.ts
+++ b/frontend/src/api/k8s/groups.ts
@@ -6,6 +6,7 @@ import { groupVersionKind } from '#~/api/k8sUtils';
 import { useAccessReview } from '#~/api/useAccessReview';
 import useK8sWatchResourceList from '#~/utilities/useK8sWatchResourceList';
 import { CustomWatchK8sResult } from '#~/types';
+import { K8sStatusError } from '#~/api/errorUtils';
 
 const accessReviewResource: AccessReviewResourceAttributes = {
   group: 'user.openshift.io',
@@ -30,6 +31,12 @@ export const useGroups = (): CustomWatchK8sResult<GroupKind[]> => {
       return [[], false, undefined];
     }
     if (!allowList) {
+      return [[], true, undefined];
+    }
+    // On BYOIDC clusters (e.g. Keycloak), the Group CRD does not exist and the watch
+    // returns a 404 K8sStatus. Treat this as loaded with no groups so the page does not hang.
+    // Other errors (5xx, network failures) are propagated so the page can surface them.
+    if (error instanceof K8sStatusError && error.statusObject.code === 404) {
       return [[], true, undefined];
     }
     return [groupData, loaded, error];

--- a/frontend/src/utilities/useK8sWatchResourceList.ts
+++ b/frontend/src/utilities/useK8sWatchResourceList.ts
@@ -6,6 +6,7 @@ import {
   useK8sWatchResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import React from 'react';
+import { K8sStatusError, isK8sStatus } from '#~/api/errorUtils';
 import { CustomWatchK8sResult } from '#~/types';
 
 const useK8sWatchResourceList = <T extends K8sResourceCommon[]>(
@@ -27,6 +28,10 @@ const useK8sWatchResourceList = <T extends K8sResourceCommon[]>(
 
     if (!error) {
       return undefined;
+    }
+
+    if (isK8sStatus(error)) {
+      return new K8sStatusError(error);
     }
 
     return new Error('Unknown error occured');


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-44140

## Description

On clusters using an external OIDC provider (e.g. Keycloak / BYOIDC), the `user.openshift.io/groups` CRD does not exist. Groups only live in the user's JWT token at login time and are never stored as Kubernetes resources.

The User Management page (`Settings > User management`) calls `useGroups()` which watches `user.openshift.io/v1/groups` to populate the group dropdown. On BYOIDC clusters this watch returns a raw `K8sStatus` 404 object. `useK8sWatchResourceList` was wrapping any non-`Error` SDK value as a generic `new Error('Unknown error occured')`, discarding the status code. As a result `useGroups()` never resolved to `loaded: true` and the page hung on the loading spinner indefinitely.

**Root cause (two layers):**
1. `useK8sWatchResourceList` silently discarded K8sStatus info from the SDK by wrapping it as a generic Error — any caller that needed to inspect the status code could not.
2. `useGroups()` had no handling for the "Group CRD not found" case.

**Fix:**
- `useK8sWatchResourceList`: wrap raw `K8sStatus` objects from the SDK in the project's `K8sStatusError` (from `errorUtils`) so callers can inspect `error.statusObject.code`.
- `useGroups()`: treat a `K8sStatusError` with `code === 404` as loaded with empty groups. Other errors (5xx, network failures) are still propagated so the page can surface them.

Once unblocked, admins can manually type their Keycloak group names in the creatable multi-select. The typed names need to match what Keycloak sends in the `groups` JWT claim — those are matched by the RHOAI operator's ClusterRoleBindings when evaluating `SelfSubjectAccessReview`.

<img width="1512" height="804" alt="Screenshot 2026-05-07 at 12 43 54 PM" src="https://github.com/user-attachments/assets/b9ab1139-b8b6-463b-b186-0d067e220478" />

## How Has This Been Tested?

- Reproduced the bug locally against a BYOIDC cluster (Keycloak): User Management page was stuck loading indefinitely.
- Applied the fix and verified the page loads correctly with an empty group list; existing configured groups (from the `Auth` resource) are displayed and new group names can be typed in.
- Verified standard OpenShift clusters (with Group CRD) are unaffected — groups still populate normally.

## Test Impact

- Updated `frontend/src/api/k8s/__tests__/groups.spec.ts`: added tests for the 404 BYOIDC case (returns empty groups) and non-404 errors (propagated).
- Existing `useK8sWatchResourceList` and `useWatchGroups` specs continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed the app hanging when loading groups on clusters without the Group Custom Resource Definition (CRD), commonly occurring in BYOIDC configurations.
- Enhanced Kubernetes error handling to properly distinguish between missing resources and other service-level errors for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->