### PR TITLE
Model serving statuses prototype - do not merge

### DIFF
--- a/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
+++ b/frontend/src/concepts/modelServing/ModelStatusIcon.tsx
@@ -99,6 +99,34 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
     }
   }, [state, defaultHeaderContent, stoppedStates]);
 
+  const labelElement = hideLabel ? (
+    <Icon
+      style={{ cursor: 'pointer' }}
+      status={statusSettings.status}
+      aria-label={statusSettings.label}
+      color={statusSettings.color}
+      onClick={onClick}
+    >
+      {statusSettings.icon}
+    </Icon>
+  ) : (
+    <Label
+      isCompact={isCompact}
+      color={statusSettings.color}
+      status={statusSettings.status}
+      icon={statusSettings.icon}
+      data-testid="model-status-text"
+      style={{ width: 'fit-content', cursor: 'pointer' }}
+      onClick={onClick}
+    >
+      {statusSettings.label}
+    </Label>
+  );
+
+  if (onClick) {
+    return labelElement;
+  }
+
   return (
     <Popover
       data-testid="model-status-tooltip"
@@ -108,29 +136,7 @@ export const ModelStatusIcon: React.FC<ModelStatusIconProps> = ({
       bodyContent={statusSettings.message || bodyContent}
       isVisible={bodyContent ? undefined : false}
     >
-      {hideLabel ? (
-        <Icon
-          style={{ cursor: 'pointer' }}
-          status={statusSettings.status}
-          aria-label={statusSettings.label}
-          color={statusSettings.color}
-          onClick={onClick}
-        >
-          {statusSettings.icon}
-        </Icon>
-      ) : (
-        <Label
-          isCompact={isCompact}
-          color={statusSettings.color}
-          status={statusSettings.status}
-          icon={statusSettings.icon}
-          data-testid="model-status-text"
-          style={{ width: 'fit-content', cursor: 'pointer' }}
-          onClick={onClick}
-        >
-          {statusSettings.label}
-        </Label>
-      )}
+      {labelElement}
     </Popover>
   );
 };

--- a/packages/kserve/extensions.ts
+++ b/packages/kserve/extensions.ts
@@ -13,6 +13,7 @@ import type {
   ModelServingPlatformFetchDeploymentStatus,
   ModelServingDeploymentFormDataExtension,
   ModelServingDeploy,
+  ModelServingDeploymentProgressStepsExtension,
   WizardField2Extension,
   WizardFieldApplyExtension,
   WizardFieldExtractorExtension,
@@ -78,6 +79,7 @@ const extensions: (
   | WizardField2Extension<WizardField<TimeoutFieldValue, undefined>, KServeDeployment>
   | WizardFieldApplyExtension<TimeoutFieldValue, KServeDeployment>
   | WizardFieldExtractorExtension<TimeoutFieldValue, KServeDeployment>
+  | ModelServingDeploymentProgressStepsExtension<KServeDeployment>
 )[] = [
   {
     type: 'app.area',
@@ -257,6 +259,17 @@ const extensions: (
       required: [SupportedArea.K_SERVE],
     },
   },
+  {
+    type: 'model-serving.deployment/progress-steps',
+    properties: {
+      platform: KSERVE_ID,
+      useProgressSteps: () =>
+        import('./src/deploymentProgressSteps').then((m) => m.useKServeProgressSteps),
+    },
+    flags: {
+      required: [SupportedArea.K_SERVE],
+    },
+  } satisfies ModelServingDeploymentProgressStepsExtension<KServeDeployment>,
 ];
 
 export default extensions;

--- a/packages/kserve/src/deploymentProgressSteps.ts
+++ b/packages/kserve/src/deploymentProgressSteps.ts
@@ -1,5 +1,8 @@
 import React from 'react';
-import type { InferenceServiceKind, EventKind } from '@odh-dashboard/internal/k8sTypes';
+import type { InferenceServiceKind, EventKind, PodKind } from '@odh-dashboard/internal/k8sTypes';
+import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import type {
   DeploymentProgressStep,
   DeploymentProgressStepStatus,
@@ -68,11 +71,41 @@ const stepStatus = (ready: boolean, error: boolean): DeploymentProgressStepStatu
   return 'pending';
 };
 
+const isPodReady = (pod: PodKind): boolean => {
+  const containerStatuses = pod.status?.containerStatuses ?? [];
+  return (
+    pod.status?.phase === 'Running' &&
+    containerStatuses.length > 0 &&
+    containerStatuses.every((cs) => cs.ready)
+  );
+};
+
 export const useKServeProgressSteps = (deployment: KServeDeployment): DeploymentProgressStep[] => {
   const { model: isvc } = deployment;
   const { namespace, name } = isvc.metadata;
 
   const [allEvents] = useWatchDeploymentEvents(namespace);
+
+  const [allPods] = useK8sWatchResourceList<PodKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(PodModel),
+      namespace,
+    },
+    PodModel,
+  );
+
+  const deploymentPods = React.useMemo(
+    () => allPods.filter((pod) => pod.metadata.name.startsWith(`${name}-predictor-`)),
+    [allPods, name],
+  );
+
+  const readyPodCount = React.useMemo(
+    () => deploymentPods.filter(isPodReady).length,
+    [deploymentPods],
+  );
+  const totalPodCount = deploymentPods.length;
+  const desiredReplicas = isvc.spec.predictor.minReplicas ?? 1;
 
   const podEvents = React.useMemo(
     () => filterDeploymentEvents(allEvents, name, new Set(['pod'])),
@@ -165,6 +198,19 @@ export const useKServeProgressSteps = (deployment: KServeDeployment): Deployment
     const allModelResourcesReady = modelResourcesChildren.every((s) => s.status === 'success');
     const anyModelResourceFailed = modelResourcesChildren.some((s) => s.status === 'danger');
 
+    const allReplicasReady = readyPodCount >= desiredReplicas && desiredReplicas > 0;
+    const modelResourcesReady =
+      allModelResourcesReady && (desiredReplicas <= 1 || allReplicasReady);
+    const replicaDescription = (() => {
+      if (predictorCondition?.reason === 'ProgressDeadlineExceeded') {
+        return predictorCondition.message;
+      }
+      if (desiredReplicas > 1 && totalPodCount > 0) {
+        return `${readyPodCount}/${desiredReplicas} pods ready`;
+      }
+      return undefined;
+    })();
+
     return [
       {
         id: 'deployment-requested',
@@ -175,10 +221,10 @@ export const useKServeProgressSteps = (deployment: KServeDeployment): Deployment
         id: 'model-resources',
         title: 'Model resources',
         status: stepStatus(
-          allModelResourcesReady,
+          modelResourcesReady,
           anyModelResourceFailed || Boolean(isProgressDeadlineExceeded),
         ),
-        description: isProgressDeadlineExceeded ? predictorCondition.message : undefined,
+        description: replicaDescription,
         children: modelResourcesChildren,
       },
       {
@@ -199,5 +245,5 @@ export const useKServeProgressSteps = (deployment: KServeDeployment): Deployment
         description: readyCondition?.status === 'False' ? readyCondition.message : undefined,
       },
     ];
-  }, [isvc, sortedPodEvents]);
+  }, [isvc, sortedPodEvents, readyPodCount, totalPodCount, desiredReplicas]);
 };

--- a/packages/kserve/src/deploymentProgressSteps.ts
+++ b/packages/kserve/src/deploymentProgressSteps.ts
@@ -1,0 +1,203 @@
+import React from 'react';
+import type { InferenceServiceKind, EventKind } from '@odh-dashboard/internal/k8sTypes';
+import type {
+  DeploymentProgressStep,
+  DeploymentProgressStepStatus,
+} from '@odh-dashboard/model-serving/extension-points';
+import {
+  useWatchDeploymentEvents,
+  filterDeploymentEvents,
+  getEventTimestamp,
+} from '@odh-dashboard/model-serving/concepts/useWatchDeploymentEvents';
+import type { KServeDeployment } from './deployments';
+
+const isStorageInitializerEvent = (event: EventKind): boolean =>
+  event.message.includes('storage-initializer');
+
+const isKServeContainerEvent = (event: EventKind): boolean =>
+  event.message.includes('kserve-container');
+
+const isAuthProxyEvent = (event: EventKind): boolean =>
+  event.message.includes('kube-rbac-proxy') || event.message.includes('oauth-proxy');
+
+const hasEventWithReason = (events: EventKind[], reason: string): boolean =>
+  events.some((e) => e.reason === reason);
+
+const hasContainerEvent = (
+  events: EventKind[],
+  reason: string,
+  containerCheck: (e: EventKind) => boolean,
+): boolean => events.some((e) => e.reason === reason && containerCheck(e));
+
+type ConditionInfo = {
+  status: string;
+  reason: string | undefined;
+  message: string | undefined;
+};
+
+const getConditionStatus = (
+  isvc: InferenceServiceKind,
+  conditionType: string,
+): ConditionInfo | undefined => {
+  const conditions = isvc.status?.conditions;
+  if (!conditions) {
+    return undefined;
+  }
+  const condition = conditions.find((c) => c.type === conditionType);
+  if (!condition) {
+    return undefined;
+  }
+  return {
+    status: condition.status,
+    reason:
+      'reason' in condition && typeof condition.reason === 'string' ? condition.reason : undefined,
+    message:
+      'message' in condition && typeof condition.message === 'string'
+        ? condition.message
+        : undefined,
+  };
+};
+
+const stepStatus = (ready: boolean, error: boolean): DeploymentProgressStepStatus => {
+  if (error) {
+    return 'danger';
+  }
+  if (ready) {
+    return 'success';
+  }
+  return 'pending';
+};
+
+export const useKServeProgressSteps = (deployment: KServeDeployment): DeploymentProgressStep[] => {
+  const { model: isvc } = deployment;
+  const { namespace, name } = isvc.metadata;
+
+  const [allEvents] = useWatchDeploymentEvents(namespace);
+
+  const podEvents = React.useMemo(
+    () => filterDeploymentEvents(allEvents, name, new Set(['pod'])),
+    [allEvents, name],
+  );
+
+  const sortedPodEvents = React.useMemo(
+    () =>
+      podEvents.toSorted(
+        (a, b) =>
+          new Date(getEventTimestamp(a)).getTime() - new Date(getEventTimestamp(b)).getTime(),
+      ),
+    [podEvents],
+  );
+
+  return React.useMemo(() => {
+    const isStopped = isvc.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
+    const modelState =
+      isvc.status?.modelStatus?.states?.targetModelState ??
+      isvc.status?.modelStatus?.states?.activeModelState ??
+      '';
+    const readyCondition = getConditionStatus(isvc, 'Ready');
+    const predictorCondition = getConditionStatus(isvc, 'PredictorReady');
+    const ingressCondition = getConditionStatus(isvc, 'IngressReady');
+
+    const isPredictorReady = predictorCondition?.status === 'True';
+    const isReady = readyCondition?.status === 'True';
+    const isIngressReady = ingressCondition?.status === 'True';
+    const isModelLoaded = modelState === 'Loaded';
+    const isModelFailed = modelState === 'FailedToLoad';
+    const isProgressDeadlineExceeded = predictorCondition?.reason === 'ProgressDeadlineExceeded';
+
+    // Events expire after ~1 hour. When the predictor is already ready,
+    // infer that all sub-steps completed even if their events are gone.
+    const inferFromCondition = isPredictorReady || isModelLoaded;
+
+    const podScheduled = hasEventWithReason(sortedPodEvents, 'Scheduled') || inferFromCondition;
+    const podScheduleFailed =
+      !inferFromCondition && hasEventWithReason(sortedPodEvents, 'FailedScheduling');
+
+    const storageInitDone =
+      hasContainerEvent(sortedPodEvents, 'Started', isStorageInitializerEvent) ||
+      inferFromCondition;
+    const storageInitFailed =
+      !inferFromCondition &&
+      sortedPodEvents.some((e) => e.reason === 'BackOff' && isStorageInitializerEvent(e));
+
+    const kserveContainerStarted =
+      hasContainerEvent(sortedPodEvents, 'Started', isKServeContainerEvent) || inferFromCondition;
+    const kserveContainerFailed =
+      !inferFromCondition &&
+      sortedPodEvents.some(
+        (e) => (e.reason === 'BackOff' || e.reason === 'Unhealthy') && isKServeContainerEvent(e),
+      );
+
+    const authProxyStarted =
+      hasContainerEvent(sortedPodEvents, 'Started', isAuthProxyEvent) || inferFromCondition;
+
+    const deploymentRequestedStatus: DeploymentProgressStepStatus = isStopped
+      ? 'pending'
+      : 'success';
+
+    const modelResourcesChildren: DeploymentProgressStep[] = [
+      {
+        id: 'pod-scheduled',
+        title: 'Pod scheduled',
+        status: stepStatus(podScheduled, podScheduleFailed),
+        description: podScheduleFailed
+          ? sortedPodEvents.find((e) => e.reason === 'FailedScheduling')?.message
+          : undefined,
+      },
+      {
+        id: 'model-downloaded',
+        title: 'Model downloaded',
+        status: stepStatus(storageInitDone, storageInitFailed),
+      },
+      {
+        id: 'model-server-started',
+        title: 'Model server started',
+        status: stepStatus(kserveContainerStarted, kserveContainerFailed),
+        description: isModelFailed ? isvc.status?.modelStatus?.lastFailureInfo?.message : undefined,
+      },
+      {
+        id: 'auth-proxy-started',
+        title: 'Auth proxy started',
+        status: stepStatus(authProxyStarted, false),
+      },
+    ];
+
+    const allModelResourcesReady = modelResourcesChildren.every((s) => s.status === 'success');
+    const anyModelResourceFailed = modelResourcesChildren.some((s) => s.status === 'danger');
+
+    return [
+      {
+        id: 'deployment-requested',
+        title: 'Deployment requested',
+        status: deploymentRequestedStatus,
+      },
+      {
+        id: 'model-resources',
+        title: 'Model resources',
+        status: stepStatus(
+          allModelResourcesReady,
+          anyModelResourceFailed || Boolean(isProgressDeadlineExceeded),
+        ),
+        description: isProgressDeadlineExceeded ? predictorCondition.message : undefined,
+        children: modelResourcesChildren,
+      },
+      {
+        id: 'model-loaded',
+        title: 'Model loaded',
+        status: stepStatus(isModelLoaded, isModelFailed),
+        description: isModelFailed ? isvc.status?.modelStatus?.lastFailureInfo?.reason : undefined,
+      },
+      {
+        id: 'ingress-ready',
+        title: 'Ingress ready',
+        status: stepStatus(isIngressReady, false),
+      },
+      {
+        id: 'deployment-ready',
+        title: 'Deployment ready',
+        status: stepStatus(isReady, readyCondition?.status === 'False' && !isStopped),
+        description: readyCondition?.status === 'False' ? readyCondition.message : undefined,
+      },
+    ];
+  }, [isvc, sortedPodEvents]);
+};

