### PR TITLE
fix(RHOAIENG-64752): update DSCI resource consumption from API v1 to v2

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1013,8 +1013,9 @@ export type DataScienceClusterList = {
 export type DataScienceClusterInitializationKindStatus = {
   conditions: K8sCondition[];
   phase?: string;
-  monitoring?: {
-    namespace?: string;
+  release?: {
+    name?: string;
+    version?: string;
   };
 };
 

--- a/backend/src/utils/dsci.ts
+++ b/backend/src/utils/dsci.ts
@@ -10,7 +10,7 @@ export const getClusterInitialization = async (
   fastify: KubeFastifyInstance,
 ): Promise<DataScienceClusterInitializationKindStatus> => {
   const result: DataScienceClusterInitializationKind | null = await fastify.kube.customObjectsApi
-    .listClusterCustomObject('dscinitialization.opendatahub.io', 'v1', 'dscinitializations')
+    .listClusterCustomObject('dscinitialization.opendatahub.io', 'v2', 'dscinitializations')
     .then((res) => (res.body as DataScienceClusterInitializationList).items[0])
     .catch((e) => {
       fastify.log.error(`Failure to fetch dsci: ${e.response.body}`);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-64752

## Description

The upstream opendatahub-operator has moved DSCInitialization (DSCI) to API `v2` as the `+kubebuilder:storageversion`. The companion DSC resource was already updated to v2 in `backend/src/utils/dsc.ts`, but the DSCI was missed.

This PR:
- Updates `backend/src/utils/dsci.ts` to fetch DSCI using `v2` instead of `v1`
- Aligns the backend `DataScienceClusterInitializationKindStatus` type with the v2 shape by replacing the unused `monitoring` field with the `release` field (matching the frontend type)

While Kubernetes API servers handle CRD version conversion automatically (so v1 still works today), using the deprecated version is a maintenance risk if the operator eventually drops v1 support.

## How Has This Been Tested?

- Backend TypeScript type-check passes (`tsc --noEmit`)
- Frontend TypeScript type-check passes
- All 85 backend unit tests pass
- Verified the upstream v2 types at `api/dscinitialization/v2/dscinitialization_types.go` to confirm the status shape

## Test Impact

No new tests needed. The changes are a version bump in an API call (`v1` → `v2`) and a type alignment. No existing mocks or tests reference the `v1` version string or the removed `monitoring` status field. All existing tests continue to pass.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Release information tracking now available, including name and version details for cluster initialization

* **Refactor**
  * Updated cluster operations to use the latest API version
  * Removed monitoring namespace tracking from cluster status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->