### PR TITLE
refactor(nim-serving): move k8s-calling functions from accounts/utils to accounts/api

### DIFF
--- a/packages/nim-serving/src/api/accounts/__tests__/api.spec.ts
+++ b/packages/nim-serving/src/api/accounts/__tests__/api.spec.ts
@@ -1,0 +1,166 @@
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
+import { mock409Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
+import { K8sStatusError } from '@odh-dashboard/internal/api/errorUtils';
+import { SecretKind } from '@odh-dashboard/internal/k8sTypes';
+import {
+  createNIMSecret,
+  createNIMAccount,
+  getNIMAccount,
+  deleteNIMAccount,
+  deleteSecret,
+  fetchExistingSecret,
+  replaceNIMSecret,
+} from '../k8s';
+import { createNIMResources, deleteNIMResources } from '../api';
+import { NIM_SECRET_NAME } from '../constants';
+
+jest.mock('../k8s', () => ({
+  ...jest.requireActual('../k8s'),
+  createNIMSecret: jest.fn(),
+  createNIMAccount: jest.fn(),
+  getNIMAccount: jest.fn(),
+  deleteNIMAccount: jest.fn(),
+  deleteSecret: jest.fn(),
+  fetchExistingSecret: jest.fn(),
+  replaceNIMSecret: jest.fn(),
+}));
+
+const mockCreateNIMSecret = jest.mocked(createNIMSecret);
+const mockCreateNIMAccount = jest.mocked(createNIMAccount);
+const mockGetNIMAccount = jest.mocked(getNIMAccount);
+const mockDeleteNIMAccount = jest.mocked(deleteNIMAccount);
+const mockDeleteSecret = jest.mocked(deleteSecret);
+const mockFetchExistingSecret = jest.mocked(fetchExistingSecret);
+const mockReplaceNIMSecret = jest.mocked(replaceNIMSecret);
+
+describe('createNIMResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should dry-run both creates, then create secret and account', async () => {
+    const createdSecret: SecretKind = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns' },
+      type: 'Opaque',
+    };
+    const createdAccount = mockNimAccount({
+      namespace: 'test-ns',
+      uid: 'account-uid-123',
+      apiKeySecretName: NIM_SECRET_NAME,
+    });
+
+    mockCreateNIMSecret.mockResolvedValue(createdSecret);
+    mockCreateNIMAccount.mockResolvedValue(createdAccount);
+
+    const result = await createNIMResources('test-ns', 'nvapi-key');
+
+    expect(mockCreateNIMSecret).toHaveBeenCalledTimes(2);
+    expect(mockCreateNIMSecret).toHaveBeenNthCalledWith(1, expect.any(Object), true);
+    expect(mockCreateNIMSecret).toHaveBeenNthCalledWith(2, expect.any(Object), undefined);
+
+    expect(mockCreateNIMAccount).toHaveBeenCalledTimes(2);
+    expect(mockCreateNIMAccount).toHaveBeenNthCalledWith(1, expect.any(Object), true);
+    expect(mockCreateNIMAccount).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        spec: { apiKeySecret: { name: NIM_SECRET_NAME } },
+      }),
+      undefined,
+    );
+
+    expect(result).toBe(createdAccount);
+  });
+
+  it('should not create any resources if dry-run fails', async () => {
+    mockCreateNIMSecret.mockRejectedValueOnce(new Error('dry-run validation failed'));
+
+    await expect(createNIMResources('test-ns', 'nvapi-key')).rejects.toThrow(
+      'dry-run validation failed',
+    );
+    expect(mockCreateNIMSecret).toHaveBeenCalledTimes(1);
+    expect(mockCreateNIMAccount).toHaveBeenCalledTimes(1);
+    expect(mockDeleteSecret).not.toHaveBeenCalled();
+  });
+
+  it('should replace existing secret if create returns 409', async () => {
+    const existingSecret: SecretKind = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns', resourceVersion: '999' },
+      type: 'Opaque',
+      data: { [NIM_SECRET_NAME]: btoa('old-key') },
+    };
+    const createdAccount = mockNimAccount({
+      namespace: 'test-ns',
+      apiKeySecretName: NIM_SECRET_NAME,
+    });
+
+    mockCreateNIMSecret.mockRejectedValue(new K8sStatusError(mock409Error({}))); // both dry-run and actual create: 409
+    mockCreateNIMAccount.mockResolvedValue(createdAccount);
+    mockFetchExistingSecret.mockResolvedValue(existingSecret);
+    mockReplaceNIMSecret.mockResolvedValue({} as SecretKind);
+
+    const result = await createNIMResources('test-ns', 'nvapi-key');
+
+    expect(mockFetchExistingSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
+    expect(mockReplaceNIMSecret).toHaveBeenCalledTimes(2);
+    expect(mockReplaceNIMSecret).toHaveBeenNthCalledWith(1, expect.any(Object), true);
+    expect(mockReplaceNIMSecret).toHaveBeenNthCalledWith(2, expect.any(Object));
+    expect(result).toBe(createdAccount);
+  });
+
+  it('should return existing account if create returns 409', async () => {
+    const existingAccount = mockNimAccount({
+      namespace: 'test-ns',
+      apiKeySecretName: NIM_SECRET_NAME,
+    });
+
+    mockCreateNIMSecret.mockResolvedValue({} as SecretKind);
+    mockCreateNIMAccount
+      .mockResolvedValueOnce(mockNimAccount({})) // dry-run succeeds
+      .mockRejectedValueOnce(new K8sStatusError(mock409Error({}))); // actual create: 409
+    mockGetNIMAccount.mockResolvedValue(existingAccount);
+
+    const result = await createNIMResources('test-ns', 'nvapi-key');
+
+    expect(mockGetNIMAccount).toHaveBeenCalledWith('test-ns');
+    expect(mockDeleteSecret).not.toHaveBeenCalled();
+    expect(result).toBe(existingAccount);
+  });
+
+  it('should clean up secret if account creation fails', async () => {
+    const createdSecret: SecretKind = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns' },
+      type: 'Opaque',
+    };
+    mockCreateNIMSecret.mockResolvedValue(createdSecret);
+    mockCreateNIMAccount
+      .mockResolvedValueOnce(mockNimAccount({}))
+      .mockRejectedValueOnce(new Error('account creation failed'));
+
+    await expect(createNIMResources('test-ns', 'nvapi-key')).rejects.toThrow(
+      'account creation failed',
+    );
+    expect(mockDeleteSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
+  });
+});
+
+describe('deleteNIMResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete both the NIM account and the secret', async () => {
+    mockDeleteNIMAccount.mockResolvedValue(undefined);
+    mockDeleteSecret.mockResolvedValue(undefined);
+
+    await deleteNIMResources('test-ns');
+
+    expect(mockDeleteNIMAccount).toHaveBeenCalledWith('test-ns');
+    expect(mockDeleteSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
+  });
+});

