### PR TITLE
[RHOAIENG-51595] User Management Settings Redesign

### DIFF
--- a/frontend/src/concepts/userConfigs/__tests__/useWatchGroups.spec.tsx
+++ b/frontend/src/concepts/userConfigs/__tests__/useWatchGroups.spec.tsx
@@ -1,25 +1,20 @@
-import { act } from 'react';
 import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { GroupsConfig } from '#~/concepts/userConfigs/groupTypes';
 import { useWatchGroups } from '#~/concepts/userConfigs/useWatchGroups';
-import { getAuth, patchAuth, useGroups } from '#~/api';
+import { useGroups } from '#~/api';
 import useNotification from '#~/utilities/useNotification';
 import { GroupKind } from '#~/k8sTypes';
 import { mockGroup } from '#~/__mocks__/mockGroup';
 import { fetchAuthGroups } from '#~/concepts/userConfigs/utils';
-import { mockAuth } from '#~/__mocks__/mockAuth';
 
 jest.mock('#~/api', () => ({
   ...jest.requireActual('#~/api'),
-  getAuth: jest.fn(),
-  patchAuth: jest.fn(),
   useGroups: jest.fn(),
 }));
 jest.mock('#~/concepts/userConfigs/utils', () => ({
   ...jest.requireActual('#~/concepts/userConfigs/utils'),
   fetchAuthGroups: jest.fn(),
 }));
