### PR TITLE
Fix: collisions with cluster storage names

### DIFF
--- a/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchStorageClasses.yaml
+++ b/packages/cypress/cypress/fixtures/e2e/dataScienceProjects/testWorkbenchStorageClasses.yaml
@@ -1,7 +1,7 @@
 # testWorkbenchStorageClasses.cy.ts Test Data #
 projectName: "test-workbench-storage-preset"
-storageClassRWO: "sc-rwo"
-storageClassMultiAccess: "sc-multi-access"
+storageClassRWO: "sc-wb-rwo"
+storageClassMultiAccess: "sc-wb-multi-access"
 workbenchRWO: "wb-rwo-test"
 workbenchMultiAccessA: "wb-multi-a"
 workbenchMultiAccessB: "wb-multi-b"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62962
## Description
  - sc-rwo in testWorkbenchStorageClasses was a prefix of sc-rwo-preset in testClusterStorageAccessModes, causing findByRole('option', { name: /^sc-rwo\b/i }) to match both elements when the tests ran in parallel on the same cluster.
  - Renamed sc-rwo to sc-wb-rwo and sc-multi-access to sc-wb-multi-access to eliminate the collision.


## How Has This Been Tested?
dashboard-e2e-tests/805/
<img width="1170" height="483" alt="image" src="https://github.com/user-attachments/assets/f2984040-c4e2-44de-8979-ccedd0b697f9" />


## Test Impact
Tests fix

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture configuration for Kubernetes storage class identifiers to reflect new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->