### PR TITLE
Revert "failed a home test"

### DIFF
--- a/packages/cypress/cypress/tests/mocked/home/home.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/home/home.cy.ts
@@ -12,10 +12,6 @@ describe('Home page', () => {
     // enabled applications page is still navigable
     enabledPage.visit();
   });
-  it('should intentionally fail', () => {
-    homePage.visit();
-    cy.get('h1').should('have.text', 'This text will never match anything real');
-  });
   it('should be not shown when disabled', () => {
     homePage.initHomeIntercepts({ disableHome: true });
     homePage.visit(false);


### PR DESCRIPTION
Reverts opendatahub-io/odh-dashboard#7498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined Home page test suite by removing obsolete test assertions and updating validation logic to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->