### PR TITLE
feat(RHOAIENG-64596): decouple Gen AI Studio navigation from OGX dependency

### DIFF
--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -46,6 +46,7 @@ type AIModelTableRowProps = {
   playgroundModels: LlamaModel[];
   onDelete?: (modelId: string) => Promise<void>;
   showActionColumn?: boolean;
+  showPlaygroundColumn?: boolean;
   allCollections: ExternalVectorStoreSummary[];
   collectionsLoaded: boolean;
   existingCollections: VectorStore[];
@@ -58,6 +59,7 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
   playgroundModels,
   onDelete,
   showActionColumn = false,
+  showPlaygroundColumn = false,
   allCollections,
   collectionsLoaded,
   existingCollections,
@@ -162,65 +164,67 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
             </Label>
           )}
         </Td>
-        <Td dataLabel="Playground">
-          {enabledModel ? (
-            <>
-              {model.model_type === 'embedding' && isVectorStoresEnabled ? (
-                <Button
-                  data-testid="see-vector-stores-button"
-                  variant={ButtonVariant.link}
-                  onClick={() => {
-                    fireMiscTrackingEvent('Available Endpoints See Vector Stores Clicked', {
-                      modelId: model.model_id,
-                    });
-                    if (namespace?.name) {
-                      navigate(genAiAiAssetsTabRoute(namespace.name, 'vectorstores'));
+        {showPlaygroundColumn && (
+          <Td dataLabel="Playground">
+            {enabledModel ? (
+              <>
+                {model.model_type === 'embedding' && isVectorStoresEnabled ? (
+                  <Button
+                    data-testid="see-vector-stores-button"
+                    variant={ButtonVariant.link}
+                    onClick={() => {
+                      fireMiscTrackingEvent('Available Endpoints See Vector Stores Clicked', {
+                        modelId: model.model_id,
+                      });
+                      if (namespace?.name) {
+                        navigate(genAiAiAssetsTabRoute(namespace.name, 'vectorstores'));
+                      }
+                    }}
+                  >
+                    See vector stores
+                  </Button>
+                ) : (
+                  <Button
+                    data-testid="try-playground-button"
+                    variant={ButtonVariant.secondary}
+                    onClick={() => {
+                      fireMiscTrackingEvent('Available Endpoints Playground Launched', {
+                        assetType,
+                        assetId: model.model_id,
+                      });
+                      navigate(genAiChatPlaygroundRoute(namespace?.name), {
+                        state: {
+                          model: enabledModel.id,
+                        },
+                      });
+                    }}
+                    // Embedding models cannot be tried in the chat playground (vector output is not supported)
+                    // Custom endpoint models are always available if they're in the list
+                    isDisabled={
+                      model.model_type === 'embedding' ||
+                      (model.model_source_type !== 'custom_endpoint' && model.status !== 'Running')
                     }
-                  }}
-                >
-                  See vector stores
-                </Button>
-              ) : (
-                <Button
-                  data-testid="try-playground-button"
-                  variant={ButtonVariant.secondary}
-                  onClick={() => {
-                    fireMiscTrackingEvent('Available Endpoints Playground Launched', {
-                      assetType,
-                      assetId: model.model_id,
-                    });
-                    navigate(genAiChatPlaygroundRoute(namespace?.name), {
-                      state: {
-                        model: enabledModel.id,
-                      },
-                    });
-                  }}
-                  // Embedding models cannot be tried in the chat playground (vector output is not supported)
-                  // Custom endpoint models are always available if they're in the list
-                  isDisabled={
-                    model.model_type === 'embedding' ||
-                    (model.model_source_type !== 'custom_endpoint' && model.status !== 'Running')
-                  }
-                >
-                  Try in playground
-                </Button>
-              )}
-            </>
-          ) : (
-            <Button
-              variant={ButtonVariant.link}
-              icon={<PlusCircleIcon />}
-              onClick={() => setIsConfigurationModalOpen(true)}
-              // Add stays enabled for embedding models (may be used in RAG configurations)
-              // Custom endpoint models are always available if they're in the list
-              isDisabled={
-                model.model_source_type !== 'custom_endpoint' && model.status !== 'Running'
-              }
-            >
-              Add to playground
-            </Button>
-          )}
-        </Td>
+                  >
+                    Try in playground
+                  </Button>
+                )}
+              </>
+            ) : (
+              <Button
+                variant={ButtonVariant.link}
+                icon={<PlusCircleIcon />}
+                onClick={() => setIsConfigurationModalOpen(true)}
+                // Add stays enabled for embedding models (may be used in RAG configurations)
+                // Custom endpoint models are always available if they're in the list
+                isDisabled={
+                  model.model_source_type !== 'custom_endpoint' && model.status !== 'Running'
+                }
+              >
+                Add to playground
+              </Button>
+            )}
+          </Td>
+        )}
         {showActionColumn && (
           <Td isActionCell>
             {model.model_source_type === 'custom_endpoint' && onDelete && (

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTable.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTable.tsx
@@ -17,6 +17,7 @@ import { aiModelColumns } from '~/app/AIAssets/data/columns';
 import useAIModelsFilter from '~/app/AIAssets/hooks/useAIModelsFilter';
 import useFetchAAEVectorStores from '~/app/hooks/useFetchAAEVectorStores';
 import useFetchVectorStores from '~/app/hooks/useFetchVectorStores';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 import {
   AssetsFilterColors,
   AssetsFilterOptions,
@@ -119,17 +120,27 @@ const AIModelsTable: React.FC<AIModelsTableProps> = ({
 }) => {
   const { filterData, onFilterUpdate, onClearFilters, filteredModels } = useAIModelsFilter(models);
   const { data: allCollections, loaded: collectionsLoaded } = useFetchAAEVectorStores();
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
   const [existingCollections] = useFetchVectorStores();
 
   // Check if any models are custom endpoints to determine if we need the action column
   const hasCustomEndpoints = models.some((model) => model.model_source_type === 'custom_endpoint');
+
+  // Filter columns based on playground availability
+  const visibleColumns = React.useMemo(
+    () =>
+      isChatPlaygroundEnabled
+        ? aiModelColumns
+        : aiModelColumns.filter((col) => col.field !== 'playground'),
+    [isChatPlaygroundEnabled],
+  );
 
   return (
     <Table
       variant="compact"
       data-testid="ai-models-table"
       data={filteredModels}
-      columns={aiModelColumns}
+      columns={visibleColumns}
       disableRowRenderSupport
       enablePagination
       emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}
@@ -155,6 +166,7 @@ const AIModelsTable: React.FC<AIModelsTableProps> = ({
           playgroundModels={playgroundModels}
           onDelete={onDelete}
           showActionColumn={hasCustomEndpoints && !!onDelete}
+          showPlaygroundColumn={isChatPlaygroundEnabled}
           allCollections={allCollections}
           collectionsLoaded={collectionsLoaded}
           existingCollections={existingCollections}

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
@@ -539,4 +539,37 @@ describe('AIModelTableRow', () => {
       expect(button.closest('button')).not.toBeDisabled();
     });
   });
+
+  describe('Playground column - disabled', () => {
+    it('should not render playground column when showPlaygroundColumn is false', () => {
+      const model = createMockAIModel();
+      render(
+        <TestWrapper>
+          <AIModelTableRow {...defaultProps} model={model} showPlaygroundColumn={false} />
+        </TestWrapper>,
+      );
+
+      expect(screen.queryByText('Add to playground')).not.toBeInTheDocument();
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+    });
+
+    it('should not render playground buttons even when model is in playground if column is disabled', () => {
+      const model = createMockAIModel({ model_id: 'test-model-id' });
+      const playgroundModel = createMockPlaygroundModel('test-model-id');
+
+      render(
+        <TestWrapper>
+          <AIModelTableRow
+            {...defaultProps}
+            model={model}
+            playgroundModels={[playgroundModel]}
+            showPlaygroundColumn={false}
+          />
+        </TestWrapper>,
+      );
+
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add to playground')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
@@ -64,6 +64,11 @@ jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled', () => ({
   default: () => false,
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <MemoryRouter>
     <GenAiContext.Provider value={mockGenAiContextValue}>
@@ -112,6 +117,7 @@ describe('AIModelTableRow', () => {
     allCollections: [],
     collectionsLoaded: true,
     existingCollections: [],
+    showPlaygroundColumn: true,
   };
 
   beforeEach(() => {

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTable.spec.tsx
@@ -14,6 +14,10 @@ jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled', () => ({
   __esModule: true,
   default: () => false,
 }));
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
 
 const mockUseAIModelsFilter = jest.mocked(useAIModelsFilter);
 

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTable.spec.tsx
@@ -8,18 +8,17 @@ import type { AIModel, LlamaModel } from '~/app/types';
 import AIModelsTable from '~/app/AIAssets/components/AIModelsTable';
 import useAIModelsFilter from '~/app/AIAssets/hooks/useAIModelsFilter';
 import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 
 jest.mock('~/app/AIAssets/hooks/useAIModelsFilter');
 jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled', () => ({
   __esModule: true,
   default: () => false,
 }));
-jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
-  __esModule: true,
-  default: () => true,
-}));
+jest.mock('~/app/hooks/useChatPlaygroundEnabled');
 
 const mockUseAIModelsFilter = jest.mocked(useAIModelsFilter);
+const mockUseChatPlaygroundEnabled = jest.mocked(useChatPlaygroundEnabled);
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <MemoryRouter>
@@ -56,6 +55,7 @@ describe('AIModelsTable', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseChatPlaygroundEnabled.mockReturnValue(true);
     mockUseAIModelsFilter.mockReturnValue({
       filterData: {},
       onFilterUpdate: jest.fn(),
@@ -120,5 +120,47 @@ describe('AIModelsTable', () => {
 
     expect(screen.getByText('Model 1')).toBeInTheDocument();
     expect(screen.queryByText('Model 2')).not.toBeInTheDocument();
+  });
+
+  describe('Playground column visibility', () => {
+    it('should include Playground column when useChatPlaygroundEnabled returns true', () => {
+      mockUseChatPlaygroundEnabled.mockReturnValue(true);
+      const models = [createMockAIModel({ model_id: 'model-1', display_name: 'Model 1' })];
+
+      mockUseAIModelsFilter.mockReturnValue({
+        filterData: {},
+        onFilterUpdate: jest.fn(),
+        onClearFilters: jest.fn(),
+        filteredModels: models,
+      });
+
+      render(
+        <TestWrapper>
+          <AIModelsTable {...defaultProps} models={models} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Playground')).toBeInTheDocument();
+    });
+
+    it('should exclude Playground column when useChatPlaygroundEnabled returns false', () => {
+      mockUseChatPlaygroundEnabled.mockReturnValue(false);
+      const models = [createMockAIModel({ model_id: 'model-1', display_name: 'Model 1' })];
+
+      mockUseAIModelsFilter.mockReturnValue({
+        filterData: {},
+        onFilterUpdate: jest.fn(),
+        onClearFilters: jest.fn(),
+        filteredModels: models,
+      });
+
+      render(
+        <TestWrapper>
+          <AIModelsTable {...defaultProps} models={models} />
+        </TestWrapper>,
+      );
+
+      expect(screen.queryByText('Playground')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServersToolbar.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/mcp/MCPServersToolbar.tsx
@@ -20,6 +20,7 @@ import { PlayIcon, FilterIcon, CloseIcon } from '@patternfly/react-icons';
 import { genAiChatPlaygroundRoute } from '~/app/utilities';
 import { MCPFilterColors } from '~/app/AIAssets/data/mcpFilterOptions';
 import { ServerStatusInfo } from '~/app/hooks/useMCPServerStatuses';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 
 interface MCPServersToolbarProps {
   onFilterUpdate: (filterType: string, value?: string) => void;
@@ -44,6 +45,7 @@ const MCPServersToolbar: React.FC<MCPServersToolbarProps> = ({
 }) => {
   const navigate = useNavigate();
   const { namespace } = useParams<{ namespace: string }>();
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
   const [currentFilterType, setCurrentFilterType] = React.useState<string>(() => {
     const keys = Object.keys(filterOptions);
@@ -116,19 +118,21 @@ const MCPServersToolbar: React.FC<MCPServersToolbarProps> = ({
           </ToolbarItem>
         </ToolbarGroup>
 
-        <ToolbarGroup variant="action-group">
-          <ToolbarItem>
-            <Button
-              variant="primary"
-              icon={<PlayIcon />}
-              onClick={handleTryInPlayground}
-              isDisabled={selectedCount === 0}
-              data-testid="try-in-playground-button"
-            >
-              Try in Playground{selectedCount > 0 ? ` (${selectedCount})` : ''}
-            </Button>
-          </ToolbarItem>
-        </ToolbarGroup>
+        {isChatPlaygroundEnabled && (
+          <ToolbarGroup variant="action-group">
+            <ToolbarItem>
+              <Button
+                variant="primary"
+                icon={<PlayIcon />}
+                onClick={handleTryInPlayground}
+                isDisabled={selectedCount === 0}
+                data-testid="try-in-playground-button"
+              >
+                Try in Playground{selectedCount > 0 ? ` (${selectedCount})` : ''}
+              </Button>
+            </ToolbarItem>
+          </ToolbarGroup>
+        )}
       </ToolbarContent>
 
       {activeFilters.length > 0 && (

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/VectorStoreTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/VectorStoreTableRow.tsx
@@ -33,6 +33,7 @@ interface VectorStoreTableRowProps {
   allCollections: ExternalVectorStoreSummary[];
   collectionsLoaded: boolean;
   existingCollections: VectorStore[];
+  showPlaygroundColumn?: boolean;
 }
 
 const VectorStoreTableRow: React.FC<VectorStoreTableRowProps> = ({
@@ -43,6 +44,7 @@ const VectorStoreTableRow: React.FC<VectorStoreTableRowProps> = ({
   allCollections,
   collectionsLoaded,
   existingCollections,
+  showPlaygroundColumn = false,
 }) => {
   const navigate = useNavigate();
   const { namespace } = React.useContext(GenAiContext);
@@ -120,39 +122,41 @@ const VectorStoreTableRow: React.FC<VectorStoreTableRowProps> = ({
         <Td dataLabel="Dimensions" style={dimStyle}>
           {store.embedding_dimension}
         </Td>
-        <Td dataLabel="Playground" style={dimStyle}>
-          {isInPlayground ? (
-            <Button
-              variant={ButtonVariant.secondary}
-              onClick={() => {
-                fireMiscTrackingEvent('Available Endpoints Playground Launched', {
-                  assetType: 'vector_store',
-                  assetId: store.vector_store_id,
-                });
-                navigate(genAiChatPlaygroundRoute(namespace?.name), {
-                  state: { vectorStoreId: store.vector_store_id },
-                });
-              }}
-            >
-              Try in playground
-            </Button>
-          ) : (
-            <Button
-              variant={ButtonVariant.link}
-              icon={<PlusCircleIcon />}
-              isDisabled={isDisabled}
-              onClick={() => {
-                setIsConfigurationModalOpen(true);
-                fireMiscTrackingEvent('Available Endpoints Playground Launched', {
-                  assetType: 'vector_store',
-                  assetId: store.vector_store_id,
-                });
-              }}
-            >
-              Add to playground
-            </Button>
-          )}
-        </Td>
+        {showPlaygroundColumn && (
+          <Td dataLabel="Playground" style={dimStyle}>
+            {isInPlayground ? (
+              <Button
+                variant={ButtonVariant.secondary}
+                onClick={() => {
+                  fireMiscTrackingEvent('Available Endpoints Playground Launched', {
+                    assetType: 'vector_store',
+                    assetId: store.vector_store_id,
+                  });
+                  navigate(genAiChatPlaygroundRoute(namespace?.name), {
+                    state: { vectorStoreId: store.vector_store_id },
+                  });
+                }}
+              >
+                Try in playground
+              </Button>
+            ) : (
+              <Button
+                variant={ButtonVariant.link}
+                icon={<PlusCircleIcon />}
+                isDisabled={isDisabled}
+                onClick={() => {
+                  setIsConfigurationModalOpen(true);
+                  fireMiscTrackingEvent('Available Endpoints Playground Launched', {
+                    assetType: 'vector_store',
+                    assetId: store.vector_store_id,
+                  });
+                }}
+              >
+                Add to playground
+              </Button>
+            )}
+          </Td>
+        )}
       </Tr>
       {isConfigurationModalOpen && (
         <ChatbotConfigurationModal

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/VectorStoresTable.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/VectorStoresTable.tsx
@@ -7,6 +7,7 @@ import {
   LlamaStackDistributionModel,
   VectorStore,
 } from '~/app/types';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 import VectorStoreTableRow from './VectorStoreTableRow';
 import VectorStoreColumns from './VectorStoreColumns';
 
@@ -26,27 +27,41 @@ const VectorStoresTable: React.FC<VectorStoresTableProps> = ({
   playgroundModels,
   lsdStatus,
   existingCollections,
-}) => (
-  <Table
-    data={vectorStores}
-    columns={VectorStoreColumns}
-    enablePagination
-    defaultSortColumn={0}
-    emptyTableView={<DashboardEmptyTableView onClearFilters={() => undefined} />}
-    rowRenderer={(store: ExternalVectorStoreSummary) => (
-      <VectorStoreTableRow
-        key={store.vector_store_id}
-        store={store}
-        allModels={allModels}
-        playgroundModels={playgroundModels}
-        lsdStatus={lsdStatus}
-        allCollections={vectorStores}
-        collectionsLoaded={collectionsLoaded}
-        existingCollections={existingCollections}
-      />
-    )}
-    data-testid="vector-stores-table"
-  />
-);
+}) => {
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
+
+  // Filter columns based on playground availability
+  const visibleColumns = React.useMemo(
+    () =>
+      isChatPlaygroundEnabled
+        ? VectorStoreColumns
+        : VectorStoreColumns.filter((col) => col.field !== 'playground'),
+    [isChatPlaygroundEnabled],
+  );
+
+  return (
+    <Table
+      data={vectorStores}
+      columns={visibleColumns}
+      enablePagination
+      defaultSortColumn={0}
+      emptyTableView={<DashboardEmptyTableView onClearFilters={() => undefined} />}
+      rowRenderer={(store: ExternalVectorStoreSummary) => (
+        <VectorStoreTableRow
+          key={store.vector_store_id}
+          store={store}
+          allModels={allModels}
+          playgroundModels={playgroundModels}
+          lsdStatus={lsdStatus}
+          allCollections={vectorStores}
+          collectionsLoaded={collectionsLoaded}
+          existingCollections={existingCollections}
+          showPlaygroundColumn={isChatPlaygroundEnabled}
+        />
+      )}
+      data-testid="vector-stores-table"
+    />
+  );
+};
 
 export default VectorStoresTable;

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/__tests__/VectorStoreTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/__tests__/VectorStoreTableRow.spec.tsx
@@ -180,4 +180,59 @@ describe('VectorStoreTableRow', () => {
       );
     });
   });
+
+  describe('Playground column - disabled', () => {
+    it('should not render playground column when showPlaygroundColumn is false', () => {
+      render(
+        <GenAiContext.Provider value={mockGenAiContextValue}>
+          <MemoryRouter>
+            <table>
+              <tbody>
+                <VectorStoreTableRow
+                  store={createStore()}
+                  allModels={[createAIModel()]}
+                  playgroundModels={[createLlamaModel()]}
+                  lsdStatus={null}
+                  allCollections={[createStore()]}
+                  collectionsLoaded
+                  existingCollections={[]}
+                  showPlaygroundColumn={false}
+                />
+              </tbody>
+            </table>
+          </MemoryRouter>
+        </GenAiContext.Provider>,
+      );
+
+      expect(screen.queryByText('Add to playground')).not.toBeInTheDocument();
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+    });
+
+    it('should not render playground buttons even when in playground if column is disabled', () => {
+      const store = createStore();
+      render(
+        <GenAiContext.Provider value={mockGenAiContextValue}>
+          <MemoryRouter>
+            <table>
+              <tbody>
+                <VectorStoreTableRow
+                  store={store}
+                  allModels={[createAIModel()]}
+                  playgroundModels={[createLlamaModel()]}
+                  lsdStatus={null}
+                  allCollections={[store]}
+                  collectionsLoaded
+                  existingCollections={[createVectorStore('vs-test-1')]}
+                  showPlaygroundColumn={false}
+                />
+              </tbody>
+            </table>
+          </MemoryRouter>
+        </GenAiContext.Provider>,
+      );
+
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add to playground')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/__tests__/VectorStoreTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/vectorstores/__tests__/VectorStoreTableRow.spec.tsx
@@ -38,6 +38,11 @@ jest.mock('../VectorStoreTableRowInfo', () => ({
   ),
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 const createStore = (
@@ -110,6 +115,7 @@ const renderRow = (props?: {
               allCollections={[store]}
               collectionsLoaded
               existingCollections={existingCollections}
+              showPlaygroundColumn
             />
           </tbody>
         </table>

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMain.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotMain.spec.tsx
@@ -25,6 +25,10 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
   fireMiscTrackingEvent: jest.fn(),
   fireSimpleTrackingEvent: jest.fn(),
 }));
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
 
 // Mock child components
 jest.mock('~/app/Chatbot/ChatbotHeader', () => ({

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
@@ -11,6 +11,10 @@ import { useChatbotConfigStore, ChatbotConfigStore, DEFAULT_CONFIG_ID } from '~/
 
 jest.mock('~/app/hooks/useFetchVectorStores');
 jest.mock('~/app/hooks/useGenAiAPI');
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
 jest.mock('~/app/Chatbot/store', () => ({
   ...jest.requireActual('~/app/Chatbot/store'),
   useChatbotConfigStore: jest.fn(),

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationCollectionsTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationCollectionsTable.spec.tsx
@@ -18,6 +18,11 @@ jest.mock('~/app/utilities/utils', () => ({
   splitLlamaModelId: jest.fn((id: string) => ({ providerId: '', id })),
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 // Mock mod-arch-shared: provide simplified Table, CheckboxTd, and useCheckboxTableBase
 jest.mock('mod-arch-shared', () => {
   const actual = jest.requireActual<typeof import('mod-arch-shared')>('mod-arch-shared');

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -26,6 +26,10 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 jest.mock('~/app/Chatbot/hooks/useGuardrailsEnabled');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled');
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
 
 const mockFireFormTrackingEvent = jest.mocked(fireFormTrackingEvent);
 const mockInstallLSD = jest.fn();

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationState.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationState.spec.tsx
@@ -11,6 +11,10 @@ import { mockGenAiContextValue } from '~/__mocks__/mockGenAiContext';
 jest.mock('~/app/hooks/useFetchLSDStatus');
 jest.mock('~/app/hooks/useFetchNemoGuardrailsStatus');
 jest.mock('~/app/Chatbot/hooks/useGuardrailsEnabled');
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
 
 const mockUseFetchLSDStatus = jest.mocked(useFetchLSDStatus);
 const mockUseFetchNemoGuardrailsStatus = jest.mocked(useFetchNemoGuardrailsStatus);

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/KnowledgeTabContent.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/KnowledgeTabContent.spec.tsx
@@ -28,6 +28,11 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
   fireMiscTrackingEvent: jest.fn(),
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 jest.mock('~/app/Chatbot/sourceUpload/ChatbotSourceUploadPanel', () => ({
   ChatbotSourceUploadPanel: ({
     uploadedFilesCount,

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLSDStatus.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLSDStatus.spec.ts
@@ -28,6 +28,11 @@ jest.mock('mod-arch-core', () => ({
   },
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 // Mock the llamaStackService
 jest.mock('~/app/services/llamaStackService', () => ({
   getLSDStatus: jest.fn(),

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLlamaModels.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLlamaModels.spec.ts
@@ -30,6 +30,11 @@ jest.mock('~/app/services/llamaStackService', () => ({
   getAAModels: jest.fn(),
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 const mockUseFetchState = jest.mocked(useFetchState);
 const mockGetModels = jest.mocked(getAAModels);
 

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLlamaModels.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchLlamaModels.spec.ts
@@ -6,6 +6,7 @@ import useFetchLlamaModels from '~/app/hooks/useFetchLlamaModels';
 import { getAAModels } from '~/app/services/llamaStackService';
 import { mockLlamaModels } from '~/__mocks__/mockLlamaStackModels';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 
 // Mock utilities/const to avoid asEnumMember error
 jest.mock('~/app/utilities/const', () => ({
@@ -30,17 +31,16 @@ jest.mock('~/app/services/llamaStackService', () => ({
   getAAModels: jest.fn(),
 }));
 
-jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
-  __esModule: true,
-  default: () => true,
-}));
+jest.mock('~/app/hooks/useChatPlaygroundEnabled');
 
 const mockUseFetchState = jest.mocked(useFetchState);
 const mockGetModels = jest.mocked(getAAModels);
+const mockUseChatPlaygroundEnabled = jest.mocked(useChatPlaygroundEnabled);
 
 describe('useFetchLlamaModels', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseChatPlaygroundEnabled.mockReturnValue(true);
   });
 
   it('should return error when no project is selected', async () => {
@@ -112,6 +112,21 @@ describe('useFetchLlamaModels', () => {
       expect(data).toEqual([]);
       expect(loaded).toBe(false);
       expect(error).toBeUndefined();
+    });
+  });
+
+  it('should return NotReadyError when playground is disabled', async () => {
+    mockUseChatPlaygroundEnabled.mockReturnValue(false);
+    const mockError = new Error('Playground is not enabled');
+    mockError.name = 'NotReadyError';
+    mockUseFetchState.mockReturnValue([[], false, mockError, jest.fn()]);
+
+    const { result } = testHook(useFetchLlamaModels)();
+
+    await waitFor(() => {
+      const { error } = result.current;
+      expect(error?.message).toBe('Playground is not enabled');
+      expect(error?.name).toBe('NotReadyError');
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
@@ -31,6 +31,11 @@ jest.mock('~/app/services/llamaStackService', () => ({
   listVectorStores: jest.fn(),
 }));
 
+jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 const mockUseFetchState = jest.mocked(useFetchState);
 const mockGetVectorStores = jest.mocked(listVectorStores);
 

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
@@ -56,9 +56,6 @@ describe('useFetchVectorStores', () => {
       expect(error?.message).toBe('Namespace not found');
       expect(error).toBeInstanceOf(Error);
     });
-
-    // Verify getVectorStores was not called
-    expect(mockGetVectorStores).not.toHaveBeenCalled();
   });
 
   it('should return NotReadyError when namespace is undefined', async () => {
@@ -73,9 +70,6 @@ describe('useFetchVectorStores', () => {
       expect(error?.message).toBe('Namespace not found');
       expect(error).toBeInstanceOf(Error);
     });
-
-    // Verify getVectorStores was not called
-    expect(mockGetVectorStores).not.toHaveBeenCalled();
   });
 
   it('should return NotReadyError when namespace is empty string', async () => {
@@ -90,9 +84,6 @@ describe('useFetchVectorStores', () => {
       expect(error?.message).toBe('Namespace not found');
       expect(error).toBeInstanceOf(Error);
     });
-
-    // Verify getVectorStores was not called
-    expect(mockGetVectorStores).not.toHaveBeenCalled();
   });
 
   it('should fetch vector stores successfully when namespace is provided', async () => {
@@ -243,8 +234,5 @@ describe('useFetchVectorStores', () => {
       expect(error?.message).toBe('Playground is not enabled');
       expect(error?.name).toBe('NotReadyError');
     });
-
-    // Verify listVectorStores was not called
-    expect(mockGetVectorStores).not.toHaveBeenCalled();
   });
 });

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useFetchVectorStores.spec.ts
@@ -7,6 +7,7 @@ import { listVectorStores } from '~/app/services/llamaStackService';
 import { VectorStore } from '~/app/types';
 import { mockVectorStores } from '~/__mocks__/mockVectorStores';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
+import useChatPlaygroundEnabled from '~/app/hooks/useChatPlaygroundEnabled';
 
 // Mock utilities/const to avoid asEnumMember error
 jest.mock('~/app/utilities/const', () => ({
@@ -31,17 +32,16 @@ jest.mock('~/app/services/llamaStackService', () => ({
   listVectorStores: jest.fn(),
 }));
 
-jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
-  __esModule: true,
-  default: () => true,
-}));
+jest.mock('~/app/hooks/useChatPlaygroundEnabled');
 
 const mockUseFetchState = jest.mocked(useFetchState);
 const mockGetVectorStores = jest.mocked(listVectorStores);
+const mockUseChatPlaygroundEnabled = jest.mocked(useChatPlaygroundEnabled);
 
 describe('useFetchVectorStores', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseChatPlaygroundEnabled.mockReturnValue(true);
   });
 
   it('should return NotReadyError when namespace is not provided', async () => {
@@ -226,5 +226,25 @@ describe('useFetchVectorStores', () => {
       expect(error?.message).toBe('Request timeout');
       expect(error).toBeInstanceOf(Error);
     });
+  });
+
+  it('should return NotReadyError when playground is disabled', async () => {
+    mockUseChatPlaygroundEnabled.mockReturnValue(false);
+    const mockError = new Error('Playground is not enabled');
+    mockError.name = 'NotReadyError';
+    mockUseFetchState.mockReturnValue([[], false, mockError, jest.fn()]);
+
+    const { result } = testHook(useFetchVectorStores)();
+
+    await waitFor(() => {
+      const [data, loaded, error] = result.current;
+      expect(data).toEqual([]);
+      expect(loaded).toBe(false);
+      expect(error?.message).toBe('Playground is not enabled');
+      expect(error?.name).toBe('NotReadyError');
+    });
+
+    // Verify listVectorStores was not called
+    expect(mockGetVectorStores).not.toHaveBeenCalled();
   });
 });

--- a/packages/gen-ai/frontend/src/app/hooks/useChatPlaygroundEnabled.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useChatPlaygroundEnabled.ts
@@ -1,18 +1,9 @@
-import React from 'react';
-import { usePluginStore } from '@openshift/dynamic-plugin-sdk';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { CHAT_PLAYGROUND } from '~/odh/extensions';
 
 const useChatPlaygroundEnabled = (): boolean => {
-  const pluginStore = usePluginStore();
-  const [isEnabled, setIsEnabled] = React.useState(false);
-
-  React.useEffect(() => {
-    const flags = pluginStore.getFeatureFlags();
-    const enabled = flags[CHAT_PLAYGROUND] === true;
-    setIsEnabled(enabled);
-  }, [pluginStore]);
-
-  return isEnabled;
+  const [chatPlaygroundEnabled] = useFeatureFlag(CHAT_PLAYGROUND);
+  return chatPlaygroundEnabled;
 };
 
 export default useChatPlaygroundEnabled;

--- a/packages/gen-ai/frontend/src/app/hooks/useChatPlaygroundEnabled.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useChatPlaygroundEnabled.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import { usePluginStore } from '@openshift/dynamic-plugin-sdk';
+import { CHAT_PLAYGROUND } from '~/odh/extensions';
+
+const useChatPlaygroundEnabled = (): boolean => {
+  const pluginStore = usePluginStore();
+  const [isEnabled, setIsEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    const flags = pluginStore.getFeatureFlags();
+    const enabled = flags[CHAT_PLAYGROUND] === true;
+    setIsEnabled(enabled);
+  }, [pluginStore]);
+
+  return isEnabled;
+};
+
+export default useChatPlaygroundEnabled;

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchLSDStatus.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchLSDStatus.ts
@@ -9,19 +9,24 @@ import {
 import { LlamaStackDistributionModel } from '~/app/types';
 import { NO_REFRESH_INTERVAL, REFRESH_INTERVAL } from '~/app/const';
 import { useGenAiAPI } from './useGenAiAPI';
+import useChatPlaygroundEnabled from './useChatPlaygroundEnabled';
 
 const useFetchLSDStatus = (
   activelyRefresh?: boolean,
 ): FetchStateObject<LlamaStackDistributionModel | null> => {
   const { api, apiAvailable } = useGenAiAPI();
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
   const callback = React.useCallback<FetchStateCallbackPromise<LlamaStackDistributionModel>>(
     async (opts: APIOptions) => {
       if (!apiAvailable) {
         return Promise.reject(new NotReadyError('API not yet available'));
       }
+      if (!isChatPlaygroundEnabled) {
+        return Promise.reject(new NotReadyError('Playground is not enabled'));
+      }
       return api.getLSDStatus(opts).then((r) => r);
     },
-    [api, apiAvailable],
+    [api, apiAvailable, isChatPlaygroundEnabled],
   );
 
   const [data, loaded, error, refresh] = useFetchState(callback, null, {

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchLlamaModels.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchLlamaModels.ts
@@ -8,18 +8,23 @@ import {
 import { LlamaModel } from '~/app/types';
 import { splitLlamaModelId } from '~/app/utilities/utils';
 import { useGenAiAPI } from './useGenAiAPI';
+import useChatPlaygroundEnabled from './useChatPlaygroundEnabled';
 
 const useFetchLlamaModels = (
   lsdNotReady?: boolean,
   includeEmbeddingModels?: boolean,
 ): FetchStateObject<LlamaModel[]> => {
   const { api, apiAvailable } = useGenAiAPI();
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
   const fetchLlamaModels = React.useCallback<FetchStateCallbackPromise<LlamaModel[]>>(async () => {
     if (!apiAvailable) {
       return Promise.reject(new NotReadyError('API not yet available'));
     }
     if (lsdNotReady) {
       return Promise.reject(new Error('LSD is not ready'));
+    }
+    if (!isChatPlaygroundEnabled) {
+      return Promise.reject(new NotReadyError('Playground is not enabled'));
     }
     // eslint-disable-next-line camelcase
     const queryParams = includeEmbeddingModels ? { include_embedding_models: true } : {};
@@ -29,7 +34,7 @@ const useFetchLlamaModels = (
       ...model,
       modelId: splitLlamaModelId(model.id).id,
     }));
-  }, [api, apiAvailable, lsdNotReady, includeEmbeddingModels]);
+  }, [api, apiAvailable, lsdNotReady, includeEmbeddingModels, isChatPlaygroundEnabled]);
 
   const [data, loaded, error, refresh] = useFetchState(fetchLlamaModels, [], {
     initialPromisePurity: true,

--- a/packages/gen-ai/frontend/src/app/hooks/useFetchVectorStores.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useFetchVectorStores.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { APIOptions, FetchState, NotReadyError, useFetchState } from 'mod-arch-core';
 import { VectorStore } from '~/app/types';
 import { useGenAiAPI } from './useGenAiAPI';
+import useChatPlaygroundEnabled from './useChatPlaygroundEnabled';
 
 const isRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object';
 
@@ -10,16 +11,20 @@ const isVectorStore = (v: unknown): v is VectorStore =>
 
 const useFetchVectorStores = (): FetchState<VectorStore[]> => {
   const { api, apiAvailable } = useGenAiAPI();
+  const isChatPlaygroundEnabled = useChatPlaygroundEnabled();
   const fetchData = React.useCallback(
     (opts: APIOptions) => {
       if (!apiAvailable) {
         return Promise.reject(new NotReadyError('API not yet available'));
       }
+      if (!isChatPlaygroundEnabled) {
+        return Promise.reject(new NotReadyError('Playground is not enabled'));
+      }
       return api
         .listVectorStores(opts)
         .then((stores) => (Array.isArray(stores) ? stores : []).filter(isVectorStore));
     },
-    [api, apiAvailable],
+    [api, apiAvailable, isChatPlaygroundEnabled],
   );
 
   return useFetchState<VectorStore[]>(fetchData, []);

--- a/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
+++ b/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
@@ -3,6 +3,7 @@ import { PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
 import { PluginStore } from '@odh-dashboard/plugin-core';
 import extensions, {
   AI_ASSET_CUSTOM_ENDPOINTS,
+  CHAT_PLAYGROUND,
   EXTERNAL_VECTOR_STORES,
   GUARDRAILS,
   MODEL_AS_SERVICE,
@@ -16,6 +17,7 @@ export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ 
     const pluginStore = new PluginStore({ 'gen-ai': extensions });
     const flags: Record<string, boolean> = {
       [PLUGIN_GEN_AI]: true,
+      [CHAT_PLAYGROUND]: true,
       [MODEL_AS_SERVICE]: true,
       [MODEL_AS_SERVICE_CAMEL]: true,
       [GUARDRAILS]: true,

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -16,6 +16,7 @@ import {
 import type { AIAssetsTabExtension } from '~/odh/extension-points';
 
 export const PLUGIN_GEN_AI = 'plugin-gen-ai';
+export const CHAT_PLAYGROUND = 'chatPlayground';
 export const GEN_AI_STUDIO = 'genAiStudio';
 export const MODEL_AS_SERVICE = 'model-as-service';
 export const MODEL_AS_SERVICE_CAMEL = 'modelAsService';
@@ -38,6 +39,14 @@ const extensions: (
     properties: {
       id: PLUGIN_GEN_AI,
       featureFlags: [GEN_AI_STUDIO],
+    },
+  },
+  {
+    type: 'app.area',
+    properties: {
+      id: CHAT_PLAYGROUND,
+      reliantAreas: [PLUGIN_GEN_AI],
+      featureFlags: [],
       customCondition: ({ dscStatus }) =>
         ['Managed', 'Unmanaged'].includes(
           dscStatus?.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
@@ -104,7 +113,7 @@ const extensions: (
   {
     type: 'app.navigation/href',
     flags: {
-      required: [PLUGIN_GEN_AI],
+      required: [CHAT_PLAYGROUND],
     },
     properties: {
       id: 'chat-playground',
@@ -191,7 +200,7 @@ const extensions: (
   {
     type: 'app.task/item',
     flags: {
-      required: [PLUGIN_GEN_AI],
+      required: [CHAT_PLAYGROUND],
     },
     properties: {
       id: 'genai-playground',

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -48,8 +48,9 @@ const extensions: (
       reliantAreas: [PLUGIN_GEN_AI],
       featureFlags: [],
       customCondition: ({ dscStatus }) =>
+        !dscStatus ||
         ['Managed', 'Unmanaged'].includes(
-          dscStatus?.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
+          dscStatus.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
         ),
     },
   },

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -48,9 +48,8 @@ const extensions: (
       reliantAreas: [PLUGIN_GEN_AI],
       featureFlags: [],
       customCondition: ({ dscStatus }) =>
-        !dscStatus ||
         ['Managed', 'Unmanaged'].includes(
-          dscStatus.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
+          dscStatus?.components?.[DataScienceStackComponent.OGX_OPERATOR]?.managementState ?? '',
         ),
     },
   },


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64596

## Description

This PR decouples the Gen AI Studio and AI Asset Endpoints navigation items from the OGX operator dependency, while keeping Playground-specific features (nav item, buttons, API calls) properly gated behind OGX installation.

<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/c673a453-eeb0-4972-b4e6-49e2458df0a5" />

### Key Changes:
- **New `CHAT_PLAYGROUND` area**: Created with OGX `customCondition` to control Playground-specific features
- **Removed OGX dependency from `PLUGIN_GEN_AI` area**: Gen AI Studio and AI Asset Endpoints are now visible when `genAiStudio=true`, regardless of OGX
- **New hook `useChatPlaygroundEnabled`**: Centralized playground availability check using plugin store flags
- **Updated data fetching hooks**: `useFetchLlamaModels`, `useFetchLSDStatus`, and `useFetchVectorStores` now internally check playground status and skip API calls when disabled
- **Conditional UI rendering**:
  - Playground columns in models and vector stores tables only render when playground enabled
  - "Try in Playground" buttons in MCP servers toolbar only render when playground enabled
  - Playground nav item requires both `genAiStudio` flag and OGX installation

### Behavior Changes:
**Before**: Both OGX installed AND genAiStudio flag required for Gen AI Studio visibility
**After**:
- Gen AI Studio nav: Visible when `genAiStudio=true` (no OGX dependency)
- AI Asset Endpoints nav: Visible when `genAiStudio=true` (no OGX dependency)  
- Playground nav: Visible only when `genAiStudio=true` AND OGX installed
- Playground buttons/columns: Visible only when OGX installed
- Playground API calls: Skipped when OGX not installed (no unnecessary requests)

## How Has This Been Tested?

Manually tested in local development environment with the following scenarios:
1. **OGX installed + genAiStudio enabled**: All nav items visible, Playground functional, buttons/columns present
2. **OGX not installed + genAiStudio enabled**: Gen AI Studio and AI Asset Endpoints visible, Playground hidden, no Playground API calls made
3. **genAiStudio disabled**: All Gen AI nav items hidden as expected

Verified:
- Navigation visibility in both scenarios
- API calls to `/lsd/models`, `/lsd/status`, `/vector-stores` are properly skipped when playground disabled
- Playground columns and buttons properly hidden/shown
- No console errors or warnings in either scenario

## Test Impact

Added unit test coverage for conditional playground rendering and API guards:

**Component Tests:**
- **AIModelTableRow.spec.tsx**: Tests verifying playground column is hidden when `showPlaygroundColumn={false}`
- **AIModelsTable.spec.tsx**: Tests verifying table column visibility based on `useChatPlaygroundEnabled` hook
- **VectorStoreTableRow.spec.tsx**: Tests verifying playground buttons are hidden when playground column is disabled

**Hook Tests:**
- **useFetchLlamaModels.spec.ts**: Test verifying `NotReadyError` is returned when playground is disabled
- **useFetchVectorStores.spec.ts**: Test verifying `NotReadyError` is returned and API is not called when playground is disabled

All modified test files now properly mock `useChatPlaygroundEnabled` with configurable return values to test both enabled and disabled scenarios.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Chat Playground feature flag and enabled it by default in the plugin store.

* **Refactor**
  * Tables, rows and toolbars now show or hide the "Playground" column and actions based on the feature flag.
  * Playground-related data fetches are blocked when the playground is disabled.

* **Tests**
  * Updated tests to cover enabled/disabled playground scenarios and verify UI and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->