### PR TITLE
refactor: replace imperative navigate() with declarative <Link> for a…

### DIFF
--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -8,6 +8,7 @@ import {
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { HomeIcon, PathMissingIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 
 const NotFound: React.FC = () => (
   <PageSection hasBodyWrapper={false}>
@@ -25,8 +26,7 @@ const NotFound: React.FC = () => (
         <Button
           icon={<HomeIcon />}
           data-testid="home-page-button"
-          component="a"
-          href="/"
+          component={(props) => <Link {...props} to="/" />}
           variant="primary"
         >
           Home

--- a/frontend/src/pages/UnauthorizedError.tsx
+++ b/frontend/src/pages/UnauthorizedError.tsx
@@ -10,6 +10,7 @@ import {
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 import { ODH_PRODUCT_NAME } from '#~/utilities/const';
 
 type UnauthorizedErrorProps = {
@@ -33,7 +34,7 @@ const UnauthorizedError: React.FC<UnauthorizedErrorProps> = ({
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
-          <Button component="a" href="/" variant="primary">
+          <Button component={(props) => <Link {...props} to="/" />} variant="primary">
             Return to Home
           </Button>
         </EmptyStateActions>

--- a/frontend/src/pages/home/resources/useResourcesSection.tsx
+++ b/frontend/src/pages/home/resources/useResourcesSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   Button,
   EmptyState,
@@ -26,7 +26,6 @@ const includedCards = [
 ];
 
 export const useResourcesSection = (): React.ReactNode => {
-  const navigate = useNavigate();
   const { docs, loaded, loadError } = useSpecifiedResources(includedCards);
   const [resourcesOpen, setResourcesOpen] = useBrowserStorage<boolean>(
     'odh.home.learning-resources.open',
@@ -78,10 +77,9 @@ export const useResourcesSection = (): React.ReactNode => {
           <StackItem>
             <Button
               data-testid="goto-learning-resources-link"
-              // Should not use component="a" due to no href
               isInline
               variant="link"
-              onClick={() => navigate('/learning-resources')}
+              component={(props) => <Link {...props} to="/learning-resources" />}
             >
               Go to <b>Learning resources</b>
             </Button>

--- a/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationPage.tsx
+++ b/frontend/src/pages/modelServing/screens/metrics/bias/BiasConfigurationPage/BiasConfigurationPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Breadcrumb, Button, EmptyStateVariant, PageSection } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { BreadcrumbItemType } from '#~/types';
 import { useModelBiasData } from '#~/concepts/trustyai/context/useModelBiasData';
@@ -23,7 +23,6 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
   inferenceService,
 }) => {
   const { biasMetricConfigs, statusState, refresh } = useModelBiasData();
-  const navigate = useNavigate();
   const firstRender = React.useRef(true);
   const [isOpen, setOpen] = React.useState(false);
 
@@ -46,7 +45,11 @@ const BiasConfigurationPage: React.FC<BiasConfigurationPageProps> = ({
         description="Manage the configuration of model bias metrics."
         breadcrumb={<Breadcrumb>{getBreadcrumbItemComponents(breadcrumbItems)}</Breadcrumb>}
         headerAction={
-          <Button onClick={() => navigate(`../${MetricsTabKeys.BIAS}`, { relative: 'path' })}>
+          <Button
+            component={(props) => (
+              <Link {...props} to={`../${MetricsTabKeys.BIAS}`} relative="path" />
+            )}
+          >
             {biasMetricConfigs.length === 0
               ? `Back to ${getDisplayNameFromK8sResource(inferenceService)}`
               : 'View metrics'}

--- a/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
+++ b/frontend/src/pages/projects/screens/projects/LaunchJupyterButton.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useCheckJupyterEnabled } from '#~/utilities/notebookControllerUtils';
 import { useIsAreaAvailable, SupportedArea } from '#~/concepts/areas';
 
 const LaunchJupyterButton: React.FC = () => {
-  const navigate = useNavigate();
   const isJupyterEnabled = useCheckJupyterEnabled();
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
 
@@ -20,13 +19,8 @@ const LaunchJupyterButton: React.FC = () => {
     >
       <Button
         data-testid="launch-standalone-notebook-server"
-        href="/notebook-controller"
-        component="a"
+        component={(props) => <Link {...props} to="/notebook-controller" />}
         variant={ButtonVariant.secondary}
-        onClick={(e) => {
-          e.preventDefault();
-          navigate('/notebook-controller');
-        }}
       >
         Start basic workbench
       </Button>

--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
@@ -102,8 +102,8 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
         currentState === 'completed'
           ? 'completed'
           : currentState === 'cancelled' || currentState === 'stopped'
-          ? 'cancelled'
-          : 'failed';
+            ? 'cancelled'
+            : 'failed';
 
       fireMiscTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_COMPLETED, {
         evaluationName: evalName,

--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTableRow.tsx
@@ -9,7 +9,7 @@ import {
   ModalHeader,
   Tooltip,
 } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { EvaluationJob, EvaluationJobState } from '~/app/types';
 import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
@@ -44,7 +44,6 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
   collectionNameMap,
   onActionComplete,
 }) => {
-  const navigate = useNavigate();
   const [confirmAction, setConfirmAction] = React.useState<ConfirmAction>(null);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isStopping, setIsStopping] = React.useState(false);
@@ -103,8 +102,8 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
         currentState === 'completed'
           ? 'completed'
           : currentState === 'cancelled' || currentState === 'stopped'
-            ? 'cancelled'
-            : 'failed';
+          ? 'cancelled'
+          : 'failed';
 
       fireMiscTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_COMPLETED, {
         evaluationName: evalName,
@@ -180,7 +179,7 @@ const EvaluationsTableRow: React.FC<EvaluationsTableRowProps> = ({
               variant="link"
               isInline
               data-testid={`evaluation-link-${rowIndex}`}
-              onClick={() => navigate(`results/${job.resource.id}`)}
+              component={(props) => <Link {...props} to={`results/${job.resource.id}`} />}
             >
               {evaluationName}
             </Button>

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -27,7 +27,7 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import {
   MlflowExperimentSelector,
@@ -53,7 +53,6 @@ import './StartEvaluationRunPage.css';
 
 const StartEvaluationRunPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
-  const navigate = useNavigate();
 
   const { benchmark, collection, isCollectionFlow, dataLoaded, loadError } =
     useEvaluationSelection(namespace);

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -95,7 +95,10 @@ const StartEvaluationRunPage: React.FC = () => {
           <EmptyStateBody>{loadError.message}</EmptyStateBody>
           <EmptyStateFooter>
             <EmptyStateActions>
-              <Button variant="primary" onClick={() => navigate(evaluationsBaseRoute(namespace))}>
+              <Button
+                variant="primary"
+                component={(props) => <Link {...props} to={evaluationsBaseRoute(namespace)} />}
+              >
                 Return to evaluations
               </Button>
             </EmptyStateActions>

--- a/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
@@ -1,30 +1,26 @@
 import * as React from 'react';
 import EmptyDetailsView from '@odh-dashboard/internal/components/EmptyDetailsView';
 import { Button } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 
-const EmptyAuthPoliciesPage: React.FC = () => {
-  const navigate = useNavigate();
-
-  return (
-    <>
-      <EmptyDetailsView
-        title="No Policies"
-        description="To get started, create a policy."
-        imageAlt="create a policy"
-        createButton={
-          <Button
-            variant="primary"
-            onClick={() => navigate(`${URL_PREFIX}/auth-policies/create`)}
-            data-testid="create-auth-policy-button"
-          >
-            Create authorization policy
-          </Button>
-        }
-      />
-    </>
-  );
-};
+const EmptyAuthPoliciesPage: React.FC = () => (
+  <>
+    <EmptyDetailsView
+      title="No Policies"
+      description="To get started, create a policy."
+      imageAlt="create a policy"
+      createButton={
+        <Button
+          variant="primary"
+          component={(props) => <Link {...props} to={`${URL_PREFIX}/auth-policies/create`} />}
+          data-testid="create-auth-policy-button"
+        >
+          Create authorization policy
+        </Button>
+      }
+    />
+  </>
+);
 
 export default EmptyAuthPoliciesPage;

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, SearchInput, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import FilterToolbar from '@odh-dashboard/internal/components/FilterToolbar';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 import {
   AuthPoliciesFilterDataType,
@@ -20,40 +20,37 @@ type AuthPoliciesToolbarProps = {
 const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
   filterData,
   onFilterUpdate,
-}) => {
-  const navigate = useNavigate();
-  return (
-    <FilterToolbar<AuthPoliciesFilterOptions>
-      data-testid="auth-policies-table-toolbar"
-      filterOptions={authPoliciesFilterOptions}
-      filterOptionRenders={{
-        [AuthPoliciesFilterOptions.keyword]: ({ onChange, ...props }) => (
-          <SearchInput
-            {...props}
-            aria-label="Filter by keyword"
-            placeholder="Filter by name or description"
-            onChange={(_event, value) => onChange(value)}
-            data-testid="auth-policies-filter-name-input"
-            style={{ width: '30ch' }}
-          />
-        ),
-      }}
-      filterData={filterData}
-      onFilterUpdate={onFilterUpdate}
-    >
-      <ToolbarGroup>
-        <ToolbarItem>
-          <Button
-            variant="primary"
-            onClick={() => navigate(`${URL_PREFIX}/auth-policies/create`)}
-            data-testid="create-auth-policy-button"
-          >
-            Create authorization policy
-          </Button>
-        </ToolbarItem>
-      </ToolbarGroup>
-    </FilterToolbar>
-  );
-};
+}) => (
+  <FilterToolbar<AuthPoliciesFilterOptions>
+    data-testid="auth-policies-table-toolbar"
+    filterOptions={authPoliciesFilterOptions}
+    filterOptionRenders={{
+      [AuthPoliciesFilterOptions.keyword]: ({ onChange, ...props }) => (
+        <SearchInput
+          {...props}
+          aria-label="Filter by keyword"
+          placeholder="Filter by name or description"
+          onChange={(_event, value) => onChange(value)}
+          data-testid="auth-policies-filter-name-input"
+          style={{ width: '30ch' }}
+        />
+      ),
+    }}
+    filterData={filterData}
+    onFilterUpdate={onFilterUpdate}
+  >
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Button
+          variant="primary"
+          component={(props) => <Link {...props} to={`${URL_PREFIX}/auth-policies/create`} />}
+          data-testid="create-auth-policy-button"
+        >
+          Create authorization policy
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+  </FilterToolbar>
+);
 
 export default AuthPoliciesToolbar;

--- a/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
@@ -1,30 +1,26 @@
 import * as React from 'react';
 import EmptyDetailsView from '@odh-dashboard/internal/components/EmptyDetailsView';
 import { Button } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 
-const EmptySubscriptionsPage: React.FC = () => {
-  const navigate = useNavigate();
-
-  return (
-    <>
-      <EmptyDetailsView
-        title="No Subscriptions"
-        description="To get started, create a subscription."
-        imageAlt="create a subscription"
-        createButton={
-          <Button
-            variant="primary"
-            onClick={() => navigate(`${URL_PREFIX}/subscriptions/create`)}
-            data-testid="create-subscription-button"
-          >
-            Create subscription
-          </Button>
-        }
-      />
-    </>
-  );
-};
+const EmptySubscriptionsPage: React.FC = () => (
+  <>
+    <EmptyDetailsView
+      title="No Subscriptions"
+      description="To get started, create a subscription."
+      imageAlt="create a subscription"
+      createButton={
+        <Button
+          variant="primary"
+          component={(props) => <Link {...props} to={`${URL_PREFIX}/subscriptions/create`} />}
+          data-testid="create-subscription-button"
+        >
+          Create subscription
+        </Button>
+      }
+    />
+  </>
+);
 
 export default EmptySubscriptionsPage;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-39209

## Description

Replaces imperative `navigate()` calls with declarative `<Link>` components for user-initiated navigation, improving accessibility (right-click, Cmd+click, screen reader support). Also replaces `component="a" href` patterns with `<Link>` to enable client-side navigation instead of full page reloads.

**Changes by category:**

**`navigate()` → `<Link>` (7 files):**
- `useResourcesSection.tsx` — "Go to Learning resources" button
- `BiasConfigurationPage.tsx` — "View metrics" / "Back to..." button (with `relative="path"`)
- `EmptySubscriptionsPage.tsx` (maas) — "Create subscription" button
- `AuthPoliciesToolbar.tsx` (maas) — "Create authorization policy" button
- `EmptyAuthPoliciesPage.tsx` (maas) — "Create authorization policy" button
- `StartEvaluationRunPage.tsx` (eval-hub) — "Return to evaluations" error state button
- `EvaluationsTableRow.tsx` (eval-hub) — evaluation name link in table

**`component="a" href` → `<Link>` (3 files):**
- `NotFound.tsx` — "Home" button (was causing full page reload)
- `UnauthorizedError.tsx` — "Return to Home" button (was causing full page reload)
- `LaunchJupyterButton.tsx` — "Start basic workbench" button (was using `component="a"` + `preventDefault` + `navigate()`, replaced with clean `<Link>`)

Cancel buttons, disabled-capable buttons, and upstream-synced packages were intentionally left unchanged per review guidance from PR #6309.

## How Has This Been Tested?

- TypeScript type-checking passes (`tsc --noEmit`) for frontend, maas, and eval-hub
- ESLint and Prettier pass on all changed files
- lint-staged pre-commit hook passed

## Test Impact

No new tests added. These are mechanical refactors that change the rendered HTML element (`<button>` → `<a>`) but preserve the same navigation behavior. Existing Cypress and unit tests that use `data-testid` selectors remain valid since no test IDs were changed.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized navigation across the app: evaluation rows, start-run page, Not Found and Unauthorized pages, resources section, bias metrics header, Jupyter launch, auth policies, and subscriptions now use consistent in-app link-based navigation for client-side routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->