### PR TITLE
add /mlflow prefix to MLflow tracking API curl calls

### DIFF
--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -666,7 +666,7 @@ const execCurlInMlflowPod = (
       `printf '%s' '${escapedBody}'`,
       '|',
       `oc exec -n ${namespace} -i ${podName} -c mlflow --`,
-      `curl -sk -X POST 'https://localhost:8443${endpoint}'`,
+      `curl -sk -X POST 'https://localhost:8443/mlflow${endpoint}'`,
       `-H 'Content-Type: application/json'`,
       `-H "Authorization: Bearer $(oc whoami -t)"`,
       `-H 'X-MLFLOW-WORKSPACE: ${ns}'`,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62488

## Description
  The MLflow tracking server routes its API under the `/mlflow/` path prefix                                                                                                                                                                         
  (e.g., `/mlflow/api/2.0/mlflow/experiments/create`), but `execCurlInMlflowPod`                                                                                                                                                                     
  was calling the unprefixed path (`/api/2.0/mlflow/experiments/create`).                                                                                                                                                                            
                                                                                                                                                                                                                                                     
  This caused the server to return an HTML 404 page, which `JSON.parse()` then                                                                                                                                                                       
  failed to parse with: `Unexpected token '<', "<!doctype "... is not valid JSON`.                                                                                                                                                                   
                                                                                                                                                                                                                                                     
  The UI-based test steps (create/rename/delete experiment) passed because the                                                                                                                                                                       
  browser goes through the dashboard proxy which handles routing correctly. Only                                                                                                                                                                     
  the direct curl calls inside the MLflow pod (used for creating experiments and                                                                                                                                                                     
  logging runs via API) hit the wrong path.                                                                                                                                                                                                          
                                                                                                                                                                                                                                                     
  Fix: add `/mlflow` prefix to the curl URL in `execCurlInMlflowPod`. 

## How Has This Been Tested?

Jenkins: dashboard-e2e-tests/716 
<img width="888" height="380" alt="image" src="https://github.com/user-attachments/assets/27c5bf16-ff86-49d5-8ecf-5f8036f962f2" />


## Test Impact
test fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MLflow REST API endpoint path routing to properly direct requests for experiment creation/deletion and run logging/updating operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->