### PR TITLE
chore: add pewter team to dashboard OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,6 +21,7 @@ filters:
       - automl-approvers
       - eval-hub-approvers
       - mlflow-approvers
+      - distributions-approvers
 
   # Catchall
   '.*':
@@ -188,6 +189,15 @@ filters:
       - eval-hub-reviewers
     labels:
       - 'area/eval-hub'
+
+  # Distributions
+  'distributions/.*':
+    approvers:
+      - distributions-approvers
+    reviewers:
+      - distributions-reviewers
+    labels:
+      - 'area/distributions'
 
   # MLflow
   'packages/mlflow.*/.*':

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,6 +16,7 @@ aliases:
     - ederign
     - dpanshug
     - claudialphonse78
+    - andyatmiami
 
   # Backup alias for managers to help with unblocking during PTO
   managers-backup-approvers:
@@ -247,6 +248,14 @@ aliases:
   agent-ops-reviewers:
     - Gkrumbach07
     - DaoDaoNoCode
+
+  # Distributions
+  distributions-approvers:
+    - andyatmiami
+    - paulovmr
+  distributions-reviewers:
+    - caponetto
+    - jenny-s51
 
   # MLflow
   mlflow-approvers:


### PR DESCRIPTION
- Updated OWNERS to include a new filter for distributions with designated approvers and reviewers.
- Added new aliases for distributions approvers and reviewers in OWNERS_ALIASES, including andyatmiami and paulovmr as approvers, and caponetto and jenny-s51 as reviewers.

ℹ️ non-code change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal review and approval routing configuration to ensure appropriate code review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->