### PR TITLE
fix: add paths: frontmatter to rules for Claude Code conditional loading

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,6 +2,10 @@
 description: ODH Dashboard monorepo architecture, package boundaries, and BFF structure
 globs: "packages/**,frontend/**,backend/**"
 alwaysApply: false
+paths:
+  - "packages/**"
+  - "frontend/**"
+  - "backend/**"
 ---
 
 # ODH Dashboard Architecture

--- a/.claude/rules/bff-go.md
+++ b/.claude/rules/bff-go.md
@@ -2,6 +2,9 @@
 description: BFF (Backend For Frontend) API patterns and Go conventions for ODH Dashboard packages
 globs: "packages/*/bff/**,packages/*/upstream/bff/**"
 alwaysApply: false
+paths:
+  - "packages/*/bff/**"
+  - "packages/*/upstream/bff/**"
 ---
 
 # BFF API Patterns & Go Conventions

--- a/.claude/rules/contract-tests.md
+++ b/.claude/rules/contract-tests.md
@@ -2,6 +2,8 @@
 description: Contract test guidelines for ODH Dashboard modules with BFF API validation
 globs: "**/contract-tests/**"
 alwaysApply: false
+paths:
+  - "**/contract-tests/**"
 ---
 
 # Contract Test Rules

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -2,6 +2,12 @@
 description: Coding conventions for TypeScript, React, PatternFly, and backend patterns in ODH Dashboard
 globs: "**/*.ts,**/*.tsx,**/*.js,**/*.jsx"
 alwaysApply: false
+paths:
+  - "frontend/src/**/*.ts"
+  - "frontend/src/**/*.tsx"
+  - "backend/src/**/*.ts"
+  - "packages/*/frontend/src/**/*.ts"
+  - "packages/*/frontend/src/**/*.tsx"
 ---
 
 # ODH Dashboard Coding Conventions

--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -3,11 +3,10 @@ description: Coding conventions for TypeScript, React, PatternFly, and backend p
 globs: "**/*.ts,**/*.tsx,**/*.js,**/*.jsx"
 alwaysApply: false
 paths:
-  - "frontend/src/**/*.ts"
-  - "frontend/src/**/*.tsx"
-  - "backend/src/**/*.ts"
-  - "packages/*/frontend/src/**/*.ts"
-  - "packages/*/frontend/src/**/*.tsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
 ---
 
 # ODH Dashboard Coding Conventions

--- a/.claude/rules/css-patternfly.md
+++ b/.claude/rules/css-patternfly.md
@@ -2,6 +2,9 @@
 description: CSS and PatternFly v6 styling conventions for ODH Dashboard
 globs: "**/*.scss,**/*.css,**/*.tsx,**/*.ts"
 alwaysApply: false
+paths:
+  - "**/*.scss"
+  - "**/*.css"
 ---
 
 # CSS & PatternFly — ODH Dashboard

--- a/.claude/rules/css-patternfly.md
+++ b/.claude/rules/css-patternfly.md
@@ -5,6 +5,8 @@ alwaysApply: false
 paths:
   - "**/*.scss"
   - "**/*.css"
+  - "**/*.tsx"
+  - "**/*.ts"
 ---
 
 # CSS & PatternFly — ODH Dashboard

--- a/.claude/rules/cypress-e2e.md
+++ b/.claude/rules/cypress-e2e.md
@@ -2,6 +2,8 @@
 description: Cypress E2E test creation and maintenance guidelines for live cluster testing
 globs: "packages/cypress/cypress/tests/e2e/**"
 alwaysApply: false
+paths:
+  - "packages/cypress/cypress/tests/e2e/**"
 ---
 
 # Cypress E2E Test Rules

--- a/.claude/rules/cypress-mock.md
+++ b/.claude/rules/cypress-mock.md
@@ -2,6 +2,9 @@
 description: Cypress mock test creation and maintenance guidelines for isolated component testing
 globs: "packages/cypress/cypress/tests/mocked/**,packages/*/frontend/src/__tests__/cypress/**"
 alwaysApply: false
+paths:
+  - "packages/cypress/cypress/tests/mocked/**"
+  - "packages/*/frontend/src/__tests__/cypress/**"
 ---
 
 # Cypress Mock Test Rules

--- a/.claude/rules/jira-creation.md
+++ b/.claude/rules/jira-creation.md
@@ -2,7 +2,6 @@
 description: Guidelines for creating Jira issues in the RHOAIENG project with proper formatting and field configuration
 globs: 
 alwaysApply: false
-paths: []
 ---
 
 # Creating Jira Issues in RHOAIENG Project

--- a/.claude/rules/jira-creation.md
+++ b/.claude/rules/jira-creation.md
@@ -2,8 +2,7 @@
 description: Guidelines for creating Jira issues in the RHOAIENG project with proper formatting and field configuration
 globs: 
 alwaysApply: false
