### PR TITLE
RHOAIENG-51669: Handle graceful degradation when monitoring stack is …

### DIFF
--- a/packages/observability/cypress/pages/observabilityDashboard.ts
+++ b/packages/observability/cypress/pages/observabilityDashboard.ts
@@ -17,14 +17,6 @@ class ObservabilityDashboardPage {
     return cy.findByText('No dashboards found.');
   }
 
-  findMonitoringUnavailableHeadline() {
-    return cy.findByText('Monitoring is not available.');
-  }
-
-  findPersesUnavailableHeadline() {
-    return cy.findByText('Perses is not available — observability dashboards cannot load.');
-  }
-
   findPersesLoadErrorTitle() {
     return cy.findByText('Unable to reach observability dashboards');
   }
@@ -43,16 +35,6 @@ class ObservabilityDashboardPage {
 
   shouldHaveEmptyState() {
     this.findEmptyState().should('exist');
-    return this;
-  }
-
-  shouldHaveMonitoringUnavailableState() {
-    this.findMonitoringUnavailableHeadline().should('exist');
-    return this;
-  }
-
-  shouldHavePersesUnavailableState() {
-    this.findPersesUnavailableHeadline().should('exist');
     return this;
   }
 

--- a/packages/observability/cypress/pages/observabilityDashboard.ts
+++ b/packages/observability/cypress/pages/observabilityDashboard.ts
@@ -17,6 +17,18 @@ class ObservabilityDashboardPage {
     return cy.findByText('No dashboards found.');
   }
 
+  findMonitoringUnavailableHeadline() {
+    return cy.findByText('Monitoring is not available.');
+  }
+
+  findPersesUnavailableHeadline() {
+    return cy.findByText('Perses is not available — observability dashboards cannot load.');
+  }
+
+  findPersesLoadErrorTitle() {
+    return cy.findByText('Unable to reach observability dashboards');
+  }
+
   findTabs() {
     return cy.findByTestId('observability-dashboard-tabs');
   }
@@ -31,6 +43,21 @@ class ObservabilityDashboardPage {
 
   shouldHaveEmptyState() {
     this.findEmptyState().should('exist');
+    return this;
+  }
+
+  shouldHaveMonitoringUnavailableState() {
+    this.findMonitoringUnavailableHeadline().should('exist');
+    return this;
+  }
+
+  shouldHavePersesUnavailableState() {
+    this.findPersesUnavailableHeadline().should('exist');
+    return this;
+  }
+
+  shouldHavePersesLoadError() {
+    this.findPersesLoadErrorTitle().should('exist');
     return this;
   }
 

--- a/packages/observability/cypress/pages/observabilityDashboard.ts
+++ b/packages/observability/cypress/pages/observabilityDashboard.ts
@@ -14,7 +14,9 @@ class ObservabilityDashboardPage {
   }
 
   findEmptyState() {
-    return cy.findByText('No dashboards found.');
+    return cy.findByText(
+      'No dashboards were found. Verify that the monitoring stack is configured correctly.',
+    );
   }
 
   findPersesLoadErrorTitle() {

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -1,4 +1,5 @@
 import type { DashboardResource } from '@perses-dev/core';
+import type { K8sCondition } from '@odh-dashboard/internal/k8sTypes';
 import { mockDashboardConfig, mockStatus } from '@odh-dashboard/internal/__mocks__';
 import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
 import { observabilityDashboardPage } from '../../pages/observabilityDashboard';
@@ -23,15 +24,39 @@ const createMockPersesDashboard = (name: string, displayName: string): Dashboard
 const mockAdminDashboard = createMockPersesDashboard('dashboard-0-cluster-admin', 'Cluster');
 const mockNonAdminDashboard = createMockPersesDashboard('dashboard-1-model', 'Model');
 
+const HEALTHY_DSCI_CONDITIONS: K8sCondition[] = [
+  {
+    lastTransitionTime: '2023-10-20T11:45:04Z',
+    type: 'MonitoringReady',
+    status: 'True',
+    reason: 'Ready',
+    message: 'Monitoring stack is available',
+  },
+  {
+    lastTransitionTime: '2023-10-20T11:45:04Z',
+    type: 'PersesAvailable',
+    status: 'True',
+    reason: 'Ready',
+    message: 'Perses is available',
+  },
+];
+
 type InitInterceptsOptions = {
   dashboards?: DashboardResource[];
   isAdmin?: boolean;
+  dsciConditions?: K8sCondition[];
 };
 
-const initIntercepts = ({ dashboards = [], isAdmin = false }: InitInterceptsOptions = {}) => {
+const initIntercepts = ({
+  dashboards = [],
+  isAdmin = false,
+  dsciConditions = HEALTHY_DSCI_CONDITIONS,
+}: InitInterceptsOptions = {}) => {
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ observabilityDashboard: true }));
 
   cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin }));