--- a/packages/nim-serving/src/api/accounts/__tests__/utils.spec.ts
+++ b/packages/nim-serving/src/api/accounts/__tests__/utils.spec.ts
@@ -1,22 +1,7 @@
 import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
-import { mock409Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
-import { K8sStatusError } from '@odh-dashboard/internal/api/errorUtils';
 import { SecretKind } from '@odh-dashboard/internal/k8sTypes';
+import { assembleNIMSecret, assembleNIMAccount, assembleUpdatedSecret } from '../k8s';
 import {
-  assembleNIMSecret,
-  assembleNIMAccount,
-  assembleUpdatedSecret,
-  createNIMSecret,
-  createNIMAccount,
-  getNIMAccount,
-  deleteNIMAccount,
-  deleteSecret,
-  fetchExistingSecret,
-  replaceNIMSecret,
-} from '../k8s';
-import {
-  createNIMResources,
-  deleteNIMResources,
   isAccountReady,
   isApiKeyValidationFailed,
   getAccountErrors,
@@ -31,24 +16,6 @@ import {
   NIM_FORCE_VALIDATION_ANNOTATION,
 } from '../constants';
 
-jest.mock('../k8s', () => ({
-  ...jest.requireActual('../k8s'),
-  createNIMSecret: jest.fn(),
-  createNIMAccount: jest.fn(),
-  getNIMAccount: jest.fn(),
-  deleteNIMAccount: jest.fn(),
-  deleteSecret: jest.fn(),
-  fetchExistingSecret: jest.fn(),
-  replaceNIMSecret: jest.fn(),
-}));
-
-const mockCreateNIMSecret = jest.mocked(createNIMSecret);
-const mockCreateNIMAccount = jest.mocked(createNIMAccount);
-const mockGetNIMAccount = jest.mocked(getNIMAccount);
-const mockDeleteNIMAccount = jest.mocked(deleteNIMAccount);
-const mockDeleteSecret = jest.mocked(deleteSecret);
-const mockFetchExistingSecret = jest.mocked(fetchExistingSecret);
-const mockReplaceNIMSecret = jest.mocked(replaceNIMSecret);
 describe('assembleNIMSecret', () => {
   it('should build a secret with a static name and the API key', () => {
     const secret = assembleNIMSecret('test-ns', 'nvapi-test-key');
@@ -89,138 +56,6 @@ describe('assembleUpdatedSecret', () => {
     expect(updated.metadata.annotations?.[NIM_FORCE_VALIDATION_ANNOTATION]).toBeDefined();
     expect(updated.stringData?.[NIM_API_KEY_DATA_KEY]).toBe('nvapi-new-key');
     expect(updated.stringData?.[NGC_API_KEY_DATA_KEY]).toBe('nvapi-new-key');
-  });
-});
-
-describe('createNIMResources', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should dry-run both creates, then create secret and account', async () => {
-    const createdSecret: SecretKind = {
-      apiVersion: 'v1',
-      kind: 'Secret',
-      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns' },
-      type: 'Opaque',
-    };
-    const createdAccount = mockNimAccount({
-      namespace: 'test-ns',
-      uid: 'account-uid-123',
-      apiKeySecretName: NIM_SECRET_NAME,
-    });
-
-    mockCreateNIMSecret.mockResolvedValue(createdSecret);
-    mockCreateNIMAccount.mockResolvedValue(createdAccount);
-
-    const result = await createNIMResources('test-ns', 'nvapi-key');
-
-    expect(mockCreateNIMSecret).toHaveBeenCalledTimes(2);
-    expect(mockCreateNIMSecret).toHaveBeenNthCalledWith(1, expect.any(Object), true);
-    expect(mockCreateNIMSecret).toHaveBeenNthCalledWith(2, expect.any(Object), undefined);
-
-    expect(mockCreateNIMAccount).toHaveBeenCalledTimes(2);
-    expect(mockCreateNIMAccount).toHaveBeenNthCalledWith(1, expect.any(Object), true);
-    expect(mockCreateNIMAccount).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        spec: { apiKeySecret: { name: NIM_SECRET_NAME } },
-      }),
-      undefined,
-    );
-
-    expect(result).toBe(createdAccount);
-  });
-
-  it('should not create any resources if dry-run fails', async () => {
-    mockCreateNIMSecret.mockRejectedValueOnce(new Error('dry-run validation failed'));
-
-    await expect(createNIMResources('test-ns', 'nvapi-key')).rejects.toThrow(
-      'dry-run validation failed',
-    );
-    expect(mockCreateNIMSecret).toHaveBeenCalledTimes(1);
-    expect(mockCreateNIMAccount).toHaveBeenCalledTimes(1);
-    expect(mockDeleteSecret).not.toHaveBeenCalled();
-  });
-
-  it('should replace existing secret if create returns 409', async () => {
-    const existingSecret: SecretKind = {
-      apiVersion: 'v1',
-      kind: 'Secret',
-      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns', resourceVersion: '999' },
-      type: 'Opaque',
-      data: { [NIM_API_KEY_DATA_KEY]: btoa('old-key') },
-    };
-    const createdAccount = mockNimAccount({
-      namespace: 'test-ns',
-      apiKeySecretName: NIM_SECRET_NAME,
-    });
-
-    mockCreateNIMSecret.mockRejectedValue(new K8sStatusError(mock409Error({}))); // both dry-run and actual create: 409
-    mockCreateNIMAccount.mockResolvedValue(createdAccount);
-    mockFetchExistingSecret.mockResolvedValue(existingSecret);
-    mockReplaceNIMSecret.mockResolvedValue({} as SecretKind);
-
-    const result = await createNIMResources('test-ns', 'nvapi-key');
-
-    expect(mockFetchExistingSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
-    expect(mockReplaceNIMSecret).toHaveBeenCalledTimes(2);
-    expect(mockReplaceNIMSecret).toHaveBeenNthCalledWith(1, expect.any(Object), true);
-    expect(mockReplaceNIMSecret).toHaveBeenNthCalledWith(2, expect.any(Object));
-    expect(result).toBe(createdAccount);
-  });
-
-  it('should return existing account if create returns 409', async () => {
-    const existingAccount = mockNimAccount({
-      namespace: 'test-ns',
-      apiKeySecretName: NIM_SECRET_NAME,
-    });
-
-    mockCreateNIMSecret.mockResolvedValue({} as SecretKind);
-    mockCreateNIMAccount
-      .mockResolvedValueOnce(mockNimAccount({})) // dry-run succeeds
-      .mockRejectedValueOnce(new K8sStatusError(mock409Error({}))); // actual create: 409
-    mockGetNIMAccount.mockResolvedValue(existingAccount);
-
-    const result = await createNIMResources('test-ns', 'nvapi-key');
-
-    expect(mockGetNIMAccount).toHaveBeenCalledWith('test-ns');
-    expect(mockDeleteSecret).not.toHaveBeenCalled();
-    expect(result).toBe(existingAccount);
-  });
-
-  it('should clean up secret if account creation fails', async () => {
-    const createdSecret: SecretKind = {
-      apiVersion: 'v1',
-      kind: 'Secret',
-      metadata: { name: NIM_SECRET_NAME, namespace: 'test-ns' },
-      type: 'Opaque',
-    };
-    mockCreateNIMSecret.mockResolvedValue(createdSecret);
-    mockCreateNIMAccount
-      .mockResolvedValueOnce(mockNimAccount({}))
-      .mockRejectedValueOnce(new Error('account creation failed'));
-
-    await expect(createNIMResources('test-ns', 'nvapi-key')).rejects.toThrow(
-      'account creation failed',
-    );
-    expect(mockDeleteSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
-  });
-});
-
-describe('deleteNIMResources', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should delete both the NIM account and the secret', async () => {
-    mockDeleteNIMAccount.mockResolvedValue(undefined);
-    mockDeleteSecret.mockResolvedValue(undefined);
-
-    await deleteNIMResources('test-ns');
-
-    expect(mockDeleteNIMAccount).toHaveBeenCalledWith('test-ns');
-    expect(mockDeleteSecret).toHaveBeenCalledWith('test-ns', NIM_SECRET_NAME);
   });
 });
 