-paths:
-  - ".claude/rules/jira-creation.md"
+paths: []
 ---
 
 # Creating Jira Issues in RHOAIENG Project

--- a/.claude/rules/jira-creation.md
+++ b/.claude/rules/jira-creation.md
@@ -2,6 +2,8 @@
 description: Guidelines for creating Jira issues in the RHOAIENG project with proper formatting and field configuration
 globs: 
 alwaysApply: false
+paths:
+  - ".claude/rules/jira-creation.md"
 ---
 
 # Creating Jira Issues in RHOAIENG Project

--- a/.claude/rules/modular-architecture.md
+++ b/.claude/rules/modular-architecture.md
@@ -2,6 +2,12 @@
 description: Modular Architecture — Module Federation, plugin/extension system, and how packages integrate with the host app
 globs: "packages/**,frontend/src/plugins/**,frontend/config/**"
 alwaysApply: false
+paths:
+  - "frontend/src/plugins/**"
+  - "frontend/config/**"
+  - "packages/plugin-core/**"
+  - "packages/plugin-template/**"
+  - "packages/app-config/src/module-federation.ts"
 ---
 
 # Modular Architecture — ODH Dashboard

--- a/.claude/rules/modular-architecture.md
+++ b/.claude/rules/modular-architecture.md
@@ -3,11 +3,9 @@ description: Modular Architecture — Module Federation, plugin/extension system
 globs: "packages/**,frontend/src/plugins/**,frontend/config/**"
 alwaysApply: false
 paths:
+  - "packages/**"
   - "frontend/src/plugins/**"
   - "frontend/config/**"
-  - "packages/plugin-core/**"
-  - "packages/plugin-template/**"
-  - "packages/app-config/src/module-federation.ts"
 ---
 
 # Modular Architecture — ODH Dashboard

--- a/.claude/rules/module-federation.md
+++ b/.claude/rules/module-federation.md
@@ -2,6 +2,14 @@
 description: Module Federation — how modules are exposed and consumed across packages in the modular architecture
 globs: "**/config/moduleFederation.js,**/config/webpack.*.js,**/module-federation.ts,**/useAppExtensions.ts,**/ExtensibilityContext.tsx,**/extensions.ts,**/extension-points.ts,**/odh/extensions.ts,**/odh/extension-points.ts"
 alwaysApply: false
+paths:
+  - "**/config/moduleFederation.js"
+  - "**/config/webpack.*.js"
+  - "**/module-federation.ts"
+  - "**/useAppExtensions.ts"
+  - "**/ExtensibilityContext.tsx"
+  - "**/odh/extensions.ts"
+  - "**/odh/extension-points.ts"
 ---
 
 # Module Federation — Modular Architecture

--- a/.claude/rules/module-federation.md
+++ b/.claude/rules/module-federation.md
@@ -8,6 +8,8 @@ paths:
   - "**/module-federation.ts"
   - "**/useAppExtensions.ts"
   - "**/ExtensibilityContext.tsx"
+  - "**/extensions.ts"
+  - "**/extension-points.ts"
   - "**/odh/extensions.ts"
   - "**/odh/extension-points.ts"
 ---

--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -2,6 +2,9 @@
 description: Guide for creating a new module/package in the ODH Dashboard monorepo
 globs: "packages/**"
 alwaysApply: false
+paths:
+  - "packages/plugin-template/**"
+  - "packages/*/package.json"
 ---
 
 # Module Onboarding — Creating a New Package

--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -3,8 +3,7 @@ description: Guide for creating a new module/package in the ODH Dashboard monore
 globs: "packages/**"
 alwaysApply: false
 paths:
-  - "packages/plugin-template/**"
-  - "packages/*/package.json"
+  - "packages/**"
 ---
 
 # Module Onboarding — Creating a New Package

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -2,8 +2,7 @@
 description: Pull request creation guidelines for odh-dashboard — must use PR template
 globs: ".github/pull_request_template.md"
 alwaysApply: false
-paths:
-  - ".github/pull_request_template.md"
+paths: []
 ---
 
 # Pull Request Creation

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,3 +1,11 @@
+---
+description: Pull request creation guidelines for odh-dashboard — must use PR template
+globs: ".github/pull_request_template.md"
+alwaysApply: false
+paths:
+  - ".github/pull_request_template.md"
+---
+
 # Pull Request Creation
 
 When creating a pull request targeting `opendatahub-io/odh-dashboard`, you **MUST** use the PR template at `.github/pull_request_template.md` as the PR body structure. Read the template, fill in every section following the HTML comment instructions within it, and include the full checklist. This rule does not apply to PRs targeting other repositories.

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -2,7 +2,6 @@
 description: Pull request creation guidelines for odh-dashboard — must use PR template
 globs: 
 alwaysApply: false
