### PR TITLE
docs(feature-store): README, AGENTS.md

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -21,37 +21,31 @@ ODH Dashboard is a monorepo managed with npm workspaces and Turbo. It provides t
 
 ### Feature Plugin Packages (`packages/`)
 
-Feature packages provide extensions and are discovered by `discoverPluginPackages.js`. They fall into two categories based on how they are built and loaded:
+Most feature packages are **Module Federation remotes** that get dynamically loaded into the main frontend at runtime. Some are **bundled libraries** that are compiled directly into the host bundle at build time — they register extensions via `package.json` exports but have no separate webpack config or dev server.
 
 #### Module Federation Remotes
 
-These packages have a `module-federation` config in `package.json`, their own webpack build under `frontend/config/`, and produce a `remoteEntry.js` that is loaded dynamically at runtime:
-
+- `gen-ai` — Gen AI / LLM features (has Go BFF)
+- `model-registry` — Model Registry UI (has Go BFF)
+- `model-serving` — Model Serving UI
+- `model-serving-backport` — Model serving backport compatibility
+- `model-training` — Model training UI
+- `maas` — Model-as-a-Service (has Go BFF)
+- `notebooks` — Notebooks management
+- `kserve` — KServe integration
 - `automl` — AutoML features (has Go BFF)
 - `autorag` — AutoRAG features (has Go BFF)
 - `eval-hub` — Evaluation Hub (has Go BFF)
-- `gen-ai` — Gen AI / LLM features (has Go BFF)
-- `maas` — Model-as-a-Service (has Go BFF)
+- `llmd-serving` — LLM serving
 - `mlflow` — MLflow integration (has Go BFF)
 - `mlflow-embedded` — Embedded MLflow integration
 - `model-registry` — Model Registry UI (has Go BFF)
 - `notebooks` — Notebooks management
 - `observability` — Observability features
 
-#### Bundled Plugin Packages
+#### Bundled Library Packages
 
-These packages export extensions but have **no** `module-federation` config. They are compiled directly into the host bundle at build time — no separate webpack build, no `remoteEntry.js`, no standalone dev server:
-
-- `feature-store` — Feature Store
-- `kserve` — KServe integration
-- `llmd-serving` — LLM serving
-- `model-serving` — Model Serving UI
-- `model-serving-backport` — Model serving backport compatibility
-- `model-training` — Model training UI
-- `nim-serving` — NIM serving
-
-#### Plugin Infrastructure
-
+- `feature-store` — Feature Store (read-only Feast UI; no BFF, proxies through main dashboard backend)
 - `plugin-core` — Core plugin utilities shared across plugins
 - `plugin-template` — Scaffold for new plugins
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -21,31 +21,37 @@ ODH Dashboard is a monorepo managed with npm workspaces and Turbo. It provides t
 
 ### Feature Plugin Packages (`packages/`)
 
-Most feature packages are **Module Federation remotes** that get dynamically loaded into the main frontend at runtime. Some are **bundled libraries** that are compiled directly into the host bundle at build time — they register extensions via `package.json` exports but have no separate webpack config or dev server.
+Feature packages provide extensions and are discovered by `discoverPluginPackages.js`. They fall into two categories based on how they are built and loaded:
 
 #### Module Federation Remotes
 
-- `gen-ai` — Gen AI / LLM features (has Go BFF)
-- `model-registry` — Model Registry UI (has Go BFF)
-- `model-serving` — Model Serving UI
-- `model-serving-backport` — Model serving backport compatibility
-- `model-training` — Model training UI
-- `maas` — Model-as-a-Service (has Go BFF)
-- `notebooks` — Notebooks management
-- `kserve` — KServe integration
+These packages have a `module-federation` config in `package.json`, their own webpack build under `frontend/config/`, and produce a `remoteEntry.js` that is loaded dynamically at runtime:
+
 - `automl` — AutoML features (has Go BFF)
 - `autorag` — AutoRAG features (has Go BFF)
 - `eval-hub` — Evaluation Hub (has Go BFF)
