### PR TITLE
fix (gen-ai): update AddVLLMProviderAndModel to handle max_tokens value passed…

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -409,7 +409,11 @@ func (c *LlamaStackConfig) AddVLLMProviderAndModel(providerID, endpointURL strin
 	// Create provider config
 	providerConfig := EmptyConfig()
 	providerConfig["base_url"] = endpointURL
-	providerConfig["max_tokens"] = "${env.VLLM_MAX_TOKENS:=4096}"
+	if maxTokens != nil {
+		providerConfig["max_tokens"] = *maxTokens
+	} else {
+		providerConfig["max_tokens"] = "${env.VLLM_MAX_TOKENS:=4096}"
+	}
 	providerConfig["api_token"] = fmt.Sprintf("${env.VLLM_API_TOKEN_%d:=fake}", index+1)
 	providerConfig["tls_verify"] = "${env.VLLM_TLS_VERIFY:=true}"
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
@@ -1156,6 +1156,19 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		require.NotNil(t, foundModel, "Model should be found in parsed config")
 		assert.NotNil(t, foundModel.MaxTokens, "MaxTokens should be set")
 		assert.Equal(t, 8192, *foundModel.MaxTokens)
+
+		// Verify provider-level max_tokens also uses the user value
+		var foundProvider *Provider
+		for i := range parsedConfig.Providers.Inference {
+			if parsedConfig.Providers.Inference[i].ProviderID == "test-provider" {
+				foundProvider = &parsedConfig.Providers.Inference[i]
+				break
+			}
+		}
+		require.NotNil(t, foundProvider, "Provider should be found in parsed config")
+		providerMaxTokens, ok := foundProvider.Config["max_tokens"]
+		require.True(t, ok, "Provider config should contain max_tokens")
+		assert.Equal(t, 8192, providerMaxTokens)
 	})
 
 	t.Run("should not include max_tokens in model configuration when not provided", func(t *testing.T) {
@@ -1164,6 +1177,9 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 
 		yamlStr, err := config.ToYAML()
 		require.NoError(t, err)
+
+		// Verify provider-level falls back to env var template
+		assert.Contains(t, yamlStr, "${env.VLLM_MAX_TOKENS:=4096}")
 
 		// Parse back and verify
 		var parsedConfig LlamaStackConfig


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58413

## Description

When adding a model via the Playground UI with an explicit `max_tokens` value, the BFF's `AddVLLMProviderAndModel` always hardcoded the provider-level `max_tokens` to the env-var template `${env.VLLM_MAX_TOKENS:=4096}`, ignoring the user-supplied value entirely.

This fix updates `AddVLLMProviderAndModel` to use the user-provided `maxTokens` at the provider config level when present, falling back to the env-var template only when no value is supplied. This ensures the LlamaStack distribution config reflects what the user actually configured in the UI.

## How Has This Been Tested?

- manually tested configuring a playground in Gen AI Studio with a "vllm-inference-1/llama-32-1b-instruct" model with max_tokens value set to 128:
  - observed in the llama-stack-config yaml that providers > inference > config > max_tokens == 128 
  - verified a chat response correctly respects the limit, with output_tokens field showing 128
  - likewise verified behaviour with a larger max_tokens value, and with no max_tokens value  

## Test Impact

- Updated existing Go unit tests in `llamastack_config_test.go` to cover the provider-level `max_tokens` behavior for both the "with value" and "without value" paths.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed max tokens configuration handling to properly use explicitly provided values when available, with automatic fallback to environment variable defaults when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->