### PR TITLE
Add subscription filtering and linking to API Keys page

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -91,6 +91,18 @@ class APIKeysPage {
     return cy.findByRole('menuitem', { name: new RegExp(status, 'i') });
   }
 
+  findSubscriptionFilterToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('api-key-subscription-filter-toggle');
+  }
+
+  findSubscriptionFilterOption(name: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId(`subscription-filter-option-${name}`);
+  }
+
+  findAllSubscriptionsOption(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('subscription-filter-option-all');
+  }
+
   findStatusFilterOptionCheckbox(status: string): Cypress.Chainable<JQuery<HTMLElement>> {
     return this.findStatusFilterOption(status).findByRole('checkbox');
   }
@@ -180,8 +192,8 @@ class APIKeyTableRow extends TableRow {
     return this.find().find('[data-label="Subscription"]');
   }
 
-  findSubscriptionPopoverButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return this.findSubscription().findByTestId('subscription-popover-button');
+  findSubscriptionDetailLink(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findSubscription().findByTestId('subscription-detail-link');
   }
 
   findCreationDate(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -100,10 +100,7 @@ describe('API Keys Page', () => {
     apiKeysPage.findTitle().should('contain.text', 'API keys');
     apiKeysPage
       .findDescription()
-      .should(
-        'contain.text',
-        'Manage API keys that can be used to authenticate with model endpoints.',
-      );
+      .should('contain.text', 'Manage your API keys and view your subscription access.');
 
     apiKeysPage.findTable().should('exist');
     apiKeysPage.findRows().should('have.length', 3);

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -52,6 +52,7 @@ describe('API Keys Page', () => {
       'GET /api/config',
       mockDashboardConfig({
         modelAsService: true,
+        mySubscriptions: true,
       }),
     );
 
@@ -88,6 +89,8 @@ describe('API Keys Page', () => {
   });
 
   it('should not show the subscriptions tab when mySubscriptions flag is disabled', () => {
+    // When mySubscriptions is disabled, the /maas/tokens route is used (no tabbed layout).
+    apiKeysPage.visit();
     apiKeysPage.findTitle().should('contain.text', 'API keys');
     apiKeysPage.findSubscriptionsTab().should('not.exist');
     apiKeysPage.findApiKeysTab().should('not.exist');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -241,7 +241,7 @@ describe('API Keys Page', () => {
     prodRow
       .findSubscriptionDetailLink()
       .should('have.attr', 'href')
-      .and('include', '/maas/subscriptions/view/premium-team-sub');
+      .and('include', '/maas/keys-and-subs/subscriptions/view/premium-team-sub');
   });
 
   it('should show plain text (no link) for a subscription that no longer exists', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -14,7 +14,6 @@ import {
   revokeAPIKeyModal,
   copyApiKeyModal,
   createApiKeyModal,
-  subscriptionPopover,
   mySubscriptionsPage,
   subscriptionsTab,
 } from '../../../pages/modelsAsAService';
@@ -22,6 +21,7 @@ import {
   mockAPIKeys,
   mockCreateAPIKeyResponse,
   mockSubscriptionListItems,
+  mockSubscriptions,
 } from '../../../utils/maasUtils';
 
 const mockSubscriptionDetails: Record<string, SubscriptionDetail> = {
@@ -80,6 +80,9 @@ describe('API Keys Page', () => {
     cy.interceptOdh('GET /maas/api/v1/subscriptions', {
       data: mockSubscriptionListItems(),
     }).as('getSubscriptions');
+    cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
+      data: mockSubscriptions(),
+    }).as('getAllSubscriptions');
     apiKeysPage.visit();
     cy.wait('@initialSearch');
   });
@@ -233,13 +236,58 @@ describe('API Keys Page', () => {
     devRow.findSubscription().should('contain.text', 'Basic Team');
   });
 
-  it('should show subscription popover with model names on click', () => {
+  it('should link subscription name to the subscription details page when subscription exists', () => {
     const prodRow = apiKeysPage.getRow('production-backend');
-    prodRow.findSubscriptionPopoverButton().click();
+    prodRow
+      .findSubscriptionDetailLink()
+      .should('have.attr', 'href')
+      .and('include', '/maas/subscriptions/view/premium-team-sub');
+  });
 
-    subscriptionPopover.findModelCount().should('contain.text', '2 models');
-    subscriptionPopover.findModelName('granite-3-8b-instruct').should('be.visible');
-    subscriptionPopover.findModelName('flan-t5-small').should('be.visible');
+  it('should show plain text (no link) for a subscription that no longer exists', () => {
+    const keyWithDeletedSub = mockAPIKeys().filter((k) => k.status === 'active');
+    cy.interceptOdh(
+      'POST /maas/api/v1/api-keys/search',
+      // Return keys with a subscription name but no subscriptionDetails entry for it
+      mockSearchResponse(keyWithDeletedSub, {}),
+    ).as('deletedSubSearch');
+    apiKeysPage.visit();
+    cy.wait('@deletedSubSearch');
+
+    const prodRow = apiKeysPage.getRow('production-backend');
+    prodRow.findSubscription().should('contain.text', 'premium-team-sub');
+    prodRow.findSubscriptionDetailLink().should('not.exist');
+  });
+
+  it('should filter api keys by subscription and clear the filter', () => {
+    const premiumKeys = mockAPIKeys().filter((k) => k.subscription === 'premium-team-sub');
+    cy.interceptOdh(
+      'POST /maas/api/v1/api-keys/search',
+      mockSearchResponse(premiumKeys, {
+        'premium-team-sub': mockSubscriptionDetails['premium-team-sub'],
+      }),
+    ).as('filterBySubscription');
+
+    apiKeysPage.findSubscriptionFilterToggle().click();
+    apiKeysPage.findSubscriptionFilterOption('premium-team-sub').click();
+
+    cy.wait('@filterBySubscription').then((interception) => {
+      expect(interception.request.body.data.filters.subscription).to.eq('premium-team-sub');
+    });
+    apiKeysPage.findToolbar().should('contain.text', 'Premium Team');
+
+    cy.interceptOdh(
+      'POST /maas/api/v1/api-keys/search',
+      mockSearchResponse(mockAPIKeys().filter((k) => k.status === 'active')),
+    ).as('clearSubscriptionFilter');
+
+    apiKeysPage.findSubscriptionFilterToggle().click();
+    apiKeysPage.findAllSubscriptionsOption().click();
+
+    cy.wait('@clearSubscriptionFilter').then((interception) => {
+      expect(interception.request.body.data.filters?.subscription).to.eq(undefined);
+    });
+    apiKeysPage.findToolbar().should('not.contain.text', 'Premium Team');
   });
 
   it('should filter api keys by username', () => {
@@ -739,6 +787,9 @@ describe('API Keys Page (Admin)', () => {
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(
       'initialSearch',
     );
+    cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
+      data: mockSubscriptions(),
+    }).as('getAllSubscriptions');
     apiKeysPage.visit();
     cy.wait('@initialSearch');
   });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -83,7 +83,7 @@ describe('API Keys Page', () => {
     cy.interceptOdh('GET /maas/api/v1/all-subscriptions', {
       data: mockSubscriptions(),
     }).as('getAllSubscriptions');
-    apiKeysPage.visit();
+    apiKeysPage.visitKeysAndSubs();
     cy.wait('@initialSearch');
   });
 
@@ -241,7 +241,7 @@ describe('API Keys Page', () => {
     prodRow
       .findSubscriptionDetailLink()
       .should('have.attr', 'href')
-      .and('include', '/maas/keys-and-subs/subscriptions/view/premium-team-sub');
+      .and('include', '/maas/keys-and-subs/subscriptions/premium-team-sub');
   });
 
   it('should show plain text (no link) for a subscription that no longer exists', () => {

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -32,6 +32,7 @@ export type UseApiKeysTableStateReturn = {
   onUsernameChange: (value: string) => void;
   onStatusToggle: (status: APIKeyStatus) => void;
   onStatusClear: (status: APIKeyStatus) => void;
+  onSubscriptionChange: (subscription: string) => void;
   onSort: (field: ApiKeySortField, direction: SortDirection) => void;
   onSetPage: (newPage: number) => void;
   onPerPageSelect: (newPerPage: number, newPage: number) => void;
@@ -52,6 +53,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
       filters: {
         ...(filterData.username && { username: filterData.username }),
         ...(filterData.statuses.length > 0 && { status: filterData.statuses }),
+        ...(filterData.subscription && { subscription: filterData.subscription }),
       },
       sort: { by: sortField, order: sortDirection },
       pagination: { limit: perPage, offset: (page - 1) * perPage },
@@ -90,6 +92,12 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
       ...prev,
       statuses: prev.statuses.filter((s) => s !== status),
     }));
+    setPage(1);
+    setIsFetching(true);
+  }, []);
+
+  const onSubscriptionChange = React.useCallback((subscription: string) => {
+    setFilterData((prev) => ({ ...prev, subscription }));
     setPage(1);
     setIsFetching(true);
   }, []);
@@ -135,6 +143,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     onUsernameChange,
     onStatusToggle,
     onStatusClear,
+    onSubscriptionChange,
     onSort,
     onSetPage,
     onPerPageSelect,

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -96,11 +96,17 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     setIsFetching(true);
   }, []);
 
-  const onSubscriptionChange = React.useCallback((subscription: string) => {
-    setFilterData((prev) => ({ ...prev, subscription }));
-    setPage(1);
-    setIsFetching(true);
-  }, []);
+  const onSubscriptionChange = React.useCallback(
+    (subscription: string) => {
+      if (filterData.subscription === subscription) {
+        return;
+      }
+      setFilterData((prev) => ({ ...prev, subscription }));
+      setPage(1);
+      setIsFetching(true);
+    },
+    [filterData.subscription],
+  );
 
   const onSort = React.useCallback((field: ApiKeySortField, direction: SortDirection) => {
     setSortField(field);

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
@@ -5,6 +5,7 @@ import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApiKeysPageLoad } from '~/app/hooks/useApiKeysPageLoad';
+import { useUserSubscriptions } from '~/app/hooks/useUserSubscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
 import ApiKeysTab from './apiKeys/ApiKeysTab';
 import SubscriptionsTab from './mySubscriptions/SubscriptionsTab';
@@ -18,9 +19,21 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
   const navigate = useNavigate();
   const apiKeysPageState = useApiKeysPageLoad();
   const { loadError: apiKeysLoadError } = apiKeysPageState;
+  const [subscriptions, subscriptionsLoaded, subscriptionsLoadError] = useUserSubscriptions();
 
   const activeTab = tab && VALID_TABS.includes(tab) ? tab : API_KEYS_TAB;
-  const showApiKeysLoadError = activeTab === API_KEYS_TAB && !!apiKeysLoadError;
+
+  // API keys tab needs both fetches to resolve before the page is considered loaded.
+  // Subscriptions tab only needs the subscriptions fetch.
+  const apiKeysTabReady =
+    (apiKeysPageState.loaded || !!apiKeysLoadError) &&
+    (subscriptionsLoaded || !!subscriptionsLoadError);
+  const subscriptionsTabReady = subscriptionsLoaded || !!subscriptionsLoadError;
+  const isPageLoaded = activeTab === SUBSCRIPTIONS_TAB ? subscriptionsTabReady : apiKeysTabReady;
+
+  const apiKeysTabError = apiKeysLoadError ?? subscriptionsLoadError;
+  const showApiKeysLoadError = activeTab === API_KEYS_TAB && !!apiKeysTabError;
+  const pageLoadError = activeTab === API_KEYS_TAB ? apiKeysTabError : subscriptionsLoadError;
 
   const onSelectTab = React.useCallback(
     (_event: React.MouseEvent, tabKey: string | number) => {
@@ -35,10 +48,12 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
         <TitleWithIcon title="API keys and subscriptions" objectType={ProjectObjectType.apiKeys} />
       }
       description="Manage your API keys and view your subscription access."
-      loaded={activeTab === SUBSCRIPTIONS_TAB || apiKeysPageState.loaded || !!apiKeysLoadError}
+      loaded={isPageLoaded}
       empty={false}
-      loadError={showApiKeysLoadError ? apiKeysLoadError : undefined}
-      errorMessage="Error loading API keys"
+      loadError={pageLoadError}
+      errorMessage={
+        activeTab === SUBSCRIPTIONS_TAB ? 'Error loading subscriptions' : 'Error loading API keys'
+      }
     >
       <Tabs
         activeKey={activeTab}
@@ -53,7 +68,9 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
           data-testid="api-keys-tab"
         >
           <PageSection isFilled>
-            {!showApiKeysLoadError && <ApiKeysTab pageState={apiKeysPageState} />}
+            {!showApiKeysLoadError && (
+              <ApiKeysTab pageState={apiKeysPageState} subscriptions={subscriptions} />
+            )}
           </PageSection>
         </Tab>
         <Tab
@@ -62,7 +79,7 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
           aria-label="Subscriptions tab"
           data-testid="subscriptions-tab"
         >
-          <SubscriptionsTab />
+          <SubscriptionsTab subscriptions={subscriptions} />
         </Tab>
       </Tabs>
     </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AllApiKeysPage.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/AllApiKeysPage.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { useApiKeysPageLoad } from '~/app/hooks/useApiKeysPageLoad';
 import ApiKeysTab from './ApiKeysTab';
 
+// TODO: Remove once we GA the My Subscriptions feature
+// This is left behind in case we turn off the My Subscriptions feature.
+
 const AllApiKeysPage: React.FC = () => {
   const pageState = useApiKeysPageLoad();
   const { loadError, loaded } = pageState;
@@ -16,7 +19,7 @@ const AllApiKeysPage: React.FC = () => {
       loadError={loadError}
       errorMessage="Error loading API keys"
     >
-      {!loadError && <ApiKeysTab pageState={pageState} />}
+      {!loadError && <ApiKeysTab pageState={pageState} subscriptions={[]} />}
     </ApplicationsPage>
   );
 };

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
@@ -2,6 +2,7 @@ import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import React from 'react';
 import { type UseApiKeysPageLoadReturn } from '~/app/hooks/useApiKeysPageLoad';
 import { APIKey } from '~/app/types/api-key';
+import { useListSubscriptions } from '~/app/hooks/useListSubscriptions';
 import CreateApiKeyModal from './CreateApiKeyModal';
 import EmptyApiKeysPage from './EmptyApiKeysPage';
 import ApiKeysTable from './allKeys/ApiKeysTable';
@@ -35,11 +36,22 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
     onUsernameChange,
     onStatusToggle,
     onStatusClear,
+    onSubscriptionChange,
     onSort,
     onSetPage,
     onPerPageSelect,
     onClearFilters,
   } = pageState;
+
+  const [allSubscriptions, subscriptionsLoaded] = useListSubscriptions();
+  const subscriptionOptions = React.useMemo(
+    () =>
+      allSubscriptions.map((sub) => ({
+        name: sub.name,
+        displayName: sub.displayName ?? sub.name,
+      })),
+    [allSubscriptions],
+  );
 
   const apiKeys = response.data;
   const hasMore = response.has_more;
@@ -109,6 +121,9 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
               onUsernameChange={onUsernameChange}
               onStatusToggle={onStatusToggle}
               onStatusClear={onStatusClear}
+              subscriptions={subscriptionOptions}
+              subscriptionsLoaded={subscriptionsLoaded}
+              onSubscriptionChange={onSubscriptionChange}
               activeApiKeys={activeApiKeys}
               refresh={refreshAll}
               onClearFilters={onClearFilters}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
@@ -2,7 +2,7 @@ import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import React from 'react';
 import { type UseApiKeysPageLoadReturn } from '~/app/hooks/useApiKeysPageLoad';
 import { APIKey } from '~/app/types/api-key';
-import { useListSubscriptions } from '~/app/hooks/useListSubscriptions';
+import { UserSubscription } from '~/app/types/subscriptions';
 import CreateApiKeyModal from './CreateApiKeyModal';
 import EmptyApiKeysPage from './EmptyApiKeysPage';
 import ApiKeysTable from './allKeys/ApiKeysTable';
@@ -11,9 +11,10 @@ import ApiKeysToolbar from './allKeys/ApiKeysToolbar';
 
 type ApiKeysTabProps = {
   pageState: UseApiKeysPageLoadReturn;
+  subscriptions: UserSubscription[];
 };
 
-const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
+const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [revokeApiKey, setRevokeApiKey] = React.useState<APIKey | undefined>(undefined);
 
@@ -43,14 +44,13 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
     onClearFilters,
   } = pageState;
 
-  const [allSubscriptions, subscriptionsLoaded] = useListSubscriptions();
   const subscriptionOptions = React.useMemo(
     () =>
-      allSubscriptions.map((sub) => ({
-        name: sub.name,
-        displayName: sub.displayName ?? sub.name,
+      subscriptions.map((sub) => ({
+        name: sub.subscription_id_header,
+        displayName: sub.display_name ?? sub.subscription_id_header,
       })),
-    [allSubscriptions],
+    [subscriptions],
   );
 
   const apiKeys = response.data;
@@ -122,7 +122,6 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
               onStatusToggle={onStatusToggle}
               onStatusClear={onStatusClear}
               subscriptions={subscriptionOptions}
-              subscriptionsLoaded={subscriptionsLoaded}
               onSubscriptionChange={onSubscriptionChange}
               activeApiKeys={activeApiKeys}
               refresh={refreshAll}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
@@ -15,8 +15,14 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import { APIKey, APIKeyStatus, ApiKeyFilterDataType, STATUS_OPTIONS } from '~/app/types/api-key';
 import ApiKeysActions from '~/app/pages/keys-and-subs/apiKeys/ApiKeysActions';
+import {
+  APIKey,
+  APIKeyStatus,
+  ApiKeyFilterDataType,
+  STATUS_OPTIONS,
+  SubscriptionOption,
+} from '~/app/types/api-key';
 
 type ApiKeysToolbarProps = {
   setIsModalOpen: (isOpen: boolean) => void;
@@ -26,6 +32,9 @@ type ApiKeysToolbarProps = {
   onUsernameChange: (value: string) => void;
   onStatusToggle: (status: APIKeyStatus) => void;
   onStatusClear: (status: APIKeyStatus) => void;
+  subscriptions: SubscriptionOption[];
+  subscriptionsLoaded: boolean;
+  onSubscriptionChange: (subscription: string) => void;
   activeApiKeys: APIKey[];
   isMaasAdmin: boolean;
   refresh: () => void;
@@ -40,12 +49,24 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
   onUsernameChange,
   onStatusToggle,
   onStatusClear,
+  subscriptions,
+  subscriptionsLoaded,
+  onSubscriptionChange,
   activeApiKeys,
   isMaasAdmin,
   refresh,
   onClearFilters,
 }) => {
   const [isStatusSelectOpen, setIsStatusSelectOpen] = React.useState(false);
+  const [isSubscriptionSelectOpen, setIsSubscriptionSelectOpen] = React.useState(false);
+
+  const selectedSubscriptionLabel = React.useMemo(() => {
+    if (!filterData.subscription) {
+      return undefined;
+    }
+    const match = subscriptions.find((s) => s.name === filterData.subscription);
+    return match?.displayName ?? filterData.subscription;
+  }, [filterData.subscription, subscriptions]);
 
   return (
     <Toolbar
@@ -107,6 +128,54 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
                       isSelected={filterData.statuses.includes(status)}
                     >
                       {status.charAt(0).toUpperCase() + status.slice(1)}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </ToolbarFilter>
+            <ToolbarFilter
+              labels={selectedSubscriptionLabel ? [selectedSubscriptionLabel] : []}
+              deleteLabel={() => onSubscriptionChange('')}
+              categoryName="Subscription"
+            >
+              <Select
+                aria-label="Filter by subscription"
+                isOpen={isSubscriptionSelectOpen}
+                selected={filterData.subscription || undefined}
+                onSelect={(_event, value) => {
+                  onSubscriptionChange(typeof value === 'string' ? value : '');
+                  setIsSubscriptionSelectOpen(false);
+                }}
+                onOpenChange={setIsSubscriptionSelectOpen}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    data-testid="api-key-subscription-filter-toggle"
+                    onClick={() => setIsSubscriptionSelectOpen((prev) => !prev)}
+                    isExpanded={isSubscriptionSelectOpen}
+                    isDisabled={!subscriptionsLoaded}
+                  >
+                    Subscription
+                  </MenuToggle>
+                )}
+                popperProps={{ appendTo: 'inline' }}
+              >
+                <SelectList>
+                  <SelectOption
+                    value=""
+                    isSelected={!filterData.subscription}
+                    data-testid="subscription-filter-option-all"
+                  >
+                    All subscriptions
+                  </SelectOption>
+                  {subscriptions.map((sub) => (
+                    <SelectOption
+                      key={sub.name}
+                      value={sub.name}
+                      isSelected={filterData.subscription === sub.name}
+                      data-testid={`subscription-filter-option-${sub.name}`}
+                    >
+                      {sub.displayName}
                     </SelectOption>
                   ))}
                 </SelectList>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
@@ -33,7 +33,6 @@ type ApiKeysToolbarProps = {
   onStatusToggle: (status: APIKeyStatus) => void;
   onStatusClear: (status: APIKeyStatus) => void;
   subscriptions: SubscriptionOption[];
-  subscriptionsLoaded: boolean;
   onSubscriptionChange: (subscription: string) => void;
   activeApiKeys: APIKey[];
   isMaasAdmin: boolean;
@@ -50,7 +49,6 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
   onStatusToggle,
   onStatusClear,
   subscriptions,
-  subscriptionsLoaded,
   onSubscriptionChange,
   activeApiKeys,
   isMaasAdmin,
@@ -133,54 +131,55 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
                 </SelectList>
               </Select>
             </ToolbarFilter>
-            <ToolbarFilter
-              labels={selectedSubscriptionLabel ? [selectedSubscriptionLabel] : []}
-              deleteLabel={() => onSubscriptionChange('')}
-              categoryName="Subscription"
-            >
-              <Select
-                aria-label="Filter by subscription"
-                isOpen={isSubscriptionSelectOpen}
-                selected={filterData.subscription || undefined}
-                onSelect={(_event, value) => {
-                  onSubscriptionChange(typeof value === 'string' ? value : '');
-                  setIsSubscriptionSelectOpen(false);
-                }}
-                onOpenChange={setIsSubscriptionSelectOpen}
-                toggle={(toggleRef) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    data-testid="api-key-subscription-filter-toggle"
-                    onClick={() => setIsSubscriptionSelectOpen((prev) => !prev)}
-                    isExpanded={isSubscriptionSelectOpen}
-                    isDisabled={!subscriptionsLoaded}
-                  >
-                    Subscription
-                  </MenuToggle>
-                )}
-                popperProps={{ appendTo: 'inline' }}
+            {subscriptions.length > 0 && (
+              <ToolbarFilter
+                labels={selectedSubscriptionLabel ? [selectedSubscriptionLabel] : []}
+                deleteLabel={() => onSubscriptionChange('')}
+                categoryName="Subscription"
               >
-                <SelectList>
-                  <SelectOption
-                    value=""
-                    isSelected={!filterData.subscription}
-                    data-testid="subscription-filter-option-all"
-                  >
-                    All subscriptions
-                  </SelectOption>
-                  {subscriptions.map((sub) => (
-                    <SelectOption
-                      key={sub.name}
-                      value={sub.name}
-                      isSelected={filterData.subscription === sub.name}
-                      data-testid={`subscription-filter-option-${sub.name}`}
+                <Select
+                  aria-label="Filter by subscription"
+                  isOpen={isSubscriptionSelectOpen}
+                  selected={filterData.subscription || undefined}
+                  onSelect={(_event, value) => {
+                    onSubscriptionChange(typeof value === 'string' ? value : '');
+                    setIsSubscriptionSelectOpen(false);
+                  }}
+                  onOpenChange={setIsSubscriptionSelectOpen}
+                  toggle={(toggleRef) => (
+                    <MenuToggle
+                      ref={toggleRef}
+                      data-testid="api-key-subscription-filter-toggle"
+                      onClick={() => setIsSubscriptionSelectOpen((prev) => !prev)}
+                      isExpanded={isSubscriptionSelectOpen}
                     >
-                      {sub.displayName}
+                      Subscription
+                    </MenuToggle>
+                  )}
+                  popperProps={{ appendTo: 'inline' }}
+                >
+                  <SelectList>
+                    <SelectOption
+                      value=""
+                      isSelected={!filterData.subscription}
+                      data-testid="subscription-filter-option-all"
+                    >
+                      All subscriptions
                     </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </ToolbarFilter>
+                    {subscriptions.map((sub) => (
+                      <SelectOption
+                        key={sub.name}
+                        value={sub.name}
+                        isSelected={filterData.subscription === sub.name}
+                        data-testid={`subscription-filter-option-${sub.name}`}
+                      >
+                        {sub.displayName}
+                      </SelectOption>
+                    ))}
+                  </SelectList>
+                </Select>
+              </ToolbarFilter>
+            )}
             {isMaasAdmin && (
               <ToolbarFilter
                 labels={filterData.username ? [filterData.username] : []}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/SubscriptionCell.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/SubscriptionCell.tsx
@@ -27,7 +27,7 @@ const SubscriptionCell: React.FC<SubscriptionCellProps> = ({
 
   return (
     <Link
-      to={`${URL_PREFIX}/keys-and-subs/subscriptions/view/${encodeURIComponent(subscriptionName)}`}
+      to={`${URL_PREFIX}/keys-and-subs/subscriptions/${encodeURIComponent(subscriptionName)}`}
       data-testid="subscription-detail-link"
     >
       {displayLabel}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/SubscriptionCell.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/SubscriptionCell.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Button, Content, ContentVariants, List, ListItem, Popover } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { URL_PREFIX } from '~/app/utilities/const';
 import { SubscriptionDetail } from '~/app/types/api-key';
 
 type SubscriptionCellProps = {
@@ -17,34 +18,20 @@ const SubscriptionCell: React.FC<SubscriptionCellProps> = ({
 
   const displayLabel = subscriptionDetail?.displayName || subscriptionName;
 
-  if (!subscriptionDetail || subscriptionDetail.models.length === 0) {
+  // Only link to the details page when the subscription still exists (detail is present).
+  // If subscriptionDetail is undefined the subscription may have been deleted, so show
+  // plain text to avoid navigating to a page that no longer exists.
+  if (!subscriptionDetail) {
     return <>{displayLabel}</>;
   }
 
-  const modelCount = subscriptionDetail.models.length;
-
   return (
-    <Popover
-      headerContent={displayLabel}
-      bodyContent={
-        <div data-testid="subscription-popover-body">
-          <Content component={ContentVariants.small}>
-            {modelCount} {modelCount === 1 ? 'model' : 'models'}
-          </Content>
-          <List isPlain>
-            {subscriptionDetail.models.map((model) => (
-              <ListItem key={model}>
-                <Content component={ContentVariants.small}>{model}</Content>
-              </ListItem>
-            ))}
-          </List>
-        </div>
-      }
+    <Link
+      to={`${URL_PREFIX}/keys-and-subs/subscriptions/view/${encodeURIComponent(subscriptionName)}`}
+      data-testid="subscription-detail-link"
     >
-      <Button variant="link" isInline data-testid="subscription-popover-button">
-        {displayLabel}
-      </Button>
-    </Popover>
+      {displayLabel}
+    </Link>
   );
 };
 

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
@@ -1,6 +1,5 @@
-import { Bullseye, Content, ContentVariants, PageSection, Spinner } from '@patternfly/react-core';
+import { Content, ContentVariants, PageSection } from '@patternfly/react-core';
 import React from 'react';
-import { useUserSubscriptions } from '~/app/hooks/useUserSubscriptions';
 import { UserSubscription } from '~/app/types/subscriptions';
 import SubscriptionsToolbar from './SubscriptionsToolbar';
 import SubscriptionsViewTable, { ModelGroupEntry } from './SubscriptionsViewTable';
@@ -38,7 +37,11 @@ export const deriveModelGroups = (subscriptions: UserSubscription[]): ModelGroup
 
 export type SubscriptionSortField = 'subscription' | 'model';
 
-const SubscriptionsTab: React.FC = () => {
+type SubscriptionsTabProps = {
+  subscriptions: UserSubscription[];
+};
+
+const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) => {
   const [subSourceFilters, setSubSourceFilters] = React.useState<string[]>([]);
   const [modelSourceFilters, setModelSourceFilters] = React.useState<string[]>([]);
   const [searchValue, setSearchValue] = React.useState('');
@@ -49,8 +52,6 @@ const SubscriptionsTab: React.FC = () => {
   const [subSortDirection, setSubSortDirection] = React.useState<'asc' | 'desc' | undefined>(
     undefined,
   );
-
-  const [subscriptions, loaded] = useUserSubscriptions();
 
   const modelGroups = React.useMemo(() => deriveModelGroups(subscriptions), [subscriptions]);
 
@@ -115,16 +116,6 @@ const SubscriptionsTab: React.FC = () => {
       return modelSortDirection === 'asc' ? nameA.localeCompare(nameB) : nameB.localeCompare(nameA);
     });
   }, [modelGroups, modelSourceFilters, searchValue, modelSortDirection]);
-
-  if (!loaded) {
-    return (
-      <PageSection isFilled>
-        <Bullseye>
-          <Spinner />
-        </Bullseye>
-      </PageSection>
-    );
-  }
 
   return (
     <PageSection isFilled>

--- a/packages/maas/frontend/src/app/types/api-key.ts
+++ b/packages/maas/frontend/src/app/types/api-key.ts
@@ -62,19 +62,27 @@ export type CreateAPIKeyRequest = {
   subscription: string;
 };
 
+export type SubscriptionOption = {
+  name: string;
+  displayName: string;
+};
+
 export const STATUS_OPTIONS: APIKeyStatus[] = ['active', 'expired', 'revoked'];
 
 export type ApiKeyFilterDataType = {
   username: string;
   statuses: APIKeyStatus[];
+  subscription: string;
 };
 
 export const initialApiKeyFilterData: ApiKeyFilterDataType = {
   username: '',
   statuses: ['active', 'expired'],
+  subscription: '',
 };
 
 export const emptyApiKeyFilterData: ApiKeyFilterDataType = {
   username: '',
   statuses: [],
+  subscription: '',
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-62830
## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a dropdown for filtering by subscription to the api keys page and also changes the subscription column to link to the subscription details page if the subscription still exists. Currently routes to `/keys-and-subs/subscriptions/view/<sub-name>`. Might need to update that once the details page route has been created
## How Has This Been Tested?
1. Run in mock mode
2. Go to the api keys page
3. See the link to the subscription details (won't actually work yet)
4. Filter by subscription in the dropdown and clear options (also try other filters and sorting)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/user-attachments/assets/2c68caf8-280d-45ce-aacc-255eae2a61a7


## Test Impact
Added cypress mock tests to cover the scenarios
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription filtering to the API keys table—filter API keys by subscription from the toolbar.
* **UI Changes**
  * Subscription names link to subscription detail pages when available; display as plain text when not.
  * Table rows no longer show a subscription popover; subscription access is presented directly.
* **Tests**
  * Updated test coverage and mocks to validate subscription listing, links, and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->