-// Mock the useNotification hook
 jest.mock('../../../utilities/useNotification', () => {
   const mock = {
     success: jest.fn(),
@@ -30,37 +25,34 @@ jest.mock('../../../utilities/useNotification', () => {
     default: jest.fn(() => mock),
   };
 });
-const getAuthMock = jest.mocked(getAuth);
-const patchAuthMock = jest.mocked(patchAuth);
+
 const fetchAuthGroupsMock = jest.mocked(fetchAuthGroups);
 const useNotificationMock = jest.mocked(useNotification);
 const useGroupsMock = jest.mocked(useGroups);
-const mockEmptyGroupSettings = {
+
+const mockEmptyGroupSettings: GroupsConfig = {
   adminGroups: [],
   allowedGroups: [],
 };
+
+const mockGroups: GroupKind[] = [mockGroup({ name: 'odh-admins' })];
 
 const createResult = (r: Partial<ReturnType<typeof useWatchGroups>>) =>
   Object.assign(
     {
       groupSettings: mockEmptyGroupSettings,
+      setGroupSettings: expect.any(Function),
+      availableGroups: mockGroups,
       loaded: true,
       isLoading: false,
-      isGroupSettingsChanged: false,
       loadError: undefined,
-      updateGroups: expect.any(Function),
-      setGroupSettings: expect.any(Function),
-      setIsGroupSettingsChanged: expect.any(Function),
     },
     r,
   );
 
 describe('useWatchGroups', () => {
   beforeEach(() => {
-    getAuthMock.mockImplementation(() => Promise.resolve(mockAuth()));
-    patchAuthMock.mockResolvedValue(mockAuth());
-    const groups: GroupKind[] = [mockGroup({ name: 'odh-admins' })];
-    useGroupsMock.mockImplementation(() => [groups, true, undefined]);
+    useGroupsMock.mockImplementation(() => [mockGroups, true, undefined]);
   });
 
   it('should fetch groups successfully', async () => {
@@ -74,56 +66,23 @@ describe('useWatchGroups', () => {
     expect(fetchAuthGroupsMock).toHaveBeenCalledTimes(1);
     expect(renderResult).hookToStrictEqual(createResult({ loaded: false, isLoading: true }));
     await renderResult.waitForNextUpdate();
-    expect(fetchAuthGroupsMock).toHaveBeenCalledTimes(1);
     expect(renderResult).hookToStrictEqual(createResult({ groupSettings: mockGroupSettings }));
     renderResult.rerender();
     expect(renderResult).hookToBeStable({
       groupSettings: true,
+      setGroupSettings: true,
+      availableGroups: true,
       loaded: true,
       isLoading: true,
-      isGroupSettingsChanged: true,
       loadError: true,
-      updateGroups: true,
-      setGroupSettings: true,
-      setIsGroupSettingsChanged: true,
     });
-
-    const mockUpdatedGroupSettings: GroupsConfig = {
-      adminGroups: [{ id: 'odh-admins', name: 'odh-admins', enabled: true }],
-      allowedGroups: [
-        { id: 'odh-admins', name: 'odh-admins', enabled: false },
-        { id: 'system:authenticated', name: 'system:authenticated', enabled: true },
-      ],
-    };
-    act(() => {
-      renderResult.result.current.setIsGroupSettingsChanged(true);
-    });
-    expect(renderResult).hookToStrictEqual(
-      createResult({ groupSettings: mockGroupSettings, isGroupSettingsChanged: true }),
-    );
-    act(() => {
-      renderResult.result.current.updateGroups(mockUpdatedGroupSettings);
-    });
-    expect(renderResult).hookToStrictEqual(
-      createResult({
-        groupSettings: mockGroupSettings,
-        isLoading: true,
-        isGroupSettingsChanged: true,
-      }),
-    );
-    await renderResult.waitForNextUpdate();
-    expect(renderResult).hookToStrictEqual(
-      createResult({ groupSettings: mockUpdatedGroupSettings }),
-    );
   });
 
-  it('should handle error', async () => {
-    fetchAuthGroupsMock.mockRejectedValue(new Error(`Error getting group settings`));
+  it('should handle fetch error', async () => {
+    fetchAuthGroupsMock.mockRejectedValue(new Error('Error getting group settings'));
     const renderResult = testHook(useWatchGroups)();
-    expect(fetchAuthGroupsMock).toHaveBeenCalledTimes(1);
     expect(renderResult).hookToStrictEqual(createResult({ loaded: false, isLoading: true }));
     await renderResult.waitForNextUpdate();
-    expect(fetchAuthGroupsMock).toHaveBeenCalledTimes(1);
     expect(renderResult).hookToStrictEqual(
       createResult({ loaded: false, loadError: new Error('Error getting group settings') }),
     );

--- a/frontend/src/concepts/userConfigs/useWatchGroups.tsx
+++ b/frontend/src/concepts/userConfigs/useWatchGroups.tsx
@@ -1,23 +1,21 @@
 import * as React from 'react';
+import { GroupKind } from '#~/k8sTypes';
 import { GroupsConfig } from '#~/concepts/userConfigs/groupTypes';
-import { fetchAuthGroups, updateAuthGroups } from '#~/concepts/userConfigs/utils';
+import { fetchAuthGroups } from '#~/concepts/userConfigs/utils';
 import useNotification from '#~/utilities/useNotification';
 import { useGroups } from '#~/api';
 
 export const useWatchGroups = (): {
   groupSettings: GroupsConfig;
+  setGroupSettings: (group: GroupsConfig) => void;
+  availableGroups: GroupKind[];
   loaded: boolean;
   isLoading: boolean;
-  isGroupSettingsChanged: boolean;
   loadError: Error | undefined;
-  updateGroups: (group: GroupsConfig) => void;
-  setGroupSettings: (group: GroupsConfig) => void;
-  setIsGroupSettingsChanged: (changed: boolean) => void;
 } => {
   const [loaded, setLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<Error | undefined>(undefined);
   const [isLoading, setIsLoading] = React.useState(false);
-  const [isGroupSettingsChanged, setIsGroupSettingsChanged] = React.useState(false);
   const notification = useNotification();
   const [groupSettings, setGroupSettings] = React.useState<GroupsConfig>({
     adminGroups: [],
@@ -25,61 +23,33 @@ export const useWatchGroups = (): {
   });
   const [groupsData, groupsDataLoaded] = useGroups();
 
-  const hasDirectAccessDataLoaded = groupsDataLoaded;
-
   React.useEffect(() => {
-    const fetchGroups = () => {
-      setIsLoading(true);
-      fetchAuthGroups(groupsData)
-        .then((groupConfig) => {
-          setGroupSettings(groupConfig);
-          setLoadError(undefined);
-          setLoaded(true);
-        })
-        .catch((error) => {
-          notification.error(`Error`, `Error getting group settings`);
-          setLoadError(error);
-          setLoaded(false);
-        })
-        .finally(() => {
-          setIsLoading(false);
-          setIsGroupSettingsChanged(false);
-        });
-    };
-
-    if (hasDirectAccessDataLoaded) {
-      fetchGroups();
+    if (!groupsDataLoaded) {
+      return;
     }
-  }, [notification, hasDirectAccessDataLoaded, groupsData]);
-
-  const updateGroups = React.useCallback(
-    (group: GroupsConfig) => {
-      setIsLoading(true);
-      updateAuthGroups(group, groupsData)
-        .then((groupsResponse) => {
-          setGroupSettings(groupsResponse);
-          notification.success('Group settings changes saved');
-        })
-        .catch((error) => {
-          setLoadError(error);
-          setLoaded(false);
-        })
-        .finally(() => {
-          setIsLoading(false);
-          setIsGroupSettingsChanged(false);
-        });
-    },
-    [groupsData, notification],
-  );
+    setIsLoading(true);
+    fetchAuthGroups(groupsData)
+      .then((groupConfig) => {
+        setGroupSettings(groupConfig);
+        setLoadError(undefined);
+        setLoaded(true);
+      })
+      .catch((error) => {
+        notification.error(`Error`, `Error getting group settings`);
+        setLoadError(error);
+        setLoaded(false);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [notification, groupsDataLoaded, groupsData]);
 
   return {
     groupSettings,
+    setGroupSettings,
+    availableGroups: groupsData,
     loaded,
     isLoading,
-    isGroupSettingsChanged,
     loadError,
-    updateGroups,
-    setGroupSettings,
-    setIsGroupSettingsChanged,
   };
 };

--- a/frontend/src/pages/groupSettings/GroupSettings.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettings.tsx
@@ -68,30 +68,23 @@ const GroupSettings: React.FC = () => {
       <Stack hasGutter>
         <StackItem>
           <GroupSettingsSection
-            title={`${ODH_PRODUCT_NAME} administrator groups`}
-            description={`These groups contain all ${ODH_PRODUCT_NAME} administrators.`}
-            infoMessage={`All cluster admins are automatically assigned as ${ODH_PRODUCT_NAME} administrators.`}
+            roleLabel="administrator"
             enabledGroupNames={enabledAdminGroups}
             availableGroups={availableGroups}
             onAdd={(name) => handleAdd(name, GroupsConfigField.ADMIN)}
             onRemove={(name) => handleRemove(name, GroupsConfigField.ADMIN)}
             isLoading={isLoading}
-            addButtonLabel="Add administrator group"
-            placeholderText="Select or type administrator group name"
             testId="data-science-administrator-groups"
           />
         </StackItem>
         <StackItem>
           <GroupSettingsSection
-            title={`${ODH_PRODUCT_NAME} user groups`}
-            description={`These groups contain all ${ODH_PRODUCT_NAME} users.`}
+            roleLabel="user"
             enabledGroupNames={enabledUserGroups}
             availableGroups={availableGroups}
             onAdd={(name) => handleAdd(name, GroupsConfigField.USER)}
             onRemove={(name) => handleRemove(name, GroupsConfigField.USER)}
             isLoading={isLoading}
-            addButtonLabel="Add user group"
-            placeholderText="Select or type user group name"
             testId="data-science-user-groups"
           />
         </StackItem>

--- a/frontend/src/pages/groupSettings/GroupSettings.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettings.tsx
@@ -1,69 +1,58 @@
 import * as React from 'react';
-import {
-  Alert,
-  Button,
-  HelperText,
-  HelperTextItem,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { Stack, StackItem } from '@patternfly/react-core';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
-import { isGroupEmpty } from '#~/utilities/utils';
 import { ODH_PRODUCT_NAME } from '#~/utilities/const';
-import SettingSection from '#~/components/SettingSection';
-import { MultiSelection, SelectionOptions } from '#~/components/MultiSelection';
 import { useWatchGroups } from '#~/concepts/userConfigs/useWatchGroups';
+import { updateAuthGroups } from '#~/concepts/userConfigs/utils';
 import TitleWithIcon from '#~/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '#~/concepts/design/utils';
-import { GroupsConfigField, GroupStatus } from '#~/concepts/userConfigs/groupTypes';
-
-const newGroupMessage = (value: string): string => `Define new group: "${value}"`;
+import { GroupsConfig, GroupsConfigField } from '#~/concepts/userConfigs/groupTypes';
+import useNotification from '#~/utilities/useNotification';
+import GroupSettingsSection from './GroupSettingsSection';
 
 const GroupSettings: React.FC = () => {
-  const {
-    groupSettings,
-    loaded,
-    isLoading,
-    isGroupSettingsChanged,
-    loadError,
-    updateGroups,
-    setGroupSettings,
-    setIsGroupSettingsChanged,
-  } = useWatchGroups();
+  const { groupSettings, setGroupSettings, availableGroups, loaded, isLoading, loadError } =
+    useWatchGroups();
+  const notification = useNotification();
 
-  const adminDesc = `Select the groups that contain all ${ODH_PRODUCT_NAME} administrators.`;
-  const userDesc = `Select the groups that contain all ${ODH_PRODUCT_NAME} users.`;
+  const enabledAdminGroups = groupSettings.adminGroups.filter((g) => g.enabled).map((g) => g.name);
+  const enabledUserGroups = groupSettings.allowedGroups.filter((g) => g.enabled).map((g) => g.name);
 
-  const handleSaveButtonClicked = async () => {
-    if (isLoading) {
-      return;
-    }
-    updateGroups(groupSettings);
-  };
+  const saveSettings = React.useCallback(
+    async (newSettings: GroupsConfig): Promise<void> => {
+      const updated = await updateAuthGroups(newSettings, availableGroups);
+      setGroupSettings(updated);
+      notification.success('Group settings changes saved');
+    },
+    [availableGroups, setGroupSettings, notification],
+  );
 
-  const handleMenuItemSelection = (newState: SelectionOptions[], field: GroupsConfigField) => {
-    const processGroup = (opt: SelectionOptions): GroupStatus => ({
-      id: String(opt.id),
-      name: opt.name,
-      enabled: opt.selected || false,
-    });
+  const handleAdd = React.useCallback(
+    (name: string, field: GroupsConfigField): Promise<void> => {
+      const key = field === GroupsConfigField.ADMIN ? 'adminGroups' : 'allowedGroups';
+      const newSettings: GroupsConfig = {
+        ...groupSettings,
+        [key]: [
+          ...groupSettings[key].filter((g) => g.name !== name),
+          { id: name, name, enabled: true },
+        ],
+      };
+      return saveSettings(newSettings);
+    },
+    [groupSettings, saveSettings],
+  );
 
-    switch (field) {
-      case GroupsConfigField.ADMIN:
-        setGroupSettings({
-          ...groupSettings,
-          adminGroups: newState.map(processGroup),
-        });
-        break;
-      case GroupsConfigField.USER:
-        setGroupSettings({
-          ...groupSettings,
-          allowedGroups: newState.map(processGroup),
-        });
-        break;
-    }
-    setIsGroupSettingsChanged(true);
-  };
+  const handleRemove = React.useCallback(
+    (name: string, field: GroupsConfigField): Promise<void> => {
+      const key = field === GroupsConfigField.ADMIN ? 'adminGroups' : 'allowedGroups';
+      const newSettings: GroupsConfig = {
+        ...groupSettings,
+        [key]: groupSettings[key].map((g) => (g.name === name ? { ...g, enabled: false } : g)),
+      };
+      return saveSettings(newSettings);
+    },
+    [groupSettings, saveSettings],
+  );
 
   return (
     <ApplicationsPage
@@ -78,88 +67,33 @@ const GroupSettings: React.FC = () => {
     >
       <Stack hasGutter>
         <StackItem>
-          <SettingSection
+          <GroupSettingsSection
             title={`${ODH_PRODUCT_NAME} administrator groups`}
-            testId="data-science-administrator-groups"
-            description={adminDesc}
-            footer={
-              <Alert
-                data-testid="data-science-administrator-info"
-                variant="info"
-                isInline
-                isPlain
-                title={`All cluster admins are automatically assigned as ${ODH_PRODUCT_NAME} administrators.`}
-              />
-            }
-          >
-            <MultiSelection
-              ariaLabel={adminDesc}
-              toggleTestId="group-setting-select"
-              value={groupSettings.adminGroups.map((g) => ({
-                id: g.id,
-                name: g.name,
-                selected: g.enabled,
-              }))}
-              setValue={(newState) => handleMenuItemSelection(newState, GroupsConfigField.ADMIN)}
-              selectionRequired
-              noSelectedOptionsMessage="One or more group must be selected"
-              popperProps={{ appendTo: document.body }}
-              isCreatable
-              createOptionMessage={newGroupMessage}
-              isCreateOptionOnTop
-            />
-            <HelperText>
-              <HelperTextItem>
-                Select from existing groups, or specify a new group name.
-              </HelperTextItem>
-            </HelperText>
-          </SettingSection>
-        </StackItem>
-        <StackItem>
-          <SettingSection
-            title={`${ODH_PRODUCT_NAME} user groups`}
-            description={userDesc}
-            testId="data-science-user-groups"
-          >
-            <MultiSelection
-              ariaLabel={userDesc}
-              toggleTestId="group-setting-select"
-              value={groupSettings.allowedGroups.map((g) => ({
-                id: g.id,
-                name: g.name,
-                selected: g.enabled,
-              }))}
-              setValue={(newState) => handleMenuItemSelection(newState, GroupsConfigField.USER)}
-              selectionRequired
-              noSelectedOptionsMessage="One or more group must be selected"
-              popperProps={{ appendTo: document.body }}
-              isCreatable
-              createOptionMessage={newGroupMessage}
-              isCreateOptionOnTop
-            />
-            <HelperText>
-              <HelperTextItem>
-                Select from existing groups, or specify a new group name.
-              </HelperTextItem>
-            </HelperText>
-          </SettingSection>
-        </StackItem>
-        <StackItem>
-          <Button
-            data-id="save-button"
-            data-testid="save-button"
-            isDisabled={
-              isLoading ||
-              !isGroupSettingsChanged ||
-              isGroupEmpty(groupSettings.adminGroups) ||
-              isGroupEmpty(groupSettings.allowedGroups)
-            }
-            variant="primary"
+            description={`These groups contain all ${ODH_PRODUCT_NAME} administrators.`}
+            infoMessage={`All cluster admins are automatically assigned as ${ODH_PRODUCT_NAME} administrators.`}
+            enabledGroupNames={enabledAdminGroups}
+            availableGroups={availableGroups}
+            onAdd={(name) => handleAdd(name, GroupsConfigField.ADMIN)}
+            onRemove={(name) => handleRemove(name, GroupsConfigField.ADMIN)}
             isLoading={isLoading}
-            onClick={handleSaveButtonClicked}
-          >
-            Save changes
-          </Button>
+            addButtonLabel="Add administrator group"
+            placeholderText="Select or type administrator group name"
+            testId="data-science-administrator-groups"
+          />
+        </StackItem>
+        <StackItem>
+          <GroupSettingsSection
+            title={`${ODH_PRODUCT_NAME} user groups`}
+            description={`These groups contain all ${ODH_PRODUCT_NAME} users.`}
+            enabledGroupNames={enabledUserGroups}
+            availableGroups={availableGroups}
+            onAdd={(name) => handleAdd(name, GroupsConfigField.USER)}
+            onRemove={(name) => handleRemove(name, GroupsConfigField.USER)}
+            isLoading={isLoading}
+            addButtonLabel="Add user group"
+            placeholderText="Select or type user group name"
+            testId="data-science-user-groups"
+          />
         </StackItem>
       </Stack>
     </ApplicationsPage>

--- a/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
@@ -173,7 +173,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                       />
                       {isDuplicate && (
                         <HelperText isLiveRegion className="pf-v6-u-mt-sm">
-                          <HelperTextItem variant="error">
+                          <HelperTextItem data-testid="duplicate-group-error" variant="error">
                             This group has already been added.
                           </HelperTextItem>
                         </HelperText>
@@ -181,7 +181,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                     </>
                   </Td>
                   <Td dataLabel="Date created" />
-                  <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+                  <Td isActionCell modifier="nowrap" className="pf-v6-u-text-align-right">
                     <Split>
                       <SplitItem>
                         <Button
@@ -219,7 +219,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                     <Content component="p">{row.name}</Content>
                   </Td>
                   <Td dataLabel="Date created">
-                    {createdDate && (
+                    {createdDate ? (
                       <Content component="p">
                         <Timestamp
                           date={createdDate}
@@ -231,9 +231,11 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                           {relativeTime(Date.now(), createdDate.getTime())}
                         </Timestamp>
                       </Content>
+                    ) : (
+                      '-'
                     )}
                   </Td>
-                  <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+                  <Td isActionCell modifier="nowrap" className="pf-v6-u-text-align-right">
                     {isLastGroup ? (
                       <Tooltip content="At least one group must be selected.">
                         <Button

--- a/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
@@ -107,7 +107,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
       setIsAdding(false);
       setNewGroupName('');
     } catch (e) {
-      setError(String(e));
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setIsSaving(false);
     }
@@ -251,7 +251,9 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                         variant="plain"
                         icon={<MinusCircleIcon />}
                         onClick={() => {
-                          onRemove(row.name).catch((e) => setError(String(e)));
+                          onRemove(row.name).catch((e) =>
+                            setError(e instanceof Error ? e.message : String(e)),
+                          );
                         }}
                       />
                     )}

--- a/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
@@ -1,0 +1,295 @@
+import * as React from 'react';
+import { CheckIcon, MinusCircleIcon, PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  HelperText,
+  HelperTextItem,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Title,
+  Timestamp,
+  TimestampTooltipVariant,
+  Tooltip,
+} from '@patternfly/react-core';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
+import { GroupKind } from '#~/k8sTypes';
+import { SortableData, Table } from '#~/components/table';
+import HeaderIcon from '#~/concepts/design/HeaderIcon';
+import { ProjectObjectType } from '#~/concepts/design/utils';
+import { formatDateForLocalTooltip, relativeTime } from '#~/utilities/time';
+import RoleBindingPermissionsNameInput from '#~/concepts/roleBinding/RoleBindingPermissionsNameInput';
+import { RoleBindingPermissionsRBType } from '#~/concepts/roleBinding/types';
+
+type GroupRow = {
+  name: string;
+  groupKind?: GroupKind;
+};
+
+const columns: SortableData<GroupRow>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    width: 40,
+    sortable: (a, b) => a.name.localeCompare(b.name),
+  },
+  {
+    field: 'date',
+    label: 'Date created',
+    width: 30,
+    info: {
+      popover:
+        'The date the group was created in OpenShift. This can differ from when the group was added to this list.',
+      ariaLabel: 'Date created help',
+    },
+    sortable: (a, b) =>
+      new Date(b.groupKind?.metadata.creationTimestamp ?? 0).getTime() -
+      new Date(a.groupKind?.metadata.creationTimestamp ?? 0).getTime(),
+  },
+];
+
+type GroupSettingsSectionProps = {
+  title: string;
+  description: string;
+  infoMessage?: string;
+  enabledGroupNames: string[];
+  availableGroups: GroupKind[];
+  onAdd: (name: string) => Promise<void>;
+  onRemove: (name: string) => Promise<void>;
+  isLoading: boolean;
+  addButtonLabel: string;
+  placeholderText: string;
+  testId?: string;
+};
+
+const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
+  title,
+  description,
+  infoMessage,
+  enabledGroupNames,
+  availableGroups,
+  onAdd,
+  onRemove,
+  isLoading,
+  addButtonLabel,
+  placeholderText,
+  testId,
+}) => {
+  const [isAdding, setIsAdding] = React.useState(false);
+  const [newGroupName, setNewGroupName] = React.useState('');
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | undefined>();
+
+  const rows: GroupRow[] = enabledGroupNames.map((name) => ({
+    name,
+    groupKind: availableGroups.find((g) => g.metadata.name === name),
+  }));
+
+  const typeAheadOptions = availableGroups
+    .map((g) => g.metadata.name)
+    .filter((name) => !enabledGroupNames.includes(name));
+
+  const isDuplicate = enabledGroupNames.includes(newGroupName);
+
+  const handleAdd = async () => {
+    if (!newGroupName || isDuplicate) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await onAdd(newGroupName);
+      setIsAdding(false);
+      setNewGroupName('');
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setNewGroupName('');
+  };
+
+  const isLastGroup = enabledGroupNames.length <= 1;
+
+  return (
+    <Stack hasGutter data-testid={testId}>
+      <StackItem>
+        <Flex
+          direction={{ default: 'row' }}
+          gap={{ default: 'gapSm' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+        >
+          <HeaderIcon type={ProjectObjectType.group} />
+          <FlexItem>
+            <Title headingLevel="h2" size="xl">
+              {title}
+            </Title>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <Content component="p">{description}</Content>
+      </StackItem>
+      {infoMessage && (
+        <StackItem>
+          <Alert
+            data-testid="data-science-administrator-info"
+            variant="info"
+            isInline
+            isPlain
+            title={infoMessage}
+          />
+        </StackItem>
+      )}
+      <StackItem>
+        <Table
+          variant="compact"
+          data={rows}
+          columns={columns}
+          data-testid={`group-settings-table ${title}`}
+          disableRowRenderSupport
+          footerRow={() =>
+            isAdding ? (
+              <Tbody>
+                <Tr>
+                  <Td dataLabel="Name">
+                    <>
+                      <RoleBindingPermissionsNameInput
+                        subjectKind={RoleBindingPermissionsRBType.GROUP}
+                        value={newGroupName}
+                        onChange={(val) => setNewGroupName(val)}
+                        onClear={() => setNewGroupName('')}
+                        placeholderText={placeholderText}
+                        typeAhead={typeAheadOptions}
+                      />
+                      {isDuplicate && (
+                        <HelperText isLiveRegion className="pf-v6-u-mt-sm">
+                          <HelperTextItem variant="error">
+                            This group has already been added.
+                          </HelperTextItem>
+                        </HelperText>
+                      )}
+                    </>
+                  </Td>
+                  <Td dataLabel="Date created" />
+                  <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+                    <Split>
+                      <SplitItem>
+                        <Button
+                          data-testid="save-new-group-button"
+                          aria-label="Save group"
+                          variant="link"
+                          icon={<CheckIcon />}
+                          isDisabled={isSaving || !newGroupName || isDuplicate}
+                          onClick={handleAdd}
+                        />
+                      </SplitItem>
+                      <SplitItem>
+                        <Button
+                          aria-label="Cancel add group"
+                          variant="plain"
+                          icon={<TimesIcon />}
+                          isDisabled={isSaving}
+                          onClick={handleCancel}
+                        />
+                      </SplitItem>
+                    </Split>
+                  </Td>
+                </Tr>
+              </Tbody>
+            ) : null
+          }
+          rowRenderer={(row) => {
+            const createdDate = row.groupKind?.metadata.creationTimestamp
+              ? new Date(row.groupKind.metadata.creationTimestamp)
+              : undefined;
+            return (
+              <Tbody key={row.name}>
+                <Tr>
+                  <Td dataLabel="Name">
+                    <Content component="p">{row.name}</Content>
+                  </Td>
+                  <Td dataLabel="Date created">
+                    {createdDate && (
+                      <Content component="p">
+                        <Timestamp
+                          date={createdDate}
+                          tooltip={{
+                            variant: TimestampTooltipVariant.custom,
+                            content: formatDateForLocalTooltip(createdDate),
+                          }}
+                        >
+                          {relativeTime(Date.now(), createdDate.getTime())}
+                        </Timestamp>
+                      </Content>
+                    )}
+                  </Td>
+                  <Td isActionCell modifier="nowrap" style={{ textAlign: 'right' }}>
+                    {isLastGroup ? (
+                      <Tooltip content="At least one group must be selected.">
+                        <Button
+                          data-testid={`remove-group-button ${row.name}`}
+                          aria-label={`Remove ${row.name}`}
+                          variant="plain"
+                          icon={<MinusCircleIcon />}
+                          isAriaDisabled
+                        />
+                      </Tooltip>
+                    ) : (
+                      <Button
+                        data-testid={`remove-group-button ${row.name}`}
+                        aria-label={`Remove ${row.name}`}
+                        variant="plain"
+                        icon={<MinusCircleIcon />}
+                        onClick={() => {
+                          onRemove(row.name).catch((e) => setError(String(e)));
+                        }}
+                      />
+                    )}
+                  </Td>
+                </Tr>
+              </Tbody>
+            );
+          }}
+        />
+      </StackItem>
+      {error && (
+        <StackItem>
+          <Alert
+            isInline
+            variant="danger"
+            title="Error"
+            actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
+          >
+            {error}
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <Button
+          data-testid="add-group-button"
+          variant="link"
+          isInline
+          icon={<PlusCircleIcon />}
+          iconPosition="left"
+          isDisabled={isLoading || isAdding}
+          onClick={() => setIsAdding(true)}
+          style={{ paddingLeft: 'var(--pf-t--global--spacer--lg)' }}
+        >
+          {addButtonLabel}
+        </Button>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default GroupSettingsSection;

--- a/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
+++ b/frontend/src/pages/groupSettings/GroupSettingsSection.tsx
@@ -24,8 +24,10 @@ import { SortableData, Table } from '#~/components/table';
 import HeaderIcon from '#~/concepts/design/HeaderIcon';
 import { ProjectObjectType } from '#~/concepts/design/utils';
 import { formatDateForLocalTooltip, relativeTime } from '#~/utilities/time';
+import { ODH_PRODUCT_NAME } from '#~/utilities/const';
 import RoleBindingPermissionsNameInput from '#~/concepts/roleBinding/RoleBindingPermissionsNameInput';
 import { RoleBindingPermissionsRBType } from '#~/concepts/roleBinding/types';
+import ContentModal from '#~/components/modals/ContentModal';
 
 type GroupRow = {
   name: string;
@@ -55,35 +57,36 @@ const columns: SortableData<GroupRow>[] = [
 ];
 
 type GroupSettingsSectionProps = {
-  title: string;
-  description: string;
-  infoMessage?: string;
+  roleLabel: 'administrator' | 'user';
   enabledGroupNames: string[];
   availableGroups: GroupKind[];
   onAdd: (name: string) => Promise<void>;
   onRemove: (name: string) => Promise<void>;
   isLoading: boolean;
-  addButtonLabel: string;
-  placeholderText: string;
   testId?: string;
 };
 
 const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
-  title,
-  description,
-  infoMessage,
+  roleLabel,
   enabledGroupNames,
   availableGroups,
   onAdd,
   onRemove,
   isLoading,
-  addButtonLabel,
-  placeholderText,
   testId,
 }) => {
+  const title = `${ODH_PRODUCT_NAME} ${roleLabel} groups`;
+  const description = `These groups contain all ${ODH_PRODUCT_NAME} ${roleLabel}s.`;
+  const infoMessage =
+    roleLabel === 'administrator'
+      ? `All cluster admins are automatically assigned as ${ODH_PRODUCT_NAME} administrators.`
+      : undefined;
   const [isAdding, setIsAdding] = React.useState(false);
   const [newGroupName, setNewGroupName] = React.useState('');
   const [isSaving, setIsSaving] = React.useState(false);
+  const [groupToRemove, setGroupToRemove] = React.useState<string | undefined>();
+  const [isRemoving, setIsRemoving] = React.useState(false);
+  const [removeError, setRemoveError] = React.useState<Error | undefined>();
   const [error, setError] = React.useState<string | undefined>();
 
   const rows: GroupRow[] = enabledGroupNames.map((name) => ({
@@ -101,6 +104,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
     if (!newGroupName || isDuplicate) {
       return;
     }
+    setError(undefined);
     setIsSaving(true);
     try {
       await onAdd(newGroupName);
@@ -168,7 +172,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                         value={newGroupName}
                         onChange={(val) => setNewGroupName(val)}
                         onClear={() => setNewGroupName('')}
-                        placeholderText={placeholderText}
+                        placeholderText={`Select or type ${roleLabel} group name`}
                         typeAhead={typeAheadOptions}
                       />
                       {isDuplicate && (
@@ -189,7 +193,7 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                           aria-label="Save group"
                           variant="link"
                           icon={<CheckIcon />}
-                          isDisabled={isSaving || !newGroupName || isDuplicate}
+                          isDisabled={isSaving || isRemoving || !newGroupName || isDuplicate}
                           onClick={handleAdd}
                         />
                       </SplitItem>
@@ -252,11 +256,8 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
                         aria-label={`Remove ${row.name}`}
                         variant="plain"
                         icon={<MinusCircleIcon />}
-                        onClick={() => {
-                          onRemove(row.name).catch((e) =>
-                            setError(e instanceof Error ? e.message : String(e)),
-                          );
-                        }}
+                        isDisabled={isSaving || isRemoving}
+                        onClick={() => setGroupToRemove(row.name)}
                       />
                     )}
                   </Td>
@@ -285,13 +286,63 @@ const GroupSettingsSection: React.FC<GroupSettingsSectionProps> = ({
           isInline
           icon={<PlusCircleIcon />}
           iconPosition="left"
-          isDisabled={isLoading || isAdding}
+          isDisabled={isLoading || isAdding || isRemoving}
           onClick={() => setIsAdding(true)}
-          style={{ paddingLeft: 'var(--pf-t--global--spacer--lg)' }}
+          className="pf-v6-u-pl-lg"
         >
-          {addButtonLabel}
+          {`Add ${roleLabel} group`}
         </Button>
       </StackItem>
+      {groupToRemove && (
+        <ContentModal
+          title={`Remove ${ODH_PRODUCT_NAME} ${roleLabel} group?`}
+          titleIconVariant="warning"
+          variant="small"
+          dataTestId="remove-group-modal"
+          onClose={() => {
+            setGroupToRemove(undefined);
+            setRemoveError(undefined);
+          }}
+          contents={
+            <>
+              The <strong>{groupToRemove}</strong> group will be removed from the {roleLabel} group
+              list. Members of this group will lose {roleLabel} access to {ODH_PRODUCT_NAME}.
+            </>
+          }
+          error={removeError}
+          alertTitle={`Error removing ${groupToRemove}`}
+          buttonActions={[
+            {
+              label: 'Remove',
+              variant: 'primary',
+              dataTestId: 'modal-remove-button',
+              isLoading: isRemoving,
+              isDisabled: isRemoving,
+              onClick: () => {
+                setRemoveError(undefined);
+                setIsRemoving(true);
+                onRemove(groupToRemove)
+                  .then(() => {
+                    setGroupToRemove(undefined);
+                  })
+                  .catch((e) => {
+                    setRemoveError(e instanceof Error ? e : new Error(String(e)));
+                  })
+                  .finally(() => setIsRemoving(false));
+              },
+            },
+            {
+              label: 'Cancel',
+              variant: 'link',
+              isDisabled: isRemoving,
+              onClick: () => {
+                setGroupToRemove(undefined);
+                setRemoveError(undefined);
+              },
+            },
+          ]}
+        />
+      )}
     </Stack>
   );
 };

--- a/packages/cypress/cypress/pages/userManagement.ts
+++ b/packages/cypress/cypress/pages/userManagement.ts
@@ -26,9 +26,10 @@ class GroupSettingSection extends Contextual<HTMLElement> {
   findGroupOption(name: string) {
     // Matches both a direct typeahead option ('rhods-admins')
     // and the creatable option shown when the name is not in the list ('Select "rhods-admins"')
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return this.find()
       .document()
-      .findByRole('option', { name: new RegExp(`^(Select "${name}"|${name})$`) });
+      .findByRole('option', { name: new RegExp(`^(Select "${escaped}"|${escaped})$`) });
   }
 
   findSaveNewGroupButton() {

--- a/packages/cypress/cypress/pages/userManagement.ts
+++ b/packages/cypress/cypress/pages/userManagement.ts
@@ -89,6 +89,14 @@ class UserManagement {
     return this;
   }
 
+  findRemoveGroupModal() {
+    return cy.findByTestId('remove-group-modal');
+  }
+
+  findModalRemoveButton() {
+    return cy.findByTestId('modal-remove-button');
+  }
+
   getAdministratorGroupSection() {
     return new GroupSettingSection(() => cy.findByTestId('data-science-administrator-groups'));
   }

--- a/packages/cypress/cypress/pages/userManagement.ts
+++ b/packages/cypress/cypress/pages/userManagement.ts
@@ -3,60 +3,62 @@ import { Contextual } from './components/Contextual';
 
 class GroupSettingSection extends Contextual<HTMLElement> {
   shouldHaveAdministratorGroupInfo() {
-    this.find().findByTestId('data-science-administrator-info');
+    this.find().findByTestId('data-science-administrator-info').should('exist');
     return this;
   }
 
-  clearMultiChipItem() {
-    this.find().findByRole('button', { name: 'Clear input value' }).click();
+  findGroupRow(name: string) {
+    return this.find().contains('td', name).closest('tr');
   }
 
-  findMultiGroupInput() {
-    return this.find().find('input');
+  findRemoveGroupButton(name: string) {
+    return this.find().findByTestId(`remove-group-button ${name}`);
   }
 
-  findMultiGroupOptions(name: string) {
-    return this.find().document().findByRole('option', { name });
+  findAddGroupButton() {
+    return this.find().findByTestId('add-group-button');
   }
 
-  private findChipGroup() {
-    return this.find().findByRole('list', { name: 'Current selections' });
+  findGroupNameInput() {
+    return this.find().findByRole('combobox');
   }
 
-  findChipItem(name: string | RegExp) {
-    return this.findChipGroup().find('li').contains('span', name);
+  findGroupOption(name: string) {
+    // Matches both a direct typeahead option ('rhods-admins')
+    // and the creatable option shown when the name is not in the list ('Select "rhods-admins"')
+    return this.find()
+      .document()
+      .findByRole('option', { name: new RegExp(`^(Select "${name}"|${name})$`) });
   }
 
-  removeChipItem(name: string) {
-    this.findChipGroup()
-      .find('li')
-      .findByRole('button', { name: `Close ${name}` })
-      .click();
+  findSaveNewGroupButton() {
+    return this.find().findByTestId('save-new-group-button');
   }
 
-  findErrorText() {
-    return this.find().findByTestId('group-selection-error-text');
+  findCancelAddGroupButton() {
+    return this.find().findByRole('button', { name: 'Cancel add group' });
   }
 
-  findMultiGroupSelectButton() {
-    return this.find().findByTestId('group-setting-select');
+  findDuplicateError() {
+    return this.find().findByText('This group has already been added.');
   }
 
-  selectMultiGroup(name: string) {
-    this.findMultiGroupSelectButton().click();
-    this.findMultiGroupOptions(name).click();
-  }
-
-  findWarningAlert(groupName: string) {
-    this.find()
-      .find('.pf-v6-c-alert.pf-m-inline.pf-m-warning')
-      .should('exist')
-      .contains(
-        `The group ${groupName} no longer exists in OpenShift and has been removed from the selected group list.`,
-      );
-    return this;
+  addGroup(name: string) {
+    this.findAddGroupButton().click();
+    this.findGroupNameInput().type(name);
+    this.findGroupOption(name).click();
+    // If the group is already in the table the save button will be aria-disabled.
+    // Cancel gracefully so the test can continue without failing.
+    this.findSaveNewGroupButton().then(($btn) => {
+      if ($btn.attr('aria-disabled') === 'true') {
+        this.findCancelAddGroupButton().click();
+      } else {
+        cy.wrap($btn).click();
+      }
+    });
   }
 }
+
 class UserManagement {
   visit(wait = true) {
     cy.visitWithLogin('/settings/user-management');
@@ -77,10 +79,6 @@ class UserManagement {
 
   findNavItem() {
     return appChrome.findNavItem({ name: 'User management', rootSection: 'Settings' });
-  }
-
-  findSubmitButton() {
-    return cy.findByTestId('save-button');
   }
 
   shouldHaveSuccessAlertMessage() {

--- a/packages/cypress/cypress/pages/userManagement.ts
+++ b/packages/cypress/cypress/pages/userManagement.ts
@@ -41,7 +41,7 @@ class GroupSettingSection extends Contextual<HTMLElement> {
   }
 
   findDuplicateError() {
-    return this.find().findByText('This group has already been added.');
+    return this.find().findByTestId('duplicate-group-error');
   }
 
   addGroup(name: string) {

--- a/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/clusterSettings/testAdminClusterSettings.cy.ts
@@ -267,7 +267,7 @@ describe('Verify that only the Cluster Admin can access Cluster Settings', () =>
 
       cy.step('Access Settings -> User management');
       userManagement.visit();
-      userManagement.findSubmitButton().should('exist');
+      userManagement.getAdministratorGroupSection().find().should('exist');
     },
   );
 });

--- a/packages/cypress/cypress/tests/e2e/settings/userManagement/testUnathorizedPermChange.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/userManagement/testUnathorizedPermChange.cy.ts
@@ -1,6 +1,6 @@
 import {
-  getGroupsConfig,
   restoreDefaultGroupsConfig,
+  updateGroupsConfig,
 } from '../../../../utils/oc_commands/groupConfig';
 import { HTPASSWD_CLUSTER_ADMIN_USER, LDAP_CONTRIBUTOR_USER } from '../../../../utils/e2eUsers';
 import { userManagement } from '../../../../pages/userManagement';
@@ -9,14 +9,8 @@ import { notFoundPage } from '../../../../pages/notFound';
 
 describe('Settings - User Management - Unauthorized Permission Change', () => {
   retryableBeforeEach(() => {
-    // Clear any existing sessions before each test
     cy.clearCookies();
     cy.clearLocalStorage();
-
-    // Use real groups config instead of mock
-    getGroupsConfig().then((result) => {
-      cy.wrap(result).as('groupsConfig');
-    });
   });
 
   after(() => {
@@ -28,50 +22,18 @@ describe('Settings - User Management - Unauthorized Permission Change', () => {
     'Set up initial permissions as admin',
     { tags: ['@Destructive', '@ODS-1660', '@Dashboard', '@NonConcurrent'] },
     () => {
-      // Start as admin user
       cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
+
+      // Set admin = rhods-admins only, user = rhods-users only — same end state as the original
+      // test which cleared all groups then selected specific ones before saving.
+      cy.step('Set admin groups to rhods-admins and user groups to rhods-users');
+      updateGroupsConfig('rhods-admins', 'rhods-users');
+
+      // Verify the new UI reflects the OC-commanded change
+      cy.step('Verify User Management page reflects the updated groups');
       userManagement.navigate();
-
-      // Set up initial permissions
-      const administratorGroupSection = userManagement.getAdministratorGroupSection();
-      const userGroupSection = userManagement.getUserGroupSection();
-
-      // Wait for the administrator group section to be fully loaded
-      administratorGroupSection.find().should('be.visible');
-
-      // Clear existing selections and type new group
-      administratorGroupSection
-        .findMultiGroupInput()
-        .should('be.visible')
-        .clear()
-        .should('have.value', '')
-        .type('rhods-admins{enter}');
-
-      // Verify the selection was made
-      administratorGroupSection.findMultiGroupInput().should('have.value', 'rhods-admins');
-
-      // Clear existing selections
-      userGroupSection.clearMultiChipItem();
-
-      // Select the group using the dropdown
-      userGroupSection.findMultiGroupSelectButton().click();
-      userGroupSection.findMultiGroupOptions('rhods-users').click();
-      // Click outside the dropdown to close it
-      cy.findByTestId('app-page-title').click();
-
-      // Wait for any animations and ensure dropdown is gone
-      cy.get('[role="listbox"]').should('not.exist');
-
-      // Verify selection by checking if the submit button becomes enabled
-      userManagement
-        .findSubmitButton()
-        .should('be.enabled', { timeout: 30000 })
-        .should('be.visible');
-      // Click the submit button
-      userManagement.findSubmitButton().click();
-
-      // Verify the success message appears
-      userManagement.shouldHaveSuccessAlertMessage();
+      userManagement.getAdministratorGroupSection().findGroupRow('rhods-admins').should('exist');
+      userManagement.getUserGroupSection().findGroupRow('rhods-users').should('exist');
     },
   );
 
@@ -82,11 +44,9 @@ describe('Settings - User Management - Unauthorized Permission Change', () => {
       cy.step('Login as unauthorized user');
       cy.visitWithLogin('/', LDAP_CONTRIBUTOR_USER);
 
-      cy.step('Attempt to access User Management');
-      // Try to access the settings page directly
+      cy.step('Attempt to access User Management directly');
       cy.visit('/settings/user-management', { failOnStatusCode: false });
 
-      // Verify we get the not found page
       cy.step('Verify unauthorized access shows not found page');
       notFoundPage.findNotFoundPage().should('exist');
       notFoundPage.findDescription().should('not.be.empty');

--- a/packages/cypress/cypress/tests/e2e/settings/userManagement/testUnauthorizedUserNotebookSpawnBlocked.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/userManagement/testUnauthorizedUserNotebookSpawnBlocked.cy.ts
@@ -1,50 +1,32 @@
-import { HTPASSWD_CLUSTER_ADMIN_USER, LDAP_CONTRIBUTOR_USER } from '../../../../utils/e2eUsers';
-import { userManagement } from '../../../../pages/userManagement';
+import { LDAP_CONTRIBUTOR_USER } from '../../../../utils/e2eUsers';
 import { header } from '../../../../pages/components/Header';
-import { restoreDefaultGroupsConfig } from '../../../../utils/oc_commands/groupConfig';
+import {
+  restoreDefaultGroupsConfig,
+  updateGroupsConfig,
+} from '../../../../utils/oc_commands/groupConfig';
 
 describe('Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook', () => {
+  before(() => {
+    // Restrict dashboard access to rhods-admins members only.
+    // Matches the original test which cleared all user groups then selected rhods-admins before saving.
+    // Admin groups are left at their default (rhods-admins) so cluster admin access is preserved.
+    cy.step('Set user (allowed) groups to rhods-admins only');
+    updateGroupsConfig('rhods-admins', 'rhods-admins');
+  });
+
+  after(() => {
+    cy.step('Restore default groups configuration');
+    restoreDefaultGroupsConfig();
+  });
+
   it(
-    'Remove Admin privileges and apply access to the Dashboard only to Admin',
-    // Note - this test should not executed alongside Smoke/Sanity as it has the potential to cause breakages within those tests
+    'Verify that the Non-admin user does not have access to Dashboard or Jupyter Notebooks',
+    // Note - this test should not be executed alongside Smoke/Sanity as it has the potential to cause breakages within those tests
     { tags: ['@Destructive', '@ODS-1680', '@Dashboard', '@NonConcurrent'] },
     () => {
-      // Authentication and navigation
-      cy.step('Log into the application');
-      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
-
-      // Navigate to User Management
-      cy.step('Navigate to User Management');
-      userManagement.navigate();
-
-      // Remove system:authenticated from the Data Science User Groups and apply rhods-admins only permissions
-      cy.step('Clear the current Data Science User Groups');
-      userManagement.getUserGroupSection().clearMultiChipItem();
-      const userGroupSection = userManagement.getUserGroupSection();
-
-      cy.step('Select rhods-admin and save it');
-      // Click the text field to open the dropdown
-      userGroupSection.findMultiGroupSelectButton().click();
-      // Click the 'rhods-admin' option from the dropdown
-      userGroupSection.findMultiGroupOptions('rhods-admins').click();
-      // Click outside the dropdown to close it (e.g., clicking on the page title)
-      cy.findByTestId('app-page-title').click();
-      // Submit the form
-      userManagement.findSubmitButton().click();
-      // Validate that changes were saved successfully
-      userManagement.shouldHaveSuccessAlertMessage();
-    },
-  );
-  it(
-    'Login as the Admin and verify that the user does not have acceess to any tabs/applications',
-    // Note - this test should not executed alongside Smoke/Sanity as it has the potential to cause breakages within those tests
-    { tags: ['@Destructive', '@ODS-1680', '@Dashboard', '@NonConcurrent'] },
-    () => {
-      // Authentication and navigation
-      cy.step('Log into the application as a Non-admin');
+      cy.step('Log into the application as a Non-admin user');
       cy.visitWithLogin('/', LDAP_CONTRIBUTOR_USER);
 
-      // Validate that the Dashboard and Jupyter Notebooks are not accessible
       cy.step('Verify that the Dashboard is not accessible');
       header.findUnauthorizedErrorSection().should('be.visible');
       header.findUnauthorizedErrorTitle().should('exist');
@@ -55,9 +37,4 @@ describe('Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook', () =>
       header.findUnauthorizedErrorTitle().should('exist');
     },
   );
-
-  after(() => {
-    cy.step('Restore default groups configuration');
-    restoreDefaultGroupsConfig();
-  });
 });

--- a/packages/cypress/cypress/tests/mocked/userManagement/userManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/userManagement/userManagement.cy.ts
@@ -73,6 +73,9 @@ describe('User Management', () => {
 
     adminSection.findRemoveGroupButton('odh-admins-1').click();
 
+    userManagement.findRemoveGroupModal().should('be.visible');
+    userManagement.findModalRemoveButton().click();
+
     cy.wait('@removeAdminGroup').then((interception) => {
       expect(interception.request.body).to.eql([
         { value: ['odh-admins'], op: 'replace', path: '/spec/adminGroups' },

--- a/packages/cypress/cypress/tests/mocked/userManagement/userManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/userManagement/userManagement.cy.ts
@@ -24,53 +24,133 @@ describe('User Management', () => {
     userManagement.visit();
   });
 
-  it('Administrator group setting', () => {
-    const administratorGroupSection = userManagement.getAdministratorGroupSection();
-    userManagement.findSubmitButton().should('be.disabled');
-    administratorGroupSection.findChipItem(/^odh-admins$/).should('exist');
-    administratorGroupSection.shouldHaveAdministratorGroupInfo();
-    administratorGroupSection.clearMultiChipItem();
-    administratorGroupSection.selectMultiGroup('odh-admins');
-    administratorGroupSection.findMultiGroupInput().type('odh-admin');
-    administratorGroupSection.findMultiGroupOptions('odh-admins-1').click();
-    administratorGroupSection.removeChipItem('odh-admins');
-    administratorGroupSection.findChipItem(/^odh-admins$/).should('not.exist');
-    administratorGroupSection.removeChipItem('odh-admins-1');
-    administratorGroupSection.findErrorText().should('exist');
-    administratorGroupSection.findMultiGroupOptions('odh-admins').click();
-    administratorGroupSection.findErrorText().should('not.exist');
-    userManagement.findSubmitButton().should('be.enabled');
+  it('should show existing enabled groups in both sections', () => {
+    const adminSection = userManagement.getAdministratorGroupSection();
+    const userSection = userManagement.getUserGroupSection();
+
+    adminSection.shouldHaveAdministratorGroupInfo();
+    adminSection.findGroupRow('odh-admins').should('exist');
+    userSection.findGroupRow('system:authenticated').should('exist');
   });
 
-  it('User group setting', () => {
-    const existingAllowedGroup = 'system:authenticated';
-    const newAllowedGroup = 'odh-admins';
+  it('should disable remove button when only one group remains', () => {
+    const adminSection = userManagement.getAdministratorGroupSection();
+    // Only 'odh-admins' is enabled in mockAuth — last group, remove must be aria-disabled
+    // (isAriaDisabled sets aria-disabled="true", not the native disabled attribute)
+    adminSection.findRemoveGroupButton('odh-admins').should('have.attr', 'aria-disabled', 'true');
+  });
 
-    const userGroupSection = userManagement.getUserGroupSection();
-    userManagement.findSubmitButton().should('be.disabled');
-    userGroupSection.findChipItem(existingAllowedGroup).should('exist');
-    userGroupSection.clearMultiChipItem();
-    userGroupSection.findErrorText().should('exist');
-    userGroupSection.selectMultiGroup(newAllowedGroup);
-    userGroupSection.findChipItem(new RegExp(`^${newAllowedGroup}$`)).should('exist');
-    userGroupSection.findMultiGroupSelectButton().click();
-    userManagement.findSubmitButton().should('be.enabled');
+  it('should add a group to the administrator section', () => {
+    const adminSection = userManagement.getAdministratorGroupSection();
 
-    const mockedAuth = mockAuth({ allowedGroups: [newAllowedGroup] });
-    cy.interceptK8s('PATCH', AuthModel, mockedAuth).as('saveGroupSetting');
+    const updatedAuth = mockAuth({ adminGroups: ['odh-admins', 'odh-admins-1'] });
+    cy.interceptK8s('PATCH', AuthModel, updatedAuth).as('saveAdminGroups');
 
-    userManagement.findSubmitButton().click();
-    cy.wait('@saveGroupSetting').then((interception) => {
+    adminSection.findAddGroupButton().click();
+    adminSection.findGroupNameInput().type('odh-admins-1');
+    adminSection.findGroupOption('odh-admins-1').click();
+    adminSection.findSaveNewGroupButton().click();
+
+    cy.wait('@saveAdminGroups').then((interception) => {
       expect(interception.request.body).to.eql([
-        { value: ['odh-admins'], op: 'replace', path: '/spec/adminGroups' },
-        { value: ['odh-admins'], op: 'replace', path: '/spec/allowedGroups' },
+        { value: ['odh-admins', 'odh-admins-1'], op: 'replace', path: '/spec/adminGroups' },
+        { value: ['system:authenticated'], op: 'replace', path: '/spec/allowedGroups' },
       ]);
-      expect(interception.response?.body.spec).to.eql({
-        adminGroups: ['odh-admins'],
-        allowedGroups: ['odh-admins'],
-      });
     });
     userManagement.shouldHaveSuccessAlertMessage();
+  });
+
+  it('should remove a group when multiple groups exist', () => {
+    // Re-mock with two admin groups so remove is not disabled
+    cy.interceptK8s(AuthModel, mockAuth({ adminGroups: ['odh-admins', 'odh-admins-1'] }));
+    cy.reload();
+    cy.findByTestId('app-page-title').should('have.text', 'User management');
+
+    const adminSection = userManagement.getAdministratorGroupSection();
+
+    const updatedAuth = mockAuth({ adminGroups: ['odh-admins'] });
+    cy.interceptK8s('PATCH', AuthModel, updatedAuth).as('removeAdminGroup');
+
+    adminSection.findRemoveGroupButton('odh-admins-1').click();
+
+    cy.wait('@removeAdminGroup').then((interception) => {
+      expect(interception.request.body).to.eql([
+        { value: ['odh-admins'], op: 'replace', path: '/spec/adminGroups' },
+        { value: ['system:authenticated'], op: 'replace', path: '/spec/allowedGroups' },
+      ]);
+    });
+    userManagement.shouldHaveSuccessAlertMessage();
+  });
+
+  it('should add a group to the user section', () => {
+    const userSection = userManagement.getUserGroupSection();
+
+    const updatedAuth = mockAuth({ allowedGroups: ['system:authenticated', 'odh-admins'] });
+    cy.interceptK8s('PATCH', AuthModel, updatedAuth).as('saveUserGroups');
+
+    userSection.findAddGroupButton().click();
+    userSection.findGroupNameInput().type('odh-admins');
+    userSection.findGroupOption('odh-admins').click();
+    userSection.findSaveNewGroupButton().click();
+
+    cy.wait('@saveUserGroups').then((interception) => {
+      expect(interception.request.body).to.eql([
+        { value: ['odh-admins'], op: 'replace', path: '/spec/adminGroups' },
+        {
+          value: ['system:authenticated', 'odh-admins'],
+          op: 'replace',
+          path: '/spec/allowedGroups',
+        },
+      ]);
+    });
+    userManagement.shouldHaveSuccessAlertMessage();
+  });
+
+  it('should add a custom group name not in the OCP groups list', () => {
+    // Simulates BYO OIDC group names or any name typed manually that is not a known K8s group.
+    // The typeahead shows 'Select "custom-oidc-group"' (create option) instead of a direct match.
+    const userSection = userManagement.getUserGroupSection();
+
+    const updatedAuth = mockAuth({ allowedGroups: ['system:authenticated', 'custom-oidc-group'] });
+    cy.interceptK8s('PATCH', AuthModel, updatedAuth).as('saveCustomGroup');
+
+    userSection.findAddGroupButton().click();
+    userSection.findGroupNameInput().type('custom-oidc-group');
+    // 'custom-oidc-group' is not in the K8s groups mock — dropdown shows 'Select "custom-oidc-group"'
+    userSection.findGroupOption('custom-oidc-group').click();
+    userSection.findSaveNewGroupButton().click();
+
+    cy.wait('@saveCustomGroup').then((interception) => {
+      expect(interception.request.body).to.eql([
+        { value: ['odh-admins'], op: 'replace', path: '/spec/adminGroups' },
+        {
+          value: ['system:authenticated', 'custom-oidc-group'],
+          op: 'replace',
+          path: '/spec/allowedGroups',
+        },
+      ]);
+    });
+    userManagement.shouldHaveSuccessAlertMessage();
+  });
+
+  it('should prevent adding a duplicate group', () => {
+    const adminSection = userManagement.getAdministratorGroupSection();
+
+    adminSection.findAddGroupButton().click();
+    adminSection.findGroupNameInput().type('odh-admins');
+    adminSection.findGroupOption('odh-admins').click();
+
+    adminSection.findDuplicateError().should('exist');
+    adminSection.findSaveNewGroupButton().should('be.disabled');
+  });
+
+  it('should cancel the add group row', () => {
+    const adminSection = userManagement.getAdministratorGroupSection();
+
+    adminSection.findAddGroupButton().click();
+    adminSection.findGroupNameInput().should('exist');
+    adminSection.findCancelAddGroupButton().click();
+    adminSection.findGroupNameInput().should('not.exist');
   });
 
   it('redirect from v2 to v3 route', () => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-51595

## Description

Redesigns the User Management settings page (`Settings > User management`) to align with the table-based permissions pattern used across the rest of the dashboard (e.g. Model Registry permissions, Project permissions).

**What changed:**

- Replaced the two multi-select chip dropdowns (admin groups / user groups) with two table sections, each showing enabled groups with **Name** and **Date created** columns.
- Changes save immediately on each add or remove — no more "Save changes" button.
- Inline add row: typeahead select (with create option for custom/BYO OIDC group names), check/cancel buttons, and duplicate detection with an accessible error message.
- Remove button per row; the last remaining group shows a disabled button with a tooltip ("At least one group must be selected.").
- `useWatchGroups` simplified to a pure fetch-only hook; mutation logic (`handleAdd`, `handleRemove`) lives in `GroupSettings.tsx` and calls `updateAuthGroups` directly.
- "Date created" column label (not "Date added") with an info `(?)` popover: *"The date the group was created in OpenShift. This can differ from when the group was added to this list."* — matches the convention used in `pages/projects/projectPermissions/columns.ts`.

**Deviations from the UX mockup — and why:**

| Mockup item | What we did instead | Reason |
|---|---|---|
| "Not seeing what you're looking for?" popover (explains 250-group cap) | Removed | The original 250-group crash ([RHOAIENG-32765](https://redhat.atlassian.net/browse/RHOAIENG-32765)) is already fixed — the SDK now paginates automatically and all groups load. The popover's premise ("some groups may not appear") is no longer accurate and would mislead users. |
| OCP group name validation via GET request | Removed | A cluster can run OCP groups **and** an external IdP simultaneously. Blocking on OCP group non-existence would produce false negatives for valid BYO OIDC/Keycloak group names. |
| "Date added" column label | Changed to **"Date created"** with info popover | The Auth CR stores group names as plain strings with no per-group timestamp. The only date available is the K8s `GroupKind.metadata.creationTimestamp` (when the group was created in OpenShift, not when it was added to this config). Labelling it "Date created" with an explanatory popover is honest; "Date added" would be misleading. Matches the pattern in `projectPermissions/columns.ts` which has the same issue and uses the same solution. |
| Lazy loading groups in batches of 250 on scroll | Not implemented | Out of scope for this redesign ticket. The root scalability bug is already fixed upstream. |

https://github.com/user-attachments/assets/2df20fbc-c11b-452e-bf75-b192977dc386

## How Has This Been Tested?

- Ran locally against a dev cluster at `localhost:4010`, verifying:
  - Admin and user group tables render correctly from the Auth CR.
  - Adding a group (known OCP group and custom BYO OIDC name) saves immediately and shows the success notification.
  - Removing a group saves immediately.
  - Duplicate detection shows an accessible error and disables the save button.
  - Last-group remove button is disabled with tooltip.
  - "Date created" column shows relative timestamps for K8s-backed groups.
- Mocked Cypress tests cover all UI flows (see Test Impact).
- E2E Cypress tests verified on a dev cluster.

## Test Impact

**Updated unit tests** (`useWatchGroups.spec.tsx`): updated to match the simplified hook API (removed `updateGroups`, `isGroupSettingsChanged`, `setIsGroupSettingsChanged`).

**New + rewritten Cypress mock tests** (`userManagement.cy.ts`) — 8 tests covering:
- Non-admin user cannot access the page
- Existing enabled groups appear in each table section
- Remove button is disabled when only one group remains
- Add group to admin section (verifies PATCH request body)
- Remove group when multiple exist (verifies PATCH request body)
- Add group to user section (verifies PATCH request body)
- Add a custom BYO OIDC group name via the "Select X" create option
- Duplicate group detection (error shown, save disabled)
- Cancel add row
- Redirect from legacy `/groupSettings` route

**Rewritten Cypress page object** (`userManagement.ts`): replaced all MultiSelection-based methods with table-based methods (`findGroupRow`, `findRemoveGroupButton`, `findAddGroupButton`, `findGroupNameInput`, `findGroupOption`, `findSaveNewGroupButton`, `findCancelAddGroupButton`, `findDuplicateError`, `addGroup`).

**Updated E2E tests**: both `testUnauthorizedUserNotebookSpawnBlocked.cy.ts` and `testUnathorizedPermChange.cy.ts` updated to use `updateGroupsConfig()` OC commands for atomic setup (same end state as original), avoiding cluster state pollution from leftover groups between test runs.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change. *(screen recording to be added before merge)*
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Group Settings: component-driven add/remove workflow, sortable group table with creation dates, and typeahead for adding groups.

* **Bug Fixes & Improvements**
  * Prevent duplicate adds, show inline errors, disable remove when only one group remains, improved modal confirmations and success notifications.

* **Tests**
  * Updated unit and Cypress tests and page helpers to match the new UI and verify add/remove behaviors and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->