### PR TITLE
[FIX] RHOAIENG-38050 : Feature Store UI does not display all resources when count exceeds 50 under All Repositories selection

### DIFF
--- a/packages/feature-store/src/api/__tests__/custom.spec.ts
+++ b/packages/feature-store/src/api/__tests__/custom.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
 import { handleFeatureStoreFailures } from '../errorUtils';
 import {
@@ -10,17 +11,17 @@ import {
   getFeatureViewByName,
   getFeatures,
   getFeatureByName,
+  getDataSources,
+  getSavedDatasets,
 } from '../custom';
-import { FEATURE_STORE_API_VERSION } from '../../const';
-
-const mockProxyPromise = Promise.resolve();
+import { FEATURE_STORE_API_VERSION, FEATURE_STORE_PAGE_SIZE } from '../../const';
 
 jest.mock('@odh-dashboard/internal/api/proxyUtils', () => ({
-  proxyGET: jest.fn(() => mockProxyPromise),
+  proxyGET: jest.fn(),
 }));
 
 jest.mock('../errorUtils', () => ({
-  handleFeatureStoreFailures: jest.fn((promise) => promise),
+  handleFeatureStoreFailures: jest.fn((promise: Promise<unknown>) => promise),
 }));
 
 const proxyGETMock = jest.mocked(proxyGET);
@@ -32,6 +33,9 @@ describe('listFeatureStoreProject', () => {
   });
 
   it('should call proxyGET and handleFeatureStoreFailures to fetch projects', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
 
@@ -50,6 +54,8 @@ describe('listFeatureStoreProject', () => {
   });
 
   it('should work with empty options', () => {
+    proxyGETMock.mockReturnValue(Promise.resolve());
+
     const hostPath = 'test-host';
     const opts = {};
 
@@ -69,25 +75,30 @@ describe('getEntities', () => {
     jest.clearAllMocks();
   });
 
-  it('should call proxyGET with all entities endpoint when no project is provided', () => {
-    const hostPath = 'test-host';
-    const opts = { dryRun: true };
+  it('should fetch all entities via pagination when no project is provided', async () => {
+    const mockEntities = [{ name: 'entity1' }, { name: 'entity2' }];
+    const mockResponse = {
+      entities: mockEntities,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
 
-    const result = getEntities(hostPath)(opts);
+    const result = await getEntities('test-host')({ dryRun: true });
 
-    expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
-      hostPath,
-      `/api/${FEATURE_STORE_API_VERSION}/entities/all?include_relationships=true`,
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/entities/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
       {},
-      opts,
+      { dryRun: true },
     );
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
-    expect(result).toBe(mockProxyPromise);
+    expect(result.entities).toEqual(mockEntities);
   });
 
   it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -104,7 +115,6 @@ describe('getEntities', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 });
@@ -115,6 +125,9 @@ describe('getEntityByName', () => {
   });
 
   it('should call proxyGET with correct endpoint for entity by name', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -132,7 +145,6 @@ describe('getEntityByName', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 });
@@ -142,25 +154,30 @@ describe('getFeatureViews', () => {
     jest.clearAllMocks();
   });
 
-  it('should call proxyGET with all feature views endpoint when no project is provided', () => {
-    const hostPath = 'test-host';
-    const opts = { dryRun: true };
+  it('should fetch all feature views via pagination when no project is provided', async () => {
+    const mockViews = [{ name: 'fv1' }, { name: 'fv2' }];
+    const mockResponse = {
+      featureViews: mockViews,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
 
-    const result = getFeatureViews(hostPath)(opts);
+    const result = await getFeatureViews('test-host')({ dryRun: true });
 
-    expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
-      hostPath,
-      `/api/${FEATURE_STORE_API_VERSION}/feature_views/all?include_relationships=true`,
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/feature_views/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
       {},
-      opts,
+      { dryRun: true },
     );
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
-    expect(result).toBe(mockProxyPromise);
+    expect(result.featureViews).toEqual(mockViews);
   });
 
   it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -177,11 +194,13 @@ describe('getFeatureViews', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 
   it('should call proxyGET with feature service filter when featureService is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -199,11 +218,13 @@ describe('getFeatureViews', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 
   it('should call proxyGET with entity filter when entity is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -221,8 +242,29 @@ describe('getFeatureViews', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
+  });
+
+  it('should paginate with entity filter when no project is provided', async () => {
+    const mockViews = [{ name: 'fv1' }];
+    const mockResponse = {
+      featureViews: mockViews,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
+
+    const result = await getFeatureViews('test-host')({ dryRun: true }, undefined, 'test-entity');
+
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/feature_views/all?entity=${encodeURIComponent(
+        'test-entity',
+      )}&include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+    expect(result.featureViews).toEqual(mockViews);
   });
 });
 
@@ -231,25 +273,30 @@ describe('getFeatureServices', () => {
     jest.clearAllMocks();
   });
 
-  it('should call proxyGET with all feature services endpoint when no project is provided', () => {
-    const hostPath = 'test-host';
-    const opts = { dryRun: true };
+  it('should fetch all feature services via pagination when no project is provided', async () => {
+    const mockServices = [{ name: 'fs1' }];
+    const mockResponse = {
+      featureServices: mockServices,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
 
-    const result = getFeatureServices(hostPath)(opts);
+    const result = await getFeatureServices('test-host')({ dryRun: true });
 
-    expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
-      hostPath,
-      `/api/${FEATURE_STORE_API_VERSION}/feature_services/all?include_relationships=true`,
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/feature_services/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
       {},
-      opts,
+      { dryRun: true },
     );
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
-    expect(result).toBe(mockProxyPromise);
+    expect(result.featureServices).toEqual(mockServices);
   });
 
   it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -266,11 +313,13 @@ describe('getFeatureServices', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 
   it('should call proxyGET with feature view filter when featureView is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -288,7 +337,6 @@ describe('getFeatureServices', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 });
@@ -299,6 +347,9 @@ describe('getFeatureServiceByName', () => {
   });
 
   it('should call proxyGET with correct endpoint for feature service by name', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -316,7 +367,6 @@ describe('getFeatureServiceByName', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 });
@@ -327,6 +377,9 @@ describe('getFeatureViewByName', () => {
   });
 
   it('should call proxyGET with correct endpoint for feature view by name', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -344,7 +397,6 @@ describe('getFeatureViewByName', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 
@@ -372,25 +424,26 @@ describe('getFeatures', () => {
     jest.clearAllMocks();
   });
 
-  it('should call proxyGET with all features endpoint when no project is provided', () => {
-    const hostPath = 'test-host';
-    const opts = { dryRun: true };
+  it('should fetch all features via pagination when no project is provided', async () => {
+    const mockFeatures = [{ name: 'feat1' }];
+    const mockResponse = { features: mockFeatures, pagination: { has_next: false } };
+    proxyGETMock.mockResolvedValue(mockResponse);
 
-    const result = getFeatures(hostPath)(opts);
+    const result = await getFeatures('test-host')({ dryRun: true });
 
-    expect(proxyGETMock).toHaveBeenCalledTimes(1);
     expect(proxyGETMock).toHaveBeenCalledWith(
-      hostPath,
-      `/api/${FEATURE_STORE_API_VERSION}/features/all`,
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/features/all?limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
       {},
-      opts,
+      { dryRun: true },
     );
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
-    expect(result).toBe(mockProxyPromise);
+    expect(result.features).toEqual(mockFeatures);
   });
 
   it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -405,7 +458,6 @@ describe('getFeatures', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
     expect(result).toBe(mockProxyPromise);
   });
 });
@@ -416,6 +468,9 @@ describe('getFeatureByName', () => {
   });
 
   it('should call proxyGET with correct endpoint for feature by name', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
     const hostPath = 'test-host';
     const opts = { dryRun: true };
     const project = 'test-project';
@@ -434,7 +489,104 @@ describe('getFeatureByName', () => {
       opts,
     );
     expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
-    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledWith(mockProxyPromise);
+    expect(result).toBe(mockProxyPromise);
+  });
+});
+
+describe('getDataSources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch all data sources via pagination when no project is provided', async () => {
+    const mockSources = [{ name: 'ds1' }];
+    const mockResponse = {
+      dataSources: mockSources,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
+
+    const result = await getDataSources('test-host')({ dryRun: true });
+
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/data_sources/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+    expect(result.dataSources).toEqual(mockSources);
+  });
+
+  it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
+    const hostPath = 'test-host';
+    const opts = { dryRun: true };
+    const project = 'test-project';
+
+    const result = getDataSources(hostPath)(opts, project);
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/data_sources?project=${encodeURIComponent(
+        project,
+      )}&include_relationships=true`,
+      {},
+      opts,
+    );
+    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(mockProxyPromise);
+  });
+});
+
+describe('getSavedDatasets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch all saved datasets via pagination when no project is provided', async () => {
+    const mockDatasets = [{ name: 'dataset1' }];
+    const mockResponse = {
+      savedDatasets: mockDatasets,
+      pagination: { has_next: false },
+      relationships: {},
+    };
+    proxyGETMock.mockResolvedValue(mockResponse);
+
+    const result = await getSavedDatasets('test-host')({ dryRun: true });
+
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/${FEATURE_STORE_API_VERSION}/saved_datasets/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+    expect(result.savedDatasets).toEqual(mockDatasets);
+  });
+
+  it('should call proxyGET with project-specific endpoint when project is provided', () => {
+    const mockProxyPromise = Promise.resolve();
+    proxyGETMock.mockReturnValue(mockProxyPromise);
+
+    const hostPath = 'test-host';
+    const opts = { dryRun: true };
+    const project = 'test-project';
+
+    const result = getSavedDatasets(hostPath)(opts, project);
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/saved_datasets?project=${encodeURIComponent(
+        project,
+      )}&include_relationships=true`,
+      {},
+      opts,
+    );
+    expect(handleFeatureStoreFailuresMock).toHaveBeenCalledTimes(1);
     expect(result).toBe(mockProxyPromise);
   });
 });

--- a/packages/feature-store/src/api/__tests__/paginationUtils.spec.ts
+++ b/packages/feature-store/src/api/__tests__/paginationUtils.spec.ts
@@ -1,0 +1,263 @@
+/* eslint-disable camelcase */
+import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
+import { fetchAllPages } from '../paginationUtils';
+import { FEATURE_STORE_PAGE_SIZE } from '../../const';
+import { FeatureStorePagination } from '../../types/global';
+
+jest.mock('@odh-dashboard/internal/api/proxyUtils', () => ({
+  proxyGET: jest.fn(),
+}));
+
+jest.mock('../errorUtils', () => ({
+  handleFeatureStoreFailures: jest.fn((promise: Promise<unknown>) => promise),
+}));
+
+const proxyGETMock = jest.mocked(proxyGET);
+
+type TestItem = { id: number };
+type TestResponse = {
+  items: TestItem[];
+  relationships: Record<string, { name: string }[]>;
+  pagination: FeatureStorePagination;
+};
+
+const makePagination = (
+  overrides: Partial<FeatureStorePagination> = {},
+): FeatureStorePagination => ({
+  page: 1,
+  limit: FEATURE_STORE_PAGE_SIZE,
+  total_count: 0,
+  total_pages: 1,
+  has_next: false,
+  has_previous: false,
+  ...overrides,
+});
+
+const buildResult = (allItems: TestItem[], allResponses: TestResponse[]): TestResponse => ({
+  ...allResponses[allResponses.length - 1],
+  items: allItems,
+  relationships: Object.assign({}, ...allResponses.map((r) => r.relationships)),
+});
+
+describe('fetchAllPages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch a single page when has_next is false', async () => {
+    const mockResponse: TestResponse = {
+      items: [{ id: 1 }, { id: 2 }],
+      relationships: { entity1: [{ name: 'rel1' }] },
+      pagination: makePagination({ total_count: 2 }),
+    };
+    proxyGETMock.mockResolvedValue(mockResponse as never);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all?include_relationships=true',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/v1/things/all?include_relationships=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.relationships).toEqual({ entity1: [{ name: 'rel1' }] });
+  });
+
+  it('should fetch multiple pages when has_next is true', async () => {
+    const page1Items = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+    const page2Items: TestItem[] = [{ id: 101 }, { id: 102 }];
+
+    proxyGETMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        relationships: {},
+        pagination: makePagination({ has_next: true, page: 1, total_pages: 2 }),
+      } as never)
+      .mockResolvedValueOnce({
+        items: page2Items,
+        relationships: {},
+        pagination: makePagination({ has_next: false, page: 2, total_pages: 2 }),
+      } as never);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(2);
+    expect(proxyGETMock).toHaveBeenNthCalledWith(
+      1,
+      'test-host',
+      `/api/v1/things/all?limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+    expect(proxyGETMock).toHaveBeenNthCalledWith(
+      2,
+      'test-host',
+      `/api/v1/things/all?limit=${FEATURE_STORE_PAGE_SIZE}&page=2`,
+      {},
+      { dryRun: true },
+    );
+    expect(result.items).toHaveLength(FEATURE_STORE_PAGE_SIZE + 2);
+  });
+
+  it('should handle an empty first page without looping', async () => {
+    const mockResponse: TestResponse = {
+      items: [],
+      relationships: {},
+      pagination: makePagination(),
+    };
+    proxyGETMock.mockResolvedValue(mockResponse as never);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(result.items).toEqual([]);
+  });
+
+  it('should propagate API errors from mid-pagination', async () => {
+    const page1Items = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+    proxyGETMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        relationships: {},
+        pagination: makePagination({ has_next: true }),
+      } as never)
+      .mockRejectedValueOnce(new Error('Server error'));
+
+    await expect(
+      fetchAllPages<TestResponse, TestItem>(
+        'test-host',
+        '/api/v1/things/all',
+        { dryRun: true },
+        (response) => response.items,
+        buildResult,
+      ),
+    ).rejects.toThrow('Server error');
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should merge relationships from multiple pages', async () => {
+    const page1Items = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+    const page1Relationships = { entity1: [{ name: 'rel-a' }], entity2: [{ name: 'rel-b' }] };
+    const page2Items: TestItem[] = [{ id: 101 }];
+    const page2Relationships = { entity3: [{ name: 'rel-c' }] };
+
+    proxyGETMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        relationships: page1Relationships,
+        pagination: makePagination({ has_next: true }),
+      } as never)
+      .mockResolvedValueOnce({
+        items: page2Items,
+        relationships: page2Relationships,
+        pagination: makePagination({ has_next: false }),
+      } as never);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(result.relationships).toEqual({
+      entity1: [{ name: 'rel-a' }],
+      entity2: [{ name: 'rel-b' }],
+      entity3: [{ name: 'rel-c' }],
+    });
+    expect(result.items).toHaveLength(FEATURE_STORE_PAGE_SIZE + 1);
+  });
+
+  it('should use ? separator when endpoint has no query params', async () => {
+    proxyGETMock.mockResolvedValue({
+      items: [],
+      relationships: {},
+      pagination: makePagination(),
+    } as never);
+
+    await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/v1/things/all?limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+  });
+
+  it('should use & separator when endpoint already has query params', async () => {
+    proxyGETMock.mockResolvedValue({
+      items: [],
+      relationships: {},
+      pagination: makePagination(),
+    } as never);
+
+    await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all?filter=true',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledWith(
+      'test-host',
+      `/api/v1/things/all?filter=true&limit=${FEATURE_STORE_PAGE_SIZE}&page=1`,
+      {},
+      { dryRun: true },
+    );
+  });
+
+  it('should stop at MAX_PAGES even if has_next is still true', async () => {
+    const fullPage = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+    proxyGETMock.mockResolvedValue({
+      items: fullPage,
+      relationships: {},
+      pagination: makePagination({ has_next: true }),
+    } as never);
+
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(100);
+    expect(result.items).toHaveLength(FEATURE_STORE_PAGE_SIZE * 100);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Reached maximum page limit'));
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/feature-store/src/api/__tests__/paginationUtils.spec.ts
+++ b/packages/feature-store/src/api/__tests__/paginationUtils.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
-import { fetchAllPages } from '../paginationUtils';
+import { fetchAllPages, mergeRelationships } from '../paginationUtils';
 import { FEATURE_STORE_PAGE_SIZE } from '../../const';
 import { FeatureStorePagination } from '../../types/global';
 
@@ -50,7 +50,7 @@ describe('fetchAllPages', () => {
       relationships: { entity1: [{ name: 'rel1' }] },
       pagination: makePagination({ total_count: 2 }),
     };
-    proxyGETMock.mockResolvedValue(mockResponse as never);
+    proxyGETMock.mockResolvedValue(mockResponse as unknown);
 
     const result = await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -80,12 +80,12 @@ describe('fetchAllPages', () => {
         items: page1Items,
         relationships: {},
         pagination: makePagination({ has_next: true, page: 1, total_pages: 2 }),
-      } as never)
+      } as unknown)
       .mockResolvedValueOnce({
         items: page2Items,
         relationships: {},
         pagination: makePagination({ has_next: false, page: 2, total_pages: 2 }),
-      } as never);
+      } as unknown);
 
     const result = await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -119,7 +119,7 @@ describe('fetchAllPages', () => {
       relationships: {},
       pagination: makePagination(),
     };
-    proxyGETMock.mockResolvedValue(mockResponse as never);
+    proxyGETMock.mockResolvedValue(mockResponse as unknown);
 
     const result = await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -140,7 +140,7 @@ describe('fetchAllPages', () => {
         items: page1Items,
         relationships: {},
         pagination: makePagination({ has_next: true }),
-      } as never)
+      } as unknown)
       .mockRejectedValueOnce(new Error('Server error'));
 
     await expect(
@@ -167,12 +167,12 @@ describe('fetchAllPages', () => {
         items: page1Items,
         relationships: page1Relationships,
         pagination: makePagination({ has_next: true }),
-      } as never)
+      } as unknown)
       .mockResolvedValueOnce({
         items: page2Items,
         relationships: page2Relationships,
         pagination: makePagination({ has_next: false }),
-      } as never);
+      } as unknown);
 
     const result = await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -195,7 +195,7 @@ describe('fetchAllPages', () => {
       items: [],
       relationships: {},
       pagination: makePagination(),
-    } as never);
+    } as unknown);
 
     await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -218,7 +218,7 @@ describe('fetchAllPages', () => {
       items: [],
       relationships: {},
       pagination: makePagination(),
-    } as never);
+    } as unknown);
 
     await fetchAllPages<TestResponse, TestItem>(
       'test-host',
@@ -242,7 +242,7 @@ describe('fetchAllPages', () => {
       items: fullPage,
       relationships: {},
       pagination: makePagination({ has_next: true }),
-    } as never);
+    } as unknown);
 
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
@@ -259,5 +259,97 @@ describe('fetchAllPages', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Reached maximum page limit'));
 
     consoleSpy.mockRestore();
+  });
+
+  it('should use hasNext (boolean) from pagination when present', async () => {
+    const page1Items = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+    const page2Items: TestItem[] = [{ id: 101 }];
+
+    proxyGETMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        relationships: {},
+        pagination: { hasNext: true, page: 1, limit: FEATURE_STORE_PAGE_SIZE },
+      } as unknown)
+      .mockResolvedValueOnce({
+        items: page2Items,
+        relationships: {},
+        pagination: { hasNext: false, page: 2, limit: FEATURE_STORE_PAGE_SIZE },
+      } as unknown);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(2);
+    expect(result.items).toHaveLength(FEATURE_STORE_PAGE_SIZE + 1);
+  });
+
+  it('should stop when hasNext is explicitly false even if page is full', async () => {
+    const fullPage = Array.from({ length: FEATURE_STORE_PAGE_SIZE }, (_, i) => ({ id: i + 1 }));
+
+    proxyGETMock.mockResolvedValue({
+      items: fullPage,
+      relationships: {},
+      pagination: { hasNext: false, page: 1, limit: FEATURE_STORE_PAGE_SIZE },
+    } as unknown);
+
+    const result = await fetchAllPages<TestResponse, TestItem>(
+      'test-host',
+      '/api/v1/things/all',
+      { dryRun: true },
+      (response) => response.items,
+      buildResult,
+    );
+
+    expect(proxyGETMock).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(FEATURE_STORE_PAGE_SIZE);
+  });
+});
+
+describe('mergeRelationships', () => {
+  it('should concatenate arrays for the same relationship key across pages', () => {
+    const responses: { relationships?: Record<string, { name: string }[]> }[] = [
+      { relationships: { entity1: [{ name: 'a' }], entity2: [{ name: 'b' }] } },
+      { relationships: { entity1: [{ name: 'c' }], entity3: [{ name: 'd' }] } },
+    ];
+
+    const result = mergeRelationships(responses);
+
+    expect(result).toEqual({
+      entity1: [{ name: 'a' }, { name: 'c' }],
+      entity2: [{ name: 'b' }],
+      entity3: [{ name: 'd' }],
+    });
+  });
+
+  it('should skip responses with undefined relationships', () => {
+    const responses: { relationships?: Record<string, { name: string }[]> }[] = [
+      { relationships: { entity1: [{ name: 'a' }] } },
+      { relationships: undefined },
+      { relationships: { entity2: [{ name: 'b' }] } },
+    ];
+
+    const result = mergeRelationships(responses);
+
+    expect(result).toEqual({
+      entity1: [{ name: 'a' }],
+      entity2: [{ name: 'b' }],
+    });
+  });
+
+  it('should return empty object when no responses have relationships', () => {
+    const responses: { relationships?: Record<string, { name: string }[]> }[] = [
+      { relationships: undefined },
+      { relationships: undefined },
+    ];
+
+    const result = mergeRelationships(responses);
+
+    expect(result).toEqual({});
   });
 });

--- a/packages/feature-store/src/api/custom.ts
+++ b/packages/feature-store/src/api/custom.ts
@@ -1,6 +1,7 @@
 import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
 import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import { handleFeatureStoreFailures } from './errorUtils';
+import { fetchAllPages, mergeRelationships } from './paginationUtils';
 import { FeatureStoreLineage, FeatureViewLineage } from '../types/lineage';
 import { FEATURE_STORE_API_VERSION } from '../const';
 import { Entity, EntityList } from '../types/entities';
@@ -28,13 +29,23 @@ export const listFeatureStoreProject =
 export const getEntities =
   (hostPath: string) =>
   (opts: K8sAPIOptions, project?: string): Promise<EntityList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/entities/all?include_relationships=true`;
     if (project) {
-      endpoint = `/api/${FEATURE_STORE_API_VERSION}/entities?project=${encodeURIComponent(
+      const endpoint = `/api/${FEATURE_STORE_API_VERSION}/entities?project=${encodeURIComponent(
         project,
       )}&include_relationships=true`;
+      return handleFeatureStoreFailures<EntityList>(proxyGET(hostPath, endpoint, {}, opts));
     }
-    return handleFeatureStoreFailures<EntityList>(proxyGET(hostPath, endpoint, {}, opts));
+    return fetchAllPages<EntityList, Entity>(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/entities/all?include_relationships=true`,
+      opts,
+      (response) => response.entities,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        entities: allItems,
+        relationships: mergeRelationships(allResponses),
+      }),
+    );
   };
 
 export const getFeatureViews =
@@ -48,39 +59,44 @@ export const getFeatureViews =
     // eslint-disable-next-line camelcase
     data_source?: string,
   ): Promise<FeatureViewsList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_views`;
-    const queryParams: string[] = [];
-
-    if (project) {
-      queryParams.push(`project=${encodeURIComponent(project)}`);
-    } else {
-      endpoint += '/all';
-    }
-
+    const filterParams: string[] = [];
     if (featureService) {
-      queryParams.push(`feature_service=${encodeURIComponent(featureService)}`);
+      filterParams.push(`feature_service=${encodeURIComponent(featureService)}`);
     }
-
     if (entity) {
-      queryParams.push(`entity=${encodeURIComponent(entity)}`);
+      filterParams.push(`entity=${encodeURIComponent(entity)}`);
     }
-
     if (feature) {
-      queryParams.push(`feature=${encodeURIComponent(feature)}`);
+      filterParams.push(`feature=${encodeURIComponent(feature)}`);
     }
     // eslint-disable-next-line camelcase
     if (data_source) {
-      queryParams.push(`data_source=${encodeURIComponent(data_source)}`);
+      filterParams.push(`data_source=${encodeURIComponent(data_source)}`);
     }
 
-    if (queryParams.length > 0) {
-      endpoint += `?${queryParams.join('&')}`;
+    if (project) {
+      const params = [
+        `project=${encodeURIComponent(project)}`,
+        ...filterParams,
+        'include_relationships=true',
+      ];
+      const endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_views?${params.join('&')}`;
+      return handleFeatureStoreFailures<FeatureViewsList>(proxyGET(hostPath, endpoint, {}, opts));
     }
 
-    endpoint +=
-      queryParams.length > 0 ? '&include_relationships=true' : '?include_relationships=true';
-
-    return handleFeatureStoreFailures<FeatureViewsList>(proxyGET(hostPath, endpoint, {}, opts));
+    const params = [...filterParams, 'include_relationships=true'];
+    const endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_views/all?${params.join('&')}`;
+    return fetchAllPages<FeatureViewsList, FeatureView>(
+      hostPath,
+      endpoint,
+      opts,
+      (response) => response.featureViews,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        featureViews: allItems,
+        relationships: mergeRelationships(allResponses),
+      }),
+    );
   };
 
 export const getEntityByName =
@@ -96,13 +112,22 @@ export const getEntityByName =
 export const getFeatures =
   (hostPath: string) =>
   (opts: K8sAPIOptions, project?: string): Promise<FeaturesList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/features/all`;
     if (project) {
-      endpoint = `/api/${FEATURE_STORE_API_VERSION}/features?project=${encodeURIComponent(
+      const endpoint = `/api/${FEATURE_STORE_API_VERSION}/features?project=${encodeURIComponent(
         project,
       )}`;
+      return handleFeatureStoreFailures<FeaturesList>(proxyGET(hostPath, endpoint, {}, opts));
     }
-    return handleFeatureStoreFailures<FeaturesList>(proxyGET(hostPath, endpoint, {}, opts));
+    return fetchAllPages<FeaturesList, Features>(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/features/all`,
+      opts,
+      (response) => response.features,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        features: allItems,
+      }),
+    );
   };
 
 export const getFeatureByName =
