### PR TITLE
feat: add Agentic Starter Kits tutorials to RHOAI Learning Resources

### DIFF
--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Agent-to-Agent (A2A) example where a CrewAI pod exposes an A2A JSON-RPC
     server and a LangGraph pod orchestrates it over HTTP. Single Dockerfile
     with A2A_ROLE selecting crew vs langgraph process.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/a2a/langgraph_crewai_agent'
+  url: 'https://red.ht/agentic-starter-kits-a2a-langgraph-crewai'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-a2a-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'A2A: LangGraph + CrewAI Multi-Agent'
+  description: >-
+    Agent-to-Agent (A2A) example where a CrewAI pod exposes an A2A JSON-RPC
+    server and a LangGraph pod orchestrates it over HTTP. Single Dockerfile
+    with A2A_ROLE selecting crew vs langgraph process.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/a2a/langgraph_crewai_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-a2a-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Agent-to-Agent (A2A) example where a CrewAI pod exposes an A2A JSON-RPC
     server and a LangGraph pod orchestrates it over HTTP. Single Dockerfile
     with A2A_ROLE selecting crew vs langgraph process.
-  url: 'https://red.ht/agentic-starter-kits-a2a-langgraph-crewai'
+  url: 'https://red.ht/3P35Gfn'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-app.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-app.yaml
@@ -1,0 +1,33 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhApplication
+metadata:
+  name: agentic-starter-kits
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  img: >-
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="36" height="36">
+      <rect x="2" y="2" width="32" height="32" rx="4" fill="#0066CC"/>
+      <circle cx="12" cy="14" r="4" fill="white" opacity="0.9"/>
+      <circle cx="24" cy="14" r="4" fill="white" opacity="0.9"/>
+      <circle cx="18" cy="26" r="4" fill="white" opacity="0.9"/>
+      <line x1="12" y1="14" x2="24" y2="14" stroke="white" stroke-width="1.5" opacity="0.6"/>
+      <line x1="12" y1="14" x2="18" y2="26" stroke="white" stroke-width="1.5" opacity="0.6"/>
+      <line x1="24" y1="14" x2="18" y2="26" stroke="white" stroke-width="1.5" opacity="0.6"/>
+      <circle cx="12" cy="14" r="2" fill="#EE0000"/>
+      <circle cx="24" cy="14" r="2" fill="#EE0000"/>
+      <circle cx="18" cy="26" r="2" fill="#EE0000"/>
+    </svg>
+  displayName: Agentic Starter Kits
+  support: community
+  provider: Red Hat
+  docsLink: ''
+  getStartedLink: 'https://github.com/red-hat-data-services/agentic-starter-kits#how-to-use-this-repository'
+  quickStart: ''
+  getStartedMarkDown: ''
+  description: >-
+    Production-ready agent templates for OpenShift AI featuring LangGraph,
+    LlamaIndex, CrewAI, AutoGen, Langflow, Google ADK, A2A, and vanilla
+    Python patterns.
+  category: Self-managed
+  hidden: true

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an AutoGen AssistantAgent that connects to MCP servers over
     SSE to load tools dynamically. Exposes a FastAPI endpoint for
     chat completions with tool-augmented reasoning.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/autogen/mcp_agent'
+  url: 'https://red.ht/agentic-starter-kits-autogen-mcp'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an AutoGen AssistantAgent that connects to MCP servers over
     SSE to load tools dynamically. Exposes a FastAPI endpoint for
     chat completions with tool-augmented reasoning.
-  url: 'https://red.ht/agentic-starter-kits-autogen-mcp'
+  url: 'https://red.ht/4nrsFx9'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-autogen-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-autogen-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build an MCP Agent with AutoGen'
+  description: >-
+    Build an AutoGen AssistantAgent that connects to MCP servers over
+    SSE to load tools dynamically. Exposes a FastAPI endpoint for
+    chat completions with tool-augmented reasoning.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/autogen/mcp_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a ReAct-style web search agent using the CrewAI framework.
     Uses a web search tool to query the internet and answer user
     questions with any OpenAI-compatible API.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/crewai/websearch_agent'
