### PR TITLE
Sync from kubeflow/model-registry 82980fd

### DIFF
--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "745d50e42bed130d50841107bdb8e94262290de0"
+    "commit": "82980fd6334c4da72681dbff2e25ce0d1f12aa03"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "431fefc217f1053462667a4336e90edbb9699cd4"
+    "commit": "a9d13f8266bb06e7f8d34f67e7c502682c8ebd95"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "efac16184b90efd7d48414e345cbc108918384ec"
+    "commit": "a4179e6cc3e284a1b17682af02516edd3f72d7e2"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "f7164e561e765668189a40b3bd8177463c3af768"
+    "commit": "efac16184b90efd7d48414e345cbc108918384ec"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "a4179e6cc3e284a1b17682af02516edd3f72d7e2"
+    "commit": "559b3c52b3b5e46ddc11b5181413116158e251df"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "1897cb7657c49f3c41324c87f04dfd00e85f5002"
+    "commit": "431fefc217f1053462667a4336e90edbb9699cd4"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "8c96833a2b8d86cbd1a6961480644c90116584ba"
+    "commit": "2b7678e9933f9478d4e95451cc9a54a571b41619"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "559b3c52b3b5e46ddc11b5181413116158e251df"
+    "commit": "745d50e42bed130d50841107bdb8e94262290de0"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "2b7678e9933f9478d4e95451cc9a54a571b41619"
+    "commit": "2c4c9bc4618096fa89aed491bceb1c6f8689fd03"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "e29f5d12441a009d9b17db6bc8a943af8c1dad3f"
+    "commit": "1897cb7657c49f3c41324c87f04dfd00e85f5002"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "f4dd7c1c909013a035a23943854c034b71c81113"
+    "commit": "e29f5d12441a009d9b17db6bc8a943af8c1dad3f"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "c95133932c56448f2c0350306ce32593257b4c9b"
+    "commit": "f7164e561e765668189a40b3bd8177463c3af768"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "a9d13f8266bb06e7f8d34f67e7c502682c8ebd95"
+    "commit": "c95133932c56448f2c0350306ce32593257b4c9b"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "2c4c9bc4618096fa89aed491bceb1c6f8689fd03"
+    "commit": "f4dd7c1c909013a035a23943854c034b71c81113"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/upstream/api/openapi/mod-arch.yaml
+++ b/packages/model-registry/upstream/api/openapi/mod-arch.yaml
@@ -2321,11 +2321,35 @@ components:
         libraryName:
           type: string
           example: transformers
+        validatedTasks:
+          type: array
+          description: >-
+            List of tasks that have been validated end-to-end for this model.
+            Follows the same naming convention as `tasks`.
+          items:
+            type: string
+          example:
+            - tool-calling
+        servingConfig:
+          $ref: "#/components/schemas/ServingConfig"
         customProperties:
           description: User provided custom properties which are not defined by its type.
           type: object
           additionalProperties:
             $ref: "#/components/schemas/MetadataValue"
+    ServingConfig:
+      description: Validated serving configurations for a model.
+      type: object
+      properties:
+        toolCalling:
+          $ref: "#/components/schemas/ToolCallingConfig"
+    ToolCallingConfig:
+      description: Tool calling configuration for vLLM serving runtime.
+      type: object
+      properties:
+        args:
+          type: string
+          description: CLI arguments to pass to the serving runtime for tool calling support.
     BaseResourceDates:
       description: Common timestamp fields for resources
       type: object

--- a/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
@@ -1730,6 +1730,13 @@ func GetFilterOptionMocks() map[string]models.FilterOption {
 		},
 	}
 
