### PR TITLE
add dependabot to test branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -197,3 +197,18 @@ updates:
   # excluded from Dependabot. Their deps are managed by their upstream repos
   # and synced in via the upstream-sync workflow. The dependency-validation
   # workflow still audits them when upstream syncs land.
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 1
+    target-branch: "dependabot-testing"
+    labels:
+      - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Simply adds another dependabot rule to target a test branch with only patch version bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

---

**Note:** This release contains only internal configuration updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->