@@ -123,17 +148,33 @@ export const getFeatureByName =
 export const getFeatureServices =
   (hostPath: string) =>
   (opts: K8sAPIOptions, project?: string, featureView?: string): Promise<FeatureServicesList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_services/all?include_relationships=true`;
     if (project) {
-      endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_services?project=${encodeURIComponent(
+      let endpoint = `/api/${FEATURE_STORE_API_VERSION}/feature_services?project=${encodeURIComponent(
         project,
       )}&include_relationships=true`;
+      if (featureView) {
+        endpoint += `&feature_view=${encodeURIComponent(featureView)}`;
+      }
+      return handleFeatureStoreFailures<FeatureServicesList>(
+        proxyGET(hostPath, endpoint, {}, opts),
+      );
     }
-    if (featureView) {
-      endpoint += `&feature_view=${encodeURIComponent(featureView)}`;
-    }
-
-    return handleFeatureStoreFailures<FeatureServicesList>(proxyGET(hostPath, endpoint, {}, opts));
+    const endpoint = featureView
+      ? `/api/${FEATURE_STORE_API_VERSION}/feature_services/all?include_relationships=true&feature_view=${encodeURIComponent(
+          featureView,
+        )}`
+      : `/api/${FEATURE_STORE_API_VERSION}/feature_services/all?include_relationships=true`;
+    return fetchAllPages<FeatureServicesList, FeatureService>(
+      hostPath,
+      endpoint,
+      opts,
+      (response) => response.featureServices,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        featureServices: allItems,
+        relationships: mergeRelationships(allResponses),
+      }),
+    );
   };
 
 export const getFeatureServiceByName =
@@ -256,14 +297,23 @@ export const getFeatureViewLineage =
 export const getSavedDatasets =
   (hostPath: string) =>
   (opts: K8sAPIOptions, project?: string): Promise<DataSetList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/saved_datasets/all?include_relationships=true`;
     if (project) {
-      endpoint = `/api/${FEATURE_STORE_API_VERSION}/saved_datasets?project=${encodeURIComponent(
+      const endpoint = `/api/${FEATURE_STORE_API_VERSION}/saved_datasets?project=${encodeURIComponent(
         project,
       )}&include_relationships=true`;
+      return handleFeatureStoreFailures<DataSetList>(proxyGET(hostPath, endpoint, {}, opts));
     }
-
-    return handleFeatureStoreFailures<DataSetList>(proxyGET(hostPath, endpoint, {}, opts));
+    return fetchAllPages<DataSetList, DataSet>(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/saved_datasets/all?include_relationships=true`,
+      opts,
+      (response) => response.savedDatasets,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        savedDatasets: allItems,
+        relationships: mergeRelationships(allResponses),
+      }),
+    );
   };
 
 export const getDataSetByName =