--- a/packages/nim-serving/src/api/accounts/api.ts
+++ b/packages/nim-serving/src/api/accounts/api.ts
@@ -1,0 +1,85 @@
+import { NIMAccountKind, SecretKind } from '@odh-dashboard/internal/k8sTypes';
+import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
+import {
+  assembleNIMSecret,
+  assembleNIMAccount,
+  assembleUpdatedSecret,
+  createNIMSecret,
+  createNIMAccount,
+  getNIMAccount,
+  deleteNIMAccount,
+  deleteSecret,
+  fetchExistingSecret,
+  replaceNIMSecret,
+} from './k8s';
+
+import { NIM_SECRET_NAME } from './constants';
+
+const isConflict = (e: unknown): boolean => getGenericErrorCode(e) === 409;
+
+export const createOrReplaceSecret = async (
+  namespace: string,
+  apiKey: string,
+  dryRun?: boolean,
+): Promise<SecretKind> => {
+  const secretData = assembleNIMSecret(namespace, apiKey);
+  try {
+    return await createNIMSecret(secretData, dryRun);
+  } catch (e) {
+    if (isConflict(e)) {
+      const existingSecret = await fetchExistingSecret(namespace, NIM_SECRET_NAME);
+      const updatedSecret = assembleUpdatedSecret(existingSecret, apiKey);
+      if (dryRun) {
+        await replaceNIMSecret(updatedSecret, true);
+        return updatedSecret;
+      }
+      return replaceNIMSecret(updatedSecret);
+    }
+    throw e;
+  }
+};
+
+export const createOrReturnAccount = async (
+  namespace: string,
+  dryRun?: boolean,
+): Promise<NIMAccountKind> => {
+  const accountData = assembleNIMAccount(namespace, NIM_SECRET_NAME);
+  try {
+    return await createNIMAccount(accountData, dryRun);
+  } catch (e) {
+    if (isConflict(e)) {
+      if (dryRun) {
+        return accountData;
+      }
+      const existing = await getNIMAccount(namespace);
+      if (existing) {
+        return existing;
+      }
+    }
+    throw e;
+  }
+};
+
+export const createNIMResources = async (
+  namespace: string,
+  apiKey: string,
+): Promise<NIMAccountKind> => {
+  await Promise.all([
+    createOrReplaceSecret(namespace, apiKey, true),
+    createOrReturnAccount(namespace, true),
+  ]);
+
+  await createOrReplaceSecret(namespace, apiKey);
+
+  try {
+    return await createOrReturnAccount(namespace);
+  } catch (e) {
+    await deleteSecret(namespace, NIM_SECRET_NAME);
+    throw e;
+  }
+};
+
+export const deleteNIMResources = async (namespace: string): Promise<void> => {
+  await deleteNIMAccount(namespace);
+  await deleteSecret(namespace, NIM_SECRET_NAME);
+};

