### PR TITLE
feat(nim-serving): force model type to NVIDIA NIM when NIM location is selected

### DIFF
--- a/packages/model-serving/src/__tests__/mockUtils.ts
+++ b/packages/model-serving/src/__tests__/mockUtils.ts
@@ -140,7 +140,7 @@ export const mockDeploymentWizardState = (
         modelType: {
           data: { type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false },
           setData: jest.fn(),
-          externalData: { data: { extraOptions: [] as SimpleSelectOption[] } },
+          externalData: { data: { extraOptions: [] as SimpleSelectOption[], forced: false } },
         },
         modelLocationData: {
           data: undefined,

--- a/packages/model-serving/src/components/deploymentWizard/__tests__/dynamicFormUtils.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/__tests__/dynamicFormUtils.spec.ts
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react';
+import type { LoadedExtension, Extension } from '@openshift/dynamic-plugin-sdk';
+import { mockExtensions } from '../../../__tests__/mockUtils';
+import { useWizardFieldOverrides } from '../dynamicFormUtils';
+import type { ModelTypeFieldOverride, DeploymentWizardFieldOverride } from '../types';
+import { isModelTypeFieldOverride } from '../types';
+
+jest.mock('@odh-dashboard/plugin-core');
+
+const makeOverrideExtension = (
+  uid: string,
+  field: DeploymentWizardFieldOverride,
+): LoadedExtension<Extension> =>
+  ({
+    uid,
+    type: 'model-serving.deployment/wizard-field-override',
+    pluginID: '',
+    pluginName: '',
+    properties: { field },
+  } as unknown as LoadedExtension<Extension>);
+
+const makeModelTypeOverride = (
+  uid: string,
+  key: string,
+  { forced, isActive = true }: { forced?: boolean; isActive?: boolean } = {},
+): LoadedExtension<Extension> =>
+  makeOverrideExtension(uid, {
+    id: 'modelType',
+    type: 'modifier',
+    isActive: () => isActive,
+    extraOption: { key, label: key },
+    ...(forced !== undefined ? { forced } : {}),
+  } as ModelTypeFieldOverride);
+
+describe('useWizardFieldOverrides', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty array when no extensions are registered', () => {
+    mockExtensions([]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return active overrides filtered by predicate', () => {
+    mockExtensions([makeModelTypeOverride('uid-a', 'Option A')]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].extraOption.key).toBe('Option A');
+  });
+
+  it('should exclude inactive overrides', () => {
+    mockExtensions([makeModelTypeOverride('uid-a', 'Option A', { isActive: false })]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toEqual([]);
+  });
+
+  it('should sort overrides deterministically by uid', () => {
+    mockExtensions([
+      makeModelTypeOverride('uid-c', 'Option C'),
+      makeModelTypeOverride('uid-a', 'Option A'),
+      makeModelTypeOverride('uid-b', 'Option B'),
+    ]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current.map((o) => o.extraOption.key)).toEqual([
+      'Option A',
+      'Option B',
+      'Option C',
+    ]);
+  });
+
+  it('should return only the forced override when one is present', () => {
+    mockExtensions([
+      makeModelTypeOverride('uid-a', 'Option A'),
+      makeModelTypeOverride('uid-b', 'NVIDIA NIM', { forced: true }),
+    ]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].extraOption.key).toBe('NVIDIA NIM');
+    expect(result.current[0].forced).toBe(true);
+  });
+
+  it('should log error and return first forced override when multiple are forced', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockExtensions([
+      makeModelTypeOverride('uid-b', 'Forced B', { forced: true }),
+      makeModelTypeOverride('uid-a', 'Forced A', { forced: true }),
+    ]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].extraOption.key).toBe('Forced A');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Multiple forced overrides detected'),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('should return all overrides when none are forced', () => {
+    mockExtensions([
+      makeModelTypeOverride('uid-a', 'Option A'),
+      makeModelTypeOverride('uid-b', 'Option B'),
+    ]);
+    const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
+    expect(result.current).toHaveLength(2);
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/__tests__/dynamicFormUtils.spec.ts
+++ b/packages/model-serving/src/components/deploymentWizard/__tests__/dynamicFormUtils.spec.ts
@@ -37,6 +37,10 @@ describe('useWizardFieldOverrides', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should return empty array when no extensions are registered', () => {
     mockExtensions([]);
     const { result } = renderHook(() => useWizardFieldOverrides(isModelTypeFieldOverride, {}));
@@ -93,7 +97,6 @@ describe('useWizardFieldOverrides', () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Multiple forced overrides detected'),
     );
-    consoleSpy.mockRestore();
   });
 
   it('should return all overrides when none are forced', () => {

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -15,10 +15,10 @@ export const useWizardFieldOverrides = <T extends DeploymentWizardFieldOverride>
 
   return React.useMemo(() => {
     const active = extensions
+      .filter((ext) => ext.properties.field.isActive(formData))
       .toSorted((a, b) => a.uid.localeCompare(b.uid))
       .map((ext) => ext.properties.field)
-      .filter(predicate)
-      .filter((field) => field.isActive(formData));
+      .filter(predicate);
 
     const forced = active.filter((field) => 'forced' in field && field.forced);
     if (forced.length > 1) {

--- a/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/dynamicFormUtils.ts
@@ -14,8 +14,23 @@ export const useWizardFieldOverrides = <T extends DeploymentWizardFieldOverride>
   const [extensions] = useResolvedExtensions(isDeploymentWizardFieldOverrideExtension);
 
   return React.useMemo(() => {
-    const all = extensions.map((ext) => ext.properties.field);
-    return all.filter(predicate).filter((field) => field.isActive(formData));
+    const active = extensions
+      .toSorted((a, b) => a.uid.localeCompare(b.uid))
+      .map((ext) => ext.properties.field)
+      .filter(predicate)
+      .filter((field) => field.isActive(formData));
+
+    const forced = active.filter((field) => 'forced' in field && field.forced);
+    if (forced.length > 1) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Multiple forced overrides detected for field "${forced[0].id}" (${forced.length} found). Using the first match.`,
+      );
+    }
+    if (forced.length > 0) {
+      return [forced[0]];
+    }
+    return active;
   }, [extensions, predicate, formData]);
 };
 

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -53,9 +53,11 @@ export const useModelTypeField = (
   );
 
   const forcedOverride = modelTypeOverrides.find((o) => o.forced);
-  const modelType = forcedOverride
-    ? { type: forcedOverride.extraOption.key, legacyVLLM: false }
-    : modelTypeState;
+  const modelType = React.useMemo(
+    () =>
+      forcedOverride ? { type: forcedOverride.extraOption.key, legacyVLLM: false } : modelTypeState,
+    [forcedOverride, modelTypeState],
+  );
 
   return React.useMemo(
     () => ({

--- a/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/ModelTypeSelectField.tsx
@@ -30,6 +30,7 @@ export type ModelTypeField = {
   externalData: {
     data: {
       extraOptions: ModelTypeFieldOverride['extraOption'][];
+      forced: boolean;
     };
   };
 };
@@ -47,19 +48,27 @@ export const useModelTypeField = (
   );
   const modelTypeOverrides = useWizardFieldOverrides(isModelTypeFieldOverride, overrideFormData);
 
-  const [modelType, setModelType] = React.useState<ModelTypeFieldData | undefined>(existingData);
+  const [modelTypeState, setModelTypeState] = React.useState<ModelTypeFieldData | undefined>(
+    existingData,
+  );
+
+  const forcedOverride = modelTypeOverrides.find((o) => o.forced);
+  const modelType = forcedOverride
+    ? { type: forcedOverride.extraOption.key, legacyVLLM: false }
+    : modelTypeState;
 
   return React.useMemo(
     () => ({
       data: modelType,
-      setData: setModelType,
+      setData: setModelTypeState,
       externalData: {
         data: {
           extraOptions: modelTypeOverrides.map((override) => override.extraOption),
+          forced: !!forcedOverride,
         },
       },
     }),
-    [modelType, setModelType, modelTypeOverrides],
+    [modelType, setModelTypeState, modelTypeOverrides, forcedOverride],
   );
 };
 
@@ -115,7 +124,7 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
           value={modelType?.type}
           toggleProps={{ style: { minWidth: '300px' } }}
           dataTestId="model-type-select"
-          isDisabled={isEditing || isDisabled}
+          isDisabled={isEditing || isDisabled || externalData.data.forced}
         />
         <ZodErrorHelperText zodIssue={validationIssues} />
       </FormGroup>
@@ -127,7 +136,7 @@ export const ModelTypeSelectField: React.FC<ModelTypeSelectFieldProps> = ({
           description="Deploy this model using a serving runtime and inference server. This deployment method does not support MaaS."
           isChecked={modelType.legacyVLLM}
           onChange={(_e, checked) => setModelType?.({ ...modelType, legacyVLLM: checked })}
-          isDisabled={isEditing || isDisabled}
+          isDisabled={isEditing || isDisabled || externalData.data.forced}
         />
       )}
     </>

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -119,7 +119,7 @@ describe('ModelTypeSelectField', () => {
     });
 
     it('should render with default props', () => {
-      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [] } }} />);
+      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [], forced: false } }} />);
       expect(screen.getByRole('button')).toBeInTheDocument();
       expect(screen.getByText('Select model type')).toBeInTheDocument();
     });
@@ -128,7 +128,7 @@ describe('ModelTypeSelectField', () => {
       render(
         <ModelTypeSelectField
           modelType={{ type: ServingRuntimeModelType.PREDICTIVE, legacyVLLM: false }}
-          externalData={{ data: { extraOptions: [] } }}
+          externalData={{ data: { extraOptions: [], forced: false } }}
         />,
       );
       expect(screen.getByText(ModelTypeLabel.PREDICTIVE)).toBeInTheDocument();
@@ -138,7 +138,7 @@ describe('ModelTypeSelectField', () => {
       render(
         <ModelTypeSelectField
           setModelType={mockSetModelType}
-          externalData={{ data: { extraOptions: [] } }}
+          externalData={{ data: { extraOptions: [], forced: false } }}
         />,
       );
       const button = screen.getByRole('button');
@@ -168,14 +168,14 @@ describe('ModelTypeSelectField', () => {
       render(
         <ModelTypeSelectField
           validationIssues={validationIssues}
-          externalData={{ data: { extraOptions: [] } }}
+          externalData={{ data: { extraOptions: [], forced: false } }}
         />,
       );
       expect(screen.getByText('Select a model type.')).toBeInTheDocument();
     });
 
     it('should render both model type options', async () => {
-      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [] } }} />);
+      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [], forced: false } }} />);
       const button = screen.getByRole('button');
 
       await act(async () => {
@@ -190,7 +190,7 @@ describe('ModelTypeSelectField', () => {
       render(
         <ModelTypeSelectField
           externalData={{
-            data: { extraOptions: [{ key: 'extra-option', label: 'Extra Option' }] },
+            data: { extraOptions: [{ key: 'extra-option', label: 'Extra Option' }], forced: false },
           }}
         />,
       );

--- a/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/fields/__tests__/ModelTypeSelectField.test.tsx
@@ -201,5 +201,21 @@ describe('ModelTypeSelectField', () => {
       });
       expect(screen.getByText('Extra Option')).toBeInTheDocument();
     });
+
+    it('should disable model type select when forced', () => {
+      render(<ModelTypeSelectField externalData={{ data: { extraOptions: [], forced: true } }} />);
+      expect(screen.getByRole('button', { name: 'Options menu' })).toHaveClass('pf-m-disabled');
+    });
+
+    it('should disable legacy checkbox when forced', () => {
+      mockUseIsAreaAvailable.mockReturnValue(mockAreaAvailabilityStatus(true));
+      render(
+        <ModelTypeSelectField
+          modelType={{ type: ServingRuntimeModelType.GENERATIVE, legacyVLLM: false }}
+          externalData={{ data: { extraOptions: [], forced: true } }}
+        />,
+      );
+      expect(screen.getByTestId('legacy-mode-checkbox')).toBeDisabled();
+    });
   });
 });

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -318,6 +318,7 @@ export const resolveFieldValue = (
 
 export type ModelTypeFieldOverride = DeploymentWizardFieldBase<'modelType'> & {
   extraOption: SimpleSelectOption;
+  forced?: boolean;
 };
 export type ModelServerTemplateFieldOverride = DeploymentWizardFieldBase<'modelServerTemplate'> & {
   extraOptions?: ModelServerOption[];

--- a/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
+++ b/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
@@ -16,4 +16,5 @@ export const NIMModelTypeOverride: ModelTypeFieldOverride = {
     key: 'NVIDIA NIM',
     label: 'NVIDIA NIM',
   },
+  forced: true,
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62857

## Description

When a user selects "NVIDIA NIM" as the model location in the deployment wizard, the model type field is now automatically set to "NVIDIA NIM" and disabled so it cannot be changed.

This is achieved by adding an optional `forced` boolean to `ModelTypeFieldOverride`. When `forced: true`, the override's `extraOption` is automatically selected and the field becomes read-only. When the user switches to a non-NIM location, the field reverts to its normal editable state.

Additionally, `useWizardFieldOverrides` now sorts extensions deterministically by uid and enforces single-forced-override semantics: if any active override has `forced: true`, only that override is returned (with a console error if multiple forced overrides are detected).

### Changes
- **`ModelTypeFieldOverride` type** (`types.ts`): Added optional `forced?: boolean` property
- **`NIMModelTypeOverride`** (`NIMModelTypeOverride.ts`): Set `forced: true`
- **`useWizardFieldOverrides`** (`dynamicFormUtils.ts`): Sort extensions by uid for deterministic ordering; when a forced override is active, return only that one and log error if multiple forced overrides exist
- **`useModelTypeField` hook** (`ModelTypeSelectField.tsx`): Derives effective model type from forced override during render (via `useMemo`); passes `forced` state through `externalData`
- **`ModelTypeSelectField` component**: Disables the dropdown and legacy checkbox when `forced` is true

## How Has This Been Tested?

- Manually tested in the deployment wizard with the `nimWizard` feature flag enabled
- Verified model type auto-selects "NVIDIA NIM" and becomes disabled when NIM location is selected
- Verified model type reverts to editable with no selection when switching to a non-NIM location (S3)
- Verified the forced value flows correctly through the submission pipeline (`wizardData.modelType.data?.type`)

## Test Impact

- Added `dynamicFormUtils.spec.ts` with 7 tests covering: deterministic uid sorting, single forced override returns only that one, multiple forced overrides logs error and returns first, no forced overrides returns all, inactive overrides excluded, empty extensions
- Added 2 tests to `ModelTypeSelectField.test.tsx` verifying the forced override disables the select and the legacy checkbox
- Updated existing test mock data to include the new `forced` field
- All 209 model-serving unit tests pass

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model type selections can be marked as forced; when forced the selection controls are disabled so they cannot be changed by users.

* **Bug Fixes**
  * Ensures only one forced override applies per field to avoid conflicts; when multiple forced overrides exist the system deterministically picks one and logs the conflict for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->