### PR TITLE
fix(automl): filter out pending query results to prevent undefined data access

### DIFF
--- a/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
+++ b/packages/automl/frontend/src/app/hooks/useAutomlResults.ts
@@ -277,7 +277,7 @@ export function useAutomlResults(
         );
       }
       return {
-        data: results.filter((r) => !r.isError).map((r) => r.data),
+        data: results.filter((r) => !r.isError && r.data != null).map((r) => r.data!),
         isPending: results.some((r) => r.isPending),
         isError: results.length > 0 && results.every((r) => r.isError),
         failedModels: results
@@ -297,13 +297,12 @@ export function useAutomlResults(
     const results: Record<string, AutomlModel> = Object.create(null);
 
     modelQueries.data.forEach((entry) => {
-      // Skip entries that failed to load or are missing
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- entry can be undefined at runtime from failed queries
-      if (!entry || !entry.name || !entry.model) {
-        if (entry?.name) {
-          // eslint-disable-next-line no-console
-          console.warn(`Skipping model ${entry.name}: failed to load model.json`);
-        }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: queryFn guarantees these but runtime data may diverge
+      if (!entry.name || !entry.model) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Skipping model with incomplete data: ${JSON.stringify({ name: entry.name, hasModel: !!entry.model })}`,
+        );
         return;
       }
 


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-64675

See https://github.com/opendatahub-io/odh-dashboard/actions/runs/26456584266/job/77892292269

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Fixes an unhandled promise rejection (`Cannot read properties of undefined (reading 'data')`) in the AutoML results page that was causing E2E test failures in `testAutomlBinaryClassification.cy.ts`.

**Root cause:** In `useAutomlResults.ts`, the `modelQueries` combine function filtered results with `!r.isError` and then mapped `r.data`, but pending queries (not errored, not yet resolved) passed the filter while having `r.data` as `undefined`. These `undefined` entries propagated downstream and caused runtime errors.

**Fix:**
- Added `r.data != null` to the combine filter so only resolved queries contribute to the data array.
- Retained defensive logging for entries with incomplete data (missing `name` or `model`), with an eslint-disable comment explaining why the guard is kept despite TypeScript's type guarantees.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- TypeScript type-checking passes (`tsc --noEmit`)
- ESLint passes with no errors or warnings
- The fix addresses the failure observed in [CI run #26456584266](https://github.com/opendatahub-io/odh-dashboard/actions/runs/26456584266)

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

No new tests added. The `useAutomlResults` hook is explicitly documented as not suitable for direct unit testing due to cascading async query dependencies. Coverage is provided through existing E2E tests (`testAutomlBinaryClassification.cy.ts`) which exercise this code path.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ x The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of AutoML results handling by filtering out invalid model data during aggregation
  * Enhanced validation to better detect and handle incomplete models with missing required information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->