+	filterOptions["validatedTasks"] = models.FilterOption{
+		Type: FilterOptionTypeString,
+		Values: []interface{}{
+			"tool-calling",
+		},
+	}
+
 	filterOptions["language"] = models.FilterOption{
 		Type: FilterOptionTypeString,
 		Values: []interface{}{

--- a/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
@@ -361,13 +361,19 @@ func GetCatalogModelMocks() []models.CatalogModel {
 		Name:             "repo1/granite-8b-code-instruct",
 		Description:      stringToPointer("Granite-8B-Code-Instruct is a 8B parameter model fine tuned from\nGranite-8B-Code-Base on a combination of permissively licensed instruction\ndata to enhance instruction following capabilities including logical\nreasoning and problem-solving skills."),
 		Provider:         stringToPointer("provider1"),
-		Tasks:            []string{"text-generation", "image-to-text"},
+		Tasks:            []string{"text-generation", "image-to-text", "tool-calling"},
+		ValidatedTasks:   []string{"tool-calling"},
 		License:          stringToPointer("Apache 2.0"),
 		LicenseLink:      stringToPointer("https://www.apache.org/licenses/LICENSE-2.0.txt"),
 		Maturity:         stringToPointer("Technology preview"),
 		Language:         []string{"ar", "cs", "de", "en", "es", "fr", "it", "ja", "ko", "nl", "pt", "zh"},
 		CustomProperties: catalogCustomPropertiesWithVariant(graniteVariantGroupId, "FP16"),
-		Logo:             stringToPointer("data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4="),
+		ServingConfig: &models.ServingConfig{
+			ToolCalling: &models.ToolCallingConfig{
+				Args: stringToPointer("--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja"),
+			},
+		},
+		Logo: stringToPointer("data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4="),
 		Readme: stringToPointer(`---
 pipeline_tag: text-generation
 inference: false

--- a/packages/model-registry/upstream/bff/internal/models/catalog_model_list.go
+++ b/packages/model-registry/upstream/bff/internal/models/catalog_model_list.go
@@ -4,6 +4,14 @@ import (
 	"github.com/kubeflow/model-registry/pkg/openapi"
 )
 
+type ToolCallingConfig struct {
+	Args *string `json:"args,omitempty"`
+}
+
+type ServingConfig struct {
+	ToolCalling *ToolCallingConfig `json:"toolCalling,omitempty"`
+}
+
 type CatalogModel struct {
 	CreateTimeSinceEpoch     *string                           `json:"createTimeSinceEpoch,omitempty"`
 	CustomProperties         *map[string]openapi.MetadataValue `json:"customProperties,omitempty"`
@@ -20,6 +28,8 @@ type CatalogModel struct {
 	Readme                   *string                           `json:"readme,omitempty"`
 	SourceId                 *string                           `json:"source_id,omitempty"`
 	Tasks                    []string                          `json:"tasks,omitempty"`
+	ValidatedTasks           []string                          `json:"validatedTasks,omitempty"`
+	ServingConfig            *ServingConfig                    `json:"servingConfig,omitempty"`
 }
 
 type CatalogModelList struct {

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -12461,9 +12461,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "devOptional": true,
       "funding": [
         {

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -157,12 +157,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -212,13 +212,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -359,28 +359,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -520,12 +520,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1325,16 +1325,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-      "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1999,31 +1999,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2031,13 +2031,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
+++ b/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
@@ -5,6 +5,7 @@ import {
   ModelCatalogNumberFilterKey,
   ModelCatalogProvider,
   ModelCatalogTask,
+  ValidatedConfiguration,
   AllLanguageCode,
   UseCaseOptionValue,
   DEFAULT_PERFORMANCE_FILTERS_QUERY_NAME,
@@ -110,6 +111,10 @@ export const mockCatalogFilterOptionsList = (
         ModelCatalogTensorType.INT8,
         ModelCatalogTensorType.MXFP4,
       ],
+    },
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+      type: 'string',
+      values: [ValidatedConfiguration.TOOL_CALLING],
     },
     [ModelCatalogStringFilterKey.HARDWARE_TYPE]: {
       type: 'string',

--- a/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogModelList.ts
+++ b/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogModelList.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { CatalogModel, CatalogModelList } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 export const mockCatalogModel = (partial?: Partial<CatalogModel>): CatalogModel => ({
   source_id: 'sample-source',
@@ -373,7 +374,8 @@ export const mockCatalogModelList = (partial?: Partial<CatalogModelList>): Catal
 // Mock models for testing
 export const mockValidatedModel = mockCatalogModel({
   name: 'validated-model',
-  tasks: ['text-generation'],
+  tasks: [ModelCatalogTask.TEXT_GENERATION, ModelCatalogTask.TOOL_CALLING],
+  validatedTasks: [ModelCatalogTask.TOOL_CALLING],
   customProperties: {
     model_type: {
       metadataType: ModelRegistryMetadataType.STRING,
@@ -382,6 +384,11 @@ export const mockValidatedModel = mockCatalogModel({
     validated: {
       metadataType: ModelRegistryMetadataType.STRING,
       string_value: '',
+    },
+  },
+  servingConfig: {
+    toolCalling: {
+      args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
     },
   },
 });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -155,7 +155,7 @@ class ModelCatalog {
   }
 
   findTaskLabel() {
-    return cy.contains('text-generation');
+    return cy.contains('Text generation');
   }
 
   findProviderLabel() {
@@ -438,6 +438,19 @@ class ModelCatalog {
 
   findAllCompressionVariants() {
     return cy.get('[data-testid^="compression-variant-"]');
+  }
+
+  // Validated Configurations Card
+  findValidatedConfigurationsCard() {
+    return cy.findByTestId('validated-configurations-card');
+  }
+
+  findToolCallingCard() {
+    return cy.findByTestId('tool-calling-card');
+  }
+
+  findToolCallingToggle() {
+    return cy.get('#tool-calling-toggle');
   }
 
   // Performance Empty State

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -21,7 +21,7 @@ import type { CatalogLabelList, CatalogModel, CatalogSource } from '~/app/modelC
 import type { ModelRegistryCustomProperties } from '~/app/types';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
-import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
+import { ValidatedConfiguration } from '~/concepts/modelCatalog/const';
 
 /**
  * Options for setting up model catalog intercepts
@@ -108,7 +108,7 @@ export const createMockModelsForLabel = (
         source_id: source.id,
         customProperties,
         ...(isValidated && {
-          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
               args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
@@ -173,7 +173,7 @@ export const interceptAllModels = (modelsPerCategory: number, useValidatedModel:
         source_id: 'sample-source',
         customProperties,
         ...(isValidated && {
-          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          validatedTasks: [ValidatedConfiguration.TOOL_CALLING],
           servingConfig: {
             toolCalling: {
               args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -21,6 +21,7 @@ import type { CatalogLabelList, CatalogModel, CatalogSource } from '~/app/modelC
 import type { ModelRegistryCustomProperties } from '~/app/types';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 /**
  * Options for setting up model catalog intercepts
@@ -91,22 +92,29 @@ export const createMockModelsForLabel = (
 ): ReturnType<typeof mockCatalogModelList> =>
   mockCatalogModelList({
     items: Array.from({ length: modelsPerCategory }, (_, i) => {
-      const customProperties =
-        i === 0 && useValidatedModel
-          ? ({
-              validated: {
-                metadataType: ModelRegistryMetadataType.STRING,
-                string_value: '',
-              },
-            } as ModelRegistryCustomProperties)
-          : undefined;
-      const name =
-        i === 0 && useValidatedModel ? 'validated-model' : `${label.toLowerCase()}-model-${i + 1}`;
+      const isValidated = i === 0 && useValidatedModel;
+      const customProperties = isValidated
+        ? ({
+            validated: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '',
+            },
+          } as ModelRegistryCustomProperties)
+        : undefined;
+      const name = isValidated ? 'validated-model' : `${label.toLowerCase()}-model-${i + 1}`;
 
       return mockCatalogModel({
         name,
         source_id: source.id,
         customProperties,
+        ...(isValidated && {
+          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          servingConfig: {
+            toolCalling: {
+              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+            },
+          },
+        }),
       });
     }),
   });
@@ -150,20 +158,28 @@ export const interceptModelsByLabel = (
 export const interceptAllModels = (modelsPerCategory: number, useValidatedModel: boolean): void => {
   const allModelsResponse = mockCatalogModelList({
     items: Array.from({ length: modelsPerCategory }, (_, i) => {
-      const customProperties =
-        i === 0 && useValidatedModel
-          ? ({
-              validated: {
-                metadataType: ModelRegistryMetadataType.STRING,
-                string_value: '',
-              },
-            } as ModelRegistryCustomProperties)
-          : undefined;
-      const name = i === 0 && useValidatedModel ? 'validated-model' : `all-models-model-${i + 1}`;
+      const isValidated = i === 0 && useValidatedModel;
+      const customProperties = isValidated
+        ? ({
+            validated: {
+              metadataType: ModelRegistryMetadataType.STRING,
+              string_value: '',
+            },
+          } as ModelRegistryCustomProperties)
+        : undefined;
+      const name = isValidated ? 'validated-model' : `all-models-model-${i + 1}`;
       return mockCatalogModel({
         name,
         source_id: 'sample-source',
         customProperties,
+        ...(isValidated && {
+          validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+          servingConfig: {
+            toolCalling: {
+              args: '--enable-auto-tool-choice \\\n--tool-call-parser granite \\\n--chat-template\nopt/app-root/template/tool_chat_template_granite.jinja',
+            },
+          },
+        }),
       });
     }),
   });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalog.cy.ts
@@ -18,6 +18,8 @@ import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/c
 import { mockCatalogFilterOptionsList } from '~/__mocks__/mockCatalogFilterOptionsList';
 import { SourceLabel, type CatalogSource } from '~/app/modelCatalogTypes';
 import { ModelRegistryMetadataType } from '~/app/types';
+import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import { ModelCatalogStringFilterKey } from '~/concepts/modelCatalog/const';
 
 type FilteredModelsInterceptConfig = {
   returnModelsForFilters?: boolean;
@@ -346,6 +348,132 @@ describe('Model Catalog Page', () => {
       expect(url).to.include('tasks%3D%27text-generation%27');
       expect(url).to.include('tensor_type.string_value%3D%27FP16%27');
       expect(url).to.include('provider%3D%27Google%27');
+    });
+  });
+
+  it('should not display validated configuration filter when feature flag is off', () => {
+    initIntercepts({});
+    modelCatalog.visit();
+    modelCatalog.findFilter('Validated configuration').should('not.exist');
+  });
+
+  describe('Validated Configuration Filter (feature flag on)', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+    });
+
+    afterEach(() => {
+      window.localStorage.removeItem(TempDevFeature.ToolCallingConfiguration);
+    });
+
+    it('checkbox should filter models', () => {
+      initIntercepts({ includeAllModelsIntercept: true });
+      setupFilteredModelsIntercept({
+        returnModelsForFilters: true,
+        modelsToReturn: [mockCatalogModel({})],
+      });
+
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
+
+      cy.wait('@getFilteredModels').then((interception) => {
+        expect(interception.request.url).to.include('validatedTasks%3D%27tool-calling%27');
+      });
+    });
+
+    it('should work combined with other filters', () => {
+      initIntercepts({ includeAllModelsIntercept: true });
+      setupFilteredModelsIntercept({
+        returnModelsForFilters: true,
+        modelsToReturn: [mockCatalogModel({})],
+      });
+
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
+      cy.wait('@getFilteredModels');
+
+      modelCatalog.findFilterCheckbox('Provider', 'Google').click();
+
+      cy.wait('@getFilteredModels').then((interception) => {
+        const { url } = interception.request;
+        expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+        expect(url).to.include('provider%3D%27Google%27');
+      });
+    });
+
+    it('should not show helper text when only one option exists', () => {
+      initIntercepts({});
+      modelCatalog.visit();
+      modelCatalog
+        .findFilterCheckbox('Validated configuration', 'tool-calling')
+        .scrollIntoView()
+        .click();
+      cy.contains('Showing models with all selected configurations').should('not.exist');
+    });
+
+    describe('with multiple options', () => {
+      const multiOptionFilterOptions = mockCatalogFilterOptionsList({
+        filters: {
+          ...mockCatalogFilterOptionsList().filters,
+          [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+            type: 'string',
+            values: ['tool-calling', 'text-generation', 'question-answering'],
+          },
+        },
+      });
+
+      const initMultiOptionIntercepts = (props: HandlersProps) => {
+        initIntercepts(props);
+        cy.interceptApi(
+          `GET /api/:apiVersion/model_catalog/models/filter_options`,
+          {
+            path: { apiVersion: MODEL_CATALOG_API_VERSION },
+            query: { namespace: 'kubeflow' },
+          },
+          multiOptionFilterOptions,
+        );
+      };
+
+      it('should show helper text when an option is selected', () => {
+        initMultiOptionIntercepts({});
+        modelCatalog.visit();
+        modelCatalog
+          .findFilterCheckbox('Validated configuration', 'tool-calling')
+          .scrollIntoView()
+          .click();
+        cy.contains('Showing models with all selected configurations').should('be.visible');
+      });
+
+      it('should send AND conditions instead of IN for multiple selections', () => {
+        initMultiOptionIntercepts({ includeAllModelsIntercept: true });
+        setupFilteredModelsIntercept({
+          returnModelsForFilters: true,
+          modelsToReturn: [mockCatalogModel({})],
+        });
+
+        modelCatalog.visit();
+        modelCatalog
+          .findFilterCheckbox('Validated configuration', 'tool-calling')
+          .scrollIntoView()
+          .click();
+        cy.wait('@getFilteredModels');
+
+        modelCatalog.findFilterCheckbox('Validated configuration', 'text-generation').click();
+
+        cy.wait('@getFilteredModels').then((interception) => {
+          const { url } = interception.request;
+          expect(url).to.include('validatedTasks%3D%27tool-calling%27');
+          expect(url).to.include('AND');
+          expect(url).to.include('validatedTasks%3D%27text-generation%27');
+          expect(url).to.not.include('IN');
+        });
+      });
     });
   });
 });

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogCard.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogCard.cy.ts
@@ -29,7 +29,7 @@ describe('ModelCatalogCard Component', () => {
 
     it('should display correct source labels', () => {
       modelCatalog.findFirstModelCatalogCard().within(() => {
-        modelCatalog.findSourceLabel().should('contain.text', 'source 2text-generationprovider1');
+        modelCatalog.findSourceLabel().should('contain.text', 'source 2Text generationprovider1');
       });
     });
 

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -10,6 +10,8 @@ import {
 import { mockCatalogModelArtifact, mockCatalogModel } from '~/__mocks__';
 import { ModelRegistryMetadataType } from '~/app/types';
 import { MODEL_CATALOG_API_VERSION } from '~/__tests__/cypress/cypress/support/commands/api';
+import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import { ModelCatalogTask } from '~/concepts/modelCatalog/const';
 
 describe('Model Catalog Details Page', () => {
   beforeEach(() => {
@@ -310,5 +312,70 @@ describe('Model Catalog Details Page - Edge Cases', () => {
     modelCatalog.findBreadcrumb().should('exist');
 
     cy.findByRole('progressbar').should('exist');
+  });
+});
+
+describe('Model Catalog Details Page - Validated Configurations Card', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
+      mockModelRegistry({ name: 'modelregistry-sample' }),
+    ]).as('getModelRegistries');
+  });
+
+  describe('with feature flag enabled', () => {
+    beforeEach(() => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+      setupValidatedModelIntercepts({});
+      interceptArtifactsList();
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+    });
+
+    it('should display the validated configurations card with tool calling content', () => {
+      modelCatalog.findValidatedConfigurationsCard().should('be.visible');
+      modelCatalog
+        .findValidatedConfigurationsCard()
+        .should('contain.text', 'Validated configurations');
+      modelCatalog.findToolCallingCard().should('be.visible');
+      modelCatalog.findToolCallingCard().should('contain.text', 'Tool Calling');
+    });
+
+    it('should show CLI args inside the tool calling card when expanded', () => {
+      modelCatalog.findToolCallingToggle().click();
+      modelCatalog.findToolCallingCard().should('contain.text', '--enable-auto-tool-choice');
+      modelCatalog.findToolCallingCard().should('contain.text', '--tool-call-parser granite');
+    });
+  });
+
+  describe('with feature flag disabled', () => {
+    it('should not display the validated configurations card', () => {
+      window.localStorage.removeItem(TempDevFeature.ToolCallingConfiguration);
+      setupValidatedModelIntercepts({});
+      interceptArtifactsList();
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+      modelCatalog.findValidatedConfigurationsCard().should('not.exist');
+    });
+  });
+
+  describe('for a non-validated model', () => {
+    it('should not display the validated configurations card', () => {
+      window.localStorage.setItem(TempDevFeature.ToolCallingConfiguration, 'true');
+      setupModelCatalogIntercepts({
+        customNonValidatedModel: mockCatalogModel({
+          name: 'non-validated-model',
+          tasks: [ModelCatalogTask.TEXT_GENERATION],
+        }),
+      });
+      modelCatalog.visit();
+      modelCatalog.findLoadingState().should('not.exist');
+      modelCatalog.findModelCatalogDetailLink().first().click();
+      modelCatalog.findBreadcrumb().should('exist');
+      modelCatalog.findValidatedConfigurationsCard().should('not.exist');
+    });
   });
 });

--- a/packages/model-registry/upstream/frontend/src/app/api/__tests__/updateTimestamps.test.ts
+++ b/packages/model-registry/upstream/frontend/src/app/api/__tests__/updateTimestamps.test.ts
@@ -1,11 +1,5 @@
 import { mockModelVersion, mockRegisteredModel } from '~/__mocks__';
-import {
-  ModelRegistryAPIs,
-  ModelState,
-  ModelRegistryMetadataType,
-  ModelVersion,
-  RegisteredModel,
-} from '~/app/types';
+import { ModelRegistryAPIs, ModelState, ModelVersion, RegisteredModel } from '~/app/types';
 import {
   bumpModelVersionTimestamp,
   bumpRegisteredModelTimestamp,
@@ -36,10 +30,6 @@ describe('updateTimestamps', () => {
   const fakeModelVersionId = 'test-model-version-id';
   const fakeRegisteredModelId = 'test-registered-model-id';
 
-  beforeEach(() => {
-    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-01-01T00:00:00.000Z');
-  });
-
   describe('bumpModelVersionTimestamp', () => {
     it('should successfully update model version timestamp', async () => {
       await bumpModelVersionTimestamp(mockApi, mockModelVersion({ id: fakeModelVersionId }));
@@ -48,59 +38,6 @@ describe('updateTimestamps', () => {
         {},
         {
           state: ModelState.LIVE,
-          customProperties: {
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
-        },
-        fakeModelVersionId,
-      );
-    });
-
-    it('should successfully update model version timestamp with customProperties of version', async () => {
-      await bumpModelVersionTimestamp(
-        mockApi,
-        mockModelVersion({
-          id: fakeModelVersionId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-      );
-
-      expect(mockApi.patchModelVersion).toHaveBeenCalledWith(
-        {},
-        {
-          state: ModelState.LIVE,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
         },
         fakeModelVersionId,
       );
@@ -125,52 +62,6 @@ describe('updateTimestamps', () => {
   });
 
   describe('bumpRegisteredModelTimestamp', () => {
-    it('should successfully update registered model timestamp with model customProperties', async () => {
-      await bumpRegisteredModelTimestamp(
-        mockApi,
-        mockRegisteredModel({
-          id: fakeRegisteredModelId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-      );
-
-      expect(mockApi.patchRegisteredModel).toHaveBeenCalledWith(
-        {},
-        {
-          state: ModelState.LIVE,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
-        },
-        fakeRegisteredModelId,
-      );
-    });
-
     it('should successfully update registered model timestamp', async () => {
       await bumpRegisteredModelTimestamp(
         mockApi,
@@ -183,13 +74,6 @@ describe('updateTimestamps', () => {
         {},
         {
           state: ModelState.LIVE,
-          customProperties: {
-            _lastModified: {
-              metadataType: ModelRegistryMetadataType.STRING,
-              // eslint-disable-next-line camelcase
-              string_value: '2024-01-01T00:00:00.000Z',
-            },
-          },
         },
         fakeRegisteredModelId,
       );
@@ -234,49 +118,6 @@ describe('updateTimestamps', () => {
           id: fakeRegisteredModelId,
         }),
         mockModelVersion({ id: fakeModelVersionId }),
-      );
-
-      expect(mockApi.patchModelVersion).toHaveBeenCalled();
-      expect(mockApi.patchRegisteredModel).toHaveBeenCalled();
-    });
-
-    it('should update both timestamps successfully with both model and version customProperties', async () => {
-      mockApi.patchModelVersion.mockResolvedValue({} as ModelVersion);
-      mockApi.patchRegisteredModel.mockResolvedValue({} as RegisteredModel);
-
-      await bumpBothTimestamps(
-        mockApi,
-
-        mockRegisteredModel({
-          id: fakeRegisteredModelId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
-        mockModelVersion({
-          id: fakeModelVersionId,
-          customProperties: {
-            'Registered from': {
-              // eslint-disable-next-line camelcase
-              string_value: 'Model catalog',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-            'Source model': {
-              // eslint-disable-next-line camelcase
-              string_value: 'test-version',
-              metadataType: ModelRegistryMetadataType.STRING,
-            },
-          },
-        }),
       );
 
       expect(mockApi.patchModelVersion).toHaveBeenCalled();

--- a/packages/model-registry/upstream/frontend/src/app/api/updateTimestamps.ts
+++ b/packages/model-registry/upstream/frontend/src/app/api/updateTimestamps.ts
@@ -1,10 +1,4 @@
-import {
-  ModelRegistryAPIs,
-  ModelState,
-  ModelRegistryMetadataType,
-  ModelVersion,
-  RegisteredModel,
-} from '~/app/types';
+import { ModelRegistryAPIs, ModelState, ModelVersion, RegisteredModel } from '~/app/types';
 
 type MinimalModelRegistryAPI = Pick<ModelRegistryAPIs, 'patchRegisteredModel'>;
 
@@ -17,21 +11,10 @@ export const bumpModelVersionTimestamp = async (
   }
 
   try {
-    const currentTime = new Date().toISOString();
     await api.patchModelVersion(
       {},
       {
-        // This is a workaround to update the timestamp on the backend. There is a bug opened for model registry team
-        // to fix this issue.
         state: ModelState.LIVE,
-        customProperties: {
-          ...modelVersion.customProperties,
-          _lastModified: {
-            metadataType: ModelRegistryMetadataType.STRING,
-            // eslint-disable-next-line camelcase
-            string_value: currentTime,
-          },
-        },
       },
       modelVersion.id,
     );
@@ -53,21 +36,10 @@ export const bumpRegisteredModelTimestamp = async (
   }
 
   try {
-    const currentTime = new Date().toISOString();
     await api.patchRegisteredModel(
       {},
       {
         state: ModelState.LIVE,
-        customProperties: {
-          ...registeredModel.customProperties,
-          // This is a workaround to update the timestamp on the backend. There is a bug opened for model registry team
-          // to fix this issue.
-          _lastModified: {
-            metadataType: ModelRegistryMetadataType.STRING,
-            // eslint-disable-next-line camelcase
-            string_value: currentTime,
-          },
-        },
       },
       registeredModel.id,
     );

--- a/packages/model-registry/upstream/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -93,6 +93,7 @@ export const ModelCatalogContext = React.createContext<ModelCatalogContextType>(
     [ModelCatalogStringFilterKey.USE_CASE]: [],
     [ModelCatalogNumberFilterKey.MAX_RPS]: undefined,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: [],
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
   },
   updateSelectedSource: () => undefined,
   selectedSourceLabel: undefined,
@@ -139,6 +140,7 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
     [ModelCatalogStringFilterKey.USE_CASE]: [],
     [ModelCatalogNumberFilterKey.MAX_RPS]: undefined,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: [],
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
   });
   const [filterOptions, filterOptionsLoaded, filterOptionsLoadError] =
     useCatalogFilterOptionList(apiState);
@@ -202,6 +204,7 @@ export const ModelCatalogContextProvider: React.FC<ModelCatalogContextProviderPr
     baseSetFilterData(ModelCatalogStringFilterKey.LICENSE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.LANGUAGE, []);
     baseSetFilterData(ModelCatalogStringFilterKey.TENSOR_TYPE, []);
+    baseSetFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
   }, [baseSetFilterData]);
 
   /**

--- a/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
@@ -36,6 +36,14 @@ export type CatalogSource = {
 
 export type CatalogSourceList = PaginationParams & { items?: CatalogSource[] };
 
+export type ToolCallingConfig = {
+  args?: string;
+};
+
+export type ServingConfig = {
+  toolCalling?: ToolCallingConfig;
+};
+
 export type CatalogModel = {
   source_id?: string;
   name: string;
@@ -45,6 +53,7 @@ export type CatalogModel = {
   language?: string[];
   logo?: string;
   tasks?: string[];
+  validatedTasks?: string[];
   libraryName?: string;
   license?: string;
   licenseLink?: string;
@@ -52,6 +61,7 @@ export type CatalogModel = {
   createTimeSinceEpoch?: string;
   lastUpdateTimeSinceEpoch?: string;
   customProperties?: ModelRegistryCustomProperties;
+  servingConfig?: ServingConfig;
 };
 
 export type PaginationParams = {

--- a/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
@@ -296,6 +296,7 @@ export type ModelCatalogStringFilterValueType = {
   [ModelCatalogStringFilterKey.LICENSE]: string;
   [ModelCatalogStringFilterKey.LANGUAGE]: AllLanguageCode;
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: ModelCatalogTensorType;
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: string;
   [ModelCatalogStringFilterKey.HARDWARE_TYPE]: string;
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: string;
   [ModelCatalogStringFilterKey.USE_CASE]: UseCaseOptionValue;
@@ -362,6 +363,7 @@ export type ModelCatalogFilterStates = {
   [ModelCatalogStringFilterKey.LICENSE]: string[];
   [ModelCatalogStringFilterKey.LANGUAGE]: AllLanguageCode[];
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: ModelCatalogTensorType[];
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: string[];
   [ModelCatalogStringFilterKey.HARDWARE_TYPE]: string[];
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: string[];
   [ModelCatalogStringFilterKey.USE_CASE]: UseCaseOptionValue[];

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -57,7 +57,12 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
               <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                 {isValidated && (
                   <Popover bodyContent={MODEL_CATALOG_POPOVER_MESSAGES.VALIDATED}>
-                    <Label variant="outline" isClickable status="success" icon={<CheckCircleIcon />}>
+                    <Label
+                      variant="outline"
+                      isClickable
+                      status="success"
+                      icon={<CheckCircleIcon />}
+                    >
                       Validated
                     </Label>
                   </Popover>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx
@@ -12,7 +12,7 @@ import {
   Popover,
   Skeleton,
 } from '@patternfly/react-core';
-import { ChartBarIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { CatalogModel, CatalogSource } from '~/app/modelCatalogTypes';
 import { catalogModelDetailsFromModel } from '~/app/routes/modelCatalog/catalogModel';
@@ -23,6 +23,7 @@ import {
   getModelName,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { MODEL_CATALOG_POPOVER_MESSAGES } from '~/concepts/modelCatalog/const';
+import { useTempDevFeatureAvailable, TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import ModelCatalogLabels from './ModelCatalogLabels';
 import ModelCatalogCardBody from './ModelCatalogCardBody';
 
@@ -32,10 +33,10 @@ type ModelCatalogCardProps = {
 };
 
 const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) => {
-  // Extract labels from customProperties and check for validated label
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
   const isValidated = isModelValidated(model);
   const isRedHat = isRedHatModel(model);
+  const isToolCallingEnabled = useTempDevFeatureAvailable(TempDevFeature.ToolCallingConfiguration);
 
   return (
     <Card isFullHeight data-testid="model-catalog-card" key={`${model.name}/${model.source_id}`}>
@@ -56,7 +57,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
               <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                 {isValidated && (
                   <Popover bodyContent={MODEL_CATALOG_POPOVER_MESSAGES.VALIDATED}>
-                    <Label color="purple" isClickable icon={<ChartBarIcon />}>
+                    <Label variant="outline" isClickable status="success" icon={<CheckCircleIcon />}>
                       Validated
                     </Label>
                   </Popover>
@@ -94,6 +95,7 @@ const ModelCatalogCard: React.FC<ModelCatalogCardProps> = ({ model, source }) =>
       <CardFooter>
         <ModelCatalogLabels
           tasks={model.tasks ?? []}
+          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
           provider={model.provider}
           labels={allLabels.filter((label) => label !== 'validated')}
           numLabels={isValidated ? 2 : 3}

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -2,16 +2,33 @@ import * as React from 'react';
 import { Stack, Spinner, Alert } from '@patternfly/react-core';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { ModelCatalogStringFilterKey } from '~/concepts/modelCatalog/const';
+import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
 import ModelPerformanceViewToggleCard from './ModelPerformanceViewToggleCard';
 import TaskFilter from './globalFilters/TaskFilter';
 import ProviderFilter from './globalFilters/ProviderFilter';
 import LicenseFilter from './globalFilters/LicenseFilter';
 import LanguageFilter from './globalFilters/LanguageFilter';
 import TensorTypeFilter from './globalFilters/TensorTypeFilter';
+import ValidatedConfigurationFilter from './globalFilters/ValidatedConfigurationFilter';
 
 const ModelCatalogFilters: React.FC = () => {
-  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError } =
+  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, filterData, setFilterData } =
     React.useContext(ModelCatalogContext);
+  const toolCallingFeatureAvailable = useTempDevFeatureAvailable(
+    TempDevFeature.ToolCallingConfiguration,
+  );
+
+  React.useEffect(() => {
+    if (
+      !toolCallingFeatureAvailable &&
+      filterData[ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION].length > 0
+    ) {
+      setFilterData(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION, []);
+    }
+    // Only react to flag changes, not filterData changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolCallingFeatureAvailable]);
+
   const filters = filterOptions?.filters;
   if (!filterOptionsLoaded) {
     return <Spinner />;
@@ -31,6 +48,11 @@ const ModelCatalogFilters: React.FC = () => {
     <Stack hasGutter>
       <ModelPerformanceViewToggleCard />
       <TaskFilter filters={getFilterProps(ModelCatalogStringFilterKey.TASK)} />
+      {toolCallingFeatureAvailable && (
+        <ValidatedConfigurationFilter
+          filters={getFilterProps(ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION)}
+        />
+      )}
       <ProviderFilter filters={getFilterProps(ModelCatalogStringFilterKey.PROVIDER)} />
       <LicenseFilter filters={getFilterProps(ModelCatalogStringFilterKey.LICENSE)} />
       <LanguageFilter filters={getFilterProps(ModelCatalogStringFilterKey.LANGUAGE)} />

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogLabels.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogLabels.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
-import { Label, LabelGroup } from '@patternfly/react-core';
+import { Icon, Label, LabelGroup } from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { MODEL_CATALOG_TASK_NAME_MAPPING, ModelCatalogTask } from '~/concepts/modelCatalog/const';
+
+const isModelCatalogTask = (task: string): task is ModelCatalogTask =>
+  Object.values<string>(ModelCatalogTask).includes(task);
+
+const getTaskDisplayName = (task: string): string =>
+  isModelCatalogTask(task) ? MODEL_CATALOG_TASK_NAME_MAPPING[task] : task;
 
 type ModelCatalogLabelsProps = {
   tasks?: string[];
+  validatedTasks?: string[];
   provider?: string;
   labels?: string[];
   numLabels: number;
@@ -10,16 +19,31 @@ type ModelCatalogLabelsProps = {
 
 const ModelCatalogLabels: React.FC<ModelCatalogLabelsProps> = ({
   tasks = [],
+  validatedTasks,
   provider,
   labels = [],
   numLabels,
 }) => (
   <LabelGroup numLabels={numLabels} isCompact>
-    {tasks.map((task) => (
-      <Label data-testid="model-catalog-label" key={task} variant="outline">
-        {task}
-      </Label>
-    ))}
+    {tasks.map((task) => {
+      const isValidatedTask = validatedTasks?.includes(task);
+      return (
+        <Label
+          data-testid="model-catalog-label"
+          key={task}
+          variant="outline"
+          icon={
+            isValidatedTask ? (
+              <Icon status="success">
+                <CheckCircleIcon />
+              </Icon>
+            ) : undefined
+          }
+        >
+          {getTaskDisplayName(task)}
+        </Label>
+      );
+    })}
     {provider && (
       <Label isCompact variant="outline">
         {provider}

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ValidatedConfigurationFilter.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Content, ContentVariants, Divider, StackItem } from '@patternfly/react-core';
+import ModelCatalogStringFilter from '~/app/pages/modelCatalog/components/ModelCatalogStringFilter';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
+import {
+  ModelCatalogStringFilterKey,
+  MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING,
+} from '~/concepts/modelCatalog/const';
+import { CatalogFilterOptions, ModelCatalogStringFilterOptions } from '~/app/modelCatalogTypes';
+
+const filterKey = ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION;
+
+type ValidatedConfigurationFilterProps = {
+  filters?: Extract<CatalogFilterOptions, Partial<ModelCatalogStringFilterOptions>>;
+};
+
+const ValidatedConfigurationFilter: React.FC<ValidatedConfigurationFilterProps> = ({ filters }) => {
+  const { filterData } = React.useContext(ModelCatalogContext);
+  const validatedConfiguration = filters?.[filterKey];
+  const filterValues = validatedConfiguration?.values ?? [];
+  const hasMultipleOptions = filterValues.length > 1;
+  const hasSelection = filterData[filterKey].length > 0;
+
+  if (!validatedConfiguration) {
+    return null;
+  }
+
+  return (
+    <>
+      <StackItem>
+        <ModelCatalogStringFilter<ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION>
+          title="Validated configuration"
+          filterKey={filterKey}
+          filterToNameMapping={MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING}
+          filters={validatedConfiguration}
+        />
+        {hasMultipleOptions && hasSelection && (
+          <Content component={ContentVariants.small} className="pf-v6-u-mt-sm">
+            Showing models with all selected configurations
+          </Content>
+        )}
+      </StackItem>
+      <Divider />
+    </>
+  );
+};
+
+export default ValidatedConfigurationFilter;

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -17,7 +17,7 @@ import {
   Skeleton,
   Label,
 } from '@patternfly/react-core';
-import { ChartBarIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 import { ApplicationsPage } from 'mod-arch-shared';
 import {
   decodeParams,
@@ -45,7 +45,6 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
   const params = useParams<CatalogModelDetailsParams>();
   const decodedParams = decodeParams(params);
   const navigate = useNavigate();
-
   const state = useCatalogModel(
     decodedParams.sourceId || '',
     encodeURIComponent(`${decodedParams.modelName}`),
@@ -155,7 +154,12 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
                     <FlexItem>{getModelName(model.name)}</FlexItem>
                     {isModelValidated(model) && (
                       <Popover bodyContent={MODEL_CATALOG_POPOVER_MESSAGES.VALIDATED}>
-                        <Label color="purple" isClickable icon={<ChartBarIcon />}>
+                        <Label
+                          variant="outline"
+                          isClickable
+                          status="success"
+                          icon={<CheckCircleIcon />}
+                        >
                           Validated
                         </Label>
                       </Popover>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Card,
   CardBody,
+  CardExpandableContent,
   CardHeader,
   Content,
   DescriptionList,
@@ -41,9 +42,12 @@ import {
   getModelArtifactUri,
   hasModelArtifacts,
   isModelValidated,
+  hasValidatedToolCalling,
   formatModelTypeDisplay,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { CatalogModelCustomPropertyKey } from '~/concepts/modelCatalog/const';
+import { useTempDevFeatureAvailable, TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
+import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 
 type ModelDetailsViewProps = {
   model: CatalogModel;
@@ -58,14 +62,13 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
   artifactLoaded,
   artifactsLoadError,
 }) => {
-  // Extract all labels from customProperties
   const allLabels = model.customProperties ? getLabels(model.customProperties) : [];
   const isValidated = isModelValidated(model);
+  const isToolCallingEnabled = useTempDevFeatureAvailable(TempDevFeature.ToolCallingConfiguration);
+  const isToolCallingValidated = isToolCallingEnabled && hasValidatedToolCalling(model);
 
-  // Extract validated_on platforms
   const validatedOnPlatforms = getValidatedOnPlatforms(model.customProperties);
 
-  // Extract model type from customProperties
   const modelTypeRaw = model.customProperties
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.MODEL_TYPE)
     : null;
@@ -75,7 +78,6 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
     [modelTypeRaw],
   );
 
-  // Extract tensor type and size from customProperties
   const tensorType = model.customProperties
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.TENSOR_TYPE)
     : '';
@@ -83,11 +85,12 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
     ? getCustomPropString(model.customProperties, CatalogModelCustomPropertyKey.SIZE)
     : '';
 
-  // Extract architectures from artifacts with memoization to prevent unnecessary recalculations
   const architectures = React.useMemo(
     () => (artifactLoaded ? getArchitecturesFromArtifacts(artifacts.items) : []),
     [artifactLoaded, artifacts.items],
   );
+
+  const [isToolCallingExpanded, setIsToolCallingExpanded] = React.useState(false);
 
   return (
     <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
@@ -132,124 +135,186 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
           </Stack>
         </SidebarContent>
         <SidebarPanel width={{ default: 'width_33' }}>
-          <Card>
-            <CardHeader>
-              <Title headingLevel="h2" size="lg">
-                Model details
-              </Title>
-            </CardHeader>
-            <CardBody>
-              <DescriptionList>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Labels</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ModelCatalogLabels
-                      tasks={model.tasks ?? []}
-                      labels={allLabels.filter((label) => label !== 'validated')}
-                      numLabels={isValidated ? 2 : 3}
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Model type</DescriptionListTerm>
-                  <DescriptionListDescription data-testid="model-type">
-                    {modelTypeDisplay}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Tensor type</DescriptionListTerm>
-                  <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Size</DescriptionListTerm>
-                  <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>License</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ExternalLink
-                      text="Agreement"
-                      to={model.licenseLink || ''}
-                      testId="model-license-link"
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Provider</DescriptionListTerm>
-                  <DescriptionListDescription>{model.provider || 'N/A'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                {validatedOnPlatforms.length > 0 && (
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>
-                      Certified platforms{' '}
-                      <Popover bodyContent="The model has been tested and verified to operate correctly on the specified enterprise platforms.">
-                        <Button
-                          variant="plain"
-                          aria-label="More info for validated on"
-                          className="pf-v6-u-p-xs"
-                          icon={<HelpIcon />}
+          <Stack hasGutter>
+            {isToolCallingValidated && (
+              <StackItem>
+                <Card data-testid="validated-configurations-card">
+                  <CardHeader>
+                    <Title headingLevel="h2" size="lg">
+                      Validated configurations
+                    </Title>
+                  </CardHeader>
+                  <CardBody>
+                    <Content component="p" className="pf-v6-u-mb-md">
+                      These configurations have been tested and validated for this model. Use them
+                      as runtime arguments when deploying.
+                    </Content>
+                    <Card
+                      id="tool-calling-card"
+                      isExpanded={isToolCallingExpanded}
+                      data-testid="tool-calling-card"
+                    >
+                      <CardHeader
+                        onExpand={() => setIsToolCallingExpanded((prev) => !prev)}
+                        toggleButtonProps={{
+                          id: 'tool-calling-toggle',
+                          'aria-label': 'Tool Calling',
+                          'aria-expanded': isToolCallingExpanded,
+                        }}
+                      >
+                        <Stack>
+                          <StackItem>
+                            <Title headingLevel="h3" size="md">
+                              Tool Calling
+                            </Title>
+                          </StackItem>
+                          <StackItem>
+                            <Content component="small">
+                              Enables agentic workflows and function calling capabilities.
+                            </Content>
+                          </StackItem>
+                        </Stack>
+                      </CardHeader>
+                      <CardExpandableContent>
+                        <CardBody>
+                          <CodeBlockComponent>
+                            {model.servingConfig?.toolCalling?.args ?? ''}
+                          </CodeBlockComponent>
+                        </CardBody>
+                      </CardExpandableContent>
+                    </Card>
+                  </CardBody>
+                </Card>
+              </StackItem>
+            )}
+            <StackItem>
+              <Card>
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">
+                    Model details
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  <DescriptionList>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Labels</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ModelCatalogLabels
+                          tasks={model.tasks ?? []}
+                          validatedTasks={isToolCallingEnabled ? model.validatedTasks : undefined}
+                          labels={allLabels.filter((label) => label !== 'validated')}
+                          numLabels={isValidated ? 2 : 3}
                         />
-                      </Popover>
-                    </DescriptionListTerm>
-                    <DescriptionListDescription>
-                      <LabelGroup numLabels={5} isCompact>
-                        {validatedOnPlatforms.map((platform) => (
-                          <Label data-testid="validated-on-label" key={platform} variant="outline">
-                            {platform}
-                          </Label>
-                        ))}
-                      </LabelGroup>
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                )}
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Model location</DescriptionListTerm>
-                  {artifactsLoadError ? (
-                    <Alert variant="danger" isInline title={artifactsLoadError.name}>
-                      {artifactsLoadError.message}
-                    </Alert>
-                  ) : !artifactLoaded ? (
-                    <Spinner size="sm" />
-                  ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
-                    <DescriptionListDescription>
-                      <InlineTruncatedClipboardCopy
-                        testId="source-image-location"
-                        textToCopy={getModelArtifactUri(artifacts.items) || ''}
-                      />
-                    </DescriptionListDescription>
-                  ) : (
-                    <p className={text.textColorDisabled}>No artifacts available</p>
-                  )}
-                </DescriptionListGroup>
-                {architectures.length > 0 && (
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Architecture</DescriptionListTerm>
-                    <DescriptionListDescription data-testid="model-architecture">
-                      {architectures.join(', ')}
-                    </DescriptionListDescription>
-                  </DescriptionListGroup>
-                )}
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Last modified</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Icon isInline style={{ marginRight: 4 }}>
-                      <OutlinedClockIcon />
-                    </Icon>
-                    <ModelTimestamp timeSinceEpoch={model.lastUpdateTimeSinceEpoch} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Published</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Icon isInline style={{ marginRight: 4 }}>
-                      <OutlinedClockIcon />
-                    </Icon>
-                    <ModelTimestamp timeSinceEpoch={model.createTimeSinceEpoch} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              </DescriptionList>
-            </CardBody>
-          </Card>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Model type</DescriptionListTerm>
+                      <DescriptionListDescription data-testid="model-type">
+                        {modelTypeDisplay}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Tensor type</DescriptionListTerm>
+                      <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Size</DescriptionListTerm>
+                      <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>License</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <ExternalLink
+                          text="Agreement"
+                          to={model.licenseLink || ''}
+                          testId="model-license-link"
+                        />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Provider</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {model.provider || 'N/A'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {validatedOnPlatforms.length > 0 && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>
+                          Certified platforms{' '}
+                          <Popover bodyContent="The model has been tested and verified to operate correctly on the specified enterprise platforms.">
+                            <Button
+                              variant="plain"
+                              aria-label="More info for validated on"
+                              className="pf-v6-u-p-xs"
+                              icon={<HelpIcon />}
+                            />
+                          </Popover>
+                        </DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <LabelGroup numLabels={5} isCompact>
+                            {validatedOnPlatforms.map((platform) => (
+                              <Label
+                                data-testid="validated-on-label"
+                                key={platform}
+                                variant="outline"
+                              >
+                                {platform}
+                              </Label>
+                            ))}
+                          </LabelGroup>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Model location</DescriptionListTerm>
+                      {artifactsLoadError ? (
+                        <Alert variant="danger" isInline title={artifactsLoadError.name}>
+                          {artifactsLoadError.message}
+                        </Alert>
+                      ) : !artifactLoaded ? (
+                        <Spinner size="sm" />
+                      ) : artifacts.items.length > 0 && hasModelArtifacts(artifacts.items) ? (
+                        <DescriptionListDescription>
+                          <InlineTruncatedClipboardCopy
+                            testId="source-image-location"
+                            textToCopy={getModelArtifactUri(artifacts.items) || ''}
+                          />
+                        </DescriptionListDescription>
+                      ) : (
+                        <p className={text.textColorDisabled}>No artifacts available</p>
+                      )}
+                    </DescriptionListGroup>
+                    {architectures.length > 0 && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Architecture</DescriptionListTerm>
+                        <DescriptionListDescription data-testid="model-architecture">
+                          {architectures.join(', ')}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Last modified</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Icon isInline style={{ marginRight: 4 }}>
+                          <OutlinedClockIcon />
+                        </Icon>
+                        <ModelTimestamp timeSinceEpoch={model.lastUpdateTimeSinceEpoch} />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Published</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Icon isInline style={{ marginRight: 4 }}>
+                          <OutlinedClockIcon />
+                        </Icon>
+                        <ModelTimestamp timeSinceEpoch={model.createTimeSinceEpoch} />
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </CardBody>
+              </Card>
+            </StackItem>
+          </Stack>
         </SidebarPanel>
       </Sidebar>
     </PageSection>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -54,6 +54,7 @@ describe('filtersToFilterQuery', () => {
     hardware_configuration = [],
     use_case = [],
     tensor_type = [],
+    validatedTasks = [],
     rps_mean = undefined,
     ttft_mean = undefined,
   }: {
@@ -66,6 +67,7 @@ describe('filtersToFilterQuery', () => {
     use_case?: UseCaseOptionValue[];
     rps_mean?: number;
     tensor_type?: ModelCatalogTensorType[];
+    validatedTasks?: string[];
     ttft_mean?: number;
   }): ModelCatalogFilterStates => ({
     [ModelCatalogStringFilterKey.TASK]: tasks,
@@ -77,6 +79,7 @@ describe('filtersToFilterQuery', () => {
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,
   });
 
@@ -170,6 +173,10 @@ describe('filtersToFilterQuery', () => {
           ModelCatalogTensorType.INT8,
           ModelCatalogTensorType.MXFP4,
         ],
+      },
+      [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: {
+        type: 'string',
+        values: ['tool-calling', 'text-generation', 'question-answering'],
       },
       [ModelCatalogStringFilterKey.HARDWARE_TYPE]: {
         type: 'string',
@@ -348,6 +355,38 @@ describe('filtersToFilterQuery', () => {
         ),
       ).toBe(
         "tasks='text-to-text' AND provider='Google' AND tensor_type.string_value IN ('FP16','INT8')",
+      );
+    });
+  });
+
+  describe('match-all (AND logic) filters', () => {
+    it('handles a single validated configuration value', () => {
+      expect(
+        filtersToFilterQuery(mockFormData({ validatedTasks: ['tool-calling'] }), mockFilterOptions),
+      ).toBe("validatedTasks='tool-calling'");
+    });
+
+    it('handles multiple validated configuration values with AND logic instead of IN', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({ validatedTasks: ['tool-calling', 'text-generation'] }),
+          mockFilterOptions,
+        ),
+      ).toBe("validatedTasks='tool-calling' AND validatedTasks='text-generation'");
+    });
+
+    it('handles validated configuration combined with other OR-logic filters', () => {
+      expect(
+        filtersToFilterQuery(
+          mockFormData({
+            tasks: [ModelCatalogTask.TEXT_TO_TEXT, ModelCatalogTask.IMAGE_TO_TEXT],
+            validatedTasks: ['tool-calling', 'text-generation'],
+            provider: [ModelCatalogProvider.GOOGLE],
+          }),
+          mockFilterOptions,
+        ),
+      ).toBe(
+        "tasks IN ('text-to-text','image-to-text') AND provider='Google' AND validatedTasks='tool-calling' AND validatedTasks='text-generation'",
       );
     });
   });
@@ -803,6 +842,7 @@ describe('hasFiltersApplied', () => {
     use_case = [],
     tensor_type = [],
     rps_mean = undefined,
+    validatedTasks = [],
     ttft_mean = undefined,
   }: {
     tasks?: ModelCatalogTask[];
@@ -813,6 +853,7 @@ describe('hasFiltersApplied', () => {
     hardware_configuration?: string[];
     use_case?: UseCaseOptionValue[];
     tensor_type?: ModelCatalogTensorType[];
+    validatedTasks?: string[];
     rps_mean?: number;
     ttft_mean?: number;
   }): ModelCatalogFilterStates => ({
@@ -825,6 +866,7 @@ describe('hasFiltersApplied', () => {
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
+    [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,
   });
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -38,6 +38,7 @@ import {
   getModelName,
   getCatalogModelTypePropertyForRegistration,
   getActiveSourceLabels,
+  hasValidatedToolCalling,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { mockCatalogModelArtifact } from '~/__mocks__/mockCatalogModelArtifactList';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -1652,5 +1653,59 @@ describe('getActiveSourceLabels', () => {
 
     const result = getActiveSourceLabels(sources, catalogLabels);
     expect(result).toEqual(['Red Hat', 'Partner', 'Community']);
+  });
+});
+
+describe('hasValidatedToolCalling', () => {
+  it('should return true when model has tool-calling in validatedTasks and servingConfig.toolCalling', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false when validatedTasks is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when validatedTasks does not include tool-calling', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: ['text-generation'],
+        servingConfig: { toolCalling: { args: '--some-args' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when servingConfig is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when servingConfig.toolCalling is missing', () => {
+    expect(
+      hasValidatedToolCalling({
+        name: 'test-model',
+        validatedTasks: [ModelCatalogTask.TOOL_CALLING],
+        servingConfig: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false when both validatedTasks and servingConfig are missing', () => {
+    expect(hasValidatedToolCalling({ name: 'test-model' })).toBe(false);
   });
 });

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -34,6 +34,7 @@ import {
   CatalogModelCustomPropertyKey,
   ModelType,
   ModelCatalogTask,
+  MATCH_ALL_FILTER_KEYS,
 } from '~/concepts/modelCatalog/const';
 import { isSourceStatusWithModels } from '~/concepts/modelCatalogSettings/const';
 import { ModelRegistryCustomProperties, ModelRegistryMetadataType } from '~/app/types';
@@ -353,6 +354,10 @@ const wrapInQuotes = (v: string): string => `'${v.replace(/'/g, "''")}'`;
 const eqFilter = (k: string, v: string) => `${k}=${wrapInQuotes(v)}`;
 const inFilter = (k: string, values: string[]) =>
   `${k} IN (${values.map((v) => wrapInQuotes(v)).join(',')})`;
+const andFilter = (k: string, values: string[]) => values.map((v) => eqFilter(k, v)).join(' AND ');
+
+const isMatchAllFilter = (filterId: string): boolean =>
+  MATCH_ALL_FILTER_KEYS.some((key) => key === filterId);
 
 /**
  * Check if a filter key has the artifacts.* prefix.
@@ -446,7 +451,7 @@ const serializeFilterEntry = (
       case 1:
         return eqFilter(queryKey, data[0]);
       default:
-        return inFilter(queryKey, data);
+        return isMatchAllFilter(filterId) ? andFilter(queryKey, data) : inFilter(queryKey, data);
     }
   }
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -33,6 +33,7 @@ import {
   SortField,
   CatalogModelCustomPropertyKey,
   ModelType,
+  ModelCatalogTask,
 } from '~/concepts/modelCatalog/const';
 import { isSourceStatusWithModels } from '~/concepts/modelCatalogSettings/const';
 import { ModelRegistryCustomProperties, ModelRegistryMetadataType } from '~/app/types';
@@ -190,6 +191,10 @@ export const shouldShowValidatedInsights = (
   model: CatalogModel,
   artifacts: CatalogArtifacts[],
 ): boolean => isModelValidated(model) && hasPerformanceArtifacts(artifacts);
+
+export const hasValidatedToolCalling = (model: CatalogModel): boolean =>
+  model.validatedTasks?.includes(ModelCatalogTask.TOOL_CALLING) === true &&
+  model.servingConfig?.toolCalling != null;
 
 export const useCatalogStringFilterState = <K extends ModelCatalogStringFilterKey>(
   filterKey: K,

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/utils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelRegistry/screens/utils.ts
@@ -88,8 +88,7 @@ export const getProperties = <T extends ModelRegistryCustomProperties>(
 ): ModelRegistryEditableCustomProperties => {
   const initial: ModelRegistryEditableCustomProperties = {};
   return Object.keys(customProperties).reduce((acc, key) => {
-    // _lastModified is a property that is required to update the timestamp on the backend and we have a workaround for it. It should be resolved by
-    // backend team
+    // _lastModified was used by a previous workaround and may still exist on older models; filter it out so users don't see it
     if (
       key === '_lastModified' ||
       key === CatalogModelCustomPropertyKey.MODEL_TYPE ||

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -4,6 +4,7 @@ export enum ModelCatalogStringFilterKey {
   LICENSE = 'license',
   LANGUAGE = 'language',
   TENSOR_TYPE = 'tensor_type.string_value',
+  VALIDATED_CONFIGURATION = 'validatedTasks',
   // Performance filter keys use backend format
   HARDWARE_TYPE = 'artifacts.hardware_type.string_value',
   HARDWARE_CONFIGURATION = 'artifacts.hardware_configuration.string_value',
@@ -182,6 +183,17 @@ export const MODEL_CATALOG_TASK_NAME_MAPPING = {
   [ModelCatalogTask.TEXT_TO_TEXT]: 'Text-to-text',
   [ModelCatalogTask.TOOL_CALLING]: 'Tool calling',
   [ModelCatalogTask.VIDEO_TO_TEXT]: 'Video-to-text',
+};
+
+export enum ValidatedConfiguration {
+  TOOL_CALLING = 'tool-calling',
+}
+
+export const MODEL_CATALOG_VALIDATED_CONFIGURATION_NAME_MAPPING: Record<
+  ValidatedConfiguration,
+  string
+> = {
+  [ValidatedConfiguration.TOOL_CALLING]: 'Tool calling',
 };
 
 export const MODEL_CATALOG_TASK_DESCRIPTION = {
@@ -444,6 +456,17 @@ export const BASIC_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.TASK,
   ModelCatalogStringFilterKey.LANGUAGE,
   ModelCatalogStringFilterKey.TENSOR_TYPE,
+  ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
+];
+
+/**
+ * Filters that use AND logic when multiple values are selected.
+ * Standard filters use OR (IN operator): items matching ANY selected value.
+ * AND filters require items to match ALL selected values.
+ * Add a filter key here to switch it from OR to AND behavior.
+ */
+export const MATCH_ALL_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
+  ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION,
 ];
 
 /**
@@ -550,6 +573,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: 'Hardware',
   [ModelCatalogStringFilterKey.USE_CASE]: 'Workload type',
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: 'Tensor type',
+  [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: 'Validated configuration',
   // Number filter keys
   [ModelCatalogNumberFilterKey.MAX_RPS]: 'Max RPS',
   // Latency field names - all use "Latency" as category name


### PR DESCRIPTION
## Description

Sync to pull in changes from:
* https://github.com/kubeflow/model-registry/pull/2687
* https://github.com/kubeflow/model-registry/pull/2710
* https://github.com/kubeflow/model-registry/pull/2707
* https://github.com/kubeflow/model-registry/pull/2685
* https://github.com/kubeflow/model-registry/pull/2686

### Conflicts Resolved

The following conflicts were resolved during this sync:

**[#2687 - Add tool calling support to Model catalog](https://github.com/kubeflow/model-registry/pull/2687)**
- `frontend/src/app/pages/modelCatalog/components/ModelCatalogCard.tsx`

*Nature of conflict:* The downstream fork includes `isRedHatModel` logic (import and card header labels) that does not exist in upstream. The upstream patch expected a simpler version of the file without Red Hat model labeling, causing the automatic patch application to fail.

*Resolution:* Applied all upstream changes (replaced `ChartBarIcon` with `CheckCircleIcon`, added `useTempDevFeatureAvailable` hook for tool calling feature flag, updated validated label styling to `variant="outline" status="success"`, added `validatedTasks` prop to `ModelCatalogLabels`) while preserving the downstream `isRedHatModel` additions (import, `isRedHat` variable, Red Hat label popover, and conditional source label logic).

## How Has This Been Tested?

Tested by running backend, frontend and the federated MR package separately as described below, verifying existing behavior in the files this diff touches, and verifying the incoming changes.

Also ran unit tests: `npm run test:unit`
and ran type check: `npm run test:type-check`
(both in `packages/model-registry/upstream/frontend`)

Process to run everything locally this way:
* Create `.env.development.local` and copy the contents of `.env.development` to it. Change the backend port to 4020 to avoid conflicts with the upstream running.
* `oc login` to a cluster with ODH installed
* Run both `frontend` and `backend` folders with `npm run start:dev` after running `npm install` on odh-dashboard root repository
* Before continuing, install [kubectl](https://kubernetes.io/docs/tasks/tools/) and [golang](https://go.dev/doc/install)
* With these two terminal tabs open, open a third terminal tab, go to `packages/model-registry/upstream` and run `make dev-install-dependencies` followed by `PORT=9100 make dev-start-federated INSECURE_SKIP_VERIFY=true`

## Test Impact

Upstream changes include their own tests.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model-registry dependency pinning to the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->