### PR TITLE
Remove group errors and allow freeform group names (#5034)

### DIFF
--- a/frontend/src/__mocks__/mockGroupConfig.ts
+++ b/frontend/src/__mocks__/mockGroupConfig.ts
@@ -3,29 +3,29 @@ import { GroupsConfig } from '#~/concepts/userConfigs/groupTypes';
 export const mockGroupSettings = (): GroupsConfig => ({
   adminGroups: [
     {
-      id: 0,
+      id: '0',
       name: 'odh-admins',
       enabled: true,
     },
     {
-      id: 1,
+      id: '1',
       name: 'odh-admins-1',
       enabled: false,
     },
   ],
   allowedGroups: [
     {
-      id: 0,
+      id: '0',
       name: 'odh-admins',
       enabled: false,
     },
     {
-      id: 1,
+      id: '1',
       name: 'odh-admins-1',
       enabled: false,
     },
     {
-      id: 2,
+      id: '2',
       name: 'system:authenticated',
       enabled: true,
     },

--- a/frontend/src/concepts/userConfigs/__tests__/useWatchGroups.spec.tsx
+++ b/frontend/src/concepts/userConfigs/__tests__/useWatchGroups.spec.tsx
@@ -132,28 +132,4 @@ describe('useWatchGroups', () => {
       'Error getting group settings',
     );
   });
-
-  it('should test admin error', async () => {
-    const mockGroupSettings: GroupsConfig = {
-      adminGroups: [{ id: 'odh-admins', name: 'odh-admins', enabled: true }],
-      allowedGroups: [],
-      errorAdmin: 'errorAdmin',
-    };
-    fetchAuthGroupsMock.mockResolvedValue(mockGroupSettings);
-    const renderResult = testHook(useWatchGroups)();
-    await renderResult.waitForNextUpdate();
-    expect(useNotificationMock().error).toHaveBeenCalledWith('Group error', 'errorAdmin');
-  });
-
-  it('should test user error', async () => {
-    const mockGroupSettings: GroupsConfig = {
-      adminGroups: [{ id: 'odh-admins', name: 'odh-admins', enabled: true }],
-      allowedGroups: [],
-      errorUser: 'errorUser',
-    };
-    fetchAuthGroupsMock.mockResolvedValue(mockGroupSettings);
-    const renderResult = testHook(useWatchGroups)();
-    await renderResult.waitForNextUpdate();
-    expect(useNotificationMock().error).toHaveBeenCalledWith('Group error', 'errorUser');
-  });
 });

--- a/frontend/src/concepts/userConfigs/groupTypes.ts
+++ b/frontend/src/concepts/userConfigs/groupTypes.ts
@@ -1,8 +1,6 @@
 export type GroupsConfig = {
   adminGroups: GroupStatus[];
   allowedGroups: GroupStatus[];
-  errorAdmin?: string;
-  errorUser?: string;
 };
 
 export enum GroupsConfigField {
@@ -11,7 +9,7 @@ export enum GroupsConfigField {
 }
 
 export type GroupStatus = {
-  id: number | string;
+  id: string;
   name: string;
   enabled: boolean;
 };

--- a/frontend/src/concepts/userConfigs/useWatchGroups.tsx
+++ b/frontend/src/concepts/userConfigs/useWatchGroups.tsx
@@ -23,7 +23,6 @@ export const useWatchGroups = (): {
     adminGroups: [],
     allowedGroups: [],
   });
-  const { errorAdmin, errorUser } = groupSettings;
   const [groupsData, groupsDataLoaded] = useGroups();
 
   const hasDirectAccessDataLoaded = groupsDataLoaded;
@@ -52,15 +51,6 @@ export const useWatchGroups = (): {
       fetchGroups();
     }
   }, [notification, hasDirectAccessDataLoaded, groupsData]);