--- a/packages/nim-serving/src/api/accounts/utils.ts
+++ b/packages/nim-serving/src/api/accounts/utils.ts
@@ -1,19 +1,6 @@
-import { NIMAccountKind, SecretKind, K8sCondition } from '@odh-dashboard/internal/k8sTypes';
-import { getGenericErrorCode } from '@odh-dashboard/internal/api/errorUtils';
-import {
-  assembleNIMSecret,
-  assembleNIMAccount,
-  assembleUpdatedSecret,
-  createNIMSecret,
-  createNIMAccount,
-  getNIMAccount,
-  deleteNIMAccount,
-  deleteSecret,
-  fetchExistingSecret,
-  replaceNIMSecret,
-} from './k8s';
+import { NIMAccountKind, K8sCondition } from '@odh-dashboard/internal/k8sTypes';
 
-import { NIM_SECRET_NAME, VALIDATION_TIMEOUT_MS } from './constants';
+import { VALIDATION_TIMEOUT_MS } from './constants';
 
 export enum NIMAccountStatus {
   LOADING = 'LOADING',
@@ -104,73 +91,4 @@ export const deriveAccountStatus = (
     return { status: NIMAccountStatus.ERROR, errorMessages: [VALIDATION_TIMEOUT_MESSAGE] };
   }
   return { status: NIMAccountStatus.PENDING, errorMessages: [] };
-};
-
-const isConflict = (e: unknown): boolean => getGenericErrorCode(e) === 409;
-
-export const createOrReplaceSecret = async (
-  namespace: string,
-  apiKey: string,
-  dryRun?: boolean,
-): Promise<SecretKind> => {
-  const secretData = assembleNIMSecret(namespace, apiKey);
-  try {
-    return await createNIMSecret(secretData, dryRun);
-  } catch (e) {
-    if (isConflict(e)) {
-      const existingSecret = await fetchExistingSecret(namespace, NIM_SECRET_NAME);
-      const updatedSecret = assembleUpdatedSecret(existingSecret, apiKey);
-      if (dryRun) {
-        await replaceNIMSecret(updatedSecret, true);
-        return updatedSecret;
-      }
-      return replaceNIMSecret(updatedSecret);
-    }
-    throw e;
-  }
-};
-
-export const createOrReturnAccount = async (
-  namespace: string,
-  dryRun?: boolean,
-): Promise<NIMAccountKind> => {
-  const accountData = assembleNIMAccount(namespace, NIM_SECRET_NAME);
-  try {
-    return await createNIMAccount(accountData, dryRun);
-  } catch (e) {
-    if (isConflict(e)) {
-      if (dryRun) {
-        return accountData;
-      }
-      const existing = await getNIMAccount(namespace);
-      if (existing) {
-        return existing;
-      }
-    }
-    throw e;
-  }
-};
-
-export const createNIMResources = async (
-  namespace: string,
-  apiKey: string,
-): Promise<NIMAccountKind> => {
-  await Promise.all([
-    createOrReplaceSecret(namespace, apiKey, true),
-    createOrReturnAccount(namespace, true),
-  ]);
-
-  await createOrReplaceSecret(namespace, apiKey);
-
-  try {
-    return await createOrReturnAccount(namespace);
-  } catch (e) {
-    await deleteSecret(namespace, NIM_SECRET_NAME);
-    throw e;
-  }
-};
-
-export const deleteNIMResources = async (namespace: string): Promise<void> => {
-  await deleteNIMAccount(namespace);
-  await deleteSecret(namespace, NIM_SECRET_NAME);
 };

