### PR TITLE
RHOAIENG-62244,RHOAIENG-62245: Multimodal chat UX — image/document upload, inline rendering, and thinking panel

### DIFF
--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -38,6 +38,7 @@ interface ChatbotConfigInstanceProps {
   onMessagesHookReady?: (hook: UseChatbotMessagesReturn) => void;
   configIndex?: number;
   isCompareMode?: boolean;
+  hasImagesInConversation?: boolean;
 }
 
 export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
@@ -54,6 +55,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   onMessagesHookReady,
   configIndex,
   isCompareMode,
+  hasImagesInConversation,
 }) => {
   const systemInstruction = useChatbotConfigStore(selectSystemInstruction(configId));
   const temperature = useChatbotConfigStore(selectTemperature(configId));
@@ -181,6 +183,7 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
         isStreamingWithoutContent={messagesHook.isStreamingWithoutContent}
         modelDisplayName={messagesHook.modelDisplayName}
         placeholderContent={PLACEHOLDER_BOT_CONTENT}
+        hasImagesInConversation={hasImagesInConversation}
       />
     </MessageBox>
   );

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMessagesList.tsx
@@ -13,6 +13,8 @@ type ChatbotMessagesListProps = {
   modelDisplayName?: string;
   /** Shown as a bot message when the conversation is empty and not loading */
   placeholderContent?: string;
+  /** Whether the conversation contains images in user messages (disables image stripping) */
+  hasImagesInConversation?: boolean;
 };
 
 const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
@@ -22,6 +24,7 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
   isStreamingWithoutContent = false,
   modelDisplayName = 'Bot',
   placeholderContent,
