### PR TITLE
feat(RHOAIENG-60621): make playground welcome prompt examples clickable

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { MessageBox, ChatbotWelcomePrompt } from '@patternfly/chatbot';
+import { MessageBox, ChatbotWelcomePrompt, WelcomePrompt } from '@patternfly/chatbot';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { MCPServerFromAPI, TokenInfo } from '~/app/types';
 import { ServerStatusInfo } from '~/app/hooks/useMCPServerStatuses';
 import useChatbotMessages, { UseChatbotMessagesReturn } from './hooks/useChatbotMessages';
@@ -33,6 +34,7 @@ interface ChatbotConfigInstanceProps {
   namespace?: string;
   showWelcomePrompt?: boolean;
   welcomeDescription?: string;
+  onWelcomePromptClick?: (message: string) => void;
   onMessagesHookReady?: (hook: UseChatbotMessagesReturn) => void;
   configIndex?: number;
   isCompareMode?: boolean;
@@ -48,6 +50,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   namespace,
   showWelcomePrompt = false,
   welcomeDescription = 'Welcome to the playground',
+  onWelcomePromptClick,
   onMessagesHookReady,
   configIndex,
   isCompareMode,
@@ -143,6 +146,24 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
     }
   }, [messagesHook, onMessagesHookReady]);
 
+  const clickablePrompts: WelcomePrompt[] = React.useMemo(
+    () =>
+      onWelcomePromptClick
+        ? sampleWelcomePrompts.map((prompt) => ({
+            ...prompt,
+            onClick: () => {
+              if (prompt.message) {
+                onWelcomePromptClick(prompt.message);
+                fireMiscTrackingEvent('Playground Welcome Prompt Selected', {
+                  promptTitle: prompt.title,
+                });
+              }
+            },
+          }))
+        : sampleWelcomePrompts,
+    [onWelcomePromptClick],
+  );
+
   return (
     <MessageBox position="top">
       {showWelcomePrompt && messagesHook.messages.length === 0 && (
@@ -150,11 +171,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
           title={username ? `Hello, ${username}` : 'Hello'}
           description={welcomeDescription}
           data-testid="chatbot-welcome-prompt"
-          style={{
-            cursor: 'default',
-            pointerEvents: 'none',
-          }}
-          prompts={sampleWelcomePrompts}
+          prompts={clickablePrompts}
         />
       )}
       <ChatbotMessages

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -420,6 +420,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
           namespace={namespace?.name}
           showWelcomePrompt
           welcomeDescription={isCompareMode ? 'Send a message to compare models' : undefined}
+          onWelcomePromptClick={handleSendMessage}
           onMessagesHookReady={getHookReadyCallback(configId)}
           configIndex={isCompareMode ? index + 1 : 0}
           isCompareMode={isCompareMode}


### PR DESCRIPTION
Remove pointerEvents: 'none' that blocked interaction on ChatbotWelcomePrompt and wire each sample prompt's onClick to send the message through the existing handleSendMessage flow, including compare-mode broadcast.

https://redhat.atlassian.net/browse/RHOAIENG-60621

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The welcome prompt cards ("Code Explanation", "Data Structuring") in the Gen AI Studio Playground were not interactive — `pointerEvents: 'none'` on the `ChatbotWelcomePrompt` component blocked all mouse events.
This fix removes the blocking styles and wires each sample prompt's `onClick` to the existing `handleSendMessage` flow. Clicking a prompt card now sends its message text through the same path as the message input, including compare-mode broadcast to all panes. Analytics tracking (`'Playground Welcome Prompt Selected'`) is also added to record usage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested clicking each prompt card — message is sent and chat session begins
- Verified compare mode: clicking a prompt in one pane sends the message to both panes
- Verified prompt cards no longer appear with a dead cursor (now shows pointer on hover)
- Ran type-check (`tsc --noEmit`) and ESLint — both pass
- Unit tests: 4/4 passed (`jest --testPathPattern="ChatbotConfigInstance"`)


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Existing unit tests for `ChatbotConfigInstance` continue to pass. The change leverages PatternFly's built-in `onClick` API on `WelcomePrompt` (already tested by the library). 
No new test added as the interaction is a thin wiring of existing `handleSendMessage` which is covered by integration/Cypress tests.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


https://github.com/user-attachments/assets/86a6fbdc-b44f-4a87-92e5-9884195359db



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Welcome prompts are now interactive and clickable instead of static text
- Users can select a welcome prompt to instantly send it as a message
- Analytics tracking added to monitor welcome prompt interactions and engagement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->