### PR TITLE
fix: re-add BUILD_MODE=RHOAI build arg to Tekton pipelines

### DIFF
--- a/.tekton/odh-dashboard-pull-request.yaml
+++ b/.tekton/odh-dashboard-pull-request.yaml
@@ -34,6 +34,9 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: build-args
+    value:
+    - "BUILD_MODE=RHOAI"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-dashboard-push.yaml
+++ b/.tekton/odh-dashboard-push.yaml
@@ -23,11 +23,14 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-dashboard:odh-stable  
+    value: quay.io/opendatahub/odh-dashboard:odh-stable
   - name: dockerfile
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "BUILD_MODE=RHOAI"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62477

## Description

The Konflux Onboarder pipeline sync ([PR #7529](https://github.com/opendatahub-io/odh-dashboard/pull/7529)) overwrote the `.tekton/` PipelineRun YAML files, removing the `build-args` parameter (`BUILD_MODE=RHOAI`) that was originally introduced in commit [95213cd](https://github.com/opendatahub-io/odh-dashboard/commit/95213cd0631b9802af62fd057dbe4c66cdbe0e22) ("conditional enablement of RHOAI env vars (#6695)").

Without this build arg, the Dockerfile defaults to `BUILD_MODE=ODH` and RHOAI-specific branding (logo, product name, doc links, etc.) is absent from the build, causing downstream test failures.

This PR re-adds `BUILD_MODE=RHOAI` to both the pull-request and push PipelineRun definitions as a temporary fix. The proper long-term solution — configuring this in [odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central) in a target-specific way so it survives future pipeline syncs without affecting ODH release builds — is tracked in the linked Jira.

## How Has This Been Tested?

This is a CI/CD configuration change restoring a previously working state. The build arg was verified working before it was overwritten by the pipeline sync.

## Test Impact

No application tests are affected. This restores the build-time configuration needed for existing tests to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->