### PR TITLE
fix(kserve): apply connection-path annotation on dry-run deploys

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -1790,6 +1790,249 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizardEdit.findModelSourceStep().should('be.enabled');
   });
 
+  describe('S3 connection-path annotation (RHOAIENG-57823)', () => {
+    it('should include connection-path when deploying with existing S3 connection', () => {
+      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
+
+      // Two S3 connections so user must actively select from dropdown
+      cy.interceptK8sList(
+        { model: SecretModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockSecretK8sResource({
+            name: 'my-s3-connection-1',
+            namespace: 'test-project',
+            displayName: 'My S3 Connection 1',
+            connectionType: 's3',
+          }),
+          mockSecretK8sResource({
+            name: 'my-s3-connection-2',
+            namespace: 'test-project',
+            displayName: 'My S3 Connection 2',
+            connectionType: 's3',
+          }),
+        ]),
+      );
+      cy.interceptK8s(
+        'GET',
+        { model: SecretModel, ns: 'test-project', name: 'my-s3-connection-1' },
+        mockSecretK8sResource({
+          name: 'my-s3-connection-1',
+          namespace: 'test-project',
+          displayName: 'My S3 Connection 1',
+          connectionType: 's3',
+        }),
+      );
+      cy.interceptK8sList(
+        { model: InferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+      cy.interceptK8sList(
+        { model: ServingRuntimeModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+
+      // Step 1: Model source
+      modelServingWizard
+        .findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE)
+        .should('exist')
+        .click();
+      modelServingWizard
+        .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
+        .should('exist')
+        .click();
+      modelServingWizard.findExistingConnectionSelect().should('exist').click();
+      modelServingWizard
+        .findExistingConnectionSelectOption('My S3 Connection 1')
+        .should('exist')
+        .click();
+      modelServingWizard.findLocationPathInput().should('exist').type('my-models/gpt2/');
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 2: Model deployment
+      modelServingWizard.findModelDeploymentNameInput().type('test-s3-deploy');
+      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').should('exist').click();
+      modelServingWizard
+        .findModelFormatSelectOption('openvino_ir - opset1')
+        .should('exist')
+        .click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 3: Advanced options — skip through
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 4: Submit
+      modelServingWizard.findSubmitButton().should('be.enabled').click();
+
+      // Verify dry-run
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'my-models/gpt2/',
+        );
+      });
+
+      // Verify actual
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'my-models/gpt2/',
+        );
+      });
+    });
+
+    it('should include connection-path when deploying with new S3 connection', () => {
+      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
+      initMockConnectionSecretIntercepts({});
+
+      cy.interceptK8sList(
+        { model: InferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+      cy.interceptK8sList(
+        { model: ServingRuntimeModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+
+      // Step 1: Model source — select S3 (new connection), fill fields and path
+      modelServingWizard
+        .findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE)
+        .should('exist')
+        .click();
+      modelServingWizard
+        .findModelLocationSelectOption(ModelLocationSelectOption.S3)
+        .should('exist')
+        .click();
+      modelServingWizard.findLocationAccessKeyInput().type('test-access-key');
+      modelServingWizard.findLocationSecretKeyInput().type('test-secret-key');
+      modelServingWizard.findLocationEndpointInput().type('https://s3.amazonaws.com/');
+      modelServingWizard.findLocationBucketInput().type('test-bucket');
+      modelServingWizard.findLocationPathInput().should('exist').type('my-models/gpt2/');
+      modelServingWizard.findSaveConnectionCheckbox().should('be.checked');
+      modelServingWizard.findSaveConnectionInput().clear().type('my-new-s3-connection');
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 2: Model deployment
+      modelServingWizard.findModelDeploymentNameInput().type('test-new-s3-deploy');
+      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').should('exist').click();
+      modelServingWizard
+        .findModelFormatSelectOption('openvino_ir - opset1')
+        .should('exist')
+        .click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 3: Advanced options — skip through
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
+      // Step 4: Submit
+      modelServingWizard.findSubmitButton().should('be.enabled').click();
+
+      // Verify dry-run has connection-path
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'my-models/gpt2/',
+        );
+      });
+
+      // Verify actual has connection-path
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'my-models/gpt2/',
+        );
+      });
+    });
+
+    it('should include connection-path when racing through wizard with existing S3 connection', () => {
+      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
+
+      cy.interceptK8sList(
+        { model: SecretModel, ns: 'test-project' },
+        mockK8sResourceList([
+          mockSecretK8sResource({
+            name: 'my-s3-connection-1',
+            namespace: 'test-project',
+            displayName: 'My S3 Connection 1',
+            connectionType: 's3',
+          }),
+          mockSecretK8sResource({
+            name: 'my-s3-connection-2',
+            namespace: 'test-project',
+            displayName: 'My S3 Connection 2',
+            connectionType: 's3',
+          }),
+        ]),
+      );
+      cy.interceptK8s(
+        'GET',
+        { model: SecretModel, ns: 'test-project', name: 'my-s3-connection-1' },
+        mockSecretK8sResource({
+          name: 'my-s3-connection-1',
+          namespace: 'test-project',
+          displayName: 'My S3 Connection 1',
+          connectionType: 's3',
+        }),
+      );
+      cy.interceptK8sList(
+        { model: InferenceServiceModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+      cy.interceptK8sList(
+        { model: ServingRuntimeModel, ns: 'test-project' },
+        mockK8sResourceList([]),
+      );
+
+      modelServingGlobal.visit('test-project');
+      modelServingGlobal.findDeployModelButton().click();
+
+      // Speed-run: minimal waits, rapid clicks
+      modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE).click();
+      modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
+      modelServingWizard.findExistingConnectionSelect().click();
+      modelServingWizard.findExistingConnectionSelectOption('My S3 Connection 1').click();
+      modelServingWizard.findLocationPathInput().type('speed-run-path/');
+      modelServingWizard.findNextButton().click();
+
+      modelServingWizard.findModelDeploymentNameInput().type('speed-test');
+      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').click();
+      modelServingWizard.findModelFormatSelectOption('openvino_ir - opset1').click();
+      modelServingWizard.findNextButton().click();
+
+      modelServingWizard.findNextButton().click();
+
+      modelServingWizard.findSubmitButton().click();
+
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'speed-run-path/',
+        );
+      });
+
+      cy.wait('@createInferenceService').then((interception) => {
+        expect(interception.request.url).not.to.include('?dryRun=All');
+        expect(interception.request.body.metadata.annotations).to.have.property(
+          'opendatahub.io/connection-path',
+          'speed-run-path/',
+        );
+      });
+    });
+  });
+
   describe('YAML', () => {
     it('Should show YAML preview mode when toggled', () => {
       initIntercepts({ modelType: ServingRuntimeModelType.GENERATIVE });

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -1790,246 +1790,92 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizardEdit.findModelSourceStep().should('be.enabled');
   });
 
-  describe('S3 connection-path annotation (RHOAIENG-57823)', () => {
-    it('should include connection-path when deploying with existing S3 connection', () => {
-      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
+  it('Deploy model with existing S3 connection should include connection-path annotation', () => {
+    initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
 
-      // Two S3 connections so user must actively select from dropdown
-      cy.interceptK8sList(
-        { model: SecretModel, ns: 'test-project' },
-        mockK8sResourceList([
-          mockSecretK8sResource({
-            name: 'my-s3-connection-1',
-            namespace: 'test-project',
-            displayName: 'My S3 Connection 1',
-            connectionType: 's3',
-          }),
-          mockSecretK8sResource({
-            name: 'my-s3-connection-2',
-            namespace: 'test-project',
-            displayName: 'My S3 Connection 2',
-            connectionType: 's3',
-          }),
-        ]),
-      );
-      cy.interceptK8s(
-        'GET',
-        { model: SecretModel, ns: 'test-project', name: 'my-s3-connection-1' },
+    // Two S3 connections so user must actively select from dropdown
+    cy.interceptK8sList(
+      { model: SecretModel, ns: 'test-project' },
+      mockK8sResourceList([
         mockSecretK8sResource({
           name: 'my-s3-connection-1',
           namespace: 'test-project',
           displayName: 'My S3 Connection 1',
           connectionType: 's3',
         }),
-      );
-      cy.interceptK8sList(
-        { model: InferenceServiceModel, ns: 'test-project' },
-        mockK8sResourceList([]),
-      );
-      cy.interceptK8sList(
-        { model: ServingRuntimeModel, ns: 'test-project' },
-        mockK8sResourceList([]),
-      );
-
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-
-      // Step 1: Model source
-      modelServingWizard
-        .findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE)
-        .should('exist')
-        .click();
-      modelServingWizard
-        .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
-        .should('exist')
-        .click();
-      modelServingWizard.findExistingConnectionSelect().should('exist').click();
-      modelServingWizard
-        .findExistingConnectionSelectOption('My S3 Connection 1')
-        .should('exist')
-        .click();
-      modelServingWizard.findLocationPathInput().should('exist').type('my-models/gpt2/');
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 2: Model deployment
-      modelServingWizard.findModelDeploymentNameInput().type('test-s3-deploy');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').should('exist').click();
-      modelServingWizard
-        .findModelFormatSelectOption('openvino_ir - opset1')
-        .should('exist')
-        .click();
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 3: Advanced options — skip through
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 4: Submit
-      modelServingWizard.findSubmitButton().should('be.enabled').click();
-
-      // Verify dry-run
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'my-models/gpt2/',
-        );
-      });
-
-      // Verify actual
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).not.to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'my-models/gpt2/',
-        );
-      });
-    });
-
-    it('should include connection-path when deploying with new S3 connection', () => {
-      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
-      initMockConnectionSecretIntercepts({});
-
-      cy.interceptK8sList(
-        { model: InferenceServiceModel, ns: 'test-project' },
-        mockK8sResourceList([]),
-      );
-      cy.interceptK8sList(
-        { model: ServingRuntimeModel, ns: 'test-project' },
-        mockK8sResourceList([]),
-      );
-
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-
-      // Step 1: Model source — select S3 (new connection), fill fields and path
-      modelServingWizard
-        .findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE)
-        .should('exist')
-        .click();
-      modelServingWizard
-        .findModelLocationSelectOption(ModelLocationSelectOption.S3)
-        .should('exist')
-        .click();
-      modelServingWizard.findLocationAccessKeyInput().type('test-access-key');
-      modelServingWizard.findLocationSecretKeyInput().type('test-secret-key');
-      modelServingWizard.findLocationEndpointInput().type('https://s3.amazonaws.com/');
-      modelServingWizard.findLocationBucketInput().type('test-bucket');
-      modelServingWizard.findLocationPathInput().should('exist').type('my-models/gpt2/');
-      modelServingWizard.findSaveConnectionCheckbox().should('be.checked');
-      modelServingWizard.findSaveConnectionInput().clear().type('my-new-s3-connection');
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 2: Model deployment
-      modelServingWizard.findModelDeploymentNameInput().type('test-new-s3-deploy');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').should('exist').click();
-      modelServingWizard
-        .findModelFormatSelectOption('openvino_ir - opset1')
-        .should('exist')
-        .click();
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 3: Advanced options — skip through
-      modelServingWizard.findNextButton().should('be.enabled').click();
-
-      // Step 4: Submit
-      modelServingWizard.findSubmitButton().should('be.enabled').click();
-
-      // Verify dry-run has connection-path
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'my-models/gpt2/',
-        );
-      });
-
-      // Verify actual has connection-path
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).not.to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'my-models/gpt2/',
-        );
-      });
-    });
-
-    it('should include connection-path when racing through wizard with existing S3 connection', () => {
-      initIntercepts({ modelType: ServingRuntimeModelType.PREDICTIVE });
-
-      cy.interceptK8sList(
-        { model: SecretModel, ns: 'test-project' },
-        mockK8sResourceList([
-          mockSecretK8sResource({
-            name: 'my-s3-connection-1',
-            namespace: 'test-project',
-            displayName: 'My S3 Connection 1',
-            connectionType: 's3',
-          }),
-          mockSecretK8sResource({
-            name: 'my-s3-connection-2',
-            namespace: 'test-project',
-            displayName: 'My S3 Connection 2',
-            connectionType: 's3',
-          }),
-        ]),
-      );
-      cy.interceptK8s(
-        'GET',
-        { model: SecretModel, ns: 'test-project', name: 'my-s3-connection-1' },
         mockSecretK8sResource({
-          name: 'my-s3-connection-1',
+          name: 'my-s3-connection-2',
           namespace: 'test-project',
-          displayName: 'My S3 Connection 1',
+          displayName: 'My S3 Connection 2',
           connectionType: 's3',
         }),
+      ]),
+    );
+    cy.interceptK8s(
+      'GET',
+      { model: SecretModel, ns: 'test-project', name: 'my-s3-connection-1' },
+      mockSecretK8sResource({
+        name: 'my-s3-connection-1',
+        namespace: 'test-project',
+        displayName: 'My S3 Connection 1',
+        connectionType: 's3',
+      }),
+    );
+    cy.interceptK8sList(
+      { model: InferenceServiceModel, ns: 'test-project' },
+      mockK8sResourceList([]),
+    );
+    cy.interceptK8sList(
+      { model: ServingRuntimeModel, ns: 'test-project' },
+      mockK8sResourceList([]),
+    );
+
+    modelServingGlobal.visit('test-project');
+    modelServingGlobal.findDeployModelButton().click();
+
+    // Step 1: Model source
+    modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE).should('exist').click();
+    modelServingWizard
+      .findModelLocationSelectOption(ModelLocationSelectOption.EXISTING)
+      .should('exist')
+      .click();
+    modelServingWizard.findExistingConnectionSelect().should('exist').click();
+    modelServingWizard
+      .findExistingConnectionSelectOption('My S3 Connection 1')
+      .should('exist')
+      .click();
+    modelServingWizard.findLocationPathInput().should('exist').type('my-models/gpt2/');
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 2: Model deployment
+    modelServingWizard.findModelDeploymentNameInput().type('test-s3-deploy');
+    modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
+    modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').should('exist').click();
+    modelServingWizard.findModelFormatSelectOption('openvino_ir - opset1').should('exist').click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 3: Advanced options — skip through
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 4: Submit
+    modelServingWizard.findSubmitButton().should('be.enabled').click();
+
+    // Verify dry-run has connection-path annotation
+    cy.wait('@createInferenceService').then((interception) => {
+      expect(interception.request.url).to.include('?dryRun=All');
+      expect(interception.request.body.metadata.annotations).to.have.property(
+        'opendatahub.io/connection-path',
+        'my-models/gpt2/',
       );
-      cy.interceptK8sList(
-        { model: InferenceServiceModel, ns: 'test-project' },
-        mockK8sResourceList([]),
+    });
+
+    // Verify actual has connection-path annotation
+    cy.wait('@createInferenceService').then((interception) => {
+      expect(interception.request.url).not.to.include('?dryRun=All');
+      expect(interception.request.body.metadata.annotations).to.have.property(
+        'opendatahub.io/connection-path',
+        'my-models/gpt2/',
       );
-      cy.interceptK8sList(
-        { model: ServingRuntimeModel, ns: 'test-project' },
-        mockK8sResourceList([]),
-      );
-
-      modelServingGlobal.visit('test-project');
-      modelServingGlobal.findDeployModelButton().click();
-
-      // Speed-run: minimal waits, rapid clicks
-      modelServingWizard.findModelTypeSelectOption(ModelTypeLabel.PREDICTIVE).click();
-      modelServingWizard.findModelLocationSelectOption(ModelLocationSelectOption.EXISTING).click();
-      modelServingWizard.findExistingConnectionSelect().click();
-      modelServingWizard.findExistingConnectionSelectOption('My S3 Connection 1').click();
-      modelServingWizard.findLocationPathInput().type('speed-run-path/');
-      modelServingWizard.findNextButton().click();
-
-      modelServingWizard.findModelDeploymentNameInput().type('speed-test');
-      modelServingWizard.findServingRuntimeTemplateSearchSelector().click();
-      modelServingWizard.findGlobalScopedTemplateOption('OpenVINO').click();
-      modelServingWizard.findModelFormatSelectOption('openvino_ir - opset1').click();
-      modelServingWizard.findNextButton().click();
-
-      modelServingWizard.findNextButton().click();
-
-      modelServingWizard.findSubmitButton().click();
-
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'speed-run-path/',
-        );
-      });
-
-      cy.wait('@createInferenceService').then((interception) => {
-        expect(interception.request.url).not.to.include('?dryRun=All');
-        expect(interception.request.body.metadata.annotations).to.have.property(
-          'opendatahub.io/connection-path',
-          'speed-run-path/',
-        );
-      });
     });
   });
 

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -310,22 +310,22 @@ export const applyConnectionData = (
       result.metadata.annotations[MetadataAnnotation.ConnectionName] =
         secretName ?? createConnectionData.nameDesc?.name ?? '';
     }