+
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({ conditions: dsciConditions }));
 
   // Mock the global Perses dashboards API endpoint
   cy.intercept('GET', '/perses/api/api/v1/dashboards', {
@@ -51,57 +76,49 @@ describe('Observability Dashboard', () => {
     observabilityDashboardPage.shouldHaveEmptyState();
   });
 
-  it('should show monitoring unavailable when DSCI reports monitoring is not ready', () => {
-    cy.interceptOdh(
-      'GET /api/dsci/status',
-      mockDsciStatus({
-        conditions: [
-          {
-            lastTransitionTime: '2023-10-20T11:45:04Z',
-            type: 'MonitoringReady',
-            status: 'False',
-            reason: 'MissingOperator',
-            message: 'Cluster Observability Operator must be installed.',
-          },
-        ],
-      }),
-    );
+  it('should hide nav and route when DSCI reports monitoring is not ready', () => {
+    initIntercepts({
+      dashboards: [],
+      isAdmin: true,
+      dsciConditions: [
+        {
+          lastTransitionTime: '2023-10-20T11:45:04Z',
+          type: 'MonitoringReady',
+          status: 'False',
+          reason: 'MissingOperator',
+          message: 'Cluster Observability Operator must be installed.',
+        },
+      ],
+    });
 
-    initIntercepts({ dashboards: [], isAdmin: true });
-
-    observabilityDashboardPage.visit();
-
-    observabilityDashboardPage.shouldHaveMonitoringUnavailableState();
+    cy.visitWithLogin('/observe-and-monitor/dashboard');
+    cy.findByTestId('not-found-page').should('exist');
   });
 
-  it('should show Perses unavailable when MonitoringReady is True but PersesAvailable is False', () => {
-    cy.interceptOdh(
-      'GET /api/dsci/status',
-      mockDsciStatus({
-        conditions: [
-          {
-            lastTransitionTime: '2023-10-20T11:45:04Z',
-            type: 'MonitoringReady',
-            status: 'True',
-            reason: 'Ready',
-            message: 'Monitoring stack is available',
-          },
-          {
-            lastTransitionTime: '2023-10-20T11:45:04Z',
-            type: 'PersesAvailable',
-            status: 'False',
-            reason: 'PersesCRDNotFoundReason',
-            message: 'Perses CRD not found in cluster.',
-          },
-        ],
-      }),
-    );
+  it('should hide nav and route when MonitoringReady is True but PersesAvailable is False', () => {
+    initIntercepts({
+      dashboards: [],
+      isAdmin: true,
+      dsciConditions: [
+        {
+          lastTransitionTime: '2023-10-20T11:45:04Z',
+          type: 'MonitoringReady',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Monitoring stack is available',
+        },
+        {
+          lastTransitionTime: '2023-10-20T11:45:04Z',
+          type: 'PersesAvailable',
+          status: 'False',
+          reason: 'PersesCRDNotFoundReason',
+          message: 'Perses CRD not found in cluster.',
+        },
+      ],
+    });
 
-    initIntercepts({ dashboards: [], isAdmin: true });
-
-    observabilityDashboardPage.visit();
-
-    observabilityDashboardPage.shouldHavePersesUnavailableState();
+    cy.visitWithLogin('/observe-and-monitor/dashboard');
+    cy.findByTestId('not-found-page').should('exist');
   });
 
   it('should show a load error when the Perses dashboards API is unreachable', () => {

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -1,5 +1,6 @@
 import type { DashboardResource } from '@perses-dev/core';
 import { mockDashboardConfig, mockStatus } from '@odh-dashboard/internal/__mocks__';
+import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
 import { observabilityDashboardPage } from '../../pages/observabilityDashboard';
 
 // Minimal test fixtures following the naming pattern from packages/observability/setup
@@ -48,6 +49,74 @@ describe('Observability Dashboard', () => {
     cy.wait('@getPersesDashboards');
 
     observabilityDashboardPage.shouldHaveEmptyState();
+  });
+
+  it('should show monitoring unavailable when DSCI reports monitoring is not ready', () => {
+    cy.interceptOdh(
+      'GET /api/dsci/status',
+      mockDsciStatus({
+        conditions: [
+          {
+            lastTransitionTime: '2023-10-20T11:45:04Z',
+            type: 'MonitoringReady',
+            status: 'False',
+            reason: 'MissingOperator',
+            message: 'Cluster Observability Operator must be installed.',
+          },
+        ],
+      }),
+    );
+
+    initIntercepts({ dashboards: [], isAdmin: true });
+
+    observabilityDashboardPage.visit();
+
+    observabilityDashboardPage.shouldHaveMonitoringUnavailableState();
+  });
+
+  it('should show Perses unavailable when MonitoringReady is True but PersesAvailable is False', () => {
+    cy.interceptOdh(
+      'GET /api/dsci/status',
+      mockDsciStatus({
+        conditions: [
+          {
+            lastTransitionTime: '2023-10-20T11:45:04Z',
+            type: 'MonitoringReady',
+            status: 'True',
+            reason: 'Ready',
+            message: 'Monitoring stack is available',
+          },
+          {
+            lastTransitionTime: '2023-10-20T11:45:04Z',
+            type: 'PersesAvailable',
+            status: 'False',
+            reason: 'PersesCRDNotFoundReason',
+            message: 'Perses CRD not found in cluster.',
+          },
+        ],
+      }),
+    );
+
+    initIntercepts({ dashboards: [], isAdmin: true });
+
+    observabilityDashboardPage.visit();
+
+    observabilityDashboardPage.shouldHavePersesUnavailableState();
+  });
+
+  it('should show a load error when the Perses dashboards API is unreachable', () => {
+    initIntercepts({ isAdmin: true });
+
+    cy.intercept('GET', '/perses/api/api/v1/dashboards', {
+      statusCode: 503,
+      body: 'Service Unavailable',
+    }).as('getPersesDashboards');
+
+    observabilityDashboardPage.visit();
+
+    cy.wait('@getPersesDashboards');
+
+    observabilityDashboardPage.shouldHavePersesLoadError();
   });
 
   it('should show both admin and non-admin dashboard tabs when user is admin', () => {

--- a/packages/observability/extensions.ts
+++ b/packages/observability/extensions.ts
@@ -6,6 +6,7 @@ import type {
 
 const ADMIN_USER = 'ADMIN_USER';
 const PLUGIN_OBSERVABILITY = 'plugin-observability';
+const BLOCKING_CONDITION_TYPES = ['MonitoringReady', 'PersesAvailable'];
 
 const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
   {
@@ -13,6 +14,10 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
     properties: {
       id: PLUGIN_OBSERVABILITY,
       featureFlags: ['observabilityDashboard'],
+      customCondition: ({ dsciStatus }) =>
+        (
+          dsciStatus?.conditions.filter((c) => BLOCKING_CONDITION_TYPES.includes(c.type)) ?? []
+        ).every((c) => c.status === 'True'),
     },
   },
   {

--- a/packages/observability/extensions.ts
+++ b/packages/observability/extensions.ts
@@ -3,10 +3,11 @@ import type {
   AreaExtension,
   RouteExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
+// eslint-disable-next-line no-restricted-syntax -- customCondition is a runtime function, not a CodeRef
+import { isMonitoringStackAvailable } from './src/utils/monitoringStackStatus';
 
 const ADMIN_USER = 'ADMIN_USER';
 const PLUGIN_OBSERVABILITY = 'plugin-observability';
-const BLOCKING_CONDITION_TYPES = ['MonitoringReady', 'PersesAvailable'];
 
 const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
   {
@@ -14,10 +15,7 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
     properties: {
       id: PLUGIN_OBSERVABILITY,
       featureFlags: ['observabilityDashboard'],
-      customCondition: ({ dsciStatus }) =>
-        (
-          dsciStatus?.conditions.filter((c) => BLOCKING_CONDITION_TYPES.includes(c.type)) ?? []
-        ).every((c) => c.status === 'True'),
+      customCondition: ({ dsciStatus }) => isMonitoringStackAvailable(dsciStatus),
     },
   },
   {

--- a/packages/observability/src/api/usePersesDashboards.ts
+++ b/packages/observability/src/api/usePersesDashboards.ts
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { DashboardResource } from '@perses-dev/core';
 import { useAccessReview } from '@odh-dashboard/internal/api/useAccessReview';
+import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
 import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import useFetch, { type FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
+import { fetchPersesDashboardsMetadata } from '../perses/perses-client';
 import {
   filterDashboards,
   filterDashboardsByThanosNonTenancyAccess,
   THANOS_QUERIER_NON_TENANCY_ACCESS,
 } from '../utils/dashboardUtils';
-import { fetchPersesDashboardsMetadata } from '../perses/perses-client';
+
+type UsePersesDashboardsOptions = {
+  /**
+   * When false, skips the Perses dashboard list request (e.g. DSCI already reports monitoring is not available).
+   */
+  fetchDashboardList?: boolean;
+};
 
 type UsePersesDashboardsResult = Omit<FetchStateObject<DashboardResource[]>, 'data'> & {
   dashboards: DashboardResource[];
@@ -17,10 +25,24 @@ type UsePersesDashboardsResult = Omit<FetchStateObject<DashboardResource[]>, 'da
 /**
  * Hook to fetch observability dashboards from Perses API
  */
-export const usePersesDashboards = (): UsePersesDashboardsResult => {
+export const usePersesDashboards = (
+  options?: UsePersesDashboardsOptions,
+): UsePersesDashboardsResult => {
+  const fetchDashboardList = options?.fetchDashboardList ?? true;
   const { isAdmin } = useUser();
   const [canAccessThanosNonTenancy, thanosNonTenancyAccessLoaded] = useAccessReview(
     THANOS_QUERIER_NON_TENANCY_ACCESS,
+  );
+
+  const fetchDashboards = React.useCallback(
+    async (opts: K8sAPIOptions) => {
+      opts.signal?.throwIfAborted();
+      if (!fetchDashboardList) {
+        return [];
+      }
+      return fetchPersesDashboardsMetadata();
+    },
+    [fetchDashboardList],
   );
 
   const {
@@ -28,7 +50,7 @@ export const usePersesDashboards = (): UsePersesDashboardsResult => {
     loaded,
     error,
     refresh,
-  } = useFetch(fetchPersesDashboardsMetadata, [], { initialPromisePurity: true });
+  } = useFetch(fetchDashboards, [], { initialPromisePurity: true });
 
   const dashboards = React.useMemo(() => {
     const afterAdminFilter = filterDashboards(allDashboards, isAdmin);

--- a/packages/observability/src/api/usePersesDashboards.ts
+++ b/packages/observability/src/api/usePersesDashboards.ts
@@ -40,7 +40,7 @@ export const usePersesDashboards = (
       if (!fetchDashboardList) {
         return [];
       }
-      return fetchPersesDashboardsMetadata();
+      return fetchPersesDashboardsMetadata(opts.signal);
     },
     [fetchDashboardList],
   );

--- a/packages/observability/src/pages/DashboardPage.tsx
+++ b/packages/observability/src/pages/DashboardPage.tsx
@@ -11,9 +11,7 @@ const NO_DASHBOARDS_HINT =
   'No dashboard definitions were returned. If this is unexpected, verify Perses and the monitoring stack are configured.';
 
 const DashboardPage: React.FC = () => {
-  const { dashboards, loaded, error } = usePersesDashboards({
-    fetchDashboardList: true,
-  });
+  const { dashboards, loaded, error } = usePersesDashboards();
 
   if (error) {
     return (

--- a/packages/observability/src/pages/DashboardPage.tsx
+++ b/packages/observability/src/pages/DashboardPage.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- Host shell wrapper for federated observability routes
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { AreaContext } from '@odh-dashboard/internal/concepts/areas/AreaContext';
 import DashboardContent from './DashboardContent';
 import { DASHBOARD_PAGE_TITLE, DASHBOARD_PAGE_DESCRIPTION } from './const';
 import { usePersesDashboards } from '../api/usePersesDashboards';
-import { getMonitoringStackSignal } from '../utils/monitoringStackStatus';
-
-const MONITORING_UNAVAILABLE_FALLBACK =
-  'Check the DSCInitialization status conditions for details.';
 
 const PERSES_LOAD_ERROR_TITLE = 'Unable to reach observability dashboards';
 
@@ -16,31 +11,9 @@ const NO_DASHBOARDS_HINT =
   'No dashboard definitions were returned. If this is unexpected, verify Perses and the monitoring stack are configured.';
 
 const DashboardPage: React.FC = () => {
-  const { dsciStatus } = React.useContext(AreaContext);
-  const monitoringSignal = React.useMemo(() => getMonitoringStackSignal(dsciStatus), [dsciStatus]);
-  const skipPersesList = monitoringSignal.kind === 'unavailable';
-
   const { dashboards, loaded, error } = usePersesDashboards({
-    fetchDashboardList: !skipPersesList,
+    fetchDashboardList: true,
   });
-
-  if (monitoringSignal.kind === 'unavailable') {
-    const subtext =
-      monitoringSignal.operatorMessage ??
-      monitoringSignal.reason ??
-      MONITORING_UNAVAILABLE_FALLBACK;
-
-    return (
-      <ApplicationsPage
-        title={DASHBOARD_PAGE_TITLE}
-        description={DASHBOARD_PAGE_DESCRIPTION}
-        loaded
-        empty
-        emptyMessage={monitoringSignal.headline}
-        subtext={subtext}
-      />
-    );
-  }
 
   if (error) {
     return (
@@ -77,7 +50,7 @@ const DashboardPage: React.FC = () => {
       loaded
       empty
       emptyMessage="No dashboards found."
-      subtext={monitoringSignal.kind === 'unknown' ? NO_DASHBOARDS_HINT : undefined}
+      subtext={NO_DASHBOARDS_HINT}
     />
   );
 };

--- a/packages/observability/src/pages/DashboardPage.tsx
+++ b/packages/observability/src/pages/DashboardPage.tsx
@@ -1,26 +1,83 @@
 import * as React from 'react';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports -- Host shell wrapper for federated observability routes
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { AreaContext } from '@odh-dashboard/internal/concepts/areas/AreaContext';
 import DashboardContent from './DashboardContent';
 import { DASHBOARD_PAGE_TITLE, DASHBOARD_PAGE_DESCRIPTION } from './const';
 import { usePersesDashboards } from '../api/usePersesDashboards';
+import { getMonitoringStackSignal } from '../utils/monitoringStackStatus';
+
+const MONITORING_UNAVAILABLE_FALLBACK =
+  'Check the DSCInitialization status conditions for details.';
+
+const PERSES_LOAD_ERROR_TITLE = 'Unable to reach observability dashboards';
+
+const NO_DASHBOARDS_HINT =
+  'No dashboard definitions were returned. If this is unexpected, verify Perses and the monitoring stack are configured.';
 
 const DashboardPage: React.FC = () => {
-  const { dashboards, loaded, error } = usePersesDashboards();
+  const { dsciStatus } = React.useContext(AreaContext);
+  const monitoringSignal = React.useMemo(() => getMonitoringStackSignal(dsciStatus), [dsciStatus]);
+  const skipPersesList = monitoringSignal.kind === 'unavailable';
 
-  // When we have valid dashboards, render with tabs
-  if (loaded && !error && dashboards.length > 0) {
+  const { dashboards, loaded, error } = usePersesDashboards({
+    fetchDashboardList: !skipPersesList,
+  });
+
+  if (monitoringSignal.kind === 'unavailable') {
+    const subtext =
+      monitoringSignal.operatorMessage ??
+      monitoringSignal.reason ??
+      MONITORING_UNAVAILABLE_FALLBACK;
+
+    return (
+      <ApplicationsPage
+        title={DASHBOARD_PAGE_TITLE}
+        description={DASHBOARD_PAGE_DESCRIPTION}
+        loaded
+        empty
+        emptyMessage={monitoringSignal.headline}
+        subtext={subtext}
+      />
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <ApplicationsPage
+        title={DASHBOARD_PAGE_TITLE}
+        description={DASHBOARD_PAGE_DESCRIPTION}
+        loaded={false}
+        empty={false}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <ApplicationsPage
+        title={DASHBOARD_PAGE_TITLE}
+        description={DASHBOARD_PAGE_DESCRIPTION}
+        loaded
+        empty={false}
+        loadError={error}
+        errorMessage={PERSES_LOAD_ERROR_TITLE}
+      />
+    );
+  }
+
+  if (dashboards.length > 0) {
     return <DashboardContent dashboards={dashboards} />;
   }
 
-  // Loading, error, or empty states - render without PersesWrapper
   return (
     <ApplicationsPage
       title={DASHBOARD_PAGE_TITLE}
       description={DASHBOARD_PAGE_DESCRIPTION}
-      loaded={loaded}
-      loadError={error}
-      empty={dashboards.length === 0}
+      loaded
+      empty
       emptyMessage="No dashboards found."
+      subtext={monitoringSignal.kind === 'unknown' ? NO_DASHBOARDS_HINT : undefined}
     />
   );
 };

--- a/packages/observability/src/pages/DashboardPage.tsx
+++ b/packages/observability/src/pages/DashboardPage.tsx
@@ -7,8 +7,8 @@ import { usePersesDashboards } from '../api/usePersesDashboards';
 
 const PERSES_LOAD_ERROR_TITLE = 'Unable to reach observability dashboards';
 
-const NO_DASHBOARDS_HINT =
-  'No dashboard definitions were returned. If this is unexpected, verify Perses and the monitoring stack are configured.';
+const NO_DASHBOARDS_MESSAGE =
+  'No dashboards were found. Verify that the monitoring stack is configured correctly.';
 
 const DashboardPage: React.FC = () => {
   const { dashboards, loaded, error } = usePersesDashboards();
@@ -47,8 +47,7 @@ const DashboardPage: React.FC = () => {
       description={DASHBOARD_PAGE_DESCRIPTION}
       loaded
       empty
-      emptyMessage="No dashboards found."
-      subtext={NO_DASHBOARDS_HINT}
+      emptyMessage={NO_DASHBOARDS_MESSAGE}
     />
   );
 };

--- a/packages/observability/src/pages/DashboardPage.tsx
+++ b/packages/observability/src/pages/DashboardPage.tsx
@@ -42,17 +42,6 @@ const DashboardPage: React.FC = () => {
     );
   }
 
-  if (!loaded) {
-    return (
-      <ApplicationsPage
-        title={DASHBOARD_PAGE_TITLE}
-        description={DASHBOARD_PAGE_DESCRIPTION}
-        loaded={false}
-        empty={false}
-      />
-    );
-  }
-
   if (error) {
     return (
       <ApplicationsPage
@@ -62,6 +51,17 @@ const DashboardPage: React.FC = () => {
         empty={false}
         loadError={error}
         errorMessage={PERSES_LOAD_ERROR_TITLE}
+      />
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <ApplicationsPage
+        title={DASHBOARD_PAGE_TITLE}
+        description={DASHBOARD_PAGE_DESCRIPTION}
+        loaded={false}
+        empty={false}
       />
     );
   }

--- a/packages/observability/src/perses/perses-client/perses-client.ts
+++ b/packages/observability/src/perses/perses-client/perses-client.ts
@@ -21,11 +21,13 @@ export const PERSES_PROXY_BASE_PATH = '/perses/api';
 // ODH Specific Code
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-export const fetchPersesDashboardsMetadata = (): Promise<DashboardResource[]> => {
+export const fetchPersesDashboardsMetadata = (
+  signal?: AbortSignal,
+): Promise<DashboardResource[]> => {
   const listDashboardsMetadata = '/api/v1/dashboards';
   const persesURL = `${PERSES_PROXY_BASE_PATH}${listDashboardsMetadata}`;
 
-  return odhPersesFetchJson<DashboardResource[]>(persesURL);
+  return odhPersesFetchJson<DashboardResource[]>(persesURL, signal);
 };
 
 export const fetchPersesProjects = (): Promise<ProjectResource[]> => {
@@ -35,12 +37,12 @@ export const fetchPersesProjects = (): Promise<ProjectResource[]> => {
   return odhPersesFetchJson<ProjectResource[]>(persesURL);
 };
 
-export async function odhPersesFetchJson<T>(url: string): Promise<T> {
-  // Use perses fetch as base fetch call as it handles refresh tokens
+export async function odhPersesFetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
   return fetchJson(url, {
     headers: {
       'Content-Type': 'application/json',
     },
+    signal,
   });
 }
 

--- a/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
+++ b/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
@@ -1,9 +1,14 @@
 import type { DataScienceClusterInitializationKindStatus } from '@odh-dashboard/internal/k8sTypes';
-import { isMonitoringStackAvailable } from '../monitoringStackStatus';
+import { isMonitoringStackAvailable, getMonitoringStatus } from '../monitoringStackStatus';
 
 describe('isMonitoringStackAvailable', () => {
   it('should return true when DSCI status is null', () => {
     expect(isMonitoringStackAvailable(null)).toBe(true);
+  });
+
+  it('should return true when conditions field is undefined', () => {
+    const dsci = {} as DataScienceClusterInitializationKindStatus;
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
   it('should return true when conditions array is empty', () => {
@@ -154,5 +159,73 @@ describe('isMonitoringStackAvailable', () => {
       ],
     };
     expect(isMonitoringStackAvailable(dsci)).toBe(true);
+  });
+});
+
+describe('getMonitoringStatus', () => {
+  it('should return available when DSCI status is null', () => {
+    expect(getMonitoringStatus(null)).toEqual({ available: true });
+  });
+
+  it('should return available when conditions is undefined', () => {
+    const dsci = {} as DataScienceClusterInitializationKindStatus;
+    expect(getMonitoringStatus(dsci)).toEqual({ available: true });
+  });
+
+  it('should return monitoring-not-ready when MonitoringReady is False', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'False',
+          reason: 'MissingOperator',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStatus(dsci)).toEqual({
+      available: false,
+      reason: 'monitoring-not-ready',
+    });
+  });
+
+  it('should return perses-not-available when MonitoringReady is True but PersesAvailable is False', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'PersesAvailable',
+          status: 'False',
+          reason: 'PersesCRDNotFound',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStatus(dsci)).toEqual({
+      available: false,
+      reason: 'perses-not-available',
+    });
+  });
+
+  it('should return available when both conditions are True', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'PersesAvailable',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStatus(dsci)).toEqual({ available: true });
   });
 });

--- a/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
+++ b/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
@@ -1,0 +1,231 @@
+import type { DataScienceClusterInitializationKindStatus } from '@odh-dashboard/internal/k8sTypes';
+import { getMonitoringStackSignal } from '../monitoringStackStatus';
+
+describe('getMonitoringStackSignal', () => {
+  it('returns unknown when DSCI status is null', () => {
+    expect(getMonitoringStackSignal(null)).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns unknown when conditions array is empty', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = { conditions: [] };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns unknown when no blocking conditions are present (older operator)', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'ReconcileComplete',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns ready when MonitoringReady is True', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Monitoring stack is available',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+  });
+
+  it('returns ready when both MonitoringReady and PersesAvailable are True', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Monitoring stack is available',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'PersesAvailable',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+  });
+
+  it('returns unavailable when MonitoringReady is False (monitoring not enabled)', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'False',
+          reason: 'Removed',
+          message: 'Monitoring is not enabled',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({
+      kind: 'unavailable',
+      headline: 'Monitoring is not available.',
+      operatorMessage: 'Monitoring is not enabled',
+      reason: 'Removed',
+    });
+  });
+
+  it('returns unavailable when MonitoringReady is False (COO missing)', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'False',
+          reason: 'MissingOperator',
+          message: 'Cluster Observability Operator must be installed',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({
+      kind: 'unavailable',
+      headline: 'Monitoring is not available.',
+      operatorMessage: 'Cluster Observability Operator must be installed',
+      reason: 'MissingOperator',
+    });
+  });
+
+  it('returns unavailable when MonitoringReady is Unknown (initializing)', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'Unknown',
+          reason: 'NotReady',
+          message: 'Monitoring stack is initializing',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({
+      kind: 'unavailable',
+      headline: 'Monitoring is not available.',
+      operatorMessage: 'Monitoring stack is initializing',
+      reason: 'NotReady',
+    });
+  });
+
+  it('returns unavailable when MonitoringReady is True but PersesAvailable is False', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          reason: 'Ready',
+          message: 'Monitoring stack is available',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'PersesAvailable',
+          status: 'False',
+          reason: 'PersesCRDNotFound',
+          message: 'Perses CRD not found — install the Perses Operator',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({
+      kind: 'unavailable',
+      headline: 'Perses is not available — observability dashboards cannot load.',
+      operatorMessage: 'Perses CRD not found — install the Perses Operator',
+      reason: 'PersesCRDNotFound',
+    });
+  });
+
+  it('reports MonitoringReady first when both it and PersesAvailable are failing', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'PersesAvailable',
+          status: 'False',
+          reason: 'PersesCRDNotFound',
+          message: 'Perses CRD not found',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'MonitoringReady',
+          status: 'False',
+          reason: 'MissingOperator',
+          message: 'COO not installed',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    const signal = getMonitoringStackSignal(dsci);
+    expect(signal.kind).toBe('unavailable');
+    if (signal.kind === 'unavailable') {
+      expect(signal.headline).toBe('Monitoring is not available.');
+      expect(signal.reason).toBe('MissingOperator');
+    }
+  });
+
+  it('returns ready when only PersesAvailable is present and True', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'PersesAvailable',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+  });
+
+  it('returns ready even when optional conditions are False', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'True',
+          reason: 'Ready',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'PersesAvailable',
+          status: 'True',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+        {
+          type: 'TempoAvailable',
+          status: 'False',
+          reason: 'TracesNotConfigured',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+  });
+
+  it('returns unavailable with no operatorMessage when condition has no message', () => {
+    const dsci: DataScienceClusterInitializationKindStatus = {
+      conditions: [
+        {
+          type: 'MonitoringReady',
+          status: 'False',
+          lastTransitionTime: '2024-01-01T00:00:00Z',
+        },
+      ],
+    };
+    const signal = getMonitoringStackSignal(dsci);
+    expect(signal.kind).toBe('unavailable');
+    if (signal.kind === 'unavailable') {
+      expect(signal.operatorMessage).toBeUndefined();
+      expect(signal.reason).toBeUndefined();
+    }
+  });
+});

--- a/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
+++ b/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
@@ -2,18 +2,18 @@ import type { DataScienceClusterInitializationKindStatus } from '@odh-dashboard/
 import { isMonitoringStackAvailable, getMonitoringStatus } from '../monitoringStackStatus';
 
 describe('isMonitoringStackAvailable', () => {
-  it('should return true when DSCI status is null', () => {
-    expect(isMonitoringStackAvailable(null)).toBe(true);
+  it('should return false when DSCI status is null', () => {
+    expect(isMonitoringStackAvailable(null)).toBe(false);
   });
 
-  it('should return true when conditions field is undefined', () => {
+  it('should return false when conditions field is undefined', () => {
     const dsci = {} as DataScienceClusterInitializationKindStatus;
-    expect(isMonitoringStackAvailable(dsci)).toBe(true);
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
-  it('should return true when conditions array is empty', () => {
+  it('should return false when conditions array is empty', () => {
     const dsci: DataScienceClusterInitializationKindStatus = { conditions: [] };
-    expect(isMonitoringStackAvailable(dsci)).toBe(true);
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
   it('should return true when no blocking conditions are present (older operator)', () => {
@@ -163,13 +163,13 @@ describe('isMonitoringStackAvailable', () => {
 });
 
 describe('getMonitoringStatus', () => {
-  it('should return available when DSCI status is null', () => {
-    expect(getMonitoringStatus(null)).toEqual({ available: true });
+  it('should return monitoring-not-ready when DSCI status is null', () => {
+    expect(getMonitoringStatus(null)).toEqual({ available: false, reason: 'monitoring-not-ready' });
   });
 
-  it('should return available when conditions is undefined', () => {
+  it('should return monitoring-not-ready when conditions is undefined', () => {
     const dsci = {} as DataScienceClusterInitializationKindStatus;
-    expect(getMonitoringStatus(dsci)).toEqual({ available: true });
+    expect(getMonitoringStatus(dsci)).toEqual({ available: false, reason: 'monitoring-not-ready' });
   });
 
   it('should return monitoring-not-ready when MonitoringReady is False', () => {

--- a/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
+++ b/packages/observability/src/utils/__tests__/monitoringStackStatus.spec.ts
@@ -1,17 +1,17 @@
 import type { DataScienceClusterInitializationKindStatus } from '@odh-dashboard/internal/k8sTypes';
-import { getMonitoringStackSignal } from '../monitoringStackStatus';
+import { isMonitoringStackAvailable } from '../monitoringStackStatus';
 
-describe('getMonitoringStackSignal', () => {
-  it('returns unknown when DSCI status is null', () => {
-    expect(getMonitoringStackSignal(null)).toEqual({ kind: 'unknown' });
+describe('isMonitoringStackAvailable', () => {
+  it('should return true when DSCI status is null', () => {
+    expect(isMonitoringStackAvailable(null)).toBe(true);
   });
 
-  it('returns unknown when conditions array is empty', () => {
+  it('should return true when conditions array is empty', () => {
     const dsci: DataScienceClusterInitializationKindStatus = { conditions: [] };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'unknown' });
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
-  it('returns unknown when no blocking conditions are present (older operator)', () => {
+  it('should return true when no blocking conditions are present (older operator)', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
@@ -21,32 +21,28 @@ describe('getMonitoringStackSignal', () => {
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'unknown' });
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
-  it('returns ready when MonitoringReady is True', () => {
+  it('should return true when MonitoringReady is True', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'True',
-          reason: 'Ready',
-          message: 'Monitoring stack is available',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
-  it('returns ready when both MonitoringReady and PersesAvailable are True', () => {
+  it('should return true when both MonitoringReady and PersesAvailable are True', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'True',
-          reason: 'Ready',
-          message: 'Monitoring stack is available',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
         {
@@ -56,124 +52,75 @@ describe('getMonitoringStackSignal', () => {
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
-  it('returns unavailable when MonitoringReady is False (monitoring not enabled)', () => {
+  it('should return false when MonitoringReady is False', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'False',
           reason: 'Removed',
-          message: 'Monitoring is not enabled',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({
-      kind: 'unavailable',
-      headline: 'Monitoring is not available.',
-      operatorMessage: 'Monitoring is not enabled',
-      reason: 'Removed',
-    });
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
-  it('returns unavailable when MonitoringReady is False (COO missing)', () => {
-    const dsci: DataScienceClusterInitializationKindStatus = {
-      conditions: [
-        {
-          type: 'MonitoringReady',
-          status: 'False',
-          reason: 'MissingOperator',
-          message: 'Cluster Observability Operator must be installed',
-          lastTransitionTime: '2024-01-01T00:00:00Z',
-        },
-      ],
-    };
-    expect(getMonitoringStackSignal(dsci)).toEqual({
-      kind: 'unavailable',
-      headline: 'Monitoring is not available.',
-      operatorMessage: 'Cluster Observability Operator must be installed',
-      reason: 'MissingOperator',
-    });
-  });
-
-  it('returns unavailable when MonitoringReady is Unknown (initializing)', () => {
+  it('should return false when MonitoringReady is Unknown', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'Unknown',
           reason: 'NotReady',
-          message: 'Monitoring stack is initializing',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({
-      kind: 'unavailable',
-      headline: 'Monitoring is not available.',
-      operatorMessage: 'Monitoring stack is initializing',
-      reason: 'NotReady',
-    });
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
-  it('returns unavailable when MonitoringReady is True but PersesAvailable is False', () => {
+  it('should return false when MonitoringReady is True but PersesAvailable is False', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'True',
-          reason: 'Ready',
-          message: 'Monitoring stack is available',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
         {
           type: 'PersesAvailable',
           status: 'False',
           reason: 'PersesCRDNotFound',
-          message: 'Perses CRD not found — install the Perses Operator',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({
-      kind: 'unavailable',
-      headline: 'Perses is not available — observability dashboards cannot load.',
-      operatorMessage: 'Perses CRD not found — install the Perses Operator',
-      reason: 'PersesCRDNotFound',
-    });
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
-  it('reports MonitoringReady first when both it and PersesAvailable are failing', () => {
+  it('should return false when both MonitoringReady and PersesAvailable are failing', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'PersesAvailable',
           status: 'False',
-          reason: 'PersesCRDNotFound',
-          message: 'Perses CRD not found',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
         {
           type: 'MonitoringReady',
           status: 'False',
-          reason: 'MissingOperator',
-          message: 'COO not installed',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    const signal = getMonitoringStackSignal(dsci);
-    expect(signal.kind).toBe('unavailable');
-    if (signal.kind === 'unavailable') {
-      expect(signal.headline).toBe('Monitoring is not available.');
-      expect(signal.reason).toBe('MissingOperator');
-    }
+    expect(isMonitoringStackAvailable(dsci)).toBe(false);
   });
 
-  it('returns ready when only PersesAvailable is present and True', () => {
+  it('should return true when only PersesAvailable is present and True', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
@@ -183,16 +130,15 @@ describe('getMonitoringStackSignal', () => {
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 
-  it('returns ready even when optional conditions are False', () => {
+  it('should ignore unrelated conditions', () => {
     const dsci: DataScienceClusterInitializationKindStatus = {
       conditions: [
         {
           type: 'MonitoringReady',
           status: 'True',
-          reason: 'Ready',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
         {
@@ -203,29 +149,10 @@ describe('getMonitoringStackSignal', () => {
         {
           type: 'TempoAvailable',
           status: 'False',
-          reason: 'TracesNotConfigured',
           lastTransitionTime: '2024-01-01T00:00:00Z',
         },
       ],
     };
-    expect(getMonitoringStackSignal(dsci)).toEqual({ kind: 'ready' });
-  });
-
-  it('returns unavailable with no operatorMessage when condition has no message', () => {
-    const dsci: DataScienceClusterInitializationKindStatus = {
-      conditions: [
-        {
-          type: 'MonitoringReady',
-          status: 'False',
-          lastTransitionTime: '2024-01-01T00:00:00Z',
-        },
-      ],
-    };
-    const signal = getMonitoringStackSignal(dsci);
-    expect(signal.kind).toBe('unavailable');
-    if (signal.kind === 'unavailable') {
-      expect(signal.operatorMessage).toBeUndefined();
-      expect(signal.reason).toBeUndefined();
-    }
+    expect(isMonitoringStackAvailable(dsci)).toBe(true);
   });
 });

--- a/packages/observability/src/utils/monitoringStackStatus.ts
+++ b/packages/observability/src/utils/monitoringStackStatus.ts
@@ -13,7 +13,7 @@ export const getMonitoringStatus = (
 ): MonitoringStatus => {
   const conditions = dsciStatus?.conditions;
   if (!Array.isArray(conditions) || conditions.length === 0) {
-    return { available: true };
+    return { available: false, reason: 'monitoring-not-ready' };
   }
 
   const byType = new Map<string, K8sCondition>();

--- a/packages/observability/src/utils/monitoringStackStatus.ts
+++ b/packages/observability/src/utils/monitoringStackStatus.ts
@@ -3,55 +3,13 @@ import type {
   K8sCondition,
 } from '@odh-dashboard/internal/k8sTypes';
 
-/**
- * Conditions checked on the DSCI to decide whether Perses dashboards can load.
- *
- * Evaluated in order — the first failing condition drives the empty-state message.
- *
- * - `MonitoringReady` — aggregate condition added by PR #3485 in the ODH operator.
- *   Reflects the overall health of the Monitoring service:
- *     True  → monitoring service is healthy
- *     False + reason "Removed" → monitoring is not enabled in DSCI
- *     False + forwarded reason/message → MonitoringAvailable is False on the Monitoring CR
- *     Unknown → initializing or error retrieving Monitoring CR status
- *
- * - `PersesAvailable` — mirrored sub-condition from the Monitoring CR.
- *   False when Perses CRDs are absent or the Perses instance failed to deploy.
- *   Checked separately because MonitoringReady may be True (prerequisites met)
- *   while Perses specifically is not yet available.
- *
- * @see {@link https://github.com/opendatahub-io/opendatahub-operator/pull/3485}
- * @see {@link https://issues.redhat.com/browse/RHOAIENG-59122}
- */
-const BLOCKING_CONDITIONS: readonly {
-  type: string;
-  headline: string;
-}[] = [
-  {
-    type: 'MonitoringReady',
-    headline: 'Monitoring is not available.',
-  },
-  {
-    type: 'PersesAvailable',
-    headline: 'Perses is not available — observability dashboards cannot load.',
-  },
-];
+const BLOCKING_CONDITION_TYPES = ['MonitoringReady', 'PersesAvailable'];
 
-export type MonitoringStackSignal =
-  | { kind: 'ready' }
-  | {
-      kind: 'unavailable';
-      headline: string;
-      operatorMessage?: string;
-      reason?: string;
-    }
-  | { kind: 'unknown' };
-
-export const getMonitoringStackSignal = (
+export const isMonitoringStackAvailable = (
   dsciStatus: DataScienceClusterInitializationKindStatus | null,
-): MonitoringStackSignal => {
+): boolean => {
   if (!dsciStatus || dsciStatus.conditions.length === 0) {
-    return { kind: 'unknown' };
+    return true;
   }
 
   const byType = new Map<string, K8sCondition>();
@@ -59,23 +17,11 @@ export const getMonitoringStackSignal = (
     byType.set(c.type, c);
   }
 
-  const matched = BLOCKING_CONDITIONS.filter((b) => byType.has(b.type));
+  const matched = BLOCKING_CONDITION_TYPES.filter((t) => byType.has(t));
 
   if (matched.length === 0) {
-    return { kind: 'unknown' };
+    return true;
   }
 
-  for (const blocker of matched) {
-    const condition = byType.get(blocker.type);
-    if (condition && condition.status !== 'True') {
-      return {
-        kind: 'unavailable',
-        headline: blocker.headline,
-        operatorMessage: condition.message,
-        reason: condition.reason,
-      };
-    }
-  }
-
-  return { kind: 'ready' };
+  return matched.every((t) => byType.get(t)?.status === 'True');
 };

--- a/packages/observability/src/utils/monitoringStackStatus.ts
+++ b/packages/observability/src/utils/monitoringStackStatus.ts
@@ -3,25 +3,37 @@ import type {
   K8sCondition,
 } from '@odh-dashboard/internal/k8sTypes';
 
-const BLOCKING_CONDITION_TYPES = ['MonitoringReady', 'PersesAvailable'];
+export type MonitoringStatus =
+  | { available: true }
+  | { available: false; reason: 'monitoring-not-ready' }
+  | { available: false; reason: 'perses-not-available' };
 
-export const isMonitoringStackAvailable = (
+export const getMonitoringStatus = (
   dsciStatus: DataScienceClusterInitializationKindStatus | null,
-): boolean => {
-  if (!dsciStatus || dsciStatus.conditions.length === 0) {
-    return true;
+): MonitoringStatus => {
+  const conditions = dsciStatus?.conditions;
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    return { available: true };
   }
 
   const byType = new Map<string, K8sCondition>();
-  for (const c of dsciStatus.conditions) {
+  for (const c of conditions) {
     byType.set(c.type, c);
   }
 
-  const matched = BLOCKING_CONDITION_TYPES.filter((t) => byType.has(t));
-
-  if (matched.length === 0) {
-    return true;
+  const monitoringReady = byType.get('MonitoringReady');
+  if (monitoringReady && monitoringReady.status !== 'True') {
+    return { available: false, reason: 'monitoring-not-ready' };
   }
 
-  return matched.every((t) => byType.get(t)?.status === 'True');
+  const persesAvailable = byType.get('PersesAvailable');
+  if (persesAvailable && persesAvailable.status !== 'True') {
+    return { available: false, reason: 'perses-not-available' };
+  }
+
+  return { available: true };
 };
+
+export const isMonitoringStackAvailable = (
+  dsciStatus: DataScienceClusterInitializationKindStatus | null,
+): boolean => getMonitoringStatus(dsciStatus).available;

--- a/packages/observability/src/utils/monitoringStackStatus.ts
+++ b/packages/observability/src/utils/monitoringStackStatus.ts
@@ -1,0 +1,81 @@
+import type {
+  DataScienceClusterInitializationKindStatus,
+  K8sCondition,
+} from '@odh-dashboard/internal/k8sTypes';
+
+/**
+ * Conditions checked on the DSCI to decide whether Perses dashboards can load.
+ *
+ * Evaluated in order — the first failing condition drives the empty-state message.
+ *
+ * - `MonitoringReady` — aggregate condition added by PR #3485 in the ODH operator.
+ *   Reflects the overall health of the Monitoring service:
+ *     True  → monitoring service is healthy
+ *     False + reason "Removed" → monitoring is not enabled in DSCI
+ *     False + forwarded reason/message → MonitoringAvailable is False on the Monitoring CR
+ *     Unknown → initializing or error retrieving Monitoring CR status
+ *
+ * - `PersesAvailable` — mirrored sub-condition from the Monitoring CR.
+ *   False when Perses CRDs are absent or the Perses instance failed to deploy.
+ *   Checked separately because MonitoringReady may be True (prerequisites met)
+ *   while Perses specifically is not yet available.
+ *
+ * @see {@link https://github.com/opendatahub-io/opendatahub-operator/pull/3485}
+ * @see {@link https://issues.redhat.com/browse/RHOAIENG-59122}
+ */
+const BLOCKING_CONDITIONS: readonly {
+  type: string;
+  headline: string;
+}[] = [
+  {
+    type: 'MonitoringReady',
+    headline: 'Monitoring is not available.',
+  },
+  {
+    type: 'PersesAvailable',
+    headline: 'Perses is not available — observability dashboards cannot load.',
+  },
+];
+
+export type MonitoringStackSignal =
+  | { kind: 'ready' }
+  | {
+      kind: 'unavailable';
+      headline: string;
+      operatorMessage?: string;
+      reason?: string;
+    }
+  | { kind: 'unknown' };
+
+export const getMonitoringStackSignal = (
+  dsciStatus: DataScienceClusterInitializationKindStatus | null,
+): MonitoringStackSignal => {
+  if (!dsciStatus || dsciStatus.conditions.length === 0) {
+    return { kind: 'unknown' };
+  }
+
+  const byType = new Map<string, K8sCondition>();
+  for (const c of dsciStatus.conditions) {
+    byType.set(c.type, c);
+  }
+
+  const matched = BLOCKING_CONDITIONS.filter((b) => byType.has(b.type));
+
+  if (matched.length === 0) {
+    return { kind: 'unknown' };
+  }
+
+  for (const blocker of matched) {
+    const condition = byType.get(blocker.type);
+    if (condition && condition.status !== 'True') {
+      return {
+        kind: 'unavailable',
+        headline: blocker.headline,
+        operatorMessage: condition.message,
+        reason: condition.reason,
+      };
+    }
+  }
+
+  return { kind: 'ready' };
+};

--- a/packages/plugin-core/src/testing/__tests__/utils.spec.ts
+++ b/packages/plugin-core/src/testing/__tests__/utils.spec.ts
@@ -40,6 +40,19 @@ describe('validateExtensions', () => {
     ]);
   });
 
+  it('should allow customCondition as a plain function', () => {
+    expectExtensionsToBeValid([
+      {
+        type: 'app.area',
+        properties: {
+          id: 'test-area',
+          featureFlags: ['testFlag'],
+          customCondition: ({ dsciStatus }: { dsciStatus: unknown }) => dsciStatus != null,
+        },
+      },
+    ]);
+  });
+
   it('should validate an invalid code ref', () => {
     expect(() =>
       expectExtensionsToBeValid([

--- a/packages/plugin-core/src/testing/utils.ts
+++ b/packages/plugin-core/src/testing/utils.ts
@@ -10,9 +10,14 @@ import { visitDeep } from '../core/internal/objects';
 const importPattern =
   /^\(\)\s*=>\s*(?:{\s*return)?\s*import\('[^']+'\)(?:\.then\(\([a-zA-Z_$][a-zA-Z0-9_$]*\)\s*=>\s*[a-zA-Z_$][a-zA-Z0-9_$]*\.[a-zA-Z_$][a-zA-Z0-9_$]*\))?/;
 
+const NON_CODE_REF_FUNCTION_KEYS = new Set(['customCondition']);
+
 export const expectExtensionsToBeValid = (extensions: Extension[]): void => {
   extensions.forEach((extension) => {
-    visitDeep(extension.properties, isCodeRef, (value) => {
+    visitDeep(extension.properties, isCodeRef, (value, key) => {
+      if (NON_CODE_REF_FUNCTION_KEYS.has(key)) {
+        return;
+      }
       const fnString = value
         .toString()
         .replace(/cov_.+;/g, '')


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-51669

## Description

Ensures the observability dashboards degrade gracefully when the monitoring stack (Cluster Observability Operator) is not installed or is unreachable.

Checks two blocking DSCI conditions (aligned with [opendatahub-operator PR #3485](https://github.com/opendatahub-io/opendatahub-operator/pull/3485)):

- **`MonitoringReady`** — aggregate condition reflecting overall monitoring service health. `False` when monitoring is disabled/removed, `Unknown` when initializing or the Monitoring CR cannot be fetched.
- **`PersesAvailable`** — mirrored sub-condition from the Monitoring CR. `False` when Perses CRDs are missing or the instance failed to deploy.

When either condition is not `True`, the page shows an empty state with the operator's error message (e.g. "Cluster Observability Operator must be installed"). When the Perses API itself is unreachable at runtime, a load error is shown. Optional sub-conditions (Tempo, alerting, tracing, etc.) are intentionally not treated as blockers — users may choose not to install those components, and Perses handles missing data at the panel level.

**Key changes:**
- New `monitoringStackStatus.ts` utility that reads DSCI conditions and classifies the signal as `ready`, `unavailable`, or `unknown`
- `DashboardPage.tsx` now gates on the monitoring signal before attempting to load dashboards
- `usePersesDashboards` hook gains an optional `fetchDashboardList` flag to skip the Perses request when monitoring is known-unavailable
- Cypress mocked tests for monitoring-unavailable, Perses-unavailable, and Perses API error scenarios
- Jest unit tests for the condition parsing logic

## How Has This Been Tested?

- Unit tests: `packages/observability` Jest suite passes (92 tests)
- Linting: `npm run lint` passes
- Type checking: `npx tsc --noEmit` passes
- Cypress mocked tests added for:
  - `MonitoringReady: False` → monitoring unavailable empty state
  - `MonitoringReady: True` + `PersesAvailable: False` → Perses unavailable empty state
  - Perses API returning 503 → load error state

## Test Impact

- Added `monitoringStackStatus.spec.ts` with 12 unit test cases covering all condition combinations (null status, empty conditions, ready, unavailable with message, unavailable without message, priority ordering, optional conditions ignored, Unknown status handling)
- Added 3 Cypress mocked test scenarios in `observabilityDashboard.cy.ts`
- Updated Cypress page object with helpers for new empty/error states

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now shows distinct user-facing states for Monitoring unavailable, Perses unavailable, and Perses load errors; area visibility respects monitoring availability.
  * Perses dashboard fetching supports cancellation to avoid stalled requests.

* **Bug Fixes**
  * Improved routing and UI behavior when monitoring/Perses are unavailable or Perses API fails.
  * Clearer empty-state messaging when no dashboards are found.

* **Tests**
  * Added unit and end-to-end tests covering monitoring status logic and unavailable/error UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->