### PR TITLE
Updating BFF mocks for My Subscriptions

### DIFF
--- a/packages/maas/bff/internal/api/api_keys_handlers_test.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers_test.go
@@ -66,10 +66,10 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			Expect(actual.Data.SubscriptionDetails).NotTo(BeNil())
 			Expect(actual.Data.SubscriptionDetails).To(HaveKey("premium-team-sub"))
 			Expect(actual.Data.SubscriptionDetails["premium-team-sub"].DisplayName).To(Equal("Premium Team"))
-			Expect(actual.Data.SubscriptionDetails["premium-team-sub"].Models).To(ConsistOf("granite-3-8b-instruct", "flan-t5-small"))
+			Expect(actual.Data.SubscriptionDetails["premium-team-sub"].Models).To(ConsistOf("Granite 3 8B Instruct", "Flan T5 Small"))
 			Expect(actual.Data.SubscriptionDetails).To(HaveKey("basic-team-sub"))
 			Expect(actual.Data.SubscriptionDetails["basic-team-sub"].DisplayName).To(Equal("Basic Team"))
-			Expect(actual.Data.SubscriptionDetails["basic-team-sub"].Models).To(ConsistOf("flan-t5-small"))
+			Expect(actual.Data.SubscriptionDetails["basic-team-sub"].Models).To(ConsistOf("Flan T5 Small"))
 		})
 		It("returns 400 if the user ID is missing", func() {
 			identity := &kubernetes.RequestIdentity{UserID: ""}
@@ -298,6 +298,9 @@ var _ = Describe("APIKeysHandlers", Ordered, func() {
 			Expect(first.SubscriptionIDHeader).NotTo(BeEmpty())
 			Expect(first.SubscriptionDescription).NotTo(BeEmpty())
 			Expect(first.ModelRefs).NotTo(BeEmpty())
+			Expect(first.ModelRefs[0].DisplayName).To(Equal("Granite 3 8B Instruct"))
+			Expect(first.ModelRefs[0].Description).To(Equal("Granite 3 8B Instruct is a large language model that is used for advanced tasks."))
+			Expect(first.KeyCount).To(BeNumerically(">", 0))
 		})
 
 		It("returns 400 when no identity is provided", func() {

--- a/packages/maas/bff/internal/integrations/maas/maas_fake_server.go
+++ b/packages/maas/bff/internal/integrations/maas/maas_fake_server.go
@@ -102,6 +102,9 @@ func handleFakeSearchAPIKeys(w http.ResponseWriter, r *http.Request) {
 			if req.Filters.Username != "" && !strings.Contains(strings.ToLower(key.Username), strings.ToLower(req.Filters.Username)) {
 				continue
 			}
+			if req.Filters.Subscription != "" && !strings.Contains(strings.ToLower(key.SubscriptionName), strings.ToLower(req.Filters.Subscription)) {
+				continue
+			}
 			if len(req.Filters.Status) > 0 {
 				matched := false
 				for _, s := range req.Filters.Status {

--- a/packages/maas/bff/internal/integrations/maas/testdata/subscriptions-list.json
+++ b/packages/maas/bff/internal/integrations/maas/testdata/subscriptions-list.json
@@ -6,12 +6,12 @@
     "priority": 10,
     "cost_center": "engineering",
     "organization_id": "org-123",
-    "keyCount": 10,
+    "key_count": 10,
     "model_refs": [
       {
         "name": "granite-3-8b-instruct",
         "display_name": "Granite 3 8B Instruct",
-        "provider": "internal",
+        "source": "internal",
         "description": "Granite 3 8B Instruct is a large language model that is used for advanced tasks.",
         "namespace": "maas-models",
         "token_rate_limits": [
@@ -21,7 +21,7 @@
       {
         "name": "flan-t5-small",
         "display_name": "Flan T5 Small",
-        "provider": "external",
+        "source": "external",
         "description": "Flan T5 Small is a small language model that is used for basic tasks.",
         "namespace": "maas-models",
         "token_rate_limits": [
@@ -38,13 +38,13 @@
     "subscription_description": "Basic Team Subscription",
     "display_name": "Basic Team",
     "priority": 1,
-    "keyCount": 5,
+    "key_count": 5,
     "model_refs": [
       {
         "name": "flan-t5-small",
         "display_name": "Flan T5 Small",
         "description": "Flan T5 Small is a small language model that is used for basic tasks.",
-        "provider": "external",
+        "source": "external",
         "namespace": "maas-models",
         "token_rate_limits": [
           { "limit": 10000, "window": "24h" }

--- a/packages/maas/bff/internal/integrations/maas/testdata/subscriptions-list.json
+++ b/packages/maas/bff/internal/integrations/maas/testdata/subscriptions-list.json
@@ -6,9 +6,13 @@
     "priority": 10,
     "cost_center": "engineering",
     "organization_id": "org-123",
+    "keyCount": 10,
     "model_refs": [
       {
         "name": "granite-3-8b-instruct",
+        "display_name": "Granite 3 8B Instruct",
+        "provider": "internal",
+        "description": "Granite 3 8B Instruct is a large language model that is used for advanced tasks.",
         "namespace": "maas-models",
         "token_rate_limits": [
           { "limit": 100000, "window": "24h" }
@@ -16,6 +20,9 @@
       },
       {
         "name": "flan-t5-small",
+        "display_name": "Flan T5 Small",
+        "provider": "external",
+        "description": "Flan T5 Small is a small language model that is used for basic tasks.",
         "namespace": "maas-models",
         "token_rate_limits": [
           { "limit": 200000, "window": "24h" }
@@ -31,9 +38,13 @@
     "subscription_description": "Basic Team Subscription",
     "display_name": "Basic Team",
     "priority": 1,
+    "keyCount": 5,
     "model_refs": [
       {
         "name": "flan-t5-small",
+        "display_name": "Flan T5 Small",
+        "description": "Flan T5 Small is a small language model that is used for basic tasks.",
+        "provider": "external",
         "namespace": "maas-models",
         "token_rate_limits": [
           { "limit": 10000, "window": "24h" }

--- a/packages/maas/bff/internal/models/api_key.go
+++ b/packages/maas/bff/internal/models/api_key.go
@@ -46,8 +46,9 @@ type APIKeySearchRequest struct {
 }
 
 type APIKeySearchFilters struct {
-	Username string   `json:"username,omitempty"`
-	Status   []string `json:"status,omitempty"`
+	Username     string   `json:"username,omitempty"`
+	Subscription string   `json:"subscription,omitempty"`
+	Status       []string `json:"status,omitempty"`
 }
 
 type APIKeySearchSort struct {

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -17,7 +17,7 @@ type BillingRateInfo struct {
 type ModelRefInfo struct {
 	Name            string               `json:"name"`
 	DisplayName     string               `json:"display_name,omitempty"`
-	Provider        string               `json:"provider,omitempty"`
+	Source          string               `json:"source,omitempty"`
 	Description     string               `json:"description,omitempty"`
 	Namespace       string               `json:"namespace,omitempty"`
 	TokenRateLimits []TokenRateLimitInfo `json:"token_rate_limits"`
@@ -30,7 +30,7 @@ type SubscriptionListItem struct {
 	SubscriptionDescription string            `json:"subscription_description"`
 	DisplayName             string            `json:"display_name,omitempty"`
 	Priority                int32             `json:"priority"`
-	KeyCount                int32             `json:"keyCount,omitempty"`
+	KeyCount                int32             `json:"key_count,omitempty"`
 	ModelRefs               []ModelRefInfo    `json:"model_refs"`
 	OrganizationID          string            `json:"organization_id,omitempty"`
 	CostCenter              string            `json:"cost_center,omitempty"`

--- a/packages/maas/bff/internal/models/subscription.go
+++ b/packages/maas/bff/internal/models/subscription.go
@@ -17,6 +17,8 @@ type BillingRateInfo struct {
 type ModelRefInfo struct {
 	Name            string               `json:"name"`
 	DisplayName     string               `json:"display_name,omitempty"`
+	Provider        string               `json:"provider,omitempty"`
+	Description     string               `json:"description,omitempty"`
 	Namespace       string               `json:"namespace,omitempty"`
 	TokenRateLimits []TokenRateLimitInfo `json:"token_rate_limits"`
 	BillingRate     *BillingRateInfo     `json:"billing_rate,omitempty"`
@@ -28,6 +30,7 @@ type SubscriptionListItem struct {
 	SubscriptionDescription string            `json:"subscription_description"`
 	DisplayName             string            `json:"display_name,omitempty"`
 	Priority                int32             `json:"priority"`
+	KeyCount                int32             `json:"keyCount,omitempty"`
 	ModelRefs               []ModelRefInfo    `json:"model_refs"`
 	OrganizationID          string            `json:"organization_id,omitempty"`
 	CostCenter              string            `json:"cost_center,omitempty"`

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -214,18 +214,34 @@ paths:
                     priority: 10
                     cost_center: engineering
                     organization_id: org-123
+                    keyCount: 10
                     model_refs:
                       - name: granite-3-8b-instruct
+                        display_name: Granite 3 8B Instruct
+                        provider: internal
+                        description: Granite 3 8B Instruct is a large language model that is used for advanced tasks.
                         namespace: maas-models
                         token_rate_limits:
                           - limit: 100000
+                            window: 24h
+                      - name: flan-t5-small
+                        display_name: Flan T5 Small
+                        provider: external
+                        description: Flan T5 Small is a small language model that is used for basic tasks.
+                        namespace: maas-models
+                        token_rate_limits:
+                          - limit: 200000
                             window: 24h
                   - subscription_id_header: basic-team-sub
                     subscription_description: Basic Team Subscription
                     display_name: Basic Team
                     priority: 1
+                    keyCount: 5
                     model_refs:
                       - name: flan-t5-small
+                        display_name: Flan T5 Small
+                        description: Flan T5 Small is a small language model that is used for basic tasks.
+                        provider: external
                         namespace: maas-models
                         token_rate_limits:
                           - limit: 10000
@@ -326,7 +342,7 @@ paths:
         - api-keys
       summary: Search and filter API keys
       operationId: searchApiKeys
-      description: Search API keys with flexible filtering, sorting, and pagination. Supports filtering by username (admin-only), status, sorting by multiple fields, and pagination.
+      description: Search API keys with flexible filtering, sorting, and pagination. Supports filtering by username (admin-only), subscription name, status, sorting by multiple fields, and pagination.
       requestBody:
         required: false
         content:
@@ -340,6 +356,11 @@ paths:
                     username:
                       type: string
                       description: Filter by username (admin-only)
+                    subscription:
+                      type: string
+                      description: >
+                        Filter by subscription. Matches the subscription id
+                        on the key
                     status:
                       type: array
                       items:
@@ -1890,6 +1911,11 @@ components:
           type: string
           description: Cost center for usage attribution
           example: engineering
+        keyCount:
+          type: integer
+          format: int32
+          description: Number of API keys associated with this subscription for the current user
+          example: 10
         labels:
           type: object
           additionalProperties:
@@ -1915,6 +1941,14 @@ components:
           type: string
           description: Human-readable display name of the model (from openshift.io/display-name annotation)
           example: Granite 3 8B Instruct
+        provider:
+          type: string
+          description: Model provider identifier (internal or external)
+          example: internal
+        description:
+          type: string
+          description: Human-readable description of the model
+          example: Granite 3 8B Instruct is a large language model that is used for advanced tasks.
         namespace:
           type: string
           description: Namespace where the MaaSModelRef lives

--- a/packages/maas/bff/openapi.yaml
+++ b/packages/maas/bff/openapi.yaml
@@ -214,11 +214,11 @@ paths:
                     priority: 10
                     cost_center: engineering
                     organization_id: org-123
-                    keyCount: 10
+                    key_count: 10
                     model_refs:
                       - name: granite-3-8b-instruct
                         display_name: Granite 3 8B Instruct
-                        provider: internal
+                        source: internal
                         description: Granite 3 8B Instruct is a large language model that is used for advanced tasks.
                         namespace: maas-models
                         token_rate_limits:
@@ -226,7 +226,7 @@ paths:
                             window: 24h
                       - name: flan-t5-small
                         display_name: Flan T5 Small
-                        provider: external
+                        source: external
                         description: Flan T5 Small is a small language model that is used for basic tasks.
                         namespace: maas-models
                         token_rate_limits:
@@ -236,12 +236,12 @@ paths:
                     subscription_description: Basic Team Subscription
                     display_name: Basic Team
                     priority: 1
-                    keyCount: 5
+                    key_count: 5
                     model_refs:
                       - name: flan-t5-small
                         display_name: Flan T5 Small
                         description: Flan T5 Small is a small language model that is used for basic tasks.
-                        provider: external
+                        source: external
                         namespace: maas-models
                         token_rate_limits:
                           - limit: 10000
@@ -1911,7 +1911,7 @@ components:
           type: string
           description: Cost center for usage attribution
           example: engineering
-        keyCount:
+        key_count:
           type: integer
           format: int32
           description: Number of API keys associated with this subscription for the current user
@@ -1941,9 +1941,9 @@ components:
           type: string
           description: Human-readable display name of the model (from openshift.io/display-name annotation)
           example: Granite 3 8B Instruct
-        provider:
+        source:
           type: string
-          description: Model provider identifier (internal or external)
+          description: Model source identifier (internal or external)
           example: internal
         description:
           type: string

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -141,7 +141,7 @@ export type BillingRateInfo = {
 export type ModelRefInfo = {
   name: string;
   display_name?: string;
-  provider?: string;
+  source?: string;
   description?: string;
   namespace?: string;
   token_rate_limits?: TokenRateLimitInfo[];
@@ -153,7 +153,7 @@ export type UserSubscription = {
   subscription_description: string;
   display_name?: string;
   priority: number;
-  keyCount?: number;
+  key_count?: number;
   model_refs: ModelRefInfo[];
   organization_id?: string;
   cost_center?: string;

--- a/packages/maas/frontend/src/app/types/subscriptions.ts
+++ b/packages/maas/frontend/src/app/types/subscriptions.ts
@@ -140,6 +140,9 @@ export type BillingRateInfo = {
 
 export type ModelRefInfo = {
   name: string;
+  display_name?: string;
+  provider?: string;
+  description?: string;
   namespace?: string;
   token_rate_limits?: TokenRateLimitInfo[];
   billing_rate?: BillingRateInfo;
@@ -150,6 +153,7 @@ export type UserSubscription = {
   subscription_description: string;
   display_name?: string;
   priority: number;
+  keyCount?: number;
   model_refs: ModelRefInfo[];
   organization_id?: string;
   cost_center?: string;


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-62470](https://redhat.atlassian.net/browse/RHOAIENG-62470)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Updating mocks for changes coming in [RHOAIENG-62410](https://redhat.atlassian.net/browse/RHOAIENG-62410)

Adds:
to `/subscriptions`
Display name, description, and provider (internal/external) to the model refs
API key count to the subscription itself

to `/api-keys/search`
ability to filter by subscription id (not display name)

^all in mock mode


https://github.com/user-attachments/assets/392b53af-055b-40b9-822f-c24c8816b465



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- To test the `/subscription` changes:
- run `npm run dev` in the root and `make dev-start-mock-federated` in the maas package
- go to your browser and open the network tab, check out the network response when you open the create api key modal
- should see: key count, model ref display name/description/provider

- To test the `api-keys/search`:
- run this:
```
curl -sS -X POST 'http://localhost:8081/api/v1/api-keys/search' \
  -H 'Content-Type: application/json' \
  -H 'kubeflow-userid: user@example.com' \
  -d '{
    "data": {
      "filters": {
        "subscription": "basic-team-sub"
      },
      "pagination": { "limit": 20, "offset": 0 }
    }
  }' | jq .
```
note the the subscription filter is the `basic-team-sub` which is the id, not the display name
you should see a list of keys returned that only use that sub


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated a couple tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add subscription filter to API key search
  * Show provider/source and description for model references
  * Display total key count per subscription

* **Bug Fixes**
  * Improve model metadata display with human-readable model names and updated descriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->