### PR TITLE
fix: remove static extensions export from agent-ops package

### DIFF
--- a/packages/agent-ops/package.json
+++ b/packages/agent-ops/package.json
@@ -3,9 +3,6 @@
   "name": "@odh-dashboard/agent-ops",
   "description": "Agent Ops plugin.",
   "version": "0.0.0",
-  "exports": {
-    "./extensions": "./frontend/src/odh/extensions.ts"
-  },
   "module-federation": {
     "name": "agentOps",
     "remoteEntry": "/remoteEntry.js",


### PR DESCRIPTION
## Description

Agent-ops had `"./extensions"` in its root `package.json` exports field, which caused `discoverPluginPackages.js` to treat it as a **statically-bundled plugin** and import it directly into the host webpack build via `plugin-extensions.ts`.

Since agent-ops is a **Module Federation remote** (like gen-ai, maas, automl, etc.), its extensions should be loaded at runtime via MF — not statically bundled. Other MF remotes don't export `"./extensions"` at the workspace package level; they rely solely on the MF runtime loading flow.

The static bundling caused webpack to trace into agent-ops's source code and resolve `@patternfly/react-core` from the package's local `node_modules/` (created by the `install:module` script). The host's CSS loader rules only cover `../node_modules/@patternfly` (the root), so CSS files from the package-local path caused `Module parse failed` errors:

```
ERROR in ../packages/agent-ops/frontend/node_modules/@patternfly/react-styles/css/layouts/Stack/stack.css
Module parse failed: Unexpected token (1:0)
```

**Fix:** Remove the `"./extensions"` export from agent-ops's `package.json`, aligning it with how all other MF remote packages are configured.

## How Has This Been Tested?

- Reproduced the exact error by running `npm run install:modules` then `npm run build`
- Verified the fix resolves the build — `npm run build` completes with 0 errors after removing the export
- Confirmed other MF remotes (gen-ai, maas, automl, etc.) do NOT have `"./extensions"` in their workspace `package.json`

## Test Impact

No test changes needed — this is a package configuration fix.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`