-
-  React.useEffect(() => {
-    if (errorAdmin) {
-      notification.error(`Group error`, errorAdmin);
-    }
-    if (errorUser) {
-      notification.error(`Group error`, errorUser);
-    }
-  }, [errorAdmin, errorUser, notification]);
 
   const updateGroups = React.useCallback(
     (group: GroupsConfig) => {

--- a/frontend/src/pages/groupSettings/GroupSettings.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettings.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Alert,
-  AlertActionCloseButton,
   Button,
   HelperText,
   HelperTextItem,
@@ -15,7 +14,10 @@ import { MultiSelection, SelectionOptions } from '#~/components/MultiSelection';
 import { useWatchGroups } from '#~/concepts/userConfigs/useWatchGroups';
 import TitleWithIcon from '#~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '#~/concepts/design/utils';
-import { GroupsConfigField } from '#~/concepts/userConfigs/groupTypes';
+import { GroupsConfigField, GroupStatus } from '#~/concepts/userConfigs/groupTypes';
+
+const CREATE_PREFIX = 'Define new group: ';
+const newGroupMessage = (value: string): string => `${CREATE_PREFIX}"${value}"`;
 
 const GroupSettings: React.FC = () => {
   const {
@@ -40,25 +42,24 @@ const GroupSettings: React.FC = () => {
   };
 
   const handleMenuItemSelection = (newState: SelectionOptions[], field: GroupsConfigField) => {
+    const processGroup = (opt: SelectionOptions): GroupStatus => ({
+      id: String(opt.id),
+      // Handle the create option situation -- show different in dropdown but not in selection
+      name: opt.name.startsWith(CREATE_PREFIX) ? String(opt.id) : opt.name,
+      enabled: opt.selected || false,
+    });
+
     switch (field) {
       case GroupsConfigField.ADMIN:
         setGroupSettings({
           ...groupSettings,
-          adminGroups: newState.map((opt) => ({
-            id: opt.id,
-            name: opt.name,
-            enabled: opt.selected || false,
-          })),
+          adminGroups: newState.map(processGroup),
         });
         break;
       case GroupsConfigField.USER:
         setGroupSettings({
           ...groupSettings,
-          allowedGroups: newState.map((opt) => ({
-            id: opt.id,
-            name: opt.name,
-            enabled: opt.selected || false,
-          })),
+          allowedGroups: newState.map(processGroup),
         });
         break;
     }
@@ -104,27 +105,15 @@ const GroupSettings: React.FC = () => {
               selectionRequired
               noSelectedOptionsMessage="One or more group must be selected"
               popperProps={{ appendTo: document.body }}
+              isCreatable
+              createOptionMessage={newGroupMessage}
+              isCreateOptionOnTop
             />
-            {groupSettings.errorAdmin ? (
-              <Alert
-                isInline
-                variant="warning"
-                title="Group error"
-                actionClose={
-                  <AlertActionCloseButton
-                    onClose={() => setGroupSettings({ ...groupSettings, errorAdmin: undefined })}
-                  />
-                }
-              >
-                <p>{groupSettings.errorAdmin}</p>
-              </Alert>
-            ) : (
-              <HelperText>
-                <HelperTextItem>
-                  View, edit, or create groups in OpenShift under User Management
-                </HelperTextItem>
-              </HelperText>
-            )}
+            <HelperText>
+              <HelperTextItem>
+                Select from existing groups, or specify a new group name.
+              </HelperTextItem>
+            </HelperText>
           </SettingSection>
         </StackItem>
         <StackItem>
@@ -145,27 +134,15 @@ const GroupSettings: React.FC = () => {
               selectionRequired
               noSelectedOptionsMessage="One or more group must be selected"
               popperProps={{ appendTo: document.body }}
+              isCreatable
+              createOptionMessage={newGroupMessage}
+              isCreateOptionOnTop
             />
-            {groupSettings.errorUser ? (
-              <Alert
-                isInline
-                variant="warning"
-                title="Group error"
-                actionClose={
-                  <AlertActionCloseButton
-                    onClose={() => setGroupSettings({ ...groupSettings, errorUser: undefined })}
-                  />
-                }
-              >
-                <p>{groupSettings.errorUser}</p>
-              </Alert>
-            ) : (
-              <HelperText>
-                <HelperTextItem>
-                  View, edit, or create groups in OpenShift under User Management
-                </HelperTextItem>
-              </HelperText>
-            )}
+            <HelperText>
+              <HelperTextItem>
+                Select from existing groups, or specify a new group name.
+              </HelperTextItem>
+            </HelperText>
           </SettingSection>
         </StackItem>
         <StackItem>


### PR DESCRIPTION
(cherry picked from commit ee8a9d1ece9a5b43601bbed4587ceccabc87c089)

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-59753

Reproduced issue without this fix, doesn't occur after the fix:
<img width="751" height="446" alt="image" src="https://github.com/user-attachments/assets/b71453e8-3716-4176-bce5-2f2b8b64b1d1" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All manual tests below have been verified on a cluster:

### Test 1: Error no longer appears with missing groups
1. Create a group and configure it in the dashboard:
   ```bash
   oc adm groups new phantom-group
   ```
2. Go to **Settings → User management**, add `phantom-group` to admin or user groups, save.
3. Delete the group:
   ```bash
   oc delete group phantom-group
   ```
4. Reload the User management page.
5. **Expected:** No error popup, no inline warning alert. The page loads normally with helper text: *"Select from existing groups, or specify a new group name."* The `phantom-group` still appears in the list (still configured in Auth CR) and can be deselected/removed.

✅ Verified

### Test 2: Freeform group creation works
1. Go to **Settings → User management**.
2. Click the admin groups or user groups dropdown.
3. Type a group name that doesn't exist (e.g., `my-new-team`).
4. **Expected:** A "Define new group:" option appears at the top of the dropdown. Selecting it adds the group to the list. (No OpenShift Group object is created — it's stored as a reference in the Auth CR only.)
5. Save the settings, reload the page.
6. **Expected:** The custom group persists in the selection.

✅ Verified

### Test 3: Existing groups still work
1. Ensure at least one real OpenShift Group exists:
   ```bash
   oc adm groups new real-group
   ```
2. Go to **Settings → User management**, select `real-group` from the dropdown, save.
3. **Expected:** Group is selected and persists after reload. No errors.

✅ Verified

### Test 4: At least one group is still required
1. Go to **Settings → User management**.
2. Deselect all admin groups (or all user groups).
3. **Expected:** The Save button is disabled with message "One or more group must be selected."

✅ Verified

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
