### PR TITLE
fix(ci): move Cypress binary cache inside workspace to fix restore failures

### DIFF
--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -15,6 +15,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set Cypress cache to workspace-local path
+      shell: bash
+      run: echo "CYPRESS_CACHE_FOLDER=${{ github.workspace }}/.cache/Cypress" >> "$GITHUB_ENV"
     - name: Root node_modules cache
       id: root-cache
       uses: actions/cache@v4
@@ -25,7 +28,7 @@ runs:
           frontend/node_modules
           frontend/src/node_modules
           packages/*/node_modules
-          ~/.cache/Cypress
+          .cache/Cypress
         key: ${{ runner.os }}-${{ inputs.node-version }}-root-modules-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.node-version }}-root-modules-
@@ -33,6 +36,10 @@ runs:
       if: inputs.force-install == 'true' || steps.root-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm install
+    - name: Ensure Cypress binary is installed
+      if: inputs.force-install == 'true' || steps.root-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npx --no-install cypress install
 
     - name: automl node_modules cache
       id: automl-cache

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -847,8 +847,8 @@ jobs:
           # Clean old webpack logs (>2 days old)
           find /tmp -name "webpack_*.log" -type f -mtime +2 -delete 2>/dev/null || true
           
-          # Note: ~/.cache/Cypress is managed by actions/cache and should not be cleaned here
-          # to avoid removing the Cypress binary on shared self-hosted runners
+          # Note: .cache/Cypress is managed by actions/cache (workspace-local via CYPRESS_CACHE_FOLDER)
+          # and should not be cleaned here to avoid removing the Cypress binary mid-run
           
           # Clean old temporary yaml files (>2 days old)
           find /tmp -name "cypress-yaml-*.yaml" -type f -mtime +2 -delete 2>/dev/null || true


### PR DESCRIPTION
## Description

The `actions/cache` toolkit has a known bug ([actions/toolkit#1831](https://github.com/actions/toolkit/issues/1831)) where `path.relative()` computes incorrect traversal paths for cached directories outside `GITHUB_WORKSPACE`. This causes `~/.cache/Cypress` to be stored as `../../../../.cache` in the tar archive, which resolves to `/home/.cache` instead of `/home/runner/.cache` — failing with "Permission denied" on `restore-key` partial matches.

When a PR changes `package-lock.json`:
1. Exact cache key misses → `restore-keys` finds a stale match from main
2. tar extracts `node_modules` (inside workspace, fine) but **fails** on `~/.cache/Cypress` (outside workspace, path traversal error)
3. `npm install` runs but doesn't re-trigger Cypress postinstall if the `cypress` package version didn't change
4. `~/.cache/Cypress` stays empty → Cypress binary missing
5. The broken state gets saved as the new cache, poisoning subsequent runs

**Fix:** Use `CYPRESS_CACHE_FOLDER` to redirect the Cypress binary into the workspace at `.cache/Cypress` (already in `.gitignore`), keeping all cached paths inside `GITHUB_WORKSPACE` where `path.relative()` works correctly. Set via `GITHUB_ENV` in the composite action so it propagates to all calling workflows without touching individual workflow `env` blocks. Added `npx cypress install` as a safety net on cache miss to bootstrap the first run after stale caches are purged.

**Outstanding PRs** that still reference `~/.cache/Cypress` in their copy of the action will need to rebase. They cannot pollute main's cache (GitHub Actions cache scoping prevents PR branches from writing to the base branch's cache).

## How Has This Been Tested?

Testing via CI

## Test Impact

N/A

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Cypress caching in CI to use a workspace-local cache directory for more reliable restores.
  * When cache is missing or forced, CI now reinstalls dependencies and explicitly ensures the Cypress binary is installed.
  * Clarified cleanup comments to avoid removing the preserved Cypress cache during test artifact cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->