### PR TITLE
Extension serving runtime templates

### DIFF
--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -25,9 +25,42 @@ import {
   SupportedArea,
 } from '@odh-dashboard/internal/concepts/areas/index';
 import type { TimeoutFieldValue } from './src/wizardFields/timeout/TimeoutField';
+import type { KServeServingRuntimeFieldType } from './src/wizardFields/servingRuntime/KServeServingRuntimeField';
 import type { KServeDeployment } from './src/deployments';
 
 export const KSERVE_ID = 'kserve';
+
+const kserveServingRuntimeFieldExtension: WizardField2Extension<
+  KServeServingRuntimeFieldType,
+  KServeDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field2',
+  properties: {
+    platform: KSERVE_ID,
+    field: () =>
+      import('./src/wizardFields/servingRuntime/KServeServingRuntimeField').then(
+        (m) => m.KServeServingRuntimeFieldWizardField,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.K_SERVE],
+  },
+};
+
+const kserveTimeoutFieldExtension: WizardField2Extension<
+  WizardField<TimeoutFieldValue, undefined>,
+  KServeDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field2',
+  properties: {
+    platform: KSERVE_ID,
+    field: () =>
+      import('./src/wizardFields/timeout/TimeoutField').then((m) => m.TimeoutFieldWizardField),
+  },
+  flags: {
+    required: [SupportedArea.K_SERVE],
+  },
+};
 
 const extensions: (
   | AreaExtension
@@ -41,6 +74,7 @@ const extensions: (
   | ModelServingStartStopAction<KServeDeployment>
   | ModelServingPlatformFetchDeploymentStatus<KServeDeployment>
   | ModelServingDeploy<KServeDeployment>
+  | WizardField2Extension<KServeServingRuntimeFieldType, KServeDeployment>
   | WizardField2Extension<WizardField<TimeoutFieldValue, undefined>, KServeDeployment>
   | WizardFieldApplyExtension<TimeoutFieldValue, KServeDeployment>
   | WizardFieldExtractorExtension<TimeoutFieldValue, KServeDeployment>
@@ -193,17 +227,8 @@ const extensions: (
       required: [SupportedArea.K_SERVE],
     },
   },
-  {
-    type: 'model-serving.deployment/wizard-field2',
-    properties: {
-      platform: KSERVE_ID,
-      field: () =>
-        import('./src/wizardFields/timeout/TimeoutField').then((m) => m.TimeoutFieldWizardField),
-    },
-    flags: {
-      required: [SupportedArea.K_SERVE],
-    },
-  },
+  kserveServingRuntimeFieldExtension,
+  kserveTimeoutFieldExtension,
   {
     type: 'model-serving.deployment/wizard-field-apply',
     properties: {

--- a/packages/kserve/src/deploy.ts
+++ b/packages/kserve/src/deploy.ts
@@ -47,7 +47,7 @@ export const deployKServeDeployment = async (
             project: projectName,
             name: wizardData.k8sNameDesc.data.k8sName.value,
             servingRuntime: serverResource,
-            scope: wizardData.modelServer.data?.selection?.scope,
+            scope: wizardData.modelServer?.data?.selection?.scope,
             templateName: serverResourceTemplateName,
           },
           dryRun,

--- a/packages/kserve/src/deployModel.ts
+++ b/packages/kserve/src/deployModel.ts
@@ -46,7 +46,7 @@ export type CreatingInferenceServiceObject = {
   name: string;
   k8sName: string;
   description: string;
-  modelType?: ServingRuntimeModelType;
+  modelType?: string;
   modelLocationData?: ModelLocationData;
   hardwareProfile: HardwareProfileConfig;
   modelFormat?: SupportedModelFormats;

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -388,7 +388,10 @@ export const applyModelType = (
   modelType: string,
 ): InferenceServiceKind => {
   if (!isKnownServingRuntimeModelType(modelType)) {
-    console.error(`Invalid model type for kserve deployment: ${modelType}`);
+    console.error(
+      `Invalid model type for kserve deployment: ${modelType}. Skipping applyModelType.`,
+    );
+    return inferenceService;
   }
 
   const result = structuredClone(inferenceService);

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -40,10 +40,7 @@ import {
 } from '@odh-dashboard/internal/concepts/connectionTypes/utils';
 import { ModelLocationData } from '@odh-dashboard/model-serving/types/form-data';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
-import {
-  isValidModelType,
-  type ModelTypeFieldData,
-} from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelTypeSelectField';
+import { type ModelTypeFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelTypeSelectField';
 import type { ModelAvailabilityFieldsData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelAvailabilityFields';
 import type { RuntimeArgsFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/RuntimeArgsField';
 import type { EnvironmentVariablesFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/EnvironmentVariablesField';
@@ -372,19 +369,28 @@ export const extractModelType = (deployment: {
   model: InferenceServiceKind;
 }): ModelTypeFieldData | null => {
   const modelType = deployment.model.metadata.annotations?.['opendatahub.io/model-type'];
-  if (modelType && isValidModelType(modelType)) {
-    return {
-      type: modelType,
-      legacyVLLM: modelType === ServingRuntimeModelType.GENERATIVE,
-    };
+  if (!modelType) {
+    return null;
   }
-  return null;
+
+  return {
+    type: modelType,
+    legacyVLLM: modelType === ServingRuntimeModelType.GENERATIVE,
+  };
+};
+
+const isKnownServingRuntimeModelType = (type?: string): type is ServingRuntimeModelType => {
+  return type === ServingRuntimeModelType.PREDICTIVE || type === ServingRuntimeModelType.GENERATIVE;
 };
 
 export const applyModelType = (
   inferenceService: InferenceServiceKind,
-  modelType: ServingRuntimeModelType,
+  modelType: string,
 ): InferenceServiceKind => {
+  if (!isKnownServingRuntimeModelType(modelType)) {
+    console.error(`Invalid model type for kserve deployment: ${modelType}`);
+  }
+
   const result = structuredClone(inferenceService);
   result.metadata.annotations = {
     ...result.metadata.annotations,

--- a/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
+++ b/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
@@ -85,7 +85,7 @@ export const isKServeServingRuntimeFieldActive = (
   }
 
   // Generative models without LLMInferenceServiceConfig flow: always show (no alternative)
-  if (vLLMDeploymentOnMaaSEnabled === false) {
+  if (!vLLMDeploymentOnMaaSEnabled) {
     if (modelType?.type === ServingRuntimeModelType.GENERATIVE) {
       return true;
     }
@@ -251,7 +251,7 @@ export const KServeServingRuntimeFieldWizardField: KServeServingRuntimeFieldType
   id: 'kserve/modelServer',
   step: 'modelDeployment',
   type: 'replacement',
-  formId: 'modelServer',
+  stateKey: 'modelServer',
   isActive: isKServeServingRuntimeFieldActive,
   reducerFunctions: {
     resolveDependencies: (formData) => ({

--- a/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
+++ b/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { z } from 'zod';
+import type { WizardField, WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
+import { isModelServerTemplateField } from '@odh-dashboard/model-serving/types/form-data';
+import { useWizardFieldOverrides } from '@odh-dashboard/model-serving/components/deploymentWizard/dynamicFormUtils';
+import ModelServerTemplateSelectField, {
+  type ModelServerOption,
+  type ModelServerSelectFieldData,
+  modelServerSelectFieldSchema,
+  getAcceleratorIdentifierFromHardwareProfile,
+} from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelServerTemplateSelectField';
+import { useModelServingClusterSettings } from '@odh-dashboard/model-serving/concepts/useModelServingClusterSettings';
+import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelTypeSelectField';
+import type {
+  HardwareProfileKind,
+  SupportedModelFormats,
+  TemplateKind,
+} from '@odh-dashboard/internal/k8sTypes';
+import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import {
+  getServingRuntimeDisplayNameFromTemplate,
+  getServingRuntimeFromTemplate,
+  getServingRuntimeVersion,
+} from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
+import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
+import { useProfileIdentifiers } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+
+// Types
+
+type KServeServingRuntimeDependencies = {
+  modelServerTemplates?: TemplateKind[];
+  modelFormat?: SupportedModelFormats;
+  hardwareProfile?: HardwareProfileKind;
+  modelType?: ModelTypeFieldData;
+  vLLMDeploymentOnMaaS?: boolean;
+};
+
+export type KServeServingRuntimeExternalData = {
+  extraOptions: ModelServerOption[];
+  suggestion?: ModelServerOption;
+};
+
+export type KServeServingRuntimeFieldValue = {
+  data?: ModelServerSelectFieldData;
+};
+
+export type KServeServingRuntimeFieldType = WizardField<
+  KServeServingRuntimeFieldValue,
+  KServeServingRuntimeExternalData,
+  KServeServingRuntimeDependencies
+>;
+
+/**
+ * Active for all deployments except generative non-legacy which is behind a feature flag.
+ */
+export const isKServeServingRuntimeFieldActive = (
+  wizardState: RecursivePartial<WizardFormData['state']>,
+): boolean => {
+  const modelType = wizardState.modelType?.data;
+  const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
+
+  if (modelType?.type === ServingRuntimeModelType.PREDICTIVE) {
+    return true;
+  }
+  if (vLLMDeploymentOnMaaSEnabled === true) {
+    if (modelType?.type === ServingRuntimeModelType.GENERATIVE && modelType.legacyVLLM === true) {
+      return true;
+    }
+  }
+  if (vLLMDeploymentOnMaaSEnabled === false) {
+    if (modelType?.type === ServingRuntimeModelType.GENERATIVE) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+// External data hook
+
+export const useKServeServingRuntimeExternalData = (
+  dependencies?: KServeServingRuntimeDependencies,
+): {
+  data: KServeServingRuntimeExternalData;
+  loaded: boolean;
+  loadError?: Error;
+} => {
+  const { data: modelServingClusterSettings } = useModelServingClusterSettings();
+
+  const formData = React.useMemo(
+    () => ({
+      modelType: { data: dependencies?.modelType },
+      devFeatureFlags: { vLLMDeploymentOnMaaS: dependencies?.vLLMDeploymentOnMaaS },
+    }),
+    [dependencies?.modelType, dependencies?.vLLMDeploymentOnMaaS],
+  );
+
+  const modelServerOverrides = useWizardFieldOverrides(isModelServerTemplateField, formData);
+
+  return React.useMemo(() => {
+    const extraOptions = modelServerOverrides.flatMap((override) => override.extraOptions ?? []);
+    const suggestion = modelServerOverrides.reduce<ModelServerOption | undefined>(
+      (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
+      undefined,
+    );
+
+    return {
+      data: { extraOptions, suggestion },
+      loaded: true,
+    };
+  }, [modelServerOverrides, modelServingClusterSettings]);
+};
+
+const computeSuggestion = (
+  templates?: TemplateKind[],
+  modelFormat?: SupportedModelFormats,
+  hardwareProfile?: HardwareProfileKind,
+): ModelServerOption | undefined => {
+  let filtered = templates;
+
+  if (modelFormat) {
+    filtered = filtered?.filter((template) =>
+      getServingRuntimeFromTemplate(template)?.spec.supportedModelFormats?.some(
+        (format) => format.name === modelFormat.name && format.version === modelFormat.version,
+      ),
+    );
+  }
+
+  const accelerator = getAcceleratorIdentifierFromHardwareProfile(hardwareProfile);
+  if (accelerator) {
+    filtered = filtered?.filter((template) =>
+      isCompatibleWithIdentifier(accelerator, getServingRuntimeFromTemplate(template)),
+    );
+  }
+
+  if (filtered?.length === 1) {
+    const suggestedTemplate = filtered[0];
+    return {
+      name: suggestedTemplate.metadata.name,
+      namespace: suggestedTemplate.metadata.namespace,
+      label: getServingRuntimeDisplayNameFromTemplate(suggestedTemplate),
+      template: suggestedTemplate,
+    };
+  }
+  return undefined;
+};
+
+// Component
+
+const KServeServingRuntimeField: KServeServingRuntimeFieldType['component'] = ({
+  value,
+  onChange,
+  externalData,
+  dependencies,
+  isEditing,
+}) => {
+  const { dashboardNamespace } = useDashboardNamespace();
+  const profileIdentifiers = useProfileIdentifiers(dependencies?.hardwareProfile);
+
+  const options = React.useMemo((): ModelServerOption[] => {
+    const result: ModelServerOption[] = [];
+
+    result.push(...(externalData?.data.extraOptions ?? []));
+
+    result.push(
+      ...(dependencies?.modelServerTemplates?.map(
+        (template) =>
+          ({
+            name: template.metadata.name,
+            namespace: template.metadata.namespace,
+            label: getServingRuntimeDisplayNameFromTemplate(template),
+            version: getServingRuntimeVersion(template),
+            compatibleWithHardwareProfile: profileIdentifiers.some((identifier) =>
+              isCompatibleWithIdentifier(identifier, getServingRuntimeFromTemplate(template)),
+            ),
+            scope: template.metadata.namespace === dashboardNamespace ? 'global' : 'project',
+            template,
+          } satisfies ModelServerOption),
+      ) ?? []),
+    );
+
+    return result;
+  }, [
+    externalData?.data.extraOptions,
+    dependencies?.modelServerTemplates,
+    dashboardNamespace,
+    profileIdentifiers,
+  ]);
+
+  return (
+    <ModelServerTemplateSelectField
+      label="Deployment resource"
+      modelServerState={{
+        data: value?.data,
+        setData: (data: ModelServerSelectFieldData) => onChange({ data }),
+        options,
+      }}
+      isEditing={isEditing}
+    />
+  );
+};
+
+// WizardField definition
+
+export const KServeServingRuntimeFieldWizardField: KServeServingRuntimeFieldType = {
+  id: 'kserve/modelServer',
+  step: 'modelDeployment',
+  type: 'replacement',
+  formId: 'modelServer',
+  isActive: isKServeServingRuntimeFieldActive,
+  reducerFunctions: {
+    resolveDependencies: (formData) => ({
+      modelServerTemplates: formData.modelFormatState.templatesFilteredForModelType,
+      modelFormat: formData.modelFormatState.modelFormat,
+      hardwareProfile: formData.hardwareProfileConfig.formData.selectedProfile,
+      modelType: formData.modelType.data,
+      vLLMDeploymentOnMaaS: formData.devFeatureFlags?.vLLMDeploymentOnMaaS,
+    }),
+    setFieldData: (value: KServeServingRuntimeFieldValue) => value,
+    getInitialFieldData: (
+      existingFieldData?: KServeServingRuntimeFieldValue,
+      externalData?: KServeServingRuntimeExternalData,
+      dependencies?: KServeServingRuntimeDependencies,
+    ): KServeServingRuntimeFieldValue => {
+      if (existingFieldData?.data?.selection) {
+        return existingFieldData;
+      }
+
+      if (externalData?.suggestion) {
+        return {
+          data: {
+            selection: externalData.suggestion,
+            autoSelect: true,
+            suggestion: externalData.suggestion,
+          },
+        };
+      }
+
+      const suggestion = computeSuggestion(
+        dependencies?.modelServerTemplates,
+        dependencies?.modelFormat,
+        dependencies?.hardwareProfile,
+      );
+      if (suggestion) {
+        return {
+          data: {
+            selection: suggestion,
+            autoSelect: true,
+            suggestion,
+          },
+        };
+      }
+
+      return { data: { autoSelect: false } };
+    },
+    validationSchema: z.object({
+      data: modelServerSelectFieldSchema,
+    }),
+  },
+  shouldResetOnDependencyChange: (prevDependencies, newDependencies) => {
+    return prevDependencies.modelType?.type !== newDependencies.modelType?.type;
+  },
+  component: KServeServingRuntimeField,
+  externalDataHook: useKServeServingRuntimeExternalData,
+};

--- a/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
+++ b/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
@@ -53,7 +53,18 @@ export type KServeServingRuntimeFieldType = WizardField<
 >;
 
 /**
- * Active for all deployments except generative non-legacy which is behind a feature flag.
+ * Determines if the KServe serving runtime field should be active in the wizard.
+ *
+ * Activation logic:
+ * - PREDICTIVE models: Always active (use traditional KServe serving runtimes)
+ * - GENERATIVE models with LLMInferenceServiceConfig flow available (vLLMDeploymentOnMaaS=true):
+ *   - Active ONLY if legacyVLLM=true (user opted for legacy vLLM deployment path)
+ *   - Inactive if legacyVLLM=false (uses LLMInferenceServiceConfig-based deployment instead)
+ * - GENERATIVE models without LLMInferenceServiceConfig flow (vLLMDeploymentOnMaaS=false):
+ *   - Always active (LLMInferenceServiceConfig not available, must use KServe serving runtime)
+ *
+ * @param wizardState Current wizard form state
+ * @returns true if the KServe serving runtime field should be shown
  */
 export const isKServeServingRuntimeFieldActive = (
   wizardState: RecursivePartial<WizardFormData['state']>,
@@ -61,14 +72,19 @@ export const isKServeServingRuntimeFieldActive = (
   const modelType = wizardState.modelType?.data;
   const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
 
+  // Predictive models always use KServe serving runtimes
   if (modelType?.type === ServingRuntimeModelType.PREDICTIVE) {
     return true;
   }
+
+  // Generative models with LLMInferenceServiceConfig flow enabled: only show if using legacy vLLM
   if (vLLMDeploymentOnMaaSEnabled === true) {
     if (modelType?.type === ServingRuntimeModelType.GENERATIVE && modelType.legacyVLLM === true) {
       return true;
     }
   }
+
+  // Generative models without LLMInferenceServiceConfig flow: always show (no alternative)
   if (vLLMDeploymentOnMaaSEnabled === false) {
     if (modelType?.type === ServingRuntimeModelType.GENERATIVE) {
       return true;
@@ -80,6 +96,13 @@ export const isKServeServingRuntimeFieldActive = (
 
 // External data hook
 
+/**
+ * External data hook for KServe serving runtime field.
+ * Fetches wizard field overrides from extensions and computes suggestions.
+ *
+ * @param dependencies Dependencies needed to resolve overrides and suggestions
+ * @returns External data object with extraOptions, suggestion, loaded state, and optional error
+ */
 export const useKServeServingRuntimeExternalData = (
   dependencies?: KServeServingRuntimeDependencies,
 ): {
@@ -100,16 +123,26 @@ export const useKServeServingRuntimeExternalData = (
   const modelServerOverrides = useWizardFieldOverrides(isModelServerTemplateField, formData);
 
   return React.useMemo(() => {
-    const extraOptions = modelServerOverrides.flatMap((override) => override.extraOptions ?? []);
-    const suggestion = modelServerOverrides.reduce<ModelServerOption | undefined>(
-      (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
-      undefined,
-    );
+    try {
+      const extraOptions = modelServerOverrides.flatMap((override) => override.extraOptions ?? []);
+      const suggestion = modelServerOverrides.reduce<ModelServerOption | undefined>(
+        (acc, override) => acc ?? override.suggestion?.(modelServingClusterSettings),
+        undefined,
+      );
 
-    return {
-      data: { extraOptions, suggestion },
-      loaded: true,
-    };
+      return {
+        data: { extraOptions, suggestion },
+        loaded: true,
+      };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error loading KServe serving runtime external data:', error);
+      return {
+        data: { extraOptions: [], suggestion: undefined },
+        loaded: true,
+        loadError: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
   }, [modelServerOverrides, modelServingClusterSettings]);
 };
 
@@ -259,6 +292,22 @@ export const KServeServingRuntimeFieldWizardField: KServeServingRuntimeFieldType
       data: modelServerSelectFieldSchema,
     }),
   },
+  /**
+   * Determines when the field should reset to its initial value.
+   *
+   * The serving runtime selection is reset ONLY when the model type changes
+   * (predictive ↔ generative), because different model types use different
+   * serving runtime templates.
+   *
+   * The field does NOT reset on modelFormat or hardwareProfile changes.
+   * While these affect which templates are compatible and which gets suggested,
+   * they don't fundamentally change the available template set, so we preserve
+   * the user's selection if they already made one.
+   *
+   * @param prevDependencies Previous dependency values
+   * @param newDependencies New dependency values
+   * @returns true if the field should reset, false to preserve current value
+   */
   shouldResetOnDependencyChange: (prevDependencies, newDependencies) => {
     return prevDependencies.modelType?.type !== newDependencies.modelType?.type;
   },

--- a/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
+++ b/packages/kserve/src/wizardFields/servingRuntime/KServeServingRuntimeField.tsx
@@ -110,7 +110,11 @@ export const useKServeServingRuntimeExternalData = (
   loaded: boolean;
   loadError?: Error;
 } => {
-  const { data: modelServingClusterSettings } = useModelServingClusterSettings();
+  const {
+    data: modelServingClusterSettings,
+    loaded: modelServingClusterSettingsLoaded,
+    error: modelServingClusterSettingsError,
+  } = useModelServingClusterSettings();
 
   const formData = React.useMemo(
     () => ({
@@ -132,18 +136,24 @@ export const useKServeServingRuntimeExternalData = (
 
       return {
         data: { extraOptions, suggestion },
-        loaded: true,
+        loaded: modelServingClusterSettingsLoaded,
+        loadError: modelServingClusterSettingsError,
       };
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Error loading KServe serving runtime external data:', error);
       return {
         data: { extraOptions: [], suggestion: undefined },
-        loaded: true,
+        loaded: modelServingClusterSettingsLoaded,
         loadError: error instanceof Error ? error : new Error(String(error)),
       };
     }
-  }, [modelServerOverrides, modelServingClusterSettings]);
+  }, [
+    modelServerOverrides,
+    modelServingClusterSettings,
+    modelServingClusterSettingsLoaded,
+    modelServingClusterSettingsError,
+  ]);
 };
 
 const computeSuggestion = (

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -216,6 +216,7 @@ const extensions: (
     },
     flags: {
       required: [LLMD_SERVING_ID],
+      disallowed: [SupportedArea.VLLM_ON_MAAS],
     },
   },
   {

--- a/packages/llmd-serving/src/__tests__/formUtils.spec.ts
+++ b/packages/llmd-serving/src/__tests__/formUtils.spec.ts
@@ -39,12 +39,22 @@ describe('isLLMInferenceServiceActive', () => {
 });
 
 describe('isGenerativeNonLegacy', () => {
-  it('returns true for GENERATIVE model type with legacyVLLM false', () => {
+  it('returns true for GENERATIVE model type with legacyVLLM false and vLLMDeploymentOnMaaS enabled', () => {
     expect(
       isGenerativeNonLegacy({
         modelType: { data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false } },
+        devFeatureFlags: { vLLMDeploymentOnMaaS: true },
       }),
     ).toBe(true);
+  });
+
+  it('returns false for GENERATIVE model type with legacyVLLM false when vLLMDeploymentOnMaaS is disabled', () => {
+    expect(
+      isGenerativeNonLegacy({
+        modelType: { data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false } },
+        devFeatureFlags: { vLLMDeploymentOnMaaS: false },
+      }),
+    ).toBe(false);
   });
 
   it('returns false for GENERATIVE model type with legacyVLLM true', () => {

--- a/packages/llmd-serving/src/deployments/deploy.ts
+++ b/packages/llmd-serving/src/deployments/deploy.ts
@@ -208,7 +208,7 @@ export const assembleLLMdDeployment = (
     {
       deploymentName: k8sName,
       deploymentNamespace: wizardData.state.project.projectName ?? '',
-      template: isLLMInferenceServiceConfig(wizardData.state.modelServer.data?.selection?.template)
+      template: isLLMInferenceServiceConfig(wizardData.state.modelServer?.data?.selection?.template)
         ? wizardData.state.modelServer.data.selection.template
         : undefined,
     },

--- a/packages/llmd-serving/src/formUtils.ts
+++ b/packages/llmd-serving/src/formUtils.ts
@@ -23,13 +23,20 @@ export const isLLMInferenceServiceActive = (
 
 /**
  *
- * @returns `true` if Generative is selected and legacyVLLM is false (items on step 2)
+ * @returns `true` if Generative is selected and legacyVLLM is false (only possible with vLLM on MaaS enabled)
  */
 export const isGenerativeNonLegacy = (
   wizardState: RecursivePartial<WizardFormData['state']>,
 ): boolean => {
-  return (
-    wizardState.modelType?.data?.type === ServingRuntimeModelType.GENERATIVE &&
-    wizardState.modelType.data.legacyVLLM !== true
-  );
+  const modelType = wizardState.modelType?.data;
+  const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
+
+  if (
+    vLLMDeploymentOnMaaSEnabled &&
+    modelType?.type === ServingRuntimeModelType.GENERATIVE &&
+    !modelType.legacyVLLM
+  ) {
+    return true;
+  }
+  return false;
 };

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -142,7 +142,7 @@ export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
   id: 'llmd-serving/modelServer',
   step: 'modelDeployment',
   type: 'replacement',
-  formId: 'modelServer',
+  stateKey: 'modelServer',
   isActive: isGenerativeNonLegacy,
   reducerFunctions: {
     resolveDependencies: (formData) => ({

--- a/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
+++ b/packages/llmd-serving/src/wizardFields/LlmConfigOptionsField.tsx
@@ -139,9 +139,10 @@ const LLMConfigOptionsField: LLMConfigOptionsFieldType['component'] = ({
 };
 
 export const LLMConfigOptionsFieldWizardField: LLMConfigOptionsFieldType = {
-  id: 'modelServer',
+  id: 'llmd-serving/modelServer',
   step: 'modelDeployment',
   type: 'replacement',
+  formId: 'modelServer',
   isActive: isGenerativeNonLegacy,
   reducerFunctions: {
     resolveDependencies: (formData) => ({

--- a/packages/llmd-serving/src/wizardFields/gateway/GatewaySelectField.tsx
+++ b/packages/llmd-serving/src/wizardFields/gateway/GatewaySelectField.tsx
@@ -188,7 +188,7 @@ export const GatewaySelectField: GatewaySelectFieldType = {
     getInitialFieldData: (existingFieldData?: GatewaySelectFieldData): GatewaySelectFieldData =>
       existingFieldData ?? { selection: undefined },
   },
-  shouldResetOnDependencyChange: true,
+  shouldResetOnDependencyChange: () => true,
   externalDataHook: useGatewayOptions,
   component: GatewaySelectFieldComponent,
   getReviewSections: getGatewayReviewSection,

--- a/packages/llmd-serving/src/wizardFields/gateway/__tests__/GatewaySelectField.spec.tsx
+++ b/packages/llmd-serving/src/wizardFields/gateway/__tests__/GatewaySelectField.spec.tsx
@@ -394,7 +394,8 @@ describe('GatewaySelectFieldComponent', () => {
 
 describe('GatewaySelectField definition', () => {
   it('should opt into resetting field data on dependency change', () => {
-    expect(GatewaySelectField.shouldResetOnDependencyChange).toBe(true);
+    const mockDeps = { project: { projectName: 'test', setProjectName: jest.fn() } };
+    expect(GatewaySelectField.shouldResetOnDependencyChange?.(mockDeps, mockDeps)).toBe(true);
   });
 
   it('should declare project as a dependency via resolveDependencies', () => {

--- a/packages/llmd-serving/src/wizardFields/modelServerField.ts
+++ b/packages/llmd-serving/src/wizardFields/modelServerField.ts
@@ -1,11 +1,24 @@
 import type { ModelServerTemplateField } from '@odh-dashboard/model-serving/types/form-data';
+import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { LLMD_OPTION } from '../deployments/server';
-import { isGenerativeNonLegacy } from '../formUtils';
+
+// Use for pre-vLLMonMaaS feature flag support
+const shouldAddLLMDOptionToRuntimeTemplates: ModelServerTemplateField['isActive'] = (
+  wizardState,
+) => {
+  const modelType = wizardState.modelType?.data;
+  const vLLMDeploymentOnMaaSEnabled = wizardState.devFeatureFlags?.vLLMDeploymentOnMaaS;
+
+  if (!vLLMDeploymentOnMaaSEnabled && modelType?.type === ServingRuntimeModelType.GENERATIVE) {
+    return true;
+  }
+  return false;
+};
 
 export const modelServerField: ModelServerTemplateField = {
   id: 'modelServerTemplate',
   type: 'modifier',
-  isActive: isGenerativeNonLegacy,
+  isActive: shouldAddLLMDOptionToRuntimeTemplates,
   extraOptions: [LLMD_OPTION],
   suggestion: (modelServingClusterSettings) => {
     return modelServingClusterSettings?.isLLMdDefault ? LLMD_OPTION : undefined;

--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -11,8 +11,10 @@ import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 import { mockK8sNameDescriptionFieldData } from '@odh-dashboard/internal/__mocks__/mockK8sNameDescriptionFieldData';
 import { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
 import { ModelServingPlatform } from '../concepts/useProjectServingPlatform';
 import type { UseModelDeploymentWizardState } from '../components/deploymentWizard/useDeploymentWizard';
+import type { WizardField } from '../components/deploymentWizard/types';
 import { deploymentStrategyRolling } from '../components/deploymentWizard/fields/DeploymentStrategyField';
 
 export const mockModelServingPlatform = ({
@@ -138,6 +140,7 @@ export const mockDeploymentWizardState = (
         modelType: {
           data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false },
           setData: jest.fn(),
+          externalData: { data: { extraOptions: [] as SimpleSelectOption[] } },
         },
         modelLocationData: {
           data: undefined,
@@ -217,15 +220,10 @@ export const mockDeploymentWizardState = (
           },
           setData: jest.fn(),
           isGenAiEnabled: true,
+          showField: false,
         },
         modelServer: {
           data: undefined,
-          setData: jest.fn(),
-          isAutoSelectChecked: undefined,
-          setIsAutoSelectChecked: jest.fn(),
-          suggestion: undefined,
-          options: [],
-          isDirty: false,
         },
         deploymentStrategy: {
           data: deploymentStrategyRolling,
@@ -246,7 +244,7 @@ export const mockDeploymentWizardState = (
         shouldAutoCheckTokens: false,
       },
       dispatch: jest.fn(),
-      fields: [],
-    },
+      fields: [] as WizardField[],
+    } as UseModelDeploymentWizardState,
     overrides,
   );

--- a/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
+++ b/packages/model-serving/src/components/deploymentWizard/deploying/useModelDeploymentSubmit.ts
@@ -78,7 +78,7 @@ export const useModelDeploymentSubmit = (
           );
         }
 
-        const serverResourceTemplateName = formState.modelServer.data?.selection?.name;
+        const serverResourceTemplateName = formState.modelServer?.data?.selection?.name;
         const allModelServerTemplates = formState.modelFormatState.templatesFilteredForModelType;
         const serverResource = serverResourceTemplateName
           ? getServingRuntimeFromTemplate(

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -58,35 +58,35 @@ export const getFieldDependencies = (
 /**
  * Determines where in the form state a field's data is stored.
  *
- * The formId allows multiple platform-specific fields to share the same form slot.
+ * The stateKey allows multiple platform-specific fields to share the same form slot.
  * For example, kserve and llmd-serving both manage the "modelServer" form field
  * but with different implementations:
- * - kserve field: { id: 'kserve/modelServer', formId: 'modelServer' }
- * - llmd field: { id: 'llmd/modelServer', formId: 'modelServer' }
+ * - kserve field: { id: 'kserve/modelServer', stateKey: 'modelServer' }
+ * - llmd field: { id: 'llmd/modelServer', stateKey: 'modelServer' }
  *
  * Both store their data at state.modelServer, and only the active field is used
  * based on the isActive() predicate.
  *
  * @param field The wizard field to get the form id for
- * @returns The formId if explicitly set, otherwise falls back to the field's id
+ * @returns The stateKey if explicitly set, otherwise falls back to the field's id
  *
  * @example
  * // Platform-specific field sharing a form slot
  * const kserveField = {
  *   id: 'kserve/modelServer',
- *   formId: 'modelServer',  // Shares slot with other platform fields
+ *   stateKey: 'modelServer',  // Shares slot with other platform fields
  *   // ...
  * };
- * getFormId(kserveField); // Returns 'modelServer'
+ * getStateKey(kserveField); // Returns 'modelServer'
  *
  * @example
  * // Standard field without shared slot
  * const standardField = {
  *   id: 'externalRoute',
- *   // formId not set
+ *   // stateKey not set
  * };
- * getFormId(standardField); // Returns 'externalRoute'
+ * getStateKey(standardField); // Returns 'externalRoute'
  */
-export const getFormId = (field: WizardField<unknown>): string => {
-  return field.formId ?? field.id;
+export const getStateKey = (field: WizardField<unknown>): string => {
+  return field.stateKey ?? field.id;
 };

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -7,6 +7,9 @@ import {
   isWizardField2Extension,
 } from '../../../extension-points';
 
+/**
+ * @deprecated Use useWizardFieldOverrides instead
+ */
 export const useWizardFieldFromExtension = <T extends DeploymentWizardField>(
   predicate: (field: DeploymentWizardField) => field is T,
   formData: RecursivePartial<WizardFormData['state']>,
@@ -19,6 +22,18 @@ export const useWizardFieldFromExtension = <T extends DeploymentWizardField>(
   }, [extensions, predicate, formData]);
 
   return React.useMemo(() => fields[0], [fields]);
+};
+
+export const useWizardFieldOverrides = <T extends DeploymentWizardField>(
+  predicate: (field: DeploymentWizardField) => field is T,
+  formData: RecursivePartial<WizardFormData['state']>,
+): T[] => {
+  const [extensions] = useResolvedExtensions(isDeploymentWizardFieldExtension);
+
+  return React.useMemo(() => {
+    const all = extensions.map((ext) => ext.properties.field);
+    return all.filter(predicate).filter((field) => field.isActive(formData));
+  }, [extensions, predicate, formData]);
 };
 
 export const useActiveFields = (
@@ -38,4 +53,14 @@ export const getFieldDependencies = (
   formData: WizardFormData['state'],
 ): Record<string, unknown> => {
   return field.reducerFunctions.resolveDependencies?.(formData) ?? {};
+};
+
+/**
+ * Where in the form state is the field data stored?
+ * Needed for fields that do the same thing but work differently in different platforms.
+ * @param field The field to get the form id for
+ * @returns The form id or the field id if no form id is set
+ */
+export const getFormId = (field: WizardField<unknown>): string => {
+  return field.formId ?? field.id;
 };

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -56,10 +56,36 @@ export const getFieldDependencies = (
 };
 
 /**
- * Where in the form state is the field data stored?
- * Needed for fields that do the same thing but work differently in different platforms.
- * @param field The field to get the form id for
- * @returns The form id or the field id if no form id is set
+ * Determines where in the form state a field's data is stored.
+ *
+ * The formId allows multiple platform-specific fields to share the same form slot.
+ * For example, kserve and llmd-serving both manage the "modelServer" form field
+ * but with different implementations:
+ * - kserve field: { id: 'kserve/modelServer', formId: 'modelServer' }
+ * - llmd field: { id: 'llmd/modelServer', formId: 'modelServer' }
+ *
+ * Both store their data at state.modelServer, and only the active field is used
+ * based on the isActive() predicate.
+ *
+ * @param field The wizard field to get the form id for
+ * @returns The formId if explicitly set, otherwise falls back to the field's id
+ *
+ * @example
+ * // Platform-specific field sharing a form slot
+ * const kserveField = {
+ *   id: 'kserve/modelServer',
+ *   formId: 'modelServer',  // Shares slot with other platform fields
+ *   // ...
+ * };
+ * getFormId(kserveField); // Returns 'modelServer'
+ *
+ * @example
+ * // Standard field without shared slot
+ * const standardField = {
+ *   id: 'externalRoute',
+ *   // formId not set
+ * };
+ * getFormId(standardField); // Returns 'externalRoute'
  */
 export const getFormId = (field: WizardField<unknown>): string => {
   return field.formId ?? field.id;

--- a/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { resolveFieldValue, type GenericFieldProps, WizardField } from '../types';
 import type { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import type { ExternalDataMap } from '../ExternalDataLoader';
-import { getFieldDependencies, getFormId } from '../dynamicFormUtils';
+import { getFieldDependencies, getStateKey } from '../dynamicFormUtils';
 
 const hasDisabledOverride = (value: unknown): value is { isDisabled: boolean } =>
   typeof value === 'object' &&
@@ -18,29 +18,29 @@ type CommonProps = {
 
 type GenericFieldRendererProps = CommonProps &
   (
-    | { parentId: string; fieldId?: never; formId?: never }
-    | { fieldId: string; parentId?: never; formId?: never }
-    | { formId: string; parentId?: never; fieldId?: never }
+    | { parentId: string; fieldId?: never; stateKey?: never }
+    | { fieldId: string; parentId?: never; stateKey?: never }
+    | { stateKey: string; parentId?: never; fieldId?: never }
   );
 
 export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
   parentId,
   fieldId,
-  formId,
+  stateKey,
   wizardState,
   externalData,
   isEditing,
   isDisabled,
 }) => {
   const fields: WizardField[] = React.useMemo(() => {
-    if (formId) {
-      return wizardState.fields.filter((f) => f.formId === formId);
+    if (stateKey) {
+      return wizardState.fields.filter((f) => f.stateKey === stateKey);
     }
     if (fieldId) {
       return wizardState.fields.filter((f) => f.id === fieldId);
     }
     return wizardState.fields.filter((f) => f.parentId === parentId);
-  }, [parentId, fieldId, formId, wizardState.fields]);
+  }, [parentId, fieldId, stateKey, wizardState.fields]);
 
   return (
     <>
@@ -49,19 +49,19 @@ export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
         return (
           <React.Fragment key={field.id}>
             <FieldComponent
-              id={getFormId(field)}
+              id={getStateKey(field)}
               value={resolveFieldValue(field, wizardState.state)}
-              initialValue={wizardState.initialData?.[getFormId(field)]}
+              initialValue={wizardState.initialData?.[getStateKey(field)]}
               onChange={(value: unknown) => {
                 wizardState.dispatch({
                   type: 'setFieldData',
-                  payload: { id: getFormId(field), data: value },
+                  payload: { id: getStateKey(field), data: value },
                 });
               }}
               externalData={externalData?.[field.id] ?? undefined}
               dependencies={getFieldDependencies(field, wizardState.state)}
               isEditing={isEditing}
-              isDisabled={isDisabled || hasDisabledOverride(wizardState.state[getFormId(field)])}
+              isDisabled={isDisabled || hasDisabledOverride(wizardState.state[getStateKey(field)])}
             />
           </React.Fragment>
         );

--- a/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/GenericFieldRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { resolveFieldValue, type GenericFieldProps, WizardField } from '../types';
 import type { UseModelDeploymentWizardState } from '../useDeploymentWizard';
 import type { ExternalDataMap } from '../ExternalDataLoader';
-import { getFieldDependencies } from '../dynamicFormUtils';
+import { getFieldDependencies, getFormId } from '../dynamicFormUtils';
 
 const hasDisabledOverride = (value: unknown): value is { isDisabled: boolean } =>
   typeof value === 'object' &&
@@ -17,22 +17,30 @@ type CommonProps = {
 } & GenericFieldProps;
 
 type GenericFieldRendererProps = CommonProps &
-  ({ parentId: string; fieldId?: never } | { fieldId: string; parentId?: never });
+  (
+    | { parentId: string; fieldId?: never; formId?: never }
+    | { fieldId: string; parentId?: never; formId?: never }
+    | { formId: string; parentId?: never; fieldId?: never }
+  );
 
 export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
   parentId,
   fieldId,
+  formId,
   wizardState,
   externalData,
   isEditing,
   isDisabled,
 }) => {
   const fields: WizardField[] = React.useMemo(() => {
+    if (formId) {
+      return wizardState.fields.filter((f) => f.formId === formId);
+    }
     if (fieldId) {
       return wizardState.fields.filter((f) => f.id === fieldId);
     }
     return wizardState.fields.filter((f) => f.parentId === parentId);
-  }, [parentId, fieldId, wizardState.fields]);
+  }, [parentId, fieldId, formId, wizardState.fields]);
 
   return (
     <>
@@ -41,19 +49,19 @@ export const GenericFieldRenderer: React.FC<GenericFieldRendererProps> = ({
         return (
           <React.Fragment key={field.id}>
             <FieldComponent
-              id={field.id}
+              id={getFormId(field)}
               value={resolveFieldValue(field, wizardState.state)}
-              initialValue={wizardState.initialData?.[field.id]}
+              initialValue={wizardState.initialData?.[getFormId(field)]}
               onChange={(value: unknown) => {
                 wizardState.dispatch({
                   type: 'setFieldData',
-                  payload: { id: field.id, data: value },
+                  payload: { id: getFormId(field), data: value },
                 });
               }}
               externalData={externalData?.[field.id] ?? undefined}
               dependencies={getFieldDependencies(field, wizardState.state)}
               isEditing={isEditing}
-              isDisabled={isDisabled || hasDisabledOverride(wizardState.state[field.id])}
+              isDisabled={isDisabled || hasDisabledOverride(wizardState.state[getFormId(field)])}
             />
           </React.Fragment>
         );

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelFormatField.tsx
@@ -67,7 +67,7 @@ export const useModelFormatField = (
         return true;
       }
       const templateModelTypes = getModelTypesFromTemplate(template);
-      if (templateModelTypes.includes(modelType.type)) {
+      if (templateModelTypes.some((type) => type === modelType.type)) {
         return true;
       }
       return false;

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelServerTemplateSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelServerTemplateSelectField.tsx
@@ -9,12 +9,7 @@ import {
   Radio,
   Truncate,
 } from '@patternfly/react-core';
-import type {
-  HardwareProfileKind,
-  SupportedModelFormats,
-  TemplateKind,
-} from '@odh-dashboard/internal/k8sTypes';
-import { isCompatibleWithIdentifier } from '@odh-dashboard/internal/pages/projects/screens/spawner/spawnerUtils';
+import type { HardwareProfileKind, TemplateKind } from '@odh-dashboard/internal/k8sTypes';
 import { ScopedType } from '@odh-dashboard/internal/pages/modelServing/screens/const';
 import ProjectScopedPopover from '@odh-dashboard/internal/components/ProjectScopedPopover';
 import ProjectScopedIcon from '@odh-dashboard/internal/components/searchSelector/ProjectScopedIcon';
@@ -23,21 +18,9 @@ import {
   ProjectScopedSearchDropdown,
 } from '@odh-dashboard/internal/components/searchSelector/ProjectScopedSearchDropdown';
 import ProjectScopedToggleContent from '@odh-dashboard/internal/components/searchSelector/ProjectScopedToggleContent';
-import {
-  getModelTypesFromTemplate,
-  getServingRuntimeDisplayNameFromTemplate,
-  getServingRuntimeFromTemplate,
-  getServingRuntimeVersion,
-} from '@odh-dashboard/internal/pages/modelServing/customServingRuntimes/utils';
 import { IdentifierResourceType } from '@odh-dashboard/internal/types';
-import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
 import ServingRuntimeVersionLabel from '@odh-dashboard/internal/pages/modelServing/screens/ServingRuntimeVersionLabel';
-import { useProfileIdentifiers } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { ModelTypeFieldData } from './ModelTypeSelectField';
-import { useModelServingClusterSettings } from '../../../concepts/useModelServingClusterSettings';
-import { useWizardFieldFromExtension } from '../dynamicFormUtils';
-import { isModelServerTemplateField } from '../types';
 
 // Schema
 const ModelServerOptionSchema = z.object({
@@ -74,134 +57,10 @@ export const getAcceleratorIdentifierFromHardwareProfile = (
   )?.identifier;
 };
 
-// Hooks
 export type ModelServerSelectField = {
   data?: ModelServerSelectFieldData;
-  setData: (data: ModelServerSelectFieldData) => void;
-  options: ModelServerOption[]; // servingRuntimes filtered on 'generative' or 'predictive' model type
-};
-
-export const useModelServerSelectField = (
-  existingData?: { data: ModelServerSelectFieldData },
-  modelServerTemplates?: TemplateKind[], // this is already filtered on 'generative' or 'predictive' model type
-  modelFormat?: SupportedModelFormats,
-  modelType?: ModelTypeFieldData,
-  hardwareProfile?: HardwareProfileKind,
-): ModelServerSelectField => {
-  const { data: modelServingClusterSettings } = useModelServingClusterSettings();
-
-  const modelServerSelectExtension = useWizardFieldFromExtension(isModelServerTemplateField, {
-    modelType: { data: modelType },
-  });
-  const { dashboardNamespace } = useDashboardNamespace();
-
-  const [modelServerState, setModelServerState] = React.useState<
-    Omit<ModelServerSelectFieldData, 'suggestion'> | undefined
-  >(existingData?.data);
-
-  const profileIdentifiers = useProfileIdentifiers(hardwareProfile);
-
-  const previousModelType = React.useRef(modelType);
-  React.useEffect(() => {
-    if (previousModelType.current !== modelType) {
-      setModelServerState(existingData?.data);
-      previousModelType.current = modelType;
-    }
-  }, [modelType, existingData, setModelServerState]);
-
-  const suggestion = React.useMemo(() => {
-    const extensionSuggestion = modelServerSelectExtension?.suggestion?.(
-      modelServingClusterSettings,
-    );
-    if (extensionSuggestion) {
-      return extensionSuggestion;
-    }
-
-    let filteredTemplates = modelServerTemplates;
-    if (modelType) {
-      filteredTemplates = filteredTemplates?.filter((template) =>
-        getModelTypesFromTemplate(template).includes(modelType.type),
-      );
-    }
-    if (modelFormat) {
-      filteredTemplates = filteredTemplates?.filter((template) =>
-        getServingRuntimeFromTemplate(template)?.spec.supportedModelFormats?.some(
-          (format) => format.name === modelFormat.name && format.version === modelFormat.version,
-        ),
-      );
-    }
-    const accelerator = getAcceleratorIdentifierFromHardwareProfile(hardwareProfile);
-    if (accelerator) {
-      filteredTemplates = filteredTemplates?.filter((template) =>
-        isCompatibleWithIdentifier(accelerator, getServingRuntimeFromTemplate(template)),
-      );
-    }
-
-    if (filteredTemplates?.length === 1) {
-      const suggestedTemplate = filteredTemplates[0];
-      return {
-        name: suggestedTemplate.metadata.name,
-        namespace: suggestedTemplate.metadata.namespace,
-        label: getServingRuntimeDisplayNameFromTemplate(suggestedTemplate),
-        scope: suggestedTemplate.metadata.namespace === dashboardNamespace ? 'global' : 'project',
-        template: suggestedTemplate,
-      };
-    }
-    return undefined;
-    // We want dependencies to be specific to the values being used. If something else inside hardwareProfile changes, then it will recompute.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    modelServerTemplates,
-    modelFormat,
-    hardwareProfile?.spec.identifiers,
-    modelType,
-    modelServerSelectExtension,
-    modelServingClusterSettings,
-    dashboardNamespace,
-  ]);
-
-  const options = React.useMemo(() => {
-    const result: ModelServerOption[] = [];
-
-    result.push(...(modelServerSelectExtension?.extraOptions || []));
-
-    result.push(
-      ...(modelServerTemplates?.map(
-        (template) =>
-          ({
-            name: template.metadata.name,
-            namespace: template.metadata.namespace,
-            label: getServingRuntimeDisplayNameFromTemplate(template),
-            version: getServingRuntimeVersion(template),
-            compatibleWithHardwareProfile: profileIdentifiers.some((identifier) =>
-              isCompatibleWithIdentifier(identifier, getServingRuntimeFromTemplate(template)),
-            ),
-            scope: template.metadata.namespace === dashboardNamespace ? 'global' : 'project',
-            template,
-          } satisfies ModelServerOption),
-      ) || []),
-    );
-
-    return result;
-  }, [
-    modelServerSelectExtension?.extraOptions,
-    modelServerTemplates,
-    dashboardNamespace,
-    profileIdentifiers,
-  ]);
-
-  const isDirty =
-    existingData || modelServerState?.selection || modelServerState?.autoSelect !== undefined;
-  const autoSelect = (suggestion && !isDirty) || (modelServerState?.autoSelect && !!suggestion);
-  return {
-    data: {
-      selection: autoSelect ? suggestion : modelServerState?.selection,
-      autoSelect,
-      suggestion,
-    },
-    setData: setModelServerState,
-    options,
-  };
+  setData?: (data: ModelServerSelectFieldData) => void;
+  options?: ModelServerOption[];
 };
 
 // Component
@@ -227,7 +86,8 @@ const OptionDropdownLabel: React.FC<{ option: ModelServerOption }> = ({ option }
 );
 
 type ModelServerTemplateSelectFieldProps = {
-  modelServerState: ModelServerSelectField;
+  modelServerState: ModelServerSelectField &
+    Required<Pick<ModelServerSelectField, 'setData' | 'options'>>;
   isEditing?: boolean;
   label?: string;
 };

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -6,42 +6,61 @@ import { FieldValidationProps } from '@odh-dashboard/internal/hooks/useZodFormVa
 import { ZodErrorHelperText } from '@odh-dashboard/internal/components/ZodErrorFormHelperText';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
-import { ModelTypeLabel } from '../types';
+import {
+  isModelTypeFieldOverride,
+  ModelLocationData,
+  ModelTypeFieldOverride,
+  ModelTypeLabel,
+} from '../types';
+import { useWizardFieldOverrides } from '../dynamicFormUtils';
 
 // Schema
-
-const modelTypeValueSchema = z.enum(
-  [ServingRuntimeModelType.PREDICTIVE, ServingRuntimeModelType.GENERATIVE],
-  {
-    // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase
-    required_error: 'Select a model type.',
-  },
-);
-
-export type ModelTypeValue = z.infer<typeof modelTypeValueSchema>;
-
 export const modelTypeSelectFieldSchema = z.object({
-  type: modelTypeValueSchema,
+  type: z.string(),
   legacyVLLM: z.boolean(),
 });
 
 export type ModelTypeFieldData = z.infer<typeof modelTypeSelectFieldSchema>;
-export const isValidModelType = (value: string): value is ModelTypeValue =>
-  value === ServingRuntimeModelType.PREDICTIVE || value === ServingRuntimeModelType.GENERATIVE;
 
 // Hooks
 
 export type ModelTypeField = {
   data: ModelTypeFieldData | undefined;
   setData: (data: ModelTypeFieldData) => void;
+  externalData: {
+    data: {
+      extraOptions: ModelTypeFieldOverride['extraOption'][];
+    };
+  };
 };
-export const useModelTypeField = (existingData?: ModelTypeFieldData): ModelTypeField => {
+export const useModelTypeField = (
+  existingData?: ModelTypeFieldData,
+  modelLocationData?: ModelLocationData,
+  vLLMDeploymentOnMaaSEnabled?: boolean,
+): ModelTypeField => {
+  const overrideFormData = React.useMemo(
+    () => ({
+      modelLocationData: { data: modelLocationData },
+      devFeatureFlags: { vLLMDeploymentOnMaaS: vLLMDeploymentOnMaaSEnabled },
+    }),
+    [modelLocationData, vLLMDeploymentOnMaaSEnabled],
+  );
+  const modelTypeOverrides = useWizardFieldOverrides(isModelTypeFieldOverride, overrideFormData);
+
   const [modelType, setModelType] = React.useState<ModelTypeFieldData | undefined>(existingData);
 
-  return {
-    data: modelType,
-    setData: setModelType,
-  };
+  return React.useMemo(
+    () => ({
+      data: modelType,
+      setData: setModelType,
+      externalData: {
+        data: {
+          extraOptions: modelTypeOverrides.map((override) => override.extraOption),
+        },
+      },
+    }),
+    [modelType, setModelType, modelTypeOverrides],
+  );
 };
 
 // Component
@@ -53,6 +72,7 @@ type ModelTypeSelectFieldProps = {
   validationIssues?: ZodIssue[];
   isEditing?: boolean;
   isDisabled?: boolean;
+  externalData: ModelTypeField['externalData'];
 };
 export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
   modelType,
@@ -61,27 +81,34 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
   validationProps,
   validationIssues = [],
   isEditing,
+  externalData,
 }) => {
   const isVLLMOnMaaSEnabled = useIsAreaAvailable(SupportedArea.VLLM_ON_MAAS).status;
+
+  const options = React.useMemo(() => {
+    return [
+      {
+        key: ServingRuntimeModelType.PREDICTIVE,
+        label: ModelTypeLabel.PREDICTIVE,
+      },
+      {
+        key: ServingRuntimeModelType.GENERATIVE,
+        label: ModelTypeLabel.GENERATIVE,
+      },
+      ...externalData.data.extraOptions,
+    ];
+  }, [externalData.data.extraOptions]);
 
   return (
     <>
       <FormGroup fieldId="model-type-select" label="Model type" isRequired>
         <SimpleSelect
-          options={[
-            {
-              key: ServingRuntimeModelType.PREDICTIVE,
-              label: ModelTypeLabel.PREDICTIVE,
-            },
-            {
-              key: ServingRuntimeModelType.GENERATIVE,
-              label: ModelTypeLabel.GENERATIVE,
-            },
-          ]}
+          options={options}
           onChange={(key) => {
-            if (isValidModelType(key)) {
-              setModelType?.({ type: key, legacyVLLM: false });
-            }
+            setModelType?.({
+              type: key,
+              legacyVLLM: key === ServingRuntimeModelType.GENERATIVE && !isVLLMOnMaaSEnabled,
+            });
           }}
           onBlur={validationProps?.onBlur}
           placeholder="Select model type"

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelServerTemplateSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelServerTemplateSelectField.test.tsx
@@ -24,7 +24,7 @@ const mockOption: ModelServerOption = {
 
 const makeModelServerState = (
   overrides: Partial<ModelServerSelectField> = {},
-): ModelServerSelectField => ({
+): ModelServerSelectField & Required<Pick<ModelServerSelectField, 'setData' | 'options'>> => ({
   data: undefined,
   setData: jest.fn(),
   options: [],

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -1,16 +1,40 @@
 import React, { act } from 'react';
 import { render, screen, fireEvent, renderHook } from '@testing-library/react';
 import { type ZodIssue } from 'zod';
+import { useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
+import type { IsAreaAvailableStatus } from '@odh-dashboard/internal/concepts/areas/types';
 import { ServingRuntimeModelType } from '@odh-dashboard/internal/types';
+import { mockExtensions } from '../../../../__tests__/mockUtils';
 import {
   ModelTypeSelectField,
   modelTypeSelectFieldSchema,
   useModelTypeField,
-  isValidModelType,
 } from '../ModelTypeSelectField';
 import { ModelTypeLabel } from '../../types';
 
+jest.mock('@odh-dashboard/plugin-core');
+jest.mock('@odh-dashboard/internal/concepts/areas', () => ({
+  ...jest.requireActual('@odh-dashboard/internal/concepts/areas'),
+  useIsAreaAvailable: jest.fn(),
+}));
+
+const mockUseIsAreaAvailable = jest.mocked(useIsAreaAvailable);
+
+const mockAreaAvailabilityStatus = (status: boolean): IsAreaAvailableStatus => ({
+  status,
+  devFlags: null,
+  featureFlags: null,
+  reliantAreas: null,
+  requiredCapabilities: null,
+  requiredComponents: null,
+  customCondition: () => false,
+});
+
 describe('ModelTypeSelectField', () => {
+  beforeEach(() => {
+    mockExtensions([]);
+    mockUseIsAreaAvailable.mockReturnValue(mockAreaAvailabilityStatus(false));
+  });
   describe('Schema validation', () => {
     it('should validate predictive', () => {
       const result = modelTypeSelectFieldSchema.safeParse({
@@ -59,18 +83,6 @@ describe('ModelTypeSelectField', () => {
     });
   });
 
-  describe('isValidModelType', () => {
-    it('should return true for valid model types', () => {
-      expect(isValidModelType(ServingRuntimeModelType.PREDICTIVE)).toBe(true);
-      expect(isValidModelType(ServingRuntimeModelType.GENERATIVE)).toBe(true);
-    });
-
-    it('should return false for invalid model types', () => {
-      expect(isValidModelType('invalid')).toBe(false);
-      expect(isValidModelType('')).toBe(false);
-    });
-  });
-
   describe('useModelTypeField hook', () => {
     it('should initialize with undefined by default', () => {
       const { result } = renderHook(() => useModelTypeField());
@@ -107,7 +119,7 @@ describe('ModelTypeSelectField', () => {
     });
 
     it('should render with default props', () => {
-      render(<ModelTypeSelectField />);
+      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [] } }} />);
       expect(screen.getByRole('button')).toBeInTheDocument();
       expect(screen.getByText('Select model type')).toBeInTheDocument();
     });
@@ -116,13 +128,19 @@ describe('ModelTypeSelectField', () => {
       render(
         <ModelTypeSelectField
           modelType={{ type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false }}
+          externalData={{ data: { extraOptions: [] } }}
         />,
       );
       expect(screen.getByText(ModelTypeLabel.PREDICTIVE)).toBeInTheDocument();
     });
 
     it('should call setModelType on valid selection', async () => {
-      render(<ModelTypeSelectField setModelType={mockSetModelType} />);
+      render(
+        <ModelTypeSelectField
+          setModelType={mockSetModelType}
+          externalData={{ data: { extraOptions: [] } }}
+        />,
+      );
       const button = screen.getByRole('button');
 
       await act(async () => {
@@ -135,7 +153,7 @@ describe('ModelTypeSelectField', () => {
 
       expect(mockSetModelType).toHaveBeenCalledWith({
         type: ServingRuntimeModelType.GENERATIVE,
-        legacyVLLM: false,
+        legacyVLLM: true,
       });
     });
 
@@ -147,12 +165,17 @@ describe('ModelTypeSelectField', () => {
           path: [],
         },
       ];
-      render(<ModelTypeSelectField validationIssues={validationIssues} />);
+      render(
+        <ModelTypeSelectField
+          validationIssues={validationIssues}
+          externalData={{ data: { extraOptions: [] } }}
+        />,
+      );
       expect(screen.getByText('Select a model type.')).toBeInTheDocument();
     });
 
     it('should render both model type options', async () => {
-      render(<ModelTypeSelectField />);
+      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [] } }} />);
       const button = screen.getByRole('button');
 
       await act(async () => {
@@ -161,6 +184,22 @@ describe('ModelTypeSelectField', () => {
 
       expect(screen.getByText(ModelTypeLabel.PREDICTIVE)).toBeInTheDocument();
       expect(screen.getByText(ModelTypeLabel.GENERATIVE)).toBeInTheDocument();
+    });
+
+    it('should render extra options', async () => {
+      render(
+        <ModelTypeSelectField
+          externalData={{
+            data: { extraOptions: [{ key: 'extra-option', label: 'Extra Option' }] },
+          }}
+        />,
+      );
+      const button = screen.getByRole('button');
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(screen.getByText('Extra Option')).toBeInTheDocument();
     });
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/steps/AdvancedOptionsStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/AdvancedOptionsStep.tsx
@@ -52,7 +52,7 @@ export const AdvancedSettingsStepContent: React.FC<AdvancedSettingsStepContentPr
   // TODO: Clean up the stuff below related to KServe. Maybe move to an extension?
   const selectedModelServer = React.useMemo(() => {
     const templates = wizardState.state.modelFormatState.templatesFilteredForModelType;
-    const modelServerData = wizardState.state.modelServer.data;
+    const modelServerData = wizardState.state.modelServer?.data;
     if (!modelServerData || !templates || templates.length === 0) {
       return undefined;
     }
@@ -63,7 +63,7 @@ export const AdvancedSettingsStepContent: React.FC<AdvancedSettingsStepContentPr
     return template?.objects[0];
   }, [
     wizardState.state.modelFormatState.templatesFilteredForModelType,
-    wizardState.state.modelServer.data,
+    wizardState.state.modelServer?.data,
   ]);
 
   const getKServeContainer = (

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -51,7 +51,7 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
           />
         )}
         <GenericFieldRenderer
-          formId="modelServer"
+          stateKey="modelServer"
           wizardState={wizardState}
           externalData={externalData}
           isEditing={wizardState.initialData?.isEditing}

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -6,7 +6,6 @@ import ProjectSection from '../fields/ProjectSection';
 import { ModelServingHardwareProfileSection } from '../fields/ModelServingHardwareProfileSection';
 import { ModelFormatField } from '../fields/ModelFormatField';
 import { NumReplicasField } from '../fields/NumReplicasField';
-import ModelServerTemplateSelectField from '../fields/ModelServerTemplateSelectField';
 import { GenericFieldRenderer } from '../fields/GenericFieldRenderer';
 import { ExternalDataMap } from '../ExternalDataLoader';
 
@@ -21,8 +20,6 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   wizardState,
   externalData,
 }) => {
-  const vLLMDeploymentOnMaaS = wizardState.fields.some((field) => field.id === 'modelServer');
-
   if (!wizardState.loaded.modelDeploymentLoaded) {
     return <Spinner data-testid="spinner" />;
   }
@@ -53,19 +50,12 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
             isEditing={wizardState.initialData?.isEditing}
           />
         )}
-        {vLLMDeploymentOnMaaS ? (
-          <GenericFieldRenderer
-            fieldId="modelServer"
-            wizardState={wizardState}
-            externalData={externalData}
-            isEditing={wizardState.initialData?.isEditing}
-          />
-        ) : (
-          <ModelServerTemplateSelectField
-            modelServerState={wizardState.state.modelServer}
-            isEditing={wizardState.initialData?.isEditing && !!wizardState.initialData.modelServer}
-          />
-        )}
+        <GenericFieldRenderer
+          formId="modelServer"
+          wizardState={wizardState}
+          externalData={externalData}
+          isEditing={wizardState.initialData?.isEditing}
+        />
         <NumReplicasField replicaState={wizardState.state.numReplicas} />
       </FormSection>
     </Form>

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelSourceStep.tsx
@@ -79,6 +79,7 @@ export const ModelSourceStepContent: React.FC<ModelSourceStepProps> = ({
           isEditing={
             !wizardState.initialData?.modelTypeField ? false : wizardState.initialData.isEditing
           }
+          externalData={wizardState.state.modelType.externalData}
         />
       </FormSection>
     </Form>

--- a/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ReviewStep.tsx
@@ -254,7 +254,7 @@ const getStatusSections = (
         {
           key: 'modelServer',
           label: 'Deployment resource',
-          comp: (state) => state.modelServer.data?.selection?.label || 'Auto-selected',
+          comp: (state) => state.modelServer?.data?.selection?.label || 'Auto-selected',
         },
         {
           key: 'numReplicas',

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -278,17 +278,39 @@ export type WizardField<
   ) => WizardReviewSection[];
 };
 
+/**
+ * Resolves the effective field value from wizard state.
+ *
+ * Retrieves the stored value from state using the field's formId (or id as fallback),
+ * then applies the field's getFieldData transformation if defined.
+ *
+ * @param field The wizard field to resolve
+ * @param state The current wizard form state
+ * @returns The resolved field value, or undefined if not present or error occurred
+ */
 export const resolveFieldValue = (
   field: WizardField,
   state: WizardFormData['state'],
 ): unknown | undefined => {
-  const storedValue: unknown = getFormId(field) in state ? state[getFormId(field)] : undefined;
+  const formId = getFormId(field);
+  if (!(formId in state)) {
+    return undefined;
+  }
+
+  const storedValue: unknown = state[formId];
   if (storedValue == null) {
     return undefined;
   }
-  return field.reducerFunctions.getFieldData
-    ? field.reducerFunctions.getFieldData(storedValue, state)
-    : storedValue;
+
+  try {
+    return field.reducerFunctions.getFieldData
+      ? field.reducerFunctions.getFieldData(storedValue, state)
+      : storedValue;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error resolving field value for ${field.id}:`, error);
+    return undefined;
+  }
 };
 
 // actual fields

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -14,10 +14,11 @@ import type {
 import type { LabeledConnection } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
 import type { z } from 'zod';
+import { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect.js';
 import type {
   ModelServerOption,
+  ModelServerSelectField,
   ModelServerSelectFieldData,
-  useModelServerSelectField,
 } from './fields/ModelServerTemplateSelectField';
 import type { useModelTypeField } from './fields/ModelTypeSelectField';
 import type { useExternalRouteField } from './fields/ExternalRouteField';
@@ -35,6 +36,7 @@ import {
 } from './fields/CreateConnectionInputFields';
 import { useProjectSection } from './fields/ProjectSection';
 import { NIMModelLocationKey } from './fields/modelLocationFields/NIMModelLocation';
+import { getFormId } from './dynamicFormUtils';
 import type { ModelServingClusterSettings } from '../../concepts/useModelServingClusterSettings';
 
 export enum ConnectionTypeRefs {
@@ -157,10 +159,13 @@ export type WizardFormData = {
     runtimeArgs: ReturnType<typeof useRuntimeArgsField>;
     environmentVariables: ReturnType<typeof useEnvironmentVariablesField>;
     modelAvailability: ReturnType<typeof useModelAvailabilityFields>;
-    modelServer: ReturnType<typeof useModelServerSelectField>;
+    modelServer?: ModelServerSelectField;
     createConnectionData: ReturnType<typeof useCreateConnectionData>;
     deploymentStrategy: ReturnType<typeof useDeploymentStrategyField>;
     canCreateRoleBindings: boolean;
+    devFeatureFlags?: {
+      vLLMDeploymentOnMaaS: boolean;
+    };
   } & Record<string, unknown>;
 };
 
@@ -229,6 +234,7 @@ export type WizardField<
   Dependencies extends Record<string, unknown> = Record<string, unknown>,
 > = DeploymentWizardFieldBase<string> & {
   type: 'addition' | 'replacement';
+  formId?: string;
   parentId?: string;
   step?: 'modelSource' | 'modelDeployment' | 'advancedOptions' | 'summary'; // used for validation of the entire step. Ideally this should be dynamic from the parent field.
   reducerFunctions: {
@@ -246,7 +252,10 @@ export type WizardField<
       wizardState: RecursivePartial<WizardFormData['state']>,
     ) => WizardStateOverrides;
   };
-  shouldResetOnDependencyChange?: boolean;
+  shouldResetOnDependencyChange?: (
+    prevDependencies: Dependencies,
+    newDependencies: Dependencies,
+  ) => boolean;
   externalDataHook?: (dependencies?: Dependencies) => {
     data: ExternalData;
     loaded: boolean;
@@ -273,7 +282,7 @@ export const resolveFieldValue = (
   field: WizardField,
   state: WizardFormData['state'],
 ): unknown | undefined => {
-  const storedValue: unknown = field.id in state ? state[field.id] : undefined;
+  const storedValue: unknown = getFormId(field) in state ? state[getFormId(field)] : undefined;
   if (storedValue == null) {
     return undefined;
   }
@@ -284,6 +293,9 @@ export const resolveFieldValue = (
 
 // actual fields
 
+export type ModelTypeFieldOverride = DeploymentWizardFieldBase<'modelType'> & {
+  extraOption: SimpleSelectOption;
+};
 export type ModelServerTemplateField = DeploymentWizardFieldBase<'modelServerTemplate'> & {
   extraOptions?: ModelServerOption[];
   suggestion?: (
@@ -304,18 +316,23 @@ export type TokenAuthField = DeploymentWizardFieldBase<'tokenAuth'> & {
 // union type
 
 export type DeploymentWizardField =
+  | ModelTypeFieldOverride
   | ModelServerTemplateField
   | ModelAvailabilityField
   | ExternalRouteField
   | TokenAuthField
   | DeploymentStrategyField;
 
+export const isModelTypeFieldOverride = (
+  field: DeploymentWizardField,
+): field is ModelTypeFieldOverride => {
+  return field.id === 'modelType';
+};
 export const isModelServerTemplateField = (
   field: DeploymentWizardField,
 ): field is ModelServerTemplateField => {
   return field.id === 'modelServerTemplate';
 };
-
 export const isModelAvailabilityField = (
   field: DeploymentWizardField,
 ): field is ModelAvailabilityField => {

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -36,7 +36,7 @@ import {
 } from './fields/CreateConnectionInputFields';
 import { useProjectSection } from './fields/ProjectSection';
 import { NIMModelLocationKey } from './fields/modelLocationFields/NIMModelLocation';
-import { getFormId } from './dynamicFormUtils';
+import { getStateKey } from './dynamicFormUtils';
 import type { ModelServingClusterSettings } from '../../concepts/useModelServingClusterSettings';
 
 export enum ConnectionTypeRefs {
@@ -234,7 +234,7 @@ export type WizardField<
   Dependencies extends Record<string, unknown> = Record<string, unknown>,
 > = DeploymentWizardFieldBase<string> & {
   type: 'addition' | 'replacement';
-  formId?: string;
+  stateKey?: string;
   parentId?: string;
   step?: 'modelSource' | 'modelDeployment' | 'advancedOptions' | 'summary'; // used for validation of the entire step. Ideally this should be dynamic from the parent field.
   reducerFunctions: {
@@ -281,7 +281,7 @@ export type WizardField<
 /**
  * Resolves the effective field value from wizard state.
  *
- * Retrieves the stored value from state using the field's formId (or id as fallback),
+ * Retrieves the stored value from state using the field's stateKey (or id as fallback),
  * then applies the field's getFieldData transformation if defined.
  *
  * @param field The wizard field to resolve
@@ -292,12 +292,12 @@ export const resolveFieldValue = (
   field: WizardField,
   state: WizardFormData['state'],
 ): unknown | undefined => {
-  const formId = getFormId(field);
-  if (!(formId in state)) {
+  const stateKey = getStateKey(field);
+  if (!(stateKey in state)) {
     return undefined;
   }
 
-  const storedValue: unknown = state[formId];
+  const storedValue: unknown = state[stateKey];
   if (storedValue == null) {
     return undefined;
   }

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizard.ts
@@ -8,6 +8,8 @@ import {
   LimitNameResourceType,
 } from '@odh-dashboard/internal/concepts/k8s/K8sNameDescriptionField/utils';
 import { useAccessReview } from '@odh-dashboard/internal/api/index';
+import useIsAreaAvailable from '@odh-dashboard/internal/concepts/areas/useIsAreaAvailable';
+import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import { accessReviewResource } from './steps/AdvancedOptionsStep';
 import { useModelFormatField } from './fields/ModelFormatField';
 import { useModelTypeField } from './fields/ModelTypeSelectField';
@@ -18,7 +20,6 @@ import { useNumReplicasField } from './fields/NumReplicasField';
 import { useRuntimeArgsField } from './fields/RuntimeArgsField';
 import { useEnvironmentVariablesField } from './fields/EnvironmentVariablesField';
 import { useModelAvailabilityFields } from './fields/ModelAvailabilityFields';
-import { useModelServerSelectField } from './fields/ModelServerTemplateSelectField';
 import { type InitialWizardFormData, type WizardField, type WizardFormData } from './types';
 import { useCreateConnectionData } from './fields/CreateConnectionInputFields';
 import { useProjectSection } from './fields/ProjectSection';
@@ -52,6 +53,8 @@ export const useModelDeploymentWizard = (
   initialProjectName?: string | undefined,
   externalDataMap: ExternalDataMap = {},
 ): UseModelDeploymentWizardState => {
+  const vLLMDeploymentOnMaaSEnabled = useIsAreaAvailable(SupportedArea.VLLM_ON_MAAS).status;
+
   // Declare reducer state first so field hooks can access it
   // `fieldValues` are user-provided, `initialValues` are calculated by the reducer
   const [formReducerState, formReducerDispatch] = React.useReducer(wizardFormReducer, {
@@ -62,12 +65,12 @@ export const useModelDeploymentWizard = (
     () => ({
       ...formReducerState.initialValues,
       ...formReducerState.fieldValues,
+      ...{ devFeatureFlags: { vLLMDeploymentOnMaaS: vLLMDeploymentOnMaaSEnabled } },
     }),
-    [formReducerState.initialValues, formReducerState.fieldValues],
+    [formReducerState.initialValues, formReducerState.fieldValues, vLLMDeploymentOnMaaSEnabled],
   );
 
   // Step 1: Model Source
-  const modelType = useModelTypeField(initialData?.modelTypeField);
   const project = useProjectSection(initialProjectName);
 
   const [canCreateRoleBindings] = useAccessReview({
@@ -83,6 +86,11 @@ export const useModelDeploymentWizard = (
     project.projectName,
     initialData?.createConnectionData,
     modelLocationData.data,
+  );
+  const modelType = useModelTypeField(
+    initialData?.modelTypeField,
+    modelLocationData.data,
+    vLLMDeploymentOnMaaSEnabled,
   );
 
   // loaded state
@@ -105,17 +113,6 @@ export const useModelDeploymentWizard = (
     project.projectName,
   );
 
-  const modelServer = useModelServerSelectField(
-    initialData?.modelServer,
-    modelFormatState.templatesFilteredForModelType,
-    modelFormatState.modelFormat,
-    modelType.data,
-    hardwareProfileConfig.formData.selectedProfile,
-  );
-  const actualModelServer = React.useMemo(() => {
-    return formState.modelServer?.data ? formState.modelServer : modelServer;
-  }, [formState.modelServer, modelServer]);
-
   const numReplicas = useNumReplicasField(initialData?.numReplicas ?? undefined);
 
   // loaded state
@@ -132,13 +129,13 @@ export const useModelDeploymentWizard = (
   const externalRoute = useExternalRouteField(
     initialData?.externalRoute ?? undefined,
     modelType,
-    actualModelServer,
+    formState.modelServer,
   );
 
   const tokenAuthentication = useTokenAuthenticationField(
     initialData?.tokenAuthentication ?? undefined,
     modelType,
-    actualModelServer,
+    formState.modelServer,
     canCreateRoleBindings,
   );
 
@@ -149,7 +146,7 @@ export const useModelDeploymentWizard = (
   const deploymentStrategy = useDeploymentStrategyField(
     initialData?.deploymentStrategy ?? undefined,
     modelType,
-    actualModelServer,
+    formState.modelServer,
   );
 
   // Step 4: Summary
@@ -172,7 +169,6 @@ export const useModelDeploymentWizard = (
       runtimeArgs,
       environmentVariables,
       modelAvailability,
-      modelServer,
       deploymentStrategy,
       canCreateRoleBindings,
       ...formState,
@@ -191,7 +187,6 @@ export const useModelDeploymentWizard = (
       runtimeArgs,
       environmentVariables,
       modelAvailability,
-      modelServer,
       deploymentStrategy,
       canCreateRoleBindings,
       formState,

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
@@ -7,7 +7,7 @@ import type {
   WizardFormData,
   WizardStateOverrides,
 } from './types';
-import { getFieldDependencies, getFormId, useActiveFields } from './dynamicFormUtils';
+import { getFieldDependencies, getStateKey, useActiveFields } from './dynamicFormUtils';
 
 ///// Field type stuff
 
@@ -81,7 +81,7 @@ export const wizardFormReducer = (
         ...state,
         initialValues: {
           ...state.initialValues,
-          [getFormId(field)]: initialValue,
+          [getStateKey(field)]: initialValue,
         },
       };
     }
@@ -137,7 +137,8 @@ export const useDeploymentWizardReducer = (
           ...action,
           payload: {
             ...action.payload,
-            existingFieldData: action.payload.existingFieldData ?? initialData?.[getFormId(field)],
+            existingFieldData:
+              action.payload.existingFieldData ?? initialData?.[getStateKey(field)],
             dependencies:
               action.payload.dependencies ?? getFieldDependencies(field, mergedStateRef.current),
           },
@@ -156,7 +157,7 @@ export const useDeploymentWizardReducer = (
     for (const prevField of prevActiveFields.current) {
       const isGone = !activeFields.some((f) => f.id === prevField.id);
       if (isGone) {
-        dispatch({ type: 'clearFieldData', payload: { id: getFormId(prevField) } });
+        dispatch({ type: 'clearFieldData', payload: { id: getStateKey(prevField) } });
       }
     }
 
@@ -173,13 +174,13 @@ export const useDeploymentWizardReducer = (
           field.shouldResetOnDependencyChange &&
           field.shouldResetOnDependencyChange(prevDependencies, dependencies)
         ) {
-          dispatch({ type: 'clearFieldData', payload: { id: getFormId(field) } });
+          dispatch({ type: 'clearFieldData', payload: { id: getStateKey(field) } });
         }
         dispatch({
           type: 'initFieldData',
           payload: {
             field,
-            existingFieldData: initialData?.[getFormId(field)],
+            existingFieldData: initialData?.[getStateKey(field)],
             externalData: field.id in externalDataMap ? externalDataMap[field.id] : undefined,
             dependencies,
           },
@@ -194,7 +195,7 @@ export const useDeploymentWizardReducer = (
   const computedOverrides = React.useMemo((): WizardStateOverrides => {
     let overrides: WizardStateOverrides = {};
     for (const field of activeFields) {
-      const storedValue: unknown = formState[getFormId(field)];
+      const storedValue: unknown = formState[getStateKey(field)];
       if (storedValue == null) {
         continue;
       }

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardReducer.tsx
@@ -7,7 +7,7 @@ import type {
   WizardFormData,
   WizardStateOverrides,
 } from './types';
-import { getFieldDependencies, useActiveFields } from './dynamicFormUtils';
+import { getFieldDependencies, getFormId, useActiveFields } from './dynamicFormUtils';
 
 ///// Field type stuff
 
@@ -81,7 +81,7 @@ export const wizardFormReducer = (
         ...state,
         initialValues: {
           ...state.initialValues,
-          [field.id]: initialValue,
+          [getFormId(field)]: initialValue,
         },
       };
     }
@@ -137,7 +137,7 @@ export const useDeploymentWizardReducer = (
           ...action,
           payload: {
             ...action.payload,
-            existingFieldData: action.payload.existingFieldData ?? initialData?.[field.id],
+            existingFieldData: action.payload.existingFieldData ?? initialData?.[getFormId(field)],
             dependencies:
               action.payload.dependencies ?? getFieldDependencies(field, mergedStateRef.current),
           },
@@ -153,6 +153,13 @@ export const useDeploymentWizardReducer = (
   const prevMergedState = React.useRef<WizardFormState>(formState);
 
   React.useEffect(() => {
+    for (const prevField of prevActiveFields.current) {
+      const isGone = !activeFields.some((f) => f.id === prevField.id);
+      if (isGone) {
+        dispatch({ type: 'clearFieldData', payload: { id: getFormId(prevField) } });
+      }
+    }
+
     for (const field of activeFields) {
       const isNew = !prevActiveFields.current.some((f) => f.id === field.id);
 
@@ -161,25 +168,22 @@ export const useDeploymentWizardReducer = (
       const isDependenciesChanged = !isEqual(dependencies, prevDependencies);
 
       if (isNew || isDependenciesChanged) {
-        if (isDependenciesChanged && field.shouldResetOnDependencyChange) {
-          dispatch({ type: 'clearFieldData', payload: { id: field.id } });
+        if (
+          isDependenciesChanged &&
+          field.shouldResetOnDependencyChange &&
+          field.shouldResetOnDependencyChange(prevDependencies, dependencies)
+        ) {
+          dispatch({ type: 'clearFieldData', payload: { id: getFormId(field) } });
         }
         dispatch({
           type: 'initFieldData',
           payload: {
             field,
-            existingFieldData: initialData?.[field.id],
+            existingFieldData: initialData?.[getFormId(field)],
             externalData: field.id in externalDataMap ? externalDataMap[field.id] : undefined,
             dependencies,
           },
         });
-      }
-    }
-
-    for (const prevField of prevActiveFields.current) {
-      const isGone = !activeFields.some((f) => f.id === prevField.id);
-      if (isGone) {
-        dispatch({ type: 'clearFieldData', payload: { id: prevField.id } });
       }
     }
 
@@ -190,7 +194,7 @@ export const useDeploymentWizardReducer = (
   const computedOverrides = React.useMemo((): WizardStateOverrides => {
     let overrides: WizardStateOverrides = {};
     for (const field of activeFields) {
-      const storedValue: unknown = formState[field.id];
+      const storedValue: unknown = formState[getFormId(field)];
       if (storedValue == null) {
         continue;
       }

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -14,6 +14,7 @@ import { environmentVariablesFieldSchema } from './fields/EnvironmentVariablesFi
 import { modelServerSelectFieldSchema } from './fields/ModelServerTemplateSelectField';
 import { modelFormatFieldSchema } from './fields/ModelFormatField';
 import { isValidProjectName } from './fields/ProjectSection';
+import { getFormId } from './dynamicFormUtils';
 
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
@@ -52,11 +53,11 @@ export const useModelDeploymentWizardValidation = (
   );
   const modelDeploymentStepValidation = useZodFormValidation(
     {
-      modelServer: state.modelServer.data,
+      modelServer: state.modelServer?.data,
       modelFormatState: state.modelFormatState.modelFormat,
       numReplicas: state.numReplicas.data,
       ...step2Fields.reduce<Record<string, unknown>>((acc, field) => {
-        acc[field.id] = state[field.id];
+        acc[getFormId(field)] = resolveFieldValue(field, state);
         return acc;
       }, {}),
     },
@@ -66,7 +67,7 @@ export const useModelDeploymentWizardValidation = (
       numReplicas: numReplicasFieldSchema,
       ...step2Fields.reduce<Record<string, z.ZodTypeAny>>((acc, field) => {
         if (field.reducerFunctions.validationSchema) {
-          acc[field.id] = field.reducerFunctions.validationSchema;
+          acc[getFormId(field)] = field.reducerFunctions.validationSchema;
         }
         return acc;
       }, {}),
@@ -82,7 +83,7 @@ export const useModelDeploymentWizardValidation = (
       runtimeArgs: state.runtimeArgs.data,
       environmentVariables: state.environmentVariables.data,
       ...step3Fields.reduce<Record<string, unknown>>((acc, field) => {
-        acc[field.id] = resolveFieldValue(field, state);
+        acc[getFormId(field)] = resolveFieldValue(field, state);
         return acc;
       }, {}),
     },
@@ -93,7 +94,7 @@ export const useModelDeploymentWizardValidation = (
       environmentVariables: environmentVariablesFieldSchema,
       ...step3Fields.reduce<Record<string, z.ZodTypeAny>>((acc, field) => {
         if (field.reducerFunctions.validationSchema) {
-          acc[field.id] = field.reducerFunctions.validationSchema;
+          acc[getFormId(field)] = field.reducerFunctions.validationSchema;
         }
         return acc;
       }, {}),

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -11,7 +11,6 @@ import { tokenAuthenticationFieldSchema } from './fields/TokenAuthenticationFiel
 import { numReplicasFieldSchema } from './fields/NumReplicasField';
 import { runtimeArgsFieldSchema } from './fields/RuntimeArgsField';
 import { environmentVariablesFieldSchema } from './fields/EnvironmentVariablesField';
-import { modelServerSelectFieldSchema } from './fields/ModelServerTemplateSelectField';
 import { modelFormatFieldSchema } from './fields/ModelFormatField';
 import { isValidProjectName } from './fields/ProjectSection';
 import { getFormId } from './dynamicFormUtils';
@@ -53,18 +52,18 @@ export const useModelDeploymentWizardValidation = (
   );
   const modelDeploymentStepValidation = useZodFormValidation(
     {
-      modelServer: state.modelServer?.data,
-      modelFormatState: state.modelFormatState.modelFormat,
-      numReplicas: state.numReplicas.data,
+      numReplicas: state.numReplicas.data ?? 0,
+      ...(state.modelFormatState.isVisible && {
+        modelFormatState: state.modelFormatState.modelFormat,
+      }),
       ...step2Fields.reduce<Record<string, unknown>>((acc, field) => {
         acc[getFormId(field)] = resolveFieldValue(field, state);
         return acc;
       }, {}),
     },
     z.object({
-      modelServer: modelServerSelectFieldSchema,
-      modelFormatState: modelFormatFieldSchema,
       numReplicas: numReplicasFieldSchema,
+      ...(state.modelFormatState.isVisible && { modelFormatState: modelFormatFieldSchema }),
       ...step2Fields.reduce<Record<string, z.ZodTypeAny>>((acc, field) => {
         if (field.reducerFunctions.validationSchema) {
           acc[getFormId(field)] = field.reducerFunctions.validationSchema;

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -13,7 +13,7 @@ import { runtimeArgsFieldSchema } from './fields/RuntimeArgsField';
 import { environmentVariablesFieldSchema } from './fields/EnvironmentVariablesField';
 import { modelFormatFieldSchema } from './fields/ModelFormatField';
 import { isValidProjectName } from './fields/ProjectSection';
-import { getFormId } from './dynamicFormUtils';
+import { getStateKey } from './dynamicFormUtils';
 
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
@@ -57,7 +57,7 @@ export const useModelDeploymentWizardValidation = (
         modelFormatState: state.modelFormatState.modelFormat,
       }),
       ...step2Fields.reduce<Record<string, unknown>>((acc, field) => {
-        acc[getFormId(field)] = resolveFieldValue(field, state);
+        acc[getStateKey(field)] = resolveFieldValue(field, state);
         return acc;
       }, {}),
     },
@@ -66,7 +66,7 @@ export const useModelDeploymentWizardValidation = (
       ...(state.modelFormatState.isVisible && { modelFormatState: modelFormatFieldSchema }),
       ...step2Fields.reduce<Record<string, z.ZodTypeAny>>((acc, field) => {
         if (field.reducerFunctions.validationSchema) {
-          acc[getFormId(field)] = field.reducerFunctions.validationSchema;
+          acc[getStateKey(field)] = field.reducerFunctions.validationSchema;
         }
         return acc;
       }, {}),
@@ -82,7 +82,7 @@ export const useModelDeploymentWizardValidation = (
       runtimeArgs: state.runtimeArgs.data,
       environmentVariables: state.environmentVariables.data,
       ...step3Fields.reduce<Record<string, unknown>>((acc, field) => {
-        acc[getFormId(field)] = resolveFieldValue(field, state);
+        acc[getStateKey(field)] = resolveFieldValue(field, state);
         return acc;
       }, {}),
     },
@@ -93,7 +93,7 @@ export const useModelDeploymentWizardValidation = (
       environmentVariables: environmentVariablesFieldSchema,
       ...step3Fields.reduce<Record<string, z.ZodTypeAny>>((acc, field) => {
         if (field.reducerFunctions.validationSchema) {
-          acc[getFormId(field)] = field.reducerFunctions.validationSchema;
+          acc[getStateKey(field)] = field.reducerFunctions.validationSchema;
         }
         return acc;
       }, {}),

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -6,6 +6,7 @@ import type {
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import type {
+  DeploymentWizardFieldExtension,
   DeployedModelServingDetails,
   ModelServingExcludeDeploymentExtension,
   ModelServingPlatformWatchDeploymentsExtension,
@@ -20,6 +21,7 @@ const extensions: (
   | ModelServingPlatformWatchDeploymentsExtension<NIMDeployment>
   | DeployedModelServingDetails<NIMDeployment>
   | ModelServingExcludeDeploymentExtension
+  | DeploymentWizardFieldExtension
 )[] = [
   {
     type: 'app.area',
@@ -70,6 +72,16 @@ const extensions: (
     },
     flags: {
       required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field',
+    properties: {
+      platform: 'nim-wizard',
+      field: () =>
+        import('./src/wizardFields/overrides/NIMModelTypeOverride').then(
+          (m) => m.NIMModelTypeOverride,
+        ),
     },
   },
 ];

--- a/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
+++ b/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
@@ -1,0 +1,19 @@
+import { RecursivePartial } from '@odh-dashboard/internal/typeHelpers';
+import type {
+  ModelTypeFieldOverride,
+  WizardFormData,
+} from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
+
+const isNIMModelTypeActive = (wizardFormData: RecursivePartial<WizardFormData['state']>): boolean =>
+  wizardFormData.modelLocationData?.data?.type === NIMModelLocationKey;
+
+export const NIMModelTypeOverride: ModelTypeFieldOverride = {
+  id: 'modelType',
+  type: 'modifier',
+  isActive: isNIMModelTypeActive,
+  extraOption: {
+    key: 'NVIDIA NIM',
+    label: 'NVIDIA NIM',
+  },
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes https://redhat.atlassian.net/browse/RHOAIENG-60278

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
2 features added:
- Adds the "NVIDIA NIM" model type if NIM is selected
- Move the kserve serving runtime templates field to an extension in the kserve package. It relies on a generative or predictive model type being selected. So if NVIDIA NIM is selected, there is no field for this being activated (which we want)

Technical stuff:
- The main thing is I added a `field.formId` property, not sure how I feel about it. We can't have 2 fields with the same id, this messes up the init and cleanup. So to allow the unique id's, this `formId` will define where in the form's state to store the info. This allows multiple fields to be saved in the same state location, which makes subsequent fields easier to reference
  - The fix for this scenario: Generative is selected > loads the llmd/modelServer > change to predictive > the llmd/modelServer unloads and the kserve/modelServer loads in. If they had the same id, the form would see a field with the same id is still persisting, so it wouldn't re-init the data. It would leave stale info
- Misc updates to help, like when to reset the field (shouldResetOnDependenciesChange)
- I also hardened the vLLMOnMaaS feature flag and made it so we pass this in for some isActive logic for the fields

Followup required:
For the NIM image selection field, we need to override this field with the NIM option, forcing this value. Also disable it so a user can't change it

<img width="938" height="781" alt="Screenshot 2026-05-15 at 3 34 03 PM" src="https://github.com/user-attachments/assets/914e1fcc-b144-4b78-9dcf-aa97cb5554b1" />
<img width="908" height="812" alt="Screenshot 2026-05-15 at 3 34 09 PM" src="https://github.com/user-attachments/assets/c3b5a13c-d8f8-48f1-8f08-3d30a308f6ca" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Main NIM flow:
1. Enable `nimWizard` flag
2. Create a new deployment
3. Select NIM, go to select the model type, the NIM option should appear only for this
4. Go to the next step, see that the "Deployment resource" doesn't appear

Other flows:
1. Check the different variations of generative / legacy and with or without the vLLMonMaaS flag enabled
2. Make sure it all still works

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
All cypress tests are still passing without any changes so it's good

We need to setup a NIM mock test soon

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment resource (serving runtime) selection field to the model deployment wizard
  * Added NVIDIA NIM as a new model-type option

* **Improvements**
  * Model type selection accepts extension-provided extra options and external suggestions
  * Wizard state handling is more resilient to missing/optional fields
  * vLLM deployment on MaaS is now gated by a feature flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->