### PR TITLE
RHOAIENG-63547: Use per-provider indexed env vars for max_tokens

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/k8smocks/token_k8s_client_mock.go
@@ -411,8 +411,8 @@ providers:
     provider_type: remote::vllm
     config:
       base_url: http://mock-model-predictor.` + namespace + `.svc.cluster.local:8080/v1
-      max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-      api_token: ${env.VLLM_API_TOKEN:=fake}
+      max_tokens: ${env.VLLM_MAX_TOKENS_1:=4096}
+      api_token: ${env.VLLM_API_TOKEN_1:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
@@ -548,7 +548,7 @@ server:
 						{Name: "VLLM_TLS_VERIFY", Value: "false"},
 						{Name: "FAISS_STORE_DIR", Value: "~/.llama/faiss"},
 						{Name: "FMS_ORCHESTRATOR_URL", Value: "http://localhost"},
-						{Name: "VLLM_MAX_TOKENS", Value: "4096"},
+						{Name: "VLLM_MAX_TOKENS_1", Value: "4096"},
 						{Name: "OGX_CONFIG_DIR", Value: "/opt/app-root/src/.ogx/distributions/rh/"},
 					},
 				},

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config.go
@@ -432,11 +432,7 @@ func (c *LlamaStackConfig) AddVLLMProviderAndModel(providerID, endpointURL strin
 	// Create provider config
 	providerConfig := EmptyConfig()
 	providerConfig["base_url"] = endpointURL
-	if maxTokens != nil {
-		providerConfig["max_tokens"] = *maxTokens
-	} else {
-		providerConfig["max_tokens"] = "${env.VLLM_MAX_TOKENS:=4096}"
-	}
+	providerConfig["max_tokens"] = fmt.Sprintf("${env.VLLM_MAX_TOKENS_%d:=4096}", index+1)
 	providerConfig["api_token"] = fmt.Sprintf("${env.VLLM_API_TOKEN_%d:=fake}", index+1)
 	providerConfig["tls_verify"] = "${env.VLLM_TLS_VERIFY:=true}"
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/llamastack_config_test.go
@@ -361,7 +361,7 @@ func TestGetModelProviderInfo_EnvVarCleaning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// URL should have env var cleaned (${env.VLLM_MAX_TOKENS:=4096} should not appear)
+	// URL should have env var cleaned (${env.VLLM_MAX_TOKENS_N:=4096} should not appear)
 	assert.NotContains(t, result.URL, "${env.", "URL should not contain environment variable placeholders")
 	assert.NotContains(t, result.URL, ":=", "URL should not contain default value syntax")
 }
@@ -1107,7 +1107,7 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		assert.NotNil(t, foundModel.MaxTokens, "MaxTokens should be set")
 		assert.Equal(t, 8192, *foundModel.MaxTokens)
 
-		// Verify provider-level max_tokens also uses the user value
+		// Verify provider-level max_tokens uses indexed env var (actual value comes from deployment env var)
 		var foundProvider *Provider
 		for i := range parsedConfig.Providers.Inference {
 			if parsedConfig.Providers.Inference[i].ProviderID == "test-provider" {
@@ -1118,7 +1118,7 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		require.NotNil(t, foundProvider, "Provider should be found in parsed config")
 		providerMaxTokens, ok := foundProvider.Config["max_tokens"]
 		require.True(t, ok, "Provider config should contain max_tokens")
-		assert.Equal(t, 8192, providerMaxTokens)
+		assert.Equal(t, "${env.VLLM_MAX_TOKENS_1:=4096}", providerMaxTokens)
 	})
 
 	t.Run("should not include max_tokens in model configuration when not provided", func(t *testing.T) {
@@ -1128,8 +1128,8 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		yamlStr, err := config.ToYAML()
 		require.NoError(t, err)
 
-		// Verify provider-level falls back to env var template
-		assert.Contains(t, yamlStr, "${env.VLLM_MAX_TOKENS:=4096}")
+		// Verify provider-level uses indexed env var template
+		assert.Contains(t, yamlStr, "${env.VLLM_MAX_TOKENS_1:=4096}")
 
 		// Parse back and verify
 		var parsedConfig LlamaStackConfig
@@ -1148,6 +1148,34 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		assert.Nil(t, foundModel.MaxTokens, "MaxTokens should be nil when not provided")
 	})
 
