### PR TITLE
add embedded mlflow UI to evalhub

### DIFF
--- a/packages/eval-hub/frontend/src/app/AppRoutes.tsx
+++ b/packages/eval-hub/frontend/src/app/AppRoutes.tsx
@@ -11,6 +11,7 @@ import ChooseBenchmarkCollectionPage from './pages/ChooseBenchmarkCollectionPage
 import ChooseStandardisedBenchmarksPage from './pages/ChooseStandardisedBenchmarksPage';
 import StartEvaluationRunPage from './pages/StartEvaluationRunPage';
 import EvaluationResultsPage from './pages/EvaluationResultsPage';
+import CompareEvaluationsPage from './pages/CompareEvaluationsPage';
 
 export const useNavData = (): NavDataItem[] => [
   {
@@ -30,6 +31,7 @@ const AppRoutes: React.FC = () => (
       >
         <Route path=":namespace" element={<EvaluationsPage />} />
         <Route path=":namespace/results/:jobId" element={<EvaluationResultsPage />} />
+        <Route path=":namespace/compare" element={<CompareEvaluationsPage />} />
         <Route path=":namespace/create" element={<NewEvaluationRunPage />} />
         <Route path=":namespace/create/collections" element={<ChooseBenchmarkCollectionPage />} />
         <Route path=":namespace/create/benchmarks" element={<ChooseStandardisedBenchmarksPage />} />

--- a/packages/eval-hub/frontend/src/app/components/MlflowCompareRuns.tsx
+++ b/packages/eval-hub/frontend/src/app/components/MlflowCompareRuns.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { loadRemote } from '@module-federation/runtime';
+
+interface MlflowCompareRunsProps {
+  experimentIds: string[];
+  runUuids: string[];
+  workspace?: string;
+}
+
+/** Shown when the federated remote entry cannot be loaded (MF boundary only). */
+const MlflowUnavailable: React.FC = () => (
+  <EmptyState
+    headingLevel="h2"
+    icon={ExclamationTriangleIcon}
+    titleText="MLflow is currently unavailable"
+    variant={EmptyStateVariant.lg}
+    data-testid="mlflow-unavailable-empty-state"
+  >
+    <EmptyStateBody>
+      The MLflow compare UI could not be loaded. Please check that MLflow is deployed and running,
+      then try again.
+    </EmptyStateBody>
+  </EmptyState>
+);
+
+const MlflowCompareRunsRemote = React.lazy(() =>
+  loadRemote<{ default: React.ComponentType<MlflowCompareRunsProps> }>(
+    'mlflowEmbedded/MlflowCompareRunsWrapper',
+  )
+    .then((mod) => mod ?? { default: MlflowUnavailable })
+    .catch(() => ({ default: MlflowUnavailable })),
+);
+
+const MlflowCompareRuns: React.FC<MlflowCompareRunsProps> = (props) => (
+  <React.Suspense
+    fallback={
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    }
+  >
+    <MlflowCompareRunsRemote {...props} />
+  </React.Suspense>
+);
+
+export default MlflowCompareRuns;

--- a/packages/eval-hub/frontend/src/app/pages/CompareEvaluationsPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/CompareEvaluationsPage.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { DeploymentMode, useModularArchContext } from 'mod-arch-core';
+import { evaluationsBaseRoute } from '~/app/routes';
+import MlflowCompareRuns from '~/app/components/MlflowCompareRuns';
+
+const parseIdList = (raw: string): string[] =>
+  raw
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+const CompareEvaluationsPage: React.FC = () => {
+  const { namespace } = useParams<{ namespace: string }>();
+  const [searchParams] = useSearchParams();
+
+  const {
+    config: { deploymentMode },
+  } = useModularArchContext();
+
+  const experimentIds = parseIdList(searchParams.get('experimentIds') ?? '');
+  const runUuids = parseIdList(searchParams.get('runUuids') ?? '');
+
+  const hasValidParams = experimentIds.length > 0 && experimentIds.length === runUuids.length;
+  const showCompare = deploymentMode === DeploymentMode.Federated && hasValidParams;
+
+  return (
+    <ApplicationsPage
+      title="Compare evaluations"
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem
+            render={() => <Link to={evaluationsBaseRoute(namespace)}>Evaluations</Link>}
+          />
+          <BreadcrumbItem isActive>Compare</BreadcrumbItem>
+        </Breadcrumb>
+      }
+      loaded
+      empty={!hasValidParams}
+      emptyMessage="Provide matching experimentIds and runUuids query parameters to compare runs."
+      provideChildrenPadding
+    >
+      {showCompare ? (
+        <MlflowCompareRuns
+          key={runUuids.join(',')}
+          experimentIds={experimentIds}
+          runUuids={runUuids}
+          workspace={namespace}
+        />
+      ) : null}
+    </ApplicationsPage>
+  );
+};
+
+export default CompareEvaluationsPage;

--- a/packages/eval-hub/frontend/src/app/pages/CompareEvaluationsPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/CompareEvaluationsPage.tsx
@@ -25,6 +25,9 @@ const CompareEvaluationsPage: React.FC = () => {
 
   const hasValidParams = experimentIds.length > 0 && experimentIds.length === runUuids.length;
   const showCompare = deploymentMode === DeploymentMode.Federated && hasValidParams;
+  const emptyMessage = !hasValidParams
+    ? 'Provide matching experimentIds and runUuids query parameters to compare runs.'
+    : 'Comparison is only available in federated deployment mode.';
 
   return (
     <ApplicationsPage
@@ -38,18 +41,16 @@ const CompareEvaluationsPage: React.FC = () => {
         </Breadcrumb>
       }
       loaded
-      empty={!hasValidParams}
-      emptyMessage="Provide matching experimentIds and runUuids query parameters to compare runs."
+      empty={!showCompare}
+      emptyMessage={emptyMessage}
       provideChildrenPadding
     >
-      {showCompare ? (
-        <MlflowCompareRuns
-          key={runUuids.join(',')}
-          experimentIds={experimentIds}
-          runUuids={runUuids}
-          workspace={namespace}
-        />
-      ) : null}
+      <MlflowCompareRuns
+        key={runUuids.join(',')}
+        experimentIds={experimentIds}
+        runUuids={runUuids}
+        workspace={namespace}
+      />
     </ApplicationsPage>
   );
 };

--- a/packages/eval-hub/frontend/src/app/routes.ts
+++ b/packages/eval-hub/frontend/src/app/routes.ts
@@ -22,3 +22,6 @@ export const evaluationStartRoute = (namespace?: string): string =>
 
 export const evaluationResultsRoute = (namespace?: string, jobId?: string): string =>
   `${evaluationsBaseRoute(namespace)}/results/${jobId ?? ':jobId'}`;
+
+export const evaluationCompareRoute = (namespace?: string): string =>
+  `${evaluationsBaseRoute(namespace)}/compare`;

--- a/packages/eval-hub/frontend/src/app/routes.ts
+++ b/packages/eval-hub/frontend/src/app/routes.ts
@@ -23,5 +23,18 @@ export const evaluationStartRoute = (namespace?: string): string =>
 export const evaluationResultsRoute = (namespace?: string, jobId?: string): string =>
   `${evaluationsBaseRoute(namespace)}/results/${jobId ?? ':jobId'}`;
 
-export const evaluationCompareRoute = (namespace?: string): string =>
-  `${evaluationsBaseRoute(namespace)}/compare`;
+export const evaluationCompareRoute = (
+  namespace?: string,
+  experimentIds?: string[],
+  runUuids?: string[],
+): string => {
+  const base = `${evaluationsBaseRoute(namespace)}/compare`;
+  if (!experimentIds?.length || !runUuids?.length) {
+    return base;
+  }
+  const params = new URLSearchParams({
+    experimentIds: experimentIds.join(','),
+    runUuids: runUuids.join(','),
+  });
+  return `${base}?${params.toString()}`;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-62049
## Description
Adds a new Eval Hub compare page that embeds MLflow’s run comparison UI via module federation.
- Adds `CompareEvaluationsPage` and wires route `/:namespace/compare`.
- Adds `evaluationCompareRoute()` helper.
- Introduces `MlflowCompareRuns` wrapper component that lazy-loads `mlflowEmbedded/MlflowCompareRunsWrapper`.
- Parses `experimentIds` and `runUuids` from query params (comma-separated), validates they are present and aligned, and shows an empty-state message when invalid.
- Renders compare UI only in `DeploymentMode.Federated` with valid parameters.
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
- Manual verification recommended:
  - Navigate to `/:namespace/compare?experimentIds=<id1,id2>&runUuids=<run1,run2>`.
  - Confirm compare view loads in federated deployment mode.
  - Confirm invalid/mismatched query params show empty-state guidance.
  - Confirm breadcrumb navigation back to Evaluations works.
- Automated tests: not added in this branch (UI integration/wiring change only).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
N/A
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New evaluations "Compare" page and URL for comparing evaluations and runs; accepts comma-separated lists and validates matching counts before enabling the compare UI.
  * Integrated MLflow comparison UI with lazy loading, a loading spinner, and a clear fallback message when the compare interface is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->