--- a/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-icons';
 import ContentModal from '@odh-dashboard/internal/components/modals/ContentModal';
 import { NIMAccountStatus } from '../../api/accounts/hooks';
-import { createNIMResources, createOrReplaceSecret } from '../../api/accounts/utils';
+import { createNIMResources, createOrReplaceSecret } from '../../api/accounts/api';
 
 type NIMApiKeyModalProps = {
   onClose: () => void;

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -23,7 +23,7 @@ import { useAccessReview } from '@odh-dashboard/internal/api';
 import NIMAccountStatusAlerts from './NIMAccountStatusAlerts';
 import NIMApiKeyModal from './NIMApiKeyModal';
 import useNIMAccountStatus, { NIMAccountStatus } from '../../api/accounts/hooks';
-import { deleteNIMResources } from '../../api/accounts/utils';
+import { deleteNIMResources } from '../../api/accounts/api';
 import { NIMAccountModel } from '../../api/accounts/k8s';
 
 const NIM_DESCRIPTION =


### PR DESCRIPTION
Follow-up from [PR #7466](https://github.com/opendatahub-io/odh-dashboard/pull/7466) review feedback.

## Description
In PR #7466, @emilys314's review noted that functions making k8s calls belong in `api.ts` files, not `utils.ts`. That PR applied the pattern to the `images/` directory. This PR applies the same pattern to the `accounts/` directory:
- Created `accounts/api.ts` with k8s-calling functions (`createOrReplaceSecret`, `createOrReturnAccount`, `createNIMResources`, `deleteNIMResources`, `isConflict`)
- Cleaned up `accounts/utils.ts` to contain only pure utility functions (`NIMAccountStatus`, `deriveAccountStatus`, `isAccountReady`, etc.)
- Updated consumer imports in `NIMApiKeyModal.tsx` and `NIMSettingsCard.tsx`
- Split tests into `api.spec.ts` and `utils.spec.ts` to match the new file organization

No logic was changed, code was only moved.

## How Has This Been Tested?
- `npm run type-check` passes
- `npm run lint` passes (no new errors)
- `npm run test-unit` passes — all 62 tests across 8 suites
- Manually tested NIM settings tile flows that use this code, see details in https://github.com/opendatahub-io/odh-dashboard/pull/7436

## Test Impact
Existing tests were split between `api.spec.ts` and `utils.spec.ts` to match the new file organization. No test logic was changed — only imports were updated.

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for NIM resource provisioning and deletion workflows, including conflict-handling scenarios.

* **Refactor**
  * Reorganized NIM resource management functions into a dedicated accounts API module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->