### PR TITLE
fix(model-serving): enable kebab actions and start/stop toggle during stopping state

### DIFF
--- a/frontend/src/components/StateActionToggle.tsx
+++ b/frontend/src/components/StateActionToggle.tsx
@@ -14,7 +14,6 @@ export type StateActionToggleProps<T extends ToggleState> = {
   onStart: () => void;
   onStop: () => void;
   isDisabled?: boolean;
-  isDisabledWhileStarting?: boolean;
 };
 
 const StateActionToggle = <T extends ToggleState>({
@@ -22,16 +21,14 @@ const StateActionToggle = <T extends ToggleState>({
   onStart,
   onStop,
   isDisabled,
-  isDisabledWhileStarting = true,
 }: StateActionToggleProps<T>): React.ReactElement => {
   const { isStarting, isRunning } = currentState;
-  const actionDisabled = isDisabled || (isStarting && isDisabledWhileStarting);
   const runningState = isRunning || isStarting;
   return (
     <Button
       data-testid="state-action-toggle"
       variant="link"
-      isDisabled={actionDisabled}
+      isDisabled={isDisabled}
       onClick={runningState ? onStop : onStart}
       isInline
     >

--- a/frontend/src/components/StateActionToggle.tsx
+++ b/frontend/src/components/StateActionToggle.tsx
@@ -24,8 +24,8 @@ const StateActionToggle = <T extends ToggleState>({
   isDisabled,
   isDisabledWhileStarting = true,
 }: StateActionToggleProps<T>): React.ReactElement => {
-  const { isStarting, isRunning, isStopping } = currentState;
-  const actionDisabled = isDisabled || isStopping || (isStarting && isDisabledWhileStarting);
+  const { isStarting, isRunning } = currentState;
+  const actionDisabled = isDisabled || (isStarting && isDisabledWhileStarting);
   const runningState = isRunning || isStarting;
   return (
     <Button

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -51,7 +51,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Stopping',
         color: 'grey',
         icon: <InProgressIcon className="ai-u-spin" />,
-        message: 'Model deployment is stopping.',
+        message: 'Waiting for the deployment to stop. You can still delete or restart the deployment.',
       };
     }
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.

--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -51,7 +51,8 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
         label: 'Stopping',
         color: 'grey',
         icon: <InProgressIcon className="ai-u-spin" />,
-        message: 'Waiting for the deployment to stop. You can still delete or restart the deployment.',
+        message:
+          'Waiting for the deployment to stop. You can still delete or restart the deployment.',
       };
     }
     // Show 'Starting' for optimistic updates or for loading/pending states from the backend.

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -185,7 +185,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
                 onClick: () => {
                   onEditInferenceService(inferenceService);
                 },
-                isDisabled: (!isNIMAvailable && isKServeNIMEnabled) || isStarting || isStopping,
+                isDisabled: (!isNIMAvailable && isKServeNIMEnabled) || isStarting,
               },
               { isSeparator: true },
               {
@@ -193,7 +193,6 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
                 onClick: () => {
                   onDeleteInferenceService(inferenceService);
                 },
-                isDisabled: isStarting || isStopping,
               },
             ]}
           />

--- a/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
+++ b/frontend/src/pages/modelServing/screens/global/InferenceServiceTableRow.tsx
@@ -171,7 +171,6 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
           }}
           onStart={onStart}
           onStop={onStop}
-          isDisabledWhileStarting={false}
         />
       </Td>
 
@@ -185,7 +184,7 @@ const InferenceServiceTableRow: React.FC<InferenceServiceTableRowProps> = ({
                 onClick: () => {
                   onEditInferenceService(inferenceService);
                 },
-                isDisabled: (!isNIMAvailable && isKServeNIMEnabled) || isStarting,
+                isDisabled: !isNIMAvailable && isKServeNIMEnabled,
               },
               { isSeparator: true },
               {

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -182,9 +182,7 @@ export const DeploymentRow: React.FC<{
                 onClick: () => {
                   navigateToDeploymentWizard(deployment.model.metadata.namespace);
                 },
-                isDisabled:
-                  deployment.status?.stoppedStates?.isStarting ||
-                  deployment.status?.stoppedStates?.isStopping,
+                isDisabled: deployment.status?.stoppedStates?.isStarting,
               },
               { isSeparator: true },
               {
@@ -192,9 +190,6 @@ export const DeploymentRow: React.FC<{
                 onClick: () => {
                   onDelete(deployment);
                 },
-                isDisabled:
-                  deployment.status?.stoppedStates?.isStarting ||
-                  deployment.status?.stoppedStates?.isStopping,
               },
             ]}
           />

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -167,7 +167,6 @@ export const DeploymentRow: React.FC<{
               currentState={deployment.status.stoppedStates}
               onStart={onStart}
               onStop={onStop}
-              isDisabledWhileStarting={false}
             />
           ) : (
             '-'
@@ -182,7 +181,6 @@ export const DeploymentRow: React.FC<{
                 onClick: () => {
                   navigateToDeploymentWizard(deployment.model.metadata.namespace);
                 },
-                isDisabled: deployment.status?.stoppedStates?.isStarting,
               },
               { isSeparator: true },
               {


### PR DESCRIPTION
<!--- Reference related issues; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

https://issues.redhat.com/browse/RHOAIENG-38037

## Description

After stopping a model deployment, users could become permanently locked out of all actions if the UI got stuck in the "Stopping" state. This happened because both the kebab menu actions (Edit, Delete) and the Start/Stop toggle were disabled while `isStopping` was true. If the K8s pod watch failed to propagate a pod deletion event (stale WebSocket, network hiccup, or a pod stuck with a finalizer), users had no escape hatch — they couldn't delete, edit, or restart the deployment.

Kebab actions — Delete is always enabled; Edit is only disabled during isStarting (both in InferenceServiceTableRow and the new DeploymentsTableRow)
I guess Edit is enabled for isStarting too.

ModelStatusIcon popover — updated the "Stopping" message to inform users they can still take action

## How Has This Been Tested?

- Deployed a test InferenceService on a live cluster (Zaffre)
- Simulated a permanently stuck "Stopping" state by adding a finalizer to the pod (blocking deletion) and setting the `serving.kserve.io/stop=true` annotation
- Verified in the dashboard that kebab actions and the Start link are now enabled during "Stopping" state
- Type-check and ESLint pass cleanly on all changed files
-
<img width="1434" height="294" alt="Screenshot 2026-05-18 at 10 57 32 AM" src="https://github.com/user-attachments/assets/a661600e-a362-455e-aaad-e4e89077a875" />
<img width="404" height="175" alt="Screenshot 2026-05-18 at 10 58 37 AM" src="https://github.com/user-attachments/assets/a23fd84e-74de-4655-a4da-800519709a1c" />


## Test Impact

No new tests added. The behavioral change (removing disabled guards) is UI-only with no testable logic. Existing Cypress tests do not assert on disabled state during stopping. The `StateActionToggle` and `DeploymentsTableRow` components have no existing unit tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edit and Delete actions remain available during deployment stopping/starting phases; controls are no longer unnecessarily disabled.
  * Start/Stop button disabled behavior simplified: button enabled/disabled is now passed directly, avoiding unintended lockouts during transitional states.

* **UI/UX**
  * Stopping status message clarified: "Waiting for the deployment to stop. You can still delete or restart the deployment."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->