+  url: 'https://red.ht/agentic-starter-kits-crewai-websearch'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-crewai-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a Web Search Agent with CrewAI'
+  description: >-
+    Build a ReAct-style web search agent using the CrewAI framework.
+    Uses a web search tool to query the internet and answer user
+    questions with any OpenAI-compatible API.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/crewai/websearch_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-crewai-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a ReAct-style web search agent using the CrewAI framework.
     Uses a web search tool to query the internet and answer user
     questions with any OpenAI-compatible API.
-  url: 'https://red.ht/agentic-starter-kits-crewai-websearch'
+  url: 'https://red.ht/4udxpcs'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     General-purpose agent using Google Agent Development Kit (ADK) 2.0 with
     web search. Uses LiteLLM to route inference through a Llama Stack
     server's OpenAI-compatible API endpoint.
-  url: 'https://red.ht/agentic-starter-kits-google-adk'
+  url: 'https://red.ht/4nqHaBi'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-google-adk-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build an Agent with Google ADK 2.0'
+  description: >-
+    General-purpose agent using Google Agent Development Kit (ADK) 2.0 with
+    web search. Uses LiteLLM to route inference through a Llama Stack
+    server's OpenAI-compatible API endpoint.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/google/adk'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-google-adk-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     General-purpose agent using Google Agent Development Kit (ADK) 2.0 with
     web search. Uses LiteLLM to route inference through a Llama Stack
     server's OpenAI-compatible API endpoint.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/google/adk'
+  url: 'https://red.ht/agentic-starter-kits-google-adk'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Agent with human-in-the-loop approval that pauses execution before
     running sensitive tools and waits for human review. Simple questions
     are answered directly without triggering the approval loop.
-  url: 'https://red.ht/agentic-starter-kits-langgraph-hitl'
+  url: 'https://red.ht/4d9prLy'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-hitl-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'LangGraph Human-in-the-Loop Agent'
+  description: >-
+    Agent with human-in-the-loop approval that pauses execution before
+    running sensitive tools and waits for human review. Simple questions
+    are answered directly without triggering the approval loop.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/human_in_the_loop'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-hitl-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Agent with human-in-the-loop approval that pauses execution before
     running sensitive tools and waits for human review. Simple questions
     are answered directly without triggering the approval loop.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/human_in_the_loop'
+  url: 'https://red.ht/agentic-starter-kits-langgraph-hitl'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an outdoor activity planning agent with Langflow that reasons
     across weather forecasts, air quality, and National Park Service data
     using a visual flow-based interface.
-  url: 'https://red.ht/agentic-starter-kits-langflow-tool-calling'
+  url: 'https://red.ht/3R6oVVU'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an outdoor activity planning agent with Langflow that reasons
     across weather forecasts, air quality, and National Park Service data
     using a visual flow-based interface.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langflow/simple_tool_calling_agent'
+  url: 'https://red.ht/agentic-starter-kits-langflow-tool-calling'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langflow-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-langflow-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a Tool-Calling Agent with Langflow'
+  description: >-
+    Build an outdoor activity planning agent with Langflow that reasons
+    across weather forecasts, air quality, and National Park Service data
+    using a visual flow-based interface.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langflow/simple_tool_calling_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-langgraph-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a ReAct Agent with LangGraph'
+  description: >-
+    Learn to build a reasoning and acting agent using LangGraph's graph-based
+    state machine. Covers tool orchestration, state persistence, and the
+    agentic decision loop.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/react_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Learn to build a reasoning and acting agent using LangGraph's graph-based
     state machine. Covers tool orchestration, state persistence, and the
     agentic decision loop.
-  url: 'https://red.ht/agentic-starter-kits-langgraph-react'
+  url: 'https://red.ht/4nri6KI'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-langgraph-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Learn to build a reasoning and acting agent using LangGraph's graph-based
     state machine. Covers tool orchestration, state persistence, and the
     agentic decision loop.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/react_agent'
+  url: 'https://red.ht/agentic-starter-kits-langgraph-react'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an event-driven agent using LlamaIndex Workflows with explicit
     step transitions, memory buffer, and tool abstraction for web search
     and other integrations.