-    // Apply connection path to the annotations if the connection type is S3ObjectStorage
-    if (
-      modelLocationData.additionalFields.modelPath &&
-      isModelServingCompatible(
-        modelLocationData.connectionTypeObject ?? [],
-        ModelServingCompatibleTypes.S3ObjectStorage,
-      )
-    ) {
-      result.metadata.annotations = {
-        ...result.metadata.annotations,
-        'opendatahub.io/connection-path': modelLocationData.additionalFields.modelPath,
-      };
-    } else {
-      // Delete connection path from the annotations if it's not present or the connection type is not S3ObjectStorage
-      delete result.metadata.annotations['opendatahub.io/connection-path'];
-    }
+  }
+  // Apply connection path to the annotations if the connection type is S3ObjectStorage
+  if (
+    modelLocationData.additionalFields.modelPath &&
+    isModelServingCompatible(
+      modelLocationData.connectionTypeObject ?? [],
+      ModelServingCompatibleTypes.S3ObjectStorage,
+    )
+  ) {
+    result.metadata.annotations = {
+      ...result.metadata.annotations,
+      'opendatahub.io/connection-path': modelLocationData.additionalFields.modelPath,
+    };
+  } else {
+    // Delete connection path from the annotations if it's not present or the connection type is not S3ObjectStorage
+    delete result.metadata.annotations?.['opendatahub.io/connection-path'];
   }
   if (
     modelLocationData.additionalFields.modelUri &&


### PR DESCRIPTION
Bug found when trying to fix https://issues.redhat.com/browse/RHOAIENG-57823, although doesn't fix the issue

## Description

The `opendatahub.io/connection-path` annotation was not being set on the InferenceService during dry-run deploys with existing S3 connections.

In `applyConnectionData` (`packages/kserve/src/deployUtils.ts`), the connection-path annotation logic was nested inside a `if (secretName || createConnectionData.nameDesc?.name)` gate. For existing connections during dry runs, the deploy flow intentionally passes `secretName = undefined` (to avoid K8s validation errors on the connection name annotation), which also prevented the connection-path annotation from being set.

This fix moves the connection-path (and the corresponding delete for non-S3 connections) outside the secretName gate, matching how `packages/llmd-serving/src/deployments/model.ts` handles these as independent concerns.

**Investigation note:** The intermittent production bug described in the Jira (connection-path missing on the actual deployed InferenceService) could not be reproduced in mock tests — the actual (non-dry-run) deploy correctly sets the annotation regardless of this fix. The timing-dependent race condition described in the Jira may require real cluster network latency to manifest. A detailed investigation report is in the Jira comments.

## How Has This Been Tested?

- Cypress mock test added that deploys with an existing S3 connection selected from a dropdown, types a folder path, and asserts the `connection-path` annotation on both the dry-run and actual InferenceService creation requests
- Test fails without the fix (dry-run annotation missing), passes with the fix
- All 28 existing `modelServingDeploy.cy.ts` tests continue to pass
- Type-check passes for `@odh-dashboard/kserve` and `@odh-dashboard/model-serving`

## Test Impact

- Added 1 new Cypress mock test covering the S3 connection-path annotation flow
- Exploratory tests (new S3 connection, speed-run variant) were also written during investigation and confirmed the actual deploy path is not affected; these were removed to keep the PR focused

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of model deployment with S3 connections by fixing potential errors in annotation handling.

* **Tests**
  * Added test coverage for deploying models with existing S3 connections to verify proper annotation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->