### PR TITLE
feat(nim-serving): add PVC caching storage field to NIM deployment wizard

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -20,6 +20,12 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   wizardState,
   externalData,
 }) => {
+  const modelDeploymentExtensionFields = React.useMemo(
+    () =>
+      wizardState.fields.filter((f) => f.step === 'modelDeployment' && !f.stateKey && !f.parentId),
+    [wizardState.fields],
+  );
+
   if (!wizardState.loaded.modelDeploymentLoaded) {
     return <Spinner data-testid="spinner" />;
   }
@@ -57,6 +63,15 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
           isEditing={wizardState.initialData?.isEditing}
         />
         <NumReplicasField replicaState={wizardState.state.numReplicas} />
+        {modelDeploymentExtensionFields.map((field) => (
+          <GenericFieldRenderer
+            key={field.id}
+            fieldId={field.id}
+            wizardState={wizardState}
+            externalData={externalData}
+            isEditing={wizardState.initialData?.isEditing}
+          />
+        ))}
       </FormSection>
     </Form>
   );

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -16,8 +16,35 @@ import type {
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import type { NIMDeployment } from './src/api/deployments/useWatchDeployments';
 import type { NIMImageFieldType } from './src/pages/deploymentWizard/fields/NIMImageField';
+import type { NIMPVCFieldType } from './src/pages/deploymentWizard/fields/NIMPVCField';
 
 export const NIM_ID = 'nvidia-nim';
+
+const nimImageFieldExtension: WizardFieldExtension<NIMImageFieldType> = {
+  type: 'model-serving.deployment/wizard-field',
+  properties: {
+    field: () =>
+      import('./src/pages/deploymentWizard/fields/NIMImageField').then(
+        (m) => m.NIMImageFieldWizardField,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
+const nimPVCFieldExtension: WizardFieldExtension<NIMPVCFieldType> = {
+  type: 'model-serving.deployment/wizard-field',
+  properties: {
+    field: () =>
+      import('./src/pages/deploymentWizard/fields/NIMPVCField').then(
+        (m) => m.NIMPVCFieldWizardField,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
 
 const extensions: (
   | AreaExtension
@@ -27,6 +54,7 @@ const extensions: (
   | ModelServingExcludeDeploymentExtension
   | DeploymentWizardFieldOverrideExtension
   | WizardFieldExtension<NIMImageFieldType>
+  | WizardFieldExtension<NIMPVCFieldType>
 )[] = [
   {
     type: 'app.area',
@@ -89,18 +117,8 @@ const extensions: (
         ),
     },
   },
-  {
-    type: 'model-serving.deployment/wizard-field',
-    properties: {
-      field: () =>
-        import('./src/pages/deploymentWizard/fields/NIMImageField').then(
-          (m) => m.NIMImageFieldWizardField,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
+  nimImageFieldExtension,
+  nimPVCFieldExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -1,0 +1,358 @@
+import React from 'react';
+import { z } from 'zod';
+import {
+  FormGroup,
+  FormSection,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
+import NumberInputWrapper from '@odh-dashboard/internal/components/NumberInputWrapper';
+import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
+import type { ProjectSectionType } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ProjectSection';
+import type { WizardField } from '@odh-dashboard/model-serving/types/form-data';
+import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
+
+export type NIMPVCStorageMode = 'new' | 'existing';
+
+export type NIMPVCFieldValue = {
+  storageMode: NIMPVCStorageMode;
+  pvcName: string;
+  modelPath: string;
+  subPath: string;
+  storageClassName: string;
+  storageSizeGi: number;
+};
+
+const DEFAULT_MODEL_PATH = '/model-store';
+const DEFAULT_SUBPATH = '/';
+const DEFAULT_STORAGE_SIZE_GI = 50;
+const MIN_STORAGE_SIZE_GI = 1;
+
+const nimPVCFieldSchema = z
+  .object({
+    storageMode: z.enum(['new', 'existing']),
+    pvcName: z.string().min(1, 'Cluster storage name is required'),
+    modelPath: z.string().min(1, 'Model path is required'),
+    subPath: z.string(),
+    storageClassName: z.string(),
+    storageSizeGi: z.number().min(MIN_STORAGE_SIZE_GI, 'Storage size must be at least 1 GiB'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.storageMode === 'new' && !data.storageClassName) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Storage class is required for new storage',
+        path: ['storageClassName'],
+      });
+    }
+  });
+
+type NIMPVCDependencies = {
+  project: ProjectSectionType;
+};
+
+type StorageClassOption = {
+  name: string;
+  displayName: string;
+};
+
+type NIMPVCExternalData = {
+  storageClasses: StorageClassOption[];
+  existingPVCs: string[];
+};
+
+const useNIMPVCExternalData = (dependencies?: {
+  project?: { projectName?: string };
+}): {
+  data: NIMPVCExternalData;
+  loaded: boolean;
+  loadError?: Error;
+} => {
+  const projectName = dependencies?.project?.projectName;
+  const loaded = !!projectName;
+
+  return React.useMemo(
+    () => ({
+      data: {
+        storageClasses: [{ name: 'gp3-csi', displayName: 'gp3-csi' }],
+        existingPVCs: [],
+      },
+      loaded,
+    }),
+    [loaded],
+  );
+};
+
+const getDefaultFieldValue = (): NIMPVCFieldValue => ({
+  storageMode: 'new',
+  pvcName: '',
+  modelPath: DEFAULT_MODEL_PATH,
+  subPath: DEFAULT_SUBPATH,
+  storageClassName: '',
+  storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
+});
+
+type NIMPVCFieldComponentProps = {
+  value?: NIMPVCFieldValue;
+  onChange: (value: NIMPVCFieldValue) => void;
+  externalData?: { data: NIMPVCExternalData; loaded: boolean; loadError?: Error };
+  isDisabled?: boolean;
+};
+
+const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
+  value,
+  onChange,
+  externalData,
+  isDisabled,
+}) => {
+  const fieldValue = React.useMemo(() => value ?? getDefaultFieldValue(), [value]);
+
+  const updateField = React.useCallback(
+    (patch: Partial<NIMPVCFieldValue>) => {
+      onChange({ ...fieldValue, ...patch });
+    },
+    [fieldValue, onChange],
+  );
+
+  const storageClasses = externalData?.data.storageClasses ?? [];
+  const existingPVCs = externalData?.data.existingPVCs ?? [];
+
+  const storageModeOptions: SimpleSelectOption[] = [
+    {
+      key: 'new',
+      label: 'Deploy the NIM image from a new cluster storage',
+    },
+    {
+      key: 'existing',
+      label: 'Deploy the NIM image from an existing cluster storage',
+    },
+  ];
+
+  const storageClassOptions: SimpleSelectOption[] = storageClasses.map((sc) => ({
+    key: sc.name,
+    label: sc.displayName,
+  }));
+
+  const existingPVCOptions: SimpleSelectOption[] = existingPVCs.map((pvc) => ({
+    key: pvc,
+    label: pvc,
+  }));
+
+  return (
+    <FormSection title="Storage and deployment option">
+      <FormGroup label="Storage and deployment option" fieldId="nim-storage-mode" isRequired>
+        <SimpleSelect
+          dataTestId="nim-storage-mode-select"
+          options={storageModeOptions}
+          value={fieldValue.storageMode}
+          onChange={(val) => {
+            const mode: NIMPVCStorageMode = val === 'existing' ? 'existing' : 'new';
+            updateField({
+              storageMode: mode,
+              pvcName: '',
+              storageClassName: mode === 'new' ? storageClasses[0]?.name ?? '' : '',
+            });
+          }}
+          isDisabled={isDisabled}
+          isFullWidth
+        />
+      </FormGroup>
+
+      {fieldValue.storageMode === 'new' ? (
+        <>
+          <FormGroup label="Cluster storage name" fieldId="nim-pvc-name" isRequired>
+            <TextInput
+              id="nim-pvc-name"
+              data-testid="nim-pvc-name-input"
+              value={fieldValue.pvcName}
+              onChange={(_event, val) => updateField({ pvcName: val })}
+              placeholder="nim-pvc"
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                This cluster storage can be reused for future deployments of this NIM image.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+
+          <FormGroup label="Model path" fieldId="nim-model-path" isRequired>
+            <TextInput
+              id="nim-model-path"
+              data-testid="nim-model-path-input"
+              value={fieldValue.modelPath}
+              onChange={(_event, val) => updateField({ modelPath: val })}
+              placeholder={DEFAULT_MODEL_PATH}
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                Path within the container where model files will be mounted.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+
+          <FormGroup label="Subpath" fieldId="nim-subpath">
+            <TextInput
+              id="nim-subpath"
+              data-testid="nim-subpath-input"
+              value={fieldValue.subPath}
+              onChange={(_event, val) => updateField({ subPath: val })}
+              placeholder="/"
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                Optional: Subdirectory within the PVC. Use this if you have multiple models stored
+                in the same PVC. Leave blank to use the root of the PVC.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+
+          <FormGroup label="Storage class" fieldId="nim-storage-class">
+            <SimpleSelect
+              dataTestId="nim-storage-class-select"
+              options={storageClassOptions}
+              value={fieldValue.storageClassName}
+              onChange={(val) => updateField({ storageClassName: val })}
+              isDisabled={isDisabled}
+              isFullWidth
+              placeholder="Select storage class"
+            />
+          </FormGroup>
+
+          <FormGroup label="NVIDIA NIM storage size" fieldId="nim-storage-size" isRequired>
+            <NumberInputWrapper
+              id="nim-storage-size"
+              data-testid="nim-storage-size-input"
+              value={fieldValue.storageSizeGi}
+              min={MIN_STORAGE_SIZE_GI}
+              onChange={(val) =>
+                updateField({
+                  storageSizeGi: Math.max(MIN_STORAGE_SIZE_GI, val ?? DEFAULT_STORAGE_SIZE_GI),
+                })
+              }
+              unit="GiB"
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                Specify the size of the PVC. Make sure it is larger than the NIM image size
+                specified by NVIDIA.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+        </>
+      ) : (
+        <>
+          <FormGroup label="Cluster storage name" fieldId="nim-existing-pvc" isRequired>
+            <SimpleSelect
+              dataTestId="nim-existing-pvc-select"
+              options={existingPVCOptions}
+              value={fieldValue.pvcName}
+              onChange={(val) => updateField({ pvcName: val })}
+              isDisabled={isDisabled}
+              isFullWidth
+              placeholder="Select..."
+            />
+          </FormGroup>
+
+          <FormGroup label="Model path" fieldId="nim-model-path-existing" isRequired>
+            <TextInput
+              id="nim-model-path-existing"
+              data-testid="nim-model-path-existing-input"
+              value={fieldValue.modelPath}
+              onChange={(_event, val) => updateField({ modelPath: val })}
+              placeholder={DEFAULT_MODEL_PATH}
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                Path within the container where model files will be mounted.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+
+          <FormGroup label="Subpath" fieldId="nim-subpath-existing">
+            <TextInput
+              id="nim-subpath-existing"
+              data-testid="nim-subpath-existing-input"
+              value={fieldValue.subPath}
+              onChange={(_event, val) => updateField({ subPath: val })}
+              placeholder="/"
+              isDisabled={isDisabled}
+            />
+            <HelperText>
+              <HelperTextItem>
+                Optional: Subdirectory within the PVC. Use this if you have multiple models stored
+                in the same PVC. Leave blank to use the root of the PVC.
+              </HelperTextItem>
+            </HelperText>
+          </FormGroup>
+        </>
+      )}
+    </FormSection>
+  );
+};
+
+export type NIMPVCFieldType = WizardField<NIMPVCFieldValue, NIMPVCExternalData, NIMPVCDependencies>;
+
+export const NIMPVCFieldWizardField: NIMPVCFieldType = {
+  id: 'nim-serving/pvcStorage',
+  step: 'modelDeployment',
+  type: 'addition',
+  isActive: (wizardFormData) =>
+    wizardFormData.modelLocationData?.data?.type === NIMModelLocationKey,
+  reducerFunctions: {
+    setFieldData: (value: NIMPVCFieldValue) => value,
+    getInitialFieldData: (existingFieldData?: NIMPVCFieldValue): NIMPVCFieldValue =>
+      existingFieldData ?? getDefaultFieldValue(),
+    validationSchema: nimPVCFieldSchema,
+    resolveDependencies: (formData) => ({ project: formData.project }),
+  },
+  component: NIMPVCFieldComponent,
+  externalDataHook: useNIMPVCExternalData,
+  getReviewSections: (value) => [
+    {
+      title: 'NIM Storage',
+      items: [
+        {
+          key: 'storageMode',
+          label: 'Storage mode',
+          value: () => (value.storageMode === 'new' ? 'New storage' : 'Existing storage'),
+        },
+        {
+          key: 'pvcName',
+          label: 'Cluster storage name',
+          value: () => value.pvcName || '-',
+        },
+        {
+          key: 'modelPath',
+          label: 'Model path',
+          value: () => value.modelPath || '-',
+        },
+        {
+          key: 'subPath',
+          label: 'Subpath',
+          value: () => value.subPath || '-',
+          optional: true,
+          isVisible: () => !!value.subPath && value.subPath !== '/',
+        },
+        {
+          key: 'storageClass',
+          label: 'Storage class',
+          value: () => value.storageClassName || '-',
+          isVisible: () => value.storageMode === 'new',
+        },
+        {
+          key: 'storageSize',
+          label: 'Storage size',
+          value: () => `${value.storageSizeGi} GiB`,
+          isVisible: () => value.storageMode === 'new',
+        },
+      ],
+    },
+  ],
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -5,6 +5,7 @@ import {
   FormSection,
   HelperText,
   HelperTextItem,
+  Skeleton,
   TextInput,
 } from '@patternfly/react-core';
 import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
@@ -16,8 +17,13 @@ import type { WizardField } from '@odh-dashboard/model-serving/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
 import { getStorageClasses } from '@odh-dashboard/internal/api/k8s/storageClasses';
 import { PVCModel } from '@odh-dashboard/internal/api/models';
-import type { PersistentVolumeClaimKind, StorageClassKind } from '@odh-dashboard/internal/k8sTypes';
-import { MetadataAnnotation } from '@odh-dashboard/internal/k8sTypes';
+import type { PersistentVolumeClaimKind } from '@odh-dashboard/internal/k8sTypes';
+import useFetch, {
+  FetchStateCallbackPromise,
+  NotReadyError,
+} from '@odh-dashboard/internal/utilities/useFetch';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { useDefaultStorageClass } from '@odh-dashboard/internal/pages/projects/screens/spawner/storage/useDefaultStorageClass';
 
 export enum NIMPVCStorageMode {
   NEW = 'new',
@@ -72,9 +78,6 @@ type NIMPVCExternalData = {
   existingPVCs: string[];
 };
 
-const isDefaultStorageClass = (sc: StorageClassKind): boolean =>
-  sc.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
-
 const isNIMPVC = (pvcName: string): boolean => pvcName.startsWith('nim-pvc');
 
 const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
@@ -93,6 +96,13 @@ const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
   return [...nimPVCs, ...otherPVCs];
 };
 
+type FetchedStorageData = {
+  storageClasses: StorageClassOption[];
+  existingPVCs: string[];
+};
+
+const DEFAULT_FETCHED_DATA: FetchedStorageData = { storageClasses: [], existingPVCs: [] };
+
 const useNIMPVCExternalData = (dependencies?: {
   project?: { projectName?: string };
 }): {
@@ -102,68 +112,51 @@ const useNIMPVCExternalData = (dependencies?: {
 } => {
   const projectName = dependencies?.project?.projectName;
 
-  const [storageClasses, setStorageClasses] = React.useState<StorageClassOption[]>([]);
-  const [defaultStorageClassName, setDefaultStorageClassName] = React.useState('');
-  const [existingPVCs, setExistingPVCs] = React.useState<string[]>([]);
-  const [loaded, setLoaded] = React.useState(false);
-  const [loadError, setLoadError] = React.useState<Error>();
+  const [defaultStorageClass, defaultSCLoaded, defaultSCError] = useDefaultStorageClass();
 
-  React.useEffect(() => {
+  const fetchCallback = React.useCallback<
+    FetchStateCallbackPromise<FetchedStorageData>
+  >(async () => {
     if (!projectName) {
-      setLoaded(false);
-      return;
+      return Promise.reject(new NotReadyError('No project selected'));
     }
+    const [scList, pvcList] = await Promise.all([
+      getStorageClasses(),
+      k8sListResourceItems<PersistentVolumeClaimKind>({
+        model: PVCModel,
+        queryOptions: { ns: projectName },
+      }),
+    ]);
 
-    let cancelled = false;
-
-    const fetchData = async () => {
-      try {
-        const [scList, pvcList] = await Promise.all([
-          getStorageClasses(),
-          k8sListResourceItems<PersistentVolumeClaimKind>({
-            model: PVCModel,
-            queryOptions: { ns: projectName },
-          }),
-        ]);
-
-        if (cancelled) {
-          return;
-        }
-
-        const scOptions = scList.map((sc) => ({
-          name: sc.metadata.name,
-          displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
-        }));
-
-        const defaultSc = scList.find(isDefaultStorageClass);
-
-        setStorageClasses(scOptions);
-        setDefaultStorageClassName(defaultSc?.metadata.name ?? '');
-        setExistingPVCs(sortPVCsNIMFirst(pvcList));
-        setLoadError(undefined);
-        setLoaded(true);
-      } catch (e) {
-        if (!cancelled) {
-          setLoadError(e instanceof Error ? e : new Error('Failed to load storage data'));
-          setLoaded(true);
-        }
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      cancelled = true;
+    return {
+      storageClasses: scList.map((sc) => ({
+        name: sc.metadata.name,
+        displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
+      })),
+      existingPVCs: sortPVCsNIMFirst(pvcList),
     };
   }, [projectName]);
 
+  const {
+    data: fetchedData,
+    loaded: fetchLoaded,
+    error: fetchError,
+  } = useFetch(fetchCallback, DEFAULT_FETCHED_DATA);
+
+  const loaded = fetchLoaded && defaultSCLoaded;
+  const loadError = fetchError ?? defaultSCError;
+
   return React.useMemo(
     () => ({
-      data: { storageClasses, defaultStorageClassName, existingPVCs },
+      data: {
+        storageClasses: fetchedData.storageClasses,
+        defaultStorageClassName: defaultStorageClass?.metadata.name ?? '',
+        existingPVCs: fetchedData.existingPVCs,
+      },
       loaded,
       loadError,
     }),
-    [storageClasses, defaultStorageClassName, existingPVCs, loaded, loadError],
+    [fetchedData, defaultStorageClass, loaded, loadError],
   );
 };
 
@@ -254,28 +247,29 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
   const storageClasses = externalData?.data.storageClasses ?? [];
   const defaultStorageClassName = externalData?.data.defaultStorageClassName ?? '';
   const existingPVCs = externalData?.data.existingPVCs ?? [];
+  const hasExistingPVCs = existingPVCs.length > 0;
 
-  React.useEffect(() => {
-    if (
-      fieldValue.storageMode === NIMPVCStorageMode.NEW &&
-      !fieldValue.storageClassName &&
-      defaultStorageClassName
-    ) {
-      updateField({ storageClassName: defaultStorageClassName });
-    }
-    // Only re-run when these specific values change, not on every fieldValue object reference change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultStorageClassName, fieldValue.storageMode, fieldValue.storageClassName]);
+  if (!externalData || !externalData.loaded) {
+    return (
+      <FormGroup label="Storage and deployment option" fieldId="nim-storage-mode" isRequired>
+        <Skeleton shape="square" width="100%" height="36px" />
+      </FormGroup>
+    );
+  }
 
   const storageModeOptions: SimpleSelectOption[] = [
     {
       key: NIMPVCStorageMode.NEW,
       label: 'Deploy the NIM image from a new cluster storage',
     },
-    {
-      key: NIMPVCStorageMode.EXISTING,
-      label: 'Deploy the NIM image from an existing cluster storage',
-    },
+    ...(hasExistingPVCs
+      ? [
+          {
+            key: NIMPVCStorageMode.EXISTING,
+            label: 'Deploy the NIM image from an existing cluster storage',
+          },
+        ]
+      : []),
   ];
 
   const storageClassOptions: SimpleSelectOption[] = storageClasses.map((sc) => ({
@@ -289,7 +283,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
   }));
 
   return (
-    <FormSection title="Storage and deployment option">
+    <FormSection>
       <FormGroup label="Storage and deployment option" fieldId="nim-storage-mode" isRequired>
         <SimpleSelect
           dataTestId="nim-storage-mode-select"
@@ -312,6 +306,13 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
           isDisabled={isDisabled}
           isFullWidth
         />
+        {externalData.loadError && (
+          <HelperText>
+            <HelperTextItem variant="error">
+              There was a problem loading storage data. Please try again later.
+            </HelperTextItem>
+          </HelperText>
+        )}
       </FormGroup>
 
       {fieldValue.storageMode === NIMPVCStorageMode.NEW ? (
@@ -340,7 +341,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             isDisabled={isDisabled}
           />
 
-          <FormGroup label="Storage class" fieldId="nim-storage-class">
+          <FormGroup label="Storage class" fieldId="nim-storage-class" isRequired>
             <SimpleSelect
               dataTestId="nim-storage-class-select"
               options={storageClassOptions}

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -8,7 +8,6 @@ import {
   Skeleton,
   TextInput,
 } from '@patternfly/react-core';
-import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
 import NumberInputWrapper from '@odh-dashboard/internal/components/NumberInputWrapper';
 import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
@@ -16,7 +15,7 @@ import type { ProjectSectionType } from '@odh-dashboard/model-serving/components
 import type { WizardField } from '@odh-dashboard/model-serving/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
 import { getStorageClasses } from '@odh-dashboard/internal/api/k8s/storageClasses';
-import { PVCModel } from '@odh-dashboard/internal/api/models';
+import { getDashboardPvcs } from '@odh-dashboard/internal/api/k8s/pvcs';
 import type { PersistentVolumeClaimKind } from '@odh-dashboard/internal/k8sTypes';
 import useFetch, {
   FetchStateCallbackPromise,
@@ -78,18 +77,20 @@ type NIMPVCExternalData = {
   existingPVCs: string[];
 };
 
-const isNIMPVC = (pvcName: string): boolean => pvcName.startsWith('nim-pvc');
+export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
+
+const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
+  pvc.metadata.annotations?.[NIM_PVC_ANNOTATION] === 'true';
 
 const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
   const nimPVCs: string[] = [];
   const otherPVCs: string[] = [];
 
   for (const pvc of pvcs) {
-    const { name } = pvc.metadata;
-    if (isNIMPVC(name)) {
-      nimPVCs.push(name);
+    if (isNIMPVC(pvc)) {
+      nimPVCs.push(pvc.metadata.name);
     } else {
-      otherPVCs.push(name);
+      otherPVCs.push(pvc.metadata.name);
     }
   }
 
@@ -122,10 +123,7 @@ const useNIMPVCExternalData = (dependencies?: {
     }
     const [scList, pvcList] = await Promise.all([
       getStorageClasses(),
-      k8sListResourceItems<PersistentVolumeClaimKind>({
-        model: PVCModel,
-        queryOptions: { ns: projectName },
-      }),
+      getDashboardPvcs(projectName),
     ]);
 
     return {

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -7,14 +7,22 @@ import {
   HelperTextItem,
   TextInput,
 } from '@patternfly/react-core';
+import { k8sListResourceItems } from '@openshift/dynamic-plugin-sdk-utils';
 import SimpleSelect from '@odh-dashboard/internal/components/SimpleSelect';
 import NumberInputWrapper from '@odh-dashboard/internal/components/NumberInputWrapper';
 import type { SimpleSelectOption } from '@odh-dashboard/internal/components/SimpleSelect';
 import type { ProjectSectionType } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ProjectSection';
 import type { WizardField } from '@odh-dashboard/model-serving/types/form-data';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
+import { getStorageClasses } from '@odh-dashboard/internal/api/k8s/storageClasses';
+import { PVCModel } from '@odh-dashboard/internal/api/models';
+import type { PersistentVolumeClaimKind, StorageClassKind } from '@odh-dashboard/internal/k8sTypes';
+import { MetadataAnnotation } from '@odh-dashboard/internal/k8sTypes';
 
-export type NIMPVCStorageMode = 'new' | 'existing';
+export enum NIMPVCStorageMode {
+  NEW = 'new',
+  EXISTING = 'existing',
+}
 
 export type NIMPVCFieldValue = {
   storageMode: NIMPVCStorageMode;
@@ -32,7 +40,7 @@ const MIN_STORAGE_SIZE_GI = 1;
 
 const nimPVCFieldSchema = z
   .object({
-    storageMode: z.enum(['new', 'existing']),
+    storageMode: z.nativeEnum(NIMPVCStorageMode),
     pvcName: z.string().min(1, 'Cluster storage name is required'),
     modelPath: z.string().min(1, 'Model path is required'),
     subPath: z.string(),
@@ -40,7 +48,7 @@ const nimPVCFieldSchema = z
     storageSizeGi: z.number().min(MIN_STORAGE_SIZE_GI, 'Storage size must be at least 1 GiB'),
   })
   .superRefine((data, ctx) => {
-    if (data.storageMode === 'new' && !data.storageClassName) {
+    if (data.storageMode === NIMPVCStorageMode.NEW && !data.storageClassName) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Storage class is required for new storage',
@@ -60,7 +68,29 @@ type StorageClassOption = {
 
 type NIMPVCExternalData = {
   storageClasses: StorageClassOption[];
+  defaultStorageClassName: string;
   existingPVCs: string[];
+};
+
+const isDefaultStorageClass = (sc: StorageClassKind): boolean =>
+  sc.metadata.annotations?.[MetadataAnnotation.StorageClassIsDefault] === 'true';
+
+const isNIMPVC = (pvcName: string): boolean => pvcName.startsWith('nim-pvc');
+
+const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
+  const nimPVCs: string[] = [];
+  const otherPVCs: string[] = [];
+
+  for (const pvc of pvcs) {
+    const { name } = pvc.metadata;
+    if (isNIMPVC(name)) {
+      nimPVCs.push(name);
+    } else {
+      otherPVCs.push(name);
+    }
+  }
+
+  return [...nimPVCs, ...otherPVCs];
 };
 
 const useNIMPVCExternalData = (dependencies?: {
@@ -71,22 +101,74 @@ const useNIMPVCExternalData = (dependencies?: {
   loadError?: Error;
 } => {
   const projectName = dependencies?.project?.projectName;
-  const loaded = !!projectName;
+
+  const [storageClasses, setStorageClasses] = React.useState<StorageClassOption[]>([]);
+  const [defaultStorageClassName, setDefaultStorageClassName] = React.useState('');
+  const [existingPVCs, setExistingPVCs] = React.useState<string[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [loadError, setLoadError] = React.useState<Error>();
+
+  React.useEffect(() => {
+    if (!projectName) {
+      setLoaded(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        const [scList, pvcList] = await Promise.all([
+          getStorageClasses(),
+          k8sListResourceItems<PersistentVolumeClaimKind>({
+            model: PVCModel,
+            queryOptions: { ns: projectName },
+          }),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        const scOptions = scList.map((sc) => ({
+          name: sc.metadata.name,
+          displayName: sc.metadata.annotations?.['openshift.io/display-name'] || sc.metadata.name,
+        }));
+
+        const defaultSc = scList.find(isDefaultStorageClass);
+
+        setStorageClasses(scOptions);
+        setDefaultStorageClassName(defaultSc?.metadata.name ?? '');
+        setExistingPVCs(sortPVCsNIMFirst(pvcList));
+        setLoadError(undefined);
+        setLoaded(true);
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError(e instanceof Error ? e : new Error('Failed to load storage data'));
+          setLoaded(true);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectName]);
 
   return React.useMemo(
     () => ({
-      data: {
-        storageClasses: [{ name: 'gp3-csi', displayName: 'gp3-csi' }],
-        existingPVCs: [],
-      },
+      data: { storageClasses, defaultStorageClassName, existingPVCs },
       loaded,
+      loadError,
     }),
-    [loaded],
+    [storageClasses, defaultStorageClassName, existingPVCs, loaded, loadError],
   );
 };
 
 const getDefaultFieldValue = (): NIMPVCFieldValue => ({
-  storageMode: 'new',
+  storageMode: NIMPVCStorageMode.NEW,
   pvcName: '',
   modelPath: DEFAULT_MODEL_PATH,
   subPath: DEFAULT_SUBPATH,
@@ -100,6 +182,59 @@ type NIMPVCFieldComponentProps = {
   externalData?: { data: NIMPVCExternalData; loaded: boolean; loadError?: Error };
   isDisabled?: boolean;
 };
+
+type ModelPathFieldsProps = {
+  modelPath: string;
+  subPath: string;
+  onModelPathChange: (val: string) => void;
+  onSubPathChange: (val: string) => void;
+  isDisabled?: boolean;
+  idSuffix?: string;
+};
+
+const ModelPathFields: React.FC<ModelPathFieldsProps> = ({
+  modelPath,
+  subPath,
+  onModelPathChange,
+  onSubPathChange,
+  isDisabled,
+  idSuffix = '',
+}) => (
+  <>
+    <FormGroup label="Model path" fieldId={`nim-model-path${idSuffix}`} isRequired>
+      <TextInput
+        id={`nim-model-path${idSuffix}`}
+        data-testid={`nim-model-path${idSuffix}-input`}
+        value={modelPath}
+        onChange={(_event, val) => onModelPathChange(val)}
+        placeholder={DEFAULT_MODEL_PATH}
+        isDisabled={isDisabled}
+      />
+      <HelperText>
+        <HelperTextItem>
+          Path within the container where model files will be mounted.
+        </HelperTextItem>
+      </HelperText>
+    </FormGroup>
+
+    <FormGroup label="Subpath" fieldId={`nim-subpath${idSuffix}`}>
+      <TextInput
+        id={`nim-subpath${idSuffix}`}
+        data-testid={`nim-subpath${idSuffix}-input`}
+        value={subPath}
+        onChange={(_event, val) => onSubPathChange(val)}
+        placeholder="/"
+        isDisabled={isDisabled}
+      />
+      <HelperText>
+        <HelperTextItem>
+          Optional: Subdirectory within the PVC. Use this if you have multiple models stored in the
+          same PVC. Leave blank to use the root of the PVC.
+        </HelperTextItem>
+      </HelperText>
+    </FormGroup>
+  </>
+);
 
 const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
   value,
@@ -117,15 +252,28 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
   );
 
   const storageClasses = externalData?.data.storageClasses ?? [];
+  const defaultStorageClassName = externalData?.data.defaultStorageClassName ?? '';
   const existingPVCs = externalData?.data.existingPVCs ?? [];
+
+  React.useEffect(() => {
+    if (
+      fieldValue.storageMode === NIMPVCStorageMode.NEW &&
+      !fieldValue.storageClassName &&
+      defaultStorageClassName
+    ) {
+      updateField({ storageClassName: defaultStorageClassName });
+    }
+    // Only re-run when these specific values change, not on every fieldValue object reference change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultStorageClassName, fieldValue.storageMode, fieldValue.storageClassName]);
 
   const storageModeOptions: SimpleSelectOption[] = [
     {
-      key: 'new',
+      key: NIMPVCStorageMode.NEW,
       label: 'Deploy the NIM image from a new cluster storage',
     },
     {
-      key: 'existing',
+      key: NIMPVCStorageMode.EXISTING,
       label: 'Deploy the NIM image from an existing cluster storage',
     },
   ];
@@ -148,11 +296,17 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
           options={storageModeOptions}
           value={fieldValue.storageMode}
           onChange={(val) => {
-            const mode: NIMPVCStorageMode = val === 'existing' ? 'existing' : 'new';
+            const mode =
+              val === NIMPVCStorageMode.EXISTING
+                ? NIMPVCStorageMode.EXISTING
+                : NIMPVCStorageMode.NEW;
             updateField({
               storageMode: mode,
               pvcName: '',
-              storageClassName: mode === 'new' ? storageClasses[0]?.name ?? '' : '',
+              storageClassName:
+                mode === NIMPVCStorageMode.NEW
+                  ? defaultStorageClassName || storageClasses[0]?.name || ''
+                  : '',
             });
           }}
           isDisabled={isDisabled}
@@ -160,7 +314,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
         />
       </FormGroup>
 
-      {fieldValue.storageMode === 'new' ? (
+      {fieldValue.storageMode === NIMPVCStorageMode.NEW ? (
         <>
           <FormGroup label="Cluster storage name" fieldId="nim-pvc-name" isRequired>
             <TextInput
@@ -178,38 +332,13 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             </HelperText>
           </FormGroup>
 
-          <FormGroup label="Model path" fieldId="nim-model-path" isRequired>
-            <TextInput
-              id="nim-model-path"
-              data-testid="nim-model-path-input"
-              value={fieldValue.modelPath}
-              onChange={(_event, val) => updateField({ modelPath: val })}
-              placeholder={DEFAULT_MODEL_PATH}
-              isDisabled={isDisabled}
-            />
-            <HelperText>
-              <HelperTextItem>
-                Path within the container where model files will be mounted.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
-
-          <FormGroup label="Subpath" fieldId="nim-subpath">
-            <TextInput
-              id="nim-subpath"
-              data-testid="nim-subpath-input"
-              value={fieldValue.subPath}
-              onChange={(_event, val) => updateField({ subPath: val })}
-              placeholder="/"
-              isDisabled={isDisabled}
-            />
-            <HelperText>
-              <HelperTextItem>
-                Optional: Subdirectory within the PVC. Use this if you have multiple models stored
-                in the same PVC. Leave blank to use the root of the PVC.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
+          <ModelPathFields
+            modelPath={fieldValue.modelPath}
+            subPath={fieldValue.subPath}
+            onModelPathChange={(val) => updateField({ modelPath: val })}
+            onSubPathChange={(val) => updateField({ subPath: val })}
+            isDisabled={isDisabled}
+          />
 
           <FormGroup label="Storage class" fieldId="nim-storage-class">
             <SimpleSelect
@@ -259,38 +388,14 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             />
           </FormGroup>
 
-          <FormGroup label="Model path" fieldId="nim-model-path-existing" isRequired>
-            <TextInput
-              id="nim-model-path-existing"
-              data-testid="nim-model-path-existing-input"
-              value={fieldValue.modelPath}
-              onChange={(_event, val) => updateField({ modelPath: val })}
-              placeholder={DEFAULT_MODEL_PATH}
-              isDisabled={isDisabled}
-            />
-            <HelperText>
-              <HelperTextItem>
-                Path within the container where model files will be mounted.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
-
-          <FormGroup label="Subpath" fieldId="nim-subpath-existing">
-            <TextInput
-              id="nim-subpath-existing"
-              data-testid="nim-subpath-existing-input"
-              value={fieldValue.subPath}
-              onChange={(_event, val) => updateField({ subPath: val })}
-              placeholder="/"
-              isDisabled={isDisabled}
-            />
-            <HelperText>
-              <HelperTextItem>
-                Optional: Subdirectory within the PVC. Use this if you have multiple models stored
-                in the same PVC. Leave blank to use the root of the PVC.
-              </HelperTextItem>
-            </HelperText>
-          </FormGroup>
+          <ModelPathFields
+            modelPath={fieldValue.modelPath}
+            subPath={fieldValue.subPath}
+            onModelPathChange={(val) => updateField({ modelPath: val })}
+            onSubPathChange={(val) => updateField({ subPath: val })}
+            isDisabled={isDisabled}
+            idSuffix="-existing"
+          />
         </>
       )}
     </FormSection>
@@ -307,8 +412,14 @@ export const NIMPVCFieldWizardField: NIMPVCFieldType = {
     wizardFormData.modelLocationData?.data?.type === NIMModelLocationKey,
   reducerFunctions: {
     setFieldData: (value: NIMPVCFieldValue) => value,
-    getInitialFieldData: (existingFieldData?: NIMPVCFieldValue): NIMPVCFieldValue =>
-      existingFieldData ?? getDefaultFieldValue(),
+    getInitialFieldData: (
+      existingFieldData?: NIMPVCFieldValue,
+      externalData?: NIMPVCExternalData,
+    ): NIMPVCFieldValue =>
+      existingFieldData ?? {
+        ...getDefaultFieldValue(),
+        storageClassName: externalData?.defaultStorageClassName ?? '',
+      },
     validationSchema: nimPVCFieldSchema,
     resolveDependencies: (formData) => ({ project: formData.project }),
   },
@@ -321,7 +432,8 @@ export const NIMPVCFieldWizardField: NIMPVCFieldType = {
         {
           key: 'storageMode',
           label: 'Storage mode',
-          value: () => (value.storageMode === 'new' ? 'New storage' : 'Existing storage'),
+          value: () =>
+            value.storageMode === NIMPVCStorageMode.NEW ? 'New storage' : 'Existing storage',
         },
         {
           key: 'pvcName',
@@ -344,13 +456,13 @@ export const NIMPVCFieldWizardField: NIMPVCFieldType = {
           key: 'storageClass',
           label: 'Storage class',
           value: () => value.storageClassName || '-',
-          isVisible: () => value.storageMode === 'new',
+          isVisible: () => value.storageMode === NIMPVCStorageMode.NEW,
         },
         {
           key: 'storageSize',
           label: 'Storage size',
           value: () => `${value.storageSizeGi} GiB`,
-          isVisible: () => value.storageMode === 'new',
+          isVisible: () => value.storageMode === NIMPVCStorageMode.NEW,
         },
       ],
     },


### PR DESCRIPTION
<!--- Reference related issues; see example below -->

https://issues.redhat.com/browse/RHOAIENG-60279

## Description

Adds a PVC caching storage wizard field to the NIM deployment wizard. Every NIM deployment requires a PVC to store the NIM container image, and this field allows users to configure that storage during deployment.

The field (`nim-serving/pvcStorage`) appears on the **Model deployment** step when the user selects NVIDIA NIM as the model location type. It supports two modes:

- **New cluster storage** — user provides a PVC name, model path, subpath, storage class, and storage size (GiB). The PVC will be created at deploy time to cache the NIM image.
- **Existing cluster storage** — user selects an existing PVC from a dropdown, with model path and subpath fields.

## How Has This Been Tested?

- `tsc --noEmit` passes on `nim-serving` and full `frontend`
- `eslint` passes with 0 errors on all changed files
- 62/62 unit tests pass in nim-serving
- Manually verified the field appears in the NIM deployment wizard on the Model deployment step when NVIDIA NIM is selected as model location
-
<img width="1626" height="836" alt="Screenshot 2026-05-28 at 2 54 42 PM" src="https://github.com/user-attachments/assets/95a21d41-e13f-4488-b694-0acc83cefe22" />
<img width="1873" height="905" alt="Screenshot 2026-05-28 at 2 57 20 PM" src="https://github.com/user-attachments/assets/d1414835-6079-40a8-bc98-17afce35088c" />


## Test Impact

No unit tests added for the PVC field component in this PR. The component follows the same pattern as `NIMImageField` which has existing tests. Unit tests for the PVC field will be added in a follow-up alongside the `wizard-field-apply` implementation when the field data flows into deployment assembly.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PVC storage configuration to the NIM deployment wizard with options to create new storage or select existing PVCs, storage class selection, size settings, and model path/subpath controls.
  * Introduced reusable wizard field extensions for NIM fields to enable consistent behavior across the wizard.

* **Refactor**
  * Deployment wizard now renders dynamic extension fields alongside standard fields for the model deployment step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->