### PR TITLE
add error code conflict for nemoguardrails

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -400,7 +400,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   };
 
   const isNemoGuardrailsConflict = (e: unknown): boolean =>
-    e instanceof Error && 'code' in e && e.code === '409';
+    e instanceof Error && 'code' in e && e.code === 'conflict';
 
   const onSubmit = () => {
     if (submitting) {
@@ -447,7 +447,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
         }),
       });
 
-      // If guardrails are enabled, init NemoGuardrails. A 409 (already initialised) is swallowed —
+      // If guardrails are enabled, init NemoGuardrails. A conflict (already initialised) is swallowed —
       // the status poller in ChatbotConfigurationState handles waiting for ready.
       // Any other error (network fault, server error) is rethrown to surface in the wizard.
       const nemoPromise: Promise<void> = guardrailsEnabled

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -342,6 +342,37 @@ describe('ChatbotConfigurationModal guardrails configuration', () => {
       );
     });
   });
+
+  it('swallows a conflict error from initNemoGuardrails and completes submit', async () => {
+    const user = userEvent.setup();
+    (useGuardrailsEnabled as jest.Mock).mockReturnValue(true);
+    mockInitNemoGuardrails.mockRejectedValue(
+      Object.assign(new Error('already initialized'), { code: 'conflict' }),
+    );
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/Error configuring playground/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces non-conflict errors from initNemoGuardrails', async () => {
+    const user = userEvent.setup();
+    (useGuardrailsEnabled as jest.Mock).mockReturnValue(true);
+    mockInitNemoGuardrails.mockRejectedValue(
+      Object.assign(new Error('internal server error'), { code: 'server_error' }),
+    );
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error configuring playground/i)).toBeInTheDocument();
+    });
+  });
 });
 
 // ─── Step navigation ──────────────────────────────────────────────────────────


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-61960

## Description

Fixes a bug in `isNemoGuardrailsConflict` where the error code was checked
against `'409'` (the HTTP status as a string) instead of `'conflict'` (the
semantic code the BFF actually sends).

**Root cause:** `conflictResponse` in the gen-ai BFF sets `Code: "conflict"` in
the error envelope. The frontend `initNemoGuardrails` service propagates that
string directly as `err.code`. The old guard `e.code === '409'` would never
match, so every "already initialised" conflict was rethrown as an unexpected
error instead of being silently swallowed. This caused the playground setup
wizard to surface a spurious error for users who had previously initialised
NemoGuardrails in the same namespace.

**Changes:**
- Correct `isNemoGuardrailsConflict` to check `e.code === 'conflict'`
- Update the inline comment to reflect the semantic code rather than the HTTP
  status number
- Add two regression tests: one verifying the conflict path is swallowed and
  submit completes, one verifying non-conflict errors are still surfaced

## How Has This Been Tested?

- Ran the existing and new Jest unit tests for `ChatbotConfigurationModal`
  (30/30 passing)
- Manually verified the BFF `conflictResponse` in `errors.go` sets
  `Code: "conflict"`, confirming the fix aligns with the actual server response

## Test Impact

Added two unit tests to `ChatbotConfigurationModal.spec.tsx`:

- `swallows a conflict error from initNemoGuardrails and completes submit` —
  mocks `initNemoGuardrails` rejecting with `{ code: 'conflict' }`, asserts
  `installLSD` is still called and no error alert is rendered
- `surfaces non-conflict errors from initNemoGuardrails` — mocks rejection with
  `{ code: 'server_error' }`, asserts the error alert IS shown

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where chatbot configuration would fail when guardrails were already initialized. The system now gracefully handles this conflict condition, allowing the configuration process to continue and complete successfully without displaying an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->