+	t.Run("should use per-provider indexed env var for max_tokens in provider config", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		maxTokens := 2048
+		config.AddVLLMProviderAndModel("test-provider", "https://test.com/v1", 0, "test-model", "llm", nil, &maxTokens, nil)
+
+		yamlStr, err := config.ToYAML()
+		require.NoError(t, err)
+
+		// Provider config should reference indexed env var, not shared one
+		assert.Contains(t, yamlStr, "max_tokens: ${env.VLLM_MAX_TOKENS_1:=4096}")
+		assert.NotContains(t, yamlStr, "max_tokens: ${env.VLLM_MAX_TOKENS:=4096}")
+	})
+
+	t.Run("should use different indexed env vars for multiple providers", func(t *testing.T) {
+		config := NewDefaultLlamaStackConfig()
+		maxTokens1 := 4096
+		maxTokens2 := 16384
+		config.AddVLLMProviderAndModel("test-provider-1", "https://test1.com/v1", 0, "test-model-1", "llm", nil, &maxTokens1, nil)
+		config.AddVLLMProviderAndModel("test-provider-2", "https://test2.com/v1", 1, "test-model-2", "llm", nil, &maxTokens2, nil)
+
+		yamlStr, err := config.ToYAML()
+		require.NoError(t, err)
+
+		// Each provider should have its own indexed env var
+		assert.Contains(t, yamlStr, "max_tokens: ${env.VLLM_MAX_TOKENS_1:=4096}")
+		assert.Contains(t, yamlStr, "max_tokens: ${env.VLLM_MAX_TOKENS_2:=4096}")
+	})
+
 	t.Run("should support multiple models with different max_tokens values", func(t *testing.T) {
 		config := NewDefaultLlamaStackConfig()
 		maxTokens1 := 4096
@@ -1158,7 +1186,7 @@ func TestAddVLLMProviderAndModel_WithMaxTokens(t *testing.T) {
 		yamlStr, err := config.ToYAML()
 		require.NoError(t, err)
 
-		// Verify both max_tokens values are in the YAML
+		// Verify both max_tokens values are in the YAML (model-level)
 		assert.Contains(t, yamlStr, "max_tokens: 4096")
 		assert.Contains(t, yamlStr, "max_tokens: 16384")
 

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/testdata/test_llama_stack_config.yaml
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/testdata/test_llama_stack_config.yaml
@@ -14,8 +14,8 @@ providers:
       provider_type: remote::vllm
       config:
         base_url: http://llama-32-3b-instruct-predictor.crimson-show.svc.cluster.local/v1
-        max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN:=fake}
+        max_tokens: ${env.VLLM_MAX_TOKENS_1:=4096}
+        api_token: ${env.VLLM_API_TOKEN_1:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
     - provider_id: sentence-transformers
       provider_type: inline::sentence-transformers
@@ -30,8 +30,8 @@ providers:
       provider_type: remote::vllm
       config:
         base_url: http://maas.apps.rosa.crimson-demo.g9ax.p3.openshiftapps.com/llm/facebook-opt-125m-simulated/v1
-        max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN_1:=fake}
+        max_tokens: ${env.VLLM_MAX_TOKENS_2:=4096}
+        api_token: ${env.VLLM_API_TOKEN_2:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   vector_io:
   - provider_id: faiss

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1373,18 +1373,25 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 			Value: "~/.llama/faiss",
 		},
 		{
-			Name:  "VLLM_MAX_TOKENS",
-			Value: "4096",
-		},
-		{
 			Name:  "SENTENCE_TRANSFORMERS_HOME",
 			Value: "/opt/app-root/src/.cache/huggingface/hub",
 		},
 	}
 
-	// Add token environment variables from existing secrets
+	// Add per-model token and max_tokens environment variables
 	for i, model := range installModels {
 		envVarName := fmt.Sprintf("VLLM_API_TOKEN_%d", i+1)
+
+		// Per-model max_tokens: use user-specified value or default to 4096
+		maxTokensEnvName := fmt.Sprintf("VLLM_MAX_TOKENS_%d", i+1)
+		maxTokensValue := "4096"
+		if model.MaxTokens != nil {
+			maxTokensValue = strconv.Itoa(*model.MaxTokens)
+		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  maxTokensEnvName,
+			Value: maxTokensValue,
+		})
 
 		if secretInfo, exists := modelSecrets[model.ModelName]; exists && secretInfo.hasToken && secretInfo.secretName != "" {
 			// Only reference the secret if it actually exists and has a valid name


### PR DESCRIPTION
## Description

Fixes a bug where the per-model `max_tokens` value set by users in the Gen AI Studio Playground configuration UI is silently ignored at inference time.

**Root cause:** The `remote::vllm` provider config referenced a single shared env var (`VLLM_MAX_TOKENS=4096`) for all model providers, while the user's value from the UI was only stored in model metadata — never propagated to the provider config that OGX actually uses.

**Fix:** Use per-provider indexed env vars (`VLLM_MAX_TOKENS_1`, `VLLM_MAX_TOKENS_2`, etc.) matching the existing `VLLM_API_TOKEN_N` pattern, populated from the user-specified value (defaulting to 4096 if not set).

### Changes

- **`llamastack_config.go`**: Provider config now uses `${env.VLLM_MAX_TOKENS_N:=4096}` (indexed) instead of shared `${env.VLLM_MAX_TOKENS:=4096}`
- **`token_k8s_client.go`**: Removed hardcoded shared `VLLM_MAX_TOKENS=4096` env var; added per-model `VLLM_MAX_TOKENS_N` env vars in the install loop using the user-specified value
- **Tests & mocks**: Updated to reflect the indexed env var pattern

### Impact

Without this fix:
- Any user who sets `max_tokens` in the Playground UI has it silently ignored
- Models with context windows <= 4096 (e.g., Qwen2.5-VL-3B) get **empty responses** because the provider requests 4096 output tokens leaving no room for input

### Testing

Verified on a real OpenShift cluster (crimson-rhoai) via the BFF install API:

| Test Case | Expected | Result |
|-----------|----------|--------|
| Single model, max_tokens=2048 | `VLLM_MAX_TOKENS_1=2048` | PASS |
| Single model, no max_tokens | `VLLM_MAX_TOKENS_1=4096` (default) | PASS |
| Two models, 1024 and 8192 | `VLLM_MAX_TOKENS_1=1024`, `VLLM_MAX_TOKENS_2=8192` | PASS |
| Update flow (delete+re-install with 512) | `VLLM_MAX_TOKENS_1=512` | PASS |

All existing unit tests pass after rebase on upstream/main.

## Jira

[RHOAIENG-63547](https://redhat.atlassian.net/browse/RHOAIENG-63547)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * vLLM providers now use per-provider indexed environment variables so each provider/model can have independent max-token and API-token settings (defaults preserved).

* **Tests**
  * Added and updated tests to verify per-provider indexed configuration is emitted and the previous shared placeholder is no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->