--- a/packages/llmd-serving/extensions/extensions.ts
+++ b/packages/llmd-serving/extensions/extensions.ts
@@ -3,6 +3,7 @@ import type {
   DeploymentWizardFieldExtension,
   ModelServingDeploy,
   ModelServingDeploymentFormDataExtension,
+  ModelServingDeploymentProgressStepsExtension,
   ModelServingPlatformWatchDeploymentsExtension,
   ModelServingDeleteModal,
   ModelServingDeploymentTransformExtension,
@@ -105,6 +106,7 @@ const extensions: (
   | WizardField2Extension<GatewaySelectFieldType, LLMdDeployment>
   | WizardFieldApplyExtension<GatewaySelectFieldData, LLMdDeployment>
   | WizardFieldExtractorExtension<GatewaySelectFieldData, LLMdDeployment>
+  | ModelServingDeploymentProgressStepsExtension<LLMdDeployment>
 )[] = [
   {
     type: 'app.area',
@@ -275,6 +277,17 @@ const extensions: (
         import('../src/deployments/status').then((m) => m.patchDeploymentStoppedStatus),
     },
   },
+  {
+    type: 'model-serving.deployment/progress-steps',
+    properties: {
+      platform: LLMD_SERVING_ID,
+      useProgressSteps: () =>
+        import('../src/deployments/deploymentProgressSteps').then((m) => m.useLLMdProgressSteps),
+    },
+    flags: {
+      required: [LLMD_SERVING_ID],
+    },
+  } satisfies ModelServingDeploymentProgressStepsExtension<LLMdDeployment>,
 ];
 
 export default extensions;

--- a/packages/llmd-serving/src/deployments/deploymentProgressSteps.ts
+++ b/packages/llmd-serving/src/deployments/deploymentProgressSteps.ts
@@ -1,5 +1,8 @@
 import React from 'react';
-import type { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import type { EventKind, PodKind } from '@odh-dashboard/internal/k8sTypes';
+import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
 import type {
   DeploymentProgressStep,
   DeploymentProgressStepStatus,
@@ -84,12 +87,48 @@ const stepStatus = (ready: boolean, error: boolean): DeploymentProgressStepStatu
   return 'pending';
 };
 
+const isPodReady = (pod: PodKind): boolean => {
+  const containerStatuses = pod.status?.containerStatuses ?? [];
+  return (
+    pod.status?.phase === 'Running' &&
+    containerStatuses.length > 0 &&
+    containerStatuses.every((cs) => cs.ready)
+  );
+};
+
 export const useLLMdProgressSteps = (deployment: LLMdDeployment): DeploymentProgressStep[] => {
   const llmisvc = deployment.model;
   const { namespace } = llmisvc.metadata;
   const { name } = llmisvc.metadata;
 
   const [allEvents] = useWatchDeploymentEvents(namespace);
+
+  const [allPods] = useK8sWatchResourceList<PodKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(PodModel),
+      namespace,
+    },
+    PodModel,
+  );
+
+  const modelPods = React.useMemo(
+    () =>
+      allPods.filter(
+        (pod) =>
+          pod.metadata.name.startsWith(`${name}-kserve-`) &&
+          !pod.metadata.name.includes('router-scheduler'),
+      ),
+    [allPods, name],
+  );
+  const routerPods = React.useMemo(
+    () => allPods.filter((pod) => pod.metadata.name.startsWith(`${name}-kserve-router-scheduler-`)),
+    [allPods, name],
+  );
+
+  const modelReadyCount = React.useMemo(() => modelPods.filter(isPodReady).length, [modelPods]);
+  const routerReadyCount = React.useMemo(() => routerPods.filter(isPodReady).length, [routerPods]);
+  const desiredReplicas = llmisvc.spec.replicas ?? 1;
 
   const crEvents = React.useMemo(
     () => filterDeploymentEvents(allEvents, name, new Set(['cr'])),
@@ -196,14 +235,39 @@ export const useLLMdProgressSteps = (deployment: LLMdDeployment): DeploymentProg
       },
     ];
 
+    const allModelReplicasReady = modelReadyCount >= desiredReplicas && desiredReplicas > 0;
     const allModelWorkloadReady =
-      mainWorkloadReady || modelWorkloadChildren.every((s) => s.status === 'success');
+      mainWorkloadReady ||
+      (modelWorkloadChildren.every((s) => s.status === 'success') &&
+        (desiredReplicas <= 1 || allModelReplicasReady));
     const anyModelWorkloadFailed =
       mainWorkloadFailed || modelWorkloadChildren.some((s) => s.status === 'danger');
+    const modelWorkloadDescription = (() => {
+      if (mainWorkloadCondition?.message) {
+        return desiredReplicas > 1 && modelPods.length > 0
+          ? `${modelReadyCount}/${desiredReplicas} pods ready — ${mainWorkloadCondition.message}`
+          : mainWorkloadCondition.message;
+      }
+      if (desiredReplicas > 1 && modelPods.length > 0) {
+        return `${modelReadyCount}/${desiredReplicas} pods ready`;
+      }
+      return undefined;
+    })();
 
     const routerReady = routerCondition?.status === 'True';
     const routerFailed = routerCondition?.reason === 'ProgressDeadlineExceeded';
     const anyRouterFailed = routerFailed || routerChildren.some((s) => s.status === 'danger');
+    const routerDescription = (() => {
+      if (routerCondition?.message) {
+        return routerPods.length > 1
+          ? `${routerReadyCount}/${routerPods.length} pods ready — ${routerCondition.message}`
+          : routerCondition.message;
+      }
+      if (routerPods.length > 1) {
+        return `${routerReadyCount}/${routerPods.length} pods ready`;
+      }
+      return undefined;
+    })();
 
     return [
       {
@@ -221,14 +285,14 @@ export const useLLMdProgressSteps = (deployment: LLMdDeployment): DeploymentProg
         id: 'model-workload',
         title: 'Model workload',
         status: stepStatus(allModelWorkloadReady, anyModelWorkloadFailed),
-        description: mainWorkloadCondition?.message,
+        description: modelWorkloadDescription,
         children: modelWorkloadChildren,
       },
       {
         id: 'router-scheduler',
         title: 'Router / scheduler',
         status: stepStatus(routerReady, anyRouterFailed),
-        description: routerCondition?.message,
+        description: routerDescription,
         children: [
           ...routerChildren,
           {
@@ -255,5 +319,15 @@ export const useLLMdProgressSteps = (deployment: LLMdDeployment): DeploymentProg
         description: readyCondition?.status === 'False' ? readyCondition.message : undefined,
       },
     ];
-  }, [llmisvc, crEvents, modelPodEvents, routerPodEvents]);
+  }, [
+    llmisvc,
+    crEvents,
+    modelPodEvents,
+    routerPodEvents,
+    modelPods,
+    routerPods,
+    modelReadyCount,
+    routerReadyCount,
+    desiredReplicas,
+  ]);
 };

