### PR TITLE
RHOAIENG-62729: Update OGX install config path from /etc/llama-stack to /etc/ogx

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
@@ -543,7 +543,7 @@ server:
 				Replicas:  &replicas,
 				Resources: workloadResources,
 				Overrides: &ogxapi.WorkloadOverrides{
-					Command: []string{"/bin/sh", "-c", "ogx run /etc/llama-stack/config.yaml"},
+					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"},
 					Env: []corev1.EnvVar{
 						{Name: "VLLM_TLS_VERIFY", Value: "false"},
 						{Name: "FAISS_STORE_DIR", Value: "~/.llama/faiss"},

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1550,7 +1550,7 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 				Replicas:  &replicas,
 				Resources: workloadResources,
 				Overrides: &ogxapi.WorkloadOverrides{
-					Command: []string{"/bin/sh", "-c", "ogx run /etc/llama-stack/config.yaml"},
+					Command: []string{"/bin/sh", "-c", "ogx run /etc/ogx/config.yaml"},
 					Env: append(envVars, corev1.EnvVar{
 						Name:  "OGX_CONFIG_DIR",
 						Value: "/opt/app-root/src/.ogx/distributions/rh/",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62729

## Description
The OGX server install path has been changed to `/etc/ogx/config.yaml` in ogx-k8s-operator (https://github.com/opendatahub-io/ogx-k8s-operator/pull/125), this PR updates the gen-ai bff InstallOGXServer to match the renamed distribution directory structure.

Changes:
- `token_k8s_client.go`: Update config path in `InstallOGXServer`
- `token_k8s_client_mock.go`: Update config path in mock to match

## How Has This Been Tested?
- `go vet ./...` — clean
- `go build ./...` — clean
- Frontend unit tests — 982/982 passed
- Contract tests — 15/15 passed
- Frontend lint — clean
- Frontend type-check — clean
- Manually tested creating a playground on an odh cluster with above ogx-k8s-operator change, and odh-ogx-core:rhoai-v3.5-ea1-latest
  - prior to change observed a CrashLoopBackOff on creation of playground

## Test Impact
Existing contract tests and unit tests cover this path. No new tests needed — this is a one-line config path rename in two files.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`