### PR TITLE
[RHOAIENG-58474] Run group selector becomes permanently disabled after searching for non-existent name

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
@@ -144,7 +144,7 @@ const InnerCustomPipelineRunToolbarSelect = <T extends PipelineVersionKF | Exper
           style={{ minWidth: '300px', maxWidth: '500px' }}
           onClick={() => setOpen(!isOpen)}
           isExpanded={isOpen}
-          isDisabled={!filteredResources.length}
+          isDisabled={!resources.length}
           isFullWidth
           data-testid={toggleTestId}
         >
@@ -153,7 +153,12 @@ const InnerCustomPipelineRunToolbarSelect = <T extends PipelineVersionKF | Exper
       }
       menu={menu}
       menuRef={menuRef}
-      onOpenChange={(open) => setOpen(open)}
+      onOpenChange={(open) => {
+        setOpen(open);
+        if (!open) {
+          setSearch('');
+        }
+      }}
     />
   );
 };

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect.tsx
@@ -156,6 +156,7 @@ const InnerCustomPipelineRunToolbarSelect = <T extends PipelineVersionKF | Exper
       onOpenChange={(open) => {
         setOpen(open);
         if (!open) {
+          doSetSearchDebounced.cancel();
           setSearch('');
         }
       }}

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/__tests__/CustomPipelineRunToolbarSelect.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/__tests__/CustomPipelineRunToolbarSelect.spec.tsx
@@ -67,7 +67,7 @@ describe('ExperimentFilterSelector', () => {
 
     // Advance timers to flush the debounced search
     act(() => {
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(250);
     });
 
     // The toggle should still be enabled even though no results match
@@ -96,7 +96,7 @@ describe('ExperimentFilterSelector', () => {
 
     // Advance timers to flush debounce
     act(() => {
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(250);
     });
 
     // Close by clicking toggle again

--- a/frontend/src/concepts/pipelines/content/pipelineSelector/__tests__/CustomPipelineRunToolbarSelect.spec.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelineSelector/__tests__/CustomPipelineRunToolbarSelect.spec.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ExperimentKF } from '#~/concepts/pipelines/kfTypes';
+import { buildMockExperimentKF } from '#~/__mocks__/mockExperimentKF';
+import { ExperimentFilterSelector } from '#~/concepts/pipelines/content/pipelineSelector/CustomPipelineRunToolbarSelect';
+
+jest.useFakeTimers();
+
+/* eslint-disable camelcase */
+const mockExperiments: ExperimentKF[] = [
+  buildMockExperimentKF({ experiment_id: '1', display_name: 'Experiment A' }),
+  buildMockExperimentKF({ experiment_id: '2', display_name: 'Experiment B' }),
+  buildMockExperimentKF({ experiment_id: '3', display_name: 'Experiment C' }),
+];
+/* eslint-enable camelcase */
+
+describe('ExperimentFilterSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should render the toggle enabled when resources exist', () => {
+    render(
+      <ExperimentFilterSelector
+        resources={mockExperiments}
+        selection={undefined}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    const toggle = screen.getByTestId('run-group-toggle-button');
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('should render the toggle disabled when no resources exist', () => {
+    render(<ExperimentFilterSelector resources={[]} selection={undefined} onSelect={jest.fn()} />);
+
+    const toggle = screen.getByTestId('run-group-toggle-button');
+    expect(toggle).toBeDisabled();
+  });
+
+  it('should keep toggle enabled after searching for a non-existent name', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ExperimentFilterSelector
+        resources={mockExperiments}
+        selection={undefined}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    const toggle = screen.getByTestId('run-group-toggle-button');
+
+    // Open the dropdown
+    await user.click(toggle);
+
+    // Type a search that matches nothing
+    const searchInput = screen.getByLabelText('Filter pipeline run groups');
+    await user.type(searchInput, 'nonexistent');
+
+    // Advance timers to flush the debounced search
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // The toggle should still be enabled even though no results match
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('should clear search when dropdown closes', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ExperimentFilterSelector
+        resources={mockExperiments}
+        selection={undefined}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    const toggle = screen.getByTestId('run-group-toggle-button');
+
+    // Open the dropdown
+    await user.click(toggle);
+
+    // Type a search
+    const searchInput = screen.getByLabelText('Filter pipeline run groups');
+    await user.type(searchInput, 'nonexistent');
+
+    // Advance timers to flush debounce
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Close by clicking toggle again
+    await user.click(toggle);
+
+    // Reopen
+    await user.click(toggle);
+
+    // Search should be cleared - the helper text should reflect all resources
+    expect(
+      screen.getByText(`Type a name to search your ${mockExperiments.length} run groups.`),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-58474

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
**Root cause:** The `MenuToggle` used `isDisabled={!filteredResources.length}`, which evaluated the *filtered* (search-matched) list. When a search matched nothing, `filteredResources` became empty, disabling the toggle. Since the search state was not cleared on close, the toggle stayed disabled permanently with no way for the user to reopen it.

**Fix (two changes in `CustomPipelineRunToolbarSelect.tsx`):**
1. Changed `isDisabled` to use `resources.length` (the full unfiltered list) — the toggle is now only disabled when there are genuinely no resources available, matching the pattern used in `SearchSelector`/`ActiveExperimentSelector`.
2. Updated `onOpenChange` to reset the search state when the dropdown closes, so the filter is fresh on next open.
Both `ExperimentFilterSelector` and `PipelineVersionFilterSelector` share the same inner component, so both are fixed.

https://github.com/user-attachments/assets/34e8d192-c459-4bf1-b4e9-1b58618c827a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified lint (`eslint`) and type-check (`tsc --noEmit`) pass with zero errors
- Ran all 63 pipeline-related test suites (452 tests) with no regressions
- Added a dedicated unit test that reproduces the exact bug scenario: type a non-matching search → flush debounce → assert toggle remains enabled

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Added new unit test file: `frontend/src/concepts/pipelines/content/pipelineSelector/__tests__/CustomPipelineRunToolbarSelect.spec.tsx`
Tests cover:
- Toggle is enabled when resources exist
- Toggle is disabled when no resources exist (correct behavior preserved)
- Toggle stays enabled after searching for a non-existent name (regression test for this bug)
- Search is cleared when the dropdown closes (verifies the reset-on-close behavior)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu toggle now reflects actual available resources (not filtered results).
  * Search input is cleared whenever the menu is closed, preventing stale queries when reopened.

* **Tests**
  * Added tests covering toggle enable/disable states, debounced search behavior, and clearing search state on menu reopen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->