### PR TITLE
RHOAIENG-62539: Fix E2E CI frontend sub-area detection skipping all PRs

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -289,7 +289,7 @@ jobs:
           # =================================================================
           # Smart Test Selection: Detect changed areas and resolve CI tags
           #
-          # Layer 1: Turbo detects changed packages (including frontend "//" workspace)
+          # Layer 1: Turbo detects changed packages (including frontend workspace)
           #          → reads e2eCiTags from each package.json (self-service, teams opt in)
           # Layer 2: For frontend changes detected by Layer 1, git diff identifies
           #          sub-areas → .github/frontend-ci-tags.json mapping resolves CI tags
@@ -340,8 +340,8 @@ jobs:
           # --- Layer 2: Frontend sub-area detection ---
           # Turbo sees the entire frontend as one workspace. When it changes,
           # use git diff to identify which sub-areas were modified.
-          # Note: Turbo reports the root/frontend workspace as "//"
-          if echo "$CHANGED_PACKAGES" | grep -qx "//"; then
+          # Turbo may report the frontend workspace as "//" or "odh-dashboard-frontend"
+          if echo "$CHANGED_PACKAGES" | grep -qxE "//|odh-dashboard-frontend"; then
             echo ""
             echo "🔍 Frontend changed — detecting sub-areas via git diff..."
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62539

## Description

The Cypress E2E test workflow's Layer 2 (frontend sub-area detection) never triggers because the guard condition checks for `//` as the frontend workspace name, but Turbo reports it as `odh-dashboard-frontend`.

In Turbo, `//` refers to the **root** workspace (top-level `package.json`), not the frontend. The frontend is a separate workspace named `odh-dashboard-frontend` (from `frontend/package.json`). Since `grep -qx "//"` never matches `odh-dashboard-frontend`, the `.github/frontend-ci-tags.json` mappings are never consulted and area-specific E2E tests (e.g., `@HardwareProfilesCI`, `@ProjectsCI`, `@PipelinesCI`) are never auto-triggered for frontend changes.

**The fix** updates the guard to match both `//` and `odh-dashboard-frontend` using extended grep:

```diff
- if echo "$CHANGED_PACKAGES" | grep -qx "//"; then
+ if echo "$CHANGED_PACKAGES" | grep -qxE "//|odh-dashboard-frontend"; then
```

**Impact:** This bug meant that for every PR changing frontend files, only package-level `e2eCiTags` (Layer 1) and manual `test:*` labels were used for E2E test selection. All 15 frontend sub-area mappings in `frontend-ci-tags.json` were dead code.

**Example:** [PR #7246](https://github.com/opendatahub-io/odh-dashboard/pull/7246) changed `frontend/src/concepts/hardwareProfiles/` files but `@HardwareProfilesCI` tests did not run. [CI logs](https://github.com/opendatahub-io/odh-dashboard/actions/runs/25744095089/job/75618024676) confirm Turbo reported `odh-dashboard-frontend` but Layer 2 was skipped.

## How Has This Been Tested?

Reproduced locally using a standalone script that simulates the detection logic with the actual Turbo output from PR #7246's CI run:

- **Buggy guard (`//` only):** Layer 2 skipped, only `@MaaSCI` detected. `@HardwareProfilesCI` and `@ProjectsCI` missing.
- **Fixed guard (`//|odh-dashboard-frontend`):** Layer 2 runs, detects `concepts/hardwareProfiles` → `@HardwareProfilesCI` and `pages/projects` → `@ProjectsCI`.

The core logic can also be verified with a simple one-liner:

```bash
# Buggy — no match
echo "odh-dashboard-frontend" | grep -qx "//" && echo "MATCHED" || echo "NO MATCH"

# Fixed — matches
echo "odh-dashboard-frontend" | grep -qxE "//|odh-dashboard-frontend" && echo "MATCHED" || echo "NO MATCH"
```

## Test Impact

No automated tests apply — this is a GitHub Actions workflow change. The fix was validated by running the extracted detection logic locally against the PR #7246 commit range, confirming the correct tags are now detected.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Cypress E2E test workflow to improve test selection accuracy for frontend changes, ensuring more targeted test execution across different workspace configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->