### PR TITLE
test(e2e): Split workbench Key/Value env var test into independent cases

### DIFF
--- a/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/dataScienceProjects/workbenches/testWorkbenchVariables.cy.ts
@@ -162,21 +162,19 @@ describe('Workbenches - variable tests', () => {
     },
   );
   it(
-    'Verify that the user can inject environment variables manually into a workbench using Key / Value',
+    'Verify user can inject Secret environment variables manually using Key / Value',
     {
       tags: ['@Sanity', '@SanitySet3', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'],
     },
     () => {
       const workbenchName = projectName;
-      const workbenchName2 = deriveWorkbenchName(projectName, 'secondwb-');
       let selectedImageStream: string;
-      let selectedImageStream2: string;
 
       // Authentication and navigation
       cy.step('Log into the application');
       cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
 
-      // Project navigation and select workbences
+      // Project navigation and select workbenches
       cy.step(`Navigate to workbenches tab of Project ${projectName}`);
       projectListPage.navigate();
       projectListPage.filterProjectByName(projectName);
@@ -189,11 +187,11 @@ describe('Workbenches - variable tests', () => {
       createSpawnerPage.getNameInput().fill(workbenchName);
       createSpawnerPage.getDescriptionInput().type(projectDescription);
 
-      // Select notebook image with fallback for first workbench
+      // Select notebook image with fallback
       selectNotebookImageWithBackendFallback(testData.notebookImage, createSpawnerPage).then(
         (imageStreamName) => {
           selectedImageStream = imageStreamName;
-          cy.log(`Selected imagestream for first workbench: ${selectedImageStream}`);
+          cy.log(`Selected imagestream for workbench: ${selectedImageStream}`);
 
           createSpawnerPage.findAddVariableButton().click();
           const secretEnvVarField = createSpawnerPage.getEnvironmentVariableTypeField(0);
@@ -209,7 +207,7 @@ describe('Workbenches - variable tests', () => {
           notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
           notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
 
-          // Use dynamic image name verification for first workbench
+          // Use dynamic image name verification
           getImageStreamDisplayName(selectedImageStream).then((displayName) => {
             notebookRow.shouldHaveNotebookImageName(displayName);
 
@@ -219,52 +217,69 @@ describe('Workbenches - variable tests', () => {
               [testData.FAKE_SECRET_KEY]: testData.FAKE_SECRET_VALUE,
             };
             validateWorkbenchEnvironmentVariables(projectName, workbenchName, secretVariables);
+          });
+        },
+      );
+    },
+  );
+  it(
+    'Verify user can inject ConfigMap environment variables manually using Key / Value',
+    {
+      tags: ['@Sanity', '@SanitySet3', '@ODS-1883', '@ODS-1864', '@Dashboard', '@Workbenches'],
+    },
+    () => {
+      const workbenchName = deriveWorkbenchName(projectName, 'secondwb-');
+      let selectedImageStream: string;
 
-            // Create a second workbench with Config Map variables via Key / Value
-            cy.step(`Create a second workbench ${workbenchName2} using config map variables`);
-            workbenchPage.findCreateButton().click();
-            createSpawnerPage.getNameInput().fill(workbenchName2);
-            createSpawnerPage.getDescriptionInput().type(projectDescription);
+      // Authentication and navigation
+      cy.step('Log into the application');
+      cy.visitWithLogin('/', HTPASSWD_CLUSTER_ADMIN_USER);
 
-            // Select notebook image with fallback for second workbench
-            selectNotebookImageWithBackendFallback(testData.notebookImage, createSpawnerPage).then(
-              (imageStreamName2) => {
-                selectedImageStream2 = imageStreamName2;
-                cy.log(`Selected imagestream for second workbench: ${selectedImageStream2}`);
+      // Project navigation and select workbenches
+      cy.step(`Navigate to workbenches tab of Project ${projectName}`);
+      projectListPage.navigate();
+      projectListPage.filterProjectByName(projectName);
+      projectListPage.findProjectLink(projectName).click();
+      projectDetails.findSectionTab('workbenches').click();
 
-                createSpawnerPage.findAddVariableButton().click();
-                const secretEnvVarField2 = createSpawnerPage.getEnvironmentVariableTypeField(0);
-                secretEnvVarField2.selectEnvironmentVariableTypeByTestId(
-                  EnvironmentVariableType.CONFIG_MAP,
-                );
-                secretEnvVarField2.selectEnvDataTypeByTestId(ConfigMapCategory.GENERIC);
-                secretEnvVarField2.findKeyInput().fill(testData.FAKE_CM_KEY);
-                secretEnvVarField2.findKeyValue().fill(testData.FAKE_CM_VALUE);
-                createSpawnerPage.findSubmitButton().click();
+      // Create workbench with Config Map variables via Key / Value
+      cy.step(`Create workbench ${workbenchName} using config map variables`);
+      workbenchPage.findCreateButton().click();
+      createSpawnerPage.getNameInput().fill(workbenchName);
+      createSpawnerPage.getDescriptionInput().type(projectDescription);
 
-                // Wait for workbench to run
-                cy.step(`Wait for workbench ${workbenchName2} to display a "Running" status`);
-                const notebookRow2 = workbenchPage.getNotebookRow(workbenchName2);
-                notebookRow2.findNotebookDescription(testData.wbVariablesTestDescription);
-                notebookRow2.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+      // Select notebook image with fallback
+      selectNotebookImageWithBackendFallback(testData.notebookImage, createSpawnerPage).then(
+        (imageStreamName) => {
+          selectedImageStream = imageStreamName;
+          cy.log(`Selected imagestream for workbench: ${selectedImageStream}`);
 
-                // Use dynamic image name verification for second workbench
-                getImageStreamDisplayName(selectedImageStream2).then((displayName2) => {
-                  notebookRow2.shouldHaveNotebookImageName(displayName2);
+          createSpawnerPage.findAddVariableButton().click();
+          const configMapEnvVarField = createSpawnerPage.getEnvironmentVariableTypeField(0);
+          configMapEnvVarField.selectEnvironmentVariableTypeByTestId(
+            EnvironmentVariableType.CONFIG_MAP,
+          );
+          configMapEnvVarField.selectEnvDataTypeByTestId(ConfigMapCategory.GENERIC);
+          configMapEnvVarField.findKeyInput().fill(testData.FAKE_CM_KEY);
+          configMapEnvVarField.findKeyValue().fill(testData.FAKE_CM_VALUE);
+          createSpawnerPage.findSubmitButton().click();
 
-                  // Validate that the variables are present in the Workbench container
-                  cy.step(`Validate that the variables are present in the Workbench container `);
-                  const configMapVariables = {
-                    [testData.FAKE_CM_KEY]: testData.FAKE_CM_VALUE,
-                  };
-                  validateWorkbenchEnvironmentVariables(
-                    projectName,
-                    workbenchName2,
-                    configMapVariables,
-                  );
-                });
-              },
-            );
+          // Wait for workbench to run
+          cy.step(`Wait for workbench ${workbenchName} to display a "Running" status`);
+          const notebookRow = workbenchPage.getNotebookRow(workbenchName);
+          notebookRow.findNotebookDescription(testData.wbVariablesTestDescription);
+          notebookRow.expectStatusLabelToBe(NotebookStatusLabel.Ready, 120000);
+
+          // Use dynamic image name verification
+          getImageStreamDisplayName(selectedImageStream).then((displayName) => {
+            notebookRow.shouldHaveNotebookImageName(displayName);
+
+            // Validate that the variables are present in the Workbench container
+            cy.step(`Validate that the variables are present in the Workbench container`);
+            const configMapVariables = {
+              [testData.FAKE_CM_KEY]: testData.FAKE_CM_VALUE,
+            };
+            validateWorkbenchEnvironmentVariables(projectName, workbenchName, configMapVariables);
           });
         },
       );


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-64757

## Description
The "inject environment variables manually using Key / Value" test created two workbenches sequentially in a single it() block with deeply nested callbacks.
When the second workbench failed (flaky under cluster load — builds 929, 942, 949), retrying re-ran both workbenches (~2 min wasted per retry).

  Split into two independent it() blocks:
  - "Verify user can inject Secret environment variables manually using Key / Value"
  - "Verify user can inject ConfigMap environment variables manually using Key / Value"

## How Has This Been Tested?
dashboard-e2e-tests/962/
<img width="1166" height="270" alt="image" src="https://github.com/user-attachments/assets/5cba02a4-efac-454b-befb-87a272dbf417" />


## Test Impact
Split test into two tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test coverage for workbench environment variable functionality by refactoring test cases to provide better isolation and clearer validation of Secret and ConfigMap variable injection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->