### PR TITLE
fix(ci): delete stale kubeconfig before oc login in E2E workflow

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -117,6 +117,9 @@ jobs:
           SECONDARY_SERVER: ${{ secrets.OC_SERVER }}
           SECONDARY_DASHBOARD: ${{ secrets.ODH_DASHBOARD_URL }}
         run: |
+          # Prevent stale/corrupt kubeconfig from blocking oc login
+          rm -f ~/.kube/config 2>/dev/null || true
+
           # Extract credentials from test-variables.yml
           TEST_VARS_FILE="/tmp/test-variables.yml"
           OC_USERNAME=$(grep -A 10 "^OCP_ADMIN_USER:" "$TEST_VARS_FILE" | grep "USERNAME:" | head -1 | sed 's/.*USERNAME: //' | tr -d ' ')
@@ -930,6 +933,9 @@ jobs:
             echo "Check that OC_SERVER_PRIMARY/OC_SERVER secrets are configured" >&2
             exit 1
           fi
+
+          # Prevent stale/corrupt kubeconfig from blocking oc login
+          rm -f "$HOME/.kube/config" 2>/dev/null || true
 
           echo "Logging in to OpenShift cluster ($CLUSTER_NAME)..."
           oc login -u "$OC_USERNAME" -p "$OC_PASSWORD" --server="$CLUSTER_URL" --insecure-skip-tls-verify > /dev/null 2>&1

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -118,6 +118,7 @@ jobs:
           SECONDARY_DASHBOARD: ${{ secrets.ODH_DASHBOARD_URL }}
         run: |
           # Prevent stale/corrupt kubeconfig from blocking oc login
+          echo "🧹 Removing stale kubeconfig to prevent corrupt config blocking login..."
           rm -f ~/.kube/config 2>/dev/null || true
 
           # Extract credentials from test-variables.yml
@@ -935,6 +936,7 @@ jobs:
           fi
 
           # Prevent stale/corrupt kubeconfig from blocking oc login
+          echo "🧹 Removing stale kubeconfig to prevent corrupt config blocking login..."
           rm -f "$HOME/.kube/config" 2>/dev/null || true
 
           echo "Logging in to OpenShift cluster ($CLUSTER_NAME)..."


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63206

## Description
  - The select-cluster and e2e-tests jobs fail when the self-hosted runner's ~/.kube/config is corrupted from a previous run (e.g., parallel writes, crashed processes). oc login tries to parse the existing config before writing new credentials, so a corrupt file blocks all subsequent workflow runs until someone SSHs in to fix it manually.
  - Added rm -f ~/.kube/config before each oc login call so it always starts fresh. oc login recreates the file with valid content, and downstream steps (oc whoami, Cypress tests, BFF services) continue to find their kubeconfig at $HOME/.kube/config as before.

## How Has This Been Tested?
Worked on: https://github.com/opendatahub-io/odh-dashboard/actions/runs/26114225412/job/76799148795 

<img width="638" height="115" alt="image" src="https://github.com/user-attachments/assets/e0d6c5b7-f61f-4414-bd1c-24a66c069399" />

<img width="780" height="158" alt="image" src="https://github.com/user-attachments/assets/c97f4473-4345-48d3-a85d-48510f96e3a1" />

<img width="238" height="216" alt="image" src="https://github.com/user-attachments/assets/ef21cadb-9147-4462-927f-303df1e19405" />





## Test Impact
CI e2e fixes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved testing reliability by adding cleanup steps to prevent stale configuration from interfering with cluster authentication during test initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->