-- `llmd-serving` — LLM serving
+- `gen-ai` — Gen AI / LLM features (has Go BFF)
+- `maas` — Model-as-a-Service (has Go BFF)
 - `mlflow` — MLflow integration (has Go BFF)
 - `mlflow-embedded` — Embedded MLflow integration
 - `model-registry` — Model Registry UI (has Go BFF)
 - `notebooks` — Notebooks management
 - `observability` — Observability features
 
-#### Bundled Library Packages
+#### Bundled Plugin Packages
+
+These packages export extensions but have **no** `module-federation` config. They are compiled directly into the host bundle at build time — no separate webpack build, no `remoteEntry.js`, no standalone dev server:
 
 - `feature-store` — Feature Store (read-only Feast UI; no BFF, proxies through main dashboard backend)
+- `kserve` — KServe integration
+- `llmd-serving` — LLM serving
+- `model-serving` — Model Serving UI
+- `model-serving-backport` — Model serving backport compatibility
+- `model-training` — Model training UI
+- `nim-serving` — NIM serving
+
+#### Plugin Infrastructure
+
 - `plugin-core` — Core plugin utilities shared across plugins
 - `plugin-template` — Scaffold for new plugins
 

--- a/.claude/skills/jira-triage/jira-project-reference.md
+++ b/.claude/skills/jira-triage/jira-project-reference.md
@@ -419,6 +419,7 @@ Labels that categorize issues by functional area. Format: `dashboard-area-{area}
 | `dashboard-area-autorag` | AutoRAG |
 | `dashboard-area-observability` | Observability |
 | `dashboard-area-applications` | Applications |
+| `dashboard-area-feast` | Feature Store / Feast |
 
 ## Area Label Signal Mapping
 
@@ -466,6 +467,7 @@ Matched against issue summary, description text, and **Jira labels** (non-area l
 | `dashboard-area-autorag` | AutoRAG, AutoX, autorag experiment, RAG pattern evaluation, autorag leaderboard, pattern details, optimization metric, faithfulness, answer correctness, context correctness, RAG patterns, vector store provider, Milvus (in AutoRAG context), chunking, embedding model, retrieval method, generation model, autorag configure, S3 file explorer (in AutoRAG context), Docling, text extraction (in AutoRAG context), test data file | |
 | `dashboard-area-observability` | observability, observability dashboard, Perses, PersesDashboard, PersesBoard, metrics dashboard, time range selector, Prometheus datasource | |
 | `dashboard-area-applications` | application, enabled application, explore application, ISV | |
+| `dashboard-area-feast` | Feature Store, Feast, feature view, feature service, feature entity, data source, saved dataset, feast registry, feature-store-ui, lineage graph, feature store project, feature store overview, feature store metrics | `FeatureStore` |
 | `dashboard-area-consistencies` | consistency, shared pattern, common component, UX consistency | |
 
 ### Code Path Signals
@@ -501,6 +503,7 @@ Matched against file paths from linked PRs, code references in descriptions, or 
 | `dashboard-area-automl` | `packages/automl/` |
 | `dashboard-area-autorag` | `packages/autorag/` |
 | `dashboard-area-observability` | `packages/observability/`, `manifests/observability/` |
+| `dashboard-area-feast` | `packages/feature-store/`, `frontend/src/pages/projects/screens/spawner/featureStore/`, `frontend/src/api/featureStore/`, `backend/src/routes/api/featurestores/` |
 | `dashboard-area-applications` | `frontend/src/pages/enabledApplications/`, `frontend/src/pages/exploreApplication/` |
 | `dashboard-area-bff` | *(cross-cutting -- shared patterns span `packages/*/bff/`)* |
 | `dashboard-area-security` | *(cross-cutting -- no dedicated directory)* |
@@ -523,6 +526,7 @@ Non-area labels on the issue that serve as keyword-equivalent signals for area m
 | `dashboard-area-genai` | `gen-ai`, `genai` |
 | `dashboard-area-maas` | `maas`, `MaaS` |
 | `dashboard-area-model-registry` | `model-registry` |
+| `dashboard-area-feast` | `feature-store`, `feast` |
 | `dashboard-area-pipelines` | `ai-pipelines` |
 
 Jira label matches have the **same confidence level as keyword matches** -- they are a content signal (reporters chose the label deliberately). They contribute to the multi-signal requirement like any other keyword dimension.
@@ -592,6 +596,7 @@ An area label can appear on issues belonging to any team. This mapping provides 
 | `dashboard-area-model-registry` | Green |
 | `dashboard-area-distributed-workloads` | Green |
 | `dashboard-area-mcp` | Green |
+| `dashboard-area-feast` | Tangerine |
 | `dashboard-area-automl` | Purple |
 | `dashboard-area-autorag` | Purple |
 

--- a/.claude/skills/jira-validate-area-label/SKILL.md
+++ b/.claude/skills/jira-validate-area-label/SKILL.md
@@ -107,7 +107,7 @@ Do not assign **only** `dashboard-area-manifests` when a high-confidence feature
 | Cluster storage | `dashboard-area-cluster-storage` |
 | Deployments | `dashboard-area-model-serving` |
 | Permissions | `dashboard-area-user-management` |
-| Feature Store | *(no area label yet)* |
+| Feature Store | `dashboard-area-feast` |
 | Settings | `dashboard-area-projects` |
 
 If feature-specific keywords are present alongside "project", assign the feature area, not `projects`.

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -113,7 +113,7 @@ Central index of key documentation in the ODH Dashboard monorepo.
 | [Model Training](packages/model-training/docs/overview.md) | Training job management; pipeline integration; resource configuration |
 | [Notebooks](packages/notebooks/docs/overview.md) | Notebook management package; workbenches frontend area interactions |
 | [Observability](packages/observability/docs/overview.md) | Metrics, logging, tracing integration; Prometheus endpoint patterns |
-| [Feature Store](packages/feature-store/README.md) | Feature store management UI; see also [overview](packages/feature-store/docs/overview.md) and [AGENTS.md](packages/feature-store/AGENTS.md) |
+| [Feature Store](packages/feature-store/docs/overview.md) | Feature store management UI; dataset versioning; see also [README](packages/feature-store/README.md) and [AGENTS.md](packages/feature-store/AGENTS.md) |
 | [LLMD Serving](packages/llmd-serving/docs/overview.md) | LLM-dedicated serving; interactions with gen-ai frontend area |
 
 ### Stubs (tooling-only packages)

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -113,7 +113,7 @@ Central index of key documentation in the ODH Dashboard monorepo.
 | [Model Training](packages/model-training/docs/overview.md) | Training job management; pipeline integration; resource configuration |
 | [Notebooks](packages/notebooks/docs/overview.md) | Notebook management package; workbenches frontend area interactions |
 | [Observability](packages/observability/docs/overview.md) | Metrics, logging, tracing integration; Prometheus endpoint patterns |
-| [Feature Store](packages/feature-store/docs/overview.md) | Feature store management UI; dataset versioning |
+| [Feature Store](packages/feature-store/README.md) | Feature store management UI; see also [overview](packages/feature-store/docs/overview.md) and [AGENTS.md](packages/feature-store/AGENTS.md) |
 | [LLMD Serving](packages/llmd-serving/docs/overview.md) | LLM-dedicated serving; interactions with gen-ai frontend area |
 
 ### Stubs (tooling-only packages)

--- a/packages/feature-store/AGENTS.md
+++ b/packages/feature-store/AGENTS.md
@@ -79,12 +79,10 @@ npm run test-unit        # Run unit tests
 npm run type-check       # Type check feature-store only
 ```
 
-## Known Issues
+## Notes for agents
 
 - Filename typo: `useFeatureStoreEnitites.ts` -- fix only with a coordinated rename of all imports across the package.
-- Detail views rely on `include_relationships=true`; omitting it yields incomplete lineage-related data.
-- Lineage graph needs `/api/v1/lineage/complete`; older Feast builds may show an empty graph.
-- Nav visibility controlled by `disableFeatureStore` on `OdhDashboardConfig` and `FeatureStore` CRDs labeled `feature-store-ui=enabled`.
+- See [Developer notes](docs/overview.md#developer-notes) in `docs/overview.md`.
 
 ## Related Code (Outside This Package)
 

--- a/packages/feature-store/AGENTS.md
+++ b/packages/feature-store/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md -- Feature Store
+
+Package-specific guidance for AI agents working on `@odh-dashboard/feature-store`.
+
+## Key Constraints
+
+- **Bundled library, not a Module Federation remote.** Do not create webpack configs, `moduleFederation.js`, dev servers, or `remoteEntry.js`. The package compiles directly into the host dashboard bundle.
+- **No BFF.** There is no Go backend in this package. All API calls use `proxyGET` from `@odh-dashboard/internal/api/proxyUtils` and route through the main dashboard backend.
+- **Read-only UI.** Never add create, update, or delete operations. The package only lists and inspects Feast objects.
+- **Backend proxy code lives elsewhere.** Proxy routes are in `backend/src/routes/api/featurestores/`, not in this package. Changes to how Feast requests are proxied require modifying the main backend.
+- **Workbench integration code lives elsewhere.** The spawner form integration is in `frontend/src/pages/projects/screens/spawner/featureStore/`. Changes to how workbenches connect to Feature Store require modifying the main frontend.
+
+## Project Structure
+
+```text
+packages/feature-store/
+├── extensions.ts                  # Plugin registration (area, nav, routes, task)
+├── docs/overview.md               # Detailed architecture documentation
+├── src/
+│   ├── FeatureStore.tsx           # Main overview component (Metrics + Lineage tabs)
+│   ├── FeatureStoreContext.tsx    # Context provider with state management
+│   ├── FeatureStoreCoreLoader.tsx # RBAC checks, CR discovery, loading states
+│   ├── FeatureStoreRoutes.tsx     # All route definitions
+│   ├── EnsureAPIAvailability.tsx  # Loading wrapper for API readiness
+│   ├── const.ts                   # Enums (FeatureStoreObject, FeatureStoreTabs)
+│   ├── routes.ts                  # Route builder functions
+│   ├── api/
+│   │   ├── custom.ts             # All Feast API calls (20+ methods via proxyGET)
+│   │   └── errorUtils.ts         # Error handling utilities
+│   ├── apiHooks/
+│   │   ├── useFeatureStoreAPIState.tsx  # Binds API methods with resolved hostPath
+│   │   ├── useFeatureStoreCR.ts         # FeatureStore CR discovery
+│   │   └── ...                          # Per-object hooks
+│   ├── hooks/
+│   │   └── useRegistryFeatureStores.ts  # Service discovery via backend
+│   ├── components/                # Shared UI components
+│   ├── screens/                   # Feature pages (entities, features, lineage, etc.)
+│   ├── types/                     # TypeScript type definitions per object type
+│   ├── utils/                     # Display helpers, filtering, context utilities
+│   ├── icons/header-icons/        # Icon components
+│   └── __mocks__/                 # Test mock data
+```
+
+## Extension System
+
+Extensions are defined in `extensions.ts` and register:
+- **Area**: `plugin-feature-store` (reliant on `SupportedArea.FEATURE_STORE`, disabled by `disableFeatureStore` flag)
+- **Navigation section**: Under `develop-and-train`
+- **7 navigation items**: Overview, Entities, Features, Feature Views, Feature Services, Data Sources, Datasets
+- **1 route**: `/develop-train/feature-store/*` -> `FeatureStoreRoutes`
+- **1 task item**: "Build reusable ML features"
+
+## API Pattern
+
+All API calls in `src/api/custom.ts` follow this pattern:
+
+```text
+getEntities(hostPath)(opts, project?) -> proxyGET(`${hostPath}/api/v1/entities?include_relationships=true&project=...`)
+```
+
+Curried helpers in `src/api/custom.ts`; see `getEntities` for full `K8sAPIOptions` / return types.
+
+- `hostPath` is resolved at runtime to `/api/featurestores/{namespace}/{projectName}`
+- The main dashboard backend proxies this to the Feast REST service
+- Always include `include_relationships=true` for detail views (lineage data depends on it)
+- Lineage graph requires `/api/v1/lineage/complete`
+
+## Development
+
+```bash
+# From repo root
+npm run dev              # Starts backend + frontend (feature-store compiles into host)
+npm run lint             # Lint all packages
+npm run type-check       # Type check all packages
+
+# From this package directory
+npm run lint             # Lint feature-store only
+npm run test-unit        # Run unit tests
+npm run type-check       # Type check feature-store only
+```
+
+## Known Issues
+
+- Filename typo: `useFeatureStoreEnitites.ts` -- fix only with a coordinated rename of all imports across the package.
+- Detail views rely on `include_relationships=true`; omitting it yields incomplete lineage-related data.
+- Lineage graph needs `/api/v1/lineage/complete`; older Feast builds may show an empty graph.
+- Nav visibility controlled by `disableFeatureStore` on `OdhDashboardConfig` and `FeatureStore` CRDs labeled `feature-store-ui=enabled`.
+
+## Related Code (Outside This Package)
+
+| Area | Location | Purpose |
+|------|----------|---------|
+| Backend proxy | `backend/src/routes/api/featurestores/` | Discovery + proxy to Feast REST API |
+| Workbench integration | `frontend/src/pages/projects/screens/spawner/featureStore/` | Feature Store selector in workbench spawner form |
+| Workbench API | `frontend/src/api/featureStore/custom.ts` | `getWorkbenchFeatureStores()` endpoint |
+| Area/flag config | `frontend/src/concepts/areas/` | `SupportedArea.FEATURE_STORE` definition |

--- a/packages/feature-store/README.md
+++ b/packages/feature-store/README.md
@@ -1,0 +1,104 @@
+# Feature Store (`@odh-dashboard/feature-store`)
+
+Read-only UI for browsing and inspecting ML features backed by a [Feast](https://feast.dev/)-compatible REST API. Users can discover feature groups, explore lineage, and understand how features relate to models.
+
+## Architecture
+
+Feature Store is a **bundled library package** -- not a Module Federation remote. It compiles directly into the main dashboard bundle at build time. There is no separate webpack config, dev server, or `remoteEntry.js`.
+
+- **No BFF**: All API calls use `proxyGET` from `@odh-dashboard/internal/api/proxyUtils`. Traffic flows: browser -> main dashboard backend -> Feast REST API (`/api/v1/...`).
+- **Read-only**: List and inspect projects, entities, feature views, features, feature services, data sources, saved datasets, lineage, and metrics. No create/update/delete.
+- **Discovery**: The backend resolves the upstream Feast host from a Kubernetes `FeatureStore` CR with label `feature-store-ui=enabled`.
+
+### Data Flow
+
+```
+Browser
+  -> GET /api/featurestores                           (discovery)
+  -> Dashboard Backend
+     -> Reads feast-configs-registry ConfigMap
+     -> Lists FeatureStore CRDs (label: feature-store-ui=enabled)
+     -> Returns available Feast instances with registry URLs
+
+Browser
+  -> GET /api/featurestores/:namespace/:project/api/v1/entities  (proxy)
+  -> Dashboard Backend
+     -> Proxies to Feast REST service (in-cluster DNS)
+     -> Forwards response to browser
+```
+
+## Pages
+
+Registers under **Develop & Train > Feature Store** in the sidebar:
+
+| Page | Path |
+|------|------|
+| Overview | `/develop-train/feature-store/overview` |
+| Entities | `/develop-train/feature-store/entities` |
+| Features | `/develop-train/feature-store/features` |
+| Feature Views | `/develop-train/feature-store/feature-views` |
+| Feature Services | `/develop-train/feature-store/feature-services` |
+| Data Sources | `/develop-train/feature-store/data-sources` |
+| Datasets | `/develop-train/feature-store/datasets` |
+
+## Development
+
+No separate dev server is needed. Feature Store code is compiled into the host dashboard.
+
+### Prerequisites
+
+- Node.js >= 22, npm >= 10
+- A cluster with a Feast service deployed (`FeatureStore` CR with label `feature-store-ui=enabled`)
+
+### Running locally
+
+```bash
+# From repo root -- starts both backend and frontend
+npm run dev
+```
+
+For local development, the backend needs to reach the Feast service. Since Feast runs inside the cluster, port-forward the registry service:
+
+```bash
+# Port-forward the Feast registry to localhost
+oc port-forward -n <feast-namespace> svc/<feast-registry-service> 8443:443
+
+# Set the env var so the backend routes to localhost
+FEAST_REGISTRY_SERVICE_PORT=8443 npm run dev
+```
+
+### Scripts
+
+```bash
+npm run lint          # Lint
+npm run lint:fix      # Lint and auto-fix
+npm run test-unit     # Run unit tests
+npm run type-check    # TypeScript type checking
+```
+
+## Package Exports
+
+| Export | Path |
+|--------|------|
+| `./extensions` | `extensions.ts` |
+| `./routes` | `src/routes.ts` |
+| `./types/*` | `src/types/` |
+| `./components/*` | `src/components/` |
+| `./screens/components/*` | `src/screens/components/` |
+| `./screens/lineage/*` | `src/screens/lineage/` |
+| `./icons/header-icons/*` | `src/icons/header-icons/` |
+| `./mocks/*` | `src/__mocks__/` |
+
+## Related Code
+
+| Area | Location |
+|------|----------|
+| Detailed architecture docs | [`docs/overview.md`](docs/overview.md) |
+| Backend proxy routes | [`backend/src/routes/api/featurestores/`](../../backend/src/routes/api/featurestores/) |
+| Workbench integration | [`frontend/src/pages/projects/screens/spawner/featureStore/`](../../frontend/src/pages/projects/screens/spawner/featureStore/) |
+| Workbench API | [`frontend/src/api/featureStore/`](../../frontend/src/api/featureStore/) |
+
+## Dependencies
+
+- `@odh-dashboard/internal` -- `proxyGET`, `useFetch`, K8s types, area/flag infrastructure
+- `@odh-dashboard/plugin-core` -- Extension types, nav and route mounting

--- a/packages/feature-store/README.md
+++ b/packages/feature-store/README.md
@@ -12,7 +12,7 @@ Feature Store is a **bundled library package** -- not a Module Federation remote
 
 ### Data Flow
 
-```
+```text
 Browser
   -> GET /api/featurestores                           (discovery)
   -> Dashboard Backend

--- a/packages/feature-store/docs/overview.md
+++ b/packages/feature-store/docs/overview.md
@@ -83,7 +83,7 @@ Located in [`backend/src/routes/api/featurestores/`](../../../backend/src/routes
 
 Shared utilities are in `featureStoreUtils.ts`: ConfigMap parsing, service info extraction, proxy URL construction, and authenticated HTTP requests.
 
-## Known Issues / Gotchas
+## Developer notes
 
 - Detail views rely on `include_relationships=true`; omitting it yields incomplete lineage-related data.
 - Lineage graph needs `/api/v1/lineage/complete`; older Feast builds may show an empty graph without a clear error.

--- a/packages/feature-store/docs/overview.md
+++ b/packages/feature-store/docs/overview.md
@@ -38,6 +38,51 @@
 | `@odh-dashboard/plugin-core` | Package | Extension types; nav and route mounting. |
 | Kubernetes | Cluster API | Feature store discovery via `feature-store-ui=enabled`. |
 
+## Related Code (Outside This Package)
+
+### Workbench Integration
+
+Located in [`frontend/src/pages/projects/screens/spawner/featureStore/`](../../../frontend/src/pages/projects/screens/spawner/featureStore/), this code integrates Feature Store into the workbench (notebook) spawner form:
+
+| File | Purpose |
+|------|---------|
+| `FeatureStoreSelector.tsx` | Multi-select dropdown for choosing Feature Store instances |
+| `useWorkbenchFeatureStores.ts` | Hook that calls `GET /api/featurestores/workbench-integration` |
+| `FeatureStoreCodeBlock.tsx` | Displays example Feast SDK Python code |
+| `utils.ts` | Generates notebook metadata: label `opendatahub.io/feast-integration=true`, annotation `opendatahub.io/feast-config=<project-names>` |
+| `FeatureStoreFormSection.tsx` | Wraps selector and code block in the spawner form |
+
+The workbench API endpoint is defined in [`frontend/src/api/featureStore/custom.ts`](../../../frontend/src/api/featureStore/custom.ts).
+
+### Backend Proxy Architecture
+
+Located in [`backend/src/routes/api/featurestores/`](../../../backend/src/routes/api/featurestores/), the backend provides three endpoints:
+
+| Endpoint | File | Purpose |
+|----------|------|---------|
+| `GET /api/featurestores/` | `featureStores.ts` | Discovery -- lists all available Feast instances |
+| `GET /api/featurestores/:namespace/:projectName/*` | `featureStores.ts` | Proxy -- forwards requests to the Feast REST API |
+| `GET /api/featurestores/workbench-integration` | `fsworkbenchIntegration.ts` | Returns accessible Feature Stores for the workbench spawner (filtered by user RBAC) |
+
+**Discovery flow:**
+1. Reads `feast-configs-registry` ConfigMap from the dashboard namespace
+2. Parses JSON to get `{ namespace -> [configmap-names] }` mapping
+3. Fetches each named ConfigMap, parses the `feature_store.yaml` key to extract `registryUrl` and `projectName`
+4. Lists `feast.dev/v1 FeatureStore` CRDs filtered by label `feature-store-ui=enabled`
+5. Cross-references CRDs with configs and returns available Feature Stores
+
+**Proxy flow:**
+1. Receives a request like `GET /api/featurestores/feast-ns/my-project/api/v1/entities`
+2. Looks up the registry URL for that namespace/project
+3. Extracts service info (service name, namespace, port) from the registry URL
+4. Constructs a target URL using Kubernetes internal DNS (`<service>.<namespace>.svc.cluster.local`)
+5. Makes an authenticated HTTP request with the user's bearer token
+6. Forwards the Feast response back to the browser
+
+**Local development:** The backend detects local dev mode (`NODE_ENV=development` or missing `KUBERNETES_SERVICE_HOST`) and routes to `localhost` instead of cluster DNS. Set `FEAST_REGISTRY_SERVICE_PORT` to match your `oc port-forward` target.
+
+Shared utilities are in `featureStoreUtils.ts`: ConfigMap parsing, service info extraction, proxy URL construction, and authenticated HTTP requests.
+
 ## Known Issues / Gotchas
 
 - Detail views rely on `include_relationships=true`; omitting it yields incomplete lineage-related data.


### PR DESCRIPTION

https://redhat.atlassian.net/browse/RHOAIENG-58686

This pull request improves Feature Store documentation by adding a package-level README and AGENTS.md that describe the bundled-library architecture, read-only scope, absence of a dedicated BFF, and the locations of related workbench and backend proxy code

It extends packages/feature-store/docs/overview.md with cross-references to the workbench integration and a concise description of backend discovery and proxy behavior. 

It also updates .claude/rules/architecture.md to distinguish Module Federation remotes from bundled library packages, and introduces the dashboard-area-feast label in Jira triage documentation to support consistent area labeling for Feature Store work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Feature Store as a bundled, read‑only Feast UI (no BFF; proxies through the main dashboard backend) and added README, developer notes, agent guidance, and related-code/integration mapping.
* **Chores**
  * Updated Jira triage: introduced dashboard-area-feast label, mapped “Feature Store” to it, added matching signals/keywords, and set default scrum team to Tangerine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->