### PR TITLE
fix: improve preflight agent — CI mode, turn limits, MLflow tracing

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: preflight
-description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review X,Y, --skip-review X,Y, --help."
-argument-hint: "[PR] [--fix] [--local] [--review X,Y] [--skip-review X,Y] [--help]"
+description: "Pre-merge readiness check for a PR or local branch. Gathers context, runs reviews and checks, reports a results table. Interactive by default — asks what to review and whether to fix. Supports flags: --fix, --local, --review X,Y, --skip-review X,Y, --ci, --help."
+argument-hint: "[PR] [--fix] [--local] [--review X,Y] [--skip-review X,Y] [--ci] [--help]"
 disable-model-invocation: true
-allowed-tools: Bash(gh *) Bash(git *) Bash(npm *) Bash(npx *) Bash(${CLAUDE_SKILL_DIR}/scripts/*)
 ---
 
 # Preflight
 
 Pre-merge readiness check. Gather context, review code, run checks, report results. Interactive by default — asks the user before making decisions. Never skip a check silently.
 
-Never push. Never comment on the PR.
+Never push (unless `--fix --ci` — push after committing fixes). Never comment on the PR (unless `--ci` flag is passed).
+
+**CI sandbox constraints (when running in GitHub Actions):**
+- **No `/tmp/` writes** — the sandbox only allows file writes within the workspace directory. Use the Write tool to create files in the workspace root (e.g., `preflight-comment.md`).
+- **No writes to `.claude/`** — this directory is treated as sensitive. Write temp files to the workspace root instead.
 
 ## --help
 
@@ -28,6 +31,8 @@ Flags:
   --review X,Y          Run specific reviewers without asking
                         Options: coderabbit, claude, style, rbac
   --skip-review X,Y     Run all reviewers EXCEPT these (no interactive prompt)
+  --ci                  Non-interactive CI mode: skip all prompts, post results
+                        as a PR comment when done
   --help                Show this help
 
 Examples:
@@ -52,8 +57,21 @@ Parse these from `$ARGUMENTS` before processing:
 - `--local` — ignore PR even if one exists, run everything locally
 - `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`)
 - `--skip-review X,Y` — run all reviewers EXCEPT the listed ones, without asking. Mutually exclusive with `--review`.
+- `--ci` — non-interactive CI mode. Skips all interactive prompts (no `AskUserQuestion`). Posts the results as a PR comment using the template in [references/ci-comment-template.md](references/ci-comment-template.md). Overrides "Never comment on the PR".
 - `--help` — print usage and stop
 - No flags — interactive mode: ask the user what to do at decision points
+
+## Execution
+
+**First, call TaskCreate for each applicable task before running any commands:**
+
+- Task 1: "Gather context" — PR metadata, sync status, changed files, Jira key
+- Task 2: "Run reviews" — fetch existing or run local reviewers
+- Task 3: "Run checks" — CI, lint, type-check, tests, PR body, Jira, coverage
+- Task 4: "Fix failing checks" — ONLY create this task if `--fix` was passed
+- Task 5: "Write results and post comment" — ONLY create this task if `--ci` was passed
+
+Then work through each task in order. Mark each task `in_progress` when starting and `completed` when done. You are not done until TaskList shows all tasks completed.
 
 ## Step 0: Prerequisites
 
@@ -147,13 +165,20 @@ Statuses:
 
 ⏭️ means CI ran this on the exact same commit. If a check can't run (OOM, missing tool), that's ❌ or ⚠️ — never ⏭️. If a check doesn't apply (no PR body because no PR), use ➖.
 
-Print a results table with every check, its status, and details. End with a verdict: any ❌ → **NOT READY**, all ✅ with ⚠️ → **READY WITH WARNINGS**, all ✅ → **READY**.
+Print the results using the format from [references/ci-comment-template.md](references/ci-comment-template.md). This format is used for both terminal output and PR comments. End with a verdict: any ❌ → **NOT READY**, all ✅ with ⚠️ → **READY WITH WARNINGS**, all ✅ → **READY**.
+
+If `--ci` was passed, post everything as a **single PR review** — inline comments on files + the full report as the review summary body. **You MUST follow the format in [references/ci-comment-template.md](references/ci-comment-template.md) exactly.** No standalone PR comments.
+
+If `--fix` was NOT passed, post the review now and skip Step 4.
+If `--fix` was passed, do NOT post yet — wait until after Step 4 so the review reflects the post-fix state.
 
 ## Step 4: Fix
 
+If `--ci` was passed without `--fix`, skip this step.
+
 If `--fix` was passed, proceed directly.
 
-If no `--fix` flag, use AskUserQuestion:
+If no `--fix` and no `--ci` flag, use AskUserQuestion:
 - "Fix failing checks"
 - "Done — just wanted the report"
 
@@ -163,6 +188,8 @@ If fixing:
 2. **Review fixes** — PR: invoke `coderabbit-autofix` (decline commit/push), then fix human threads. Local: fix issues from Step 2 review.
 3. **CI/lint/test fixes** — fix specific errors in files changed by this branch. Don't auto-format directories. Don't fix pre-existing issues.
 4. **Cleanup** — `/simplify` on changed files, lint those files. Skip if nothing changed.
-5. **Commit** — one commit, descriptive message, `Co-Authored-By` + `Signed-off-by`. Never push.
+5. **Commit** — one commit, descriptive message, `Co-Authored-By` + `Signed-off-by`.
+6. **Push** — only if `--ci` was also passed (`--fix --ci`). Push to the PR branch: `git push`. In interactive mode (no `--ci`), never push.
+7. **Recalculate** — re-run lint and type-check on changed files. Update the checks table with post-fix results. The review must reflect the current state, not the pre-fix state.
 
-After fixing, run lint and type-check on changed files to verify. Print updated table — ⏭️ checks keep original status (nothing pushed), local checks get updated.
+If `--ci` was passed, now post the PR review with the updated results (see template).

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -32,7 +32,7 @@ Flags:
                         Options: coderabbit, claude, style, rbac
   --skip-review X,Y     Run all reviewers EXCEPT these (no interactive prompt)
   --ci                  Non-interactive CI mode: skip all prompts, post results
-                        as a PR comment when done
+                        as a PR review when done
   --help                Show this help
 
 Examples:
@@ -57,7 +57,7 @@ Parse these from `$ARGUMENTS` before processing:
 - `--local` — ignore PR even if one exists, run everything locally
 - `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`)
 - `--skip-review X,Y` — run all reviewers EXCEPT the listed ones, without asking. Mutually exclusive with `--review`.
-- `--ci` — non-interactive CI mode. Skips all interactive prompts (no `AskUserQuestion`). Posts the results as a PR comment using the template in [references/ci-comment-template.md](references/ci-comment-template.md). Overrides "Never comment on the PR".
+- `--ci` — non-interactive CI mode. Skips all interactive prompts (no `AskUserQuestion`). Posts the results as a PR review using the template in [references/ci-comment-template.md](references/ci-comment-template.md).
 - `--help` — print usage and stop
 - No flags — interactive mode: ask the user what to do at decision points
 
@@ -169,8 +169,9 @@ Print the results using the format from [references/ci-comment-template.md](refe
 
 If `--ci` was passed, post everything as a **single PR review** — inline comments on files + the full report as the review summary body. **You MUST follow the format in [references/ci-comment-template.md](references/ci-comment-template.md) exactly.** No standalone PR comments.
 
-If `--fix` was NOT passed, post the review now and skip Step 4.
-If `--fix` was passed, do NOT post yet — wait until after Step 4 so the review reflects the post-fix state.
+- If `--ci` without `--fix`: post the review now and skip Step 4.
+- If `--ci` with `--fix`: do NOT post yet — wait until after Step 4 so the review reflects the post-fix state.
+- If no `--ci`: just print results to terminal, do not post a review.
 
 ## Step 4: Fix
 

--- a/.claude/skills/preflight/references/ci-comment-template.md
+++ b/.claude/skills/preflight/references/ci-comment-template.md
@@ -1,0 +1,163 @@
+# Preflight Report Template
+
+Used for terminal output and PR review in `--ci` mode. Everything is posted as a **single PR review** — inline comments on files + the report as the review summary body. No standalone PR comments.
+
+## What Goes Where
+
+| Severity | Inline comment on file | Review summary body |
+|----------|------------------------|---------------------|
+| 🔴 Critical | Yes | Counted in review row |
+| 🟠 Major | Yes | Counted in review row |
+| 🟡 Minor | Yes | Counted in review row |
+| 🧹 Nit | **No** | Yes (expandable section) |
+
+## Review Summary Body
+
+The review `body` field contains the full preflight report. Format:
+
+```markdown
+## Preflight Agent Report
+
+**Verdict:** <emoji> <READY | READY WITH WARNINGS | NOT READY>
+**Mode:** <check-only | managed>
+**Commit:** [`<short SHA>`](https://github.com/OWNER/REPO/commit/<full SHA>)
+
+<details>
+<summary>Checks</summary>
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Conflicts | ✅ | Mergeable, up to date |
+| CI | ⏭️ | 39 passed |
+| Lint | ⏭️ | Covered by CI |
+| Type Check | ⏭️ | Covered by CI |
+| Unit Tests | ⏭️ | Covered by CI |
+| Jira | ❌ | No Jira key found |
+| Test Coverage | ⚠️ | No test files added |
+| PR Body | ⚠️ | Minimal — missing template sections |
+| Review | 🟡 3 minor · 🧹 2 nits | See inline comments + nits below |
+
+</details>
+
+<details>
+<summary>🧹 Nitpick comments (2)</summary>
+
+<details>
+<summary>frontend/src/app/navigation/NavItem.tsx (1)</summary>
+
+`27`: _🧹 Nit_ · _Style review_
+
+**Prefer `const` over `let` for variables that are never reassigned.**
+
+</details>
+
+<details>
+<summary>frontend/src/app/navigation/FlatNavSection.tsx (1)</summary>
+
+`55`: _🧹 Nit_ · _Claude review_
+
+**Unnecessary else after early return.**
+
+</details>
+
+</details>
+
+<details>
+<summary>Fixes applied (3 files changed)</summary>
+
+- `FlatNavSection.tsx` — replaced hardcoded colors with PF tokens, fixed `==` to `===`
+- `NavSidebar.tsx` — replaced `<div onClick>` with PF `<Button variant="link">`
+- `useNavLayout.ts` — replaced module-level mutable state with React Context
+
+</details>
+
+---
+*Automated by ODH Dashboard Agent*
+```
+
+**Rules:**
+- Only include check rows that were evaluated
+- Status emojis: ✅ passed · ❌ failed · ⚠️ warning · ⏭️ covered by CI · ➖ n/a
+- **Commit** must be a clickable link
+- **Checks** go in a collapsible `<details>` section
+- **Nits** go in a collapsible `<details>` section, grouped by file with nested `<details>`
+- **Fixes** (if `--fix` mode) go in a collapsible `<details>` section listing what changed
+- Only include sections that have content (no empty collapsibles)
+- **Footer** is just `*Automated by ODH Dashboard Agent*` — no link
+
+## Inline Review Comments (Critical, Major, Minor only — NOT Nits)
+
+Format for each inline comment:
+
+```markdown
+_<severity badge>_ · _<reviewer source>_
+
+**<Short title.>**
+
+<Description. Use `code` formatting for identifiers.>
+```
+
+If the review produced a concrete suggested fix, include it:
+
+```markdown
+<details>
+<summary>Suggested fix</summary>
+
+```diff
+- <old code>
++ <new code>
+```
+
+</details>
+```
+
+**Severity badges:**
+
+| Badge | When |
+|-------|------|
+| `🔴 Critical` | Security, data loss, crash |
+| `🟠 Major` | Bug, incorrect behavior, missing guard |
+| `🟡 Minor` | Code quality, naming, style |
+
+**Reviewer source** — tag which reviewer(s) flagged the issue:
+
+| Source | When |
+|--------|------|
+| `Claude review` | Found by `/review` |
+| `Style review` | Found by `/style-review` |
+| `RBAC review` | Found by `/rbac-review` |
+| `CodeRabbit` | Found by CodeRabbit (PR or CLI) |
+| `Claude review, Style review` | Found by multiple reviewers |
+
+**Rules for inline comments:**
+- Only include `Suggested fix` when the review actually produced a concrete code change — do NOT fabricate diffs
+- Do NOT post inline comments for Nits — those go in the review summary only
+- Only post for findings with specific file + line
+- Always include the reviewer source tag
+
+## Submitting the Review
+
+Post as a **single PR review** with inline comments AND the summary body:
+
+1. Use the **Write tool** to create `preflight-review.json` in the workspace root.
+2. Post with: `gh api repos/OWNER/REPO/pulls/PR/reviews --input preflight-review.json`
+
+The `body` field is the full report. The `comments` array has the inline findings.
+
+```json
+{
+  "event": "COMMENT",
+  "body": "## Preflight Agent Report\n\n**Verdict:** ...\n\n<details>...",
+  "comments": [
+    {
+      "path": "src/components/Foo.tsx",
+      "line": 42,
+      "body": "_🟠 Major_ · _Style review_\n\n**Use PF token instead of hardcoded color.**\n\n..."
+    }
+  ]
+}
+```
+
+## Recalculating After Fixes
+
+When `--fix` is passed, the checks table in the review summary must reflect the state **after** fixes are applied. Re-run lint and type-check on changed files after fixing and use those results in the table. Do NOT post the pre-fix results table.

--- a/.claude/skills/preflight/references/fix.md
+++ b/.claude/skills/preflight/references/fix.md
@@ -1,0 +1,20 @@
+# Step 4: Fix
+
+Only runs when `--fix` is passed. If `--ci` without `--fix`, skip entirely.
+
+If no `--fix` and no `--ci`, ask the user:
+- "Fix failing checks"
+- "Done — just wanted the report"
+
+## Fix procedure
+
+1. **Rebase** if conflicts found. Don't push.
+2. **Review fixes** — PR: invoke `coderabbit-autofix` (decline commit/push), then fix human threads. Local: fix issues from Step 2 review.
+3. **CI/lint/test fixes** — fix specific errors in files changed by this branch. Don't auto-format directories. Don't fix pre-existing issues.
+4. **Cleanup** — `/simplify` on changed files, lint those files. Skip if nothing changed.
+5. **Commit** — one commit, descriptive message, `Co-Authored-By` + `Signed-off-by`.
+6. **Push** — only if `--ci` was also passed (`--fix --ci`). Push to the PR branch: `git push`. In interactive mode (no `--ci`), never push.
+
+7. **Recalculate** — re-run lint and type-check on changed files. Update the checks table with post-fix results. The review must reflect the current state, not the pre-fix state.
+
+If `--ci` was passed, now post the PR review with the updated results.

--- a/.claude/skills/preflight/references/gather-context.md
+++ b/.claude/skills/preflight/references/gather-context.md
@@ -1,0 +1,37 @@
+# Step 1: Gather Context
+
+Try to find a PR (unless `--local`):
+- If a number/URL was given, use it
+- Otherwise: `gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number'`
+- If found, fetch metadata: `gh pr view "$pr_number" --json title,headRefName,baseRefName,mergeable,mergeStateStatus,number,body,author,reviewDecision`
+
+Get repo info:
+```bash
+owner=$(gh repo view --json owner --jq '.owner.login')
+repo=$(gh repo view --json name --jq '.name')
+```
+
+**Check if local matches PR** (determines whether CI results are trustworthy):
+```bash
+pr_sha=$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid')
+local_sha=$(git rev-parse HEAD)
+has_changes=$(git status --porcelain)
+```
+
+If `pr_sha == local_sha` AND no uncommitted changes: **local is synced with PR**. CI results apply.
+Otherwise: CI results don't apply — need to run checks locally.
+
+Figure out base branch and affected packages:
+```bash
+# If PR exists, use gh (avoids merge-base issues in CI checkout):
+gh pr diff "$pr_number" --name-only | cut -d'/' -f1-2 | sort -u
+# If no PR, fall back to git:
+git diff --name-only origin/${base_branch:-main} | cut -d'/' -f1-2 | sort -u
+```
+
+Extract Jira key from PR title/body, branch name, or recent commits:
+```bash
+grep -oE '[A-Z][A-Z0-9]+-[0-9]+' <<< "$pr_title $pr_body" | head -1 || git branch --show-current | grep -oE '[A-Z][A-Z0-9]+-[0-9]+' | head -1
+```
+
+**Efficiency:** Combine these into as few Bash calls as possible.

--- a/.claude/skills/preflight/references/reviews.md
+++ b/.claude/skills/preflight/references/reviews.md
@@ -1,0 +1,24 @@
+# Step 2: Reviews
+
+## PR exists and synced
+Fetch existing reviews:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/fetch-review-threads.sh "$owner" "$repo" "$pr_number"
+```
+Report: CodeRabbit threads with severity, human threads, review decision.
+
+## No PR, not synced, or --local
+No reviews exist on this code. Determine which reviewers to run:
+
+- If `--review X,Y` was passed → run those directly
+- If `--skip-review X,Y` was passed → run all EXCEPT those (no prompt)
+- If `--ci` was passed → run all available reviewers without asking
+- Otherwise → use AskUserQuestion with multiSelect
+
+Available reviewers:
+- **CodeRabbit CLI** — `coderabbit review --agent` (requires CLI installed)
+- **Claude review** — invoke `/review` built-in skill
+- **Style review** — invoke `/style-review`
+- **RBAC review** — invoke `/rbac-review`
+
+If a reviewer fails, report the failure — don't silently fall back.

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -233,15 +233,33 @@ jobs:
       - name: Install MLflow
         run: pip install "mlflow[genai]>=3.5"
 
+      - name: Verify MLflow connection
+        continue-on-error: true
+        run: |
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer $MLFLOW_TRACKING_TOKEN" \
+            -H "Content-Type: application/json" \
+            -H "X-Mlflow-Workspace: $MLFLOW_WORKSPACE" \
+            -d '{"max_results": 1}' \
+            "$MLFLOW_TRACKING_URI/api/2.0/mlflow/experiments/search")
+          echo "MLflow API: HTTP $CODE"
+          if [ "$CODE" != "200" ]; then
+            echo "::warning::MLflow returned $CODE — tracing may not work"
+          fi
+
       - name: Configure MLflow tracing
         run: |
-          mkdir -p .claude
-          printf '.claude/settings.local.json\n' >> .git/info/exclude
-          cat > .claude/settings.local.json << 'SETTINGS'
+          mkdir -p ~/.claude
+          cat > ~/.claude/settings.local.json << 'SETTINGS'
           {
             "env": { "MLFLOW_CLAUDE_TRACING_ENABLED": "true" },
             "hooks": {
               "Stop": [{
+                "matcher": "",
+                "hooks": [{ "type": "command", "command": "which mlflow >/dev/null 2>&1 && mlflow autolog claude stop-hook || true" }]
+              }],
+              "StopFailure": [{
                 "matcher": "",
                 "hooks": [{ "type": "command", "command": "which mlflow >/dev/null 2>&1 && mlflow autolog claude stop-hook || true" }]
               }]
@@ -256,16 +274,16 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
-          claude_args: "--max-turns 30 --model claude-opus-4-6 --disallowedTools Edit,Write,NotebookEdit"
-          prompt: >-
-            Run /preflight ${{ env.PR_NUMBER }} --skip-review coderabbit to check
-            this PR. You are in agent-check-only mode — do NOT modify files,
-            commit, or push. Run preflight once, then post a summary PR comment
-            via gh pr comment ${{ env.PR_NUMBER }}. The comment must have a
-            Preflight Agent Report header, verdict with mode, the results table
-            with status emojis, an expandable Tracing section, and a footer
-            linking to
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          claude_args: >-
+            --max-turns 120
+            --model "claude-sonnet-4-6[1m]"
+            --permission-mode acceptEdits
+            --allowedTools "Bash(gh *)"
+            --allowedTools "Bash(git *)"
+            --allowedTools "Bash(npm *)"
+            --allowedTools "Bash(npx *)"
+            --allowedTools "Bash(bash *)"
+          prompt: "/preflight ${{ env.PR_NUMBER }} --skip-review coderabbit --ci"
 
       # ── Fix (iterative) ──
       - name: Preflight fix
@@ -274,19 +292,16 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
-          claude_args: "--max-turns 80 --model claude-opus-4-6"
-          prompt: >-
-            /goal Run /preflight ${{ env.PR_NUMBER }} --fix --skip-review coderabbit
-            to check and fix this PR. You are in agent-managed mode — edit files,
-            commit, and push as needed. If /preflight reports NOT READY, fix the
-            issues and re-run. Track each iteration's results. Stop after 5 runs
-            or 2 consecutive with no improvement. The goal is met when /preflight
-            reports READY or READY WITH WARNINGS AND you have posted a summary PR
-            comment via gh pr comment ${{ env.PR_NUMBER }}. The comment must have
-            a Preflight Agent Report header, verdict with iteration count and mode,
-            the results table with status emojis, an expandable Iteration History
-            section, an expandable Tracing section, and a footer linking to
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          claude_args: >-
+            --max-turns 200
+            --model "claude-sonnet-4-6[1m]"
+            --permission-mode acceptEdits
+            --allowedTools "Bash(gh *)"
+            --allowedTools "Bash(git *)"
+            --allowedTools "Bash(npm *)"
+            --allowedTools "Bash(npx *)"
+            --allowedTools "Bash(bash *)"
+          prompt: "/preflight ${{ env.PR_NUMBER }} --fix --skip-review coderabbit --ci"
 
       # ── Report ──
       - name: Update check run (success)
@@ -300,7 +315,7 @@ jobs:
             -X PATCH \
             -f "status=completed" -f "conclusion=success" \
             -f "output[title]=Preflight passed ($MODE)" \
-            -f "output[summary]=See PR comment for full report."
+            -f "output[summary]=See PR review for full report."
 
       - name: Update check run (failure)
         if: failure() && steps.check-run.outputs.id


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62022

## Description

Improvements to the ODH Dashboard Agent workflow based on real-world testing.

**Workflow changes:**
- Bump max-turns: 30→120 (check-only), 80→200 (managed)
- Switch from Opus to Sonnet (cost reduction)
- Remove `/goal` wrapper — direct `/preflight --ci` invocation
- Add `StopFailure` hook for MLflow tracing on error exit
- Add MLflow verify step with `continue-on-error` (cluster may be offline)
- Add explicit MLflow flush step (`if: always()`)

**Preflight skill changes:**
- Add `--ci` flag: non-interactive, skips all prompts, posts PR comment
- Add comment template (`references/ci-comment-template.md`) for consistent output
- Add efficiency instruction: batch bash commands to reduce turn count
- Instruct use of `--body-file` for comment posting (avoids shell quoting retries)

## How Has This Been Tested?

Tested on a fork with mirrored PRs. Verified skill invocation, turn count (34 turns on 3-file PR), MLflow env passthrough, and comment posting.

## Test Impact

No automated tests — CI workflow and skill definition changes.

## Request review criteria:

- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-interactive `--ci` preflight mode: posts a single CI-formatted PR review (inline comments for Critical/Major/Minor; Nits in the review body). `--fix` creates fix tasks; pushes occur only with `--fix --ci`. Reviews are reposted after fixes.

* **Documentation**
  * Added CI report template, reviewer-selection and step/task conditional behavior, detailed fix workflow guidance, and CI sandbox constraints for temp file locations.

* **Chores**
  * CI workflow: added external verification step and adjusted tracing/run configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->