### PR TITLE
Fix(RHOAIENG-62527):Added fallback for ingress and ocproute for Rayjobs dashboard url

### DIFF
--- a/packages/model-training/src/hooks/__tests__/useRayClusterDashboardURL.spec.ts
+++ b/packages/model-training/src/hooks/__tests__/useRayClusterDashboardURL.spec.ts
@@ -40,17 +40,29 @@ const mockHTTPRouteResource = (path?: string) => ({
   },
 });
 
+const mockGatewayConfigResource = (domain?: string, useStatus = true) => ({
+  ...(useStatus ? { status: { domain } } : { spec: { domain } }),
+});
+
+const loadedFetch = (data: unknown) => ({
+  data,
+  loaded: true,
+  error: undefined,
+  refresh: jest.fn(),
+});
+
 describe('useGatewayHostname', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should return hostname when Gateway is loaded', () => {
-    useFetchMock.mockReturnValue({
-      data: mockGatewayResource('rh-ai.apps.example.com'),
-      loaded: true,
-      error: undefined,
-      refresh: jest.fn(),
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? loadedFetch(mockGatewayResource('rh-ai.apps.example.com'))
+        : loadedFetch(mockGatewayConfigResource('fallback.example.com'));
     });
 
     const renderResult = testHook(useGatewayHostname)();
@@ -60,26 +72,43 @@ describe('useGatewayHostname', () => {
     expect(renderResult.result.current.error).toBeUndefined();
   });
 
-  it('should return null hostname when Gateway has no listeners', () => {
-    useFetchMock.mockReturnValue({
-      data: mockGatewayResource(),
-      loaded: true,
-      error: undefined,
-      refresh: jest.fn(),
+  it('should fall back to GatewayConfig status.domain when Gateway has no hostname', () => {
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? loadedFetch(mockGatewayResource())
+        : loadedFetch(mockGatewayConfigResource('rh-ai.apps.example.com'));
     });
 
     const renderResult = testHook(useGatewayHostname)();
 
-    expect(renderResult.result.current.hostname).toBeNull();
+    expect(renderResult.result.current.hostname).toBe('rh-ai.apps.example.com');
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
-  it('should return null hostname when data is null', () => {
-    useFetchMock.mockReturnValue({
-      data: null,
-      loaded: true,
-      error: undefined,
-      refresh: jest.fn(),
+  it('should fall back to GatewayConfig spec.domain when status.domain is unset', () => {
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? loadedFetch(mockGatewayResource())
+        : loadedFetch(mockGatewayConfigResource('rh-ai.apps.example.com', false));
+    });
+
+    const renderResult = testHook(useGatewayHostname)();
+
+    expect(renderResult.result.current.hostname).toBe('rh-ai.apps.example.com');
+    expect(renderResult.result.current.loaded).toBe(true);
+  });
+
+  it('should return null hostname when Gateway and GatewayConfig have no domain', () => {
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? loadedFetch(mockGatewayResource())
+        : loadedFetch(mockGatewayConfigResource());
     });
 
     const renderResult = testHook(useGatewayHostname)();
@@ -103,6 +132,23 @@ describe('useGatewayHostname', () => {
     expect(renderResult.result.current.hostname).toBeNull();
     expect(renderResult.result.current.error).toBe(mockError);
   });
+
+  it('should prefer Gateway error over GatewayConfig error when both fail', () => {
+    const gatewayError = new Error('Gateway fetch failed');
+    const configError = new Error('GatewayConfig fetch failed');
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      return callCount === 1
+        ? { data: null, loaded: true, error: gatewayError, refresh: jest.fn() }
+        : { data: null, loaded: true, error: configError, refresh: jest.fn() };
+    });
+
+    const renderResult = testHook(useGatewayHostname)();
+
+    expect(renderResult.result.current.error).toBe(gatewayError);
+    expect(renderResult.result.current.hostname).toBeNull();
+  });
 });
 
 describe('useRayClusterDashboardURL', () => {
@@ -116,21 +162,12 @@ describe('useRayClusterDashboardURL', () => {
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        // useGatewayHostname call
-        return {
-          data: mockGatewayResource('rh-ai.apps.example.com'),
-          loaded: true,
-          error: undefined,
-          refresh: jest.fn(),
-        };
+        return loadedFetch(mockGatewayResource('rh-ai.apps.example.com'));
       }
-      // useRayClusterDashboardURL HTTPRoute call
-      return {
-        data: mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'),
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
+      }
+      return loadedFetch(mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'));
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
@@ -140,6 +177,27 @@ describe('useRayClusterDashboardURL', () => {
     );
     expect(renderResult.result.current.loaded).toBe(true);
     expect(renderResult.result.current.error).toBeUndefined();
+  });
+
+  it('should return full URL using GatewayConfig status.domain on OcpRoute clusters', () => {
+    let callCount = 0;
+    useFetchMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return loadedFetch(mockGatewayResource());
+      }
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource('rh-ai.apps.example.com'));
+      }
+      return loadedFetch(mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'));
+    });
+
+    const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
+
+    expect(renderResult.result.current.url).toBe(
+      'https://rh-ai.apps.example.com/ray/my-ns/my-cluster/#/',
+    );
+    expect(renderResult.result.current.loaded).toBe(true);
   });
 
   it('should return null URL when rayClusterName is undefined', () => {
@@ -156,24 +214,17 @@ describe('useRayClusterDashboardURL', () => {
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
-  it('should return null URL when Gateway has no hostname', () => {
+  it('should return null URL when neither Gateway nor GatewayConfig provides a domain', () => {
     let callCount = 0;
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return {
-          data: mockGatewayResource(),
-          loaded: true,
-          error: undefined,
-          refresh: jest.fn(),
-        };
+        return loadedFetch(mockGatewayResource());
       }
-      return {
-        data: mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'),
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
+      }
+      return loadedFetch(mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'));
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
@@ -187,19 +238,12 @@ describe('useRayClusterDashboardURL', () => {
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return {
-          data: mockGatewayResource('rh-ai.apps.example.com'),
-          loaded: true,
-          error: undefined,
-          refresh: jest.fn(),
-        };
+        return loadedFetch(mockGatewayResource('rh-ai.apps.example.com'));
       }
-      return {
-        data: mockHTTPRouteResource(),
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
+      }
+      return loadedFetch(mockHTTPRouteResource());
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
@@ -220,12 +264,10 @@ describe('useRayClusterDashboardURL', () => {
           refresh: jest.fn(),
         };
       }
-      return {
-        data: mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'),
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource('rh-ai.apps.example.com'));
+      }
+      return loadedFetch(mockHTTPRouteResource('/ray/my-ns/my-cluster/#/'));
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
@@ -239,12 +281,10 @@ describe('useRayClusterDashboardURL', () => {
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return {
-          data: mockGatewayResource('rh-ai.apps.example.com'),
-          loaded: true,
-          error: undefined,
-          refresh: jest.fn(),
-        };
+        return loadedFetch(mockGatewayResource('rh-ai.apps.example.com'));
+      }
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
       }
       return {
         data: null,
@@ -260,7 +300,7 @@ describe('useRayClusterDashboardURL', () => {
     expect(renderResult.result.current.url).toBeNull();
   });
 
-  it('should propagate Gateway error and report loaded', () => {
+  it('should propagate Gateway error when GatewayConfig provides no domain', () => {
     const gatewayError = new Error('Gateway fetch failed');
     let callCount = 0;
     useFetchMock.mockImplementation(() => {
@@ -273,12 +313,12 @@ describe('useRayClusterDashboardURL', () => {
           refresh: jest.fn(),
         };
       }
-      return {
-        data: null,
-        loaded: true,
-        error: undefined,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        // GatewayConfig resolves but provides no domain — hostname remains null,
+        // so the Gateway error surfaces to the caller.
+        return loadedFetch(mockGatewayConfigResource());
+      }
+      return loadedFetch(null);
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
@@ -294,12 +334,10 @@ describe('useRayClusterDashboardURL', () => {
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return {
-          data: mockGatewayResource('rh-ai.apps.example.com'),
-          loaded: true,
-          error: undefined,
-          refresh: jest.fn(),
-        };
+        return loadedFetch(mockGatewayResource('rh-ai.apps.example.com'));
+      }
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
       }
       return {
         data: null,
@@ -316,30 +354,24 @@ describe('useRayClusterDashboardURL', () => {
     expect(renderResult.result.current.url).toBeNull();
   });
 
-  it('should prefer Gateway error when both have errors', () => {
-    const gatewayError = new Error('Gateway error');
-    const routeError = new Error('Route error');
+  it('should prefer Gateway hostname error over HTTPRoute error when both fail', () => {
+    const gatewayError = new Error('Gateway fetch failed');
+    const routeError = new Error('HTTPRoute fetch failed');
     let callCount = 0;
     useFetchMock.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        return {
-          data: null,
-          loaded: true,
-          error: gatewayError,
-          refresh: jest.fn(),
-        };
+        return { data: null, loaded: true, error: gatewayError, refresh: jest.fn() };
       }
-      return {
-        data: null,
-        loaded: true,
-        error: routeError,
-        refresh: jest.fn(),
-      };
+      if (callCount === 2) {
+        return loadedFetch(mockGatewayConfigResource());
+      }
+      return { data: null, loaded: true, error: routeError, refresh: jest.fn() };
     });
 
     const renderResult = testHook(useRayClusterDashboardURL)('my-cluster', 'my-ns');
 
     expect(renderResult.result.current.error).toBe(gatewayError);
+    expect(renderResult.result.current.url).toBeNull();
   });
 });

--- a/packages/model-training/src/hooks/useRayClusterDashboardURL.ts
+++ b/packages/model-training/src/hooks/useRayClusterDashboardURL.ts
@@ -3,15 +3,35 @@ import useFetch, { NotReadyError } from '@odh-dashboard/internal/utilities/useFe
 import { k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { GatewayModel, HTTPRouteModel } from '@odh-dashboard/internal/api/models';
 import { useDashboardNamespace } from '@odh-dashboard/internal/redux/selectors/project';
+import type { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { GatewayResource, HTTPRouteResource } from '../k8sTypes';
 
 const GATEWAY_NAME = 'data-science-gateway';
 const GATEWAY_NAMESPACE = 'openshift-ingress';
+const GATEWAY_CONFIG_NAME = 'default-gateway';
+
+const GatewayConfigModel: K8sModelCommon = {
+  apiVersion: 'v1alpha1',
+  apiGroup: 'services.platform.opendatahub.io',
+  kind: 'GatewayConfig',
+  plural: 'gatewayconfigs',
+};
+
+type GatewayConfigResource = K8sResourceCommon & {
+  spec?: { domain?: string };
+  status?: { domain?: string };
+};
 
 const getGateway = (): Promise<GatewayResource> =>
   k8sGetResource<GatewayResource>({
     model: GatewayModel,
     queryOptions: { name: GATEWAY_NAME, ns: GATEWAY_NAMESPACE },
+  });
+
+const getGatewayConfig = (): Promise<GatewayConfigResource> =>
+  k8sGetResource<GatewayConfigResource>({
+    model: GatewayConfigModel,
+    queryOptions: { name: GATEWAY_CONFIG_NAME },
   });
 
 const getHTTPRoute = (name: string, namespace: string): Promise<HTTPRouteResource> =>
@@ -22,26 +42,48 @@ const getHTTPRoute = (name: string, namespace: string): Promise<HTTPRouteResourc
 
 /**
  * Fetches the Gateway hostname from the cluster-wide `data-science-gateway`.
- * The result is shared across all consumers since the Gateway is a singleton.
+ * Falls back to GatewayConfig `status.domain` (or `spec.domain`) when the Gateway listener has
+ * no hostname (clusters using ingressMode: OcpRoute leave the hostname field unset).
  */
 export const useGatewayHostname = (): {
   hostname: string | null;
   loaded: boolean;
   error: Error | undefined;
 } => {
-  const { data, loaded, error } = useFetch<GatewayResource | null>(
+  const {
+    data: gateway,
+    loaded: gatewayLoaded,
+    error: gatewayError,
+  } = useFetch<GatewayResource | null>(
     React.useCallback(() => getGateway(), []),
     null,
     { initialPromisePurity: true },
   );
 
+  const {
+    data: gatewayConfig,
+    loaded: configLoaded,
+    error: configError,
+  } = useFetch<GatewayConfigResource | null>(
+    React.useCallback(() => getGatewayConfig(), []),
+    null,
+    { initialPromisePurity: true },
+  );
+
+  const hostname =
+    gateway?.spec?.listeners?.[0]?.hostname ?? // ← Gateway API mode
+    gatewayConfig?.status?.domain ?? // ← OcpRoute mode
+    gatewayConfig?.spec?.domain ?? // ← older/other clusters
+    null;
+
   return React.useMemo(
     () => ({
-      hostname: data?.spec?.listeners?.[0]?.hostname ?? null,
-      loaded,
-      error,
+      hostname,
+      loaded: (gatewayLoaded || !!gatewayError) && (configLoaded || !!configError),
+      // Only surface errors when no hostname could be resolved — avoid showing an error
+      error: hostname ? undefined : gatewayError ?? configError,
     }),
-    [data, loaded, error],
+    [hostname, gatewayLoaded, configLoaded, gatewayError, configError],
   );
 };
 


### PR DESCRIPTION

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

Closes [RHOAIENG-62527](https://redhat.atlassian.net/browse/RHOAIENG-62527)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

<img width="2394" height="1602" alt="image" src="https://github.com/user-attachments/assets/9213a706-296c-4ace-ae88-a67206f239b9" />


https://github.com/user-attachments/assets/6427cded-46e3-4073-b8a5-5501990e8a3d



The Ray cluster dashboard URL was not showing on clusters using `ingressMode: OcpRoute`.

On these clusters, ODH leaves `Gateway.spec.listeners[0].hostname` empty and instead
publishes the public domain in `GatewayConfig.status.domain`. The hook only checked
the Gateway listener, so hostname resolution always returned `null` → no URL shown.

**Fix:** fetch the `default-gateway` `GatewayConfig` CR and use it as a fallback

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Manually verified on a cluster with ingressMode: OcpRoute , the Ray dashboard URL now appears and is clickable after applying the fix.



## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
 Added unit test cases of `useRayClusterDashboardURL.spec.ts` to cover the new fallback paths:
- GatewayConfig status.domain fallback (OcpRoute clusters)
- GatewayConfig spec.domain fallback (older clusters)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Ray Cluster Dashboard URL resolution with improved fallback mechanisms for Gateway configuration
  * Strengthened error handling to prioritize and surface the most relevant connection errors
  * Extended test coverage for edge cases in hostname and URL resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->