-paths: []
 ---
 
 # Pull Request Creation

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,6 +1,6 @@
 ---
 description: Pull request creation guidelines for odh-dashboard — must use PR template
-globs: ".github/pull_request_template.md"
+globs: 
 alwaysApply: false
 paths: []
 ---

--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -3,8 +3,8 @@ description: React component, hook, and page development conventions for ODH Das
 globs: "**/*.tsx,**/*.ts"
 alwaysApply: false
 paths:
-  - "frontend/src/**/*.tsx"
-  - "packages/*/frontend/src/**/*.tsx"
+  - "**/*.tsx"
+  - "**/*.ts"
 ---
 
 # React Development — ODH Dashboard

--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -2,6 +2,9 @@
 description: React component, hook, and page development conventions for ODH Dashboard
 globs: "**/*.tsx,**/*.ts"
 alwaysApply: false
+paths:
+  - "frontend/src/**/*.tsx"
+  - "packages/*/frontend/src/**/*.tsx"
 ---
 
 # React Development — ODH Dashboard

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -2,6 +2,11 @@
 description: Security review guidelines for auth, secrets, input validation, and K8s API interactions
 globs: "backend/**,**/api/**,**/routes/**,**/middleware/**"
 alwaysApply: false
+paths:
+  - "backend/**"
+  - "**/api/**"
+  - "**/routes/**"
+  - "**/middleware/**"
 ---
 
 # ODH Dashboard Security Review Guidelines

--- a/.claude/rules/testing-standards.md
+++ b/.claude/rules/testing-standards.md
@@ -2,6 +2,12 @@
 description: Cross-cutting testing standards for choosing and applying the right test type in ODH Dashboard
 globs: "**/__tests__/**,**/cypress/**,**/contract-tests/**,**/*.spec.*,**/*.test.*"
 alwaysApply: false
+paths:
+  - "**/__tests__/**"
+  - "**/cypress/**"
+  - "**/contract-tests/**"
+  - "**/*.spec.*"
+  - "**/*.test.*"
 ---
 
 # ODH Dashboard Testing Standards

--- a/.claude/rules/third-party-theming.md
+++ b/.claude/rules/third-party-theming.md
@@ -2,6 +2,10 @@
 description: Theming external libraries (Perses, etc.) with PatternFly tokens in ODH Dashboard
 globs: "packages/observability/**,packages/*/src/**/*theme*,packages/*/src/**/*Theme*"
 alwaysApply: false
+paths:
+  - "packages/observability/**"
+  - "packages/*/src/**/*theme*"
+  - "packages/*/src/**/*Theme*"
 ---
 
 # Third-Party Library Theming — ODH Dashboard

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -2,6 +2,9 @@
 description: Jest unit test guidelines for utilities, hooks, and components
 globs: "**/__tests__/**/*.spec.ts,**/__tests__/**/*.spec.tsx"
 alwaysApply: false
+paths:
+  - "**/__tests__/**/*.spec.ts"
+  - "**/__tests__/**/*.spec.tsx"
 ---
 
 # Unit Test Rules


### PR DESCRIPTION
## Description

Rules in `.claude/rules/` used Cursor-only frontmatter fields (`globs:`, `alwaysApply:`, `description:`) which Claude Code silently ignores. This caused **all 56k tokens** of rules to load on every session startup, regardless of what files were being worked on.

This PR adds `paths:` (YAML array) — the field Claude Code actually recognizes — alongside the existing Cursor fields so both tools conditionally load rules only when matching files are touched.

Additionally, overly broad patterns were tightened for Claude Code's `paths:` field:
- `conventions.md`: `**/*.ts` → `frontend/src/**/*.ts`, `packages/*/frontend/src/**/*.ts`
- `css-patternfly.md`: `**/*.tsx,**/*.ts` → `**/*.scss`, `**/*.css` only
- `react.md`: `**/*.tsx` → `frontend/src/**/*.tsx`, `packages/*/frontend/src/**/*.tsx`
- `modular-architecture.md`: `packages/**` → specific plugin/config paths
- `module-onboarding.md`: `packages/**` → `packages/plugin-template/**`, `packages/*/package.json`

Cursor fields (`globs:`, `alwaysApply:`, `description:`) are preserved for dual compatibility.

## How Has This Been Tested?

Verified that all 17 rule files have valid YAML frontmatter with both `globs:` (Cursor) and `paths:` (Claude Code) fields. Confirmed via Claude Code `/context` that rules were previously all loading at session start (~56k tokens under "Memory files").

## Test Impact

No tests needed — this is a metadata-only change to `.claude/rules/` frontmatter. No application code is modified.

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined rule/config front-matter to add explicit path-based scoping across many guidelines, narrowing applicability for architecture, BFF, contract-tests, conventions, CSS/PatternFly, Cypress (e2e & mocked), modular architecture, module federation, onboarding, pull-request guidance, React, security, testing standards, third‑party theming, and unit-test discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->