### PR TITLE
Upgrade Node.js base image from ubi9/nodejs-20 to ubi9/nodejs-22

### DIFF
--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -16,7 +16,7 @@ on:
       - '!**.gitignore'
       - '!**.md'
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 jobs:
   test-and-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/modular-arch-quality-gates.yml
+++ b/.github/workflows/modular-arch-quality-gates.yml
@@ -19,7 +19,7 @@ permissions:
   actions: read
 
 env:
-  NODE_VERSION: 20.x
+  NODE_VERSION: 22.x
   PACKAGES_PATHS: packages
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on: [push, pull_request]
 env:
-  NODE_VERSION: 20.x
+  NODE_VERSION: 22.x
   DO_NOT_TRACK: 1
 jobs:
   Setup:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-# Use ubi9/nodejs-20 as default base image
-ARG BASE_IMAGE="registry.access.redhat.com/ubi9/nodejs-20:latest"
+# Use ubi9/nodejs-22 as default base image
+ARG BASE_IMAGE="registry.access.redhat.com/ubi9/nodejs-22:latest"
 
 FROM ${BASE_IMAGE} as builder
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/opendatahub-io/odh-dashboard/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "main": "src/server.ts",
   "scripts": {

--- a/docs/workspace-dockerfiles.md
+++ b/docs/workspace-dockerfiles.md
@@ -78,7 +78,7 @@ Workspace Dockerfiles support parameterization through build arguments:
 | `MODULE_NAME` | Name of the module to build | `template` |
 | `UI_SOURCE_CODE` | Path to UI source relative to repo root | `./packages/${MODULE_NAME}/upstream/frontend` |
 | `BFF_SOURCE_CODE` | Path to BFF source relative to repo root | `./packages/${MODULE_NAME}/upstream/bff` |
-| `NODE_BASE_IMAGE` | Base image for Node.js build stage | `registry.access.redhat.com/ubi9/nodejs-20:latest` |
+| `NODE_BASE_IMAGE` | Base image for Node.js build stage | `registry.access.redhat.com/ubi9/nodejs-22:latest` |
 | `GOLANG_BASE_IMAGE` | Base image for Go build stage | `registry.access.redhat.com/ubi9/go-toolset:1.24` |
 | `DISTROLESS_BASE_IMAGE` | Base image for final runtime stage | `registry.access.redhat.com/ubi9-minimal:latest` |
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/opendatahub-io/odh-dashboard/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "run-s build:prod",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "turbo": "^2.4.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "backend": {
@@ -73,7 +73,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@types/jest": "^29.5.3",
@@ -315,7 +315,7 @@
         "yaml-eslint-parser": "^1.3.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@babel/preset-env": "^7.21.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/opendatahub-io/odh-dashboard/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "npm@10.9.2",
   "workspaces": [

--- a/packages/gen-ai/Dockerfile.openshift
+++ b/packages/gen-ai/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # Frontend build stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 AS ui-builder
+FROM registry.access.redhat.com/ubi9/nodejs-22 AS ui-builder
 COPY ./frontend/ ./
 RUN npm cache clean --force && npm ci --omit=optional && npm run build
 

--- a/packages/gen-ai/Dockerfile.workspace
+++ b/packages/gen-ai/Dockerfile.workspace
@@ -8,7 +8,7 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
 ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
 

--- a/packages/model-registry/Dockerfile.workspace
+++ b/packages/model-registry/Dockerfile.workspace
@@ -8,7 +8,7 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
 ARG GOLANG_BASE_IMAGE=registry.redhat.io/ubi9/go-toolset@sha256:82b82ecf4aedf67c4369849047c2680dba755fe57547bbb05eca211b22038e29
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
 

--- a/packages/model-registry/upstream/frontend/package-lock.json
+++ b/packages/model-registry/upstream/frontend/package-lock.json
@@ -92,7 +92,7 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@babel/preset-env": "^7.26.9",

--- a/packages/model-registry/upstream/frontend/package.json
+++ b/packages/model-registry/upstream/frontend/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "run-s build:prod",

--- a/packages/plugin-template/Dockerfile.workspace
+++ b/packages/plugin-template/Dockerfile.workspace
@@ -8,7 +8,7 @@ ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/upstream/bff
 
 # Set the base images for the build stages
-ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
 ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
 ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
 

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -8,7 +8,7 @@ ARG POETRY_CACHE=$USER_HOME/.poetry-cache
 ARG CHROME=https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 ARG OCP_CLI=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz
 ARG NVM_INSTALLER=https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh
-ARG NODE_VERSION=v20.18.0
+ARG NODE_VERSION=v22.5.1
 ARG OCM_CLI=https://github.com/openshift-online/ocm-cli/releases/download/v1.0.7/ocm-linux-amd64
 
 USER root


### PR DESCRIPTION
## Summary
- `ubi9/nodejs-20` has been **deprecated**, causing `deprecated-base-image-check` failures in Konflux/conforma builds for `odh-dashboard` and `odh-mod-arch-model-registry` components.
- Migrates all Dockerfiles, CI workflows, engine constraints, and docs from Node.js 20 to Node.js 22.

## Changes
- **Dockerfiles**: `Dockerfile`, `packages/gen-ai/Dockerfile.openshift`, `packages/gen-ai/Dockerfile.workspace`, `packages/model-registry/Dockerfile.workspace`, `packages/plugin-template/Dockerfile.workspace`, `scripts/ci/Dockerfile`
- **CI Workflows**: `test.yml`, `modular-arch-quality-gates.yml`, `gen-ai-frontend-build.yml`
- **package.json engines**: root, `backend/`, `frontend/`, `packages/model-registry/upstream/frontend/`
- **package-lock.json**: Updated project engine entries (third-party deps unchanged)
- **Docs**: `docs/workspace-dockerfiles.md`

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-64644

## Test plan
- [x] `npm ci` — passed with Node 22
- [x] `npm run build` — webpack compiled successfully
- [x] Unit tests — 251 suites, 2177 tests all passed
- [ ] CI pipeline validation after merge