### PR TITLE
RHOAIENG-62609: Complete LlamaStack→OGX rename in Cypress, mocked tests, and BFF

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -71,7 +71,7 @@ const initIntercepts = ({
         [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
         // Gen AI plugin registers PLUGIN_GEN_AI with this required component; without it the
         // save-as-ai-asset UI stays hidden while genAiStudio is still true in dashboard config.
-        [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
     }),
   );

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingLlmd.cy.ts
@@ -70,7 +70,7 @@ const initIntercepts = ({
     mockDscStatus({
       components: {
         [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-        [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
     }),
   );

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -63,7 +63,7 @@ describe('API Keys Page', () => {
       'GET /api/dsc/status',
       mockDscStatus({
         components: {
-          [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+          [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
         conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),
@@ -683,7 +683,7 @@ describe('API Keys Page (Admin)', () => {
       'GET /api/dsc/status',
       mockDscStatus({
         components: {
-          [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+          [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
         conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -30,7 +30,7 @@ const setupAuthPoliciesCommon = () => {
     'GET /api/dsc/status',
     mockDscStatus({
       components: {
-        [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
       conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
     }),

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasDeploymentWizard.cy.ts
@@ -40,7 +40,7 @@ describe('MaaS Deployment Wizard', () => {
       mockDscStatus({
         components: {
           [DataScienceStackComponent.K_SERVE]: { managementState: 'Managed' },
-          [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+          [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
         },
         conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
       }),

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -28,7 +28,7 @@ const setupCommonIntercepts = () => {
     'GET /api/dsc/status',
     mockDscStatus({
       components: {
-        [DataScienceStackComponent.LLAMA_STACK_OPERATOR]: { managementState: 'Managed' },
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
       },
       conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
     }),

--- a/packages/cypress/cypress/utils/oc_commands/genAi.ts
+++ b/packages/cypress/cypress/utils/oc_commands/genAi.ts
@@ -1,5 +1,5 @@
 import { pollUntilSuccess, waitForNamespace } from './baseCommands';
-import { waitForLlamaStackOperatorReady } from './llamaStackDistribution';
+import { waitForOGXReady } from './llamaStackDistribution';
 import { appChrome } from '../../pages/appChrome';
 import type { CommandLineResult } from '../../types';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
@@ -37,14 +37,14 @@ const buildPatchCommand = (resource: string, patchJson: object, namespace?: stri
 };
 
 /**
- * Set the LlamaStack operator management state.
+ * Set the OGX operator management state in the DataScienceCluster.
  */
-const setLlamaStackState = (state: 'Managed' | 'Removed'): Cypress.Chainable<CommandLineResult> => {
-  const patchSpec = { spec: { components: { llamastackoperator: { managementState: state } } } };
+const setComponentState = (state: 'Managed' | 'Removed'): Cypress.Chainable<CommandLineResult> => {
+  const patchSpec = { spec: { components: { ogx: { managementState: state } } } };
   return cy.exec(buildPatchCommand(DSC_RESOURCE, patchSpec)).then((result) => {
     if (result.exitCode !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
-      throw new Error(`Failed to set LlamaStack state to ${state}: ${maskedStderr}`);
+      throw new Error(`Failed to set OGX state to ${state}: ${maskedStderr}`);
     }
     return result;
   });
@@ -162,7 +162,7 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
 
 /**
  * Enable Gen AI backend resources without waiting for sidebar visibility.
- * Sets LlamaStack operator to Managed, waits for readiness, namespace,
+ * Sets OGX operator to Managed, waits for readiness, namespace,
  * enables Gen AI Studio flag, and polls for the feature flag.
  *
  * Useful for composition when a caller will perform its own sidebar check.
@@ -170,11 +170,11 @@ const waitForGenAiStudioInSidebar = (): Cypress.Chainable<boolean> => {
 export const enableGenAiBackend = (): Cypress.Chainable<Cypress.Exec> => {
   const namespace = getApplicationsNamespace();
 
-  cy.step('Set LlamaStack to Managed');
-  return setLlamaStackState('Managed')
+  cy.step('Set OGX component to Managed');
+  return setComponentState('Managed')
     .then(() => {
-      cy.step('Wait for LlamaStack operator to be ready');
-      return waitForLlamaStackOperatorReady();
+      cy.step('Wait for OGX operator to be ready');
+      return waitForOGXReady();
     })
     .then(() => {
       cy.step(`Wait for namespace ${namespace} to be created`);
@@ -191,19 +191,18 @@ export const enableGenAiBackend = (): Cypress.Chainable<Cypress.Exec> => {
 };
 
 /**
- * Poll until the DSC status reports llamastackoperator as Managed.
- * The dashboard frontend reads DSC status to evaluate the plugin-gen-ai area flag.
+ * Poll until the DSC status reports the OGX component as Managed.
  */
-const waitForDSCLlamaStackManaged = (): Cypress.Chainable<Cypress.Exec> =>
+const waitForDSCComponentManaged = (): Cypress.Chainable<Cypress.Exec> =>
   pollUntilSuccess(
-    `oc get ${DSC_RESOURCE} -o json | jq -e '.status.components.llamastackoperator.managementState == "Managed"'`,
-    'DSC status to reflect llamastackoperator as Managed',
+    `oc get ${DSC_RESOURCE} -o json | jq -e '.status.components.ogx.managementState == "Managed"'`,
+    'DSC status to reflect ogx as Managed',
     { maxAttempts: 60, pollIntervalMs: 5000 },
   );
 
 /**
  * Enable Gen AI features by patching the DataScienceCluster and ODHDashboardConfig resources.
- * Sets LlamaStack operator to Managed, waits for the operator to be ready,
+ * Sets OGX operator to Managed, waits for the operator to be ready,
  * waits for the namespace, enables Gen AI Studio, polls for the feature flag,
  * verifies DSC status, and finally polls until it appears in the sidebar.
  *
@@ -212,8 +211,8 @@ const waitForDSCLlamaStackManaged = (): Cypress.Chainable<Cypress.Exec> =>
 export const enableGenAiFeatures = (): Cypress.Chainable<boolean> => {
   return enableGenAiBackend()
     .then(() => {
-      cy.step('Verify DSC status reflects llamastackoperator as Managed');
-      return waitForDSCLlamaStackManaged();
+      cy.step('Verify DSC status reflects OGX component as Managed');
+      return waitForDSCComponentManaged();
     })
     .then(() => {
       cy.step('Wait for Gen AI Studio to appear in sidebar');
@@ -223,15 +222,15 @@ export const enableGenAiFeatures = (): Cypress.Chainable<boolean> => {
 
 /**
  * Disable Gen AI features by patching the DataScienceCluster and ODHDashboardConfig resources.
- * Sets LlamaStack operator to Removed and disables Gen AI Studio and Model as Service.
+ * Sets OGX operator to Removed and disables Gen AI Studio.
  *
  * @returns A Cypress chainable that resolves when both patches are applied successfully.
  */
 export const disableGenAiFeatures = (): Cypress.Chainable<CommandLineResult> => {
   const namespace = getApplicationsNamespace();
 
-  cy.step('Set LlamaStack to Removed');
-  return setLlamaStackState('Removed').then(() => {
+  cy.step('Set OGX component to Removed');
+  return setComponentState('Removed').then(() => {
     cy.step('Disable Gen AI Studio');
     return setGenAiStudioEnabled(false, namespace);
   });

--- a/packages/cypress/cypress/utils/oc_commands/llamaStackDistribution.ts
+++ b/packages/cypress/cypress/utils/oc_commands/llamaStackDistribution.ts
@@ -29,19 +29,18 @@ const DEFAULT_POLL_OPTIONS: Required<PollOptions> = {
 };
 
 /**
- * DSC condition names — older clusters use LlamaStackOperatorReady,
- * newer ones will surface OGXOperatorReady once the DSC is updated.
+ * DSC condition name for the OGX operator readiness.
  */
-const DSC_OPERATOR_CONDITIONS = ['LlamaStackOperatorReady', 'OGXOperatorReady'] as const;
+const DSC_OGX_CONDITION = 'OGXReady';
 
 /**
- * Wait for the LlamaStack operator to be ready by polling the DataScienceCluster status.
- * Checks for the LlamaStackOperatorReady condition to be True.
+ * Wait for the OGX operator to be ready by polling the DataScienceCluster status.
+ * Checks for the OGXReady condition to be True.
  *
  * @param options Polling options (maxAttempts, pollIntervalMs).
  * @returns A Cypress chainable that resolves when the operator is ready.
  */
-export const waitForLlamaStackOperatorReady = (
+export const waitForOGXReady = (
   options: PollOptions = {},
 ): Cypress.Chainable<CommandLineResult> => {
   const { maxAttempts, pollIntervalMs } = { ...DEFAULT_POLL_OPTIONS, ...options };
@@ -49,8 +48,7 @@ export const waitForLlamaStackOperatorReady = (
   const totalTimeout = maxAttempts * pollIntervalMs;
 
   const check = (attemptNumber = 1): Cypress.Chainable<CommandLineResult> => {
-    const conditionFilter = DSC_OPERATOR_CONDITIONS.map((c) => `@.type=="${c}"`).join(' || ');
-    const command = `oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(${conditionFilter})].status}'`;
+    const command = `oc get datasciencecluster default-dsc -o jsonpath='{.status.conditions[?(@.type=="${DSC_OGX_CONDITION}")].status}'`;
 
     return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
       const raw = result.stdout.trim();
@@ -58,20 +56,20 @@ export const waitForLlamaStackOperatorReady = (
       const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(1);
 
       if (isReady) {
-        cy.log(`✅ LlamaStackOperatorReady condition is True (after ${elapsedTime}s)`);
+        cy.log(`OGXReady condition is True (after ${elapsedTime}s)`);
         return cy.wrap(result);
       }
 
       if (attemptNumber >= maxAttempts) {
         throw new Error(
-          `LlamaStackOperatorReady condition not True after ${maxAttempts} attempts (${elapsedTime}s). Current status: ${
+          `OGXReady condition not True after ${maxAttempts} attempts (${elapsedTime}s). Current status: ${
             raw || 'not found'
           }`,
         );
       }
 
       cy.log(
-        `⏳ Waiting for LlamaStackOperatorReady (attempt ${attemptNumber}/${maxAttempts}, status: ${
+        `Waiting for OGXReady (attempt ${attemptNumber}/${maxAttempts}, status: ${
           raw || 'not found'
         }, elapsed: ${elapsedTime}s)`,
       );
@@ -80,7 +78,7 @@ export const waitForLlamaStackOperatorReady = (
     });
   };
 
-  cy.step(`Polling for LlamaStackOperatorReady condition (max ${totalTimeout / 1000}s)`);
+  cy.step(`Polling for OGXReady condition (max ${totalTimeout / 1000}s)`);
   return check();
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/mlflow.ts
+++ b/packages/cypress/cypress/utils/oc_commands/mlflow.ts
@@ -44,19 +44,16 @@ export const isMlflowOperatorManaged = (): Cypress.Chainable<boolean> =>
     });
 
 /**
- * Check if Gen AI (LlamaStack operator) is currently set to Managed in the DSC.
+ * Check if Gen AI (OGX operator) is currently set to Managed in the DSC.
  */
 export const isGenAiEnabled = (): Cypress.Chainable<boolean> =>
   cy
-    .exec(
-      `oc get ${DSC_RESOURCE} -o jsonpath="{.spec.components.llamastackoperator.managementState}"`,
-      { failOnNonZeroExit: false },
-    )
+    .exec(`oc get ${DSC_RESOURCE} -o jsonpath="{.spec.components.ogx.managementState}"`, {
+      failOnNonZeroExit: false,
+    })
     .then((result) => {
       if (result.exitCode !== 0) {
-        throw new Error(
-          `Failed to read llamastackoperator state: ${maskSensitiveInfo(result.stderr)}`,
-        );
+        throw new Error(`Failed to read ogx state: ${maskSensitiveInfo(result.stderr)}`);
       }
       return result.stdout.replace(/"/g, '').trim() === 'Managed';
     });
@@ -218,8 +215,8 @@ const logSidebarDiagnostics = (): void => {
     (resp) => {
       if (resp.status === 200 && resp.body?.components) {
         const mlflow = resp.body.components.mlflowoperator?.managementState ?? '(missing)';
-        const llama = resp.body.components.llamastackoperator?.managementState ?? '(missing)';
-        cy.log(`[DIAG] /api/dsc/status: mlflowoperator=${mlflow}, llamastackoperator=${llama}`);
+        const ogx = resp.body.components.ogx?.managementState ?? '(missing)';
+        cy.log(`[DIAG] /api/dsc/status: mlflowoperator=${mlflow}, ogx=${ogx}`);
       } else {
         cy.log(`[DIAG] /api/dsc/status: HTTP ${resp.status}`);
       }
@@ -549,7 +546,7 @@ export const disableMlflowFeatures = (
 
 /**
  * Enable all features required for Prompt Management:
- * 1. Enable Gen AI backend (LlamaStack operator, genAiStudio flag)
+ * 1. Enable Gen AI backend (OGX operator, genAiStudio flag)
  * 2. Enable MLflow backend (operator, CR, tracking pod readiness)
  * 3. Verify DSC status reflects both operators as Managed
  * 4. Single sidebar poll for "Prompts" nav item (confirms frontend picked up the state)
@@ -566,7 +563,7 @@ export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => 
     })
     .then(() => {
       cy.step('Verify DSC status reflects both operators as Managed');
-      return waitForDSCComponentsManaged(['llamastackoperator', 'mlflowoperator']);
+      return waitForDSCComponentsManaged(['ogx', 'mlflowoperator']);
     })
     .then(() => {
       cy.step('Establish browser session for remote entry check');
@@ -580,7 +577,7 @@ export const enablePromptManagementFeatures = (): Cypress.Chainable<boolean> => 
     .then(() => {
       cy.step('Wait for dashboard backend to reflect both operators as Managed');
       return waitForDashboardDSCStatus({
-        llamastackoperator: 'Managed',
+        ogx: 'Managed',
         mlflowoperator: 'Managed',
       });
     })

--- a/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_vectorstores_handler_test.go
@@ -83,6 +83,43 @@ func uploadTestFile(baseURL string) (string, error) {
 	return id, nil
 }
 
+// createVectorStoreWithRetry creates a vector store through the handler,
+// retrying on transient 502 errors from the OGX server during provider initialization.
+func createVectorStoreWithRetry(app *App, name string, client llamastack.LlamaStackClientInterface) (string, error) {
+	const maxRetries = 5
+	const retryDelay = 2 * time.Second
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		payload := CreateVectorStoreRequest{Name: name}
+		jsonData, _ := json.Marshal(payload)
+
+		req := httptest.NewRequest(http.MethodPost,
+			"/gen-ai/api/v1/vectorstores?namespace="+testutil.TestNamespace,
+			bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		identity := &integrations.RequestIdentity{Token: "test-token"}
+		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+		ctx = context.WithValue(ctx, constants.LlamaStackClientKey, client)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		app.LlamaStackCreateVectorStoreHandler(rr, req, nil)
+
+		if rr.Code == http.StatusCreated {
+			var resp VectorStoreResponse
+			if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+				return "", err
+			}
+			return resp.Data.(map[string]interface{})["id"].(string), nil
+		}
+
+		if attempt < maxRetries {
+			time.Sleep(retryDelay)
+		}
+	}
+	return "", fmt.Errorf("create vector store failed after %d retries", maxRetries)
+}
+
 var _ = Describe("LlamaStackListVectorStoresHandler", func() {
 	var app App
 
@@ -604,26 +641,10 @@ var _ = Describe("LlamaStackDeleteVectorStoreHandler", func() {
 		t := GinkgoT()
 		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.GetTestLlamaStackURL(), "token_mock", false, nil, "/v1")
 
-		// First create a vector store to delete
-		createPayload := CreateVectorStoreRequest{Name: "VS to Delete"}
-		jsonData, err := json.Marshal(createPayload)
-		assert.NoError(t, err)
+		vsID, err := createVectorStoreWithRetry(&app, "VS to Delete", llamaStackClient)
+		require.NoError(t, err, "setup: create vector store should succeed")
 
-		createReq := httptest.NewRequest(http.MethodPost, "/gen-ai/api/v1/vectorstores?namespace="+testutil.TestNamespace, bytes.NewBuffer(jsonData))
-		createReq.Header.Set("Content-Type", "application/json")
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		createCtx := context.WithValue(createReq.Context(), constants.RequestIdentityKey, identity)
-		createCtx = context.WithValue(createCtx, constants.LlamaStackClientKey, llamaStackClient)
-		createReq = createReq.WithContext(createCtx)
-
-		createRR := httptest.NewRecorder()
-		app.LlamaStackCreateVectorStoreHandler(createRR, createReq, nil)
-		require.Equal(t, http.StatusCreated, createRR.Code, "setup: create vector store should succeed")
-
-		var createResp VectorStoreResponse
-		err = json.Unmarshal(createRR.Body.Bytes(), &createResp)
-		assert.NoError(t, err)
-		vsID := createResp.Data.(map[string]interface{})["id"].(string)
 
 		// Now delete it
 		req := httptest.NewRequest(http.MethodDelete, constants.VectorStoresDeletePath+"?namespace=default&vector_store_id="+vsID, nil)
@@ -700,26 +721,10 @@ var _ = Describe("LlamaStackListVectorStoreFilesHandler", func() {
 		t := GinkgoT()
 		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.GetTestLlamaStackURL(), "token_mock", false, nil, "/v1")
 
-		// Create a vector store first to get a valid ID
-		createPayload := CreateVectorStoreRequest{Name: "VS for File List"}
-		jsonData, err := json.Marshal(createPayload)
-		assert.NoError(t, err)
+		vsID, err := createVectorStoreWithRetry(&app, "VS for File List", llamaStackClient)
+		require.NoError(t, err, "setup: create vector store should succeed")
 
-		createReq := httptest.NewRequest(http.MethodPost, "/gen-ai/api/v1/vectorstores?namespace="+testutil.TestNamespace, bytes.NewBuffer(jsonData))
-		createReq.Header.Set("Content-Type", "application/json")
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		createCtx := context.WithValue(createReq.Context(), constants.RequestIdentityKey, identity)
-		createCtx = context.WithValue(createCtx, constants.LlamaStackClientKey, llamaStackClient)
-		createReq = createReq.WithContext(createCtx)
-
-		createRR := httptest.NewRecorder()
-		app.LlamaStackCreateVectorStoreHandler(createRR, createReq, nil)
-		require.Equal(t, http.StatusCreated, createRR.Code, "setup: create vector store should succeed")
-
-		var createResp VectorStoreResponse
-		err = json.Unmarshal(createRR.Body.Bytes(), &createResp)
-		assert.NoError(t, err)
-		vsID := createResp.Data.(map[string]interface{})["id"].(string)
 
 		req := httptest.NewRequest(http.MethodGet, constants.VectorStoreFilesListPath+"?namespace=default&vector_store_id="+vsID, nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
@@ -749,26 +754,10 @@ var _ = Describe("LlamaStackListVectorStoreFilesHandler", func() {
 		t := GinkgoT()
 		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.GetTestLlamaStackURL(), "token_mock", false, nil, "/v1")
 
-		// Create a vector store first
-		createPayload := CreateVectorStoreRequest{Name: "VS for Param Test"}
-		jsonData, err := json.Marshal(createPayload)
-		assert.NoError(t, err)
+		vsID, err := createVectorStoreWithRetry(&app, "VS for Param Test", llamaStackClient)
+		require.NoError(t, err, "setup: create vector store should succeed")
 
-		createReq := httptest.NewRequest(http.MethodPost, "/gen-ai/api/v1/vectorstores?namespace="+testutil.TestNamespace, bytes.NewBuffer(jsonData))
-		createReq.Header.Set("Content-Type", "application/json")
 		identity := &integrations.RequestIdentity{Token: "test-token"}
-		createCtx := context.WithValue(createReq.Context(), constants.RequestIdentityKey, identity)
-		createCtx = context.WithValue(createCtx, constants.LlamaStackClientKey, llamaStackClient)
-		createReq = createReq.WithContext(createCtx)
-
-		createRR := httptest.NewRecorder()
-		app.LlamaStackCreateVectorStoreHandler(createRR, createReq, nil)
-		require.Equal(t, http.StatusCreated, createRR.Code, "setup: create vector store should succeed")
-
-		var createResp VectorStoreResponse
-		err = json.Unmarshal(createRR.Body.Bytes(), &createResp)
-		assert.NoError(t, err)
-		vsID := createResp.Data.(map[string]interface{})["id"].(string)
 
 		req := httptest.NewRequest(http.MethodGet, constants.VectorStoreFilesListPath+"?namespace=default&vector_store_id="+vsID+"&limit=10&order=desc&filter=completed", nil)
 		ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
@@ -844,25 +833,8 @@ var _ = Describe("LlamaStackDeleteVectorStoreFileHandler", func() {
 		llamaStackClient := app.llamaStackClientFactory.CreateClient(testutil.GetTestLlamaStackURL(), "token_mock", false, nil, "/v1")
 		identity := &integrations.RequestIdentity{Token: "test-token"}
 
-		// Create a vector store first
-		createPayload := CreateVectorStoreRequest{Name: "VS for File Delete"}
-		jsonData, err := json.Marshal(createPayload)
-		assert.NoError(t, err)
-
-		createReq := httptest.NewRequest(http.MethodPost, "/gen-ai/api/v1/vectorstores?namespace="+testutil.TestNamespace, bytes.NewBuffer(jsonData))
-		createReq.Header.Set("Content-Type", "application/json")
-		createCtx := context.WithValue(createReq.Context(), constants.RequestIdentityKey, identity)
-		createCtx = context.WithValue(createCtx, constants.LlamaStackClientKey, llamaStackClient)
-		createReq = createReq.WithContext(createCtx)
-
-		createRR := httptest.NewRecorder()
-		app.LlamaStackCreateVectorStoreHandler(createRR, createReq, nil)
-		require.Equal(t, http.StatusCreated, createRR.Code, "setup: create vector store should succeed")
-
-		var createResp VectorStoreResponse
-		err = json.Unmarshal(createRR.Body.Bytes(), &createResp)
-		assert.NoError(t, err)
-		vsID := createResp.Data.(map[string]interface{})["id"].(string)
+		vsID, err := createVectorStoreWithRetry(&app, "VS for File Delete", llamaStackClient)
+		require.NoError(t, err, "setup: create vector store should succeed")
 
 		// Upload a file (not added to the vector store)
 		fileResp, err := uploadTestFile(testutil.GetTestLlamaStackURL())

--- a/packages/gen-ai/bff/testdata/llamastack/requirements.txt
+++ b/packages/gen-ai/bff/testdata/llamastack/requirements.txt
@@ -7,5 +7,6 @@ pymilvus==2.6.9
 chardet==7.1.0
 ollama==0.6.1
 pypdf==6.9.0
+regex>=2024.11.6
 rich>=13
 setuptools>=75,<81

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -39,13 +39,9 @@ const extensions: (
       id: PLUGIN_GEN_AI,
       featureFlags: [GEN_AI_STUDIO],
       customCondition: ({ dscStatus }) =>
-        [
-          DataScienceStackComponent.LLAMA_STACK_OPERATOR,
-          DataScienceStackComponent.OGX_OPERATOR,
-        ].some((key) => {
-          const state = dscStatus?.components?.[key]?.managementState;
-          return state === 'Managed' || state === 'Unmanaged';
-        }),
+        ['Managed', 'Unmanaged'].includes(
+          dscStatus?.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
+        ),
     },
   },
   {


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHOAIENG-62609

## Description

Follow-up to #7403 — removes all remaining backward-compatible `llamastackoperator` references from Cypress E2E utilities, mocked test fixtures, frontend extension flags, and BFF test infrastructure. This is a clean break: only `ogx` is supported going forward.

### Changes

**Cypress E2E Utilities**
- `genAi.ts`: Renamed `setLlamaStackState` → `setComponentState`, patches `spec.components.ogx` only (no fallback). Renamed `waitForDSCLlamaStackManaged` → `waitForDSCComponentManaged`, polls `status.components.ogx` only. Updated all `cy.step()` messages.
- `llamaStackDistribution.ts`: Replaced `DSC_OPERATOR_CONDITIONS` array (`['LlamaStackOperatorReady', 'OGXOperatorReady']`) with single `DSC_OGX_CONDITION = 'OGXReady'`. Renamed `waitForLlamaStackOperatorReady` → `waitForOGXReady`.
- `mlflow.ts`: Updated `isGenAiEnabled()` to check `spec.components.ogx`, diagnostic logging to `resp.body.components.ogx`, `enablePromptManagementFeatures()` to use `['ogx', 'mlflowoperator']`, and `waitForDashboardDSCStatus()` to use `{ ogx: 'Managed' }`.

**Frontend**
- `extensions.ts`: Simplified `customCondition` from an array `.some()` checking both `LLAMA_STACK_OPERATOR` and `OGX_OPERATOR` to a direct `OGX_OPERATOR`-only check using concise arrow expression (fixes ESLint `explicit-module-boundary-types` lint error).

**Mocked Tests** (6 files)
- Updated DSC mock components from `DataScienceStackComponent.LLAMA_STACK_OPERATOR` → `DataScienceStackComponent.OGX_OPERATOR` in:
  - `maasApiKeys.cy.ts`, `maasSubscriptions.cy.ts`, `maasAuthPolicies.cy.ts`, `maasDeploymentWizard.cy.ts`
  - `modelServingDeploy.cy.ts`, `modelServingLlmd.cy.ts`

**BFF Test Infrastructure**
- `requirements.txt`: Added `regex>=2024.11.6` to override transitive dependency `regex==2019.12.9` (from `ogx → tiktoken → regex`) which fails to build on macOS ARM64 / Python 3.13.

### CI Failures Fixed

The following nightly E2E tests were timing out at 480s because they polled for `LlamaStackOperatorReady` / patched `spec.components.llamastackoperator`, which no longer exist on clusters running the renamed OGX operator:
- `Gen AI: serving runtime, model deployment (URI), and playground` (`testGenAi.cy.ts`)
- `Verify Prompt Management page` (`testPromptManagement.cy.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Gen AI test infrastructure to use the OGX operator for component management verification across model serving, deployment, and API key tests.
  * Replaced operator polling and status checks in test utilities to target OGX instead of LlamaStack components.
  * Updated frontend extension logic for Gen AI readiness checks.

* **Chores**
  * Added dependency constraint for test environment dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->