@@ -293,13 +343,23 @@ export const getDataSetByName =
 export const getDataSources =
   (hostPath: string) =>
   (opts: K8sAPIOptions, project?: string): Promise<DataSourceList> => {
-    let endpoint = `/api/${FEATURE_STORE_API_VERSION}/data_sources/all?include_relationships=true`;
     if (project) {
-      endpoint = `/api/${FEATURE_STORE_API_VERSION}/data_sources?project=${encodeURIComponent(
+      const endpoint = `/api/${FEATURE_STORE_API_VERSION}/data_sources?project=${encodeURIComponent(
         project,
       )}&include_relationships=true`;
+      return handleFeatureStoreFailures<DataSourceList>(proxyGET(hostPath, endpoint, {}, opts));
     }
-    return handleFeatureStoreFailures<DataSourceList>(proxyGET(hostPath, endpoint, {}, opts));
+    return fetchAllPages<DataSourceList, DataSource>(
+      hostPath,
+      `/api/${FEATURE_STORE_API_VERSION}/data_sources/all?include_relationships=true`,
+      opts,
+      (response) => response.dataSources,
+      (allItems, allResponses) => ({
+        ...allResponses[allResponses.length - 1],
+        dataSources: allItems,
+        relationships: mergeRelationships(allResponses),
+      }),
+    );
   };
 
 export const getDataSourceByName =

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -16,7 +16,7 @@ export const mergeRelationships = <R>(
   for (const { relationships } of allResponses) {
     if (relationships) {
       for (const [key, value] of Object.entries(relationships)) {
-        merged[key] = key in merged ? [...merged[key], ...value] : value;
+        merged[key] = key in merged ? [...merged[key], ...value] : [...value];
       }
     }
   }
@@ -46,7 +46,7 @@ export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
     const items = getItems(response);
     allItems.push(...items);
     allResponses.push(response);
-    hasNext = response.pagination.has_next ?? items.length >= FEATURE_STORE_PAGE_SIZE;
+    hasNext = response.pagination.has_next ?? false;
     page++;
   } while (hasNext && page <= MAX_PAGES);
 

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -8,10 +8,20 @@ const MAX_PAGES = 100;
 
 type PaginatedResponse = { pagination: Partial<FeatureStorePagination> & Record<string, unknown> };
 
-/** Merges `relationships` maps from all page responses into a single object. */
+/** Merges `relationships` maps from all page responses, concatenating arrays per key. */
 export const mergeRelationships = <R>(
   allResponses: { relationships?: Record<string, R[]> }[],
-): Record<string, R[]> => Object.assign({}, ...allResponses.map((r) => r.relationships));
+): Record<string, R[]> => {
+  const merged: Record<string, R[]> = {};
+  for (const { relationships } of allResponses) {
+    if (relationships) {
+      for (const [key, value] of Object.entries(relationships)) {
+        merged[key] = key in merged ? [...merged[key], ...value] : value;
+      }
+    }
+  }
+  return merged;
+};
 
 /** Fetches all pages from a paginated /all endpoint using `pagination.has_next`. */
 export const fetchAllPages = async <T extends PaginatedResponse, TItem>(

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -23,7 +23,7 @@ export const mergeRelationships = <R>(
   return merged;
 };
 
-/** Fetches all pages from a paginated /all endpoint using `pagination.has_next`. */
+/** Fetches all pages from a paginated /all endpoint. */
 export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
   hostPath: string,
   endpoint: string,
@@ -46,7 +46,15 @@ export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
     const items = getItems(response);
     allItems.push(...items);
     allResponses.push(response);
-    hasNext = response.pagination.has_next ?? false;
+
+    const pag: Record<string, unknown> = response.pagination;
+    const hasNextField = pag.hasNext ?? pag.has_next;
+    if (typeof hasNextField === 'boolean') {
+      hasNext = hasNextField;
+    } else {
+      const totalPages = Number(pag.totalPages ?? pag.total_pages ?? 0);
+      hasNext = totalPages > 0 ? page < totalPages : items.length >= FEATURE_STORE_PAGE_SIZE;
+    }
     page++;
   } while (hasNext && page <= MAX_PAGES);
 

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -47,13 +47,16 @@ export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
     allItems.push(...items);
     allResponses.push(response);
 
-    const pag: Record<string, unknown> = response.pagination;
-    const hasNextField = pag.hasNext ?? pag.has_next;
-    if (typeof hasNextField === 'boolean') {
-      hasNext = hasNextField;
+    if (items.length === 0) {
+      hasNext = false;
     } else {
-      const totalPages = Number(pag.totalPages ?? pag.total_pages ?? 0);
-      hasNext = totalPages > 0 ? page < totalPages : items.length >= FEATURE_STORE_PAGE_SIZE;
+      const pag: Record<string, unknown> = response.pagination;
+      const hasNextField = pag.hasNext ?? pag.has_next;
+      if (typeof hasNextField === 'boolean') {
+        hasNext = hasNextField;
+      } else {
+        hasNext = items.length >= FEATURE_STORE_PAGE_SIZE;
+      }
     }
     page++;
   } while (hasNext && page <= MAX_PAGES);

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -1,0 +1,51 @@
+import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
+import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { handleFeatureStoreFailures } from './errorUtils';
+import { FEATURE_STORE_PAGE_SIZE } from '../const';
+
+const MAX_PAGES = 100;
+
+// eslint-disable-next-line camelcase
+type PaginatedResponse = { pagination: { has_next?: boolean; [key: string]: unknown } };
+
+/** Merges `relationships` maps from all page responses into a single object. */
+export const mergeRelationships = <R>(
+  allResponses: { relationships?: Record<string, R[]> }[],
+): Record<string, R[]> => Object.assign({}, ...allResponses.map((r) => r.relationships));
+
+/** Fetches all pages from a paginated /all endpoint using `pagination.has_next`. */
+export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
+  hostPath: string,
+  endpoint: string,
+  opts: K8sAPIOptions,
+  getItems: (response: T) => TItem[],
+  buildResult: (allItems: TItem[], allResponses: T[]) => T,
+): Promise<T> => {
+  const separator = endpoint.includes('?') ? '&' : '?';
+  const allItems: TItem[] = [];
+  const allResponses: T[] = [];
+  let page = 1;
+  let hasNext: boolean;
+
+  do {
+    const pageEndpoint = `${endpoint}${separator}limit=${FEATURE_STORE_PAGE_SIZE}&page=${page}`;
+    // eslint-disable-next-line no-await-in-loop
+    const response = await handleFeatureStoreFailures<T>(
+      proxyGET(hostPath, pageEndpoint, {}, opts),
+    );
+    const items = getItems(response);
+    allItems.push(...items);
+    allResponses.push(response);
+    hasNext = response.pagination.has_next ?? items.length >= FEATURE_STORE_PAGE_SIZE;
+    page++;
+  } while (hasNext && page <= MAX_PAGES);
+
+  if (hasNext && page > MAX_PAGES) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[fetchAllPages] Reached maximum page limit (${MAX_PAGES}). Results may be incomplete for endpoint: ${endpoint}`,
+    );
+  }
+
+  return buildResult(allItems, allResponses);
+};

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -47,16 +47,11 @@ export const fetchAllPages = async <T extends PaginatedResponse, TItem>(
     allItems.push(...items);
     allResponses.push(response);
 
-    if (items.length === 0) {
-      hasNext = false;
+    const pag: Record<string, unknown> = response.pagination;
+    if (typeof pag.hasNext === 'boolean') {
+      hasNext = pag.hasNext;
     } else {
-      const pag: Record<string, unknown> = response.pagination;
-      const hasNextField = pag.hasNext ?? pag.has_next;
-      if (typeof hasNextField === 'boolean') {
-        hasNext = hasNextField;
-      } else {
-        hasNext = items.length >= FEATURE_STORE_PAGE_SIZE;
-      }
+      hasNext = items.length >= FEATURE_STORE_PAGE_SIZE;
     }
     page++;
   } while (hasNext && page <= MAX_PAGES);

--- a/packages/feature-store/src/api/paginationUtils.ts
+++ b/packages/feature-store/src/api/paginationUtils.ts
@@ -2,11 +2,11 @@ import { proxyGET } from '@odh-dashboard/internal/api/proxyUtils';
 import { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import { handleFeatureStoreFailures } from './errorUtils';
 import { FEATURE_STORE_PAGE_SIZE } from '../const';
+import { FeatureStorePagination } from '../types/global';
 
 const MAX_PAGES = 100;
 
-// eslint-disable-next-line camelcase
-type PaginatedResponse = { pagination: { has_next?: boolean; [key: string]: unknown } };
+type PaginatedResponse = { pagination: Partial<FeatureStorePagination> & Record<string, unknown> };
 
 /** Merges `relationships` maps from all page responses into a single object. */
 export const mergeRelationships = <R>(

--- a/packages/feature-store/src/const.ts
+++ b/packages/feature-store/src/const.ts
@@ -1,6 +1,9 @@
 import { ProjectList } from './types/featureStoreProjects';
 
 export const FEATURE_STORE_API_VERSION = 'v1';
+
+/** Max items per page for /all endpoints (Feast API rejects limit > 100 with 422). */
+export const FEATURE_STORE_PAGE_SIZE = 100;
 export const FEATURE_STORE_UI_LABEL_KEY = 'feature-store-ui';
 export const FEATURE_STORE_UI_LABEL_VALUE = 'enabled';
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://redhat.atlassian.net/browse/RHOAIENG-38050

## Description
The "All feature stores" page only showed up to 50 resources because the Feast registry REST API defaults to 50 items per page, and the UI only loaded the first page. The Feast API enforces a strict `limit <= 100` (returning 422 for higher values), so a single large request isn't possible. Implemented a `fetchAllPages` utility that fetches in batches of 100 until all items are retrieved, with relationship merging across pages and a MAX_PAGES safety guard.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
---
*before*

- "All Feature store" page

<img width="3024" height="1898" alt="Screenshot 2026-05-11 at 12 12 50 PM" src="https://github.com/user-attachments/assets/2e754a6b-ff6b-4f58-a576-9ccf9070614f" />

---
- "Project" page

<img width="3024" height="1898" alt="Screenshot 2026-05-11 at 12 12 59 PM" src="https://github.com/user-attachments/assets/d7d88613-4f06-43be-b60a-d4456a9b1197" />

--------

*after*

- "All Feature store" page
<img width="3024" height="1898" alt="Screenshot 2026-05-14 at 12 00 48 PM" src="https://github.com/user-attachments/assets/7e7e249f-69d4-4349-aae5-615faccde2b6" />

## How Has This Been Tested?
Reproduced with 55+ entities on a live cluster — verified UI shows "1-10 of 57" instead of truncating at 50.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
Added `paginationUtils.spec.ts` (7 tests: single/multi-page, empty page, mid-pagination error, relationship merge, separator handling) and updated `custom.spec.ts` (new filter+pagination test for getFeatureViews).
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated and expanded pagination tests to validate multi-page aggregation, per-test mock behavior, error handling, query construction, and max-page limits.

* **Refactor**
  * List endpoints now fetch and merge paginated results across pages for large result sets (entities, features, feature views, feature services, data sources, saved datasets).
  * Added a consistent page-size (100) and max-page safeguard with a console warning if limits are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->