### PR TITLE
Fix: run group dropdown footer overlap and align the menu footer

### DIFF
--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -74,4 +74,8 @@ body,
   &.pf-m-drilldown:not(.pf-m-scrollable) {
     overflow: hidden;
   }
+  // Make tables inside menus transparent for consistent background
+  .pf-v6-c-table {
+    --pf-v6-c-table--BackgroundColor: transparent;
+  }
 }

--- a/frontend/src/app/App.scss
+++ b/frontend/src/app/App.scss
@@ -74,7 +74,11 @@ body,
   &.pf-m-drilldown:not(.pf-m-scrollable) {
     overflow: hidden;
   }
-  // Make tables inside menus transparent for consistent background
+}
+
+// Tables inside SearchSelector menus (e.g. run group selector) have their own background
+// which clashes with the menu in dark mode.
+.odh-search-selector__menu {
   .pf-v6-c-table {
     --pf-v6-c-table--BackgroundColor: transparent;
   }

--- a/frontend/src/components/searchSelector/SearchSelector.tsx
+++ b/frontend/src/components/searchSelector/SearchSelector.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   MenuContainer,
   MenuContent,
+  MenuFooter,
   MenuList,
   MenuSearch,
   MenuSearchInput,
@@ -28,6 +29,8 @@ type SearchSelectorProps = {
    * Resulting children (React.ReactNode) can be anything that can be rendered inside <MenuList />.
    */
   children: ((opts: ManualSearchSelectorOpts) => React.ReactNode) | React.ReactNode;
+  /** Content rendered after MenuContent (outside the scroll area), e.g. a sticky footer button. */
+  footer?: ((opts: ManualSearchSelectorOpts) => React.ReactNode) | React.ReactNode;
   isLoading?: boolean;
   isDisabled?: boolean;
   isFullWidth?: boolean;
@@ -48,6 +51,7 @@ type SearchSelectorProps = {
 
 const SearchSelector: React.FC<SearchSelectorProps> = ({
   children,
+  footer,
   dataTestId,
   isLoading,
   isDisabled,
@@ -154,6 +158,13 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
                 : children}
             </MenuList>
           </MenuContent>
+          {footer != null && (
+            <MenuFooter>
+              {typeof footer === 'function'
+                ? footer({ menuClose: () => setIsOpen(false) })
+                : footer}
+            </MenuFooter>
+          )}
         </Menu>
       }
     />

--- a/frontend/src/components/searchSelector/SearchSelector.tsx
+++ b/frontend/src/components/searchSelector/SearchSelector.tsx
@@ -120,6 +120,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
       }
       menu={
         <Menu
+          className="odh-search-selector__menu"
           data-testid={`${dataTestId}-menu`}
           ref={menuRef}
           isScrollable

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EmptyStateVariant, Button, Divider } from '@patternfly/react-core';
+import { EmptyStateVariant, Button } from '@patternfly/react-core';
 import { TableVariant } from '@patternfly/react-table';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import PipelineSelectorTableRow from '#~/concepts/pipelines/content/pipelineSelector/PipelineSelectorTableRow';
@@ -54,62 +54,9 @@ const InnerExperimentSelector: React.FC<
         }
         searchHelpText={`Type a name to search your ${totalSize} run groups.`}
         isDisabled={totalSize === 0}
-      >
-        {({ menuClose }) => (
-          <>
-            <div className="pf-v6-c-menu__content">
-              <TableBase
-                itemCount={fetchedSize}
-                loading={!loaded}
-                emptyTableView={
-                  <DashboardEmptyTableView
-                    hasIcon={false}
-                    onClearFilters={onSearchClear}
-                    variant={EmptyStateVariant.xs}
-                  />
-                }
-                data-testid={`${dataTestId}-table-list`}
-                borders={false}
-                variant={TableVariant.compact}
-                columns={experimentSelectorColumns}
-                data={experiments}
-                rowRenderer={(row) => (
-                  <PipelineSelectorTableRow
-                    key={row.experiment_id}
-                    obj={row}
-                    onClick={() => {
-                      onSelect(row);
-                      menuClose();
-                    }}
-                  />
-                )}
-                getColumnSort={getTableColumnSort({
-                  columns: experimentSelectorColumns,
-                  ...sortProps,
-                })}
-                footerRow={() =>
-                  loaded ? (
-                    <PipelineViewMoreFooterRow
-                      visibleLength={experiments.length}
-                      totalSize={fetchedSize}
-                      errorTitle="Error loading more run groups"
-                      onClick={onLoadMore}
-                      colSpan={2}
-                    />
-                  ) : null
-                }
-              />
-            </div>
-            {loaded && (
-              <div
-                className="pf-v6-c-menu__footer pf-v6-u-box-shadow-sm-top"
-                style={{
-                  position: 'sticky',
-                  bottom: 0,
-                  backgroundColor: 'var(--pf-v6-c-menu--BackgroundColor)',
-                }}
-              >
-                <Divider />
+        footer={
+          initialLoaded
+            ? ({ menuClose }) => (
                 <Button
                   variant="link"
                   icon={<PlusCircleIcon />}
@@ -117,13 +64,55 @@ const InnerExperimentSelector: React.FC<
                     menuClose();
                     setIsModalOpen(true);
                   }}
-                  style={{ paddingLeft: '20px' }}
                 >
                   Create new run group
                 </Button>
-              </div>
+              )
+            : undefined
+        }
+      >
+        {({ menuClose }) => (
+          <TableBase
+            itemCount={fetchedSize}
+            loading={!loaded}
+            emptyTableView={
+              <DashboardEmptyTableView
+                hasIcon={false}
+                onClearFilters={onSearchClear}
+                variant={EmptyStateVariant.xs}
+              />
+            }
+            data-testid={`${dataTestId}-table-list`}
+            borders={false}
+            variant={TableVariant.compact}
+            columns={experimentSelectorColumns}
+            data={experiments}
+            rowRenderer={(row) => (
+              <PipelineSelectorTableRow
+                key={row.experiment_id}
+                obj={row}
+                onClick={() => {
+                  onSelect(row);
+                  menuClose();
+                }}
+              />
             )}
-          </>
+            getColumnSort={getTableColumnSort({
+              columns: experimentSelectorColumns,
+              ...sortProps,
+            })}
+            footerRow={() =>
+              loaded ? (
+                <PipelineViewMoreFooterRow
+                  visibleLength={experiments.length}
+                  totalSize={fetchedSize}
+                  errorTitle="Error loading more run groups"
+                  onClick={onLoadMore}
+                  colSpan={2}
+                />
+              ) : null
+            }
+          />
         )}
       </SearchSelector>
       {isModalOpen && (

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -55,7 +55,7 @@ const InnerExperimentSelector: React.FC<
         searchHelpText={`Type a name to search your ${totalSize} run groups.`}
         isDisabled={totalSize === 0}
         footer={
-          initialLoaded
+          initialLoaded && loaded
             ? ({ menuClose }) => (
                 <Button
                   variant="link"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
For https://issues.redhat.com/browse/RHOAIENG-58475

In the **Run group** selector (Create run form), the **Create new run group** action at the bottom of the dropdown overlapped the empty/filtered table content

Current:
<img width="497" height="361" alt="image" src="https://github.com/user-attachments/assets/ceef10cd-df4a-487b-8707-1bf4a5d1ee68" />

Before: 
<img width="443" height="326" alt="image" src="https://github.com/user-attachments/assets/f0747c37-2aa9-4b3b-b445-701ede370b4a" />


This change:

- Adds an optional `footer` prop to `SearchSelector`, rendered with PatternFly `MenuFooter` **outside** `MenuContent` (scrollable area), matching the [scrollable menu with search and footer](https://www.patternfly.org/components/menus/menu/html/#scrollable-menu-with-search-and-footer) pattern.
- Moves the run group **Create new run group** button into that footer via `ExperimentSelector`.
- Removes the footer `Divider` and custom `pf-v6-c-menu__footer` / sticky styling (PF footer uses box-shadow, not a divider).
- Removes the extra `pf-v6-c-menu__content` wrapper so the table matches other selectors (e.g. pipeline selector).
- Uses `initialLoaded` (not `loaded`) to keep the footer visible while search results reload, so the footer looks the same before and after typing in the search box.


## How Has This Been Tested?

Manually Tested 

- Open **Create run** (or any form with **Run group** selector).
- Open the run group dropdown with no search text — confirm **Create new run group** sits below the list/empty state without overlap.
- Type a search that returns no results — confirm empty state and footer do not overlap; footer styling matches the initial state.
- Type a search that returns results — confirm footer remains visible and clickable while results load.
- Click **Create new run group** — modal opens and dropdown closes.

## Test Impact

Manual UI verification only. No new unit or Cypress tests; behavior is layout/structure in existing components. Existing selector tests should be unaffected.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selector supports an optional footer rendered after the menu content; accepts static content or a callback (callback receives a menuClose helper).

* **Refactor**
  * “Create new run group” action moved into the selector footer; menu content simplified while preserving selection and load-more behavior.

* **Style**
  * Tables inside selector menus use a transparent background for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->