### PR TITLE
feat: add RBAC review to preflight skill

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: preflight
-description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review coderabbit,claude,style, --help."
-argument-hint: "[PR] [--fix] [--local] [--review coderabbit,claude,style] [--help]"
+description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review coderabbit,claude,style,rbac, --help."
+argument-hint: "[PR] [--fix] [--local] [--review coderabbit,claude,style,rbac] [--help]"
 disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *) Bash(npm *) Bash(npx *) Bash(${CLAUDE_SKILL_DIR}/scripts/*)
 ---
@@ -26,14 +26,14 @@ Flags:
   --fix                 Fix failing checks after reporting
   --local               Ignore PR even if one exists, run everything locally
   --review X,Y          Run specific reviewers without asking
-                        Options: coderabbit, claude, style
+                        Options: coderabbit, claude, style, rbac
   --help                Show this help
 
 Examples:
   /preflight                                  Check current branch (auto-detect PR)
   /preflight 1234                             Check PR #1234
   /preflight --fix                            Check and fix current branch
-  /preflight --review coderabbit,style        Run specific reviewers
+  /preflight --review coderabbit,style,rbac    Run specific reviewers
   /preflight 1234 --review claude --fix       Check PR, run Claude review, fix issues
 
 How it works:
@@ -48,7 +48,7 @@ How it works:
 Parse these from `$ARGUMENTS` before processing:
 - `--fix` — after reporting, fix failing checks without asking
 - `--local` — ignore PR even if one exists, run everything locally
-- `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`)
+- `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`)
 - `--help` — print usage and stop
 - No flags — interactive mode: ask the user what to do at decision points
 
@@ -128,6 +128,7 @@ If `--review` flag was passed, use those reviewers directly. Otherwise use AskUs
 - "CodeRabbit CLI" — run `coderabbit review --agent` (requires CLI installed)
 - "Claude review" — invoke `/review` built-in skill
 - "Style review" — invoke `/style-review` for code style and pattern checks
+- "RBAC review" — invoke `/rbac-review` for Kubernetes RBAC permission enforcement checks
 - "Skip review" — no review
 
 Run whichever the user picks. If a reviewer fails (e.g. CR CLI not installed or errors), report the failure clearly — don't silently fall back to something else.

--- a/.claude/skills/preflight/references/checks.md
+++ b/.claude/skills/preflight/references/checks.md
@@ -83,6 +83,15 @@ Report: `Style (local)` as the source.
 
 Report: `Claude (local)` as the source.
 
+### RBAC Review
+
+| Context | How to check |
+|---|---|
+| Ran in Step 2 | Results from `/rbac-review` invocation |
+| Not run | ➖ "not run" |
+
+Report: `RBAC (local)` as the source. Any critical findings → ❌. Warnings only → ⚠️. None or info only → ✅.
+
 ## Jira
 
 Checks that the work is tracked in Jira.


### PR DESCRIPTION
## Description

Adds `/rbac-review` as a selectable reviewer in the `/preflight` skill, alongside CodeRabbit, Claude, and Style reviews. This enables automated Kubernetes RBAC permission enforcement checks during pre-merge readiness checks.

**Changes:**
- Updated frontmatter `description` and `argument-hint` to include `rbac`
- Added `rbac` to `--review` flag options in help text and flag parsing
- Added "RBAC review" option to the interactive reviewer picker in Step 2
- Added RBAC Review check definition in `checks.md` with severity-based status mapping

## How Has This Been Tested?

- Verified `/preflight --help` shows `rbac` in the `--review` options
- Verified `/preflight --review rbac` invokes the `/rbac-review` skill
- Verified interactive mode shows "RBAC review" as a selectable option

## Test Impact

No automated tests — this is a Claude Code skill definition (Markdown), not application code.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Extended preflight command to support RBAC as a reviewer option with updated help text and examples
* Added RBAC Review check documentation defining how findings are reported based on severity levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->