### PR TITLE
fix: agent checkout fails on same-repo PRs

### DIFF
--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -73,7 +73,7 @@ jobs:
           PR_DATA=$(gh pr view "$ISSUE_NUMBER" --repo "$REPO" --json headRefOid,headRefName,headRepository)
           SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
           REF=$(echo "$PR_DATA" | jq -r '.headRefName')
-          HR=$(echo "$PR_DATA" | jq -r 'if .headRepository then .headRepository.owner.login + "/" + .headRepository.name else empty end')
+          HR=$(echo "$PR_DATA" | jq -r 'if .headRepository.owner then .headRepository.owner.login + "/" + .headRepository.name else empty end')
           echo "→ Preflight $MODE for PR #$ISSUE_NUMBER"
           MATRIX=$(jq -nc --arg n "$ISSUE_NUMBER" --arg m "$MODE" --arg s "$SHA" --arg r "$REF" --arg h "${HR:-$REPO}" \
             '[{"pr_number":$n,"mode":$m,"head_sha":$s,"head_ref":$r,"head_repo":$h}]')
@@ -99,7 +99,7 @@ jobs:
             NUM=$(echo "$pr_json" | jq -r '.number')
             SHA=$(echo "$pr_json" | jq -r '.headRefOid')
             REF=$(echo "$pr_json" | jq -r '.headRefName')
-            HR=$(echo "$pr_json" | jq -r 'if .headRepository then .headRepository.owner.login + "/" + .headRepository.name else empty end')
+            HR=$(echo "$pr_json" | jq -r 'if .headRepository.owner then .headRepository.owner.login + "/" + .headRepository.name else empty end')
             HR="${HR:-$REPO}"
             LABELS=$(echo "$pr_json" | jq -r '[.labels[].name] | join(",")')
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-57640

## Description

Fixes the ODH Dashboard Agent workflow failing on same-repo PRs (non-fork).

`gh pr view --json headRepository` returns an object with `name` but no `owner` field for same-repo PRs. The jq expression `.headRepository.owner.login` evaluates to `null`, producing `/odh-dashboard` instead of `opendatahub-io/odh-dashboard`. The checkout step then fails with:

```
Invalid repository '/odh-dashboard'. Expected format owner/repo.
```

Fix: check for `.headRepository.owner` instead of `.headRepository`. When absent, falls back to `$REPO` (the base repo).

## How Has This Been Tested?

Verified `gh pr view 7413 --json headRepository` returns `{"headRepository":{"id":"...","name":"odh-dashboard"}}` with no owner field. The updated jq expression correctly returns empty, triggering the `${HR:-$REPO}` fallback.

## Test Impact

No tests — CI workflow YAML fix.

## Request review criteria:

- [x] Testing instructions have been added in the PR body
- [x] The code follows our [Best Practices](/docs/best-practices.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Actions workflow stability by enhancing repository information handling in pull request scanning processes to properly handle edge cases where certain repository metadata may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->