### PR TITLE
Fix upstream-sync skill to create cross-fork PRs against upstream repo

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -217,15 +217,18 @@ Copy the "Request review criteria" section exactly as it appears in `.github/pul
 
 **Push and create PR:**
 
-1. Ask user for confirmation before pushing
-2. Push the branch: `git push -u origin <branch-name>`
-3. Create the PR:
+1. Detect the upstream repo and fork owner:
+   - Run `git remote get-url upstream` to extract `<upstream-owner>/<upstream-repo>`
+   - Run `git remote get-url origin` to extract `<fork-owner>`
+2. Ask user for confirmation before pushing
+3. Push the branch to the fork: `git push -u origin <branch-name>`
+4. Create a cross-fork PR against the upstream repo:
    ```bash
-   gh pr create --title "<title>" --body "<body>"
+   gh pr create --repo <upstream-owner>/<upstream-repo> --head <fork-owner>:<branch-name> --base main --title "<title>" --body "<body>"
    ```
-4. Report the PR URL to the user
-5. **Only if in PR Test Mode** (the user passed a PR URL argument — the branch name starts with `tmp-sync-pr-`): immediately close the PR after creating it, since it exists only to share the branch and trigger CI:
+5. Report the PR URL to the user
+6. **Only if in PR Test Mode** (the user passed a PR URL argument — the branch name starts with `tmp-sync-pr-`): immediately close the PR after creating it, since it exists only to share the branch and trigger CI:
    ```bash
-   gh pr close <pr-number>
+   gh pr close <pr-number> --repo <upstream-owner>/<upstream-repo>
    ```
    **Do NOT close the PR in normal mode.** Normal sync PRs are meant to be reviewed and merged.

--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -108,19 +108,41 @@ When conflicts are detected:
    - Continue the sync: `cd packages/<package-name> && npm run update-subtree -- --continue`
    - Repeat this phase if more conflicts are encountered
 
-### Phase 4: Run Tests
+### Phase 4: Lint and Tests
 
-After the sync completes successfully, run tests. Check which test scripts are available in the package's upstream frontend:
+After the sync completes successfully, run lint and tests. Check which scripts are available in the package's upstream frontend:
 
 ```bash
 cd packages/<package-name>/upstream/frontend && cat package.json | grep -E '"test:|"type-check'
 ```
 
-Run whichever of these are available:
+**Step 1: Lint (required before creating a PR)**
+
+Run lint first — CI will reject the PR if this fails:
+
+```bash
+cd packages/<package-name>/upstream/frontend && npm run test:lint
+```
+
+If lint fails, try auto-fixing:
+
+```bash
+cd packages/<package-name>/upstream/frontend && npm run test:fix
+```
+
+After auto-fix, re-run `test:lint` to confirm all issues are resolved. If issues remain that can't be auto-fixed, fix them manually. Stage and commit any lint fixes:
+
+```bash
+git add packages/<package-name> && git commit -m "Fix lint issues from upstream sync"
+```
+
+**Step 2: Unit tests**
 
 ```bash
 cd packages/<package-name>/upstream/frontend && npm run test:unit
 ```
+
+**Step 3: Type check**
 
 ```bash
 cd packages/<package-name>/upstream/frontend && npm run test:type-check


### PR DESCRIPTION
## Description

Two improvements to the upstream-sync skill (`.claude/skills/upstream-sync/SKILL.md`):

### 1. Create cross-fork PRs against upstream repo

The skill's "Push and create PR" phase was using `gh pr create` without `--repo`, which defaults to creating PRs against the user's fork instead of the upstream repo (`opendatahub-io/odh-dashboard`). This meant every sync required manual correction to retarget the PR.

Updated the skill to:
- Detect the upstream repo and fork owner from git remotes (`git remote get-url upstream` / `origin`)
- Create cross-fork PRs using `gh pr create --repo <upstream> --head <fork-owner>:<branch>`
- Also use `--repo` on `gh pr close` in PR Test Mode

### 2. Add lint pre-check to Phase 4

CI rejects PRs that fail lint (as seen in [#7605](https://github.com/opendatahub-io/odh-dashboard/actions/runs/26084258430/job/76693215702?pr=7605)). Updated Phase 4 from "Run Tests" to "Lint and Tests" with three explicit steps:
- **Step 1: Lint** — runs `test:lint` first, auto-fixes with `test:fix` if it fails, commits any fixes
- **Step 2: Unit tests** — `test:unit`
- **Step 3: Type check** — `test:type-check`

## How Has This Been Tested?

Verified the cross-fork issue by running a model-registry sync where the PR was initially created against the fork, then had to be manually re-created against upstream. The updated instructions match the working `gh pr create` command used to fix it.

Verified the lint gap by observing CI failure on #7605 due to a formatting issue in a conflict-resolved file that would have been caught by running `test:lint` locally before creating the PR.

## Test Impact

Documentation-only change (agent skill instructions). No code tests affected.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`