-  url: 'https://red.ht/agentic-starter-kits-llamaindex-websearch'
+  url: 'https://red.ht/4nnQzts'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build an event-driven agent using LlamaIndex Workflows with explicit
     step transitions, memory buffer, and tool abstraction for web search
     and other integrations.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/llamaindex/websearch_agent'
+  url: 'https://red.ht/agentic-starter-kits-llamaindex-websearch'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-llamaindex-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-llamaindex-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a Workflow Agent with LlamaIndex'
+  description: >-
+    Build an event-driven agent using LlamaIndex Workflows with explicit
+    step transitions, memory buffer, and tool abstraction for web search
+    and other integrations.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/llamaindex/websearch_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a LangGraph ReAct agent with PostgreSQL-backed conversation
     memory. Full chat history is persisted in the database while a FIFO
     sliding window keeps only the last N messages in the LLM context.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/react_with_database_memory'
+  url: 'https://red.ht/agentic-starter-kits-langgraph-memory'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-memory-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a ReAct Agent with Database Memory'
+  description: >-
+    Build a LangGraph ReAct agent with PostgreSQL-backed conversation
+    memory. Full chat history is persisted in the database while a FIFO
+    sliding window keeps only the last N messages in the LLM context.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/react_with_database_memory'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-memory-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a LangGraph ReAct agent with PostgreSQL-backed conversation
     memory. Full chat history is persisted in the database while a FIFO
     sliding window keeps only the last N messages in the LLM context.
-  url: 'https://red.ht/agentic-starter-kits-langgraph-memory'
+  url: 'https://red.ht/4drobSV'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-rag-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build an Agentic RAG System'
+  description: >-
+    Build a retrieval-augmented generation agent that autonomously decides
+    when to query a Milvus vector store. Uses a three-node LangGraph
+    workflow for intelligent document retrieval and context-aware generation.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/agentic_rag'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a retrieval-augmented generation agent that autonomously decides
     when to query a Milvus vector store. Uses a three-node LangGraph
     workflow for intelligent document retrieval and context-aware generation.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/langgraph/agentic_rag'
+  url: 'https://red.ht/agentic-starter-kits-langgraph-rag'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-rag-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Build a retrieval-augmented generation agent that autonomously decides
     when to query a Milvus vector store. Uses a three-node LangGraph
     workflow for intelligent document retrieval and context-aware generation.
-  url: 'https://red.ht/agentic-starter-kits-langgraph-rag'
+  url: 'https://red.ht/4fjmoSd'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
@@ -1,0 +1,15 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: agentic-starter-kits-vanilla-python-tutorial
+  annotations:
+    opendatahub.io/categories: 'Agent Templates,Getting started'
+spec:
+  type: tutorial
+  displayName: 'Build a Minimal Agent with OpenAI Responses API'
+  description: >-
+    Create a lightweight agent using only the OpenAI Python client and
+    an Action/Observation loop with tools. No framework dependencies --
+    works with OpenAI or any compatible API including Llama Stack.
+  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/vanilla_python/openai_responses_agent'
+  appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Create a lightweight agent using only the OpenAI Python client and
     an Action/Observation loop with tools. No framework dependencies --
     works with OpenAI or any compatible API including Llama Stack.
-  url: 'https://github.com/red-hat-data-services/agentic-starter-kits/tree/rhoai-3.5/agents/vanilla_python/openai_responses_agent'
+  url: 'https://red.ht/agentic-starter-kits-vanilla-python-openai'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/agentic-starter-kits-vanilla-python-tutorial.yaml
@@ -11,5 +11,5 @@ spec:
     Create a lightweight agent using only the OpenAI Python client and
     an Action/Observation loop with tools. No framework dependencies --
     works with OpenAI or any compatible API including Llama Stack.
-  url: 'https://red.ht/agentic-starter-kits-vanilla-python-openai'
+  url: 'https://red.ht/49t8Yzi'
   appName: agentic-starter-kits

