### PR TITLE
fix: use compact jq output in dependency-validation detect-dirs

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -42,14 +42,14 @@ jobs:
 
           DIRS="[]"
           if echo "$CHANGED" | grep -qE '^package-lock\.json$'; then
-            DIRS=$(echo "$DIRS" | jq '. + ["."]')
+            DIRS=$(echo "$DIRS" | jq -c '. + ["."]')
           fi
 
           for dir in $(echo "$CHANGED" | grep -oE '^packages/[^/]+(/upstream)?(/workspaces)?/frontend' | sort -u); do
-            DIRS=$(echo "$DIRS" | jq --arg d "$dir" '. + [$d]')
+            DIRS=$(echo "$DIRS" | jq -c --arg d "$dir" '. + [$d]')
           done
 
-          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "dirs=$(echo "$DIRS" | jq -c '.')" >> "$GITHUB_OUTPUT"
           echo "Directories to audit: $DIRS"
 
   audit:


### PR DESCRIPTION
Follow-up to https://issues.redhat.com/browse/RHOAIENG-57877

## Description

Identified in https://github.com/opendatahub-io/odh-dashboard/actions/runs/25932779744/job/76230610236?pr=7479. The `detect-dirs` job in the dependency-validation workflow errors because `jq` outputs pretty-printed multiline JSON by default. 

When writing to `GITHUB_OUTPUT`, the multiline value breaks parsing:

```
dirs=[
  "."
]
```

GitHub Actions expects `key=value` on a single line and rejects `  "."` as an invalid format.

This adds the `-c` (compact) flag to all `jq` calls that build the `DIRS` array so the value stays on a single line: `dirs=["."]`.

## How Has This Been Tested?

Verified that `echo '[]' | jq -c '. + ["."]'` produces `["."]` (single line) vs `echo '[]' | jq '. + ["."]'` which produces a pretty-printed multiline array that breaks `GITHUB_OUTPUT`.

## Test Impact

CI workflow config only — no unit or cypress tests applicable.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build automation for dependency validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->