### PR TITLE
Fix: testEnabledISVs e2e Cypress test

### DIFF
--- a/packages/cypress/cypress/tests/e2e/applications/explore/testEnabledISVs.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/explore/testEnabledISVs.cy.ts
@@ -1,7 +1,7 @@
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../../utils/e2eUsers';
 import { explorePage } from '../../../../pages/explore';
 import { getOcResourceNames } from '../../../../utils/oc_commands/applications';
-import { filterRhoaiIfHidden, filterFeatureFlaggedApps } from '../../../../utils/appCheckUtils';
+import { filterHiddenApps, filterFeatureFlaggedApps } from '../../../../utils/appCheckUtils';
 import { retryableBefore } from '../../../../utils/retryableHooks';
 
 const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
@@ -11,8 +11,8 @@ describe('Verify RHODS Explore Section Contains Only Expected ISVs', () => {
 
   retryableBefore(() => {
     getOcResourceNames(applicationNamespace, 'OdhApplication').then((metadataNames) =>
-      filterRhoaiIfHidden(metadataNames)
-        .then((filteredRhoaiApps) => filterFeatureFlaggedApps(filteredRhoaiApps))
+      filterHiddenApps(applicationNamespace, metadataNames)
+        .then((visibleApps) => filterFeatureFlaggedApps(visibleApps))
         .then((filteredApps) => {
           expectedISVs = filteredApps;
           cy.log(

--- a/packages/cypress/cypress/utils/appCheckUtils.ts
+++ b/packages/cypress/cypress/utils/appCheckUtils.ts
@@ -1,33 +1,37 @@
-import * as yaml from 'js-yaml';
-
 /**
- * Reads and parses the rhoai-app.yaml YAML file and returns a boolean based on the 'hidden' value.
- * @returns Cypress chainable boolean indicating whether RHOAI is hidden.
- */
-export function isRhoaiHidden(): Cypress.Chainable<boolean> {
-  const rhoaiYamlPath = '../../manifests/rhoai/apps/rhoai/rhoai-app.yaml';
-
-  return cy.readFile(rhoaiYamlPath).then((fileContent) => {
-    // Parse the YAML content
-    const parsedYaml = yaml.load(fileContent) as { spec?: { hidden?: boolean } };
-
-    // Extract the "hidden" property
-    const isHidden = parsedYaml.spec?.hidden === true;
-
-    return isHidden;
-  });
-}
-
-/**
- * Filters the applications list by excluding RHOAI if it is hidden=true in the rhoai-app.yaml.
+ * Filters out applications that have spec.hidden === true in their OdhApplication CR.
+ * Queries the cluster for all OdhApplication CRs and excludes any with hidden set.
+ * @param applicationNamespace - The namespace containing OdhApplication CRs.
  * @param apps - Array of application names.
  * @returns Cypress chainable array of filtered application names.
  */
-export function filterRhoaiIfHidden(apps: string[]): Cypress.Chainable<string[]> {
-  return isRhoaiHidden().then((isHidden) => {
-    const filteredApps = isHidden ? apps.filter((app) => app !== 'rhoai') : apps;
-    return filteredApps;
-  });
+export function filterHiddenApps(
+  applicationNamespace: string,
+  apps: string[],
+): Cypress.Chainable<string[]> {
+  return cy
+    .exec(`oc get OdhApplication -n ${applicationNamespace} -o json`, {
+      failOnNonZeroExit: false,
+    })
+    .then((result) => {
+      if (result.exitCode !== 0 || !result.stdout.trim()) {
+        cy.log(`Failed to query OdhApplication CRs: ${result.stderr}`);
+        return cy.wrap(apps);
+      }
+
+      const items: { metadata: { name: string }; spec?: { hidden?: boolean } }[] =
+        JSON.parse(result.stdout).items || [];
+
+      const hiddenNames = new Set(
+        items.filter((item) => item.spec?.hidden === true).map((item) => item.metadata.name),
+      );
+
+      if (hiddenNames.size > 0) {
+        cy.log(`Filtering out hidden apps: ${[...hiddenNames].join(', ')}`);
+      }
+
+      return cy.wrap(apps.filter((app) => !hiddenNames.has(app)));
+    });
 }
 
 /**


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62943
## Description
Fix testEnabledISVs Cypress tests

  - filterRhoaiIfHidden() only excluded the rhoai app by reading a local YAML manifest. After PR #7524 added agentic-starter-kits with hidden: true, the test failed because it expected a card that the frontend correctly hides.
  - Replaced with filterHiddenApps() which queries the cluster for all OdhApplication CRs and filters out any with spec.hidden === true, handling current and future hidden apps automatically. 
  - Removed the js-yaml dependency from the utility since the new approach reads directly from the cluster.

## How Has This Been Tested?
dashboard-e2e-tests/800/ 
<img width="1197" height="194" alt="image" src="https://github.com/user-attachments/assets/ca8c11d5-55ab-4354-865f-8429dd485b22" />


## Test Impact
Test fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Explore E2E test filtering to determine hidden applications based on cluster configuration rather than local configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->