### PR TITLE
pin GitHub Actions to commit SHAs for supply-chain security [RHOAIENG-64670]

### DIFF
--- a/.github/actions/module-caches/action.yml
+++ b/.github/actions/module-caches/action.yml
@@ -20,7 +20,7 @@ runs:
       run: echo "CYPRESS_CACHE_FOLDER=${{ github.workspace }}/.cache/Cypress" >> "$GITHUB_ENV"
     - name: Root node_modules cache
       id: root-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           node_modules
@@ -44,7 +44,7 @@ runs:
     - name: automl node_modules cache
       id: automl-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/automl/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-automl-${{ hashFiles('packages/automl/frontend/package-lock.json') }}
@@ -57,7 +57,7 @@ runs:
     - name: autorag node_modules cache
       id: autorag-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/autorag/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-autorag-${{ hashFiles('packages/autorag/frontend/package-lock.json') }}
@@ -70,7 +70,7 @@ runs:
     - name: eval-hub node_modules cache
       id: eval-hub-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/eval-hub/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}
@@ -83,7 +83,7 @@ runs:
     - name: gen-ai node_modules cache
       id: gen-ai-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/gen-ai/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}
@@ -96,7 +96,7 @@ runs:
     - name: maas node_modules cache
       id: maas-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/maas/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-maas-${{ hashFiles('packages/maas/frontend/package-lock.json') }}
@@ -109,7 +109,7 @@ runs:
     - name: mlflow node_modules cache
       id: mlflow-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/mlflow/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-mlflow-${{ hashFiles('packages/mlflow/frontend/package-lock.json') }}
@@ -122,7 +122,7 @@ runs:
     - name: model-registry node_modules cache
       id: model-registry-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/model-registry/upstream/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}
@@ -135,7 +135,7 @@ runs:
     - name: notebooks node_modules cache
       id: notebooks-cache
       if: inputs.include-modules == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: packages/notebooks/upstream/workspaces/frontend/node_modules
         key: ${{ runner.os }}-${{ inputs.node-version }}-modules-notebooks-${{ hashFiles('packages/notebooks/upstream/workspaces/frontend/package-lock.json') }}

--- a/.github/workflows/automl-bff-tests.yml
+++ b/.github/workflows/automl-bff-tests.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.24.6"
 

--- a/.github/workflows/autorag-bff-tests.yml
+++ b/.github/workflows/autorag-bff-tests.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.24.6"
 

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Generate GitHub App token (managed)
         if: matrix.mode == 'managed'
         id: app-token-managed
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
@@ -184,7 +184,7 @@ jobs:
       - name: Generate GitHub App token (check-only)
         if: matrix.mode == 'check-only'
         id: app-token-readonly
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.CLAUDE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
@@ -214,7 +214,7 @@ jobs:
           echo "id=$CHECK_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.HEAD_REPO }}
           ref: ${{ env.HEAD_SHA }}
@@ -222,12 +222,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
 
       - name: Set up Python and MLflow
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install MLflow
@@ -270,7 +270,7 @@ jobs:
       # ── Check (read-only) ──
       - name: Preflight check
         if: matrix.mode == 'check-only'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
