### PR TITLE
fix: set MODULE_NAME=agent-ops in Dockerfile.workspace

### DIFF
--- a/packages/agent-ops/Dockerfile.workspace
+++ b/packages/agent-ops/Dockerfile.workspace
@@ -3,7 +3,7 @@
 # Build from repository root: docker build --file ./packages/<module>/Dockerfile.workspace .
 
 # Source code arguments - can be overridden for different modules
-ARG MODULE_NAME=mod-arch
+ARG MODULE_NAME=agent-ops
 ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
 ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
 


### PR DESCRIPTION
## Summary
- Fix `MODULE_NAME=mod-arch` → `MODULE_NAME=agent-ops` in `packages/agent-ops/Dockerfile.workspace`
- The installer generated the generic default, causing Konflux builds to fail with `stat: "/packages/mod-arch/frontend": no such file or directory`

## Jira
https://issues.redhat.com/browse/RHOAIENG-63302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration default for the module used when builds run without overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->