### PR TITLE
feat: add Claude Preflight Agent GitHub Action

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: preflight
-description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review coderabbit,claude,style,rbac, --help."
-argument-hint: "[PR] [--fix] [--local] [--review coderabbit,claude,style,rbac] [--help]"
+description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review X,Y, --skip-review X,Y, --help."
+argument-hint: "[PR] [--fix] [--local] [--review X,Y] [--skip-review X,Y] [--help]"
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *) Bash(npm *) Bash(npx *) Bash(${CLAUDE_SKILL_DIR}/scripts/*)
 ---
@@ -27,6 +27,7 @@ Flags:
   --local               Ignore PR even if one exists, run everything locally
   --review X,Y          Run specific reviewers without asking
                         Options: coderabbit, claude, style, rbac
+  --skip-review X,Y     Run all reviewers EXCEPT these (no interactive prompt)
   --help                Show this help
 
 Examples:
@@ -34,6 +35,7 @@ Examples:
   /preflight 1234                             Check PR #1234
   /preflight --fix                            Check and fix current branch
   /preflight --review coderabbit,style,rbac    Run specific reviewers
+  /preflight --skip-review coderabbit         Run all reviewers except CodeRabbit
   /preflight 1234 --review claude --fix       Check PR, run Claude review, fix issues
 
 How it works:
@@ -49,6 +51,7 @@ Parse these from `$ARGUMENTS` before processing:
 - `--fix` — after reporting, fix failing checks without asking
 - `--local` — ignore PR even if one exists, run everything locally
 - `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`)
+- `--skip-review X,Y` — run all reviewers EXCEPT the listed ones, without asking. Mutually exclusive with `--review`.
 - `--help` — print usage and stop
 - No flags — interactive mode: ask the user what to do at decision points
 
@@ -124,7 +127,7 @@ Report what's there — CodeRabbit threads with severity, human threads, review 
 
 If no PR exists, or PR exists but is not synced, or `--local`: no reviews have been done on this code yet. Ask the user what reviewer to run:
 
-If `--review` flag was passed, use those reviewers directly. Otherwise use AskUserQuestion with `multiSelect: true` so the user can pick any combination:
+If `--review` flag was passed, use those reviewers directly. If `--skip-review` flag was passed, run all reviewers except the listed ones (no interactive prompt). Otherwise use AskUserQuestion with `multiSelect: true` so the user can pick any combination:
 - "CodeRabbit CLI" — run `coderabbit review --agent` (requires CLI installed)
 - "Claude review" — invoke `/review` built-in skill
 - "Style review" — invoke `/style-review` for code style and pattern checks

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -1,0 +1,330 @@
+name: ODH Dashboard Agent
+
+# Preflight checks on PRs using Claude Code.
+#
+# Triggers:
+#   issue_comment    — @odh-dashboard-agent preflight check|fix
+#   schedule (30min) — polls agent-managed/agent-check-only labeled PRs
+#
+# Only org members can trigger via comments.
+# Cron runs from main — scans labeled PRs for new reviews/CI/comments.
+#
+# Required Secrets:
+#   CLAUDE_APP_ID, CLAUDE_APP_PRIVATE_KEY, GCP_CREDENTIALS_JSON,
+#   GCP_PROJECT_ID, MLFLOW_TRACKING_URI, MLFLOW_TRACKING_TOKEN,
+#   MLFLOW_EXPERIMENT_NAME, MLFLOW_WORKSPACE
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "17,47 * * * *"
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  checks: read
+
+jobs:
+  # ------------------------------------------------------------------ #
+  #  Router                                                             #
+  # ------------------------------------------------------------------ #
+  router:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.comment.outputs.matrix || steps.cron.outputs.matrix || '[]' }}
+
+    steps:
+      - name: Route issue_comment
+        id: comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          AUTHOR_ASSOC: ${{ github.event.comment.author_association }}
+          ACTOR: ${{ github.triggering_actor }}
+          IS_PR: ${{ github.event.issue.pull_request.url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$ACTOR" == *"[bot]"* ]]; then
+            echo "Skipping: bot comment"; exit 0
+          fi
+          if [[ ! "$AUTHOR_ASSOC" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+            echo "Skipping: $AUTHOR_ASSOC not authorized"; exit 0
+          fi
+          if [ -z "$IS_PR" ]; then
+            echo "Skipping: not a PR"; exit 0
+          fi
+
+          MODE=""
+          if echo "$COMMENT_BODY" | grep -qi "@odh-dashboard-agent.*preflight.*fix"; then
+            MODE=managed
+          elif echo "$COMMENT_BODY" | grep -qi "@odh-dashboard-agent.*preflight"; then
+            MODE=check-only
+          fi
+
+          if [ -z "$MODE" ]; then
+            echo "Skipping: no @odh-dashboard-agent command found"; exit 0
+          fi
+
+          PR_DATA=$(gh pr view "$ISSUE_NUMBER" --repo "$REPO" --json headRefOid,headRefName,headRepository)
+          SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
+          REF=$(echo "$PR_DATA" | jq -r '.headRefName')
+          HR=$(echo "$PR_DATA" | jq -r 'if .headRepository then .headRepository.owner.login + "/" + .headRepository.name else empty end')
+          echo "→ Preflight $MODE for PR #$ISSUE_NUMBER"
+          MATRIX=$(jq -nc --arg n "$ISSUE_NUMBER" --arg m "$MODE" --arg s "$SHA" --arg r "$REF" --arg h "${HR:-$REPO}" \
+            '[{"pr_number":$n,"mode":$m,"head_sha":$s,"head_ref":$r,"head_repo":$h}]')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+      - name: Route schedule
+        id: cron
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          PRS=$(gh pr list --repo "$REPO" --state open \
+            --json number,labels,headRefOid,headRefName,headRepository \
+            --jq '.[] | select(.labels | map(.name) | (index("agent-managed") or index("agent-check-only")))' 2>/dev/null)
+
+          if [ -z "$PRS" ]; then
+            echo "No labeled PRs"; exit 0
+          fi
+
+          MATRIX="[]"
+          while IFS= read -r pr_json; do
+            NUM=$(echo "$pr_json" | jq -r '.number')
+            SHA=$(echo "$pr_json" | jq -r '.headRefOid')
+            REF=$(echo "$pr_json" | jq -r '.headRefName')
+            HR=$(echo "$pr_json" | jq -r 'if .headRepository then .headRepository.owner.login + "/" + .headRepository.name else empty end')
+            HR="${HR:-$REPO}"
+            LABELS=$(echo "$pr_json" | jq -r '[.labels[].name] | join(",")')
+
+            # Dual-label guard
+            if echo "$LABELS" | grep -q "agent-managed" && echo "$LABELS" | grep -q "agent-check-only"; then
+              echo "PR #$NUM: has both labels, skipping"; continue
+            fi
+
+            LAST=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+              --jq '.check_runs[] | select(.name == "ODH Dashboard Agent") | .completed_at' 2>/dev/null | head -1)
+
+            NEEDS_RUN=false
+            if [ -z "$LAST" ]; then
+              echo "PR #$NUM: no previous run"
+              NEEDS_RUN=true
+            else
+              REVIEW=$(gh api "repos/$REPO/pulls/$NUM/reviews?per_page=1" --jq '.[0].submitted_at // empty' 2>/dev/null)
+              COMMENT=$(gh api "repos/$REPO/issues/$NUM/comments?sort=created&direction=desc&per_page=1" --jq '.[0].created_at // empty' 2>/dev/null)
+              CI=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+                --jq '[.check_runs[] | select(.name != "ODH Dashboard Agent") | .completed_at // empty] | map(select(. != "")) | sort | last // empty' 2>/dev/null)
+
+              for ts in "$REVIEW" "$COMMENT" "$CI"; do
+                if [ -n "$ts" ] && [[ "$ts" > "$LAST" ]]; then
+                  echo "PR #$NUM: new activity"
+                  NEEDS_RUN=true; break
+                fi
+              done
+            fi
+
+            if [ "$NEEDS_RUN" = "true" ]; then
+              echo "$LABELS" | grep -q "agent-managed" && MODE=managed || MODE=check-only
+              echo "→ Preflight $MODE for PR #$NUM (cron)"
+              MATRIX=$(echo "$MATRIX" | jq -c --arg n "$NUM" --arg m "$MODE" --arg s "$SHA" --arg r "$REF" --arg h "$HR" \
+                '. + [{"pr_number":$n,"mode":$m,"head_sha":$s,"head_ref":$r,"head_repo":$h}]')
+            fi
+          done <<< "$PRS"
+
+          if [ "$MATRIX" != "[]" ]; then
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ------------------------------------------------------------------ #
+  #  Preflight                                                          #
+  # ------------------------------------------------------------------ #
+  preflight:
+    needs: router
+    if: needs.router.outputs.matrix != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.router.outputs.matrix) }}
+      fail-fast: false
+    concurrency:
+      group: claude-preflight-pr-${{ matrix.pr_number }}
+      cancel-in-progress: true
+
+    env:
+      PR_NUMBER: ${{ matrix.pr_number }}
+      MODE: ${{ matrix.mode }}
+      HEAD_SHA: ${{ matrix.head_sha }}
+      HEAD_REF: ${{ matrix.head_ref }}
+      HEAD_REPO: ${{ matrix.head_repo }}
+      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      CLOUD_ML_REGION: us-east5
+      MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+      MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
+      MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
+      MLFLOW_WORKSPACE: ${{ secrets.MLFLOW_WORKSPACE }}
+      MLFLOW_ENABLE_WORKSPACES: "true"
+      MLFLOW_CLAUDE_TRACING_ENABLED: "true"
+
+    steps:
+      - name: Generate GitHub App token (managed)
+        if: matrix.mode == 'managed'
+        id: app-token-managed
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+
+      - name: Generate GitHub App token (check-only)
+        if: matrix.mode == 'check-only'
+        id: app-token-readonly
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
+          permission-checks: write
+
+      - name: Resolve token
+        id: app-token
+        run: |
+          echo "token=${{ steps.app-token-managed.outputs.token || steps.app-token-readonly.outputs.token }}" >> "$GITHUB_OUTPUT"
+
+      - name: Create check run
+        id: check-run
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          CHECK_RUN_ID=$(gh api "repos/$REPO/check-runs" \
+            -f "name=ODH Dashboard Agent" \
+            -f "head_sha=$HEAD_SHA" \
+            -f "status=in_progress" \
+            -f "output[title]=Preflight running..." \
+            -f "output[summary]=**Mode:** $MODE | **PR:** #$PR_NUMBER | **Trigger:** $EVENT_NAME" \
+            --jq '.id')
+          echo "id=$CHECK_RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HEAD_REPO }}
+          ref: ${{ env.HEAD_SHA }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Set up Python and MLflow
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install MLflow
+        run: pip install "mlflow[genai]>=3.5"
+
+      - name: Configure MLflow tracing
+        run: |
+          mkdir -p .claude
+          printf '.claude/settings.local.json\n' >> .git/info/exclude
+          cat > .claude/settings.local.json << 'SETTINGS'
+          {
+            "env": { "MLFLOW_CLAUDE_TRACING_ENABLED": "true" },
+            "hooks": {
+              "Stop": [{
+                "matcher": "",
+                "hooks": [{ "type": "command", "command": "which mlflow >/dev/null 2>&1 && mlflow autolog claude stop-hook || true" }]
+              }]
+            }
+          }
+          SETTINGS
+
+      # ── Check (read-only) ──
+      - name: Preflight check
+        if: matrix.mode == 'check-only'
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_vertex: "true"
+          claude_args: "--max-turns 30 --model claude-opus-4-6 --disallowedTools Edit,Write,NotebookEdit"
+          prompt: >-
+            Run /preflight ${{ env.PR_NUMBER }} --skip-review coderabbit to check
+            this PR. You are in agent-check-only mode — do NOT modify files,
+            commit, or push. Run preflight once, then post a summary PR comment
+            via gh pr comment ${{ env.PR_NUMBER }}. The comment must have a
+            Preflight Agent Report header, verdict with mode, the results table
+            with status emojis, an expandable Tracing section, and a footer
+            linking to
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+
+      # ── Fix (iterative) ──
+      - name: Preflight fix
+        if: matrix.mode == 'managed'
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_vertex: "true"
+          claude_args: "--max-turns 80 --model claude-opus-4-6"
+          prompt: >-
+            /goal Run /preflight ${{ env.PR_NUMBER }} --fix --skip-review coderabbit
+            to check and fix this PR. You are in agent-managed mode — edit files,
+            commit, and push as needed. If /preflight reports NOT READY, fix the
+            issues and re-run. Track each iteration's results. Stop after 5 runs
+            or 2 consecutive with no improvement. The goal is met when /preflight
+            reports READY or READY WITH WARNINGS AND you have posted a summary PR
+            comment via gh pr comment ${{ env.PR_NUMBER }}. The comment must have
+            a Preflight Agent Report header, verdict with iteration count and mode,
+            the results table with status emojis, an expandable Iteration History
+            section, an expandable Tracing section, and a footer linking to
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+
+      # ── Report ──
+      - name: Update check run (success)
+        if: success() && steps.check-run.outputs.id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          CHECK_RUN_ID: ${{ steps.check-run.outputs.id }}
+        run: |
+          gh api "repos/$REPO/check-runs/$CHECK_RUN_ID" \
+            -X PATCH \
+            -f "status=completed" -f "conclusion=success" \
+            -f "output[title]=Preflight passed ($MODE)" \
+            -f "output[summary]=See PR comment for full report."
+
+      - name: Update check run (failure)
+        if: failure() && steps.check-run.outputs.id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          CHECK_RUN_ID: ${{ steps.check-run.outputs.id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api "repos/$REPO/check-runs/$CHECK_RUN_ID" \
+            -X PATCH \
+            -f "status=completed" -f "conclusion=failure" \
+            -f "output[title]=Preflight failed ($MODE)" \
+            -f "output[summary]=Check the [workflow run]($RUN_URL)."
+
+      - name: Update check run (cancelled)
+        if: cancelled() && steps.check-run.outputs.id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          CHECK_RUN_ID: ${{ steps.check-run.outputs.id }}
+        run: |
+          gh api "repos/$REPO/check-runs/$CHECK_RUN_ID" \
+            -X PATCH \
+            -f "status=completed" -f "conclusion=cancelled" \
+            -f "output[title]=Preflight cancelled ($MODE)" \
+            -f "output[summary]=Superseded by a newer run."


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-57640

## Description

Add an automated preflight check GitHub Action workflow using Claude Code + `/goal` for iterative PR validation.

**Triggers:**
- `issue_comment` — comment `@odh-dashboard-agent preflight check` (read-only) or `@odh-dashboard-agent preflight fix` (managed mode)
- `schedule` (every 30 min) — polls PRs with `agent-managed` or `agent-check-only` labels for new activity (reviews, CI, comments)

**Two modes:**
- **check-only** — read-only single-pass `/preflight`, posts report. `Edit`/`Write`/`NotebookEdit` tools disabled.
- **managed** — `/goal` iterates `/preflight --fix` until all checks pass or hits early backoff (max 5 iterations, stops after 2 consecutive with no improvement). Can edit, commit, and push.

**Architecture:**
- Router job determines if/how to run, outputs JSON matrix
- Preflight job fans out via matrix strategy (parallel processing of multiple PRs)
- Per-PR concurrency with cancel-in-progress
- Check Run API reports "ODH Dashboard Agent" in the PR checks list
- Google Vertex AI (Opus) via GCP service account key
- MLflow tracing with stop hook for trace flush

**Security:**
- Only org members (OWNER/MEMBER/COLLABORATOR) can trigger via comments
- Bot comments ignored
- All user input passed via env vars — no inline `${{ }}` in run blocks
- `GITHUB_TOKEN` scoped to read-only; all writes use GitHub App token
- Fork-safe: both triggers run in base repo context

**Required secrets:**
| Secret | Description |
|--------|-------------|
| `CLAUDE_APP_ID` | GitHub App ID |
| `CLAUDE_APP_PRIVATE_KEY` | GitHub App private key (.pem) |
| `GCP_CREDENTIALS_JSON` | GCP service account key JSON |
| `GCP_PROJECT_ID` | GCP project ID for Vertex AI |
| `MLFLOW_TRACKING_URI` | MLflow server URI |
| `MLFLOW_TRACKING_TOKEN` | MLflow bearer token |
| `MLFLOW_EXPERIMENT_NAME` | MLflow experiment name |
| `MLFLOW_WORKSPACE` | MLflow workspace name |

## How Has This Been Tested?

- YAML syntax validated locally with Python `yaml.safe_load()`
- GitHub Actions expression syntax reviewed — no nested or inline injection vectors
- Router job verified on CI (routes correctly, skips when no label/command)
- CodeRabbit CLI review run locally; all findings addressed
- Full end-to-end testing requires secrets configured on the repository

## Test Impact

No automated tests — this is a CI workflow YAML file. Testing requires GitHub Actions infrastructure and configured secrets. Test by:
1. Adding required secrets to the repository
2. Commenting `@odh-dashboard-agent preflight check` on any PR
3. Adding `agent-managed` label to a PR and waiting for cron pickup

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated "ODH Dashboard Agent" workflow triggered by PR comments or on a schedule with "managed" and "check-only" modes, per-PR concurrency with automatic cancellation, visible PR check runs, and formatted PR comment reports.

* **Documentation**
  * Updated preflight skill docs to add a new --skip-review flag (mutually exclusive with --review) and examples showing its behavior.

* **Chores**
  * Added scheduled and comment-based automation for continuous PR processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->