### PR TITLE
fix(e2e): increase timeout for RayJob empty state check after deletion

### DIFF
--- a/packages/cypress/cypress/pages/modelTraining.ts
+++ b/packages/cypress/cypress/pages/modelTraining.ts
@@ -130,8 +130,8 @@ class TrainingJobTable {
     return this;
   }
 
-  findEmptyState() {
-    return cy.findByTestId('empty-state-body');
+  findEmptyState(timeout?: number) {
+    return cy.findByTestId('empty-state-body', timeout !== undefined ? { timeout } : {});
   }
 
   findToolbar() {

--- a/packages/cypress/cypress/tests/e2e/modelTraining/rayJobs/testPauseAndScaleRayjob.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelTraining/rayJobs/testPauseAndScaleRayjob.cy.ts
@@ -248,7 +248,7 @@ describe('Verify pause, scale worker nodes, and delete RayJob', () => {
       deleteModal.findSubmitButton().should('be.enabled').click();
 
       cy.step('Verify RayJob is removed from the UI');
-      trainingJobTable.findEmptyState().should('be.visible');
+      trainingJobTable.findEmptyState(120000).should('be.visible');
 
       cy.step('Verify RayJob is deleted on the cluster');
       verifyRayJobDeleted(rayJobName, projectName);


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-63803

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

The `testPauseAndScaleRayjob` E2E test fails at step 32 ("Verify RayJob is removed from the UI") with:
`Timed out retrying after 10000ms: Unable to find an element by: [data-testid="empty-state-body"]`

`findEmptyState()` uses the default 10s Cypress timeout, but RayJob deletion requires tearing down the entire RayCluster (head + worker pods), which exceeds 10 seconds. The test's own `verifyRayJobDeleted` on the very next line already allows 120s for the same deletion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] CI sanity suite (`SanitySet1`) passes with `testPauseAndScaleRayjob` no longer timing out.
- [ ] TrainJob tests (`testTrainjobLifecycle`, `testTrainjobProgression`) continue to pass (unaffected — they call `findEmptyState()` without a timeout).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test timeout configuration in model training tests to support customizable timeout parameters for UI state verification.
  * Updated test wait times for job deletion scenarios to ensure reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->