### PR TITLE
feat(RHOAIENG-63760): add offline env vars to OGX CR

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1376,6 +1376,18 @@ func (kc *TokenKubernetesClient) InstallOGXServer(ctx context.Context, identity 
 			Name:  "SENTENCE_TRANSFORMERS_HOME",
 			Value: "/opt/app-root/src/.cache/huggingface/hub",
 		},
+		{
+			Name:  "HF_HUB_OFFLINE",
+			Value: "1",
+		},
+		{
+			Name:  "TRANSFORMERS_OFFLINE",
+			Value: "1",
+		},
+		{
+			Name:  "HF_DATASETS_OFFLINE",
+			Value: "1",
+		},
 	}
 
 	// Add per-model token and max_tokens environment variables


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63760

## Description

Add offline environment variables to the OGXServer CR to support disconnected environments. This change adds three environment variables that are applied when creating the OGX deployment:

* `HF_HUB_OFFLINE=1`
* `TRANSFORMERS_OFFLINE=1`  
* `HF_DATASETS_OFFLINE=1`

These variables prevent the OGX server from attempting to reach external HuggingFace Hub services in air-gapped/disconnected environments.

**Prerequisites:**
- https://github.com/opendatahub-io/ogx-distribution/pull/404 (OGX distribution support for offline mode)

## How Has This Been Tested?

Manually tested by applying these environment variables to an existing OGXServer deployment and verifying:
- The OGXServer pod starts successfully with the offline env vars set
- No attempts to reach external HuggingFace services
- Models load correctly from local cache

## Test Impact

No automated tests added. This is a Go BFF code change that adds environment variables to the OGXServer Custom Resource during installation. Testing requires:
- A disconnected/air-gapped cluster environment
- The prerequisite OGX distribution PR to be merged and deployed
- Manual verification of offline model loading behavior

Automated testing would require mocking disconnected environments which is not currently in scope.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
N/A - No UI changes (Go BFF code only)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to \`main\`