### PR TITLE
fix(manifests): reduce dashboard pod memory requests to restore schedulability [RHOAIENG-64650]

### DIFF
--- a/manifests/core-bases/base/deployment.yaml
+++ b/manifests/core-bases/base/deployment.yaml
@@ -37,10 +37,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 1Gi
               ephemeral-storage: 50Mi
             limits:
-              memory: 2Gi
+              memory: 1Gi
           livenessProbe:
             tcpSocket:
               port: 8080
@@ -113,10 +113,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 1Gi
               ephemeral-storage: 10Mi
             limits:
-              memory: 2Gi
+              memory: 1Gi
           volumeMounts:
             - mountPath: /etc/tls/private
               name: proxy-tls


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64650

## Description

PR [#7224](https://github.com/opendatahub-io/odh-dashboard/pull/7224) aligned container resources with K8s best practices (removed CPU limits, set memory req == limit for QoS). However, it bumped `odh-dashboard` and `kube-rbac-proxy` memory from 1Gi to 2Gi each, re-introducing the scheduling problem that PR [#6828](https://github.com/opendatahub-io/odh-dashboard/pull/6828) had previously fixed.

**The problem:** With 2Gi memory per core container, each pod requires 7.5Gi total memory. With 2 replicas = 15Gi, which exceeds what QE clusters (`odh-e2e-rhoai`) can schedule — blocking nightlies for 2+ days.

**The fix:** Reduce memory requests/limits for `odh-dashboard` and `kube-rbac-proxy` from 2Gi back to 1Gi, keeping all other best practices from #7224:
- No CPU limits (avoids throttling)
- Ephemeral-storage requests (prevents eviction)
- Memory request == limit (prevents OOM from overcommit)

### Resource impact per replica

| Container | CPU req | Mem req/limit | Change |
|---|---|---|---|
| `odh-dashboard` | 500m | 1Gi/1Gi | 2Gi → 1Gi |
| `kube-rbac-proxy` | 500m | 1Gi/1Gi | 2Gi → 1Gi |
| 7× sidecar BFFs | 300m | 512Mi/512Mi | no change |
| **Total** | **3100m** | **5.5Gi** | was 7.5Gi |

With 2 replicas: **6200m CPU / 11Gi memory** (down from 15Gi).

## How Has This Been Tested?

### Manifest validation
- `kustomize build manifests/odh` — builds successfully, verified all containers have correct resource blocks

### Live cluster validation (ROSA cluster `ui-monarch-rosa`)

1. Stopped dashboard operator: `oc scale deployment dashboard-operator -n opendatahub --replicas=0`
2. Patched deployment with reduced memory values via `oc patch`
3. Rollout completed successfully — pod running 9/9 containers with 0 restarts
4. Verified actual memory usage via `oc adm top pod --containers`:
   - `odh-dashboard`: 101Mi (1Gi gives ~10x headroom)
   - `kube-rbac-proxy`: 20Mi
   - Sidecars: 13-26Mi each
5. **Performance test — 20 sequential requests** to `/api/health`: 20/20 succeeded, avg 2.17s response time
6. **Concurrent load test — 20 simultaneous requests**: all returned HTTP 200, max response time 2.59s
7. Dashboard UI page loads correctly (198KB, HTTP 200)
8. Restored operator: `oc scale deployment dashboard-operator -n opendatahub --replicas=1`

## Test Impact

Manifest-only change — no application code or tests affected. Validated via `kustomize build` and live cluster testing.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted memory resource allocation for core application containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->