### PR TITLE
fix(RHOAIENG-58475): fix dropdown menu footer overlap with empty table

### DIFF
--- a/frontend/src/components/searchSelector/SearchSelector.tsx
+++ b/frontend/src/components/searchSelector/SearchSelector.tsx
@@ -32,6 +32,7 @@ type SearchSelectorProps = {
   isDisabled?: boolean;
   isFullWidth?: boolean;
   dataTestId: string;
+  menuFooter?: ((opts: ManualSearchSelectorOpts) => React.ReactNode) | React.ReactNode;
   minWidth?: string;
   onSearchChange: (newValue: string) => void;
   onSearchClear: () => void;
@@ -52,6 +53,7 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
   isLoading,
   isDisabled,
   isFullWidth,
+  menuFooter,
   minWidth,
   onSearchChange,
   onSearchClear,
@@ -154,6 +156,10 @@ const SearchSelector: React.FC<SearchSelectorProps> = ({
                 : children}
             </MenuList>
           </MenuContent>
+          {menuFooter != null &&
+            (typeof menuFooter === 'function'
+              ? menuFooter({ menuClose: () => setIsOpen(false) })
+              : menuFooter)}
         </Menu>
       }
     />

--- a/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
+++ b/frontend/src/concepts/pipelines/content/experiment/ExperimentSelector.tsx
@@ -54,76 +54,67 @@ const InnerExperimentSelector: React.FC<
         }
         searchHelpText={`Type a name to search your ${totalSize} run groups.`}
         isDisabled={totalSize === 0}
+        menuFooter={({ menuClose }) =>
+          loaded ? (
+            <div className="pf-v6-c-menu__footer">
+              <Divider />
+              <Button
+                variant="link"
+                icon={<PlusCircleIcon />}
+                onClick={() => {
+                  menuClose();
+                  setIsModalOpen(true);
+                }}
+                style={{ paddingLeft: '20px' }}
+              >
+                Create new run group
+              </Button>
+            </div>
+          ) : null
+        }
       >
         {({ menuClose }) => (
-          <>
-            <div className="pf-v6-c-menu__content">
-              <TableBase
-                itemCount={fetchedSize}
-                loading={!loaded}
-                emptyTableView={
-                  <DashboardEmptyTableView
-                    hasIcon={false}
-                    onClearFilters={onSearchClear}
-                    variant={EmptyStateVariant.xs}
-                  />
-                }
-                data-testid={`${dataTestId}-table-list`}
-                borders={false}
-                variant={TableVariant.compact}
-                columns={experimentSelectorColumns}
-                data={experiments}
-                rowRenderer={(row) => (
-                  <PipelineSelectorTableRow
-                    key={row.experiment_id}
-                    obj={row}
-                    onClick={() => {
-                      onSelect(row);
-                      menuClose();
-                    }}
-                  />
-                )}
-                getColumnSort={getTableColumnSort({
-                  columns: experimentSelectorColumns,
-                  ...sortProps,
-                })}
-                footerRow={() =>
-                  loaded ? (
-                    <PipelineViewMoreFooterRow
-                      visibleLength={experiments.length}
-                      totalSize={fetchedSize}
-                      errorTitle="Error loading more run groups"
-                      onClick={onLoadMore}
-                      colSpan={2}
-                    />
-                  ) : null
-                }
+          <TableBase
+            itemCount={fetchedSize}
+            loading={!loaded}
+            emptyTableView={
+              <DashboardEmptyTableView
+                hasIcon={false}
+                onClearFilters={onSearchClear}
+                variant={EmptyStateVariant.xs}
               />
-            </div>
-            {loaded && (
-              <div
-                className="pf-v6-c-menu__footer pf-v6-u-box-shadow-sm-top"
-                style={{
-                  position: 'sticky',
-                  bottom: 0,
-                  backgroundColor: 'var(--pf-v6-c-menu--BackgroundColor)',
+            }
+            data-testid={`${dataTestId}-table-list`}
+            borders={false}
+            variant={TableVariant.compact}
+            columns={experimentSelectorColumns}
+            data={experiments}
+            rowRenderer={(row) => (
+              <PipelineSelectorTableRow
+                key={row.experiment_id}
+                obj={row}
+                onClick={() => {
+                  onSelect(row);
+                  menuClose();
                 }}
-              >
-                <Divider />
-                <Button
-                  variant="link"
-                  icon={<PlusCircleIcon />}
-                  onClick={() => {
-                    menuClose();
-                    setIsModalOpen(true);
-                  }}
-                  style={{ paddingLeft: '20px' }}
-                >
-                  Create new run group
-                </Button>
-              </div>
+              />
             )}
-          </>
+            getColumnSort={getTableColumnSort({
+              columns: experimentSelectorColumns,
+              ...sortProps,
+            })}
+            footerRow={() =>
+              loaded ? (
+                <PipelineViewMoreFooterRow
+                  visibleLength={experiments.length}
+                  totalSize={fetchedSize}
+                  errorTitle="Error loading more run groups"
+                  onClick={onLoadMore}
+                  colSpan={2}
+                />
+              ) : null
+            }
+          />
         )}
       </SearchSelector>
       {isModalOpen && (


### PR DESCRIPTION
## Description

Fixes the "Create new run group" footer button overlapping with the empty table content in the experiment selector dropdown.

**Root cause:** The footer was rendered *inside* the `MenuContent` scroll container (`maxMenuHeight="200px"`) with `position: sticky; bottom: 0`. When the table showed an empty state, the sticky footer visually overlapped the empty state content.

**Fix:** Added a `menuFooter` prop to `SearchSelector` that renders footer content *outside* the `MenuContent` scroll container but still inside the `Menu`. This gives the footer its own layout space, preventing overlap regardless of whether the table is empty or populated.

## Jira
[RHOAIENG-58475](https://redhat.atlassian.net/browse/RHOAIENG-58475)

## How Has This Been Tested?

- Verified lint passes on both changed files
- Confirmed no existing tests reference the footer button or need updating

## Test Impact

No new tests needed — this is a structural fix (moving a React element to a different rendering position in the component tree). Existing Cypress pipeline create-run tests cover the experiment selector flow.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our [Best Practices](/docs/best-practices.md)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown search menus now support optional custom footer sections with full action capabilities

* **Refactor**
  * Improved menu layout and structure for better content organization
  * Footer elements repositioned to render within dropdown menus instead of external areas
  * Simplified overall dropdown menu architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->