--- a/packages/llmd-serving/src/deployments/deploymentProgressSteps.ts
+++ b/packages/llmd-serving/src/deployments/deploymentProgressSteps.ts
@@ -1,0 +1,259 @@
+import React from 'react';
+import type { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import type {
+  DeploymentProgressStep,
+  DeploymentProgressStepStatus,
+} from '@odh-dashboard/model-serving/extension-points';
+import {
+  useWatchDeploymentEvents,
+  filterDeploymentEvents,
+  getEventTimestamp,
+} from '@odh-dashboard/model-serving/concepts/useWatchDeploymentEvents';
+import type { LLMdDeployment, LLMInferenceServiceKind } from '../types';
+
+const getCondition = (
+  llmisvc: LLMInferenceServiceKind,
+  conditionType: string,
+): { status?: string; reason?: string; message?: string } | undefined =>
+  llmisvc.status?.conditions?.find((c) => c.type === conditionType);
+
+const conditionToStatus = (
+  condition: { status?: string; reason?: string; message?: string } | undefined,
+): DeploymentProgressStepStatus => {
+  if (!condition) {
+    return 'pending';
+  }
+  if (condition.status === 'True') {
+    return 'success';
+  }
+  if (condition.reason === 'ProgressDeadlineExceeded') {
+    return 'danger';
+  }
+  if (condition.reason === 'Stopped') {
+    return 'pending';
+  }
+  return 'pending';
+};
+
+const getResourceCreatedSteps = (crEvents: EventKind[]): DeploymentProgressStep[] => {
+  const createdEvents = crEvents.filter((e) => e.reason === 'Created');
+  if (createdEvents.length === 0) {
+    return [];
+  }
+
+  const sorted = createdEvents.toSorted(
+    (a, b) => new Date(getEventTimestamp(a)).getTime() - new Date(getEventTimestamp(b)).getTime(),
+  );
+
+  const successStatus: DeploymentProgressStepStatus = 'success';
+  return sorted.map((event, index) => ({
+    id: `resource-created-${index}`,
+    title: event.message,
+    status: successStatus,
+  }));
+};
+
+const isModelPodEvent = (event: EventKind, deploymentName: string): boolean =>
+  event.involvedObject.kind === 'Pod' &&
+  event.involvedObject.name.startsWith(`${deploymentName}-kserve-`) &&
+  !event.involvedObject.name.includes('router-scheduler');
+
+const isRouterPodEvent = (event: EventKind, deploymentName: string): boolean =>
+  event.involvedObject.kind === 'Pod' &&
+  event.involvedObject.name.includes(`${deploymentName}-kserve-router-scheduler-`);
+
+const hasEventReason = (events: EventKind[], reason: string): boolean =>
+  events.some((e) => e.reason === reason);
+
+const hasPodStarted = (events: EventKind[], containerName: string): boolean =>
+  events.some((e) => e.reason === 'Started' && e.message.includes(containerName));
+
+const hasPodFailed = (events: EventKind[], containerName: string): boolean =>
+  events.some(
+    (e) =>
+      (e.reason === 'BackOff' || e.reason === 'Unhealthy') && e.message.includes(containerName),
+  );
+
+const stepStatus = (ready: boolean, error: boolean): DeploymentProgressStepStatus => {
+  if (error) {
+    return 'danger';
+  }
+  if (ready) {
+    return 'success';
+  }
+  return 'pending';
+};
+
+export const useLLMdProgressSteps = (deployment: LLMdDeployment): DeploymentProgressStep[] => {
+  const llmisvc = deployment.model;
+  const { namespace } = llmisvc.metadata;
+  const { name } = llmisvc.metadata;
+
+  const [allEvents] = useWatchDeploymentEvents(namespace);
+
+  const crEvents = React.useMemo(
+    () => filterDeploymentEvents(allEvents, name, new Set(['cr'])),
+    [allEvents, name],
+  );
+
+  const podEvents = React.useMemo(
+    () => filterDeploymentEvents(allEvents, name, new Set(['pod'])),
+    [allEvents, name],
+  );
+
+  const modelPodEvents = React.useMemo(
+    () => podEvents.filter((e) => isModelPodEvent(e, name)),
+    [podEvents, name],
+  );
+
+  const routerPodEvents = React.useMemo(
+    () => podEvents.filter((e) => isRouterPodEvent(e, name)),
+    [podEvents, name],
+  );
+
+  return React.useMemo(() => {
+    const isStopped = llmisvc.metadata.annotations?.['serving.kserve.io/stop'] === 'true';
+    const readyCondition = getCondition(llmisvc, 'Ready');
+    const mainWorkloadCondition = getCondition(llmisvc, 'MainWorkloadReady');
+    const routerCondition = getCondition(llmisvc, 'RouterReady');
+    const httpRoutesCondition = getCondition(llmisvc, 'HTTPRoutesReady');
+    const inferencePoolCondition = getCondition(llmisvc, 'InferencePoolReady');
+    const presetsCondition = getCondition(llmisvc, 'PresetsCombined');
+
+    const isReady = readyCondition?.status === 'True';
+
+    const deploymentRequestedStatus: DeploymentProgressStepStatus = isStopped
+      ? 'pending'
+      : 'success';
+
+    const resourceCreatedChildren = getResourceCreatedSteps(crEvents);
+    // If events expired but conditions exist, resources were created
+    const hasConditions = (llmisvc.status?.conditions?.length ?? 0) > 0;
+    const allResourcesCreated = resourceCreatedChildren.length > 0 || hasConditions;
+
+    // Events expire after ~1 hour. When a workload condition is already True,
+    // infer that all sub-steps completed even if their events are gone.
+    const mainWorkloadReady = mainWorkloadCondition?.status === 'True';
+    const mainWorkloadFailed =
+      mainWorkloadCondition?.reason === 'ProgressDeadlineExceeded' ||
+      mainWorkloadCondition?.reason === 'MinimumReplicasUnavailable';
+    const inferModelFromCondition = mainWorkloadReady;
+
+    const routerIsReady = routerCondition?.status === 'True';
+    const inferRouterFromCondition = routerIsReady;
+
+    const modelPodScheduled =
+      hasEventReason(modelPodEvents, 'Scheduled') || inferModelFromCondition;
+    const modelPodScheduleFailed =
+      !inferModelFromCondition && hasEventReason(modelPodEvents, 'FailedScheduling');
+    const modelStorageInitDone =
+      hasPodStarted(modelPodEvents, 'storage-initializer') || inferModelFromCondition;
+    const modelServerStarted = hasPodStarted(modelPodEvents, 'main') || inferModelFromCondition;
+    const modelServerFailed = !inferModelFromCondition && hasPodFailed(modelPodEvents, 'main');
+
+    const routerPodScheduled =
+      hasEventReason(routerPodEvents, 'Scheduled') || inferRouterFromCondition;
+    const routerPodScheduleFailed =
+      !inferRouterFromCondition && hasEventReason(routerPodEvents, 'FailedScheduling');
+    const tokenizerStarted =
+      hasPodStarted(routerPodEvents, 'tokenizer') || inferRouterFromCondition;
+    const schedulerStarted = hasPodStarted(routerPodEvents, 'main') || inferRouterFromCondition;
+    const schedulerFailed = !inferRouterFromCondition && hasPodFailed(routerPodEvents, 'main');
+
+    const modelWorkloadChildren: DeploymentProgressStep[] = [
+      {
+        id: 'model-pod-scheduled',
+        title: 'Pod scheduled',
+        status: stepStatus(modelPodScheduled, modelPodScheduleFailed),
+      },
+      {
+        id: 'model-downloaded',
+        title: 'Model downloaded',
+        status: stepStatus(modelStorageInitDone, false),
+      },
+      {
+        id: 'model-server-started',
+        title: 'Model server started',
+        status: stepStatus(modelServerStarted, modelServerFailed),
+      },
+    ];
+
+    const routerChildren: DeploymentProgressStep[] = [
+      {
+        id: 'router-pod-scheduled',
+        title: 'Pod scheduled',
+        status: stepStatus(routerPodScheduled, routerPodScheduleFailed),
+      },
+      {
+        id: 'tokenizer-ready',
+        title: 'Tokenizer ready',
+        status: stepStatus(tokenizerStarted, false),
+      },
+      {
+        id: 'scheduler-started',
+        title: 'Scheduler started',
+        status: stepStatus(schedulerStarted, schedulerFailed),
+      },
+    ];
+
+    const allModelWorkloadReady =
+      mainWorkloadReady || modelWorkloadChildren.every((s) => s.status === 'success');
+    const anyModelWorkloadFailed =
+      mainWorkloadFailed || modelWorkloadChildren.some((s) => s.status === 'danger');
+
+    const routerReady = routerCondition?.status === 'True';
+    const routerFailed = routerCondition?.reason === 'ProgressDeadlineExceeded';
+    const anyRouterFailed = routerFailed || routerChildren.some((s) => s.status === 'danger');
+
+    return [
+      {
+        id: 'deployment-requested',
+        title: 'Deployment requested',
+        status: deploymentRequestedStatus,
+      },
+      {
+        id: 'resources-created',
+        title: 'Resources created',
+        status: stepStatus(allResourcesCreated, false),
+        children: resourceCreatedChildren.length > 0 ? resourceCreatedChildren : undefined,
+      },
+      {
+        id: 'model-workload',
+        title: 'Model workload',
+        status: stepStatus(allModelWorkloadReady, anyModelWorkloadFailed),
+        description: mainWorkloadCondition?.message,
+        children: modelWorkloadChildren,
+      },
+      {
+        id: 'router-scheduler',
+        title: 'Router / scheduler',
+        status: stepStatus(routerReady, anyRouterFailed),
+        description: routerCondition?.message,
+        children: [
+          ...routerChildren,
+          {
+            id: 'http-routes-ready',
+            title: 'HTTP routes ready',
+            status: conditionToStatus(httpRoutesCondition),
+          },
+          {
+            id: 'inference-pool-ready',
+            title: 'Inference pool ready',
+            status: conditionToStatus(inferencePoolCondition),
+          },
+        ],
+      },
+      {
+        id: 'presets-combined',
+        title: 'Presets combined',
+        status: conditionToStatus(presetsCondition),
+      },
+      {
+        id: 'deployment-ready',
+        title: 'Deployment ready',
+        status: stepStatus(isReady, readyCondition?.status === 'False' && !isStopped),
+        description: readyCondition?.status === 'False' ? readyCondition.message : undefined,
+      },
+    ];
+  }, [llmisvc, crEvents, modelPodEvents, routerPodEvents]);
+};

--- a/packages/model-serving/docs/deployment-status-inferenceservice.md
+++ b/packages/model-serving/docs/deployment-status-inferenceservice.md
@@ -1,0 +1,201 @@
+# Deployment Status — InferenceService (KServe Standard)
+
+**API:** `serving.kserve.io/v1beta1` `InferenceService`
+
+## TL;DR — Progress Steps
+
+```
+1. Deployment requested
+2. Model resources
+   ├── Pod scheduled
+   ├── Model downloaded          ← storage-initializer completed
+   ├── Model server started      ← kserve-container running
+   └── Auth proxy started        ← kube-rbac-proxy running
+3. Model loaded                  ← modelStatus.activeModelState = Loaded
+4. Ingress ready                 ← condition IngressReady: True
+5. Deployment ready              ← condition Ready: True
+```
+
+| Step | Signal source |
+|------|---------------|
+| Deployment requested | ISVC exists and not stopped |
+| Pod scheduled | Pod event `reason=Scheduled` |
+| Model downloaded | storage-initializer init container completed (Pod event `reason=Started`) |
+| Model server started | Pod event `reason=Started` for `kserve-container` |
+| Auth proxy started | Pod event `reason=Started` for `kube-rbac-proxy` |
+| Model loaded | `status.modelStatus.states.activeModelState = Loaded` |
+| Ingress ready | `status.conditions[IngressReady].status = True` |
+| Deployment ready | `status.conditions[Ready].status = True` |
+
+**Error steps** (shown only when relevant):
+- Pod scheduling failed → replaces "Pod scheduled" (Pod condition `reason=Unschedulable`)
+- Model download failed → replaces "Model downloaded" (storage-initializer `CrashLoopBackOff`)
+- Model server crashed → replaces "Model server started" (`modelStatus.lastFailureInfo`)
+- Progress deadline exceeded → timeout error after "Model resources" (Deployment `reason=ProgressDeadlineExceeded`)
+
+---
+
+This document covers the status signals available for standard KServe InferenceService deployments (raw/standard deployment mode as used by ODH).
+
+## Resource Chain
+
+```
+InferenceService
+├── Deployment (<name>-predictor)
+│   └── ReplicaSet (<name>-predictor-<hash>)
+│       └── Pod(s) (<name>-predictor-<hash>-<id>)
+│           ├── storage-initializer (init container) — model download
+│           ├── kserve-container — model server (OpenVINO, vLLM, NIM runtime, etc.)
+│           ├── kube-rbac-proxy — auth proxy sidecar
+│           └── agent — kserve model agent sidecar
+├── Service (<name>-predictor) — predictor ClusterIP service
+├── Service (<name>-metrics) — metrics endpoint (odh-model-controller)
+├── HorizontalPodAutoscaler (<name>-predictor) — autoscaling
+├── ServingRuntime (<name> or user-specified) — model server template
+├── Route (OpenShift, odh-model-controller) — external access
+├── ServiceMonitor (odh-model-controller) — Prometheus scraping
+└── ClusterRoleBinding (odh-model-controller) — RBAC for auth proxy
+```
+
+## Status Conditions
+
+### Condition Hierarchy
+
+```
+Ready (Knative LivingConditionSet rollup)
+├── PredictorReady — predictor Deployment available
+│   └── Derived from: Deployment.status.conditions[Available, Progressing]
+├── IngressReady — network path established
+└── Stopped (separate, not in Ready set) — force-stop annotation present
+```
+
+Additional conditions (informational, not gating `Ready`):
+- `LatestDeploymentReady` — latest Deployment revision ready (odh-model-controller sets this with `AuthProxyPreserved` reason)
+
+### Condition Details
+
+| Condition | True | False |
+|-----------|------|-------|
+| `Ready` | Both `PredictorReady` and `IngressReady` are True | Any gate condition is False |
+| `PredictorReady` | Deployment has minimum availability | reason: `MinimumReplicasUnavailable`, `ProgressDeadlineExceeded`, `Stopped` |
+| `IngressReady` | Service/Route created and accessible | InferenceService is stopped or ingress not yet reconciled |
+| `Stopped` | `serving.kserve.io/stop` annotation is set | InferenceService is running (severity: Info) |
+| `LatestDeploymentReady` | Latest Deployment revision matches desired | reason: `AuthProxyPreserved` (informational — avoids pod restart) |
+
+### Common Reason Strings
+
+| Reason | Condition | Meaning |
+|--------|-----------|---------|
+| `NewReplicaSetAvailable` | `PredictorReady` | Deployment rolled out successfully |
+| `MinimumReplicasUnavailable` | `PredictorReady` | Pods not yet ready or crashing |
+| `ProgressDeadlineExceeded` | `PredictorReady` | Rollout timed out — something is stuck |
+| `Stopped` | `PredictorReady`, `Ready` | Intentionally stopped via annotation |
+| `AuthProxyPreserved` | `LatestDeploymentReady` | Auth proxy container kept to avoid restart |
+
+## Model Status (`status.modelStatus`)
+
+This subsystem tracks model loading lifecycle independently of Pod readiness. It is computed by the KServe controller from Pod container statuses.
+
+### State Machine
+
+```
+Pending ──► Loading ──► Loaded
+   │            │
+   │            ▼
+   └──────► FailedToLoad
+```
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `transitionStatus` | `UpToDate` | Target model state reached |
+| | `InProgress` | Model loading or pending |
+| | `BlockedByFailedLoad` | Model failed to load |
+| | `InvalidSpec` | Predictor spec validation failed |
+| `activeModelState` | `Loaded` | Model is serving |
+| | `Pending` | Pod exists but model not yet loaded |
+| | `Loading` | `storage-initializer` running (downloading model) |
+| | `FailedToLoad` | Model load failed |
+| `targetModelState` | Same enum | Target state during transitions |
+| `copies.totalCopies` | int | Number of Ready pods |
+| `copies.failedCopies` | int | Number of failed pods |
+
+### Last Failure Info
+
+When `targetModelState` is `FailedToLoad`, `lastFailureInfo` provides details:
+
+| Field | Source |
+|-------|--------|
+| `reason` | `ModelLoadFailed`, `RuntimeUnhealthy`, `RuntimeDisabled`, `NoSupportingRuntime`, `RuntimeNotRecognized`, `InvalidPredictorSpec` |
+| `exitCode` | From `containerStatuses[].lastState.terminated.exitCode` or `.state.terminated.exitCode` |
+| `message` | From container termination message |
+
+### How Model State is Derived (from Pod inspection)
+
+1. **0 ready pods** → `Pending` (or `FailedToLoad` if Knative conditions are False)
+2. **`storage-initializer` init container:**
+   - `.state.Running` (no prior termination) → `Loading`
+   - `.state.Terminated` with `Reason=Error` → `FailedToLoad` (exitCode from termination)
+   - `.state.Waiting` with `Reason=CrashLoopBackOff` → `FailedToLoad` (exitCode from last termination)
+3. **InferenceService `IsReady()`** → `Loaded`
+4. **`kserve-container`:**
+   - `.state.Terminated` with `Reason=Error` → `FailedToLoad`
+   - `.state.Waiting` with `Reason=CrashLoopBackOff` → `FailedToLoad`
+   - Otherwise → `Pending`
+
+## Events
+
+### On InferenceService CR (emitted by KServe controller)
+
+| Reason | Type | Message | When |
+|--------|------|---------|------|
+| `InferenceServiceReady` | Normal | `InferenceService [<name>] is Ready` | Transition to Ready |
+| `InferenceServiceNotReady` | Warning | `InferenceService [<name>] is no longer Ready because of: <conditions>` | Transition from Ready |
+| `InternalError` | Warning | `<error message>` | Reconcile error |
+| `UpdateFailed` | Warning | `Failed to update status for InferenceService "<name>": <error>` | Status write failed |
+
+### On Pods (emitted by kubelet)
+
+| Reason | Type | Container context | Meaning |
+|--------|------|-------------------|---------|
+| `Scheduled` | Normal | — | Pod assigned to node |
+| `AddedInterface` | Normal | — | Network interface (OVN/Multus) |
+| `Pulling` | Normal | storage-initializer, kserve-container, kube-rbac-proxy | Image pull started |
+| `Pulled` | Normal | (same) | Image pull completed (includes size and duration) |
+| `Created` | Normal | (same) | Container created |
+| `Started` | Normal | (same) | Container started |
+| `FailedMount` | Warning | — | Volume mount failure (e.g. missing serving cert Secret) |
+| `Unhealthy` | Warning | kserve-container | Readiness/startup probe failed |
+| `BackOff` | Warning | kserve-container, storage-initializer | CrashLoopBackOff |
+| `Killing` | Normal | kserve-container | Container being stopped |
+
+### On Deployment (emitted by Deployment controller)
+
+| Reason | Type | Message |
+|--------|------|---------|
+| `ScalingReplicaSet` | Normal | `Scaled up replica set <name>-<hash> from 0 to N` |
+
+### On HorizontalPodAutoscaler
+
+| Reason | Type | Message |
+|--------|------|---------|
+| `FailedGetResourceMetric` | Warning | `failed to get cpu utilization: ...` |
+| `FailedComputeMetricsReplicas` | Warning | `invalid metrics (N invalid out of M)...` |
+
+HPA metric warnings are common during startup and usually resolve once pods are ready. Persistent warnings indicate a metrics-server or pod health issue.
+
+## Event Filtering Strategy
+
+To scope events to the current deployment instance:
+
+1. **CR-level events:** `involvedObject.kind=InferenceService,involvedObject.name=<name>`
+2. **Pod events:** List Pods with `labelSelector=serving.kserve.io/inferenceservice=<name>`, identify the latest ReplicaSet, then watch `involvedObject.kind=Pod,involvedObject.uid=<pod-uid>` for each relevant Pod
+3. **Deployment events:** `involvedObject.kind=Deployment,involvedObject.name=<name>-predictor`
+
+## Stopped State
+
+An InferenceService is stopped when:
+- `metadata.annotations['serving.kserve.io/stop']` is set (not `"false"`)
+- `status.conditions` shows `Stopped: True` (severity: Info)
+- `PredictorReady: False` with reason `Stopped`
+- `Ready: False` with reason `Stopped`
+- `modelStatus.transitionStatus` is empty, `modelStatus.states` is nil

--- a/packages/model-serving/docs/deployment-status-inferenceservice.md
+++ b/packages/model-serving/docs/deployment-status-inferenceservice.md
@@ -8,30 +8,25 @@
 1. Deployment requested
 2. Model resources
    ├── Pod scheduled
-   ├── Model downloaded          ← storage-initializer completed
-   ├── Model server started      ← kserve-container running
-   └── Auth proxy started        ← kube-rbac-proxy running
-3. Model loaded                  ← modelStatus.activeModelState = Loaded
-4. Ingress ready                 ← condition IngressReady: True
-5. Deployment ready              ← condition Ready: True
+   ├── Model downloaded
+   ├── Model server started
+   └── Auth proxy started
+3. Model loaded
+4. Ingress ready
+5. Deployment ready
 ```
 
-| Step | Signal source |
-|------|---------------|
-| Deployment requested | ISVC exists and not stopped |
-| Pod scheduled | Pod event `reason=Scheduled` |
-| Model downloaded | storage-initializer init container completed (Pod event `reason=Started`) |
-| Model server started | Pod event `reason=Started` for `kserve-container` |
-| Auth proxy started | Pod event `reason=Started` for `kube-rbac-proxy` |
-| Model loaded | `status.modelStatus.states.activeModelState = Loaded` |
-| Ingress ready | `status.conditions[IngressReady].status = True` |
-| Deployment ready | `status.conditions[Ready].status = True` |
-
-**Error steps** (shown only when relevant):
-- Pod scheduling failed → replaces "Pod scheduled" (Pod condition `reason=Unschedulable`)
-- Model download failed → replaces "Model downloaded" (storage-initializer `CrashLoopBackOff`)
-- Model server crashed → replaces "Model server started" (`modelStatus.lastFailureInfo`)
-- Progress deadline exceeded → timeout error after "Model resources" (Deployment `reason=ProgressDeadlineExceeded`)
+| Step | Sub-step | Success signal | Error signal | Fallback (events expired) |
+|------|----------|---------------|-------------|--------------------------|
+| **Deployment requested** | | ISVC exists, `stop` annotation absent | — | Always derivable |
+| **Model resources** | | All children green | Any child red, or `PredictorReady.reason = ProgressDeadlineExceeded` | `PredictorReady: True` → all children green |
+| | Pod scheduled | Pod event `reason=Scheduled` | Pod event `reason=FailedScheduling` | `PredictorReady: True` or `modelStatus = Loaded` |
+| | Model downloaded | Pod event `reason=Started` where `message` contains `storage-initializer` | Pod event `reason=BackOff` where `message` contains `storage-initializer` | `PredictorReady: True` or `modelStatus = Loaded` |
+| | Model server started | Pod event `reason=Started` where `message` contains `kserve-container` | Pod event `reason=BackOff\|Unhealthy` where `message` contains `kserve-container`; also `modelStatus.lastFailureInfo.message` | `PredictorReady: True` or `modelStatus = Loaded` |
+| | Auth proxy started | Pod event `reason=Started` where `message` contains `kube-rbac-proxy` or `oauth-proxy` | — | `PredictorReady: True` or `modelStatus = Loaded` |
+| **Model loaded** | | `status.modelStatus.states.activeModelState = "Loaded"` or `targetModelState = "Loaded"` | `targetModelState = "FailedToLoad"`; description from `lastFailureInfo.reason` | Always derivable from ISVC status |
+| **Ingress ready** | | `status.conditions[IngressReady].status = "True"` | — | Always derivable from ISVC status |
+| **Deployment ready** | | `status.conditions[Ready].status = "True"` | `Ready.status = "False"` and not stopped; description from `Ready.message` | Always derivable from ISVC status |
 
 ---
 

--- a/packages/model-serving/docs/deployment-status-llminferenceservice.md
+++ b/packages/model-serving/docs/deployment-status-llminferenceservice.md
@@ -1,0 +1,213 @@
+# Deployment Status — LLMInferenceService (LLM-D / Disaggregated Serving)
+
+**API:** `serving.kserve.io/v1alpha2` `LLMInferenceService`
+
+## TL;DR — Progress Steps
+
+```
+1. Deployment requested
+2. Resources created
+   ├── Secrets & service accounts ← Created events on LLMISVC
+   ├── Services                   ← Created events on LLMISVC
+   ├── Inference pool             ← Created events on LLMISVC
+   └── HTTP route                 ← Created events on LLMISVC
+3. Model workload
+   ├── Pod scheduled              ← Pod event for <name>-kserve-* pod
+   ├── Model downloaded           ← storage-initializer completed
+   └── Model server started       ← main container running
+4. Router / scheduler
+   ├── Pod scheduled              ← Pod event for <name>-kserve-router-scheduler-* pod
+   ├── Tokenizer ready            ← tokenizer container running
+   └── Scheduler started          ← main container running
+5. Presets combined               ← condition PresetsCombined: True
+6. Deployment ready               ← condition Ready: True
+```
+
+| Step | Signal source |
+|------|---------------|
+| Deployment requested | LLMISVC exists and not stopped |
+| Resources created | LLMISVC events `reason=Created` (one per child resource) |
+| Model workload | Condition `MainWorkloadReady: True` |
+| Router / scheduler | Conditions `SchedulerWorkloadReady: True` + `HTTPRoutesReady: True` + `InferencePoolReady: True` |
+| Presets combined | `status.conditions[PresetsCombined].status = True` |
+| Deployment ready | `status.conditions[Ready].status = True` |
+
+**Error steps** (shown only when relevant):
+- Pod scheduling failed → replaces "Pod scheduled" in either workload section
+- Model server crashed → replaces "Model server started" (model pod `BackOff`/`Unhealthy`)
+- Scheduler crashed → replaces "Scheduler started" (router pod `BackOff`)
+- Progress deadline exceeded → timeout on model workload or router (Deployment `reason=ProgressDeadlineExceeded`)
+- Gateway not ready → replaces "HTTP route" (`GatewaysNotReady`)
+
+**Note:** Steps 3 and 4 can progress independently — the model workload may be ready while the router is still starting, or vice versa.
+
+---
+
+This document covers the status signals available for LLMInferenceService deployments, which use the LLM-D disaggregated serving architecture with separate model workload and router/scheduler components.
+
+## Resource Chain
+
+```
+LLMInferenceService
+├── Deployment (<name>-kserve) — model workload
+│   └── ReplicaSet → Pod(s)
+│       ├── storage-initializer (init) — model download
+│       └── main — model server (e.g. vLLM)
+├── Deployment (<name>-kserve-router-scheduler) — EPP scheduler
+│   └── ReplicaSet → Pod(s)
+│       ├── storage-initializer (init) — tokenizer download
+│       ├── tokenizer — kv-cache tokenizer sidecar
+│       └── main — inference scheduler
+├── Service (<name>-kserve-workload-svc) — model pod communication
+├── Service (<name>-epp-service) — Endpoint Picker Protocol
+├── ServiceAccount (<name>-epp-sa) — EPP identity
+├── Secret (<name>-kserve-self-signed-certs) — TLS certificates
+├── InferencePool (<name>-inference-pool) — Gateway API inference pool
+├── HTTPRoute (<name>-kserve-route) — Gateway API routing
+└── DestinationRule (<name>-kserve-shadow-svc) — Istio shadow service (OCP)
+```
+
+All owned children use the label `app.kubernetes.io/part-of: llminferenceservice` and have `ownerReferences` pointing to the LLMInferenceService.
+
+### Child Resource Labels
+
+| Deployment | Labels |
+|------------|--------|
+| `<name>-kserve` | `app.kubernetes.io/component: llminferenceservice-workload`, `kserve.io/component: workload`, `llm-d.ai/role: both` |
+| `<name>-kserve-router-scheduler` | `app.kubernetes.io/component: llminferenceservice-router-scheduler` |
+
+## Status Conditions
+
+### Condition Hierarchy
+
+LLMInferenceService has the richest condition tree of any model serving platform:
+
+```
+Ready (Knative LivingConditionSet rollup)
+├── WorkloadsReady (rollup via DetermineWorkloadReadiness)
+│   ├── MainWorkloadReady         ← model Deployment Available condition
+│   ├── WorkerWorkloadReady       ← worker LeaderWorkerSet (multi-node, optional)
+│   ├── PrefillWorkloadReady      ← prefill Deployment (disaggregated P/D, optional)
+│   └── PrefillWorkerWorkloadReady ← prefill LeaderWorkerSet (optional)
+├── RouterReady (rollup via DetermineRouterReadiness)
+│   ├── HTTPRoutesReady           ← HTTPRoute accepted by gateway controller
+│   ├── InferencePoolReady        ← InferencePool created and accepted
+│   ├── SchedulerWorkloadReady    ← router-scheduler Deployment Available
+│   └── GatewaysReady             ← referenced Gateway programmed (optional)
+└── PresetsCombined               ← config presets merged (does NOT gate Ready)
+```
+
+### Rollup Rules
+
+**`DetermineWorkloadReadiness`:** Iterates `MainWorkloadReady`, `WorkerWorkloadReady`, `PrefillWorkloadReady`, `PrefillWorkerWorkloadReady`. Skips `nil` (unset) conditions. First `False` sub-condition propagates its `reason` and `message` to `WorkloadsReady`. If none are False, `WorkloadsReady` is True.
+
+**`DetermineRouterReadiness`:** Same pattern over `GatewaysReady`, `HTTPRoutesReady`, `InferencePoolReady`, `SchedulerWorkloadReady`.
+
+**`Ready`:** Knative `LivingConditionSet` — both `WorkloadsReady` and `RouterReady` must be True.
+
+**`PresetsCombined`** is tracked separately and is **not** in the `Ready` set.
+
+### Condition Details
+
+| Condition | True when | False reason examples |
+|-----------|-----------|----------------------|
+| `MainWorkloadReady` | Model Deployment `Available=True` | `MinimumReplicasUnavailable`, `ProgressDeadlineExceeded`, `Stopped` |
+| `WorkerWorkloadReady` | Worker LWS `Available=True` | LWS condition reason |
+| `PrefillWorkloadReady` | Prefill Deployment `Available=True` | Same as Main |
+| `SchedulerWorkloadReady` | Scheduler Deployment has available replicas | `ProgressDeadlineExceeded`, `MinimumReplicasUnavailable` |
+| `HTTPRoutesReady` | HTTPRoute accepted by gateway controller | `HTTPRoutesNotReady`, `RefsInvalidReason` |
+| `InferencePoolReady` | InferencePool CR accepted | `InferencePoolNotReady` |
+| `GatewaysReady` | Referenced Gateway `Programmed=True` | `GatewaysNotReady`, `GatewayPreconditionNotMet` |
+| `PresetsCombined` | Base config + presets merged successfully | `CombineBaseError`, `Stopped` |
+
+### How Workload Conditions Map to Deployment Status
+
+The `propagateDeploymentStatus` function in the KServe LLMISVC reconciler reads child Deployment status:
+
+1. `Deployment.status.conditions[type=Available].status=True` → mark workload ready
+2. `Deployment.status.conditions[type=Available].status≠True` or `Progressing.status=False` → mark not ready with the Deployment condition's reason and message
+3. No `Available` condition yet → not ready, reason `Progressing`
+
+## Model Status
+
+**LLMInferenceService does NOT have a `modelStatus` subsystem.** There is no `activeModelState`, `targetModelState`, `transitionStatus`, or `lastFailureInfo`.
+
+Model loading state must be inferred from:
+- `MainWorkloadReady` condition (reflects Deployment availability, which depends on container readiness)
+- Pod `initContainerStatuses` for `storage-initializer` (model download progress/failures)
+- Pod `containerStatuses` for `main` (model server health)
+
+## Events
+
+### On LLMInferenceService CR (emitted by KServe LLMISVC controller)
+
+These events are **very useful** — they provide a built-in progress tracker for child resource creation:
+
+| Reason | Type | Message pattern | Example |
+|--------|------|-----------------|---------|
+| `Created` | Normal | `Created <kind> <namespace>/<name>` | `Created v1.Deployment emily/llmd-cpu-kserve` |
+| `Updated` | Normal | `Updated <kind> <namespace>/<name>` | `Updated v1.Secret emily/llmd-cpu-kserve-self-signed-certs` |
+| `Deleted` | Normal | `Deleted <kind> <namespace>/<name>` | `Deleted v1.Service emily/llmd-cpu-epp-service` |
+| `Error` | Warning | `Reconciliation failed: <error>` | Reconcile error |
+| `ScalingCRDNotFound` | Warning | `Required scaling CRD not installed: <error>` | Missing KEDA/WVA CRD |
+
+**Note:** LLMInferenceService does **NOT** emit `Ready`/`NotReady` transition events (unlike InferenceService).
+
+### Observed Child Resource Creation Events (ordered)
+
+From a real deployment (`llmd-cpu`), the `Created` events on the LLMISVC resource showed this sequence:
+
+1. `Created v1.Secret emily/llmd-cpu-kserve-self-signed-certs`
+2. `Created v1.Deployment emily/llmd-cpu-kserve`
+3. `Created v1.Service emily/llmd-cpu-kserve-workload-svc`
+4. `Created v1.ServiceAccount emily/llmd-cpu-epp-sa`
+5. `Created v1.Service emily/llmd-cpu-epp-service`
+6. `Created v1alpha2.InferencePool emily/llmd-cpu-inference-pool`
+7. `Created v1.InferencePool emily/llmd-cpu-inference-pool`
+8. `Created v1.HTTPRoute emily/llmd-cpu-kserve-route`
+9. `Created v1.DestinationRule emily/llmd-cpu-kserve-shadow-svc`
+10. `Created v1.Deployment emily/llmd-cpu-kserve-router-scheduler`
+
+### On Pods (emitted by kubelet)
+
+Same kubelet events as InferenceService (Scheduled, Pulling, Pulled, Created, Started, BackOff, Unhealthy, etc.), but now across **two separate Deployment chains**:
+
+**Model pod events (`<name>-kserve-*`):**
+- `storage-initializer` init container events (model download)
+- `main` container events (model server startup, health probes)
+
+**Router-scheduler pod events (`<name>-kserve-router-scheduler-*`):**
+- `storage-initializer` init container events (tokenizer download)
+- `tokenizer` container events
+- `main` container events (scheduler startup)
+
+### On LLMInferenceService from odh-model-controller
+
+| Reason | Type | Message |
+|--------|------|---------|
+| `ReconcileError` | Warning | `Failed to reconcile LLMInferenceService: <error>` |
+
+## Event Filtering Strategy
+
+LLMInferenceService events come from multiple sources:
+
+1. **CR-level events:** `involvedObject.kind=LLMInferenceService,involvedObject.name=<name>` — gives the `Created`/`Updated`/`Deleted` child resource events
+2. **Model pod events:** List Pods with label `app.kubernetes.io/component=llminferenceservice-workload,app.kubernetes.io/name=<name>`
+3. **Router pod events:** List Pods with label `app.kubernetes.io/component=llminferenceservice-router-scheduler,app.kubernetes.io/name=<name>`
+4. **Deployment events:** `involvedObject.kind=Deployment,involvedObject.name=<name>-kserve` and `<name>-kserve-router-scheduler`
+
+## Stopped State
+
+An LLMInferenceService is stopped when:
+- `metadata.annotations['serving.kserve.io/stop']` is set
+- Sub-conditions are marked `False` with reason `Stopped`
+- Child workload Deployments are deleted
+- `PresetsCombined` may show a warning with reason `Stopped`
+
+## Multi-Deployment Considerations
+
+A key UI challenge: the model workload and router-scheduler can fail independently. Your `llmd-cpu` example shows:
+- Model pod: `CrashLoopBackOff` on `main` container (vLLM failing to start)
+- Router-scheduler pod: `CrashLoopBackOff` on `main` container (scheduler can't connect)
+
+Both roll up to `Ready: False` with `ProgressDeadlineExceeded`, but a useful status display should distinguish which component is failing. The condition hierarchy already captures this: `MainWorkloadReady` vs `SchedulerWorkloadReady` give independent signals.

--- a/packages/model-serving/docs/deployment-status-llminferenceservice.md
+++ b/packages/model-serving/docs/deployment-status-llminferenceservice.md
@@ -7,39 +7,40 @@
 ```
 1. Deployment requested
 2. Resources created
-   ├── Secrets & service accounts ← Created events on LLMISVC
-   ├── Services                   ← Created events on LLMISVC
-   ├── Inference pool             ← Created events on LLMISVC
-   └── HTTP route                 ← Created events on LLMISVC
+   ├── (dynamic sub-steps from Created events)
 3. Model workload
-   ├── Pod scheduled              ← Pod event for <name>-kserve-* pod
-   ├── Model downloaded           ← storage-initializer completed
-   └── Model server started       ← main container running
+   ├── Pod scheduled
+   ├── Model downloaded
+   └── Model server started
 4. Router / scheduler
-   ├── Pod scheduled              ← Pod event for <name>-kserve-router-scheduler-* pod
-   ├── Tokenizer ready            ← tokenizer container running
-   └── Scheduler started          ← main container running
-5. Presets combined               ← condition PresetsCombined: True
-6. Deployment ready               ← condition Ready: True
+   ├── Pod scheduled
+   ├── Tokenizer ready
+   ├── Scheduler started
+   ├── HTTP routes ready
+   └── Inference pool ready
+5. Presets combined
+6. Deployment ready
 ```
 
-| Step | Signal source |
-|------|---------------|
-| Deployment requested | LLMISVC exists and not stopped |
-| Resources created | LLMISVC events `reason=Created` (one per child resource) |
-| Model workload | Condition `MainWorkloadReady: True` |
-| Router / scheduler | Conditions `SchedulerWorkloadReady: True` + `HTTPRoutesReady: True` + `InferencePoolReady: True` |
-| Presets combined | `status.conditions[PresetsCombined].status = True` |
-| Deployment ready | `status.conditions[Ready].status = True` |
+Steps 3 and 4 progress independently — the model workload may be ready while the router is still starting, or vice versa.
 
-**Error steps** (shown only when relevant):
-- Pod scheduling failed → replaces "Pod scheduled" in either workload section
-- Model server crashed → replaces "Model server started" (model pod `BackOff`/`Unhealthy`)
-- Scheduler crashed → replaces "Scheduler started" (router pod `BackOff`)
-- Progress deadline exceeded → timeout on model workload or router (Deployment `reason=ProgressDeadlineExceeded`)
-- Gateway not ready → replaces "HTTP route" (`GatewaysNotReady`)
-
-**Note:** Steps 3 and 4 can progress independently — the model workload may be ready while the router is still starting, or vice versa.
+| Step | Sub-step | Success signal | Error signal | Fallback (events expired) |
+|------|----------|---------------|-------------|--------------------------|
+| **Deployment requested** | | LLMISVC exists, `stop` annotation absent | — | Always derivable |
+| **Resources created** | | LLMISVC events `reason=Created` exist, or any `status.conditions` present | — | `status.conditions` length > 0 → resources were created |
+| | *(dynamic)* | One sub-step per LLMISVC event `reason=Created`; title = `event.message` (e.g. `"Created v1.Deployment emily/llmd-cpu-kserve"`) | — | Events expire; parent still shows success from conditions |
+| **Model workload** | | All children green, or `MainWorkloadReady: True` | Any child red, or `MainWorkloadReady.reason = ProgressDeadlineExceeded\|MinimumReplicasUnavailable`; description from `MainWorkloadReady.message` | `MainWorkloadReady: True` → all children green |
+| | Pod scheduled | Model pod event `reason=Scheduled` (pod name matches `<name>-kserve-*`, excludes `router-scheduler`) | Model pod event `reason=FailedScheduling` | `MainWorkloadReady: True` |
+| | Model downloaded | Model pod event `reason=Started` where `message` contains `storage-initializer` | — | `MainWorkloadReady: True` |
+| | Model server started | Model pod event `reason=Started` where `message` contains `main` | Model pod event `reason=BackOff\|Unhealthy` where `message` contains `main` | `MainWorkloadReady: True` |
+| **Router / scheduler** | | All children green, or `RouterReady: True` | Any child red, or `RouterReady.reason = ProgressDeadlineExceeded`; description from `RouterReady.message` | `RouterReady: True` → all children green |
+| | Pod scheduled | Router pod event `reason=Scheduled` (pod name matches `<name>-kserve-router-scheduler-*`) | Router pod event `reason=FailedScheduling` | `RouterReady: True` |
+| | Tokenizer ready | Router pod event `reason=Started` where `message` contains `tokenizer` | — | `RouterReady: True` |
+| | Scheduler started | Router pod event `reason=Started` where `message` contains `main` | Router pod event `reason=BackOff\|Unhealthy` where `message` contains `main` | `RouterReady: True` |
+| | HTTP routes ready | `status.conditions[HTTPRoutesReady].status = "True"` | `HTTPRoutesReady.status = "False"` | Always derivable from LLMISVC status |
+| | Inference pool ready | `status.conditions[InferencePoolReady].status = "True"` | `InferencePoolReady.status = "False"` | Always derivable from LLMISVC status |
+| **Presets combined** | | `status.conditions[PresetsCombined].status = "True"` | `PresetsCombined.status = "False"` | Always derivable from LLMISVC status |
+| **Deployment ready** | | `status.conditions[Ready].status = "True"` | `Ready.status = "False"` and not stopped; description from `Ready.message` | Always derivable from LLMISVC status |
 
 ---
 

--- a/packages/model-serving/docs/deployment-status-nimservice.md
+++ b/packages/model-serving/docs/deployment-status-nimservice.md
@@ -1,0 +1,207 @@
+# Deployment Status — NIMService (NVIDIA NIM)
+
+**API:** `apps.nvidia.com/v1alpha1` `NIMService`
+**Controller:** `k8s-nim-operator` (separate from KServe)
+
+## TL;DR — Progress Steps
+
+```
+1. Deployment requested
+2. NIM provisioning
+   ├── Cache PVC created          ← NIMService condition NIM_CACHE_PVC_CREATED: True
+   └── InferenceService created   ← child ISVC exists in namespace
+3. Model resources
+   ├── Pod scheduled              ← Pod event on child ISVC pod
+   ├── Model downloaded           ← storage-initializer completed
+   ├── Model server started       ← kserve-container running
+   └── Auth proxy started         ← kube-rbac-proxy running
+4. Model loaded                   ← child ISVC modelStatus.activeModelState = Loaded
+5. Ingress ready                  ← child ISVC condition IngressReady: True
+6. Deployment ready               ← NIMService condition Ready: True
+```
+
+| Step | Signal source |
+|------|---------------|
+| Deployment requested | NIMService exists |
+| Cache PVC created | `status.conditions[NIM_CACHE_PVC_CREATED].status = True` (may be absent if PVC is user-provided) |
+| InferenceService created | Child ISVC with same name exists in namespace |
+| Model resources | Same Pod events as InferenceService (via child ISVC pods) |
+| Model loaded | Child ISVC `status.modelStatus.states.activeModelState = Loaded` |
+| Ingress ready | Child ISVC `status.conditions[IngressReady].status = True` |
+| Deployment ready | NIMService `status.conditions[Ready].status = True` |
+
+**Error steps** (shown only when relevant):
+- PVC creation failed → replaces "Cache PVC created"
+- InferenceService failed → NIMService event `reason=Failed` with message
+- Pod scheduling failed → same as InferenceService
+- Model download/server failures → same as InferenceService (via child ISVC)
+
+**Note:** Step 2 is unique to NIM — the operator must provision the PVC and InferenceService before the standard KServe Pod lifecycle begins. Steps 3–5 are identical to InferenceService, sourced from the child ISVC.
+
+---
+
+NIMService is a **wrapper** around InferenceService. It creates and manages a child InferenceService, which in turn creates the Deployment, Pods, Services, and HPA. The NIM layer adds PVC lifecycle management for model caching and a simplified status view.
+
+## Resource Chain
+
+```
+NIMService
+├── InferenceService (same name, same namespace — created by NIM operator)
+│   ├── Deployment (<name>-predictor)
+│   │   └── ReplicaSet → Pod(s)
+│   │       ├── storage-initializer (init) — model download
+│   │       ├── kserve-container — NIM runtime
+│   │       ├── kube-rbac-proxy — auth proxy sidecar
+│   │       └── agent — kserve model agent
+│   ├── Service (<name>-predictor)
+│   ├── Service (<name>-metrics)
+│   ├── HorizontalPodAutoscaler (<name>-predictor)
+│   └── [all standard InferenceService child resources]
+├── PersistentVolumeClaim (optional — NIM model cache)
+├── ServiceAccount
+├── Role / RoleBinding
+└── ServiceMonitor (optional)
+```
+
+NIMService does **not** create Deployments directly — it delegates entirely to the child InferenceService for workload management.
+
+## Status Conditions
+
+### On NIMService
+
+| Condition | Meaning |
+|-----------|---------|
+| `Ready` | Top-level readiness — True when child InferenceService predictor is ready |
+| `Failed` | True on hard failure; False when ready |
+| `NIM_CACHE_PVC_CREATED` | PVC for NIM model cache created successfully |
+
+**`status.state`**: Parallel simple enum — `Ready`, `NotReady`, or `Failed`.
+
+### How NIMService Ready is Computed
+
+NIMService checks the child **InferenceService's `PredictorReady`** condition (not top-level `Ready`):
+
+```
+NIMService Ready = InferenceService.status.conditions[PredictorReady].status == True
+```
+
+When the child ISVC predictor is ready, NIMService emits a `Ready` event with the Deployment's progress message.
+
+### On the Child InferenceService
+
+The child InferenceService has the **full InferenceService condition set** and `modelStatus`:
+
+| Condition | Meaning |
+|-----------|---------|
+| `Ready` | Full ISVC readiness (PredictorReady + IngressReady) |
+| `PredictorReady` | Deployment available |
+| `IngressReady` | Network path established |
+| `LatestDeploymentReady` | Latest Deployment revision ready |
+| `Stopped` | Force-stop active |
+
+Plus the full `modelStatus` subsystem (see [InferenceService doc](./deployment-status-inferenceservice.md)).
+
+### Common NIMService Failure Reasons
+
+| Reason (on `Ready`/`Failed`) | Meaning |
+|-------------------------------|---------|
+| `Ready` | Deployment rolled out successfully |
+| `NotReady` | Predictor not yet ready (message includes Deployment status) |
+| `NIMCacheNotReady` | NIM model cache PVC not ready |
+| `InferenceServiceFailed` | Child InferenceService failed |
+| `ServiceAccountFailed` | ServiceAccount creation failed |
+| `PVCCreated` | PVC created (on `NIM_CACHE_PVC_CREATED` condition) |
+
+## Model Status
+
+NIMService itself does **not** have a `modelStatus` field. However, the child InferenceService **does** have the full `modelStatus` subsystem:
+
+```
+InferenceService (child).status.modelStatus:
+  transitionStatus:  UpToDate | InProgress | BlockedByFailedLoad
+  states:
+    activeModelState:  Loaded | Pending | FailedToLoad
+    targetModelState:  Loaded | Pending | FailedToLoad
+  lastFailureInfo:
+    reason:   ModelLoadFailed | RuntimeUnhealthy | ...
+    exitCode: <int32>
+  copies:
+    totalCopies: <int>
+    failedCopies: <int>
+```
+
+To get detailed model loading diagnostics for NIM deployments, read the child InferenceService's `modelStatus`, not the NIMService status.
+
+## Events
+
+### On NIMService CR (emitted by k8s-nim-operator)
+
+| Reason | Type | Message pattern |
+|--------|------|-----------------|
+| `Ready` | Normal | `NIMService <name> ready, msg: <deployment message>` |
+| `NotReady` | Normal | `NIMService <name> not ready yet, msg: <deployment message>` |
+| `Failed` | Warning | `NIMService <name> failed, msg: <error>` |
+| `ReconcileFailed` | Warning | Reconciliation error |
+| `Delete` | Normal | Deletion lifecycle |
+
+### On Child InferenceService
+
+Same events as a standalone InferenceService:
+
+| Reason | Type | Message |
+|--------|------|---------|
+| `InferenceServiceReady` | Normal | `InferenceService [<name>] is Ready` |
+| `InferenceServiceNotReady` | Warning | `InferenceService [<name>] is no longer Ready because of: <conditions>` |
+
+### On Pods
+
+Standard kubelet events (Scheduled, Pulling, Pulled, Created, Started, BackOff, Unhealthy, etc.) — identical to InferenceService pods.
+
+## Event Filtering Strategy
+
+NIMService events come from two levels:
+
+1. **NIMService-level:** `involvedObject.kind=NIMService,involvedObject.name=<name>` — gives Ready/NotReady/Failed lifecycle
+2. **Child InferenceService-level:** `involvedObject.kind=InferenceService,involvedObject.name=<name>` — gives ISVC Ready/NotReady transitions
+3. **Pod-level:** Same strategy as InferenceService — filter by latest ReplicaSet pods
+
+## Two-Layer Status
+
+When displaying NIMService status, there are two complementary layers:
+
+### Layer 1: NIMService (simplified view)
+
+- `status.state`: `Ready` / `NotReady` / `Failed`
+- `status.conditions[Ready]`: single readiness signal
+- `status.conditions[NIM_CACHE_PVC_CREATED]`: PVC lifecycle
+- NIMService events: `Ready`/`NotReady`/`Failed` with summary messages
+
+### Layer 2: Child InferenceService (detailed view)
+
+- Full condition set (`PredictorReady`, `IngressReady`, `LatestDeploymentReady`, `Stopped`)
+- Full `modelStatus` (loading state machine, failure info with exit codes)
+- Pod-level events (container pulls, crashes, probe failures)
+
+A status component for NIM should show Layer 1 as the summary and allow drilling into Layer 2 for diagnostics.
+
+## Stopped State
+
+NIMService respects the same stop mechanism as InferenceService:
+- `metadata.annotations['serving.kserve.io/stop']` on the child InferenceService
+- NIMService `Ready` condition goes False
+- `status.state` becomes `NotReady`
+- Child ISVC shows `Stopped: True`
+
+## NIM-Specific Considerations
+
+### PVC Lifecycle
+
+NIM models are typically large (10–100+ GB). The `NIM_CACHE_PVC_CREATED` condition tracks whether the cache PVC was successfully created. PVC binding may take time if using `WaitForFirstConsumer` storage class (the PVC won't bind until a Pod is scheduled that references it).
+
+### Model Cache Reuse
+
+NIM deployments may reuse a pre-existing PVC (`existing-pvc-mock-nim` pattern). In this case, `NIM_CACHE_PVC_CREATED` may not be present since the PVC was user-provided.
+
+### Restart Counts
+
+NIM containers can have high restart counts during initial model loading since NIM runtime images often need to download and convert model weights on first start. A `CrashLoopBackOff` during the first few minutes may be normal behavior, not a permanent failure. The `modelStatus.lastFailureInfo.exitCode` from the child InferenceService helps distinguish expected startup crashes from real errors.

--- a/packages/model-serving/docs/deployment-status-nimservice.md
+++ b/packages/model-serving/docs/deployment-status-nimservice.md
@@ -8,35 +8,34 @@
 ```
 1. Deployment requested
 2. NIM provisioning
-   ├── Cache PVC created          ← NIMService condition NIM_CACHE_PVC_CREATED: True
-   └── InferenceService created   ← child ISVC exists in namespace
+   ├── Cache PVC created
+   └── InferenceService created
 3. Model resources
-   ├── Pod scheduled              ← Pod event on child ISVC pod
-   ├── Model downloaded           ← storage-initializer completed
-   ├── Model server started       ← kserve-container running
-   └── Auth proxy started         ← kube-rbac-proxy running
-4. Model loaded                   ← child ISVC modelStatus.activeModelState = Loaded
-5. Ingress ready                  ← child ISVC condition IngressReady: True
-6. Deployment ready               ← NIMService condition Ready: True
+   ├── Pod scheduled
+   ├── Model downloaded
+   ├── Model server started
+   └── Auth proxy started
+4. Model loaded
+5. Ingress ready
+6. Deployment ready
 ```
 
-| Step | Signal source |
-|------|---------------|
-| Deployment requested | NIMService exists |
-| Cache PVC created | `status.conditions[NIM_CACHE_PVC_CREATED].status = True` (may be absent if PVC is user-provided) |
-| InferenceService created | Child ISVC with same name exists in namespace |
-| Model resources | Same Pod events as InferenceService (via child ISVC pods) |
-| Model loaded | Child ISVC `status.modelStatus.states.activeModelState = Loaded` |
-| Ingress ready | Child ISVC `status.conditions[IngressReady].status = True` |
-| Deployment ready | NIMService `status.conditions[Ready].status = True` |
+Step 2 is unique to NIM — the operator must provision the PVC and InferenceService before the standard KServe Pod lifecycle begins. Steps 3–5 are identical to InferenceService, sourced from the child ISVC.
 
-**Error steps** (shown only when relevant):
-- PVC creation failed → replaces "Cache PVC created"
-- InferenceService failed → NIMService event `reason=Failed` with message
-- Pod scheduling failed → same as InferenceService
-- Model download/server failures → same as InferenceService (via child ISVC)
-
-**Note:** Step 2 is unique to NIM — the operator must provision the PVC and InferenceService before the standard KServe Pod lifecycle begins. Steps 3–5 are identical to InferenceService, sourced from the child ISVC.
+| Step | Sub-step | Success signal | Error signal | Fallback (events expired) |
+|------|----------|---------------|-------------|--------------------------|
+| **Deployment requested** | | NIMService exists | — | Always derivable |
+| **NIM provisioning** | | Both children green | Either child red | Always derivable from NIMService/ISVC status |
+| | Cache PVC created | NIMService `status.conditions[NIM_CACHE_PVC_CREATED].status = "True"` | `NIM_CACHE_PVC_CREATED.status = "False"` | May be absent if PVC is user-provided (skip step) |
+| | InferenceService created | Child ISVC with same name exists in namespace | NIMService event `reason=Failed` | Watch for child ISVC resource existence |
+| **Model resources** | | All children green | Any child red, or child ISVC `PredictorReady.reason = ProgressDeadlineExceeded` | Child ISVC `PredictorReady: True` → all children green |
+| | Pod scheduled | Pod event `reason=Scheduled` on child ISVC pod | Pod event `reason=FailedScheduling` | Child ISVC `PredictorReady: True` or `modelStatus = Loaded` |
+| | Model downloaded | Pod event `reason=Started` where `message` contains `storage-initializer` | Pod event `reason=BackOff` where `message` contains `storage-initializer` | Child ISVC `PredictorReady: True` or `modelStatus = Loaded` |
+| | Model server started | Pod event `reason=Started` where `message` contains `kserve-container` | Pod event `reason=BackOff\|Unhealthy` where `message` contains `kserve-container`; also child ISVC `modelStatus.lastFailureInfo.message` | Child ISVC `PredictorReady: True` or `modelStatus = Loaded` |
+| | Auth proxy started | Pod event `reason=Started` where `message` contains `kube-rbac-proxy` or `oauth-proxy` | — | Child ISVC `PredictorReady: True` or `modelStatus = Loaded` |
+| **Model loaded** | | Child ISVC `status.modelStatus.states.activeModelState = "Loaded"` | `targetModelState = "FailedToLoad"`; description from `lastFailureInfo.reason` | Always derivable from child ISVC status |
+| **Ingress ready** | | Child ISVC `status.conditions[IngressReady].status = "True"` | — | Always derivable from child ISVC status |
+| **Deployment ready** | | NIMService `status.conditions[Ready].status = "True"` | `Ready.status = "False"`; description from NIMService event `reason=NotReady\|Failed` | Always derivable from NIMService status |
 
 ---
 

--- a/packages/model-serving/docs/deployment-status-overview.md
+++ b/packages/model-serving/docs/deployment-status-overview.md
@@ -1,0 +1,114 @@
+# Model Serving Deployment Status — Overview
+
+## Purpose
+
+This document describes how model serving deployment statuses work at the Kubernetes level, what resources and signals are available, and how the dashboard can surface them to users. It serves as the technical foundation for building a deployment status component analogous to the existing Notebook "Workbench status" modal.
+
+## Comparison with Notebook Status
+
+The existing Workbench status modal for Notebooks derives its entire progress view from **raw `v1/Event` objects** mapped to a fixed linear checklist. This works because Notebooks have a single StatefulSet with one Pod containing two containers.
+
+Model serving deployments are fundamentally different:
+
+| Aspect | Notebook | Model Serving Deployment |
+|--------|----------|--------------------------|
+| Primary resource | `Notebook` (StatefulSet) | `InferenceService`, `LLMInferenceService`, or `NIMService` |
+| Status conditions | None (event-derived) | Rich structured condition hierarchy |
+| Model loading state | N/A | `modelStatus` state machine (ISVC only) |
+| Child Deployments | 0 (StatefulSet) | 1–2+ Deployments |
+| Containers per Pod | 2 (notebook + proxy) | 3–4 (init + model + proxy + agent) |
+| Pod replicas | Always 1 | Configurable, often >1 |
+| Controller events on CR | None | `Created`/`Deleted`/`Updated` (LLMISVC), `Ready`/`NotReady` (ISVC, NIM) |
+
+## Data Sources (Kubernetes)
+
+### 1. Status Conditions (primary signal)
+
+Every model serving CR has `status.conditions[]` — a list of typed conditions with `status`, `reason`, `message`, and `lastTransitionTime`. This is the **primary structured signal** for deployment health.
+
+- **InferenceService:** 2-level rollup (`PredictorReady` + `IngressReady` → `Ready`)
+- **LLMInferenceService:** 3-level hierarchy (8+ conditions rolling up to `Ready`)
+- **NIMService:** Simple `Ready` + `Failed` + optional `NIM_CACHE_PVC_CREATED` AND what **InferenceService** has
+
+### 2. Model Status (InferenceService only)
+
+`status.modelStatus` provides a state machine for model loading lifecycle:
+
+```
+transitionStatus:  UpToDate | InProgress | BlockedByFailedLoad | InvalidSpec
+states:
+  activeModelState:  Loaded | Pending | Loading | FailedToLoad | Standby
+  targetModelState:  (same enum)
+lastFailureInfo:
+  reason:   ModelLoadFailed | RuntimeUnhealthy | RuntimeDisabled | ...
+  exitCode: <int32>
+  message:  <string>
+copies:
+  totalCopies:  <int>
+  failedCopies: <int>
+```
+
+### 3. Events (`v1/Event`)
+
+Events are created **in the same namespace** as the involved object. Relevant event sources:
+
+| Source | `involvedObject.kind` | Key reasons |
+|--------|----------------------|-------------|
+| KServe controller | `InferenceService` | `InferenceServiceReady`, `InferenceServiceNotReady` |
+| KServe LLMISVC controller | `LLMInferenceService` | `Created`, `Updated`, `Deleted` (per child resource) |
+| NIM operator | `NIMService` | `Ready`, `NotReady`, `Failed` |
+| Kubelet | `Pod` | `Scheduled`, `Pulling`, `Pulled`, `Created`, `Started`, `BackOff`, `Unhealthy`, `FailedMount` |
+| Deployment controller | `Deployment` | `ScalingReplicaSet` |
+| ReplicaSet controller | `ReplicaSet` | `SuccessfulCreate` |
+| HPA controller | `HorizontalPodAutoscaler` | `FailedGetResourceMetric`, `FailedComputeMetricsReplicas` |
+
+### 4. Child Resource Status
+
+Deployment `.status.conditions` (particularly `Available` and `Progressing`) provide direct health signals. The `ProgressDeadlineExceeded` reason on `Progressing` is the canonical "stuck" indicator.
+
+## Platform-Specific Details
+
+Each platform has its own resource chain, condition set, and event patterns:
+
+- [InferenceService (KServe Standard)](./deployment-status-inferenceservice.md)
+- [LLMInferenceService (LLM-D / Disaggregated Serving)](./deployment-status-llminferenceservice.md)
+- [NIMService (NVIDIA NIM)](./deployment-status-nimservice.md)
+
+## Design Considerations for the UI
+
+### Conditions as primary data source
+
+Unlike notebooks (which have no conditions and derive everything from Pod events), model serving CRs have rich structured conditions. The status component should use `status.conditions` as the backbone.
+
+### Platform-agnostic structure
+
+A shared status component could have:
+
+- **Header:** status label (from top-level `Ready` condition) + deployment name
+- **Conditions tab:** render the condition tree (flat for ISVC, hierarchical for LLMISVC)
+- **Model status tab** (ISVC/NIM only): loading state visualization
+- **Events tab:** raw events log (same pattern as notebook's events log)
+
+### Multi-Deployment awareness
+
+LLMInferenceService has multiple Deployments (model + router-scheduler). The condition hierarchy already aggregates these, but a detailed view may want per-deployment breakdowns.
+
+### Replica deduplication
+
+With multiple Pods, event filtering needs to target the **latest ReplicaSet** per Deployment. Stale ReplicaSets from previous rollouts produce irrelevant events.
+
+### Controller vs Pod events
+
+- **Controller events** (on the CR itself) provide high-level lifecycle milestones
+- **Pod events** (on individual Pods) provide container-level detail (image pulls, probe failures, crashes)
+- Both are valuable at different zoom levels
+
+## Controllers Involved
+
+Two controllers set status on model serving resources:
+
+| Controller | Manages |
+|------------|---------|
+| **KServe** (`kserve` repo) | `InferenceService` conditions, `modelStatus`, `LLMInferenceService` conditions, child resource CRUD events |
+| **odh-model-controller** | Auxiliary resources (OpenShift Route, metrics Service/ServiceMonitor, KEDA, ClusterRoleBinding); `LatestDeploymentReady` condition with `AuthProxyPreserved` reason; `ReconcileError` events on LLMISVC/Gateway |
+| **k8s-nim-operator** | `NIMService` conditions and events; delegates to child `InferenceService` |

--- a/packages/model-serving/extension-points/index.ts
+++ b/packages/model-serving/extension-points/index.ts
@@ -533,3 +533,29 @@ export const isModelServingExcludeDeployment = (
   extension: Extension,
 ): extension is ModelServingExcludeDeploymentExtension =>
   extension.type === 'model-serving.platform/exclude-deployment';
+
+//// Deployment progress steps (status modal)
+
+export type DeploymentProgressStepStatus = 'pending' | 'success' | 'danger' | 'warning' | 'info';
+
+export type DeploymentProgressStep = {
+  id: string;
+  title: string;
+  status: DeploymentProgressStepStatus;
+  description?: string;
+  children?: DeploymentProgressStep[];
+};
+
+export type ModelServingDeploymentProgressStepsExtension<D extends Deployment = Deployment> =
+  Extension<
+    'model-serving.deployment/progress-steps',
+    {
+      platform: D['modelServingPlatformId'];
+      useProgressSteps: CodeRef<(deployment: D) => DeploymentProgressStep[]>;
+    }
+  >;
+
+export const isModelServingDeploymentProgressSteps = <D extends Deployment = Deployment>(
+  extension: Extension,
+): extension is ModelServingDeploymentProgressStepsExtension<D> =>
+  extension.type === 'model-serving.deployment/progress-steps';

--- a/packages/model-serving/package.json
+++ b/packages/model-serving/package.json
@@ -23,6 +23,7 @@
     "./types/form-data": "./src/components/deploymentWizard/types.ts",
     "./concepts/auth": "./src/concepts/auth.ts",
     "./concepts/useModelServingClusterSettings": "./src/concepts/useModelServingClusterSettings.tsx",
+    "./concepts/useWatchDeploymentEvents": "./src/concepts/useWatchDeploymentEvents.ts",
     "./utils": "./src/concepts/utils.ts"
   },
   "dependencies": {

--- a/packages/model-serving/src/components/deployments/DeploymentEventLog.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentEventLog.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import {
+  Checkbox,
+  Content,
+  List,
+  ListItem,
+  Panel,
+  PanelMain,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import {
+  filterDeploymentEvents,
+  getDeploymentEventFilters,
+  getEventFullMessage,
+  getEventTimestamp,
+} from '../../concepts/useWatchDeploymentEvents';
+
+type DeploymentEventLogProps = {
+  events: EventKind[];
+  deploymentName: string;
+  loaded: boolean;
+};
+
+const DeploymentEventLog: React.FC<DeploymentEventLogProps> = ({
+  events,
+  deploymentName,
+  loaded,
+}) => {
+  const filters = React.useMemo(() => getDeploymentEventFilters(deploymentName), [deploymentName]);
+
+  const [activeFilterIds, setActiveFilterIds] = React.useState<Set<string>>(
+    () => new Set(['cr', 'pod']),
+  );
+
+  const toggleFilter = React.useCallback((filterId: string, checked: boolean) => {
+    setActiveFilterIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(filterId);
+      } else {
+        next.delete(filterId);
+      }
+      return next;
+    });
+  }, []);
+
+  const filteredEvents = React.useMemo(
+    () =>
+      filterDeploymentEvents(events, deploymentName, activeFilterIds).toSorted(
+        (a, b) =>
+          new Date(getEventTimestamp(b)).getTime() - new Date(getEventTimestamp(a)).getTime(),
+      ),
+    [events, deploymentName, activeFilterIds],
+  );
+
+  return (
+    <>
+      <Toolbar isSticky>
+        <ToolbarContent>
+          {filters.map((filter) => (
+            <ToolbarItem key={filter.id}>
+              <Checkbox
+                id={`event-filter-${filter.id}`}
+                label={filter.label}
+                isChecked={activeFilterIds.has(filter.id)}
+                onChange={(_event, checked) => toggleFilter(filter.id, checked)}
+              />
+            </ToolbarItem>
+          ))}
+        </ToolbarContent>
+      </Toolbar>
+      <Panel isScrollable>
+        <PanelMain>
+          {!loaded ? (
+            <Content>Loading events...</Content>
+          ) : filteredEvents.length === 0 ? (
+            <Content data-testid="no-events-message">No matching events found.</Content>
+          ) : (
+            <List isPlain isBordered data-testid="deployment-event-logs">
+              {filteredEvents.map((event, index) => (
+                <ListItem key={event.metadata.uid ?? `event-${index}`}>
+                  {getEventFullMessage(event)}
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </PanelMain>
+      </Panel>
+    </>
+  );
+};
+
+export default DeploymentEventLog;

--- a/packages/model-serving/src/components/deployments/DeploymentLogsTab.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentLogsTab.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { Button, Content, Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { SyncAltIcon } from '@patternfly/react-icons';
+import { PodKind } from '@odh-dashboard/internal/k8sTypes';
+import { PodModel } from '@odh-dashboard/internal/api/models/k8s';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
+import { getPodContainerLogText } from '@odh-dashboard/internal/api/k8s/pods';
+import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+
+const TAIL_LINES = 500;
+
+type DeploymentLogsTabProps = {
+  namespace: string;
+  deploymentName: string;
+};
+
+type ContainerInfo = {
+  name: string;
+  isInit: boolean;
+};
+
+const getContainersForPod = (pod: PodKind): ContainerInfo[] => {
+  const initContainers = (pod.spec.initContainers ?? []).map((c) => ({
+    name: c.name,
+    isInit: true,
+  }));
+  const containers = pod.spec.containers.map((c) => ({
+    name: c.name,
+    isInit: false,
+  }));
+  return [...initContainers, ...containers];
+};
+
+const useDeploymentPods = (namespace: string, deploymentName: string): [PodKind[], boolean] => {
+  const [pods, loaded] = useK8sWatchResourceList<PodKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(PodModel),
+      namespace,
+    },
+    PodModel,
+  );
+
+  const filteredPods = React.useMemo(
+    () => pods.filter((pod) => pod.metadata.name.startsWith(`${deploymentName}-`)),
+    [pods, deploymentName],
+  );
+
+  return [filteredPods, loaded];
+};
+
+const DeploymentLogsTab: React.FC<DeploymentLogsTabProps> = ({ namespace, deploymentName }) => {
+  const [pods, podsLoaded] = useDeploymentPods(namespace, deploymentName);
+  const [selectedPodName, setSelectedPodName] = React.useState<string | undefined>();
+  const [selectedContainer, setSelectedContainer] = React.useState<string | undefined>();
+  const [logs, setLogs] = React.useState<string>('');
+  const [logsLoading, setLogsLoading] = React.useState(false);
+  const [logsError, setLogsError] = React.useState<string | undefined>();
+
+  const selectedPod = React.useMemo(
+    () => pods.find((p) => p.metadata.name === selectedPodName),
+    [pods, selectedPodName],
+  );
+
+  const containers = React.useMemo(
+    () => (selectedPod ? getContainersForPod(selectedPod) : []),
+    [selectedPod],
+  );
+
+  React.useEffect(() => {
+    if (!selectedPodName && pods.length > 0) {
+      setSelectedPodName(pods[0].metadata.name);
+    }
+  }, [pods, selectedPodName]);
+
+  React.useEffect(() => {
+    if (containers.length > 0 && !containers.some((c) => c.name === selectedContainer)) {
+      const mainContainer = containers.find((c) => !c.isInit);
+      setSelectedContainer(mainContainer?.name ?? containers[0].name);
+    }
+  }, [containers, selectedContainer]);
+
+  const fetchLogs = React.useCallback(() => {
+    if (!selectedPodName || !selectedContainer) {
+      return;
+    }
+    setLogsLoading(true);
+    setLogsError(undefined);
+    getPodContainerLogText(namespace, selectedPodName, selectedContainer, TAIL_LINES)
+      .then((text) => {
+        setLogs(text);
+        setLogsLoading(false);
+      })
+      .catch((err: unknown) => {
+        setLogsError(err instanceof Error ? err.message : String(err));
+        setLogs('');
+        setLogsLoading(false);
+      });
+  }, [namespace, selectedPodName, selectedContainer]);
+
+  React.useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
+
+  if (!podsLoaded) {
+    return (
+      <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+        <Spinner size="lg" />
+      </Flex>
+    );
+  }
+
+  if (pods.length === 0) {
+    return <Content data-testid="no-pods-message">No pods found for this deployment.</Content>;
+  }
+
+  const podOptions = pods.map((pod) => ({
+    key: pod.metadata.name,
+    label: pod.metadata.name,
+  }));
+
+  const containerOptions = containers.map((c) => ({
+    key: c.name,
+    label: c.isInit ? `${c.name} (init)` : c.name,
+  }));
+
+  return (
+    <Flex direction={{ default: 'column' }} style={{ height: '100%' }} gap={{ default: 'gapSm' }}>
+      <FlexItem>
+        <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>
+            <SimpleSelect
+              options={podOptions}
+              value={selectedPodName}
+              onChange={(key) => setSelectedPodName(key)}
+              placeholder="Select pod"
+              dataTestId="pod-selector"
+              popperProps={{ maxWidth: undefined }}
+            />
+          </FlexItem>
+          <FlexItem>
+            <SimpleSelect
+              options={containerOptions}
+              value={selectedContainer}
+              onChange={(key) => setSelectedContainer(key)}
+              placeholder="Select container"
+              dataTestId="container-selector"
+              popperProps={{ maxWidth: undefined }}
+            />
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="plain"
+              aria-label="Refresh logs"
+              onClick={fetchLogs}
+              isDisabled={logsLoading}
+              data-testid="refresh-logs"
+            >
+              <SyncAltIcon />
+            </Button>
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+      <FlexItem flex={{ default: 'flex_1' }} style={{ minHeight: 0, overflow: 'auto' }}>
+        {logsLoading ? (
+          <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+            <Spinner size="lg" />
+          </Flex>
+        ) : logsError ? (
+          <Content data-testid="logs-error">Failed to load logs: {logsError}</Content>
+        ) : (
+          <pre
+            data-testid="deployment-logs-content"
+            style={{
+              margin: 0,
+              padding: 'var(--pf-t--global--spacer--sm)',
+              fontSize: 'var(--pf-t--global--font--size--sm)',
+              whiteSpace: 'pre',
+              backgroundColor: 'var(--pf-t--global--background--color--secondary--default)',
+              height: '100%',
+              overflow: 'auto',
+            }}
+          >
+            {logs || 'No logs available.'}
+          </pre>
+        )}
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default DeploymentLogsTab;

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.scss
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.scss
@@ -1,0 +1,13 @@
+.deployment-status-modal {
+  &__content-height {
+    height: 500px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__filled-stack-item {
+    overflow-y: auto;
+    min-height: 0;
+  }
+}

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -1,0 +1,192 @@
+/* eslint-disable @odh-dashboard/no-restricted-imports */
+import React from 'react';
+import {
+  Content,
+  Flex,
+  FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  ProgressStep,
+  ProgressStepper,
+  ProgressStepVariant,
+  Stack,
+  StackItem,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
+import { ResolvedExtension } from '@openshift/dynamic-plugin-sdk';
+import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/ModelStatusIcon';
+import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
+import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
+import DeploymentEventLog from './DeploymentEventLog';
+import { useResolvedDeploymentExtension } from '../../concepts/extensionUtils';
+import { useWatchDeploymentEvents } from '../../concepts/useWatchDeploymentEvents';
+import {
+  Deployment,
+  DeploymentProgressStep,
+  isModelServingDeploymentProgressSteps,
+  ModelServingDeploymentProgressStepsExtension,
+} from '../../../extension-points';
+import './DeploymentStatusModal.scss';
+
+const PROGRESS_TAB = 'Progress';
+const EVENT_LOG_TAB = 'Events log';
+
+const progressStepVariants: Record<DeploymentProgressStep['status'], ProgressStepVariant> = {
+  pending: ProgressStepVariant.pending,
+  success: ProgressStepVariant.success,
+  danger: ProgressStepVariant.danger,
+  warning: ProgressStepVariant.warning,
+  info: ProgressStepVariant.info,
+};
+
+type DeploymentStatusModalProps = {
+  deployment: Deployment;
+  onClose: () => void;
+  buttons: React.ReactNode;
+};
+
+const ProgressStepsList: React.FC<{ steps: DeploymentProgressStep[] }> = ({ steps }) => (
+  <ProgressStepper isVertical data-testid="deployment-progress-steps">
+    {steps.map((step) => (
+      <ProgressStep
+        key={step.id}
+        variant={progressStepVariants[step.status]}
+        aria-label={step.status}
+        id={step.id}
+        titleId={`${step.id}-title`}
+        description={step.description}
+        data-testid={`progress-step-${step.id}`}
+      >
+        {step.title}
+        {step.children && step.children.length > 0 ? (
+          <ProgressStepsList steps={step.children} />
+        ) : null}
+      </ProgressStep>
+    ))}
+  </ProgressStepper>
+);
+
+type ResolvedProgressTabProps = {
+  deployment: Deployment;
+  extension: ResolvedExtension<ModelServingDeploymentProgressStepsExtension>;
+};
+
+const ResolvedProgressTab: React.FC<ResolvedProgressTabProps> = ({ deployment, extension }) => {
+  const progressSteps = extension.properties.useProgressSteps(deployment);
+
+  if (progressSteps.length === 0) {
+    return (
+      <Content data-testid="no-progress-steps">
+        No progress information available for this deployment.
+      </Content>
+    );
+  }
+
+  return (
+    <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }} style={{ height: '100%' }}>
+      <FlexItem flex={{ default: 'flex_1' }} style={{ overflowY: 'scroll', minHeight: 0 }}>
+        <ProgressStepsList steps={progressSteps} />
+      </FlexItem>
+    </Flex>
+  );
+};
+
+const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
+  deployment,
+  onClose,
+  buttons,
+}) => {
+  const [activeTab, setActiveTab] = React.useState<string>(PROGRESS_TAB);
+  const { namespace } = deployment.model.metadata;
+  const { name: deploymentName } = deployment.model.metadata;
+
+  const [progressStepsExtension, extensionLoaded] = useResolvedDeploymentExtension(
+    isModelServingDeploymentProgressSteps,
+    deployment,
+  );
+
+  const [events, eventsLoaded] = useWatchDeploymentEvents(namespace);
+
+  const renderProgress = () => {
+    if (!extensionLoaded) {
+      return <Content>Loading progress...</Content>;
+    }
+    if (!progressStepsExtension) {
+      return (
+        <Content data-testid="no-progress-steps">
+          No progress information available for this deployment.
+        </Content>
+      );
+    }
+    return <ResolvedProgressTab deployment={deployment} extension={progressStepsExtension} />;
+  };
+
+  const renderEvents = () => (
+    <DeploymentEventLog events={events} deploymentName={deploymentName} loaded={eventsLoaded} />
+  );
+
+  return (
+    <Modal
+      appendTo={document.body}
+      variant={ModalVariant.medium}
+      isOpen
+      onClose={onClose}
+      data-testid="deployment-status-modal"
+    >
+      <ModalHeader
+        data-testid="deployment-status-modal-header"
+        title={
+          <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <FlexItem>Deployment status</FlexItem>
+            <FlexItem>
+              <ModelStatusIcon
+                state={deployment.status?.state ?? ModelDeploymentState.UNKNOWN}
+                stoppedStates={deployment.status?.stoppedStates}
+              />
+            </FlexItem>
+          </Flex>
+        }
+      />
+      <ModalBody className="deployment-status-modal__content-height">
+        <Stack hasGutter style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <StackItem>
+            <Content component="p" data-testid="deployment-status-name">
+              {getDisplayNameFromK8sResource(deployment.model)}
+            </Content>
+          </StackItem>
+          <StackItem>
+            <Tabs
+              activeKey={activeTab}
+              onSelect={(_ev, tabIndex) => setActiveTab(`${tabIndex}`)}
+              aria-label="deployment status details"
+            >
+              <Tab
+                eventKey={PROGRESS_TAB}
+                aria-label={PROGRESS_TAB}
+                title={<TabTitleText>{PROGRESS_TAB}</TabTitleText>}
+                data-testid="expand-progress"
+              />
+              <Tab
+                eventKey={EVENT_LOG_TAB}
+                aria-label={EVENT_LOG_TAB}
+                title={<TabTitleText>{EVENT_LOG_TAB}</TabTitleText>}
+                data-testid="expand-events"
+              />
+            </Tabs>
+          </StackItem>
+          <StackItem isFilled className="deployment-status-modal__filled-stack-item">
+            {activeTab === PROGRESS_TAB ? renderProgress() : renderEvents()}
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>{buttons}</ModalFooter>
+    </Modal>
+  );
+};
+
+export default DeploymentStatusModal;

--- a/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
+++ b/packages/model-serving/src/components/deployments/DeploymentStatusModal.tsx
@@ -23,6 +23,7 @@ import { ModelStatusIcon } from '@odh-dashboard/internal/concepts/modelServing/M
 import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/internal/concepts/k8s/utils';
 import DeploymentEventLog from './DeploymentEventLog';
+import DeploymentLogsTab from './DeploymentLogsTab';
 import { useResolvedDeploymentExtension } from '../../concepts/extensionUtils';
 import { useWatchDeploymentEvents } from '../../concepts/useWatchDeploymentEvents';
 import {
@@ -34,7 +35,8 @@ import {
 import './DeploymentStatusModal.scss';
 
 const PROGRESS_TAB = 'Progress';
-const EVENT_LOG_TAB = 'Events log';
+const EVENT_LOG_TAB = 'Events';
+const LOGS_TAB = 'Logs';
 
 const progressStepVariants: Record<DeploymentProgressStep['status'], ProgressStepVariant> = {
   pending: ProgressStepVariant.pending,
@@ -177,10 +179,20 @@ const DeploymentStatusModal: React.FC<DeploymentStatusModalProps> = ({
                 title={<TabTitleText>{EVENT_LOG_TAB}</TabTitleText>}
                 data-testid="expand-events"
               />
+              <Tab
+                eventKey={LOGS_TAB}
+                aria-label={LOGS_TAB}
+                title={<TabTitleText>{LOGS_TAB}</TabTitleText>}
+                data-testid="expand-logs"
+              />
             </Tabs>
           </StackItem>
           <StackItem isFilled className="deployment-status-modal__filled-stack-item">
-            {activeTab === PROGRESS_TAB ? renderProgress() : renderEvents()}
+            {activeTab === PROGRESS_TAB && renderProgress()}
+            {activeTab === EVENT_LOG_TAB && renderEvents()}
+            {activeTab === LOGS_TAB && (
+              <DeploymentLogsTab namespace={namespace} deploymentName={deploymentName} />
+            )}
           </StackItem>
         </Stack>
       </ModalBody>

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Spinner } from '@patternfly/react-core';
+import { Button, Spinner } from '@patternfly/react-core';
 import { Td, Tbody } from '@patternfly/react-table';
 import ResourceActionsColumn from '@odh-dashboard/internal/components/ResourceActionsColumn';
 import ResourceTr from '@odh-dashboard/internal/components/ResourceTr';
@@ -16,6 +16,7 @@ import DeploymentLastDeployed from '../DeploymentLastDeployed';
 import DeploymentStatus from '../DeploymentStatus';
 import DeployedModelsVersion from '../DeployedModelsVersion';
 import ModelServingStopModal from '../ModelServingStopModal';
+import DeploymentStatusModal from '../DeploymentStatusModal';
 import { useDeploymentExtension } from '../../../concepts/extensionUtils';
 import {
   Deployment,
@@ -54,6 +55,7 @@ export const DeploymentRow: React.FC<{
   const [isExpanded, setExpanded] = React.useState(false);
   const [dontShowModalValue] = useStopModalPreference();
   const [isOpenConfirm, setOpenConfirm] = React.useState(false);
+  const [isStatusModalOpen, setStatusModalOpen] = React.useState(false);
 
   const { watchDeployment } = useModelDeploymentNotification(deployment);
 
@@ -159,6 +161,7 @@ export const DeploymentRow: React.FC<{
             bodyContent={deployment.status?.message}
             defaultHeaderContent="Inference Service Status"
             stoppedStates={deployment.status?.stoppedStates}
+            onClick={() => setStatusModalOpen(true)}
           />
         </Td>
         <Td dataLabel="State toggle">
@@ -219,6 +222,54 @@ export const DeploymentRow: React.FC<{
                 .then((resolvedFunction) => resolvedFunction(deployment, true));
             }
           }}
+        />
+      )}
+      {isStatusModalOpen && (
+        <DeploymentStatusModal
+          deployment={deployment}
+          onClose={() => setStatusModalOpen(false)}
+          buttons={
+            <>
+              {startStopActionExtension && deployment.status?.stoppedStates ? (
+                deployment.status.stoppedStates.isStopped ? (
+                  <Button
+                    key="start"
+                    variant="primary"
+                    onClick={() => {
+                      onStart();
+                      setStatusModalOpen(false);
+                    }}
+                    data-testid="status-modal-start"
+                  >
+                    Start deployment
+                  </Button>
+                ) : (
+                  <Button
+                    key="stop"
+                    variant="primary"
+                    onClick={() => {
+                      onStop();
+                      setStatusModalOpen(false);
+                    }}
+                    data-testid="status-modal-stop"
+                  >
+                    Stop deployment
+                  </Button>
+                )
+              ) : null}
+              <Button
+                key="edit"
+                variant="link"
+                onClick={() => {
+                  navigateToDeploymentWizard(deployment.model.metadata.namespace);
+                  setStatusModalOpen(false);
+                }}
+                data-testid="status-modal-edit"
+              >
+                Edit deployment
+              </Button>
+            </>
+          }
         />
       )}
     </>

--- a/packages/model-serving/src/concepts/useWatchDeploymentEvents.ts
+++ b/packages/model-serving/src/concepts/useWatchDeploymentEvents.ts
@@ -1,0 +1,80 @@
+import { EventKind } from '@odh-dashboard/internal/k8sTypes';
+import { EventModel } from '@odh-dashboard/internal/api/models/k8s';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
+import { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
+
+export const useWatchDeploymentEvents = (namespace: string): CustomWatchK8sResult<EventKind[]> =>
+  useK8sWatchResourceList<EventKind[]>(
+    {
+      isList: true,
+      groupVersionKind: groupVersionKind(EventModel),
+      namespace,
+    },
+    EventModel,
+  );
+
+export const getEventTimestamp = (event: EventKind): string =>
+  event.lastTimestamp || event.eventTime;
+
+export const getEventFullMessage = (event: EventKind): string =>
+  `${getEventTimestamp(event)} [${event.reason}] [${event.type}] ${event.message}`;
+
+export type EventFilter = {
+  label: string;
+  id: string;
+  match: (event: EventKind) => boolean;
+};
+
+export const getDeploymentEventFilters = (deploymentName: string): EventFilter[] => [
+  {
+    id: 'cr',
+    label: 'Deployment CR',
+    match: (event) =>
+      (event.involvedObject.kind === 'InferenceService' ||
+        event.involvedObject.kind === 'LLMInferenceService' ||
+        event.involvedObject.kind === 'NIMService') &&
+      event.involvedObject.name === deploymentName,
+  },
+  {
+    id: 'pod',
+    label: 'Pods',
+    match: (event) =>
+      event.involvedObject.kind === 'Pod' &&
+      event.involvedObject.name.startsWith(`${deploymentName}-`),
+  },
+  {
+    id: 'deployment',
+    label: 'Deployments',
+    match: (event) =>
+      event.involvedObject.kind === 'Deployment' &&
+      event.involvedObject.name.startsWith(`${deploymentName}-`),
+  },
+  {
+    id: 'replicaset',
+    label: 'ReplicaSets',
+    match: (event) =>
+      event.involvedObject.kind === 'ReplicaSet' &&
+      event.involvedObject.name.startsWith(`${deploymentName}-`),
+  },
+  {
+    id: 'hpa',
+    label: 'Autoscalers',
+    match: (event) =>
+      event.involvedObject.kind === 'HorizontalPodAutoscaler' &&
+      event.involvedObject.name.startsWith(`${deploymentName}-`),
+  },
+];
+
+export const filterDeploymentEvents = (
+  events: EventKind[],
+  deploymentName: string,
+  activeFilterIds: Set<string>,
+): EventKind[] => {
+  const filters = getDeploymentEventFilters(deploymentName);
+  const activeFilters = filters.filter((f) => activeFilterIds.has(f.id));
+  if (activeFilters.length === 0) {
+    return [];
+  }
+  return events.filter((event) => activeFilters.some((f) => f.match(event)));
+};


### PR DESCRIPTION
So this is a visual prototype alongside a technical proposal on how to get there. (NOTE: code is vibe coded and not reviewed, this won't be used in final version)

Model serving has a lot more resources than workbenches to check for the progress steps of a deployment. 
- Workbenches has 
  - no status conditions
  -  is just looking at kubernetes Events on its `StatefulSet` and the single `Pod`
- Model serving, on the other hand, has:
  - status conditions from the main resource 
  - multiple possible Deployments (a model AND a scheduler)
  - Duplicate pods if there is > 1 replica
  - Different model serving platforms (LLMInferenceServices has different information than an InferenceService)

This will look at the the status.condition entries of the main resource and supplement that with core Events. LLMInferenceServices have a lot more info on the conditions about the progress. 

For multiple replicas, we can find the healthiest pod to get the status from. Users only need one pod to be healthy for the deployment to work. We can also show how many pods are ready, (0/2 or 1/2 or 2/2)

There is an events tab that can filter the events based on the other resources. This was added because of how many resources events can come from.

Finally I added a pod logs because why not.

InferenceService
<img width="851" height="669" alt="Screenshot 2026-05-20 at 2 11 02 PM" src="https://github.com/user-attachments/assets/7a76169c-a73f-4496-81e1-f39d984e2fbb" />
<img width="854" height="664" alt="Screenshot 2026-05-20 at 2 11 07 PM" src="https://github.com/user-attachments/assets/c6f17ce2-9276-4968-8b66-f98d51441f4b" />

<img width="848" height="660" alt="Screenshot 2026-05-20 at 2 10 05 PM" src="https://github.com/user-attachments/assets/46cf6473-076e-4900-ba4a-10abd06149ae" />
<img width="845" height="659" alt="Screenshot 2026-05-19 at 4 56 12 PM" src="https://github.com/user-attachments/assets/797e659c-b50a-496d-86ce-088551025829" />
<img width="844" height="649" alt="Screenshot 2026-05-19 at 4 56 02 PM" src="https://github.com/user-attachments/assets/dbe4dcd2-2265-454b-96d1-5af846c03836" />

LLMInferenceServices

<img width="850" height="655" alt="Screenshot 2026-05-20 at 2 12 20 PM" src="https://github.com/user-attachments/assets/1e8240c0-6170-4a5e-b144-c386e508b55d" />
<img width="852" height="661" alt="Screenshot 2026-05-19 at 4 55 19 PM" src="https://github.com/user-attachments/assets/79164461-cd76-40d5-891d-a9419bf98715" />
<img width="849" height="658" alt="Screenshot 2026-05-19 at 4 55 31 PM" src="https://github.com/user-attachments/assets/86cc28a9-422b-4e1b-8242-f966a24a505f" />
<img width="847" height="651" alt="Screenshot 2026-05-19 at 4 55 40 PM" src="https://github.com/user-attachments/assets/c8770cdf-3ad3-4011-8e45-c2d46be40d8a" />

NIMServices will be similar to InferenceServices