--- a/manifests/rhoai/apps/agentic-starter-kits/kustomization.yaml
+++ b/manifests/rhoai/apps/agentic-starter-kits/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - agentic-starter-kits-app.yaml
+  - agentic-starter-kits-langgraph-tutorial.yaml
+  - agentic-starter-kits-llamaindex-tutorial.yaml
+  - agentic-starter-kits-crewai-tutorial.yaml
+  - agentic-starter-kits-autogen-tutorial.yaml
+  - agentic-starter-kits-langflow-tutorial.yaml
+  - agentic-starter-kits-vanilla-python-tutorial.yaml
+  - agentic-starter-kits-google-adk-tutorial.yaml
+  - agentic-starter-kits-a2a-tutorial.yaml
+  - agentic-starter-kits-rag-tutorial.yaml
+  - agentic-starter-kits-memory-tutorial.yaml
+  - agentic-starter-kits-hitl-tutorial.yaml

--- a/manifests/rhoai/apps/kustomization.yaml
+++ b/manifests/rhoai/apps/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./rhoai
   - ./starburst-enterprise
   - ./watson-x
+  - ./agentic-starter-kits


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4914
Supersedes #6299

## Description

Adds 11 OdhDocument tutorial manifests for [Agentic Starter Kits](https://github.com/red-hat-data-services/agentic-starter-kits) agent patterns to the RHOAI dashboard Learning Resources page.

A hidden OdhApplication (`hidden: true`) provides the icon and metadata inheritance for the tutorials without appearing on the Explore page.

URLs use `red.ht` short links — random short URLs per release (e.g. `red.ht/4nri6KI`) managed via the Red Hat URL shortener dashboard. Enables redirect updates without manifest PRs and supports overlapping RHOAI release support windows with separate URL sets per version

### Resources added

| Resource | Kind | Description |
|----------|------|-------------|
| `agentic-starter-kits` | OdhApplication (hidden) | Parent app for icon/metadata inheritance |
| `agentic-starter-kits-langgraph-tutorial` | OdhDocument | LangGraph ReAct agent |
| `agentic-starter-kits-rag-tutorial` | OdhDocument | LangGraph Agentic RAG |
| `agentic-starter-kits-memory-tutorial` | OdhDocument | LangGraph ReAct + DB Memory |
| `agentic-starter-kits-hitl-tutorial` | OdhDocument | LangGraph Human-in-the-Loop |
| `agentic-starter-kits-llamaindex-tutorial` | OdhDocument | LlamaIndex WebSearch |
| `agentic-starter-kits-crewai-tutorial` | OdhDocument | CrewAI WebSearch |
| `agentic-starter-kits-vanilla-python-tutorial` | OdhDocument | Vanilla Python OpenAI Responses |
| `agentic-starter-kits-autogen-tutorial` | OdhDocument | AutoGen MCP |
| `agentic-starter-kits-google-adk-tutorial` | OdhDocument | Google ADK 2.0 |
| `agentic-starter-kits-langflow-tutorial` | OdhDocument | Langflow Tool-Calling |
| `agentic-starter-kits-a2a-tutorial` | OdhDocument | A2A LangGraph + CrewAI |


### Self checklist
- [x] Tested manually on RHOAI 3.5 cluster — tutorials appear in Learning Resources
- [x] No app card on Explore page
- [x] All 11 tutorial URLs resolve to live content
- [x] No code changes — YAML manifests only, no tests needed

## Test plan
- [x] Apply manifests to RHOAI cluster: `kubectl kustomize manifests/rhoai/shared/apps/agentic-starter-kits/ | oc apply -n redhat-ods-applications -f -`
- [x] Verify 11 tutorials appear in Learning Resources section
- [x] Verify "Agent Templates" category tab appears in sidebar filter
- [x] Verify no "Agentic Starter Kits" app card on Explore page
- [x] Verify each tutorial link opens correct GitHub README on `rhoai-3.5` branch

<img width="1506" height="861" alt="Screenshot 2026-05-12 at 10 39 16 PM" src="https://github.com/user-attachments/assets/0d0a0177-0673-4e1f-a6e2-e3faac7232d9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)