### PR TITLE
docs: fix package classification in architecture.md

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -17,24 +17,37 @@ ODH Dashboard is a monorepo managed with npm workspaces and Turbo. It provides t
 
 ### Feature Plugin Packages (`packages/`)
 
-Each feature package is a **Module Federation remote** that gets dynamically loaded into the main frontend:
+Feature packages export extensions via `./extensions` in `package.json` and are discovered by `discoverPluginPackages.js`. They fall into two categories based on how they are built and loaded:
 
-- `gen-ai` — Gen AI / LLM features (has Go BFF)
-- `model-registry` — Model Registry UI (has Go BFF)
-- `model-serving` — Model Serving UI
-- `model-serving-backport` — Model serving backport compatibility
-- `model-training` — Model training UI
-- `maas` — Model-as-a-Service (has Go BFF)
-- `notebooks` — Notebooks management
-- `kserve` — KServe integration
+#### Module Federation Remotes
+
+These packages have a `module-federation` config in `package.json`, their own webpack build under `frontend/config/`, and produce a `remoteEntry.js` that is loaded dynamically at runtime:
+
 - `automl` — AutoML features (has Go BFF)
 - `autorag` — AutoRAG features (has Go BFF)
 - `eval-hub` — Evaluation Hub (has Go BFF)
-- `feature-store` — Feature Store
-- `llmd-serving` — LLM serving
+- `gen-ai` — Gen AI / LLM features (has Go BFF)
+- `maas` — Model-as-a-Service (has Go BFF)
 - `mlflow` — MLflow integration (has Go BFF)
 - `mlflow-embedded` — Embedded MLflow integration
+- `model-registry` — Model Registry UI (has Go BFF)
+- `notebooks` — Notebooks management
 - `observability` — Observability features
+
+#### Bundled Plugin Packages
+
+These packages export extensions but have **no** `module-federation` config. They are compiled directly into the host bundle at build time — no separate webpack build, no `remoteEntry.js`, no standalone dev server:
+
+- `feature-store` — Feature Store
+- `kserve` — KServe integration
+- `llmd-serving` — LLM serving
+- `model-serving` — Model Serving UI
+- `model-serving-backport` — Model serving backport compatibility
+- `model-training` — Model training UI
+- `nim-serving` — NIM serving
+
+#### Plugin Infrastructure
+
 - `plugin-core` — Core plugin utilities shared across plugins
 - `plugin-template` — Scaffold for new plugins
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -17,7 +17,7 @@ ODH Dashboard is a monorepo managed with npm workspaces and Turbo. It provides t
 
 ### Feature Plugin Packages (`packages/`)
 
-Feature packages export extensions via `./extensions` in `package.json` and are discovered by `discoverPluginPackages.js`. They fall into two categories based on how they are built and loaded:
+Feature packages provide extensions and are discovered by `discoverPluginPackages.js`. They fall into two categories based on how they are built and loaded:
 
 #### Module Federation Remotes
 
@@ -72,7 +72,7 @@ These packages export extensions but have **no** `module-federation` config. The
 
 ## BFF (Backend-for-Frontend) Architecture
 
-Several packages have a Go-based BFF service: `automl`, `autorag`, `eval-hub`, `gen-ai`, `maas`, `mlflow`.
+Several packages have a Go-based BFF service: `automl`, `autorag`, `eval-hub`, `gen-ai`, `maas`, `mlflow`, `model-registry`.
 - Located in `bff/` within the package
 - Check each package's `bff/go.mod` for its required Go toolchain version
 - Exposes REST APIs consumed by the package's frontend


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62925

## Description

The `architecture.md` rule file incorrectly stated that **all** feature packages under `packages/` are Module Federation remotes. In reality, only packages with a `module-federation` config block in their `package.json` are true MF remotes (loaded dynamically at runtime via `remoteEntry.js`). The remaining feature packages are **bundled plugin packages** — they export extensions but are compiled directly into the host bundle at build time.

This was flagged during review of #7580 by @DipanshuGupta.

**Changes:**
- Split the "Feature Plugin Packages" section into three subsections:
  - **Module Federation Remotes** (10 packages) — have own webpack build, `remoteEntry.js`, standalone dev server
  - **Bundled Plugin Packages** (7 packages) — export extensions but compiled into host at build time
  - **Plugin Infrastructure** — `plugin-core` and `plugin-template`
- Added `nim-serving` which was missing from the original listing
- Removed the inaccurate blanket statement about all packages being MF remotes

## How Has This Been Tested?

Documentation-only change. Verified the classification by checking which packages have `module-federation` in their `package.json`:
```bash
grep -rl '"module-federation"' packages/*/package.json
```

## Test Impact

No tests needed — this is a documentation/rule file correction with no code changes.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified plugin taxonomy by splitting feature packages into two deployment types (runtime-loaded remotes vs bundled plugins) and regrouped package lists accordingly.
  * Added a "Plugin Infrastructure" section and updated the backend service package listing to include the model-registry component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->