### PR TITLE
fix(plugin-core): fix Turbo cache invalidation for extensions validation [RHOAIENG-64669]

### DIFF
--- a/frontend/src/plugins/extensions/__tests__/extensions.spec.ts
+++ b/frontend/src/plugins/extensions/__tests__/extensions.spec.ts
@@ -1,9 +1,0 @@
-import { expectExtensionsToBeValid } from '@odh-dashboard/plugin-core/testing';
-import extensions from '../index';
-
-describe('frontend extensions', () => {
-  it('should be valid', () => {
-    expect(extensions.length).toBeGreaterThan(0);
-    expectExtensionsToBeValid(extensions);
-  });
-});

--- a/frontend/src/plugins/extensions/__tests__/extensions.spec.ts
+++ b/frontend/src/plugins/extensions/__tests__/extensions.spec.ts
@@ -1,0 +1,9 @@
+import { expectExtensionsToBeValid } from '@odh-dashboard/plugin-core/testing';
+import extensions from '../index';
+
+describe('frontend extensions', () => {
+  it('should be valid', () => {
+    expect(extensions.length).toBeGreaterThan(0);
+    expectExtensionsToBeValid(extensions);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37979,8 +37979,16 @@
       "devDependencies": {
         "@odh-dashboard/eslint-config": "*",
         "@odh-dashboard/jest-config": "*",
-        "@odh-dashboard/tsconfig": "*"
+        "@odh-dashboard/tsconfig": "*",
+        "@types/node": "^17.0.29"
       }
+    },
+    "packages/plugin-core/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/plugin-template": {
       "name": "@odh-dashboard/template",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37980,13 +37980,23 @@
         "@odh-dashboard/eslint-config": "*",
         "@odh-dashboard/jest-config": "*",
         "@odh-dashboard/tsconfig": "*",
-        "@types/node": "^17.0.29"
+        "@types/node": "^22.0.0"
       }
     },
     "packages/plugin-core/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/plugin-core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -130,7 +130,7 @@ module.exports = {
         '**/extension-points/**/*.ts',
         '**/extension-points.ts',
       ],
-      excludedFiles: ['**/extensions/index.ts', '**/extensions-points/index.ts'],
+      excludedFiles: ['**/extensions/index.ts', '**/extensions-points/index.ts', '**/__tests__/**'],
       rules: {
         '@typescript-eslint/consistent-type-imports': 'error',
         'no-restricted-syntax': [

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -22,6 +22,6 @@
     "@odh-dashboard/eslint-config": "*",
     "@odh-dashboard/jest-config": "*",
     "@odh-dashboard/tsconfig": "*",
-    "@types/node": "^17.0.29"
+    "@types/node": "^22.0.0"
   }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@odh-dashboard/eslint-config": "*",
     "@odh-dashboard/jest-config": "*",
-    "@odh-dashboard/tsconfig": "*"
+    "@odh-dashboard/tsconfig": "*",
+    "@types/node": "^17.0.29"
   }
 }

--- a/packages/plugin-core/src/testing/__tests__/extensions.spec.ts
+++ b/packages/plugin-core/src/testing/__tests__/extensions.spec.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
-import { expectExtensionsToBeValid } from '@odh-dashboard/plugin-core/testing';
 import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import { expectExtensionsToBeValid } from '../utils';
 
 describe('workspace extensions', () => {
   it('should be valid', () => {

--- a/packages/plugin-core/turbo.json
+++ b/packages/plugin-core/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test-unit": {
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/**/extensions.ts", "$TURBO_ROOT$/frontend/src/plugins/extensions/**"]
+    }
+  }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64669

## Description

Turbo's caching determines cache validity based on input files within a package's workspace boundary. When a test dynamically requires files from other packages at runtime (cross-package dependency), changes to those external files do not invalidate the test's cache. CI then serves a stale "pass" result even when the external files contain regressions.

**Concrete example:** `frontend/src/plugins/__tests__/extensions.spec.ts` validates all workspace extension files by dynamically requiring every package that exports `./extensions`. When an extension file in another package is modified with invalid content (e.g., PR #7598 — `packages/observability/extensions.ts`), Turbo served the cached test result because the modified file was outside the `frontend/src` workspace input set.

**Fix:**

1. **Moved** the workspace extensions validation test from `frontend/src/plugins/__tests__/` to `packages/plugin-core/src/testing/__tests__/` — its natural home since `plugin-core` owns the `expectExtensionsToBeValid` utility.
2. **Created** `packages/plugin-core/turbo.json` with explicit `inputs` that glob all extension files across the repo (`$TURBO_ROOT$/packages/**/extensions.ts` and `$TURBO_ROOT$/frontend/src/plugins/extensions/**`), ensuring any change to these files invalidates the `plugin-core` test-unit cache.
3. **Excluded `__tests__/`** from the extensions `import type` lint rule in `packages/eslint-config/typescript.js` — test files need runtime imports for validation.
4. **Bumped `@types/node`** to `^22.0.0` in `plugin-core` to align with the workspace `engines.node` constraint.

## How Has This Been Tested?

- Ran `turbo run type-check --filter=@odh-dashboard/plugin-core` — passes
- Ran `turbo run lint --filter=@odh-dashboard/plugin-core` — passes
- Ran `turbo run test-unit --filter=@odh-dashboard/plugin-core` — 4 suites, 8 tests pass (includes the moved extensions test)
- Ran `frontend/src` jest directly — 307 suites, 2949 tests pass (no regressions from removing the old test)

## Test Impact

This PR improves test infrastructure — the test itself is the deliverable:
- `packages/plugin-core/src/testing/__tests__/extensions.spec.ts` — cross-workspace validation of all extension files (moved from frontend, with proper Turbo cache invalidation)

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`