### PR TITLE
add dependabot group update types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,13 @@ updates:
     groups:
       patternfly:
         applies-to: version-updates
+        update-types:
+          - "patch"
         patterns:
           - "@patternfly/*"
       patch-updates:
         applies-to: version-updates
+        update-types:
+          - "patch"
         exclude-patterns:
           - "@patternfly/*"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Dependabot groups are not respecting the ignore version config.

Adding `update-types` to groups to further re-enforce only patch updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better organize how patch-level updates are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->