+  hasImagesInConversation = false,
 }) => {
   // Show loading dots only for non-streaming requests
   // During streaming, loading dots are handled within the bot message itself
@@ -41,21 +44,25 @@ const ChatbotMessagesList: React.FC<ChatbotMessagesListProps> = ({
         />
       )}
       {messageList.map((message, index) => {
-        // Destructure metrics from message to avoid passing it to PatternFly Message component
-        const { metrics, ...messageProps } = message;
+        // Destructure metrics and extraContent from message to avoid passing raw to PatternFly
+        const { metrics, extraContent: messageExtraContent, ...messageProps } = message;
 
-        // Build extraContent with metrics if present (for bot messages)
-        const extraContent =
-          message.role === 'bot' && metrics
-            ? { endContent: <ChatbotMessagesMetrics metrics={metrics} /> }
-            : undefined;
+        // Merge message's own extraContent with metrics endContent
+        const extraContent = {
+          ...messageExtraContent,
+          ...(message.role === 'bot' &&
+            metrics && {
+              endContent: <ChatbotMessagesMetrics metrics={metrics} />,
+            }),
+        };
 
         return (
           <React.Fragment key={message.id}>
             <Message
               {...messageProps}
-              extraContent={extraContent}
+              extraContent={Object.keys(extraContent).length > 0 ? extraContent : undefined}
               data-testid={`chatbot-message-${message.role}`}
+              {...(hasImagesInConversation && { hasNoImagesInUserMessages: false })}
             />
             {index === messageList.length - 1 && <div ref={scrollRef} />}
           </React.Fragment>

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -5,15 +5,21 @@ import {
   DrawerContent,
   DrawerContentBody,
   DropEvent,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
 } from '@patternfly/react-core';
 import { Chatbot, ChatbotContent, ChatbotDisplayMode } from '@patternfly/chatbot';
 import { useLocation } from 'react-router-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import DashboardModalFooter from '@odh-dashboard/internal/concepts/dashboard/DashboardModalFooter';
 import { useUserContext } from '~/app/context/UserContext';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import useFetchBFFConfig from '~/app/hooks/useFetchBFFConfig';
-import { isLlamaModelEnabled } from '~/app/utilities';
+import { uploadVisionFile } from '~/app/services/llamaStackService';
+import { isLlamaModelEnabled, URL_PREFIX } from '~/app/utilities';
 import { getId } from '~/app/utilities/utils';
 import { TokenInfo, ResponseMetrics } from '~/app/types';
 import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
@@ -27,7 +33,10 @@ import useFileManagement from './hooks/useFileManagement';
 import useDarkMode from './hooks/useDarkMode';
 import { ChatbotSettingsPanel } from './components/ChatbotSettingsPanel';
 import ChatbotPaneHeader from './components/ChatbotPaneHeader';
-import ChatbotMessageInput from './components/ChatbotMessageInput';
+import ChatbotMessageInput, {
+  ImageUploadState,
+  PendingDocChip,
+} from './components/ChatbotMessageInput';
 import SourceUploadErrorAlert from './components/alerts/SourceUploadErrorAlert';
 import SourceUploadSuccessAlert from './components/alerts/SourceUploadSuccessAlert';
 import SourceDeleteSuccessAlert from './components/alerts/SourceDeleteSuccessAlert';
@@ -181,6 +190,33 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     new Map(),
   );
 
+  // Vision image upload state
+  const [imageUploadState, setImageUploadState] = React.useState<ImageUploadState>({
+    uploading: false,
+    progress: 0,
+    fileId: null,
+    previewUrl: null,
+    fileName: null,
+  });
+  const [hasImageInConversation, setHasImageInConversation] = React.useState(false);
+  const [pendingDocChips, setPendingDocChips] = React.useState<PendingDocChip[]>([]);
+  const [showReplaceMediaModal, setShowReplaceMediaModal] = React.useState(false);
+  const pendingReplaceFileRef = React.useRef<File | null>(null);
+  const visionXhrRef = React.useRef<XMLHttpRequest | null>(null);
+  const uploadGenRef = React.useRef(0);
+  const previewUrlRef = React.useRef<string | null>(null);
+  previewUrlRef.current = imageUploadState.previewUrl;
+
+  // Revoke unsent image preview blob URL on unmount
+  React.useEffect(
+    () => () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    },
+    [],
+  );
+
   // Callbacks
   const setSelectedModel = React.useCallback(
     (model: string) => {
@@ -234,31 +270,256 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     [],
   );
 
+  const hasReadyImage = !!imageUploadState.fileId && !imageUploadState.uploading;
+  const hasReadyDocs = pendingDocChips.some((c) => c.status === 'uploaded');
+  const hasReadyAttachments = hasReadyImage || hasReadyDocs;
+
   const handleSendMessage = React.useCallback(
     (message: string) => {
+      let effectiveMessage = message;
+      if (!message.trim() && hasReadyAttachments) {
+        if (hasReadyImage && hasReadyDocs) {
+          effectiveMessage = 'Describe the image and summarize the attached documents';
+        } else if (hasReadyImage) {
+          effectiveMessage = 'Describe the image';
+        } else {
+          effectiveMessage = 'Summarize the attached documents';
+        }
+      }
+
       const compareID = isCompareMode ? getId() : '';
-      messageHooksRef.current.forEach((hook) => hook.handleMessageSend(message, compareID));
-      setLastInput(message);
+      const fileId = imageUploadState.fileId || undefined;
+      const imagePreview =
+        imageUploadState.previewUrl && imageUploadState.fileName
+          ? { previewUrl: imageUploadState.previewUrl, fileName: imageUploadState.fileName }
+          : undefined;
+
+      const docAttachments = pendingDocChips
+        .filter((c) => c.status === 'uploaded')
+        .map((c) => c.fileName);
+
+      messageHooksRef.current.forEach((hook) =>
+        hook.handleMessageSend(
+          effectiveMessage,
+          compareID,
+          fileId,
+          imagePreview,
+          docAttachments.length > 0 ? docAttachments : undefined,
+        ),
+      );
+      setLastInput(effectiveMessage);
+
+      if (fileId) {
+        setHasImageInConversation(true);
+        setImageUploadState({
+          uploading: false,
+          progress: 0,
+          fileId: null,
+          previewUrl: null,
+          fileName: null,
+        });
+      }
+
+      setPendingDocChips([]);
     },
-    [setLastInput, isCompareMode],
+    [
+      setLastInput,
+      isCompareMode,
+      imageUploadState.fileId,
+      imageUploadState.previewUrl,
+      imageUploadState.fileName,
+      pendingDocChips,
+      hasReadyAttachments,
+      hasReadyImage,
+      hasReadyDocs,
+    ],
   );
 
   const handleStopStreaming = React.useCallback(() => {
     messageHooksRef.current.forEach((hook) => hook.handleStopStreaming());
   }, []);
 
+  React.useEffect(() => {
+    setPendingDocChips((prev) => {
+      const updated = prev.map((chip) => {
+        const match = sourceManagement.filesWithSettings.find((f) => f.file.name === chip.fileName);
+        if (!match) {
+          return chip;
+        }
+        if (match.status === 'uploaded' && chip.status !== 'uploaded') {
+          return { ...chip, status: 'uploaded' as const };
+        }
+        if (match.status === 'failed' && chip.status !== 'failed') {
+          return { ...chip, status: 'failed' as const };
+        }
+        return chip;
+      });
+      // Remove chips whose files were removed from filesWithSettings (e.g. modal cancelled)
+      const filtered = updated.filter(
+        (chip) =>
+          chip.status === 'uploaded' ||
+          chip.status === 'failed' ||
+          sourceManagement.filesWithSettings.some((f) => f.file.name === chip.fileName),
+      );
+      const hasChanges =
+        filtered.length !== prev.length || filtered.some((chip, i) => chip !== prev[i]);
+      return hasChanges ? filtered : prev;
+    });
+  }, [sourceManagement.filesWithSettings]);
+
   const handleAttach = React.useCallback(
     <T extends File>(acceptedFiles: T[], _fileRejections: unknown, event: DropEvent) => {
+      const newChips: PendingDocChip[] = acceptedFiles.map((file) => ({
+        id: crypto.randomUUID(),
+        fileName: file.name,
+        status: 'uploading' as const,
+      }));
+      setPendingDocChips((prev) => [...prev, ...newChips]);
+
       sourceManagement.handleSourceDrop(event, acceptedFiles).catch((error) => {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
         alertManagement.onShowErrorAlert(
           `Failed to process files: ${errorMessage}`,
           'File Upload Error',
         );
+        const failedNames = new Set(acceptedFiles.map((f) => f.name));
+        setPendingDocChips((prev) => prev.filter((c) => !failedNames.has(c.fileName)));
       });
     },
     [sourceManagement, alertManagement],
   );
+
+  const handleRemoveDocChip = React.useCallback(
+    (chipId: string) => {
+      const chip = pendingDocChips.find((c) => c.id === chipId);
+      if (!chip) {
+        return;
+      }
+
+      if (chip.status === 'uploaded') {
+        const matchedFile = fileManagement.files.find((f) => f.filename === chip.fileName);
+        if (matchedFile) {
+          Promise.resolve(fileManagement.deleteFileById(matchedFile.id)).catch(() => {
+            // Best-effort deletion — chip is already removed from UI
+          });
+        }
+      }
+      sourceManagement.removeUploadedSource(chip.fileName);
+
+      setPendingDocChips((prev) => prev.filter((c) => c.id !== chipId));
+    },
+    [pendingDocChips, fileManagement, sourceManagement],
+  );
+
+  const performImageUpload = React.useCallback(
+    (file: File) => {
+      uploadGenRef.current += 1;
+      const gen = uploadGenRef.current;
+
+      const previewUrl = URL.createObjectURL(file);
+      const ext = file.name.lastIndexOf('.');
+      const normalizedName =
+        ext !== -1 ? file.name.slice(0, ext) + file.name.slice(ext).toLowerCase() : file.name;
+      setImageUploadState({
+        uploading: true,
+        progress: 0,
+        fileId: null,
+        previewUrl,
+        fileName: normalizedName,
+      });
+
+      const url = `${URL_PREFIX}/api/v1/lsd/files/vision?namespace=${encodeURIComponent(namespace?.name || '')}`;
+      const { promise, xhr } = uploadVisionFile(url, file, (percent) => {
+        setImageUploadState((prev) => ({ ...prev, progress: percent }));
+      });
+      visionXhrRef.current = xhr;
+
+      promise
+        .then((response) => {
+          if (uploadGenRef.current !== gen) {
+            return;
+          }
+          setImageUploadState((prev) => ({
+            ...prev,
+            uploading: false,
+            fileId: response.data.id,
+          }));
+        })
+        .catch((error) => {
+          if (uploadGenRef.current !== gen) {
+            return;
+          }
+          URL.revokeObjectURL(previewUrl);
+          setImageUploadState({
+            uploading: false,
+            progress: 0,
+            fileId: null,
+            previewUrl: null,
+            fileName: null,
+          });
+          if (error instanceof Error && error.message !== 'Upload aborted') {
+            alertManagement.onShowErrorAlert(
+              `${file.name} failed to upload. Please try again.`,
+              'Image Upload Error',
+            );
+          }
+        })
+        .finally(() => {
+          if (uploadGenRef.current === gen) {
+            visionXhrRef.current = null;
+          }
+        });
+    },
+    [namespace?.name, alertManagement],
+  );
+
+  const handleImageUpload = React.useCallback(
+    (file: File) => {
+      if (imageUploadState.fileName && !hasImageInConversation) {
+        pendingReplaceFileRef.current = file;
+        setShowReplaceMediaModal(true);
+        return;
+      }
+      performImageUpload(file);
+    },
+    [imageUploadState.fileName, hasImageInConversation, performImageUpload],
+  );
+
+  const handleReplaceMediaConfirm = React.useCallback(() => {
+    if (imageUploadState.uploading) {
+      visionXhrRef.current?.abort();
+    }
+    if (imageUploadState.previewUrl) {
+      URL.revokeObjectURL(imageUploadState.previewUrl);
+    }
+    setShowReplaceMediaModal(false);
+    const file = pendingReplaceFileRef.current;
+    pendingReplaceFileRef.current = null;
+    if (file) {
+      performImageUpload(file);
+    }
+  }, [imageUploadState.uploading, imageUploadState.previewUrl, performImageUpload]);
+
+  const handleReplaceMediaCancel = React.useCallback(() => {
+    setShowReplaceMediaModal(false);
+    pendingReplaceFileRef.current = null;
+  }, []);
+
+  const handleRemoveImage = React.useCallback(() => {
+    if (imageUploadState.uploading) {
+      visionXhrRef.current?.abort();
+    }
+    if (imageUploadState.previewUrl) {
+      URL.revokeObjectURL(imageUploadState.previewUrl);
+    }
+    setImageUploadState({
+      uploading: false,
+      progress: 0,
+      fileId: null,
+      previewUrl: null,
+      fileName: null,
+    });
+  }, [imageUploadState.uploading, imageUploadState.previewUrl]);
 
   const openSettingsToTab = location.state?.openSettingsToTab;
 
@@ -346,6 +607,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     if (ref) {
       ref.current = () => {
         messageHooksRef.current.forEach((hook) => hook.clearConversation());
+        setHasImageInConversation(false);
+        handleRemoveImage();
+        setPendingDocChips([]);
       };
     }
     return () => {
@@ -353,7 +617,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         ref.current = null;
       }
     };
-  }, [clearAllMessagesRef]);
+  }, [clearAllMessagesRef, handleRemoveImage]);
 
   // Expose hasConversationMessages to parent (beyond the initial welcome message)
   React.useEffect(() => {
@@ -424,6 +688,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
           onMessagesHookReady={getHookReadyCallback(configId)}
           configIndex={isCompareMode ? index + 1 : 0}
           isCompareMode={isCompareMode}
+          hasImagesInConversation={hasImageInConversation}
         />
       </ChatbotContent>
     </Chatbot>
@@ -454,6 +719,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         onClose={() => setIsNewChatModalOpen(false)}
         onConfirm={() => {
           messageHooksRef.current.forEach((hook) => hook.clearConversation());
+          setHasImageInConversation(false);
+          handleRemoveImage();
+          setPendingDocChips([]);
           if (isCompareMode) {
             fireMiscTrackingEvent('Playground Compare Chat Cleared', { success: true });
           }
@@ -542,12 +810,21 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                 isSendDisabled={
                   !modelsLoaded ||
                   !primarySelectedModel ||
-                  Array.from(disabledStates.values()).some(Boolean)
+                  Array.from(disabledStates.values()).some(Boolean) ||
+                  imageUploadState.uploading ||
+                  pendingDocChips.some((c) => c.status === 'uploading')
                 }
                 showAttachButton={!isCompareMode}
-                onAttach={handleAttach}
-                onShowErrorAlert={alertManagement.onShowErrorAlert}
+                onDocumentAttach={handleAttach}
                 isDarkMode={isDarkMode}
+                onImageUpload={handleImageUpload}
+                imageUploadState={imageUploadState}
+                onRemoveImage={handleRemoveImage}
+                isImageUploadDisabled={hasImageInConversation}
+                isAudioUploadDisabled
+                pendingDocChips={pendingDocChips}
+                onRemoveDocChip={handleRemoveDocChip}
+                alwaysShowSendButton={hasReadyAttachments}
               />
             </div>
           </DrawerContentBody>
@@ -563,6 +840,34 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
           }}
           onCancel={() => setPendingCloseConfigId(null)}
         />
+      )}
+
+      {showReplaceMediaModal && (
+        <Modal
+          isOpen
+          onClose={handleReplaceMediaCancel}
+          variant="small"
+          data-testid="replace-media-modal"
+        >
+          <ModalHeader title="Replace media file?" />
+          <ModalBody>
+            <p>
+              This conversation already has a media file attached. Only one image, audio, or video
+              file is supported per conversation.
+            </p>
+            <p style={{ marginTop: 'var(--pf-t--global--spacer--md)' }}>
+              The new file will replace the existing media attachment. Text file attachments are not
+              affected.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <DashboardModalFooter
+              submitLabel="Replace"
+              onSubmit={handleReplaceMediaConfirm}
+              onCancel={handleReplaceMediaCancel}
+            />
+          </ModalFooter>
+        </Modal>
       )}
     </>
   );

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotPlayground.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotPlayground.spec.tsx
@@ -1,0 +1,1308 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-shadow, react/no-unused-prop-types */
+import * as React from 'react';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+// ───────────────────── Mock functions ─────────────────────
+
+const mockHandleSourceDrop = jest.fn().mockResolvedValue(undefined);
+const mockRemoveUploadedSource = jest.fn();
+const mockDeleteFileById = jest.fn().mockResolvedValue(undefined);
+const mockRefreshFiles = jest.fn().mockResolvedValue(undefined);
+const mockOnShowErrorAlert = jest.fn();
+const mockHandleMessageSend = jest.fn().mockResolvedValue(undefined);
+
+let mockFilesWithSettings: Array<{
+  id: string;
+  file: File;
+  settings: null;
+  status: string;
+}> = [];
+let mockFileManagementFiles: Array<{ id: string; filename: string }> = [];
+
+// ───────────────────── Module mocks ─────────────────────
+
+jest.mock('~/app/Chatbot/hooks/useSourceManagement', () => ({
+  __esModule: true,
+  default: () => ({
+    selectedSourceSettings: null,
+    isSourceSettingsOpen: false,
+    autoEnableRag: false,
+    get filesWithSettings() {
+      return mockFilesWithSettings;
+    },
+    currentFileForSettings: null,
+    pendingFiles: [],
+    isUploading: false,
+    uploadProgress: { current: 0, total: 0 },
+    setAutoEnableRag: jest.fn(),
+    handleSourceDrop: mockHandleSourceDrop,
+    removeUploadedSource: mockRemoveUploadedSource,
+    handleSourceSettingsSubmit: jest.fn(),
+    handleModalClose: jest.fn(),
+    setIsSourceSettingsOpen: jest.fn(),
+    setSelectedSourceSettings: jest.fn(),
+  }),
+}));
+
+jest.mock('~/app/Chatbot/hooks/useFileManagement', () => ({
+  __esModule: true,
+  default: () => ({
+    get files() {
+      return mockFileManagementFiles;
+    },
+    isLoading: false,
+    error: null,
+    refreshFiles: mockRefreshFiles,
+    deleteFileById: mockDeleteFileById,
+    isDeleting: false,
+    currentVectorStoreId: 'vs-test-123',
+  }),
+}));
+
+jest.mock('~/app/Chatbot/hooks/useAlertManagement', () => ({
+  __esModule: true,
+  default: () => ({
+    showUploadSuccessAlert: false,
+    showDeleteSuccessAlert: false,
+    showErrorAlert: false,
+    errorAlertKey: 0,
+    errorMessage: '',
+    errorTitle: '',
+    onShowUploadSuccessAlert: jest.fn(),
+    onShowDeleteSuccessAlert: jest.fn(),
+    onShowErrorAlert: mockOnShowErrorAlert,
+    onHideUploadSuccessAlert: jest.fn(),
+    onHideDeleteSuccessAlert: jest.fn(),
+    onHideErrorAlert: jest.fn(),
+  }),
+}));
+
+jest.mock('~/app/Chatbot/hooks/useChatbotMessages', () => ({
+  __esModule: true,
+  default: () => ({
+    messages: [],
+    isLoading: false,
+    isStreamingWithoutContent: false,
+    isMessageSendButtonDisabled: false,
+    modelDisplayName: 'Test Model',
+    scrollToBottomRef: { current: null },
+    handleMessageSend: mockHandleMessageSend,
+    handleStopStreaming: jest.fn(),
+    clearConversation: jest.fn(),
+    lastResponseMetrics: null,
+  }),
+}));
+
+jest.mock('~/app/Chatbot/hooks/useDarkMode', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+jest.mock('~/app/hooks/useFetchBFFConfig', () => ({
+  __esModule: true,
+  default: () => ({ data: null, isLoading: false }),
+}));
+
+jest.mock('~/app/hooks/useFetchMCPServers', () => ({
+  __esModule: true,
+  default: () => ({ data: [], loaded: true, error: undefined }),
+}));
+
+jest.mock('~/app/hooks/useMCPServerStatuses', () => ({
+  __esModule: true,
+  default: () => ({
+    serverStatuses: new Map(),
+    checkServerStatus: jest.fn(),
+  }),
+}));
+
+jest.mock('~/app/services/llamaStackService', () => ({
+  uploadVisionFile: jest.fn(),
+}));
+
+jest.mock('~/app/context/UserContext', () => ({
+  useUserContext: () => ({
+    username: 'test-user',
+    userAvatar: '',
+  }),
+}));
+
+jest.mock('~/app/context/ChatbotContext', () => {
+  const { createContext } = require('react');
+  return {
+    ChatbotContext: createContext({
+      models: [{ id: 'test-model', name: 'Test Model' }],
+      modelsLoaded: true,
+      aiModels: [],
+      maasModels: [],
+      lastInput: '',
+      setLastInput: jest.fn(),
+      lsdStatus: null,
+      lsdStatusLoaded: true,
+      aiModelsLoaded: true,
+      maasModelsLoaded: true,
+      modelsError: undefined,
+      lsdStatusError: undefined,
+      aiModelsError: undefined,
+      maasModelsError: undefined,
+      nemoGuardrailsStatus: null,
+      nemoGuardrailsStatusLoaded: true,
+      nemoGuardrailsStatusError: undefined,
+      refresh: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('~/app/context/GenAiContext', () => {
+  const { createContext } = require('react');
+  return {
+    GenAiContext: createContext({
+      namespace: { name: 'test-ns' },
+      apiState: { apiAvailable: true, api: {} },
+      refreshAPIState: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('~/app/utilities', () => ({
+  isLlamaModelEnabled: jest.fn(() => true),
+  URL_PREFIX: '/gen-ai',
+}));
+
+jest.mock('~/app/utilities/utils', () => ({
+  getId: jest.fn(() => 'mock-compare-id'),
+  getLlamaModelDisplayName: jest.fn((id: string) => id),
+  splitLlamaModelId: jest.fn((id: string) => ({ providerId: 'p', id })),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
+  fireMiscTrackingEvent: jest.fn(),
+  fireFormTrackingEvent: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/dashboard/DashboardModalFooter', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({
+      onSubmit,
+      onCancel,
+      submitLabel,
+    }: {
+      onSubmit: () => void;
+      onCancel: () => void;
+      submitLabel?: string;
+    }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': 'modal-footer' },
+        React.createElement(
+          'button',
+          { 'data-testid': 'modal-submit', onClick: onSubmit, type: 'button' },
+          submitLabel || 'Submit',
+        ),
+        React.createElement(
+          'button',
+          { 'data-testid': 'modal-cancel', onClick: onCancel, type: 'button' },
+          'Cancel',
+        ),
+      ),
+  };
+});
+
+jest.mock('@patternfly/chatbot', () => {
+  const React = require('react');
+  return {
+    Chatbot: ({ children }: { children: unknown }) => React.createElement('div', null, children),
+    ChatbotContent: ({ children }: { children: unknown }) =>
+      React.createElement('div', null, children),
+    ChatbotDisplayMode: { embedded: 'embedded' },
+    MessageBox: ({ children }: { children: unknown }) => React.createElement('div', null, children),
+    ChatbotWelcomePrompt: () => React.createElement('div', null, 'Welcome'),
+    FileDetailsLabel: (props: {
+      fileName: string;
+      isLoading?: boolean;
+      onClose?: (e: unknown) => void;
+      'data-testid'?: string;
+      hasTruncation?: boolean;
+    }) =>
+      React.createElement(
+        'div',
+        { 'data-testid': props['data-testid'] || `file-label-${props.fileName}` },
+        React.createElement('span', { 'data-testid': 'chip-file-name' }, props.fileName),
+        props.isLoading
+          ? React.createElement('span', { 'data-testid': 'chip-loading' }, 'Loading')
+          : null,
+        !props.isLoading && props.onClose
+          ? React.createElement(
+              'button',
+              {
+                'data-testid': 'chip-close',
+                onClick: (e: unknown) => props.onClose!(e),
+                type: 'button',
+              },
+              '×',
+            )
+          : null,
+      ),
+    MessageBar: (props: {
+      onSendMessage: (msg: string) => void;
+      isSendButtonDisabled: boolean;
+      hasAttachButton: boolean;
+      hasStopButton?: boolean;
+      handleStopButton?: () => void;
+      alwayShowSendButton?: boolean;
+      attachMenuProps?: {
+        isAttachMenuOpen: boolean;
+        setIsAttachMenuOpen: (v: boolean) => void;
+        attachMenuItems: unknown;
+        onAttachMenuToggleClick: () => void;
+      };
+      'data-testid'?: string;
+      buttonProps?: unknown;
+    }) =>
+      React.createElement(
+        'div',
+        {
+          'data-testid': 'chatbot-message-bar',
+          'data-always-show-send': props.alwayShowSendButton ? 'true' : 'false',
+        },
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'send-button',
+            disabled: props.isSendButtonDisabled,
+            onClick: () => props.onSendMessage('test msg'),
+            type: 'button',
+          },
+          'Send',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'send-empty-button',
+            disabled: props.isSendButtonDisabled,
+            onClick: () => props.onSendMessage(''),
+            type: 'button',
+          },
+          'Send Empty',
+        ),
+        props.hasAttachButton && props.attachMenuProps
+          ? React.createElement(
+              'button',
+              {
+                'data-testid': 'attach-toggle',
+                onClick: props.attachMenuProps.onAttachMenuToggleClick,
+                type: 'button',
+              },
+              'Attach',
+            )
+          : null,
+        props.hasAttachButton && props.attachMenuProps?.isAttachMenuOpen
+          ? React.createElement(
+              'div',
+              { 'data-testid': 'attach-menu' },
+              props.attachMenuProps.attachMenuItems,
+            )
+          : null,
+      ),
+    ChatbotFootnote: () => null,
+  };
+});
+
+jest.mock('@patternfly/react-core', () => {
+  const React = require('react');
+  const actual = jest.requireActual('@patternfly/react-core');
+  return {
+    ...actual,
+    Modal: ({
+      children,
+      isOpen,
+      'data-testid': testId,
+    }: {
+      children: unknown;
+      isOpen?: boolean;
+      'data-testid'?: string;
+    }) =>
+      isOpen ? React.createElement('div', { 'data-testid': testId || 'modal' }, children) : null,
+    ModalHeader: ({ title }: { title: string }) => React.createElement('div', null, title),
+    ModalBody: ({ children }: { children: unknown }) => React.createElement('div', null, children),
+    ModalFooter: ({ children }: { children: unknown }) =>
+      React.createElement('div', null, children),
+    MenuItem: ({
+      children,
+      onClick,
+      isDisabled,
+    }: {
+      children: string;
+      onClick?: () => void;
+      isDisabled?: boolean;
+      icon?: unknown;
+    }) => {
+      const label = typeof children === 'string' ? children : 'item';
+      return React.createElement(
+        'button',
+        {
+          'data-testid': `menu-item-${label.replace(/\s+/g, '-').toLowerCase()}`,
+          onClick: isDisabled ? undefined : onClick,
+          disabled: isDisabled,
+          type: 'button',
+        },
+        children,
+      );
+    },
+    MenuList: ({ children }: { children: unknown }) => React.createElement('div', null, children),
+  };
+});
+
+jest.mock('@patternfly/react-icons', () => {
+  const React = require('react');
+  return {
+    OutlinedFileImageIcon: () => React.createElement('span'),
+    VolumeUpIcon: () => React.createElement('span'),
+    OutlinedFileAltIcon: () => React.createElement('span'),
+  };
+});
+
+jest.mock('~/app/Chatbot/sourceUpload/ChatbotSourceSettingsModal', () => ({
+  ChatbotSourceSettingsModal: () => null,
+}));
+
+jest.mock('~/app/Chatbot/components/ChatbotSettingsPanel', () => {
+  const React = require('react');
+  return {
+    ChatbotSettingsPanel: () => React.createElement('div', { 'data-testid': 'settings-panel' }),
+  };
+});
+
+jest.mock('~/app/Chatbot/components/ChatbotPaneHeader', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('div', { 'data-testid': 'pane-header' }),
+  };
+});
+
+jest.mock('~/app/Chatbot/components/ViewCodeModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/Chatbot/components/ChatModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/Chatbot/ChatbotPane', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: unknown }) => React.createElement('div', null, children),
+  };
+});
+
+jest.mock('~/app/Chatbot/components/CloseChatCompareModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/Chatbot/ChatbotConfigInstance', () => {
+  const React = require('react');
+  return {
+    ChatbotConfigInstance: () => React.createElement('div', { 'data-testid': 'config-instance' }),
+  };
+});
+
+jest.mock('~/app/Chatbot/components/alerts/SourceUploadErrorAlert', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/Chatbot/components/alerts/SourceUploadSuccessAlert', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/Chatbot/components/alerts/SourceDeleteSuccessAlert', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// Mock crypto.randomUUID
+let uuidCounter = 0;
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    randomUUID: jest.fn(() => `uuid-${++uuidCounter}`),
+  },
+  writable: true,
+});
+
+// Mock URL.createObjectURL / revokeObjectURL (not available in JSDOM)
+global.URL.createObjectURL = jest.fn(() => 'blob:mock-preview-url');
+global.URL.revokeObjectURL = jest.fn();
+
+// ───────────────────── Import after mocks ─────────────────────
+
+import ChatbotPlayground from '~/app/Chatbot/ChatbotPlayground';
+import { useChatbotConfigStore } from '~/app/Chatbot/store/useChatbotConfigStore';
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+
+// Access the setLastInput mock from the mocked context default value
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSetLastInput = (ChatbotContext as any)._currentValue.setLastInput as jest.Mock;
+
+// ───────────────────── Helpers ─────────────────────
+
+const renderPlayground = () =>
+  render(
+    <MemoryRouter initialEntries={['/gen-ai-studio/playground/test-ns']}>
+      <ChatbotPlayground
+        isViewCodeModalOpen={false}
+        setIsViewCodeModalOpen={jest.fn()}
+        isNewChatModalOpen={false}
+        setIsNewChatModalOpen={jest.fn()}
+      />
+    </MemoryRouter>,
+  );
+
+const createFile = (name: string, type = 'text/plain', size = 100): File =>
+  new File(['x'.repeat(size)], name, { type });
+
+/**
+ * Create a mock FileList from an array of Files.
+ */
+const createFileList = (files: File[]): FileList => {
+  const list = {
+    length: files.length,
+    item: (i: number) => files[i] || null,
+    *[Symbol.iterator]() {
+      for (const f of files) {
+        yield f;
+      }
+    },
+  } as unknown as FileList;
+  files.forEach((f, i) => {
+    Object.defineProperty(list, i, { value: f, enumerable: true });
+  });
+  return list;
+};
+
+/**
+ * Trigger document file upload by programmatically setting files on the hidden
+ * input and firing a change event — mirrors what the browser does.
+ */
+const triggerDocumentUpload = async (files: File[]) => {
+  const input = screen.getByTestId('document-file-input') as HTMLInputElement;
+  Object.defineProperty(input, 'files', { value: createFileList(files), configurable: true });
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+};
+
+// ───────────────────── Tests ─────────────────────
+
+describe('ChatbotPlayground — inline document chips', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uuidCounter = 0;
+    mockFilesWithSettings = [];
+    mockFileManagementFiles = [];
+
+    act(() => {
+      useChatbotConfigStore.setState({
+        configurations: {
+          [DEFAULT_CONFIG_ID]: {
+            ...DEFAULT_CONFIGURATION,
+            selectedModel: 'test-model',
+          },
+        },
+        configIds: [DEFAULT_CONFIG_ID],
+      });
+    });
+  });
+
+  describe('handleAttach — inline doc chip creation', () => {
+    it('creates chips immediately on file selection with uploading status', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('doc-a.txt'), createFile('doc-b.txt')]);
+
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-uuid-2')).toBeInTheDocument();
+    });
+
+    it('chips have unique IDs from crypto.randomUUID', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('a.txt'), createFile('b.txt')]);
+
+      // UUIDs are sequential: uuid-1, uuid-2
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-uuid-2')).toBeInTheDocument();
+    });
+
+    it('chip fileName matches the File name', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('report-2024.txt')]);
+
+      const chip = screen.getByTestId('doc-chip-uuid-1');
+      expect(chip.querySelector('[data-testid="chip-file-name"]')).toHaveTextContent(
+        'report-2024.txt',
+      );
+    });
+
+    it('calls sourceManagement.handleSourceDrop with the files', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('x.txt'), createFile('y.txt')]);
+
+      expect(mockHandleSourceDrop).toHaveBeenCalledTimes(1);
+      const [, filesArg] = mockHandleSourceDrop.mock.calls[0];
+      expect(filesArg).toHaveLength(2);
+      expect(filesArg[0].name).toBe('x.txt');
+      expect(filesArg[1].name).toBe('y.txt');
+    });
+
+    it('shows error alert on handleSourceDrop failure', async () => {
+      mockHandleSourceDrop.mockRejectedValueOnce(new Error('Upload API failed'));
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('fail.txt')]);
+
+      await waitFor(() => {
+        expect(mockOnShowErrorAlert).toHaveBeenCalledWith(
+          expect.stringContaining('Upload API failed'),
+          'File Upload Error',
+        );
+      });
+    });
+
+    it('appends to existing chips without replacing', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('first.txt')]);
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+
+      await triggerDocumentUpload([createFile('second.txt')]);
+      // Both chips should exist
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-uuid-2')).toBeInTheDocument();
+    });
+
+    it('chips show loading spinner while uploading (no close button)', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('loading.txt')]);
+
+      const chip = screen.getByTestId('doc-chip-uuid-1');
+      expect(chip.querySelector('[data-testid="chip-loading"]')).toBeInTheDocument();
+      expect(chip.querySelector('[data-testid="chip-close"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('useEffect — chip status sync with filesWithSettings', () => {
+    it('updates chip to uploaded when filesWithSettings transitions', async () => {
+      const file = createFile('sync-test.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file]);
+
+      // Initially uploading
+      let chip = screen.getByTestId('doc-chip-uuid-1');
+      expect(chip.querySelector('[data-testid="chip-loading"]')).toBeInTheDocument();
+
+      // Simulate filesWithSettings transition to uploaded
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-1', file, settings: null, status: 'uploaded' }];
+        // Trigger re-render by poking the store
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        chip = screen.getByTestId('doc-chip-uuid-1');
+        expect(chip.querySelector('[data-testid="chip-close"]')).toBeInTheDocument();
+        expect(chip.querySelector('[data-testid="chip-loading"]')).not.toBeInTheDocument();
+      });
+    });
+
+    it('updates chip to failed when filesWithSettings transitions to failed', async () => {
+      const file = createFile('fail-test.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file]);
+
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-f', file, settings: null, status: 'failed' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        const chip = screen.getByTestId('doc-chip-uuid-1');
+        // Failed chips show close button (not loading)
+        expect(chip.querySelector('[data-testid="chip-close"]')).toBeInTheDocument();
+        expect(chip.querySelector('[data-testid="chip-loading"]')).not.toBeInTheDocument();
+      });
+    });
+
+    it('handles both files transitioning to uploaded', async () => {
+      const file1 = createFile('multi-a.txt');
+      const file2 = createFile('multi-b.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file1, file2]);
+
+      await act(async () => {
+        mockFilesWithSettings = [
+          { id: 'fws-a', file: file1, settings: null, status: 'uploaded' },
+          { id: 'fws-b', file: file2, settings: null, status: 'uploaded' },
+        ];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        const chip1 = screen.getByTestId('doc-chip-uuid-1');
+        const chip2 = screen.getByTestId('doc-chip-uuid-2');
+        expect(chip1.querySelector('[data-testid="chip-close"]')).toBeInTheDocument();
+        expect(chip2.querySelector('[data-testid="chip-close"]')).toBeInTheDocument();
+      });
+    });
+
+    it('removes chip when file disappears from filesWithSettings (modal cancelled)', async () => {
+      const file = createFile('cancel-test.txt');
+      mockFilesWithSettings = [{ id: 'fws-c', file, settings: null, status: 'pending' }];
+
+      renderPlayground();
+      await triggerDocumentUpload([file]);
+
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+
+      // File removed from filesWithSettings (modal cancelled)
+      await act(async () => {
+        mockFilesWithSettings = [];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('retains uploaded chips even if removed from filesWithSettings', async () => {
+      const file = createFile('retain.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file]);
+
+      // Transition to uploaded
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-r', file, settings: null, status: 'uploaded' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('doc-chip-uuid-1').querySelector('[data-testid="chip-close"]'),
+        ).toBeInTheDocument();
+      });
+
+      // Remove from filesWithSettings (auto-dismiss)
+      await act(async () => {
+        mockFilesWithSettings = [];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      // Uploaded chip is retained
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+    });
+
+    it('retains failed chips even if removed from filesWithSettings', async () => {
+      const file = createFile('failed-retain.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file]);
+
+      // Transition to failed
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-fr', file, settings: null, status: 'failed' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('doc-chip-uuid-1').querySelector('[data-testid="chip-close"]'),
+        ).toBeInTheDocument();
+      });
+
+      // Remove from filesWithSettings
+      await act(async () => {
+        mockFilesWithSettings = [];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      // Failed chip is retained
+      expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+    });
+  });
+
+  describe('handleRemoveDocChip', () => {
+    const uploadAndTransition = async (file: File) => {
+      await triggerDocumentUpload([file]);
+
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-x', file, settings: null, status: 'uploaded' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('doc-chip-uuid-1').querySelector('[data-testid="chip-close"]'),
+        ).toBeInTheDocument();
+      });
+    };
+
+    it('removes uploaded chip and calls deleteFileById', async () => {
+      const user = userEvent.setup();
+      const file = createFile('remove-me.txt');
+      mockFileManagementFiles = [{ id: 'file-id-1', filename: 'remove-me.txt' }];
+
+      renderPlayground();
+      await uploadAndTransition(file);
+
+      const closeBtn = screen
+        .getByTestId('doc-chip-uuid-1')
+        .querySelector('[data-testid="chip-close"]') as HTMLElement;
+      await user.click(closeBtn);
+
+      expect(mockDeleteFileById).toHaveBeenCalledWith('file-id-1');
+      expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+    });
+
+    it('always calls removeUploadedSource regardless of status', async () => {
+      const user = userEvent.setup();
+      const file = createFile('any-status.txt');
+      mockFileManagementFiles = [{ id: 'file-id-2', filename: 'any-status.txt' }];
+
+      renderPlayground();
+      await uploadAndTransition(file);
+
+      const closeBtn = screen
+        .getByTestId('doc-chip-uuid-1')
+        .querySelector('[data-testid="chip-close"]') as HTMLElement;
+      await user.click(closeBtn);
+
+      expect(mockRemoveUploadedSource).toHaveBeenCalledWith('any-status.txt');
+    });
+
+    it('removes chip from state after clicking close', async () => {
+      const user = userEvent.setup();
+      const file = createFile('gone.txt');
+      mockFileManagementFiles = [{ id: 'file-id-3', filename: 'gone.txt' }];
+
+      renderPlayground();
+      await uploadAndTransition(file);
+
+      const closeBtn = screen
+        .getByTestId('doc-chip-uuid-1')
+        .querySelector('[data-testid="chip-close"]') as HTMLElement;
+      await user.click(closeBtn);
+
+      expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+    });
+
+    it('does not call deleteFileById when filename not found in fileManagement.files', async () => {
+      const user = userEvent.setup();
+      const file = createFile('orphan.txt');
+      mockFileManagementFiles = []; // No matching file
+
+      renderPlayground();
+      await uploadAndTransition(file);
+
+      const closeBtn = screen
+        .getByTestId('doc-chip-uuid-1')
+        .querySelector('[data-testid="chip-close"]') as HTMLElement;
+      await user.click(closeBtn);
+
+      expect(mockDeleteFileById).not.toHaveBeenCalled();
+      expect(mockRemoveUploadedSource).toHaveBeenCalledWith('orphan.txt');
+      expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('handleSendMessage — docAttachments filtering and clearing', () => {
+    it('filters only uploaded chip fileNames for docAttachments (send disabled while one uploading)', async () => {
+      const uploadedFile = createFile('ready.txt');
+      const uploadingFile = createFile('pending.txt');
+
+      renderPlayground();
+      await triggerDocumentUpload([uploadedFile, uploadingFile]);
+
+      // Both files present in filesWithSettings: one uploaded, one still processing
+      await act(async () => {
+        mockFilesWithSettings = [
+          { id: 'fws-ready', file: uploadedFile, settings: null, status: 'uploaded' },
+          { id: 'fws-pend', file: uploadingFile, settings: null, status: 'pending' },
+        ];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      // Verify one chip is uploaded (close button) and one is still uploading (loading)
+      await waitFor(() => {
+        const chip1 = screen.getByTestId('doc-chip-uuid-1');
+        expect(chip1.querySelector('[data-testid="chip-close"]')).toBeInTheDocument();
+        const chip2 = screen.getByTestId('doc-chip-uuid-2');
+        expect(chip2.querySelector('[data-testid="chip-loading"]')).toBeInTheDocument();
+      });
+
+      // Send is disabled because second chip is still uploading
+      expect(screen.getByTestId('send-button')).toBeDisabled();
+    });
+
+    it('send is enabled and chips clear after all uploaded and send clicked', async () => {
+      const file = createFile('will-clear.txt');
+
+      renderPlayground();
+      await triggerDocumentUpload([file]);
+
+      // Transition to uploaded so send is enabled
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-clr', file, settings: null, status: 'uploaded' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('doc-chip-uuid-1')).toBeInTheDocument();
+        expect(screen.getByTestId('send-button')).not.toBeDisabled();
+      });
+
+      // Click send using fireEvent for synchronous behavior
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-button'));
+      });
+
+      // Chips should be cleared after send
+      await waitFor(() => {
+        expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('send handler runs successfully (no chips to clear scenario)', async () => {
+      renderPlayground();
+
+      // Verify send is enabled (model is auto-selected, no uploading chips)
+      await waitFor(() => {
+        expect(screen.getByTestId('send-button')).not.toBeDisabled();
+      });
+
+      // Click should not throw — verifies the full send handler executes without error
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-button'));
+      });
+
+      // No chips exist, so nothing to assert about chip clearing;
+      // the test passes if no runtime error occurs in the handler
+      expect(screen.queryByTestId('doc-chip-uuid-1')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('isSendDisabled — upload gating', () => {
+    it('send button disabled while any chip is uploading', async () => {
+      renderPlayground();
+
+      await triggerDocumentUpload([createFile('blocking.txt')]);
+
+      expect(screen.getByTestId('send-button')).toBeDisabled();
+    });
+
+    it('send button enabled when all chips are uploaded', async () => {
+      const file = createFile('done.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file]);
+
+      // Initially disabled
+      expect(screen.getByTestId('send-button')).toBeDisabled();
+
+      // Transition to uploaded
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-done', file, settings: null, status: 'uploaded' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('send-button')).not.toBeDisabled();
+      });
+    });
+
+    it('send button becomes disabled again when new uploading chip is added after all were uploaded', async () => {
+      const file1 = createFile('first-done.txt');
+      renderPlayground();
+
+      await triggerDocumentUpload([file1]);
+
+      // Transition to uploaded
+      await act(async () => {
+        mockFilesWithSettings = [{ id: 'fws-fd', file: file1, settings: null, status: 'uploaded' }];
+        useChatbotConfigStore.setState({
+          configurations: {
+            [DEFAULT_CONFIG_ID]: {
+              ...DEFAULT_CONFIGURATION,
+              selectedModel: 'test-model',
+            },
+          },
+          configIds: [DEFAULT_CONFIG_ID],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('send-button')).not.toBeDisabled();
+      });
+
+      // Add another file that's still uploading
+      await triggerDocumentUpload([createFile('second-pending.txt')]);
+
+      // Send should be disabled again
+      expect(screen.getByTestId('send-button')).toBeDisabled();
+    });
+  });
+
+  describe('default message injection and alwaysShowSendButton', () => {
+    const triggerImageUpload = async () => {
+      const { uploadVisionFile } = require('~/app/services/llamaStackService') as {
+        uploadVisionFile: jest.Mock;
+      };
+      uploadVisionFile.mockReturnValue({
+        promise: Promise.resolve({ data: { id: 'img-file-123' } }),
+        xhr: { abort: jest.fn() },
+      });
+
+      const input = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const imageFile = new File(['pixels'], 'photo.png', { type: 'image/png' });
+      Object.defineProperty(input, 'files', {
+        value: createFileList([imageFile]),
+        configurable: true,
+      });
+
+      await act(async () => {
+        fireEvent.change(input);
+      });
+
+      // Wait for upload to complete and state to settle
+      await waitFor(() => {
+        expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+          'data-always-show-send',
+          'true',
+        );
+      });
+    };
+
+    it('sets alwaysShowSendButton=true when image is uploaded', async () => {
+      renderPlayground();
+      await triggerImageUpload();
+
+      expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+        'data-always-show-send',
+        'true',
+      );
+    });
+
+    it('sets alwaysShowSendButton=true when doc chips are uploaded', async () => {
+      renderPlayground();
+
+      mockFilesWithSettings = [
+        { id: 'fws-1', file: createFile('report.pdf'), settings: null, status: 'uploaded' },
+      ];
+      useChatbotConfigStore.setState({
+        configurations: {
+          [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION, selectedModel: 'test-model' },
+        },
+        configIds: [DEFAULT_CONFIG_ID],
+      });
+
+      await triggerDocumentUpload([createFile('report.pdf')]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+          'data-always-show-send',
+          'true',
+        );
+      });
+    });
+
+    it('injects "Describe the image" when send is clicked with empty text and image only', async () => {
+      renderPlayground();
+      await triggerImageUpload();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-empty-button'));
+      });
+
+      expect(mockSetLastInput).toHaveBeenCalledWith('Describe the image');
+    });
+
+    it('injects "Summarize the attached documents" when send is clicked with empty text and docs only', async () => {
+      renderPlayground();
+
+      mockFilesWithSettings = [
+        { id: 'fws-1', file: createFile('report.pdf'), settings: null, status: 'uploaded' },
+      ];
+      useChatbotConfigStore.setState({
+        configurations: {
+          [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION, selectedModel: 'test-model' },
+        },
+        configIds: [DEFAULT_CONFIG_ID],
+      });
+
+      await triggerDocumentUpload([createFile('report.pdf')]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+          'data-always-show-send',
+          'true',
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-empty-button'));
+      });
+
+      expect(mockSetLastInput).toHaveBeenCalledWith('Summarize the attached documents');
+    });
+
+    it('injects combined message when send is clicked with empty text and both image + docs', async () => {
+      renderPlayground();
+      await triggerImageUpload();
+
+      mockFilesWithSettings = [
+        { id: 'fws-1', file: createFile('report.pdf'), settings: null, status: 'uploaded' },
+      ];
+
+      await triggerDocumentUpload([createFile('report.pdf')]);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+          'data-always-show-send',
+          'true',
+        );
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-empty-button'));
+      });
+
+      expect(mockSetLastInput).toHaveBeenCalledWith(
+        'Describe the image and summarize the attached documents',
+      );
+    });
+
+    it('does NOT inject default message when user typed text', async () => {
+      renderPlayground();
+      await triggerImageUpload();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('send-button'));
+      });
+
+      expect(mockSetLastInput).toHaveBeenCalledWith('test msg');
+    });
+
+    it('alwaysShowSendButton is false when no attachments', () => {
+      renderPlayground();
+      expect(screen.getByTestId('chatbot-message-bar')).toHaveAttribute(
+        'data-always-show-send',
+        'false',
+      );
+    });
+  });
+
+  describe('replace media modal', () => {
+    const setupImageUpload = () => {
+      const { uploadVisionFile } = require('~/app/services/llamaStackService') as {
+        uploadVisionFile: jest.Mock;
+      };
+      uploadVisionFile.mockReturnValue({
+        promise: Promise.resolve({ data: { id: 'img-file-1' } }),
+        xhr: { abort: jest.fn() },
+      });
+      return uploadVisionFile;
+    };
+
+    const triggerImageFileChange = async (fileName = 'photo.png') => {
+      const input = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const imageFile = new File(['pixels'], fileName, { type: 'image/png' });
+      Object.defineProperty(input, 'files', {
+        value: createFileList([imageFile]),
+        configurable: true,
+      });
+      await act(async () => {
+        fireEvent.change(input);
+      });
+    };
+
+    it('opens replace-media modal when uploading a second image before sending', async () => {
+      const uploadVisionFile = setupImageUpload();
+      renderPlayground();
+
+      // First upload
+      await triggerImageFileChange('first.png');
+      await waitFor(() => {
+        expect(uploadVisionFile).toHaveBeenCalledTimes(1);
+      });
+
+      // Second upload triggers the modal instead of uploading
+      await triggerImageFileChange('second.png');
+      expect(screen.getByTestId('replace-media-modal')).toBeInTheDocument();
+      expect(uploadVisionFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('confirm replaces image and revokes old blob', async () => {
+      const uploadVisionFile = setupImageUpload();
+      renderPlayground();
+
+      await triggerImageFileChange('first.png');
+      await waitFor(() => {
+        expect(uploadVisionFile).toHaveBeenCalledTimes(1);
+      });
+
+      // Trigger replace modal
+      await triggerImageFileChange('second.png');
+      expect(screen.getByTestId('replace-media-modal')).toBeInTheDocument();
+
+      // Click Replace (submit)
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('modal-submit'));
+      });
+
+      // Modal closes and new upload starts
+      expect(screen.queryByTestId('replace-media-modal')).not.toBeInTheDocument();
+      expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-preview-url');
+      await waitFor(() => {
+        expect(uploadVisionFile).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('cancel closes modal without uploading', async () => {
+      const uploadVisionFile = setupImageUpload();
+      renderPlayground();
+
+      await triggerImageFileChange('first.png');
+      await waitFor(() => {
+        expect(uploadVisionFile).toHaveBeenCalledTimes(1);
+      });
+
+      // Trigger replace modal
+      await triggerImageFileChange('second.png');
+      expect(screen.getByTestId('replace-media-modal')).toBeInTheDocument();
+
+      // Click Cancel
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('modal-cancel'));
+      });
+
+      // Modal closes, no new upload
+      expect(screen.queryByTestId('replace-media-modal')).not.toBeInTheDocument();
+      expect(uploadVisionFile).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
@@ -1,72 +1,178 @@
 import * as React from 'react';
-import { DropEvent } from '@patternfly/react-core';
-import { ChatbotFootnote, MessageBar } from '@patternfly/chatbot';
+import {
+  Alert,
+  AlertActionCloseButton,
+  DropEvent,
+  MenuItem,
+  MenuList,
+} from '@patternfly/react-core';
+import { ChatbotFootnote, FileDetailsLabel, MessageBar } from '@patternfly/chatbot';
 import { FileRejection } from 'react-dropzone';
-import { FILE_UPLOAD_CONFIG, ERROR_MESSAGES } from '~/app/Chatbot/const';
+import { OutlinedFileImageIcon, VolumeUpIcon, OutlinedFileAltIcon } from '@patternfly/react-icons';
+import {
+  VISION_UPLOAD_CONFIG,
+  FILE_UPLOAD_CONFIG,
+  ERROR_MESSAGES,
+  ALERT_TIMEOUT_MS,
+} from '~/app/Chatbot/const';
+
+export interface ImageUploadState {
+  uploading: boolean;
+  progress: number;
+  fileId: string | null;
+  previewUrl: string | null;
+  fileName: string | null;
+}
+
+export interface PendingDocChip {
+  id: string;
+  fileName: string;
+  status: 'uploading' | 'uploaded' | 'failed';
+}
 
 interface ChatbotMessageInputProps {
-  /** Callback when a message is sent */
   onSendMessage: (message: string) => void;
-  /** Callback when stop button is clicked */
   onStopStreaming: () => void;
-  /** Whether any instance is currently loading */
   isLoading: boolean;
-  /** Whether the send button should be disabled */
   isSendDisabled: boolean;
-  /** Whether to show the attach button (hidden in compare mode) */
   showAttachButton?: boolean;
-  /** Callback for file attachment */
-  onAttach?: <T extends File>(
+  onDocumentAttach?: <T extends File>(
     acceptedFiles: T[],
     fileRejections: FileRejection[],
     event: DropEvent,
   ) => void;
-  /** Callback for showing error alerts */
-  onShowErrorAlert?: (message: string, title: string) => void;
-  /** Whether dark mode is enabled */
   isDarkMode?: boolean;
+  onImageUpload: (file: File) => void;
+  imageUploadState: ImageUploadState;
+  onRemoveImage: () => void;
+  isImageUploadDisabled: boolean;
+  isAudioUploadDisabled: boolean;
+  pendingDocChips?: PendingDocChip[];
+  onRemoveDocChip?: (chipId: string) => void;
+  alwaysShowSendButton?: boolean;
 }
 
-/**
- * Shared message input component for the chatbot.
- * Used in both single and compare modes.
- */
 const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
   onSendMessage,
   onStopStreaming,
   isLoading,
   isSendDisabled,
   showAttachButton = true,
-  onAttach,
-  onShowErrorAlert,
+  onDocumentAttach,
   isDarkMode,
+  onImageUpload,
+  imageUploadState,
+  onRemoveImage,
+  isImageUploadDisabled,
+  isAudioUploadDisabled,
+  pendingDocChips,
+  onRemoveDocChip,
+  alwaysShowSendButton,
 }) => {
-  const handleAttachRejected = React.useCallback(
-    (fileRejections: FileRejection[]) => {
-      const errorMessages = fileRejections
-        .map((rejection) => {
-          const fileErrors = rejection.errors.map((error) => {
-            switch (error.code) {
-              case 'file-too-large':
-                return ERROR_MESSAGES.FILE_TOO_LARGE;
-              case 'too-many-files':
-                return ERROR_MESSAGES.TOO_MANY_FILES;
-              case 'file-invalid-type':
-                return `File type not supported. Accepted types: ${FILE_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}`;
-              default:
-                return error.message;
-            }
-          });
-          return `${rejection.file.name}: ${fileErrors.join(', ')}`;
-        })
-        .join('; ');
+  const [isAttachMenuOpen, setIsAttachMenuOpen] = React.useState(false);
+  const [validationError, setValidationError] = React.useState<string | null>(null);
+  const imageInputRef = React.useRef<HTMLInputElement>(null);
+  const documentInputRef = React.useRef<HTMLInputElement>(null);
 
-      onShowErrorAlert?.(
-        `${ERROR_MESSAGES.FILE_UPLOAD_REJECTED}: ${errorMessages}`,
-        'File Upload Error',
-      );
+  React.useEffect(() => {
+    if (!validationError) {
+      return undefined;
+    }
+    const timer = setTimeout(() => setValidationError(null), ALERT_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [validationError]);
+
+  const handleMenuSelect = React.useCallback((action: string) => {
+    setIsAttachMenuOpen(false);
+    if (action === 'upload-image') {
+      imageInputRef.current?.click();
+    } else if (action === 'upload-documents') {
+      documentInputRef.current?.click();
+    }
+  }, []);
+
+  const handleImageFileSelect = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      // Reset the input so re-selecting the same file triggers onChange
+      // eslint-disable-next-line no-param-reassign
+      event.target.value = '';
+
+      if (!VISION_UPLOAD_CONFIG.ALLOWED_MIME_TYPES.includes(file.type)) {
+        setValidationError(`${file.name} is not a supported file type. Accepted types: JPG, PNG.`);
+        return;
+      }
+      if (file.size > VISION_UPLOAD_CONFIG.MAX_FILE_SIZE) {
+        setValidationError(
+          `${file.name} exceeds maximum size of ${VISION_UPLOAD_CONFIG.MAX_FILE_SIZE / (1024 * 1024)} MB. Try a smaller file.`,
+        );
+        return;
+      }
+      onImageUpload(file);
     },
-    [onShowErrorAlert],
+    [onImageUpload],
+  );
+
+  const handleDocumentFileSelect = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files || []);
+      if (!files.length) {
+        return;
+      }
+      // eslint-disable-next-line no-param-reassign
+      event.target.value = '';
+
+      const allowedMimes = Object.keys(FILE_UPLOAD_CONFIG.ALLOWED_FILE_TYPES);
+      const errors: string[] = [];
+      const accepted: File[] = [];
+
+      for (const file of files) {
+        if (file.size > FILE_UPLOAD_CONFIG.MAX_FILE_SIZE) {
+          errors.push(`${file.name}: ${ERROR_MESSAGES.FILE_TOO_LARGE}`);
+        } else if (!allowedMimes.includes(file.type)) {
+          errors.push(
+            `${file.name}: File type not supported. Accepted types: ${FILE_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}`,
+          );
+        } else {
+          accepted.push(file);
+        }
+      }
+
+      if (errors.length) {
+        setValidationError(`${ERROR_MESSAGES.FILE_UPLOAD_REJECTED}: ${errors.join('; ')}`);
+      }
+      if (accepted.length && onDocumentAttach) {
+        onDocumentAttach(accepted, [], new Event('change'));
+      }
+    },
+    [onDocumentAttach],
+  );
+
+  const attachMenuItems = React.useMemo(
+    () => (
+      <MenuList>
+        <MenuItem
+          icon={<OutlinedFileImageIcon />}
+          isDisabled={isImageUploadDisabled}
+          onClick={() => handleMenuSelect('upload-image')}
+        >
+          Upload image
+        </MenuItem>
+        <MenuItem icon={<VolumeUpIcon />} isDisabled={isAudioUploadDisabled}>
+          Upload audio
+        </MenuItem>
+        <MenuItem
+          icon={<OutlinedFileAltIcon />}
+          onClick={() => handleMenuSelect('upload-documents')}
+        >
+          Upload documents
+        </MenuItem>
+      </MenuList>
+    ),
+    [isImageUploadDisabled, isAudioUploadDisabled, handleMenuSelect],
   );
 
   return (
@@ -79,6 +185,49 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           : 'var(--pf-t--global--background--color--100)',
       }}
     >
+      {validationError && (
+        <div style={{ paddingBottom: '0.5rem' }}>
+          <Alert
+            variant="danger"
+            isInline
+            title={validationError}
+            actionClose={<AlertActionCloseButton onClose={() => setValidationError(null)} />}
+            data-testid="vision-validation-error"
+          />
+        </div>
+      )}
+      {(imageUploadState.fileName || (pendingDocChips && pendingDocChips.length > 0)) && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.5rem',
+            paddingBottom: '0.5rem',
+          }}
+        >
+          {imageUploadState.fileName && (
+            <FileDetailsLabel
+              fileName={imageUploadState.fileName}
+              isLoading={imageUploadState.uploading}
+              onClose={imageUploadState.uploading ? undefined : onRemoveImage}
+              hasTruncation
+              variant="outline"
+              data-testid="vision-file-preview"
+            />
+          )}
+          {pendingDocChips?.map((chip) => (
+            <FileDetailsLabel
+              key={chip.id}
+              fileName={chip.fileName}
+              isLoading={chip.status === 'uploading'}
+              onClose={chip.status === 'uploading' ? undefined : () => onRemoveDocChip?.(chip.id)}
+              hasTruncation
+              variant="outline"
+              data-testid={`doc-chip-${chip.id}`}
+            />
+          ))}
+        </div>
+      )}
       <div
         style={{
           border: isDarkMode ? 'none' : '1px solid var(--pf-t--global--border--color--default)',
@@ -95,15 +244,21 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           hasAttachButton={showAttachButton}
           isSendButtonDisabled={isSendDisabled}
           hasStopButton={isLoading}
+          alwayShowSendButton={alwaysShowSendButton}
           data-testid="chatbot-message-bar"
-          onAttach={onAttach}
-          onAttachRejected={handleAttachRejected}
-          allowedFileTypes={FILE_UPLOAD_CONFIG.ALLOWED_FILE_TYPES}
-          maxSize={FILE_UPLOAD_CONFIG.MAX_FILE_SIZE}
-          maxFiles={FILE_UPLOAD_CONFIG.MAX_FILES_IN_VECTOR_STORE}
+          {...(showAttachButton
+            ? {
+                attachMenuProps: {
+                  isAttachMenuOpen,
+                  setIsAttachMenuOpen,
+                  attachMenuItems,
+                  onAttachMenuToggleClick: () => setIsAttachMenuOpen(!isAttachMenuOpen),
+                },
+              }
+            : {})}
           buttonProps={{
             attach: {
-              tooltipContent: `Upload files (${FILE_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}, max ${FILE_UPLOAD_CONFIG.MAX_FILE_SIZE / (1024 * 1024)}MB)`,
+              tooltipContent: 'Attach',
               inputTestId: 'chatbot-attach-input',
             },
             send: {
@@ -115,6 +270,23 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           }}
         />
       </div>
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept={VISION_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}
+        style={{ display: 'none' }}
+        onChange={handleImageFileSelect}
+        data-testid="vision-file-input"
+      />
+      <input
+        ref={documentInputRef}
+        type="file"
+        accept={FILE_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}
+        multiple
+        style={{ display: 'none' }}
+        onChange={handleDocumentFileSelect}
+        data-testid="document-file-input"
+      />
       <div style={{ paddingTop: '1rem', textAlign: 'center' }}>
         <ChatbotFootnote label="This chatbot uses AI. Check for mistakes." />
       </div>

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/StreamingThinkingSection.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/StreamingThinkingSection.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ExpandableSection } from '@patternfly/react-core';
+
+export const StreamingThinkingSection: React.FC<{
+  reasoningText: string;
+  isComplete: boolean;
+}> = ({ reasoningText, isComplete }) => {
+  const [isExpanded, setIsExpanded] = React.useState(true);
+
+  React.useEffect(() => {
+    if (isComplete) {
+      setIsExpanded(false);
+    }
+  }, [isComplete]);
+
+  return React.createElement(
+    ExpandableSection,
+    {
+      toggleContent: 'Show thinking',
+      isExpanded,
+      onToggle: (_e: React.MouseEvent, expanded: boolean) => setIsExpanded(expanded),
+    },
+    React.createElement(
+      'div',
+      { style: { fontSize: 'var(--pf-t--global--font--size--sm)', whiteSpace: 'pre-wrap' } },
+      reasoningText,
+    ),
+  );
+};

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import ChatbotMessageInput from '~/app/Chatbot/components/ChatbotMessageInput';
-import { ERROR_MESSAGES, FILE_UPLOAD_CONFIG } from '~/app/Chatbot/const';
+import ChatbotMessageInput, {
+  ImageUploadState,
+  PendingDocChip,
+} from '~/app/Chatbot/components/ChatbotMessageInput';
+import { VISION_UPLOAD_CONFIG } from '~/app/Chatbot/const';
 
-// Mock the PatternFly chatbot components
 jest.mock('@patternfly/chatbot', () => ({
   MessageBar: ({
     onSendMessage,
@@ -12,7 +14,7 @@ jest.mock('@patternfly/chatbot', () => ({
     hasAttachButton,
     isSendButtonDisabled,
     hasStopButton,
-    onAttachRejected,
+    attachMenuProps,
     'data-testid': testId,
   }: {
     onSendMessage: (message: string) => void;
@@ -20,7 +22,12 @@ jest.mock('@patternfly/chatbot', () => ({
     hasAttachButton: boolean;
     isSendButtonDisabled: boolean;
     hasStopButton: boolean;
-    onAttachRejected: (rejections: unknown[]) => void;
+    attachMenuProps?: {
+      isAttachMenuOpen: boolean;
+      setIsAttachMenuOpen: (open: boolean) => void;
+      attachMenuItems: React.ReactNode;
+      onAttachMenuToggleClick: () => void;
+    };
     'data-testid': string;
   }) => (
     <div data-testid={testId}>
@@ -42,36 +49,102 @@ jest.mock('@patternfly/chatbot', () => ({
           Stop
         </button>
       )}
-      {hasAttachButton && (
-        <button data-testid="mock-attach-button" type="button">
-          Attach
-        </button>
+      {hasAttachButton && attachMenuProps && (
+        <div data-testid="mock-attach-menu">
+          <button
+            data-testid="mock-attach-toggle"
+            onClick={attachMenuProps.onAttachMenuToggleClick}
+            type="button"
+          >
+            Attach
+          </button>
+          {attachMenuProps.isAttachMenuOpen && (
+            <div data-testid="mock-menu-items">{attachMenuProps.attachMenuItems}</div>
+          )}
+        </div>
       )}
-      <button
-        data-testid="mock-reject-button"
-        onClick={() =>
-          onAttachRejected([
-            {
-              file: { name: 'test.exe' },
-              errors: [{ code: 'file-invalid-type', message: 'Invalid type' }],
-            },
-          ])
-        }
-        type="button"
-      >
-        Trigger Reject
-      </button>
     </div>
   ),
   ChatbotFootnote: ({ label }: { label: string }) => <div data-testid="mock-footnote">{label}</div>,
+  FileDetailsLabel: ({
+    fileName,
+    isLoading,
+    onClose,
+    'data-testid': testId,
+  }: {
+    fileName: string;
+    isLoading?: boolean;
+    onClose?: (event: React.MouseEvent) => void;
+    'data-testid'?: string;
+  }) => (
+    <div data-testid={testId || 'file-details-label'}>
+      <span data-testid="file-name">{fileName}</span>
+      {isLoading && <span data-testid="file-loading-spinner">Loading...</span>}
+      {!isLoading && onClose && (
+        <button data-testid="file-close-button" onClick={(e) => onClose(e)} type="button">
+          Close
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+jest.mock('@patternfly/react-core', () => ({
+  ...jest.requireActual('@patternfly/react-core'),
+  MenuItem: ({
+    children,
+    icon,
+    isDisabled,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    icon?: React.ReactNode;
+    isDisabled?: boolean;
+    onClick?: () => void;
+  }) => {
+    const label = typeof children === 'string' ? children : 'unknown';
+    return (
+      <button
+        data-testid={`menu-item-${label.replace(/\s+/g, '-').toLowerCase()}`}
+        onClick={isDisabled ? undefined : onClick}
+        disabled={isDisabled}
+        type="button"
+      >
+        {icon}
+        {children}
+      </button>
+    );
+  },
+  MenuList: ({ children }: { children: React.ReactNode }) => (
+    <ul data-testid="mock-menu-list">{children}</ul>
+  ),
+}));
+
+jest.mock('@patternfly/react-icons', () => ({
+  OutlinedFileImageIcon: () => <span data-testid="icon-image" />,
+  VolumeUpIcon: () => <span data-testid="icon-audio" />,
+  OutlinedFileAltIcon: () => <span data-testid="icon-document" />,
 }));
 
 describe('ChatbotMessageInput', () => {
+  const defaultImageUploadState: ImageUploadState = {
+    uploading: false,
+    progress: 0,
+    fileId: null,
+    previewUrl: null,
+    fileName: null,
+  };
+
   const defaultProps = {
     onSendMessage: jest.fn(),
     onStopStreaming: jest.fn(),
     isLoading: false,
     isSendDisabled: false,
+    onImageUpload: jest.fn(),
+    imageUploadState: defaultImageUploadState,
+    onRemoveImage: jest.fn(),
+    isImageUploadDisabled: false,
+    isAudioUploadDisabled: true,
   };
 
   beforeEach(() => {
@@ -80,13 +153,11 @@ describe('ChatbotMessageInput', () => {
 
   it('renders the message bar', () => {
     render(<ChatbotMessageInput {...defaultProps} />);
-
     expect(screen.getByTestId('chatbot-message-bar')).toBeInTheDocument();
   });
 
   it('renders the footnote with AI warning', () => {
     render(<ChatbotMessageInput {...defaultProps} />);
-
     expect(screen.getByTestId('mock-footnote')).toHaveTextContent(
       'This chatbot uses AI. Check for mistakes.',
     );
@@ -105,106 +176,518 @@ describe('ChatbotMessageInput', () => {
 
   it('shows stop button when isLoading is true', () => {
     render(<ChatbotMessageInput {...defaultProps} isLoading />);
-
     expect(screen.getByTestId('mock-stop-button')).toBeInTheDocument();
   });
 
   it('does not show stop button when isLoading is false', () => {
     render(<ChatbotMessageInput {...defaultProps} isLoading={false} />);
-
     expect(screen.queryByTestId('mock-stop-button')).not.toBeInTheDocument();
-  });
-
-  it('calls onStopStreaming when stop button is clicked', async () => {
-    const user = userEvent.setup();
-    const mockOnStopStreaming = jest.fn();
-    render(
-      <ChatbotMessageInput {...defaultProps} isLoading onStopStreaming={mockOnStopStreaming} />,
-    );
-
-    const stopButton = screen.getByTestId('mock-stop-button');
-    await user.click(stopButton);
-
-    expect(mockOnStopStreaming).toHaveBeenCalledTimes(1);
   });
 
   it('disables send button when isSendDisabled is true', () => {
     render(<ChatbotMessageInput {...defaultProps} isSendDisabled />);
-
     expect(screen.getByTestId('mock-send-button')).toBeDisabled();
   });
 
-  it('enables send button when isSendDisabled is false', () => {
-    render(<ChatbotMessageInput {...defaultProps} isSendDisabled={false} />);
-
-    expect(screen.getByTestId('mock-send-button')).not.toBeDisabled();
-  });
-
-  it('shows attach button by default', () => {
-    render(<ChatbotMessageInput {...defaultProps} />);
-
-    expect(screen.getByTestId('mock-attach-button')).toBeInTheDocument();
-  });
-
-  it('hides attach button when showAttachButton is false', () => {
+  it('hides attach menu when showAttachButton is false', () => {
     render(<ChatbotMessageInput {...defaultProps} showAttachButton={false} />);
-
-    expect(screen.queryByTestId('mock-attach-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-attach-menu')).not.toBeInTheDocument();
   });
 
-  it('calls onShowErrorAlert with file rejection error message', async () => {
-    const user = userEvent.setup();
-    const mockOnShowErrorAlert = jest.fn();
-    render(<ChatbotMessageInput {...defaultProps} onShowErrorAlert={mockOnShowErrorAlert} />);
+  describe('attach menu', () => {
+    it('renders attach menu toggle', () => {
+      render(<ChatbotMessageInput {...defaultProps} />);
+      expect(screen.getByTestId('mock-attach-toggle')).toBeInTheDocument();
+    });
 
-    const rejectButton = screen.getByTestId('mock-reject-button');
-    await user.click(rejectButton);
+    it('opens attach menu on toggle click and shows three menu items', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} />);
 
-    expect(mockOnShowErrorAlert).toHaveBeenCalledWith(
-      expect.stringContaining(ERROR_MESSAGES.FILE_UPLOAD_REJECTED),
-      'File Upload Error',
-    );
-    expect(mockOnShowErrorAlert).toHaveBeenCalledWith(
-      expect.stringContaining(FILE_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS),
-      'File Upload Error',
-    );
-  });
+      await user.click(screen.getByTestId('mock-attach-toggle'));
 
-  it('applies light mode styles when isDarkMode is false', () => {
-    const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode={false} />);
+      expect(screen.getByTestId('menu-item-upload-image')).toBeInTheDocument();
+      expect(screen.getByTestId('menu-item-upload-audio')).toBeInTheDocument();
+      expect(screen.getByTestId('menu-item-upload-documents')).toBeInTheDocument();
+    });
 
-    const outerDiv = container.firstChild as HTMLElement;
-    expect(outerDiv).toHaveStyle({
-      backgroundColor: 'var(--pf-t--global--background--color--100)',
+    it('disables "Upload image" when isImageUploadDisabled is true', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} isImageUploadDisabled />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+
+      const imageItem = screen.getByTestId('menu-item-upload-image');
+      expect(imageItem).toBeDisabled();
+    });
+
+    it('"Upload audio" is always disabled', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+
+      const audioItem = screen.getByTestId('menu-item-upload-audio');
+      expect(audioItem).toBeDisabled();
+    });
+
+    it('clicking "Upload image" triggers the hidden file input', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const clickSpy = jest.spyOn(fileInput, 'click');
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-image'));
+
+      expect(clickSpy).toHaveBeenCalled();
+      clickSpy.mockRestore();
+    });
+
+    it('clicking "Upload documents" triggers the hidden document file input', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('document-file-input') as HTMLInputElement;
+      const clickSpy = jest.spyOn(fileInput, 'click');
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-documents'));
+
+      expect(clickSpy).toHaveBeenCalled();
+      clickSpy.mockRestore();
+    });
+
+    it('does not trigger file input when "Upload image" is disabled', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} isImageUploadDisabled />);
+
+      const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const clickSpy = jest.spyOn(fileInput, 'click');
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-image'));
+
+      expect(clickSpy).not.toHaveBeenCalled();
+      clickSpy.mockRestore();
     });
   });
 
-  it('applies dark mode styles when isDarkMode is true', () => {
-    const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode />);
+  describe('image upload via hidden input', () => {
+    it('triggers onImageUpload when a valid image file is selected', () => {
+      const mockOnImageUpload = jest.fn();
+      render(<ChatbotMessageInput {...defaultProps} onImageUpload={mockOnImageUpload} />);
 
-    const outerDiv = container.firstChild as HTMLElement;
-    expect(outerDiv).toHaveStyle({
-      backgroundColor: 'var(--pf-t--global--dark--background--color--100)',
+      const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const file = new File(['image-data'], 'photo.jpg', { type: 'image/jpeg' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnImageUpload).toHaveBeenCalledWith(file);
+    });
+
+    it('shows validation error for unsupported file type', () => {
+      render(<ChatbotMessageInput {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const file = new File(['data'], 'document.gif', { type: 'image/gif' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      expect(screen.getByText(/is not a supported file type/)).toBeInTheDocument();
+    });
+
+    it('shows validation error for file exceeding size limit', () => {
+      render(<ChatbotMessageInput {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+      const largeContent = new Uint8Array(VISION_UPLOAD_CONFIG.MAX_FILE_SIZE + 1);
+      const file = new File([largeContent], 'huge.png', { type: 'image/png' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      expect(screen.getByText(/exceeds maximum size/)).toBeInTheDocument();
+    });
+
+    it('auto-dismisses validation error after timeout', async () => {
+      jest.useFakeTimers();
+      try {
+        render(<ChatbotMessageInput {...defaultProps} />);
+
+        const fileInput = screen.getByTestId('vision-file-input') as HTMLInputElement;
+        const file = new File(['data'], 'bad.gif', { type: 'image/gif' });
+        fireEvent.change(fileInput, { target: { files: [file] } });
+
+        expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+
+        jest.advanceTimersByTime(8000);
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('vision-validation-error')).not.toBeInTheDocument();
+        });
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 
-  it('applies border in light mode', () => {
-    const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode={false} />);
+  describe('image preview chip', () => {
+    it('renders FileDetailsLabel when a file name is present', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          imageUploadState={{ ...defaultImageUploadState, fileName: 'test.jpg' }}
+        />,
+      );
 
-    const innerDiv = container.querySelector('[data-testid="chatbot-message-bar"]')
-      ?.parentElement as HTMLElement;
-    expect(innerDiv).toHaveStyle({
-      border: '1px solid var(--pf-t--global--border--color--default)',
+      expect(screen.getByTestId('vision-file-preview')).toBeInTheDocument();
+      expect(screen.getByTestId('file-name')).toHaveTextContent('test.jpg');
+    });
+
+    it('does not render FileDetailsLabel when no file name', () => {
+      render(<ChatbotMessageInput {...defaultProps} />);
+      expect(screen.queryByTestId('vision-file-preview')).not.toBeInTheDocument();
+    });
+
+    it('shows loading spinner during upload', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          imageUploadState={{
+            ...defaultImageUploadState,
+            fileName: 'uploading.png',
+            uploading: true,
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('file-loading-spinner')).toBeInTheDocument();
+      expect(screen.queryByTestId('file-close-button')).not.toBeInTheDocument();
+    });
+
+    it('shows close button when upload is complete', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          imageUploadState={{
+            ...defaultImageUploadState,
+            fileName: 'done.jpg',
+            uploading: false,
+            fileId: 'file-123',
+          }}
+        />,
+      );
+
+      expect(screen.queryByTestId('file-loading-spinner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('file-close-button')).toBeInTheDocument();
+    });
+
+    it('calls onRemoveImage when close button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockOnRemoveImage = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          onRemoveImage={mockOnRemoveImage}
+          imageUploadState={{
+            ...defaultImageUploadState,
+            fileName: 'remove-me.jpg',
+            uploading: false,
+            fileId: 'file-456',
+          }}
+        />,
+      );
+
+      await user.click(screen.getByTestId('file-close-button'));
+      expect(mockOnRemoveImage).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('does not apply border in dark mode', () => {
-    const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode />);
+  describe('styling', () => {
+    it('applies light mode background', () => {
+      const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode={false} />);
+      const outerDiv = container.firstChild as HTMLElement;
+      expect(outerDiv).toHaveStyle({
+        backgroundColor: 'var(--pf-t--global--background--color--100)',
+      });
+    });
 
-    const innerDiv = container.querySelector('[data-testid="chatbot-message-bar"]')
-      ?.parentElement as HTMLElement;
-    expect(innerDiv).toHaveStyle({
-      border: 'none',
+    it('applies dark mode background', () => {
+      const { container } = render(<ChatbotMessageInput {...defaultProps} isDarkMode />);
+      const outerDiv = container.firstChild as HTMLElement;
+      expect(outerDiv).toHaveStyle({
+        backgroundColor: 'var(--pf-t--global--dark--background--color--100)',
+      });
+    });
+  });
+
+  describe('document chips', () => {
+    const docChips: PendingDocChip[] = [
+      { id: 'chip-1', fileName: 'PR_STYLE_GUIDE.md', status: 'uploaded' },
+      { id: 'chip-2', fileName: 'rag-testing.txt', status: 'uploading' },
+    ];
+
+    it('renders doc chips alongside image chip', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          imageUploadState={{ ...defaultImageUploadState, fileName: 'photo.jpg' }}
+          pendingDocChips={docChips}
+        />,
+      );
+
+      expect(screen.getByTestId('vision-file-preview')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-1')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-2')).toBeInTheDocument();
+    });
+
+    it('renders doc chips without image chip', () => {
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={docChips} />);
+
+      expect(screen.queryByTestId('vision-file-preview')).not.toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-1')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-2')).toBeInTheDocument();
+    });
+
+    it('shows loading spinner for uploading doc chips', () => {
+      const uploadingChips: PendingDocChip[] = [
+        { id: 'chip-uploading', fileName: 'data.csv', status: 'uploading' },
+      ];
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={uploadingChips} />);
+
+      const chip = screen.getByTestId('doc-chip-chip-uploading');
+      expect(chip.querySelector('[data-testid="file-loading-spinner"]')).toBeInTheDocument();
+      expect(chip.querySelector('[data-testid="file-close-button"]')).not.toBeInTheDocument();
+    });
+
+    it('shows close button for uploaded doc chips', () => {
+      const uploadedChips: PendingDocChip[] = [
+        { id: 'chip-done', fileName: 'report.pdf', status: 'uploaded' },
+      ];
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={uploadedChips} />);
+
+      const chip = screen.getByTestId('doc-chip-chip-done');
+      expect(chip.querySelector('[data-testid="file-loading-spinner"]')).not.toBeInTheDocument();
+      expect(chip.querySelector('[data-testid="file-close-button"]')).toBeInTheDocument();
+    });
+
+    it('calls onRemoveDocChip when close button is clicked on uploaded chip', async () => {
+      const user = userEvent.setup();
+      const mockOnRemoveDocChip = jest.fn();
+      const uploadedChips: PendingDocChip[] = [
+        { id: 'chip-remove', fileName: 'notes.txt', status: 'uploaded' },
+      ];
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          pendingDocChips={uploadedChips}
+          onRemoveDocChip={mockOnRemoveDocChip}
+        />,
+      );
+
+      const closeButton = screen
+        .getByTestId('doc-chip-chip-remove')
+        .querySelector('[data-testid="file-close-button"]') as HTMLElement;
+      await user.click(closeButton);
+      expect(mockOnRemoveDocChip).toHaveBeenCalledWith('chip-remove');
+    });
+
+    it('does not render chip area when no image and no doc chips', () => {
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={[]} />);
+
+      expect(screen.queryByTestId('vision-file-preview')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('doc-chip-chip-1')).not.toBeInTheDocument();
+    });
+
+    it('renders failed status chip with close button (not spinner)', () => {
+      const failedChips: PendingDocChip[] = [
+        { id: 'chip-fail', fileName: 'broken.pdf', status: 'failed' },
+      ];
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={failedChips} />);
+
+      const chip = screen.getByTestId('doc-chip-chip-fail');
+      expect(chip.querySelector('[data-testid="file-loading-spinner"]')).not.toBeInTheDocument();
+      expect(chip.querySelector('[data-testid="file-close-button"]')).toBeInTheDocument();
+    });
+
+    it('calls onRemoveDocChip when close button is clicked on failed chip', async () => {
+      const user = userEvent.setup();
+      const mockOnRemoveDocChip = jest.fn();
+      const failedChips: PendingDocChip[] = [
+        { id: 'chip-fail-remove', fileName: 'bad.csv', status: 'failed' },
+      ];
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          pendingDocChips={failedChips}
+          onRemoveDocChip={mockOnRemoveDocChip}
+        />,
+      );
+
+      const closeButton = screen
+        .getByTestId('doc-chip-chip-fail-remove')
+        .querySelector('[data-testid="file-close-button"]') as HTMLElement;
+      await user.click(closeButton);
+      expect(mockOnRemoveDocChip).toHaveBeenCalledWith('chip-fail-remove');
+    });
+
+    it('renders 3+ chips correctly', () => {
+      const manyChips: PendingDocChip[] = [
+        { id: 'chip-a', fileName: 'file-a.txt', status: 'uploaded' },
+        { id: 'chip-b', fileName: 'file-b.pdf', status: 'uploaded' },
+        { id: 'chip-c', fileName: 'file-c.csv', status: 'uploading' },
+        { id: 'chip-d', fileName: 'file-d.txt', status: 'failed' },
+      ];
+      render(<ChatbotMessageInput {...defaultProps} pendingDocChips={manyChips} />);
+
+      expect(screen.getByTestId('doc-chip-chip-a')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-b')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-c')).toBeInTheDocument();
+      expect(screen.getByTestId('doc-chip-chip-d')).toBeInTheDocument();
+    });
+
+    it('renders chips in array order', () => {
+      const orderedChips: PendingDocChip[] = [
+        { id: 'first', fileName: 'alpha.txt', status: 'uploaded' },
+        { id: 'second', fileName: 'beta.txt', status: 'uploaded' },
+        { id: 'third', fileName: 'gamma.txt', status: 'uploaded' },
+      ];
+      const { container } = render(
+        <ChatbotMessageInput {...defaultProps} pendingDocChips={orderedChips} />,
+      );
+
+      const chipElements = container.querySelectorAll('[data-testid^="doc-chip-"]');
+      expect(chipElements[0]).toHaveAttribute('data-testid', 'doc-chip-first');
+      expect(chipElements[1]).toHaveAttribute('data-testid', 'doc-chip-second');
+      expect(chipElements[2]).toHaveAttribute('data-testid', 'doc-chip-third');
+    });
+
+    it('send button is disabled when isSendDisabled is true (driven by uploading chips)', () => {
+      render(<ChatbotMessageInput {...defaultProps} isSendDisabled />);
+
+      const sendButton = screen.getByTestId('mock-send-button');
+      expect(sendButton).toBeDisabled();
+    });
+  });
+
+  describe('document file validation', () => {
+    const onDocumentAttach = jest.fn();
+
+    beforeEach(() => {
+      onDocumentAttach.mockClear();
+    });
+
+    it('rejects unsupported file types and shows validation error', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} onDocumentAttach={onDocumentAttach} />);
+
+      // Open menu and click "Upload documents"
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-documents'));
+
+      // Set an .exe file on the document input
+      const input = screen.getByTestId('document-file-input') as HTMLInputElement;
+      const badFile = new File(['data'], 'malware.exe', { type: 'application/x-msdownload' });
+      Object.defineProperty(input, 'files', {
+        value: [badFile],
+        configurable: true,
+      });
+      Object.defineProperty(input, 'length', { value: 1, configurable: true });
+      fireEvent.change(input);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      });
+      expect(onDocumentAttach).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized files and shows validation error', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} onDocumentAttach={onDocumentAttach} />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-documents'));
+
+      const input = screen.getByTestId('document-file-input') as HTMLInputElement;
+      // 11MB file exceeds 10MB limit
+      const bigFile = new File(['x'.repeat(11 * 1024 * 1024)], 'huge.txt', {
+        type: 'text/plain',
+      });
+      Object.defineProperty(input, 'files', { value: [bigFile], configurable: true });
+      fireEvent.change(input);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      });
+      expect(onDocumentAttach).not.toHaveBeenCalled();
+    });
+
+    it('passes only valid files from a mixed batch', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} onDocumentAttach={onDocumentAttach} />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-documents'));
+
+      const input = screen.getByTestId('document-file-input') as HTMLInputElement;
+      const validFile = new File(['valid'], 'good.txt', { type: 'text/plain' });
+      const invalidFile = new File(['bad'], 'bad.exe', { type: 'application/x-msdownload' });
+
+      const mockFileList = [validFile, invalidFile] as unknown as FileList;
+      Object.defineProperty(mockFileList, 'length', { value: 2 });
+      Object.defineProperty(mockFileList, 'item', {
+        value: (i: number) => [validFile, invalidFile][i],
+      });
+      Object.defineProperty(input, 'files', { value: mockFileList, configurable: true });
+      fireEvent.change(input);
+
+      // Validation error shown for the rejected file
+      await waitFor(() => {
+        expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      });
+      // But valid file was still passed to onDocumentAttach
+      expect(onDocumentAttach).toHaveBeenCalledWith([validFile], [], expect.any(Event));
+    });
+
+    it('validation error auto-dismisses after timeout', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ChatbotMessageInput {...defaultProps} onDocumentAttach={onDocumentAttach} />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-documents'));
+
+      const input = screen.getByTestId('document-file-input') as HTMLInputElement;
+      const badFile = new File(['x'], 'bad.exe', { type: 'application/x-msdownload' });
+      Object.defineProperty(input, 'files', { value: [badFile], configurable: true });
+      fireEvent.change(input);
+
+      expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+
+      // Advance past ALERT_TIMEOUT_MS (8000ms)
+      jest.advanceTimersByTime(8100);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('vision-validation-error')).not.toBeInTheDocument();
+      });
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe('alwaysShowSendButton', () => {
+    it('passes alwayShowSendButton to MessageBar when true', () => {
+      const { container } = render(<ChatbotMessageInput {...defaultProps} alwaysShowSendButton />);
+      const messageBar = container.querySelector('[data-testid="chatbot-message-bar"]');
+      expect(messageBar).toBeInTheDocument();
+    });
+
+    it('passes alwayShowSendButton=false to MessageBar when prop is false', () => {
+      const { container } = render(
+        <ChatbotMessageInput {...defaultProps} alwaysShowSendButton={false} />,
+      );
+      const messageBar = container.querySelector('[data-testid="chatbot-message-bar"]');
+      expect(messageBar).toBeInTheDocument();
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/const.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/const.ts
@@ -31,7 +31,7 @@ export const sampleWelcomePrompts: WelcomePrompt[] = [
   },
 ];
 
-// File upload constants
+// File upload constants (RAG / vector store documents)
 export const FILE_UPLOAD_CONFIG = {
   MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB in bytes
   MAX_FILES_IN_VECTOR_STORE: 10, // Maximum number of files allowed in vector store
@@ -41,6 +41,14 @@ export const FILE_UPLOAD_CONFIG = {
     'text/plain': ['.txt'],
   },
   ACCEPTED_EXTENSIONS: '.pdf,.csv,.txt',
+} as const;
+
+// Vision image upload constants (separate from RAG documents)
+export const VISION_UPLOAD_ALLOWED_MIME_TYPES: readonly string[] = ['image/jpeg', 'image/png'];
+export const VISION_UPLOAD_CONFIG = {
+  MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB
+  ALLOWED_MIME_TYPES: VISION_UPLOAD_ALLOWED_MIME_TYPES,
+  ACCEPTED_EXTENSIONS: '.jpg,.jpeg,.png',
 } as const;
 
 // Job polling constants

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/StreamingThinkingSection.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/StreamingThinkingSection.spec.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@patternfly/chatbot', () => ({
+  FileDetailsLabel: jest.fn(({ fileName }: { fileName: string }) => fileName),
+}));
+
+// eslint-disable-next-line import/first
+import { StreamingThinkingSection } from '~/app/Chatbot/components/StreamingThinkingSection';
+
+describe('StreamingThinkingSection', () => {
+  it('should render with "Show thinking" toggle text', () => {
+    render(<StreamingThinkingSection reasoningText="test reasoning" isComplete={false} />);
+
+    expect(screen.getByText('Show thinking')).toBeInTheDocument();
+  });
+
+  it('should start expanded when isComplete is false', () => {
+    render(<StreamingThinkingSection reasoningText="visible reasoning" isComplete={false} />);
+
+    expect(screen.getByText('visible reasoning')).toBeVisible();
+  });
+
+  it('should display reasoningText inside the expandable body', () => {
+    render(
+      <StreamingThinkingSection reasoningText="Step 1: analyze the problem" isComplete={false} />,
+    );
+
+    expect(screen.getByText('Step 1: analyze the problem')).toBeInTheDocument();
+  });
+
+  it('should auto-collapse when isComplete transitions from false to true', () => {
+    const { rerender } = render(
+      <StreamingThinkingSection reasoningText="thinking..." isComplete={false} />,
+    );
+
+    expect(screen.getByText('thinking...')).toBeVisible();
+
+    rerender(<StreamingThinkingSection reasoningText="thinking..." isComplete />);
+
+    expect(screen.getByText('thinking...')).not.toBeVisible();
+  });
+
+  it('should allow user to manually toggle expanded/collapsed state', async () => {
+    const user = userEvent.setup();
+    render(<StreamingThinkingSection reasoningText="reasoning content" isComplete={false} />);
+
+    expect(screen.getByText('reasoning content')).toBeVisible();
+
+    await user.click(screen.getByText('Show thinking'));
+
+    expect(screen.getByText('reasoning content')).not.toBeVisible();
+
+    await user.click(screen.getByText('Show thinking'));
+
+    expect(screen.getByText('reasoning content')).toBeVisible();
+  });
+
+  it('should remain collapsed after auto-collapse', () => {
+    const { rerender } = render(
+      <StreamingThinkingSection reasoningText="done thinking" isComplete={false} />,
+    );
+
+    rerender(<StreamingThinkingSection reasoningText="done thinking" isComplete />);
+
+    expect(screen.getByText('done thinking')).not.toBeVisible();
+  });
+
+  it('should apply correct styling to body content', () => {
+    render(<StreamingThinkingSection reasoningText="styled text" isComplete={false} />);
+
+    const bodyDiv = screen.getByText('styled text');
+    expect(bodyDiv).toHaveStyle({
+      fontSize: 'var(--pf-t--global--font--size--sm)',
+      whiteSpace: 'pre-wrap',
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.sources.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.sources.spec.ts
@@ -5,6 +5,9 @@ import { CreateResponseRequest, SimplifiedResponseData } from '~/app/types';
 import { mockModelId, mockSuccessResponse, mockNamespace, defaultMcpProps } from './consts';
 
 // Mock external dependencies
+jest.mock('@patternfly/chatbot', () => ({
+  FileDetailsLabel: jest.fn(({ fileName }: { fileName: string }) => fileName),
+}));
 jest.mock('~/app/services/llamaStackService');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/utilities/utils', () => ({

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessages.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, @typescript-eslint/no-require-imports */
 import * as React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import useChatbotMessages from '~/app/Chatbot/hooks/useChatbotMessages';
@@ -12,6 +12,9 @@ import {
 } from './consts';
 
 // Mock external dependencies
+jest.mock('@patternfly/chatbot', () => ({
+  FileDetailsLabel: jest.fn(({ fileName }: { fileName: string }) => fileName),
+}));
 jest.mock('~/app/services/llamaStackService');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/utilities/utils', () => ({
@@ -674,6 +677,525 @@ describe('useChatbotMessages', () => {
       });
 
       expect(mockCreateResponse.mock.calls[0][0]).not.toHaveProperty('subscription');
+    });
+  });
+
+  describe('multimodal input (vision)', () => {
+    it('should construct multimodal input when fileId is provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Describe this image', undefined, 'file-vision-123');
+      });
+
+      const payload = mockCreateResponse.mock.calls[0][0];
+      expect(Array.isArray(payload.input)).toBe(true);
+      expect(payload.input).toEqual([
+        { type: 'input_text', text: 'Describe this image' },
+        { type: 'input_image', file_id: 'file-vision-123' },
+      ]);
+    });
+
+    it('should send only input_image when message text is empty', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('', undefined, 'file-vision-456');
+      });
+
+      const payload = mockCreateResponse.mock.calls[0][0];
+      expect(payload.input).toEqual([{ type: 'input_image', file_id: 'file-vision-456' }]);
+    });
+
+    it('should send plain string input when no fileId is provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Plain text message');
+      });
+
+      const payload = mockCreateResponse.mock.calls[0][0];
+      expect(typeof payload.input).toBe('string');
+      expect(payload.input).toBe('Plain text message');
+    });
+
+    it('should preserve multimodal content in chat_context for subsequent turns', async () => {
+      // Need unique IDs so the multimodalContentRef map distinguishes user vs bot messages
+      const mockGetId = jest.requireMock('~/app/utilities/utils').getId as jest.Mock;
+      let idCounter = 0;
+      mockGetId.mockImplementation(() => `msg-${idCounter++}`);
+
+      try {
+        mockCreateResponse.mockResolvedValue(mockSuccessResponse);
+
+        const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+        // First turn: multimodal message with image
+        await act(async () => {
+          await result.current.handleMessageSend(
+            'What is in this image?',
+            undefined,
+            'file-img-789',
+          );
+        });
+
+        // Second turn: plain text follow-up
+        await act(async () => {
+          await result.current.handleMessageSend('Tell me more about it');
+        });
+
+        const secondPayload = mockCreateResponse.mock.calls[1][0];
+        expect(secondPayload.chat_context).toHaveLength(2);
+        expect(secondPayload.chat_context![0]).toMatchObject({
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'What is in this image?' },
+            { type: 'input_image', file_id: 'file-img-789' },
+          ],
+        });
+        expect(secondPayload.chat_context![1]).toMatchObject({
+          role: 'assistant',
+          content: 'This is a bot response',
+        });
+      } finally {
+        mockGetId.mockImplementation(() => 'mock-id');
+      }
+    });
+  });
+
+  describe('inline image rendering', () => {
+    it('should set extraContent.beforeMainContent as img element when imagePreview is provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Describe this image', undefined, 'file-123', {
+          previewUrl: 'blob:http://localhost/abc',
+          fileName: 'photo.png',
+        });
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.role).toBe('user');
+      expect(userMessage.content).toBe('Describe this image');
+      expect(userMessage.extraContent).toBeDefined();
+      expect(React.isValidElement(userMessage.extraContent?.beforeMainContent)).toBe(true);
+    });
+
+    it('should not include markdown image syntax in content when imagePreview is provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Describe this image', undefined, 'file-123', {
+          previewUrl: 'blob:http://localhost/abc',
+          fileName: 'photo.png',
+        });
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.content).not.toContain('![');
+      expect(userMessage.content).not.toContain('blob:');
+    });
+
+    it('should render content as empty string when only an image (no text) is sent', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('', undefined, 'file-123', {
+          previewUrl: 'blob:http://localhost/abc',
+          fileName: 'photo.png',
+        });
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.role).toBe('user');
+      expect(userMessage.content).toBe('');
+      expect(React.isValidElement(userMessage.extraContent?.beforeMainContent)).toBe(true);
+    });
+
+    it('should set content to text message when both image and text are provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('What is this?', undefined, 'file-123', {
+          previewUrl: 'blob:http://localhost/abc',
+          fileName: 'photo.png',
+        });
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.content).toBe('What is this?');
+      expect(React.isValidElement(userMessage.extraContent?.beforeMainContent)).toBe(true);
+    });
+
+    it('should not set extraContent when no imagePreview is provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Hello, bot!');
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.content).toBe('Hello, bot!');
+      expect(userMessage.extraContent).toBeUndefined();
+    });
+  });
+
+  describe('thinking collapsible (non-streaming)', () => {
+    it('should set extraContent.beforeMainContent on bot message when reasoningContent exists', async () => {
+      const responseWithReasoning: SimplifiedResponseData = {
+        ...mockSuccessResponse,
+        reasoningContent: 'I need to think about this step by step...',
+      };
+      mockCreateResponse.mockResolvedValueOnce(responseWithReasoning);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Solve this puzzle');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.role).toBe('bot');
+      expect(botMessage.extraContent).toBeDefined();
+      expect(botMessage.extraContent?.beforeMainContent).toBeDefined();
+      expect(botMessage.deepThinking).toBeUndefined();
+    });
+
+    it('should not set extraContent.beforeMainContent when no reasoningContent exists', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Hello');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.role).toBe('bot');
+      expect(botMessage.extraContent?.beforeMainContent).toBeUndefined();
+      expect(botMessage.deepThinking).toBeUndefined();
+    });
+  });
+
+  describe('streaming thinking collapsible', () => {
+    it('should show reasoning in extraContent.beforeMainContent during streaming (not in content)', async () => {
+      mockCreateResponse.mockImplementation(
+        (
+          _request: CreateResponseRequest,
+          opts?: {
+            onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
+            abortSignal?: AbortSignal;
+          },
+        ) => {
+          if (opts?.onStreamData) {
+            opts.onStreamData('Let me think about this\n', false, true);
+            opts.onStreamData('Step 1: analyze\n', false, true);
+            opts.onStreamData('The answer is 42', false, false);
+          }
+          return Promise.resolve({
+            ...mockSuccessResponse,
+            content: 'The answer is 42',
+            reasoningContent: 'Let me think about this\nStep 1: analyze',
+          });
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isStreamingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('What is the meaning of life?');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.role).toBe('bot');
+      expect(botMessage.extraContent?.beforeMainContent).toBeDefined();
+      expect(React.isValidElement(botMessage.extraContent?.beforeMainContent)).toBe(true);
+      expect(botMessage.deepThinking).toBeUndefined();
+    });
+
+    it('should include final answer in content after reasoning completes', async () => {
+      mockCreateResponse.mockImplementation(
+        (
+          _request: CreateResponseRequest,
+          opts?: {
+            onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
+            abortSignal?: AbortSignal;
+          },
+        ) => {
+          if (opts?.onStreamData) {
+            opts.onStreamData('thinking...\n', false, true);
+            opts.onStreamData('The answer is 42', false, false);
+          }
+          return Promise.resolve({
+            ...mockSuccessResponse,
+            content: 'The answer is 42',
+            reasoningContent: 'thinking...',
+          });
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isStreamingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('Question');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.content).toBe('The answer is 42');
+      expect(botMessage.extraContent?.beforeMainContent).toBeDefined();
+    });
+
+    it('should handle responses with no reasoning (direct answer)', async () => {
+      mockCreateResponse.mockImplementation(
+        (
+          _request: CreateResponseRequest,
+          opts?: {
+            onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
+            abortSignal?: AbortSignal;
+          },
+        ) => {
+          if (opts?.onStreamData) {
+            opts.onStreamData('Hello! How can I help?', false, false);
+          }
+          return Promise.resolve({
+            ...mockSuccessResponse,
+            content: 'Hello! How can I help?',
+          });
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isStreamingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('Hi');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.content).toBe('Hello! How can I help?');
+      expect(botMessage.extraContent?.beforeMainContent).toBeUndefined();
+    });
+
+    it('should handle responses with only reasoning (no answer tokens)', async () => {
+      mockCreateResponse.mockImplementation(
+        (
+          _request: CreateResponseRequest,
+          opts?: {
+            onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
+            abortSignal?: AbortSignal;
+          },
+        ) => {
+          if (opts?.onStreamData) {
+            opts.onStreamData('Deep thoughts...\n', false, true);
+          }
+          return Promise.resolve({
+            ...mockSuccessResponse,
+            content: '',
+            reasoningContent: 'Deep thoughts...',
+          });
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useChatbotMessages(createDefaultHookProps({ isStreamingEnabled: true })),
+      );
+
+      await act(async () => {
+        await result.current.handleMessageSend('Think');
+      });
+
+      const botMessage = result.current.messages[1];
+      expect(botMessage.extraContent?.beforeMainContent).toBeDefined();
+    });
+  });
+
+  describe('reasoning effort in payload', () => {
+    it('reasoning field is never sent in request payload', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Hello');
+      });
+
+      const payload = mockCreateResponse.mock.calls[0][0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((payload as any).reasoning).toBeUndefined();
+    });
+  });
+
+  describe('inline document chips in sent message', () => {
+    it('should set extraContent.afterMainContent when docAttachments are provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend(
+          'Check these files',
+          undefined,
+          undefined,
+          undefined,
+          ['PR_STYLE_GUIDE.md', 'rag-testing.txt'],
+        );
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.role).toBe('user');
+      expect(userMessage.content).toBe('Check these files');
+      expect(userMessage.extraContent).toBeDefined();
+      expect(React.isValidElement(userMessage.extraContent?.afterMainContent)).toBe(true);
+    });
+
+    it('should not set extraContent.afterMainContent when no docAttachments are provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Hello without docs');
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.extraContent).toBeUndefined();
+    });
+
+    it('should not set afterMainContent when docAttachments is empty array', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('No docs', undefined, undefined, undefined, []);
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.extraContent).toBeUndefined();
+    });
+
+    it('should set both beforeMainContent and afterMainContent when image and docs are provided', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend(
+          'Image and docs',
+          undefined,
+          'file-123',
+          { previewUrl: 'blob:http://localhost/abc', fileName: 'photo.png' },
+          ['report.pdf'],
+        );
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.extraContent).toBeDefined();
+      expect(React.isValidElement(userMessage.extraContent?.beforeMainContent)).toBe(true);
+      expect(React.isValidElement(userMessage.extraContent?.afterMainContent)).toBe(true);
+    });
+
+    it('should create FileDetailsLabel elements with correct fileName and hasTruncation for each attachment', async () => {
+      const { FileDetailsLabel } = require('@patternfly/chatbot');
+
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Files here', undefined, undefined, undefined, [
+          'report.pdf',
+          'data.csv',
+        ]);
+      });
+
+      const wrapper = result.current.messages[0].extraContent
+        ?.afterMainContent as React.ReactElement;
+      const children = wrapper.props.children as React.ReactElement[];
+      expect(children).toHaveLength(2);
+      expect(children[0].type).toBe(FileDetailsLabel);
+      expect(children[0].props).toEqual(
+        expect.objectContaining({ fileName: 'report.pdf', hasTruncation: true }),
+      );
+      expect(children[1].type).toBe(FileDetailsLabel);
+      expect(children[1].props).toEqual(
+        expect.objectContaining({ fileName: 'data.csv', hasTruncation: true }),
+      );
+    });
+
+    it('should create exactly N FileDetailsLabel elements for N doc attachments', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Three docs', undefined, undefined, undefined, [
+          'a.pdf',
+          'b.txt',
+          'c.csv',
+        ]);
+      });
+
+      const wrapper = result.current.messages[0].extraContent
+        ?.afterMainContent as React.ReactElement;
+      const children = wrapper.props.children as React.ReactElement[];
+      expect(children).toHaveLength(3);
+    });
+
+    it('afterMainContent wrapper div has correct flex styles', async () => {
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Check styles', undefined, undefined, undefined, [
+          'doc.pdf',
+        ]);
+      });
+
+      const userMessage = result.current.messages[0];
+      const wrapper = userMessage.extraContent?.afterMainContent as React.ReactElement;
+      expect(wrapper.type).toBe('div');
+      expect(wrapper.props.style).toEqual({
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '0.5rem',
+        marginTop: '0.5rem',
+      });
+    });
+
+    it('works correctly with a single doc attachment', async () => {
+      const { FileDetailsLabel } = require('@patternfly/chatbot');
+
+      mockCreateResponse.mockResolvedValueOnce(mockSuccessResponse);
+      const { result } = renderHook(() => useChatbotMessages(createDefaultHookProps()));
+
+      await act(async () => {
+        await result.current.handleMessageSend('Single doc', undefined, undefined, undefined, [
+          'only-one.pdf',
+        ]);
+      });
+
+      const userMessage = result.current.messages[0];
+      expect(userMessage.extraContent).toBeDefined();
+      expect(React.isValidElement(userMessage.extraContent?.afterMainContent)).toBe(true);
+
+      const wrapper = userMessage.extraContent?.afterMainContent as React.ReactElement;
+      // With React.createElement spread args, single child is in props.children
+      const children = Array.isArray(wrapper.props.children)
+        ? wrapper.props.children
+        : [wrapper.props.children];
+      expect(children).toHaveLength(1);
+      expect(children[0].type).toBe(FileDetailsLabel);
+      expect(children[0].props).toEqual(
+        expect.objectContaining({ fileName: 'only-one.pdf', hasTruncation: true }),
+      );
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessagesControls.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useChatbotMessagesControls.spec.ts
@@ -5,6 +5,9 @@ import useChatbotMessages from '~/app/Chatbot/hooks/useChatbotMessages';
 import { CreateResponseRequest, SimplifiedResponseData } from '~/app/types';
 
 // Mock external dependencies
+jest.mock('@patternfly/chatbot', () => ({
+  FileDetailsLabel: jest.fn(({ fileName }: { fileName: string }) => fileName),
+}));
 jest.mock('~/app/services/llamaStackService');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/utilities/utils', () => ({

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useChatbotMessages.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
-import { MessageProps, ToolResponseProps } from '@patternfly/chatbot';
+import { FileDetailsLabel, MessageProps, ToolResponseProps } from '@patternfly/chatbot';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import userAvatar from '~/app/bgimages/user_avatar.svg';
 import botAvatar from '~/app/bgimages/bot_avatar.svg';
@@ -9,6 +9,7 @@ import {
   ChatMessageRole,
   CreateResponseRequest,
   GuardrailInlineConfig,
+  InputContentPart,
   MCPToolCallData,
   MCPServerFromAPI,
   ResponseMetrics,
@@ -31,6 +32,7 @@ import {
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { useChatbotConfigStore } from '~/app/Chatbot/store';
+import { StreamingThinkingSection } from '~/app/Chatbot/components/StreamingThinkingSection';
 
 export type GuardrailsConfig = {
   enabled: boolean;
@@ -50,7 +52,13 @@ export interface UseChatbotMessagesReturn {
   isMessageSendButtonDisabled: boolean;
   isLoading: boolean;
   isStreamingWithoutContent: boolean;
-  handleMessageSend: (message: string, compareID?: string) => Promise<void>;
+  handleMessageSend: (
+    message: string,
+    compareID?: string,
+    fileId?: string,
+    imagePreview?: { previewUrl: string; fileName: string },
+    docAttachments?: string[],
+  ) => Promise<void>;
   handleStopStreaming: () => void;
   clearConversation: () => void;
   scrollToBottomRef: React.RefObject<HTMLDivElement>;
@@ -125,6 +133,10 @@ const useChatbotMessages = ({
   const abortControllerRef = React.useRef<AbortController | null>(null);
   const isStoppingStreamRef = React.useRef<boolean>(false);
   const isClearingRef = React.useRef<boolean>(false);
+  const multimodalContentRef = React.useRef<Map<string, InputContentPart[]>>(new Map());
+  const imagePreviewRef = React.useRef<Map<string, { previewUrl: string; fileName: string }>>(
+    new Map(),
+  );
   const { api, apiAvailable } = useGenAiAPI();
   const { aiModels } = React.useContext(ChatbotContext);
 
@@ -220,6 +232,13 @@ const useChatbotMessages = ({
     [],
   );
 
+  // Create a collapsible thinking section (no Card wrapper) to display reasoning content
+  const createThinkingCollapsible = React.useCallback(
+    (reasoningText: string): React.ReactNode =>
+      React.createElement(StreamingThinkingSection, { reasoningText, isComplete: true }),
+    [],
+  );
+
   const handleStopStreaming = React.useCallback(() => {
     if (abortControllerRef.current) {
       isStoppingStreamRef.current = true;
@@ -262,6 +281,9 @@ const useChatbotMessages = ({
     setIsStreamingWithoutContent(false);
     setLastResponseMetrics(null);
     isStoppingStreamRef.current = false;
+    multimodalContentRef.current.clear();
+    imagePreviewRef.current.forEach(({ previewUrl }) => URL.revokeObjectURL(previewUrl));
+    imagePreviewRef.current.clear();
 
     // Reset clearing flag after state updates complete
     // Use setTimeout to ensure this runs after React finishes all state updates
@@ -270,7 +292,45 @@ const useChatbotMessages = ({
     }, 0);
   }, []);
 
-  const handleMessageSend = async (message: string, compareID?: string) => {
+  const handleMessageSend = async (
+    message: string,
+    compareID?: string,
+    fileId?: string,
+    imagePreview?: { previewUrl: string; fileName: string },
+    docAttachments?: string[],
+  ) => {
+    const extraContent: Record<string, React.ReactNode> = {};
+    if (imagePreview) {
+      extraContent.beforeMainContent = React.createElement('img', {
+        src: imagePreview.previewUrl,
+        alt: imagePreview.fileName,
+        className: 'chatbot-inline-image',
+        style: {
+          maxWidth: '300px',
+          maxHeight: '300px',
+          width: 'auto',
+          height: 'auto',
+          objectFit: 'contain' as const,
+          borderRadius: 'var(--pf-t--global--border--radius--medium)',
+          display: 'block',
+          marginBottom: 'var(--pf-t--global--spacer--sm)',
+        },
+      });
+    }
+    if (docAttachments?.length) {
+      extraContent.afterMainContent = React.createElement(
+        'div',
+        { style: { display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '0.5rem' } },
+        ...docAttachments.map((fileName, index) =>
+          React.createElement(FileDetailsLabel, {
+            key: `${fileName}-${index}`,
+            fileName,
+            hasTruncation: true,
+          }),
+        ),
+      );
+    }
+
     const userMessage: MessageProps = {
       id: getId(),
       role: 'user',
@@ -278,7 +338,25 @@ const useChatbotMessages = ({
       name: username || 'User',
       avatar: userAvatar,
       timestamp: new Date().toLocaleString(),
+      ...(Object.keys(extraContent).length > 0 && { extraContent }),
     };
+
+    // Track blob URL for cleanup on unmount/clearConversation
+    if (imagePreview) {
+      imagePreviewRef.current.set(userMessage.id!, imagePreview);
+    }
+
+    // Build multimodal input when a vision file_id is provided
+    let input: string | InputContentPart[] = message;
+    if (fileId) {
+      const parts: InputContentPart[] = [];
+      if (message.trim()) {
+        parts.push({ type: 'input_text', text: message });
+      }
+      parts.push({ type: 'input_image', file_id: fileId });
+      input = parts;
+      multimodalContentRef.current.set(userMessage.id!, parts);
+    }
 
     setMessages((prev) => [...prev, userMessage]);
     setIsMessageSendButtonDisabled(true);
@@ -307,7 +385,7 @@ const useChatbotMessages = ({
       const selectedModel = aiModels.find((model) => model.model_id === baseModelId);
 
       const responsesPayload: CreateResponseRequest = {
-        input: message,
+        input,
         model: modelId,
         ...(isRagEnabled &&
           currentVectorStoreId && {
@@ -317,7 +395,7 @@ const useChatbotMessages = ({
           .map((msg) => ({
             role:
               msg.role === ChatMessageRole.USER ? ChatMessageRole.USER : ChatMessageRole.ASSISTANT,
-            content: msg.content || '',
+            content: multimodalContentRef.current.get(msg.id!) || msg.content || '',
           }))
           .filter((msg) => msg.content),
         instructions: systemInstruction,
@@ -371,6 +449,39 @@ const useChatbotMessages = ({
         // Handle streaming response with line-by-line display like ChatGPT
         const completeLines: string[] = [];
         let currentPartialLine = '';
+        let isInReasoningPhase = false;
+
+        // Separate accumulators for reasoning content (streamed inside collapsible)
+        const reasoningLines: string[] = [];
+        let reasoningPartialLine = '';
+        let finalReasoningText = '';
+
+        const updateReasoningDisplay = () => {
+          const reasoningDisplay =
+            reasoningLines.join('\n') +
+            (reasoningPartialLine
+              ? (reasoningLines.length > 0 ? '\n' : '') + reasoningPartialLine
+              : '');
+
+          setMessages((prevMessages) =>
+            prevMessages.map((msg) =>
+              msg.id === botMessageId
+                ? {
+                    ...msg,
+                    content: '',
+                    isLoading: false,
+                    extraContent: {
+                      ...msg.extraContent,
+                      beforeMainContent: React.createElement(StreamingThinkingSection, {
+                        reasoningText: reasoningDisplay,
+                        isComplete: false,
+                      }),
+                    },
+                  }
+                : msg,
+            ),
+          );
+        };
 
         const updateMessage = (showPartialLine = true, hasContent = false) => {
           // Combine complete lines with current partial line for display
@@ -380,13 +491,25 @@ const useChatbotMessages = ({
               ? (completeLines.length > 0 ? '\n' : '') + currentPartialLine
               : '');
 
+          const thinkingExtra = finalReasoningText
+            ? {
+                extraContent: {
+                  beforeMainContent: React.createElement(StreamingThinkingSection, {
+                    reasoningText: finalReasoningText,
+                    isComplete: true,
+                  }),
+                },
+              }
+            : {};
+
           setMessages((prevMessages) =>
             prevMessages.map((msg) =>
               msg.id === botMessageId
                 ? {
                     ...msg,
                     content: displayContent,
-                    isLoading: !hasContent, // Hide loading dots once we have content
+                    isLoading: !hasContent,
+                    ...thinkingExtra,
                   }
                 : msg,
             ),
@@ -395,8 +518,43 @@ const useChatbotMessages = ({
 
         const streamingResponse = await api.createResponse(responsesPayload, {
           abortSignal: abortControllerRef.current.signal,
-          onStreamData: (chunk: string, clearPrevious?: boolean) => {
+          onStreamData: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => {
             if (clearPrevious) {
+              completeLines.length = 0;
+              currentPartialLine = '';
+            }
+
+            // Handle reasoning tokens: stream live inside the collapsible
+            if (isReasoning) {
+              isInReasoningPhase = true;
+
+              if (chunk && isStreamingWithoutContent) {
+                setIsStreamingWithoutContent(false);
+              }
+
+              reasoningPartialLine += chunk;
+              const lines = reasoningPartialLine.split('\n');
+              if (lines.length > 1) {
+                reasoningLines.push(...lines.slice(0, -1));
+                reasoningPartialLine = lines[lines.length - 1];
+                updateReasoningDisplay();
+              } else if (!isStoppingStreamRef.current) {
+                if (timeoutRef.current) {
+                  clearTimeout(timeoutRef.current);
+                }
+                timeoutRef.current = setTimeout(() => updateReasoningDisplay(), 50);
+              }
+              return;
+            }
+
+            // First answer token: save reasoning, auto-collapse thinking section
+            if (isInReasoningPhase) {
+              isInReasoningPhase = false;
+              finalReasoningText =
+                reasoningLines.join('\n') +
+                (reasoningPartialLine
+                  ? (reasoningLines.length > 0 ? '\n' : '') + reasoningPartialLine
+                  : '');
               completeLines.length = 0;
               currentPartialLine = '';
             }
@@ -458,7 +616,16 @@ const useChatbotMessages = ({
             }
           : {};
 
-        // Use the processed content from the response which has file citation tokens replaced
+        // Finalize message in a single update to avoid flicker
+        const toolResponse = streamingResponse.toolCallData
+          ? createToolResponse(streamingResponse.toolCallData)
+          : undefined;
+        const thinkingCollapsible =
+          typeof streamingResponse.reasoningContent === 'string' &&
+          streamingResponse.reasoningContent
+            ? createThinkingCollapsible(streamingResponse.reasoningContent)
+            : undefined;
+
         setMessages((prevMessages) =>
           prevMessages.map((msg) =>
             msg.id === botMessageId
@@ -467,31 +634,18 @@ const useChatbotMessages = ({
                   content: streamingResponse.content,
                   isLoading: false,
                   ...sourcesProps,
+                  ...(toolResponse && { toolResponse }),
+                  ...(thinkingCollapsible && {
+                    extraContent: { ...msg.extraContent, beforeMainContent: thinkingCollapsible },
+                  }),
+                  ...(streamingResponse.metrics && { metrics: streamingResponse.metrics }),
                 }
               : msg,
           ),
         );
 
-        // Add tool response and metrics if available from streaming response
-        if (streamingResponse.toolCallData || streamingResponse.metrics) {
-          const toolResponse = streamingResponse.toolCallData
-            ? createToolResponse(streamingResponse.toolCallData)
-            : undefined;
-          setMessages((prevMessages) =>
-            prevMessages.map((msg) =>
-              msg.id === botMessageId
-                ? {
-                    ...msg,
-                    ...(toolResponse && { toolResponse }),
-                    ...(streamingResponse.metrics && { metrics: streamingResponse.metrics }),
-                  }
-                : msg,
-            ),
-          );
-          // Update last response metrics for pane header display
-          if (streamingResponse.metrics) {
-            setLastResponseMetrics(streamingResponse.metrics);
-          }
+        if (streamingResponse.metrics) {
+          setLastResponseMetrics(streamingResponse.metrics);
         }
       } else {
         // Handle non-streaming response
@@ -516,6 +670,11 @@ const useChatbotMessages = ({
             }
           : {};
 
+        const thinkingCollapsible =
+          typeof response.reasoningContent === 'string' && response.reasoningContent
+            ? createThinkingCollapsible(response.reasoningContent)
+            : undefined;
+
         const botMessage: ChatbotMessageProps = {
           id: getId(),
           role: 'bot',
@@ -524,6 +683,9 @@ const useChatbotMessages = ({
           avatar: botAvatar,
           timestamp: new Date().toLocaleString(),
           ...(toolResponse && { toolResponse }),
+          ...(thinkingCollapsible && {
+            extraContent: { beforeMainContent: thinkingCollapsible },
+          }),
           ...sourcesProps,
           ...(response.metrics && { metrics: response.metrics }),
         };
@@ -613,6 +775,19 @@ const useChatbotMessages = ({
       abortControllerRef.current = null;
     }
   };
+
+  React.useEffect(
+    () => () => {
+      imagePreviewRef.current.forEach(({ previewUrl }) => {
+        try {
+          URL.revokeObjectURL(previewUrl);
+        } catch {
+          // URL.revokeObjectURL may be unavailable in test environments
+        }
+      });
+    },
+    [],
+  );
 
   return {
     messages,

--- a/packages/gen-ai/frontend/src/app/app.css
+++ b/packages/gen-ai/frontend/src/app/app.css
@@ -64,3 +64,4 @@ body,
 .pf-v6-c-popover .pf-v6-c-clipboard-copy.pf-m-inline {
   padding: var(--pf-t--global--spacer--xs);
 }
+

--- a/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.spec.ts
+++ b/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.spec.ts
@@ -14,6 +14,7 @@ import {
   getMCPServers,
   getMCPServerStatus,
   getMCPServerTools,
+  uploadVisionFile,
 } from '~/app/services/llamaStackService';
 import { URL_PREFIX } from '~/app/utilities';
 import { mockLlamaModels } from '~/__mocks__/mockLlamaStackModels';
@@ -322,6 +323,97 @@ describe('llamaStackService', () => {
         await expect(
           createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(mockCreateResponseRequest),
         ).rejects.toThrow();
+      });
+
+      describe('think-tag stripping', () => {
+        it('extracts reasoning from <think>...</think> and returns remaining content', async () => {
+          const response = {
+            ...mockBackendResponse,
+            output: [
+              {
+                id: 'out-1',
+                type: 'completion_message',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: '<think>I need to reason about this</think>Here is the answer',
+                  },
+                ],
+              },
+            ],
+          };
+          mockedRestCREATE.mockResolvedValueOnce({ data: response });
+
+          const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+            mockCreateResponseRequest,
+          );
+
+          expect(result.content).toBe('Here is the answer');
+          expect(result.reasoningContent).toBe('I need to reason about this');
+        });
+
+        it('extracts bare reasoning before </think> (no opening tag)', async () => {
+          const response = {
+            ...mockBackendResponse,
+            output: [
+              {
+                id: 'out-1',
+                type: 'completion_message',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: 'Some reasoning here</think>Actual answer',
+                  },
+                ],
+              },
+            ],
+          };
+          mockedRestCREATE.mockResolvedValueOnce({ data: response });
+
+          const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+            mockCreateResponseRequest,
+          );
+
+          expect(result.content).toBe('Actual answer');
+          expect(result.reasoningContent).toBe('Some reasoning here');
+        });
+
+        it('returns content as-is when no think tags present', async () => {
+          mockedRestCREATE.mockResolvedValueOnce({ data: mockBackendResponse });
+
+          const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+            mockCreateResponseRequest,
+          );
+
+          expect(result.content).toBe('This is a test response');
+          expect(result.reasoningContent).toBeUndefined();
+        });
+
+        it('handles empty think tag and returns content only', async () => {
+          const response = {
+            ...mockBackendResponse,
+            output: [
+              {
+                id: 'out-1',
+                type: 'completion_message',
+                content: [
+                  {
+                    type: 'output_text',
+                    text: '<think></think>Direct answer without reasoning',
+                  },
+                ],
+              },
+            ],
+          };
+          mockedRestCREATE.mockResolvedValueOnce({ data: response });
+
+          const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+            mockCreateResponseRequest,
+          );
+
+          expect(result.content).toBe('Direct answer without reasoning');
+          expect(result.reasoningContent).toBeUndefined();
+        });
       });
     });
 
@@ -653,6 +745,117 @@ describe('llamaStackService', () => {
             body: JSON.stringify(mockStreamingRequest),
           },
         );
+      });
+    });
+
+    describe('reasoning streaming', () => {
+      // Wiring smoke tests: verify streamCreateResponse correctly calls onStreamData
+      // and populates result.reasoningContent. Chunk-level edge cases live in
+      // packages/gen-ai/frontend/src/app/services/__tests__/thinkTagParser.spec.ts
+
+      it('accumulates reasoning from reasoning_text.delta and wires onStreamData', async () => {
+        const mockStreamData = jest.fn();
+
+        const mockReader = {
+          read: jest
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": "Let me think", "type": "response.reasoning_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": " step by step", "type": "response.reasoning_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": "The answer is 42", "type": "response.output_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: jest.fn(),
+        };
+
+        mockFetch.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+          mockStreamingRequest,
+          { onStreamData: mockStreamData },
+        );
+
+        expect(result.reasoningContent).toBe('Let me think step by step');
+        expect(result.content).toBe('The answer is 42');
+        expect(mockStreamData).toHaveBeenCalledWith('Let me think', false, true);
+        expect(mockStreamData).toHaveBeenCalledWith(' step by step', false, true);
+        expect(mockStreamData).toHaveBeenCalledWith('The answer is 42');
+      });
+
+      it('no reasoningContent when no reasoning events are present', async () => {
+        const mockStreamData = jest.fn();
+
+        const mockReader = {
+          read: jest
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": "Hello", "type": "response.output_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: jest.fn(),
+        };
+
+        mockFetch.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+          mockStreamingRequest,
+          { onStreamData: mockStreamData },
+        );
+
+        expect(result.reasoningContent).toBeUndefined();
+        expect(result.content).toBe('Hello');
+        expect(mockStreamData).not.toHaveBeenCalledWith(expect.anything(), false, true);
+      });
+
+      it('wires embedded <think> tags — splits reasoning and content via onStreamData', async () => {
+        const mockStreamData = jest.fn();
+
+        const mockReader = {
+          read: jest
+            .fn()
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": "<think>Let me reason", "type": "response.output_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode(
+                'data: {"delta": " about this</think>The answer", "type": "response.output_text.delta"}\n',
+              ),
+            })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          releaseLock: jest.fn(),
+        };
+
+        mockFetch.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const result = await createResponse(URL_PREFIX, { namespace: TEST_NAMESPACE })(
+          mockStreamingRequest,
+          { onStreamData: mockStreamData },
+        );
+
+        expect(result.reasoningContent).toBe('Let me reason about this');
+        expect(result.content).toBe('The answer');
+        expect(mockStreamData).toHaveBeenCalledWith('Let me reason', false, true);
+        expect(mockStreamData).toHaveBeenCalledWith('The answer');
       });
     });
   });
@@ -1168,6 +1371,141 @@ describe('llamaStackService', () => {
         expect.objectContaining({ namespace: TEST_NAMESPACE }),
         {},
       );
+    });
+  });
+
+  describe('uploadVisionFile', () => {
+    let mockXhr: {
+      open: jest.Mock;
+      send: jest.Mock;
+      abort: jest.Mock;
+      status: number;
+      statusText: string;
+      responseText: string;
+      onload: (() => void) | null;
+      onerror: (() => void) | null;
+      onabort: (() => void) | null;
+      upload: { onprogress: ((e: Partial<ProgressEvent>) => void) | null };
+    };
+
+    beforeEach(() => {
+      mockXhr = {
+        open: jest.fn(),
+        send: jest.fn(),
+        abort: jest.fn(),
+        status: 200,
+        statusText: 'OK',
+        responseText: '{"data":{"id":"file-abc123"}}',
+        onload: null,
+        onerror: null,
+        onabort: null,
+        upload: { onprogress: null },
+      };
+      jest
+        .spyOn(window, 'XMLHttpRequest')
+        .mockImplementation(() => mockXhr as unknown as XMLHttpRequest);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should upload a file and return the file id', async () => {
+      const file = new File(['image-data'], 'test.png', { type: 'image/png' });
+      const { promise } = uploadVisionFile('/api/upload', file);
+
+      expect(mockXhr.open).toHaveBeenCalledWith('POST', '/api/upload');
+      expect(mockXhr.send).toHaveBeenCalled();
+
+      const sentFormData = mockXhr.send.mock.calls[0][0] as FormData;
+      expect(sentFormData.get('file')).toBe(file);
+
+      mockXhr.onload!();
+
+      const result = await promise;
+      expect(result).toEqual({ data: { id: 'file-abc123' } });
+    });
+
+    it('should call onProgress with percentage', async () => {
+      const onProgress = jest.fn();
+      const file = new File(['image-data'], 'test.png', { type: 'image/png' });
+      const { promise } = uploadVisionFile('/api/upload', file, onProgress);
+
+      mockXhr.upload.onprogress!({ lengthComputable: true, loaded: 50, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(50);
+
+      mockXhr.upload.onprogress!({ lengthComputable: true, loaded: 100, total: 100 });
+      expect(onProgress).toHaveBeenCalledWith(100);
+
+      mockXhr.onload!();
+      await promise;
+    });
+
+    it('should not call onProgress when lengthComputable is false', async () => {
+      const onProgress = jest.fn();
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      const { promise } = uploadVisionFile('/api/upload', file, onProgress);
+
+      mockXhr.upload.onprogress!({ lengthComputable: false, loaded: 0, total: 0 });
+      expect(onProgress).not.toHaveBeenCalled();
+
+      mockXhr.onload!();
+      await promise;
+    });
+
+    it('should reject on HTTP error status', async () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      mockXhr.status = 413;
+      mockXhr.statusText = 'Payload Too Large';
+
+      const { promise } = uploadVisionFile('/api/upload', file);
+      mockXhr.onload!();
+
+      await expect(promise).rejects.toThrow('Upload failed: 413 Payload Too Large');
+    });
+
+    it('should reject on invalid JSON response', async () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      mockXhr.responseText = 'not json';
+
+      const { promise } = uploadVisionFile('/api/upload', file);
+      mockXhr.onload!();
+
+      await expect(promise).rejects.toThrow('Invalid response from server');
+    });
+
+    it('should reject on malformed response shape', async () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      mockXhr.responseText = JSON.stringify({ result: 'ok' });
+
+      const { promise } = uploadVisionFile('/api/upload', file);
+      mockXhr.onload!();
+
+      await expect(promise).rejects.toThrow('Invalid response shape: missing data.id');
+    });
+
+    it('should reject on network error', async () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      const { promise } = uploadVisionFile('/api/upload', file);
+      mockXhr.onerror!();
+
+      await expect(promise).rejects.toThrow('Network error during upload');
+    });
+
+    it('should reject on abort', async () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      const { promise } = uploadVisionFile('/api/upload', file);
+      mockXhr.onabort!();
+
+      await expect(promise).rejects.toThrow('Upload aborted');
+    });
+
+    it('should return an xhr object that can be aborted', () => {
+      const file = new File(['data'], 'test.png', { type: 'image/png' });
+      const { xhr } = uploadVisionFile('/api/upload', file);
+
+      xhr.abort();
+      expect(mockXhr.abort).toHaveBeenCalled();
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/services/__tests__/thinkTagParser.spec.ts
+++ b/packages/gen-ai/frontend/src/app/services/__tests__/thinkTagParser.spec.ts
@@ -1,0 +1,224 @@
+import { ThinkTagParser, ThinkTagOutput } from '~/app/services/thinkTagParser';
+
+const reasoning = (text: string): ThinkTagOutput => ({ reasoning: text });
+const content = (text: string): ThinkTagOutput => ({ content: text });
+const both = (r: string, c: string): ThinkTagOutput => ({ reasoning: r, content: c });
+const empty = (): ThinkTagOutput => ({});
+
+describe('ThinkTagParser', () => {
+  let parser: ThinkTagParser;
+
+  beforeEach(() => {
+    parser = new ThinkTagParser();
+  });
+
+  // ─── dedicated channel ────────────────────────────────────────────────────
+
+  describe('dedicated channel', () => {
+    it('hasDedicatedChannel starts false', () => {
+      expect(parser.hasDedicatedChannel).toBe(false);
+    });
+
+    it('notifyDedicatedReasoningEvent sets hasDedicatedChannel', () => {
+      parser.notifyDedicatedReasoningEvent();
+      expect(parser.hasDedicatedChannel).toBe(true);
+    });
+
+    it('processOutputDelta returns content-only after dedicated event', () => {
+      parser.notifyDedicatedReasoningEvent();
+      expect(parser.processOutputDelta('The answer')).toEqual(content('The answer'));
+    });
+
+    it('multiple notifyDedicatedReasoningEvent calls are idempotent', () => {
+      parser.notifyDedicatedReasoningEvent();
+      parser.notifyDedicatedReasoningEvent();
+      expect(parser.hasDedicatedChannel).toBe(true);
+      expect(parser.processOutputDelta('ok')).toEqual(content('ok'));
+    });
+  });
+
+  // ─── no think tags ────────────────────────────────────────────────────────
+
+  describe('no think tags', () => {
+    it('plain content is returned as-is', () => {
+      expect(parser.processOutputDelta('Hello world')).toEqual(content('Hello world'));
+    });
+
+    it('subsequent deltas are also content after plain start', () => {
+      parser.processOutputDelta('Hello');
+      expect(parser.processOutputDelta(' world')).toEqual(content(' world'));
+    });
+
+    it('flush returns empty when no buffer', () => {
+      parser.processOutputDelta('Hello');
+      expect(parser.flush()).toEqual(empty());
+    });
+  });
+
+  // ─── full <think>...</think> tag ─────────────────────────────────────────
+
+  describe('full <think>...</think> tag', () => {
+    it('single chunk containing full tags', () => {
+      expect(parser.processOutputDelta('<think>I am thinking</think>The answer')).toEqual(
+        both('I am thinking', 'The answer'),
+      );
+    });
+
+    it('open tag and close tag in separate chunks', () => {
+      expect(parser.processOutputDelta('<think>Let me reason')).toEqual(reasoning('Let me reason'));
+      expect(parser.processOutputDelta(' about this</think>The answer')).toEqual(
+        both(' about this', 'The answer'),
+      );
+    });
+
+    it('open tag alone (no content after)', () => {
+      expect(parser.processOutputDelta('<think>')).toEqual(empty());
+    });
+
+    it('reasoning content across multiple chunks', () => {
+      parser.processOutputDelta('<think>chunk one');
+      expect(parser.processOutputDelta(' chunk two</think>answer')).toEqual(
+        both(' chunk two', 'answer'),
+      );
+    });
+
+    it('leading newlines after close tag are trimmed', () => {
+      expect(parser.processOutputDelta('<think>think</think>\n\nAnswer')).toEqual(
+        both('think', 'Answer'),
+      );
+    });
+
+    it('content after close tag is clean when no leading newlines', () => {
+      expect(parser.processOutputDelta('<think>reason</think>direct')).toEqual(
+        both('reason', 'direct'),
+      );
+    });
+  });
+
+  // ─── empty think block ────────────────────────────────────────────────────
+
+  describe('empty think block', () => {
+    it('<think></think>answer returns only content', () => {
+      const result = parser.processOutputDelta('<think></think>answer');
+      expect(result.reasoning).toBeUndefined();
+      expect(result.content).toBe('answer');
+    });
+
+    it('<think></think> with no answer returns empty', () => {
+      const result = parser.processOutputDelta('<think></think>');
+      expect(result.reasoning).toBeUndefined();
+      expect(result.content).toBeUndefined();
+    });
+  });
+
+  // ─── partial open tag across chunks ──────────────────────────────────────
+
+  describe('partial open tag across chunks', () => {
+    it('<thi | nk>reasoning</think>answer', () => {
+      expect(parser.processOutputDelta('<thi')).toEqual(empty());
+      expect(parser.processOutputDelta('nk>reasoning</think>answer')).toEqual(
+        both('reasoning', 'answer'),
+      );
+    });
+
+    it('<t | hink>reasoning</think>answer', () => {
+      expect(parser.processOutputDelta('<t')).toEqual(empty());
+      expect(parser.processOutputDelta('hink>reasoning</think>answer')).toEqual(
+        both('reasoning', 'answer'),
+      );
+    });
+
+    it('< alone (partial) then rest of tag', () => {
+      expect(parser.processOutputDelta('<')).toEqual(empty());
+      expect(parser.processOutputDelta('think>reason</think>answer')).toEqual(
+        both('reason', 'answer'),
+      );
+    });
+  });
+
+  // ─── bare </think> pattern (no opening tag) ───────────────────────────────
+
+  describe('bare </think> pattern', () => {
+    it('reasoning</think>answer splits correctly', () => {
+      expect(parser.processOutputDelta('Some reasoning</think>Actual answer')).toEqual(
+        both('Some reasoning', 'Actual answer'),
+      );
+    });
+
+    it('</think> with no preceding reasoning', () => {
+      const result = parser.processOutputDelta('</think>answer');
+      expect(result.reasoning).toBeUndefined();
+      expect(result.content).toBe('answer');
+    });
+
+    it('bare close tag with no following content', () => {
+      const result = parser.processOutputDelta('reasoning</think>');
+      expect(result.reasoning).toBe('reasoning');
+      expect(result.content).toBeUndefined();
+    });
+  });
+
+  // ─── partial close tag across chunks ─────────────────────────────────────
+
+  describe('partial close tag across chunks', () => {
+    it('close tag split: </thi | nk>answer', () => {
+      parser.processOutputDelta('<think>reasoning</thi');
+      expect(parser.processOutputDelta('nk>answer text')).toEqual(content('answer text'));
+    });
+
+    it('close tag split: </think | > (just the angle bracket in second chunk)', () => {
+      parser.processOutputDelta('<think>reasoning</think');
+      expect(parser.processOutputDelta('>answer')).toEqual(content('answer'));
+    });
+
+    it('false alarm: partial that turns out not to be a close tag', () => {
+      // </thi is buffered, then 'ng is great' arrives — not a close tag
+      parser.processOutputDelta('<think>reason');
+      const r1 = parser.processOutputDelta('ing</thi');
+      expect(r1).toEqual(reasoning('ing'));
+      // next chunk doesn't complete the tag
+      const r2 = parser.processOutputDelta('s is not a tag');
+      expect(r2.reasoning).toContain('</thi');
+    });
+  });
+
+  // ─── stream ends mid-think ────────────────────────────────────────────────
+
+  describe('stream ends mid-think (flush)', () => {
+    it('reasoning is emitted immediately by processOutputDelta for unclosed think tag', () => {
+      // "thinking forever" is not buffered — it is returned by processOutputDelta directly
+      const result = parser.processOutputDelta('<think>thinking forever');
+      expect(result).toEqual(reasoning('thinking forever'));
+      // flush has nothing left to emit
+      expect(parser.flush()).toEqual(empty());
+    });
+
+    it('flush emits buffered partial close tag when stream ends mid-detecting_close', () => {
+      // chunk ends with partial </think> — goes into detecting_close with buffer='</thi'
+      const r1 = parser.processOutputDelta('<think>reason</thi');
+      expect(r1).toEqual(reasoning('reason'));
+      // stream ends before next chunk arrives
+      const flushed = parser.flush();
+      expect(flushed.reasoning).toContain('</thi');
+    });
+
+    it('flush is empty when stream ended cleanly', () => {
+      parser.processOutputDelta('<think>reason</think>answer');
+      expect(parser.flush()).toEqual(empty());
+    });
+
+    it('flush emits partial open tag as reasoning when stream ends mid-detecting-open', () => {
+      // Stream ends while a partial <think> opener is still buffered
+      const result = parser.processOutputDelta('<thi');
+      expect(result).toEqual(empty()); // buffered, nothing emitted yet
+      const flushed = parser.flush();
+      expect(flushed.reasoning).toBe('<thi'); // partial tag flushed as reasoning
+    });
+
+    it('flush is idempotent — second call returns empty', () => {
+      parser.processOutputDelta('<think>reason</thi');
+      parser.flush();
+      expect(parser.flush()).toEqual(empty());
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -52,6 +52,7 @@ import {
 } from '~/app/types';
 import { URL_PREFIX, extractMCPToolCallData } from '~/app/utilities';
 import { GUARDRAIL_ERROR_CODES } from '~/app/Chatbot/const';
+import { ThinkTagParser } from './thinkTagParser';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -181,9 +182,19 @@ const extractContentFromOutput = (output?: OutputItem[]): string => {
  */
 const transformBackendResponse = (backendResponse: BackendResponseData): SimplifiedResponseData => {
   const toolCallData = extractMCPToolCallData(backendResponse.output);
-  const content = extractContentFromOutput(backendResponse.output);
+  let content = extractContentFromOutput(backendResponse.output);
   const annotations = extractAnnotationsFromOutput(backendResponse.output);
   const sources = buildSourcesFromAnnotations(annotations);
+
+  // Strip <think>...</think> or bare reasoning (content before </think>) from content
+  let reasoningContent: string | undefined;
+  const thinkMatchFull = content.match(/^<think>([\s\S]*?)<\/think>\s*/);
+  const thinkMatchBare = !thinkMatchFull ? content.match(/^([\s\S]*?)<\/think>\s*/) : null;
+  const thinkMatch = thinkMatchFull || thinkMatchBare;
+  if (thinkMatch) {
+    reasoningContent = (thinkMatchFull ? thinkMatch[1] : thinkMatch[1]).trim();
+    content = content.slice(thinkMatch[0].length);
+  }
 
   return {
     id: backendResponse.id,
@@ -195,6 +206,7 @@ const transformBackendResponse = (backendResponse: BackendResponseData): Simplif
     ...(toolCallData && { toolCallData }),
     ...(sources.length > 0 && { sources }),
     ...(backendResponse.metrics && { metrics: backendResponse.metrics }),
+    ...(reasoningContent && { reasoningContent }),
   };
 };
 
@@ -243,7 +255,7 @@ const postCreateResponse = (
 const streamCreateResponse = (
   url: string,
   request: CreateResponseRequest,
-  onStreamData: (chunk: string, clearPrevious?: boolean) => void,
+  onStreamData: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void,
   abortSignal?: AbortSignal,
 ): Promise<SimplifiedResponseData> =>
   new Promise((resolve, reject) => {
@@ -277,10 +289,13 @@ const streamCreateResponse = (
         }
 
         let fullContent = '';
+        let reasoningContent = '';
         let completeResponseData: BackendResponseData | null = null;
         let metricsData: ResponseMetrics | null = null;
         let receivedRefusal = false;
         const decoder = new TextDecoder();
+
+        const thinkParser = new ThinkTagParser();
 
         try {
           let done = false;
@@ -307,9 +322,21 @@ const streamCreateResponse = (
                       return;
                     }
 
-                    if (data.delta && data.type === 'response.output_text.delta') {
-                      fullContent += data.delta;
-                      onStreamData(data.delta);
+                    if (data.type === 'response.reasoning_text.delta' && data.delta) {
+                      thinkParser.notifyDedicatedReasoningEvent();
+                      reasoningContent += data.delta;
+                      onStreamData(data.delta, false, true);
+                    } else if (data.delta && data.type === 'response.output_text.delta') {
+                      const { delta } = data;
+                      const parsed = thinkParser.processOutputDelta(delta);
+                      if (parsed.reasoning) {
+                        reasoningContent += parsed.reasoning;
+                        onStreamData(parsed.reasoning, false, true);
+                      }
+                      if (parsed.content) {
+                        fullContent += parsed.content;
+                        onStreamData(parsed.content);
+                      }
                     } else if (data.type === 'response.refusal.delta') {
                       if (data.delta) {
                         const isFirstRefusal = !receivedRefusal;
@@ -327,7 +354,6 @@ const streamCreateResponse = (
                       data.type === 'response.metrics' &&
                       isResponseMetrics(data.metrics)
                     ) {
-                      // Capture metrics from the BFF response.metrics event
                       metricsData = data.metrics;
                     }
                   } catch {
@@ -341,6 +367,17 @@ const streamCreateResponse = (
           reader.releaseLock();
         }
 
+        // Flush any remaining buffered partial tag
+        const flushed = thinkParser.flush();
+        if (flushed.reasoning) {
+          reasoningContent += flushed.reasoning;
+          onStreamData(flushed.reasoning, false, true);
+        }
+        if (flushed.content) {
+          fullContent += flushed.content;
+          onStreamData(flushed.content);
+        }
+
         const toolCallData = completeResponseData?.output
           ? extractMCPToolCallData(completeResponseData.output)
           : undefined;
@@ -350,9 +387,22 @@ const streamCreateResponse = (
           ? extractAnnotationsFromOutput(completeResponseData.output)
           : [];
         const sources = buildSourcesFromAnnotations(annotations);
-        const finalContent = completeResponseData?.output
+        let finalContent = completeResponseData?.output
           ? extractContentFromOutput(completeResponseData.output)
           : fullContent;
+
+        // Strip <think>...</think> or bare reasoning (content before </think>) from final content
+        const thinkMatchFull = finalContent.match(/^<think>([\s\S]*?)<\/think>\s*/);
+        const thinkMatchBare = !thinkMatchFull
+          ? finalContent.match(/^([\s\S]*?)<\/think>\s*/)
+          : null;
+        const thinkMatch = thinkMatchFull || thinkMatchBare;
+        if (thinkMatch) {
+          if (!reasoningContent) {
+            reasoningContent = (thinkMatchFull ? thinkMatch[1] : thinkMatch[1]).trim();
+          }
+          finalContent = finalContent.slice(thinkMatch[0].length);
+        }
 
         resolve({
           id: completeResponseData?.id || 'streaming-response',
@@ -363,6 +413,7 @@ const streamCreateResponse = (
           ...(toolCallData && { toolCallData }),
           ...(sources.length > 0 && { sources }),
           ...(metricsData && { metrics: metricsData }),
+          ...(reasoningContent && { reasoningContent }),
         });
       })
       .catch((error) => {
@@ -389,7 +440,7 @@ export const createResponse =
   (
     data: CreateResponseRequest,
     opts: APIOptions & {
-      onStreamData?: (chunk: string, clearPrevious?: boolean) => void;
+      onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
       abortSignal?: AbortSignal;
     } = {},
   ): Promise<SimplifiedResponseData> => {
@@ -501,6 +552,57 @@ export const uploadSource = (
 export const getFileUploadStatus = modArchRestGET<FileUploadStatusResponse>(
   '/lsd/files/upload/status',
 );
+
+// Vision image upload -- uses XHR for progress tracking
+export const uploadVisionFile = (
+  url: string,
+  file: File,
+  onProgress?: (percent: number) => void,
+): { promise: Promise<{ data: { id: string } }>; xhr: XMLHttpRequest } => {
+  const xhr = new XMLHttpRequest();
+  const promise = new Promise<{ data: { id: string } }>((resolve, reject) => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    xhr.open('POST', url);
+    xhr.timeout = 60_000;
+
+    if (onProgress) {
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          onProgress(Math.round((e.loaded / e.total) * 100));
+        }
+      };
+    }
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const parsed = JSON.parse(xhr.responseText);
+          if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            parsed.data &&
+            typeof parsed.data.id === 'string'
+          ) {
+            resolve(parsed);
+          } else {
+            reject(new Error('Invalid response shape: missing data.id'));
+          }
+        } catch {
+          reject(new Error('Invalid response from server'));
+        }
+      } else {
+        reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
+      }
+    };
+    xhr.onerror = () => reject(new Error('Network error during upload'));
+    xhr.ontimeout = () => reject(new Error('Upload timed out'));
+    xhr.onabort = () => reject(new Error('Upload aborted'));
+    xhr.send(formData);
+  });
+  return { promise, xhr };
+};
 
 // LSD Models
 export const getLSDModels = modArchRestGET<LlamaModel[]>('/lsd/models');

--- a/packages/gen-ai/frontend/src/app/services/thinkTagParser.ts
+++ b/packages/gen-ai/frontend/src/app/services/thinkTagParser.ts
@@ -1,0 +1,215 @@
+/**
+ * ThinkTagParser — stateful parser for embedded <think>...</think> reasoning blocks.
+ *
+ * Some LLM models embed reasoning tokens directly in output_text.delta events using
+ * one of two formats:
+ *   - "<think>reasoning</think>answer"  (explicit open + close tags)
+ *   - "reasoning</think>answer"         (bare close tag, no opener)
+ *
+ * Models that use a dedicated response.reasoning_text.delta channel never embed tags;
+ * call notifyDedicatedReasoningEvent() when one arrives and processOutputDelta() will
+ * return content-only after that.
+ *
+ * One instance should be created per streaming response. Call:
+ *   - notifyDedicatedReasoningEvent() for each response.reasoning_text.delta event
+ *   - processOutputDelta(delta) for each response.output_text.delta event
+ *   - flush() once after the stream ends
+ *
+ * Each call returns { reasoning?, content? } — the caller routes each to onStreamData.
+ */
+
+export type ThinkTagOutput = {
+  reasoning?: string;
+  content?: string;
+};
+
+type ThinkTagState = 'initial' | 'in_think' | 'detecting_close' | 'done';
+
+const THINK_OPEN = '<think>';
+const THINK_CLOSE = '</think>';
+
+export class ThinkTagParser {
+  private state: ThinkTagState = 'initial';
+  private buffer = '';
+  private _hasDedicatedChannel = false;
+
+  /**
+   * Call when a response.reasoning_text.delta event arrives.
+   * Marks the model as using a dedicated reasoning channel — subsequent
+   * processOutputDelta calls will return content-only without tag parsing.
+   */
+  notifyDedicatedReasoningEvent(): void {
+    this._hasDedicatedChannel = true;
+    if (this.state === 'initial') {
+      this.state = 'done';
+    }
+  }
+
+  /**
+   * Whether the model uses response.reasoning_text.delta for reasoning.
+   * When true, all output_text.delta events are pure content — skip parsing.
+   */
+  get hasDedicatedChannel(): boolean {
+    return this._hasDedicatedChannel;
+  }
+
+  /**
+   * Process one response.output_text.delta chunk.
+   * Returns reasoning and/or content to emit via onStreamData.
+   */
+  processOutputDelta(delta: string): ThinkTagOutput {
+    if (this._hasDedicatedChannel) {
+      return { content: delta };
+    }
+
+    if (this.state === 'initial') {
+      return this.handleInitial(delta);
+    }
+
+    if (this.state === 'in_think') {
+      return this.handleInThink(delta);
+    }
+
+    if (this.state === 'detecting_close') {
+      return this.handleDetectingClose(delta);
+    }
+
+    // state === 'done' — normal output
+    return { content: delta };
+  }
+
+  /**
+   * Flush any buffered partial tag content at end of stream.
+   * Must be called once after the stream loop ends.
+   */
+  flush(): ThinkTagOutput {
+    if (!this.buffer) {
+      return {};
+    }
+    const buffered = this.buffer;
+    this.buffer = '';
+
+    if (this.state === 'detecting_close' || this.state === 'in_think') {
+      return { reasoning: buffered };
+    }
+    // initial or done — treat as content
+    return { content: buffered };
+  }
+
+  // ─── private state handlers ───────────────────────────────────────────────
+
+  private handleInitial(delta: string): ThinkTagOutput {
+    if (delta.startsWith(THINK_OPEN)) {
+      this.state = 'in_think';
+      const remainder = delta.slice(THINK_OPEN.length);
+      if (!remainder) {
+        return {};
+      }
+      return this.handleInThink(remainder);
+    }
+
+    if (delta.startsWith('<') && THINK_OPEN.startsWith(delta)) {
+      // Partial open tag at start of stream — buffer and wait
+      this.buffer = delta;
+      this.state = 'in_think';
+      return {};
+    }
+
+    if (delta.includes(THINK_CLOSE)) {
+      // Bare form: "reasoning</think>answer"
+      const closeIdx = delta.indexOf(THINK_CLOSE);
+      const reasoning = delta.slice(0, closeIdx);
+      const content = delta.slice(closeIdx + THINK_CLOSE.length);
+      this.state = 'done';
+      return {
+        ...(reasoning ? { reasoning } : {}),
+        ...(content ? { content } : {}),
+      };
+    }
+
+    // No think tags — model uses plain output
+    this.state = 'done';
+    return { content: delta };
+  }
+
+  private handleInThink(rawDelta: string): ThinkTagOutput {
+    // If there's a buffered partial open tag, prepend it
+    let delta = rawDelta;
+    if (this.buffer) {
+      delta = this.buffer + delta;
+      this.buffer = '';
+      if (delta.startsWith(THINK_OPEN)) {
+        delta = delta.slice(THINK_OPEN.length);
+        if (!delta) {
+          return {};
+        }
+      }
+    }
+
+    const closeIdx = delta.indexOf(THINK_CLOSE);
+    if (closeIdx !== -1) {
+      // Found </think> — split reasoning from content
+      const reasoning = delta.slice(0, closeIdx);
+      const afterClose = delta.slice(closeIdx + THINK_CLOSE.length);
+      this.state = 'done';
+      const trimmedContent = afterClose.replace(/^\n+/, '');
+      return {
+        ...(reasoning ? { reasoning } : {}),
+        ...(trimmedContent ? { content: trimmedContent } : {}),
+      };
+    }
+
+    // Check for partial </think> at end of chunk
+    const partialClose = this.findPartialClose(delta);
+    if (partialClose) {
+      const safeChunk = delta.slice(0, -partialClose.length);
+      this.buffer = partialClose;
+      this.state = 'detecting_close';
+      return safeChunk ? { reasoning: safeChunk } : {};
+    }
+
+    // Whole delta is reasoning
+    return { reasoning: delta };
+  }
+
+  private handleDetectingClose(delta: string): ThinkTagOutput {
+    this.buffer += delta;
+
+    if (this.buffer.length >= THINK_CLOSE.length) {
+      if (this.buffer.startsWith(THINK_CLOSE)) {
+        // Confirmed close tag
+        const afterClose = this.buffer.slice(THINK_CLOSE.length);
+        this.state = 'done';
+        this.buffer = '';
+        const trimmed = afterClose.replace(/^\n+/, '');
+        return trimmed ? { content: trimmed } : {};
+      }
+
+      // Not a close tag — the buffer was a false alarm; treat as reasoning
+      const buffered = this.buffer;
+      this.buffer = '';
+      this.state = 'in_think';
+      return { reasoning: buffered };
+    }
+
+    if (!THINK_CLOSE.startsWith(this.buffer)) {
+      // Buffer can no longer form a close tag — flush as reasoning
+      const buffered = this.buffer;
+      this.buffer = '';
+      this.state = 'in_think';
+      return { reasoning: buffered };
+    }
+
+    // Still accumulating — need more chunks
+    return {};
+  }
+
+  private findPartialClose(delta: string): string {
+    for (let i = 1; i < THINK_CLOSE.length; i++) {
+      if (delta.endsWith(THINK_CLOSE.slice(0, i))) {
+        return THINK_CLOSE.slice(0, i);
+      }
+    }
+    return '';
+  }
+}

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -198,6 +198,7 @@ export type SimplifiedResponseData = {
   toolCallData?: MCPToolCallData; // Optional - only present when MCP tool calls exist
   sources?: SourceItem[]; // Optional - file sources from RAG annotations
   metrics?: ResponseMetrics; // Optional - response metrics (latency, TTFT, usage)
+  reasoningContent?: string; // Optional - accumulated reasoning/thinking text from thinking models
 };
 
 export type FileError = {
@@ -623,7 +624,7 @@ type GetFileUploadStatus = ModArchRestGET<FileUploadStatusResponse>;
 type CreateResponse = (
   data: CreateResponseRequest,
   opts?: APIOptions & {
-    onStreamData?: (chunk: string, clearPrevious?: boolean) => void;
+    onStreamData?: (chunk: string, clearPrevious?: boolean, isReasoning?: boolean) => void;
     abortSignal?: AbortSignal;
   },
 ) => Promise<SimplifiedResponseData>;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62244
https://issues.redhat.com/browse/RHOAIENG-62245

## Description

Implements the full multimodal chat UX for the gen-ai Playground, covering Stories 1.2 (image upload component) and 1.3 (inline rendering, thinking panel, document chips, and send-button defaults).

### Story 1.2: Image upload component
- **Attach menu** with Upload image, Upload audio (disabled), Upload documents options
- **Client-side validation** for file type (JPG/PNG) and size (10MB limit) with auto-dismissing alerts
- **XHR-based upload** to `/gen-ai/api/v1/lsd/files/vision` with progress tracking
- **Image preview chip** with loading spinner and close/remove button
- **One-image-per-conversation** enforcement with disabled menu item
- **Vision-specific constants** (`VISION_UPLOAD_CONFIG`)

### Story 1.3: Multimodal chat UX — inline rendering, thinking panel, and document chips
- **Inline image rendering** in chat transcript (300px max-height thumbnail, border-radius)
- **Custom StreamingThinkingSection** component using PatternFly `ExpandableSection`
- **Live streaming of reasoning tokens** with auto-collapse when main answer begins
- **BFF `<think>` tag parsing** via `ThinkTagParser` class — handles `<think>reasoning</think>answer`, bare `reasoning</think>answer`, and partial tags split across SSE chunks
- **`response.reasoning_text.delta`** event handling for dedicated reasoning channels
- **Inline document chips** — transient in input area (with upload/close), persistent read-only in sent messages
- **"Replace media file?" modal** when re-uploading an image
- **Always-show send button** when attachments (image/docs) are ready, even with empty text
- **Default message injection** — "Describe the image" / "Summarize the attached documents" / combined
- **Uppercase image extension normalization** (.PNG → .png for icon display)
- **Blob URL revocation** on unmount and new-chat to prevent memory leaks
- **Merged streaming completion** to eliminate one-frame flicker
- **thinkBuffer flush emits onStreamData** for live UI consistency

### CodeRabbit review fixes
- **XHR upload timeout** — 60s timeout + `ontimeout` handler to prevent indefinite hangs
- **Stale upload race guard** — generation counter prevents aborted upload callbacks from wiping replacement state
- **Clear doc chips on external reset** — `clearAllMessagesRef` now also clears `pendingDocChips`
- **Attachment chip key collision** — index-suffixed keys prevent DOM reuse for same-name files
- **reasoningContent typeof guard** — runtime check before rendering thinking collapsible
- **Bare `</think>` streaming** — initial parser state now handles `reasoning</think>answer` without `<think>` prefix
- **Wire `isAudioUploadDisabled`** — prop destructured and applied to audio menu item
- **Test timer safety** — `jest.useFakeTimers` wrapped in try-finally to prevent leaks

## How Has This Been Tested?

- **Unit tests**: All 1118 gen-ai frontend tests pass (82 suites)
- **Playwright E2E**: Full flow tested against live cluster:
  1. Image upload + inline preview + send with vision model
  2. Reasoning models with streaming thinking tokens
  3. Document chip upload + inline rendering in transcript
  4. Replace media modal confirm/cancel
  5. Empty-text send with attachments → default message injection

## Test Impact

**New tests added:**

`thinkTagParser.spec.ts` (29 tests, new file):
- 9 `describe` blocks covering all state machine paths: dedicated channel, no tags, full `<think>...</think>`, empty block, partial open tag, bare `</think>`, partial close tag, stream-ends-mid-think flush
- Zero `mockFetch` — directly instantiates `ThinkTagParser` and feeds deltas

`ChatbotPlayground.spec.tsx` (33 tests):
- Inline doc chip lifecycle (creation, status sync, removal, send clearing)
- Send button gating (disabled while uploading, enabled when uploaded)
- Default message injection (image-only, docs-only, combined, no-injection with text)
- `alwaysShowSendButton` prop propagation
- Replace media modal (open, confirm with revoke, cancel)

`llamaStackService.spec.ts` (slimmed to wiring smoke tests):
- Reasoning channel wiring (dedicated `reasoning_text.delta` → `onStreamData`, embedded `<think>` → split)
- Chunk-level edge cases moved to `thinkTagParser.spec.ts`

`useChatbotMessages.spec.ts` (multiple new tests):
- Multimodal input construction, image persistence, reasoning effort payload
- Inline image/doc rendering in messages

`ChatbotMessageInput.spec.tsx` (new tests):
- Document chip rendering, loading states, close buttons
- `alwaysShowSendButton` prop

`StreamingThinkingSection.spec.tsx` (new file):
- Expand/collapse behavior, auto-collapse on streaming end

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`