@@ -288,7 +288,7 @@ jobs:
       # ── Fix (iterative) ──
       - name: Preflight fix
         if: matrix.mode == 'managed'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -246,13 +246,13 @@ jobs:
       bff_packages: ${{ steps.detect.outputs.bff_packages }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -869,7 +869,7 @@ jobs:
           echo "✅ Cleanup complete (non-critical, continued on any errors)"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
@@ -880,12 +880,12 @@ jobs:
           include-modules: 'true'
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore OpenShift CLI tarball cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: oc-cache
         with:
           path: ${{ runner.temp }}/oc.tar.gz
@@ -1116,7 +1116,7 @@ jobs:
 
       - name: Setup Go for BFF builds
         if: needs.get-test-tags.outputs.bff_packages != '[]'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
           cache: false
@@ -1287,7 +1287,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-results-${{ matrix.tag }}
           path: |

--- a/.github/workflows/eval-hub-bff-tests.yml
+++ b/.github/workflows/eval-hub-bff-tests.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.24.3"
 

--- a/.github/workflows/eval-hub-frontend-tests.yml
+++ b/.github/workflows/eval-hub-frontend-tests.yml
@@ -27,10 +27,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: eval-hub node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/eval-hub/frontend/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-eval-hub-${{ hashFiles('packages/eval-hub/frontend/package-lock.json') }}

--- a/.github/workflows/gen-ai-bff-build.yml
+++ b/.github/workflows/gen-ai-bff-build.yml
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: packages/gen-ai/bff/go.mod
 
@@ -31,7 +31,7 @@ jobs:
         run: make clean
 
       - name: Run lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12.2
           working-directory: packages/gen-ai/bff

--- a/.github/workflows/gen-ai-frontend-build.yml
+++ b/.github/workflows/gen-ai-frontend-build.yml
@@ -25,15 +25,15 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'packages/gen-ai/bff/go.mod'
           cache-dependency-path: 'packages/gen-ai/bff/go.sum'
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: gen-ai node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/gen-ai/frontend/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-gen-ai-${{ hashFiles('packages/gen-ai/frontend/package-lock.json') }}

--- a/.github/workflows/maas-bff-tests.yml
+++ b/.github/workflows/maas-bff-tests.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25.9"
 

--- a/.github/workflows/mlflow-bff-tests.yml
+++ b/.github/workflows/mlflow-bff-tests.yml
@@ -24,10 +24,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.0'
 

--- a/.github/workflows/model-registry-bff-tests.yml
+++ b/.github/workflows/model-registry-bff-tests.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25.0'
 

--- a/.github/workflows/model-registry-frontend-tests.yml
+++ b/.github/workflows/model-registry-frontend-tests.yml
@@ -27,10 +27,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: model-registry node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/model-registry/upstream/frontend/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-model-registry-${{ hashFiles('packages/model-registry/upstream/frontend/package-lock.json') }}

--- a/.github/workflows/modular-arch-quality-gates.yml
+++ b/.github/workflows/modular-arch-quality-gates.yml
@@ -31,7 +31,7 @@ jobs:
       changed-modules: ${{ steps.check-changes.outputs.changed-modules }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -127,7 +127,7 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Generate test matrix
         id: generate-matrix
@@ -166,10 +166,10 @@ jobs:
         module: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -405,7 +405,7 @@ jobs:
 
       - name: Upload per-module assessment
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: app-gate-${{ matrix.module }}
           path: ${{ github.workspace }}/app-gate/*.md
@@ -418,7 +418,7 @@ jobs:
     if: always() && needs.detect-changes.outputs.has-changes == 'true'
     steps:
       - name: Download per-module assessments
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: app-gate-*
           merge-multiple: true
@@ -471,7 +471,7 @@ jobs:
           # yamllint enable rule:line-length
 
       - name: Upload summary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-gates-summary
           path: quality-gates-summary.md

--- a/.github/workflows/pr-image-expiry.yml
+++ b/.github/workflows/pr-image-expiry.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install crane
         shell: bash

--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: odh-release
           fetch-depth: 0

--- a/.github/workflows/release-odh-dashboard.yml
+++ b/.github/workflows/release-odh-dashboard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
       - name: Check authorized user
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
       - name: Create ${{ github.event.inputs.RELEASE_VERSION }}-odh-release branch
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
       - name: Retrieve latest SHA from ${{ github.event.inputs.RELEASE_VERSION }}-odh-release branch
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
-      - uses: fregante/setup-git-user@v2
+      - uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
       - name: Pull latest release tag ${{ github.event.inputs.RELEASE_VERSION }}-odh from Quay
         shell: bash
         run: |
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: '0'
       - name: Create Tag and Release Notes

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
         with:
           # for now, we will only label PRs as stale, not issues
           days-before-issue-stale: -1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
   Setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate all package-lock.json files
         run: ./scripts/check-package-lock.sh --all
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -38,9 +38,9 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           include-modules: 'true'
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             **/.turbo
@@ -63,9 +63,9 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -74,7 +74,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           include-modules: 'true'
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             **/.turbo
@@ -88,9 +88,9 @@ jobs:
     needs: [Setup, Lint, Type-Check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -98,7 +98,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             **/.turbo
@@ -109,7 +109,7 @@ jobs:
         run: |
           npm run test-unit-coverage
       - name: Upload unit test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unit-coverage
           path: ./jest-coverage
@@ -121,9 +121,9 @@ jobs:
     outputs:
       test-groups: ${{ steps.set-groups.outputs.test-groups }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -190,13 +190,13 @@ jobs:
     needs: [Setup, Lint, Type-Check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
           cache-dependency-path: |
@@ -229,7 +229,7 @@ jobs:
           fi
         id: upload-results
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: steps.upload-results.outputs.results-dir != ''
         with:
           name: contract-test-results
@@ -241,13 +241,13 @@ jobs:
     outputs:
       cypress-cache-key: ${{ steps.key.outputs.cypress-cache-key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate cypress cache key
         id: key
         run: |
           echo "cypress-cache-key=${{ runner.os }}-${{ env.NODE_VERSION }}-cypress-build-${{ github.sha }}" >> $GITHUB_OUTPUT
       - name: Cypress build cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cypress-build-cache
         with:
           lookup-only: true
@@ -262,7 +262,7 @@ jobs:
           include-modules: 'true'
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         if: steps.cypress-build-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Build for cypress
@@ -277,9 +277,9 @@ jobs:
       matrix:
         test-group: ${{ fromJson(needs.Get-Test-Groups.outputs.test-groups) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Module caches
@@ -289,7 +289,7 @@ jobs:
           include-modules: 'true'
       - name: Restore Cypress build cache
         id: cypress-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             **/public-cypress
@@ -307,13 +307,13 @@ jobs:
         if: ${{ always() }}
         run: echo "TEST_GROUP_NAME=$(echo '${{ matrix.test-group.name }}' | tr '/-' '_')" >> $GITHUB_ENV
       - name: Upload Cypress Mock results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}
         with:
           name: cypress-results-${{ env.TEST_GROUP_NAME }}
           path: ./packages/cypress/results/mocked
       - name: Upload Cypress coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-coverage-${{ env.TEST_GROUP_NAME }}
           path: ./packages/cypress/coverage
@@ -322,13 +322,13 @@ jobs:
     needs: [Unit-Tests, Cypress-Mock-Tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.3.0
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: all-artifacts
       - name: Install dependencies
@@ -355,7 +355,7 @@ jobs:
           npx nyc report --reporter=html --reporter=text-summary --temp-directory ./coverage -t ./coverage --report-dir ./coverage/report
           cp ./coverage/unit-coverage-final.json ./coverage/combined-coverage-final.json || true
       - name: Upload combined results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: combined-coverage-results
           path: ./coverage/combined-coverage-final.json
@@ -364,7 +364,7 @@ jobs:
           rm -rf ./coverage/unit-coverage-final.json
           find ./coverage -name "*-coverage-final.json" -type f -delete
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/validate-kustomize.yml
+++ b/.github/workflows/validate-kustomize.yml
@@ -30,14 +30,14 @@ jobs:
             path: manifests/odh
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             manifests
 
       - name: Cache kustomize
         id: cache-kustomize
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/kustomize/${{ env.KUSTOMIZE_VERSION }}
           key: kustomize-${{ runner.os }}-${{ env.KUSTOMIZE_VERSION }}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64670

## Description

Pins all external GitHub Action references in `.github/` workflow and composite action files to their full 40-character commit SHAs instead of mutable version tags. This hardens CI against supply-chain attacks where a tag could be force-pushed to point at malicious code.

Original version tags are preserved as trailing `# vX` comments so reviewers and maintainers can still see which version is in use at a glance.

20 files updated; no version upgrades introduced. Actions that were already SHA-pinned (`dependency-validation.yml`, `dependabot-auto-merge.yml`, `agentready-weekly.yml`) and the already-pinned `astral-sh/setup-uv` in `test.yml` were left unchanged. Local composite action references (`./.github/actions/...`) are unaffected.

## How Has This Been Tested?

SHA values were resolved via `git ls-remote` against each action's upstream repository at its current tag. A post-change grep confirmed zero remaining unpinned external action references across all `.github/` files.

## Test Impact

No new tests are applicable — this change only affects GitHub Actions reference format (tag to SHA) with no behavioral or code-level changes. CI workflows should resolve identically since the SHAs correspond exactly to the previously referenced tags.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit references for improved build reliability and reproducibility across multiple CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->