### PR TITLE
Feat:Removed Service account usage from feature store resource and workbench integration

### DIFF
--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -171,7 +171,7 @@ describe('featureStoreUtils', () => {
   });
 
   describe('getServiceFromCRD', () => {
-    it('should derive service name and namespace from CRD', () => {
+    it('should derive service name, namespace, and default to https/443 when TLS is not configured', () => {
       const crd = createFeatureStoreCRD();
 
       const result = getServiceFromCRD(crd);
@@ -179,10 +179,12 @@ describe('featureStoreUtils', () => {
       expect(result).toEqual({
         serviceName: SERVICE_NAME.BANKING_REST,
         namespace: NAMESPACE.VIEWER,
+        protocol: PROTOCOL.HTTPS,
+        port: PORT.HTTPS_DEFAULT,
       });
     });
 
-    it('should handle CRD names with hyphens', () => {
+    it('should handle CRD names with hyphens and default to https/443', () => {
       const crd = createFeatureStoreCRD({
         metadata: { name: 'my-complex-name', namespace: NAMESPACE.DEFAULT },
       });
@@ -192,10 +194,12 @@ describe('featureStoreUtils', () => {
       expect(result).toEqual({
         serviceName: 'feast-my-complex-name-registry-rest',
         namespace: NAMESPACE.DEFAULT,
+        protocol: PROTOCOL.HTTPS,
+        port: PORT.HTTPS_DEFAULT,
       });
     });
 
-    it('should handle CRD names with underscores', () => {
+    it('should handle CRD names with underscores and default to https/443', () => {
       const crd = createFeatureStoreCRD({
         metadata: { name: 'feast_rbac', namespace: NAMESPACE.TEST_NS },
       });
@@ -205,6 +209,58 @@ describe('featureStoreUtils', () => {
       expect(result).toEqual({
         serviceName: 'feast-feast_rbac-registry-rest',
         namespace: NAMESPACE.TEST_NS,
+        protocol: PROTOCOL.HTTPS,
+        port: PORT.HTTPS_DEFAULT,
+      });
+    });
+
+    it('should return http/80 when tls.disable is true', () => {
+      const crd = createFeatureStoreCRD({
+        spec: {
+          services: {
+            registry: {
+              local: {
+                server: {
+                  tls: { disable: true },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = getServiceFromCRD(crd);
+
+      expect(result).toEqual({
+        serviceName: SERVICE_NAME.BANKING_REST,
+        namespace: NAMESPACE.VIEWER,
+        protocol: PROTOCOL.HTTP,
+        port: PORT.HTTP_DEFAULT,
+      });
+    });
+
+    it('should return https/443 when tls.disable is false', () => {
+      const crd = createFeatureStoreCRD({
+        spec: {
+          services: {
+            registry: {
+              local: {
+                server: {
+                  tls: { disable: false },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = getServiceFromCRD(crd);
+
+      expect(result).toEqual({
+        serviceName: SERVICE_NAME.BANKING_REST,
+        namespace: NAMESPACE.VIEWER,
+        protocol: PROTOCOL.HTTPS,
+        port: PORT.HTTPS_DEFAULT,
       });
     });
   });

--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -1,13 +1,13 @@
 import {
-  parseNamespacesData,
-  extractServiceInfo,
   constructRegistryProxyUrl,
-  findRegistryUrlForFeatureStore,
   createFeatureStoreResponse,
-  filterEnabledCRDs,
   handleError,
-  FeatureStoreCRD,
-  ClientConfigInfo,
+  isRegistryReady,
+  getServiceFromCRD,
+  listFeastNamespaces,
+  listFeastFeatureStoreCRDs,
+  getFeastFeatureStoreCRD,
+  type FeatureStoreCRD,
 } from '../routes/api/featurestores/featureStoreUtils';
 
 const NAMESPACE = {
@@ -15,45 +15,23 @@ const NAMESPACE = {
   DEFAULT: 'default',
   TEST_NS: 'test-ns',
   NAMESPACE_WITH_DASH: 'namespace-with-dash',
-  TEST_FEAST_BANKING: 'test-feast-banking',
 } as const;
 
 const PROJECT = {
   BANKING: 'banking',
   RETAIL: 'retail',
   TEST: 'test',
-  ENABLED_2: 'enabled-2',
-  NO_LABELS: 'no-labels',
-  FRAUD_DETECT: 'fraud_detect',
-  CREDIT_SCORING_LOCAL: 'credit_scoring_local',
-} as const;
-
-const CONFIG_NAME = {
-  BANKING: 'banking-config',
-  RETAIL: 'retail-config',
-  FRAUD_DETECT: 'feast-fraud-detect-client',
-  CREDIT_SCORING_LOCAL: 'feast-sample-git-client',
 } as const;
 
 const SERVICE_NAME = {
   BANKING_REST: 'feast-banking-registry-rest',
   RETAIL_REST: 'feast-retail-registry-rest',
   TEST_REST: 'feast-test-registry-rest',
-  COMPLEX_REST: 'feast-my-complex-name-registry-rest',
-  FRAUD_DETECT_REST: 'feast-fraud-detect-registry-rest',
-  CREDIT_SCORING_REST: 'feast-sample-git-registry-rest',
 } as const;
 
 const REGISTRY_URL = {
   BANKING_HTTPS: 'https://feast-banking-registry.viewer.svc.cluster.local',
-  BANKING_HTTPS_WITH_PORT: 'https://feast-banking-registry.viewer.svc.cluster.local:8080',
-  RETAIL_HTTP: 'http://feast-retail-registry.default.svc.cluster.local',
   RETAIL_HTTPS: 'https://feast-retail-registry.default.svc.cluster.local',
-  TEST_NO_PROTOCOL: 'feast-test-registry.test-ns.svc.cluster.local',
-  COMPLEX_NAME: 'feast-my-complex-name-registry.namespace-with-dash.svc.cluster.local',
-  FRAUD_DETECT_HTTPS: 'https://feast-fraud-detect-registry.test-feast-banking.svc.cluster.local',
-  CREDIT_SCORING_HTTPS: 'https://feast-sample-git-registry.credit-namespace.svc.cluster.local',
-  INVALID: 'invalid-url-format',
 } as const;
 
 const API_PATH = {
@@ -78,16 +56,33 @@ const createMockFastify = () =>
   ({
     log: {
       error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
     },
   } as any);
 
-const createClientConfigInfo = (overrides: Partial<ClientConfigInfo> = {}): ClientConfigInfo => ({
-  configName: CONFIG_NAME.BANKING,
-  namespace: NAMESPACE.VIEWER,
-  registryUrl: REGISTRY_URL.BANKING_HTTPS,
-  projectName: PROJECT.BANKING,
-  ...overrides,
+const createMockApi = () => ({
+  setApiKey: jest.fn(),
+  listClusterCustomObject: jest.fn(),
+  listNamespacedCustomObject: jest.fn(),
+  getNamespacedCustomObject: jest.fn(),
 });
+
+const createMockKubeFastify = (mockApi = createMockApi()) =>
+  ({
+    log: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+    },
+    kube: {
+      customObjectsApi: mockApi,
+    },
+  } as any);
+
+const KUBE_HEADERS = { Authorization: 'Bearer test-token' } as Record<string, string>;
 
 const createFeatureStoreCRD = (overrides: Partial<FeatureStoreCRD> = {}): FeatureStoreCRD => ({
   apiVersion: 'feast.dev/v1',
@@ -125,110 +120,91 @@ describe('featureStoreUtils', () => {
     });
   });
 
-  describe('parseNamespacesData', () => {
-    it('should parse valid namespaces data', () => {
-      const configMapData = JSON.stringify({
-        namespaces: {
-          namespace1: ['config1', 'config2'],
-          namespace2: ['config3'],
+  describe('isRegistryReady', () => {
+    it('should return true when Registry condition is True', () => {
+      const crd = createFeatureStoreCRD({
+        status: {
+          conditions: [
+            { type: 'Registry', status: 'True', lastTransitionTime: '2024-01-01T00:00:00Z' },
+          ],
         },
       });
 
-      const result = parseNamespacesData(configMapData);
+      expect(isRegistryReady(crd)).toBe(true);
+    });
 
-      expect(result).toEqual({
-        namespaces: {
-          namespace1: ['config1', 'config2'],
-          namespace2: ['config3'],
+    it('should return false when Registry condition is False', () => {
+      const crd = createFeatureStoreCRD({
+        status: {
+          conditions: [
+            { type: 'Registry', status: 'False', lastTransitionTime: '2024-01-01T00:00:00Z' },
+          ],
         },
       });
+
+      expect(isRegistryReady(crd)).toBe(false);
     });
 
-    it('should handle empty namespaces object', () => {
-      const configMapData = JSON.stringify({ namespaces: {} });
+    it('should return false when no conditions exist', () => {
+      const crd = createFeatureStoreCRD({ status: { conditions: [] } });
 
-      const result = parseNamespacesData(configMapData);
-
-      expect(result).toEqual({ namespaces: {} });
+      expect(isRegistryReady(crd)).toBe(false);
     });
 
-    it('should handle missing namespaces key', () => {
-      const configMapData = JSON.stringify({});
+    it('should return false when status is missing', () => {
+      const crd = createFeatureStoreCRD();
 
-      const result = parseNamespacesData(configMapData);
-
-      expect(result).toEqual({ namespaces: {} });
+      expect(isRegistryReady(crd)).toBe(false);
     });
 
-    it('should throw error on invalid JSON', () => {
-      const invalidJson = 'not valid json';
+    it('should return false when Registry condition is absent but other conditions exist', () => {
+      const crd = createFeatureStoreCRD({
+        status: {
+          conditions: [
+            { type: 'Ready', status: 'True', lastTransitionTime: '2024-01-01T00:00:00Z' },
+          ],
+        },
+      });
 
-      expect(() => parseNamespacesData(invalidJson)).toThrow('Failed to parse namespaces data');
+      expect(isRegistryReady(crd)).toBe(false);
     });
   });
 
-  describe('extractServiceInfo', () => {
-    it('should extract service info from https URL with port', () => {
-      const result = extractServiceInfo(REGISTRY_URL.BANKING_HTTPS_WITH_PORT);
+  describe('getServiceFromCRD', () => {
+    it('should derive service name and namespace from CRD', () => {
+      const crd = createFeatureStoreCRD();
+
+      const result = getServiceFromCRD(crd);
 
       expect(result).toEqual({
         serviceName: SERVICE_NAME.BANKING_REST,
-        serviceNamespace: NAMESPACE.VIEWER,
-        originalUrl: REGISTRY_URL.BANKING_HTTPS_WITH_PORT,
-        protocol: PROTOCOL.HTTPS,
-        port: PORT.CUSTOM_8080,
+        namespace: NAMESPACE.VIEWER,
       });
     });
 
-    it('should extract service info from https URL without port', () => {
-      const result = extractServiceInfo(REGISTRY_URL.BANKING_HTTPS);
+    it('should handle CRD names with hyphens', () => {
+      const crd = createFeatureStoreCRD({
+        metadata: { name: 'my-complex-name', namespace: NAMESPACE.DEFAULT },
+      });
+
+      const result = getServiceFromCRD(crd);
 
       expect(result).toEqual({
-        serviceName: SERVICE_NAME.BANKING_REST,
-        serviceNamespace: NAMESPACE.VIEWER,
-        originalUrl: REGISTRY_URL.BANKING_HTTPS,
-        protocol: PROTOCOL.HTTPS,
-        port: PORT.HTTPS_DEFAULT,
+        serviceName: 'feast-my-complex-name-registry-rest',
+        namespace: NAMESPACE.DEFAULT,
       });
     });
 
-    it('should extract service info from http URL without port', () => {
-      const result = extractServiceInfo(REGISTRY_URL.RETAIL_HTTP);
-
-      expect(result).toEqual({
-        serviceName: SERVICE_NAME.RETAIL_REST,
-        serviceNamespace: NAMESPACE.DEFAULT,
-        originalUrl: REGISTRY_URL.RETAIL_HTTP,
-        protocol: PROTOCOL.HTTP,
-        port: PORT.HTTP_DEFAULT,
+    it('should handle CRD names with underscores', () => {
+      const crd = createFeatureStoreCRD({
+        metadata: { name: 'feast_rbac', namespace: NAMESPACE.TEST_NS },
       });
-    });
 
-    it('should default to https when no protocol specified', () => {
-      const result = extractServiceInfo(REGISTRY_URL.TEST_NO_PROTOCOL);
+      const result = getServiceFromCRD(crd);
 
       expect(result).toEqual({
-        serviceName: SERVICE_NAME.TEST_REST,
-        serviceNamespace: NAMESPACE.TEST_NS,
-        originalUrl: REGISTRY_URL.TEST_NO_PROTOCOL,
-        protocol: PROTOCOL.HTTPS,
-        port: PORT.HTTPS_DEFAULT,
-      });
-    });
-
-    it('should throw error for invalid URL format', () => {
-      expect(() => extractServiceInfo(REGISTRY_URL.INVALID)).toThrow('Invalid registry URL format');
-    });
-
-    it('should handle service names with hyphens', () => {
-      const result = extractServiceInfo(REGISTRY_URL.COMPLEX_NAME);
-
-      expect(result).toEqual({
-        serviceName: SERVICE_NAME.COMPLEX_REST,
-        serviceNamespace: NAMESPACE.NAMESPACE_WITH_DASH,
-        originalUrl: REGISTRY_URL.COMPLEX_NAME,
-        protocol: PROTOCOL.HTTPS,
-        port: PORT.HTTPS_DEFAULT,
+        serviceName: 'feast-feast_rbac-registry-rest',
+        namespace: NAMESPACE.TEST_NS,
       });
     });
   });
@@ -327,39 +303,238 @@ describe('featureStoreUtils', () => {
     });
   });
 
-  describe('findRegistryUrlForFeatureStore', () => {
-    const registryUrls: ClientConfigInfo[] = [
-      createClientConfigInfo(),
-      createClientConfigInfo({
-        configName: CONFIG_NAME.RETAIL,
-        namespace: NAMESPACE.DEFAULT,
-        registryUrl: REGISTRY_URL.RETAIL_HTTPS,
-        projectName: PROJECT.RETAIL,
-      }),
-    ];
+  describe('listFeastNamespaces', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    let mockApi: ReturnType<typeof createMockApi>;
 
-    it('should find registry URL for existing feature store', () => {
-      const result = findRegistryUrlForFeatureStore(PROJECT.BANKING, registryUrls);
-
-      expect(result).toBe(REGISTRY_URL.BANKING_HTTPS);
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApi = createMockApi();
+      mockFastify = createMockKubeFastify(mockApi);
     });
 
-    it('should find registry URL for second feature store', () => {
-      const result = findRegistryUrlForFeatureStore(PROJECT.RETAIL, registryUrls);
+    it('should return project names for accessible namespaces', async () => {
+      mockApi.listClusterCustomObject.mockResolvedValue({
+        body: {
+          items: [{ metadata: { name: 'feast-ns-1' } }, { metadata: { name: 'feast-ns-2' } }],
+        },
+      });
 
-      expect(result).toBe(REGISTRY_URL.RETAIL_HTTPS);
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual(['feast-ns-1', 'feast-ns-2']);
+      expect(mockApi.listClusterCustomObject).toHaveBeenCalledWith(
+        'project.openshift.io',
+        'v1',
+        'projects',
+        undefined,
+        undefined,
+        undefined,
+        'opendatahub.io/feast=true',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: KUBE_HEADERS },
+      );
     });
 
-    it('should return null for non-existent feature store', () => {
-      const result = findRegistryUrlForFeatureStore('non-existent', registryUrls);
+    it('should filter out items with falsy names', async () => {
+      mockApi.listClusterCustomObject.mockResolvedValue({
+        body: {
+          items: [
+            { metadata: { name: 'feast-ns-1' } },
+            { metadata: { name: '' } },
+            { metadata: { name: 'feast-ns-2' } },
+          ],
+        },
+      });
+
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual(['feast-ns-1', 'feast-ns-2']);
+    });
+
+    it('should return empty array when no projects exist', async () => {
+      mockApi.listClusterCustomObject.mockResolvedValue({
+        body: { items: [] },
+      });
+
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array on 403 without throwing', async () => {
+      mockApi.listClusterCustomObject.mockRejectedValue({ statusCode: 403 });
+
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array and log on non-403 errors', async () => {
+      mockApi.listClusterCustomObject.mockRejectedValue(new Error('network failure'));
+
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to list Feast namespaces for user'),
+      );
+    });
+  });
+
+  describe('listFeastFeatureStoreCRDs', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApi = createMockApi();
+      mockFastify = createMockKubeFastify(mockApi);
+    });
+
+    it('should return enabled FeatureStore CRDs for the namespace', async () => {
+      const crd1 = createFeatureStoreCRD({
+        metadata: { name: 'banking', namespace: NAMESPACE.VIEWER },
+      });
+      const crd2 = createFeatureStoreCRD({
+        metadata: { name: 'retail', namespace: NAMESPACE.VIEWER },
+      });
+
+      mockApi.listNamespacedCustomObject.mockResolvedValue({
+        body: { items: [crd1, crd2] },
+      });
+
+      const result = await listFeastFeatureStoreCRDs(mockFastify, NAMESPACE.VIEWER, KUBE_HEADERS);
+
+      expect(result).toEqual([crd1, crd2]);
+      expect(mockApi.listNamespacedCustomObject).toHaveBeenCalledWith(
+        'feast.dev',
+        'v1',
+        NAMESPACE.VIEWER,
+        'featurestores',
+        undefined,
+        undefined,
+        undefined,
+        'feature-store-ui=enabled',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: KUBE_HEADERS },
+      );
+    });
+
+    it('should return empty array when no enabled CRDs exist', async () => {
+      mockApi.listNamespacedCustomObject.mockResolvedValue({
+        body: { items: [] },
+      });
+
+      const result = await listFeastFeatureStoreCRDs(mockFastify, NAMESPACE.DEFAULT, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array on 403 without throwing', async () => {
+      mockApi.listNamespacedCustomObject.mockRejectedValue({ statusCode: 403 });
+
+      const result = await listFeastFeatureStoreCRDs(mockFastify, NAMESPACE.VIEWER, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array and log on non-403 errors', async () => {
+      mockApi.listNamespacedCustomObject.mockRejectedValue(new Error('timeout'));
+
+      const result = await listFeastFeatureStoreCRDs(mockFastify, NAMESPACE.VIEWER, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to list FeatureStore CRDs in ${NAMESPACE.VIEWER}`),
+      );
+    });
+  });
+
+  describe('getFeastFeatureStoreCRD', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApi = createMockApi();
+      mockFastify = createMockKubeFastify(mockApi);
+    });
+
+    it('should return the CRD when found', async () => {
+      const crd = createFeatureStoreCRD();
+      mockApi.getNamespacedCustomObject.mockResolvedValue({ body: crd });
+
+      const result = await getFeastFeatureStoreCRD(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        PROJECT.BANKING,
+        KUBE_HEADERS,
+      );
+
+      expect(result).toEqual(crd);
+      expect(mockApi.getNamespacedCustomObject).toHaveBeenCalledWith(
+        'feast.dev',
+        'v1',
+        NAMESPACE.VIEWER,
+        'featurestores',
+        PROJECT.BANKING,
+        { headers: KUBE_HEADERS },
+      );
+    });
+
+    it('should return null on 404', async () => {
+      mockApi.getNamespacedCustomObject.mockRejectedValue({ statusCode: 404 });
+
+      const result = await getFeastFeatureStoreCRD(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        PROJECT.BANKING,
+        KUBE_HEADERS,
+      );
 
       expect(result).toBeNull();
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
     });
 
-    it('should return null for empty registry URLs array', () => {
-      const result = findRegistryUrlForFeatureStore(PROJECT.BANKING, []);
+    it('should return null on 403', async () => {
+      mockApi.getNamespacedCustomObject.mockRejectedValue({ statusCode: 403 });
+
+      const result = await getFeastFeatureStoreCRD(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        PROJECT.BANKING,
+        KUBE_HEADERS,
+      );
 
       expect(result).toBeNull();
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
+    });
+
+    it('should return null and log on unexpected errors', async () => {
+      mockApi.getNamespacedCustomObject.mockRejectedValue(new Error('cluster unreachable'));
+
+      const result = await getFeastFeatureStoreCRD(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        PROJECT.BANKING,
+        KUBE_HEADERS,
+      );
+
+      expect(result).toBeNull();
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Failed to get FeatureStore CRD ${NAMESPACE.VIEWER}/${PROJECT.BANKING}`,
+        ),
+      );
     });
   });
 
@@ -422,82 +597,6 @@ describe('featureStoreUtils', () => {
       );
 
       expect(result.namespace).toBeUndefined();
-    });
-  });
-
-  describe('filterEnabledCRDs', () => {
-    const crds: FeatureStoreCRD[] = [
-      createFeatureStoreCRD({
-        metadata: {
-          name: PROJECT.BANKING,
-          namespace: NAMESPACE.VIEWER,
-          labels: {
-            'feature-store-ui': 'enabled',
-          },
-        },
-      }),
-      createFeatureStoreCRD({
-        metadata: {
-          name: PROJECT.RETAIL,
-          namespace: NAMESPACE.DEFAULT,
-          labels: {
-            'feature-store-ui': 'disabled',
-          },
-        },
-      }),
-      createFeatureStoreCRD({
-        metadata: {
-          name: PROJECT.TEST,
-          namespace: NAMESPACE.TEST_NS,
-        },
-      }),
-      createFeatureStoreCRD({
-        metadata: {
-          name: PROJECT.ENABLED_2,
-          namespace: NAMESPACE.VIEWER,
-          labels: {
-            'feature-store-ui': 'enabled',
-            'other-label': 'value',
-          },
-        },
-      }),
-    ];
-
-    it('should filter CRDs with feature-store-ui label set to enabled', () => {
-      const result = filterEnabledCRDs(crds);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].metadata.name).toBe(PROJECT.BANKING);
-      expect(result[1].metadata.name).toBe(PROJECT.ENABLED_2);
-    });
-
-    it('should return empty array when no CRDs are enabled', () => {
-      const disabledCrds = crds.filter(
-        (crd) => crd.metadata.name !== PROJECT.BANKING && crd.metadata.name !== PROJECT.ENABLED_2,
-      );
-
-      const result = filterEnabledCRDs(disabledCrds);
-
-      expect(result).toHaveLength(0);
-    });
-
-    it('should return empty array for empty input', () => {
-      const result = filterEnabledCRDs([]);
-
-      expect(result).toHaveLength(0);
-    });
-
-    it('should handle CRDs with no labels', () => {
-      const noLabelsCrd = createFeatureStoreCRD({
-        metadata: {
-          name: PROJECT.NO_LABELS,
-          namespace: NAMESPACE.DEFAULT,
-        },
-      });
-
-      const result = filterEnabledCRDs([noLabelsCrd]);
-
-      expect(result).toHaveLength(0);
     });
   });
 });

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -1,33 +1,8 @@
+import * as https from 'https';
+import * as http from 'http';
 import { KubeFastifyInstance } from '../../../types';
-import { getConfigMap } from '../../../utils/envUtils';
-import { V1ConfigMap } from '@kubernetes/client-node';
-import { groupBy } from 'lodash';
 
-const DEFAULT_HTTPS_PORT = '443';
-const DEFAULT_HTTP_PORT = '80';
-const FEATURE_STORE_YAML_KEY = 'feature_store.yaml';
 const REGISTRY_CONDITION_TYPE = 'Registry';
-const PROTOCOL_REGEX = /^(https?):\/\//;
-const SERVICE_NAME_REGEX = /feast-(.+)-registry\.(.+)\.svc\.cluster\.local(:\d+)?/;
-
-export interface NamespacesData {
-  namespaces: Record<string, string[]>;
-}
-
-export interface RegistryUrlInfo {
-  serviceName: string;
-  serviceNamespace: string;
-  originalUrl: string;
-  protocol: string;
-  port: string;
-}
-
-export interface ClientConfigInfo {
-  configName: string;
-  namespace: string;
-  registryUrl: string;
-  projectName: string;
-}
 
 export interface FeatureStoreCRD {
   apiVersion: string;
@@ -39,6 +14,13 @@ export interface FeatureStoreCRD {
   };
   spec?: {
     feastProject?: string;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      lastTransitionTime: string;
+    }>;
   };
 }
 
@@ -59,62 +41,172 @@ export function handleError(fastify: KubeFastifyInstance, error: unknown, contex
   return errorMessage;
 }
 
-export const fetchConfigMap = async (
+function getUserScopedCustomObjectsApi(
   fastify: KubeFastifyInstance,
-  namespace: string,
-  name: string,
-): Promise<V1ConfigMap | null> => {
-  try {
-    const configMap = await getConfigMap(fastify, namespace, name);
-    return configMap;
-  } catch (error: unknown) {
-    if (error && typeof error === 'object' && 'statusCode' in error && error.statusCode === 404) {
-      fastify.log.warn(`ConfigMap '${name}' not found in namespace '${namespace}'`);
-      return null;
-    }
-    throw error;
-  }
-};
+  kubeHeaders: Record<string, string>,
+) {
+  return { api: fastify.kube.customObjectsApi, opts: { headers: kubeHeaders } };
+}
 
-export function parseNamespacesData(configMapData: string): NamespacesData {
+/** Lists custom objects cluster-wide or namespace-scoped using the user's token. Returns [] on 403. */
+async function listCustomObjects<T>(
+  fastify: KubeFastifyInstance,
+  kubeHeaders: Record<string, string>,
+  params: {
+    group: string;
+    version: string;
+    plural: string;
+    namespace?: string;
+    labelSelector?: string;
+    errorContext: string;
+  },
+): Promise<T[]> {
   try {
-    const parsed = JSON.parse(configMapData);
-    return {
-      namespaces: parsed.namespaces || {},
-    };
+    const { api, opts } = getUserScopedCustomObjectsApi(fastify, kubeHeaders);
+    const { group, version, plural, namespace, labelSelector } = params;
+
+    const response = namespace
+      ? ((await api.listNamespacedCustomObject(
+          group,
+          version,
+          namespace,
+          plural,
+          undefined,
+          undefined,
+          undefined,
+          labelSelector,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          opts,
+        )) as { body: { items?: T[] } })
+      : ((await api.listClusterCustomObject(
+          group,
+          version,
+          plural,
+          undefined,
+          undefined,
+          undefined,
+          labelSelector,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          opts,
+        )) as { body: { items?: T[] } });
+
+    return response.body.items || [];
   } catch (error) {
-    throw new Error(
-      `Failed to parse namespaces data: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const statusCode =
+      error && typeof error === 'object' && 'statusCode' in error
+        ? (error as { statusCode: number }).statusCode
+        : undefined;
+
+    if (statusCode === 403) {
+      fastify.log.debug(`Access denied (403): ${params.errorContext} - skipping`);
+      return [];
+    }
+
+    handleError(fastify, error, params.errorContext);
+    return [];
   }
 }
 
-export function extractServiceInfo(registryUrl: string): RegistryUrlInfo {
-  const protocolMatch = registryUrl.match(PROTOCOL_REGEX);
-  const protocol = protocolMatch ? protocolMatch[1] : 'https';
+/**
+ * Lists OpenShift projects accessible to the user with the `opendatahub.io/feast=true` label.
+ * DEV_MODE impersonation headers (Impersonate-User) are forwarded via kubeHeaders.
+ */
+export async function listFeastNamespaces(
+  fastify: KubeFastifyInstance,
+  kubeHeaders: Record<string, string>,
+): Promise<string[]> {
+  const items = await listCustomObjects<{ metadata: { name: string } }>(fastify, kubeHeaders, {
+    group: 'project.openshift.io',
+    version: 'v1',
+    plural: 'projects',
+    labelSelector: 'opendatahub.io/feast=true',
+    errorContext: 'Failed to list Feast namespaces for user',
+  });
+  return items.map((p) => p.metadata.name).filter(Boolean);
+}
 
-  const urlWithoutProtocol = registryUrl.replace(PROTOCOL_REGEX, '');
-  const serviceMatch = urlWithoutProtocol.match(SERVICE_NAME_REGEX);
+/**
+ * Lists FeatureStore CRDs with the `feature-store-ui=enabled` label in a namespace.
+ * Returns [] on 403 so inaccessible namespaces don't break the full listing.
+ */
+export async function listFeastFeatureStoreCRDs(
+  fastify: KubeFastifyInstance,
+  namespace: string,
+  kubeHeaders: Record<string, string>,
+): Promise<FeatureStoreCRD[]> {
+  return listCustomObjects<FeatureStoreCRD>(fastify, kubeHeaders, {
+    group: 'feast.dev',
+    version: 'v1',
+    plural: 'featurestores',
+    namespace,
+    labelSelector: 'feature-store-ui=enabled',
+    errorContext: `Failed to list FeatureStore CRDs in ${namespace}`,
+  });
+}
 
-  if (!serviceMatch) {
-    throw new Error(`Invalid registry URL format: ${registryUrl}`);
+/**
+ * Fetches a single FeatureStore CRD by name.
+ * Accepts the full kubeHeaders so impersonation headers are forwarded.
+ * Returns null on 403/404.
+ */
+export async function getFeastFeatureStoreCRD(
+  fastify: KubeFastifyInstance,
+  namespace: string,
+  name: string,
+  kubeHeaders: Record<string, string>,
+): Promise<FeatureStoreCRD | null> {
+  try {
+    const { api, opts } = getUserScopedCustomObjectsApi(fastify, kubeHeaders);
+
+    const response = (await api.getNamespacedCustomObject(
+      'feast.dev',
+      'v1',
+      namespace,
+      'featurestores',
+      name,
+      opts,
+    )) as { body: FeatureStoreCRD };
+
+    return response.body;
+  } catch (error) {
+    const statusCode =
+      error && typeof error === 'object' && 'statusCode' in error
+        ? (error as { statusCode: number }).statusCode
+        : undefined;
+
+    if (statusCode === 403 || statusCode === 404) {
+      return null;
+    }
+
+    handleError(fastify, error, `Failed to get FeatureStore CRD ${namespace}/${name}`);
+    return null;
   }
+}
 
-  const extractedName = serviceMatch[1];
-  const extractedNamespace = serviceMatch[2];
-  const portMatch = serviceMatch[3];
+/**
+ * Returns true if the FeatureStore CRD has a ready Registry condition.
+ */
+export function isRegistryReady(crd: FeatureStoreCRD): boolean {
+  return !!crd.status?.conditions?.find((c) => c.type === 'Registry' && c.status === 'True');
+}
 
-  const serviceName = `feast-${extractedName}-registry-rest`;
-  // Extract port number, default based on protocol
-  const defaultPort = protocol === 'https' ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
-  const port = portMatch ? portMatch.substring(1) : defaultPort;
-
+/**
+ * Derives the Feast registry REST service name and namespace from a CRD.
+ * Convention: service name = `feast-{crd.metadata.name}-registry-rest`
+ */
+export function getServiceFromCRD(crd: FeatureStoreCRD): {
+  serviceName: string;
+  namespace: string;
+} {
   return {
-    serviceName,
-    serviceNamespace: extractedNamespace,
-    originalUrl: registryUrl,
-    protocol,
-    port,
+    serviceName: `feast-${crd.metadata.name}-registry-rest`,
+    namespace: crd.metadata.namespace,
   };
 }
 
@@ -148,18 +240,6 @@ export function constructRegistryProxyUrl(
   }
 
   return `${protocol}://${serviceName}.${serviceNamespace}.svc.cluster.local:${port}/${path}`;
-}
-
-export function findRegistryUrlForFeatureStore(
-  featureStoreName: string,
-  registryUrls: ClientConfigInfo[],
-): string | null {
-  for (const registryInfo of registryUrls) {
-    if (registryInfo.projectName === featureStoreName) {
-      return registryInfo.registryUrl;
-    }
-  }
-  return null;
 }
 
 export function createFeatureStoreResponse(
@@ -200,121 +280,6 @@ export function createFeatureStoreResponse(
   };
 }
 
-export function filterEnabledCRDs(crds: FeatureStoreCRD[]): FeatureStoreCRD[] {
-  return crds.filter((crd) => crd.metadata?.labels?.['feature-store-ui'] === 'enabled');
-}
-
-function parseFeatureStoreConfigMap(
-  configMap: V1ConfigMap,
-): { registryUrl: string; projectName: string } | null {
-  if (!configMap.data?.[FEATURE_STORE_YAML_KEY]) {
-    return null;
-  }
-
-  const yamlContent = configMap.data[FEATURE_STORE_YAML_KEY];
-
-  const registryMatch = yamlContent.match(/registry:\s*\n\s*path:\s*(.+)/);
-  if (!registryMatch) {
-    return null;
-  }
-
-  const registryUrl = registryMatch[1].trim();
-  const projectMatch = yamlContent.match(/^project:\s*(.+)$/m);
-  const projectName = projectMatch ? projectMatch[1].trim() : 'unknown';
-
-  return { registryUrl, projectName };
-}
-
-export async function getClientConfigs(
-  fastify: KubeFastifyInstance,
-  namespaces: Record<string, string[]>,
-  labelSelector?: string,
-): Promise<ClientConfigInfo[]> {
-  const clientConfigs: ClientConfigInfo[] = [];
-
-  for (const [ns, configNames] of Object.entries(namespaces)) {
-    if (!Array.isArray(configNames)) continue;
-
-    for (const configName of configNames) {
-      try {
-        const clientConfig = await getConfigMap(fastify, ns, configName);
-
-        if (labelSelector) {
-          const labels = clientConfig.metadata?.labels || {};
-          const [key, value] = labelSelector.split('=');
-          if (labels[key] !== value) {
-            continue;
-          }
-        }
-
-        const parsed = parseFeatureStoreConfigMap(clientConfig);
-        if (!parsed) {
-          continue;
-        }
-
-        clientConfigs.push({
-          configName,
-          namespace: ns,
-          registryUrl: parsed.registryUrl,
-          projectName: parsed.projectName,
-        });
-      } catch (error) {
-        fastify.log.warn(
-          `Failed to process config ${configName} in namespace ${ns}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
-  }
-
-  return clientConfigs;
-}
-
-export async function fetchFromRegistry(
-  fastify: KubeFastifyInstance,
-  registryUrl: string,
-  userToken?: string,
-): Promise<Array<{ name: string; project?: string }>> {
-  try {
-    const serviceInfo = extractServiceInfo(registryUrl);
-    const { protocol, port } = serviceInfo;
-
-    const directUrl = constructRegistryProxyUrl(
-      serviceInfo.serviceName,
-      serviceInfo.serviceNamespace,
-      'api/v1/projects',
-      false,
-      protocol,
-      port,
-    );
-
-    const { data } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
-      fastify,
-      directUrl,
-      userToken,
-      {
-        rejectUnauthorized: false, // Skip TLS verification for internal services
-      },
-    );
-
-    const result =
-      data.projects?.map((project: FeastProject) => ({
-        name: project.name || project.spec?.name || 'unknown',
-        project: project.name || project.spec?.name || 'unknown',
-      })) || [];
-
-    return result;
-  } catch (error) {
-    fastify.log.warn(
-      `Failed to fetch from registry ${registryUrl}: ${
-        error instanceof Error ? error.message : String(error)
-      }. This is expected when running locally or when feast registry is not configured.`,
-    );
-    throw error;
-  }
-}
-
 export async function makeAuthenticatedHttpRequest<T = unknown>(
   fastify: KubeFastifyInstance,
   url: string,
@@ -327,8 +292,6 @@ export async function makeAuthenticatedHttpRequest<T = unknown>(
 ): Promise<{ data: T; statusCode: number }> {
   const { timeout = 60000, rejectUnauthorized = false, agent } = options;
 
-  const https = require('https');
-  const http = require('http');
   const urlObj = new URL(url);
 
   const isHttps = urlObj.protocol === 'https:';
@@ -382,96 +345,4 @@ export async function makeAuthenticatedHttpRequest<T = unknown>(
 
     req.end();
   });
-}
-
-export async function batchFetchConfigMapsByNamespace(
-  fastify: KubeFastifyInstance,
-  clientConfigsData: ClientConfigInfo[],
-): Promise<Map<string, V1ConfigMap>> {
-  const configMapMap = new Map<string, V1ConfigMap>();
-
-  const configsByNamespace = groupBy(clientConfigsData, 'namespace');
-
-  const namespacePromises = Object.entries(configsByNamespace).map(async ([namespace]) => {
-    try {
-      const response = await fastify.kube.coreV1Api.listNamespacedConfigMap(namespace);
-      const configMaps = response.body.items || [];
-
-      configMaps.forEach((configMap) => {
-        const name = configMap.metadata?.name;
-        if (name) {
-          configMapMap.set(`${namespace}/${name}`, configMap);
-        }
-      });
-    } catch (error) {
-      fastify.log.warn(`Failed to list ConfigMaps in namespace ${namespace}: ${error.message}`);
-    }
-  });
-
-  await Promise.all(namespacePromises);
-  return configMapMap;
-}
-
-export async function getClientConfigsBatched(
-  fastify: KubeFastifyInstance,
-  namespaces: Record<string, string[]>,
-  labelSelector?: string,
-): Promise<ClientConfigInfo[]> {
-  const clientConfigs: ClientConfigInfo[] = [];
-
-  const allConfigs: ClientConfigInfo[] = [];
-  for (const [ns, configNames] of Object.entries(namespaces)) {
-    if (!Array.isArray(configNames)) continue;
-    for (const configName of configNames) {
-      allConfigs.push({
-        configName,
-        namespace: ns,
-        registryUrl: '',
-        projectName: '',
-      });
-    }
-  }
-
-  const configMapMap = await batchFetchConfigMapsByNamespace(fastify, allConfigs);
-
-  for (const config of allConfigs) {
-    try {
-      const clientConfig = configMapMap.get(`${config.namespace}/${config.configName}`);
-
-      if (!clientConfig) {
-        fastify.log.warn(
-          `ConfigMap ${config.configName} not found in namespace ${config.namespace}`,
-        );
-        continue;
-      }
-
-      if (labelSelector) {
-        const labels = clientConfig.metadata?.labels || {};
-        const [key, value] = labelSelector.split('=');
-        if (labels[key] !== value) {
-          continue;
-        }
-      }
-
-      const parsed = parseFeatureStoreConfigMap(clientConfig);
-      if (!parsed) {
-        continue;
-      }
-
-      clientConfigs.push({
-        configName: config.configName,
-        namespace: config.namespace,
-        registryUrl: parsed.registryUrl,
-        projectName: parsed.projectName,
-      });
-    } catch (error) {
-      fastify.log.warn(
-        `Failed to process config ${config.configName} in namespace ${config.namespace}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-
-  return clientConfigs;
 }

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -14,6 +14,17 @@ export interface FeatureStoreCRD {
   };
   spec?: {
     feastProject?: string;
+    services?: {
+      registry?: {
+        local?: {
+          server?: {
+            tls?: {
+              disable?: boolean;
+            };
+          };
+        };
+      };
+    };
   };
   status?: {
     conditions?: Array<{
@@ -203,10 +214,15 @@ export function isRegistryReady(crd: FeatureStoreCRD): boolean {
 export function getServiceFromCRD(crd: FeatureStoreCRD): {
   serviceName: string;
   namespace: string;
+  protocol: 'http' | 'https';
+  port: string;
 } {
+  const tlsDisabled = crd.spec?.services?.registry?.local?.server?.tls?.disable === true;
   return {
     serviceName: `feast-${crd.metadata.name}-registry-rest`,
     namespace: crd.metadata.namespace,
+    protocol: tlsDisabled ? 'http' : 'https',
+    port: tlsDisabled ? '80' : '443',
   };
 }
 

--- a/backend/src/routes/api/featurestores/featureStores.ts
+++ b/backend/src/routes/api/featurestores/featureStores.ts
@@ -1,22 +1,18 @@
 import { FastifyReply } from 'fastify';
-import * as https from 'https';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { getAccessToken, getDirectCallOptions } from '../../../utils/directCallUtils';
 import { createCustomError } from '../../../utils/requestUtils';
-import { getNamespaces } from '../../../utils/notebookUtils';
 import {
-  parseNamespacesData,
-  findRegistryUrlForFeatureStore,
-  extractServiceInfo,
+  listFeastNamespaces,
+  listFeastFeatureStoreCRDs,
+  getFeastFeatureStoreCRD,
   constructRegistryProxyUrl,
   createFeatureStoreResponse,
-  filterEnabledCRDs,
-  getClientConfigsBatched,
-  fetchFromRegistry,
-  fetchConfigMap,
-  handleError,
   makeAuthenticatedHttpRequest,
-  type FeatureStoreCRD,
+  handleError,
+  isRegistryReady,
+  getServiceFromCRD,
+  type FeastProjectsResponse,
 } from './featureStoreUtils';
 
 interface FeatureStoreResponse {
@@ -40,12 +36,6 @@ interface FeatureStore {
   };
 }
 
-interface CustomObjectResponse {
-  body: {
-    items?: FeatureStoreCRD[];
-  };
-}
-
 function buildFeatureStoreResponse(
   featureStores: FeatureStore[],
   enabledCRDCount: number,
@@ -53,227 +43,160 @@ function buildFeatureStoreResponse(
   return { featureStores, enabledCRDCount };
 }
 
-async function fetchFeatureStoreCRDs(
-  fastify: KubeFastifyInstance,
-  namespace: string,
-): Promise<FeatureStoreCRD[]> {
-  try {
-    const response = (await fastify.kube.customObjectsApi.listNamespacedCustomObject(
-      'feast.dev',
-      'v1',
-      namespace,
-      'featurestores',
-    )) as CustomObjectResponse;
-
-    const items = response.body.items || [];
-    return items;
-  } catch (error) {
-    handleError(fastify, error, `Error fetching FeatureStore CRDs from namespace ${namespace}`);
-    return [];
-  }
-}
-
-async function processFeatureStoreConfigs(
-  fastify: KubeFastifyInstance,
-  namespace: string,
-  clientConfigs: string[],
-  enabledProjectNames: string[],
-  userToken?: string,
-): Promise<FeatureStore[]> {
-  const allClientConfigs = await getClientConfigsBatched(fastify, { [namespace]: clientConfigs });
-
-  const filteredConfigs = allClientConfigs.filter((config) =>
-    enabledProjectNames.includes(config.projectName),
-  );
-
-  const featureStores: FeatureStore[] = [];
-
-  for (const clientConfig of filteredConfigs) {
-    const projectName = clientConfig.projectName;
-    const registryUrl = clientConfig.registryUrl;
-
-    if (!projectName || !registryUrl) {
-      fastify.log.warn(`Client config missing projectName or registryUrl`);
-      continue;
-    }
-
-    try {
-      const registryResponse = await fetchFromRegistry(fastify, registryUrl, userToken);
-
-      featureStores.push(
-        ...registryResponse.map((fs) => {
-          const name =
-            fs.name ||
-            extractServiceInfo(registryUrl)
-              .serviceName.replace('feast-', '')
-              .replace('-registry-rest', '');
-          return createFeatureStoreResponse(
-            name,
-            fs.project || name,
-            registryUrl,
-            'True',
-            namespace,
-          );
-        }),
-      );
-    } catch (error) {
-      fastify.log.warn(
-        `Failed to process client config for project ${projectName} in namespace ${namespace}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-
-  return featureStores;
-}
-
-async function handleFeatureStoreProxy(
-  fastify: KubeFastifyInstance,
-  req: OauthFastifyRequest<{
-    Params: { namespace: string; projectName: string };
-  }>,
-  reply: FastifyReply,
-): Promise<void> {
-  const { namespace, projectName } = req.params;
-  const urlParts = req.url.split('/');
-  const namespaceIndex = urlParts.indexOf(namespace);
-  const pathAfterProject = urlParts.slice(namespaceIndex + 2).join('/');
-  const path = pathAfterProject || 'api/v1/projects';
-
-  const { dashboardNamespace } = getNamespaces(fastify);
-  const feastConfig = await fetchConfigMap(fastify, dashboardNamespace, 'feast-configs-registry');
-
-  if (!feastConfig) {
-    throw createCustomError(
-      'ConfigMap not found',
-      'feast-configs-registry ConfigMap not found',
-      404,
-    );
-  }
-
-  if (!feastConfig.data?.namespaces) {
-    throw createCustomError(
-      'No namespaces data found',
-      'feast-configs-registry ConfigMap has no namespaces data',
-      404,
-    );
-  }
-
-  const namespacesData = parseNamespacesData(feastConfig.data.namespaces);
-  const clientConfigs = await getClientConfigsBatched(fastify, namespacesData.namespaces);
-
-  const namespaceConfigs = clientConfigs.filter((config) => config.namespace === namespace);
-  const registryUrl = findRegistryUrlForFeatureStore(projectName, namespaceConfigs);
-
-  if (!registryUrl) {
-    throw createCustomError(
-      'Registry URL not found',
-      `Registry URL not found for feature store: ${projectName}`,
-      404,
-    );
-  }
-
-  const serviceInfo = extractServiceInfo(registryUrl);
-  const proxyUrl = constructRegistryProxyUrl(
-    serviceInfo.serviceName,
-    serviceInfo.serviceNamespace,
-    path,
-    true,
-    serviceInfo.protocol,
-    serviceInfo.port,
-  );
-
-  const token = await getAccessToken(await getDirectCallOptions(fastify, req, ''));
-
-  if (!token) {
-    throw createCustomError('No access token', 'User authentication required', 401);
-  }
-
-  try {
-    const { data, statusCode } = await makeAuthenticatedHttpRequest(fastify, proxyUrl, token, {
-      timeout: 60000,
-      rejectUnauthorized: false,
-      agent: new https.Agent({
-        rejectUnauthorized: false,
-      }),
-    });
-
-    reply.code(statusCode).type('application/json').send(data);
-  } catch (directError) {
-    const errorMessage = handleError(fastify, directError, 'Direct request error');
-    throw createCustomError('Registry request failed', errorMessage, 500);
-  }
-}
-
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  /**
+   * GET /api/featurestores/
+   *
+   * Discovers Feature Stores the logged-in user has access to:
+   *   1. Lists OpenShift projects with opendatahub.io/feast=true (user-scoped)
+   *   2. Lists FeatureStore CRDs with feature-store-ui=enabled in each project (user-scoped)
+   *   3. Derives the Feast registry service URL from the CRD name (no ConfigMap needed)
+   *   4. Fetches project metadata from each ready registry
+   *   5. Returns enabledCRDCount so the UI can warn when multiple CRDs have UI enabled
+   */
   fastify.get('/', async (req: OauthFastifyRequest<Record<string, never>>, reply: FastifyReply) => {
     try {
-      const { dashboardNamespace } = getNamespaces(fastify);
-      const feastConfig = await fetchConfigMap(
-        fastify,
-        dashboardNamespace,
-        'feast-configs-registry',
+      const kubeHeaders = (await getDirectCallOptions(fastify, req, '')).headers as Record<
+        string,
+        string
+      >;
+      const token = getAccessToken({ headers: kubeHeaders });
+
+      if (!token) {
+        throw createCustomError('No access token', 'User authentication required', 401);
+      }
+
+      const namespaces = await listFeastNamespaces(fastify, kubeHeaders);
+
+      if (namespaces.length === 0) {
+        reply.send(buildFeatureStoreResponse([], 0));
+        return;
+      }
+
+      // allCRDs.length === enabledCRDCount: listFeastFeatureStoreCRDs filters by feature-store-ui=enabled.
+      const crdsByNamespace = await Promise.all(
+        namespaces.map((ns) => listFeastFeatureStoreCRDs(fastify, ns, kubeHeaders)),
       );
+      const allCRDs = crdsByNamespace.flat();
+      const enabledCRDCount = allCRDs.length;
 
-      if (!feastConfig) {
-        reply.send(buildFeatureStoreResponse([], 0));
-        return;
-      }
+      const featureStoreResults = await Promise.all(
+        allCRDs.map(async (crd): Promise<FeatureStore[]> => {
+          if (!isRegistryReady(crd)) {
+            fastify.log.debug(
+              `Skipping ${crd.metadata.namespace}/${crd.metadata.name} - Registry not ready`,
+            );
+            return [];
+          }
 
-      if (!feastConfig.data?.namespaces) {
-        fastify.log.warn(`No namespaces data found in ConfigMap ${feastConfig.metadata?.name}`);
-        reply.send(buildFeatureStoreResponse([], 0));
-        return;
-      }
-
-      const namespacesData = parseNamespacesData(feastConfig.data.namespaces);
-      const namespaces = namespacesData.namespaces;
-
-      const token = await getAccessToken(await getDirectCallOptions(fastify, req, ''));
-
-      const namespacePromises = Object.entries(namespaces)
-        .filter(([, clientConfigs]) => Array.isArray(clientConfigs))
-        .map(async ([ns, clientConfigs]) => {
-          const allCrds = await fetchFeatureStoreCRDs(fastify, ns);
-          const enabledCrds = filterEnabledCRDs(allCrds as FeatureStoreCRD[]);
-          const enabledProjectNames = enabledCrds
-            .map((crd) => crd.spec?.feastProject)
-            .filter(Boolean);
-          const featureStores = await processFeatureStoreConfigs(
-            fastify,
-            ns,
-            clientConfigs,
-            enabledProjectNames,
-            token,
+          const { serviceName, namespace: registryNamespace } = getServiceFromCRD(crd);
+          const registryUrl = constructRegistryProxyUrl(
+            serviceName,
+            registryNamespace,
+            'api/v1/projects',
+            true,
           );
-          return { featureStores, enabledCRDCount: enabledCrds.length };
-        });
+          const baseRegistryUrl = constructRegistryProxyUrl(
+            serviceName,
+            registryNamespace,
+            '',
+            true,
+          ).replace(/\/$/, '');
 
-      const namespaceResults = await Promise.all(namespacePromises);
-      const allFeatureStores = namespaceResults.flatMap((r) => r.featureStores);
-      const totalEnabledCRDCount = namespaceResults.reduce((sum, r) => sum + r.enabledCRDCount, 0);
+          try {
+            const { data } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+              fastify,
+              registryUrl,
+              token,
+              {},
+            );
 
-      reply.send(buildFeatureStoreResponse(allFeatureStores, totalEnabledCRDCount));
-    } catch (error) {
-      const errorMessage = handleError(
-        fastify,
-        error,
-        'Failed to fetch feature stores from registry',
+            const projects = data.projects || [];
+            return projects
+              .map((fs) => fs.spec?.name || fs.name)
+              .filter((n): n is string => !!n)
+              .map((projectName) =>
+                // name = CRD name for proxy lookup; project = Feast project name.
+                createFeatureStoreResponse(
+                  crd.metadata.name,
+                  crd.spec?.feastProject || projectName,
+                  baseRegistryUrl,
+                  'True',
+                  crd.metadata.namespace,
+                ),
+              );
+          } catch (error) {
+            fastify.log.warn(
+              `Failed to fetch from registry for ${crd.metadata.namespace}/${crd.metadata.name}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            return [];
+          }
+        }),
       );
+
+      reply.send(buildFeatureStoreResponse(featureStoreResults.flat(), enabledCRDCount));
+    } catch (error) {
+      const errorMessage = handleError(fastify, error, 'Failed to fetch feature stores');
       throw createCustomError('Failed to fetch feature stores', errorMessage, 500);
     }
   });
 
+  /**
+   * GET /api/featurestores/:namespace/:name/*
+   *
+   * Proxies a request to the Feast registry REST API.
+   * Looks up the FeatureStore CRD directly by namespace + name using the
+   * user's token and derives the service URL — no ConfigMap lookup needed.
+   */
   fastify.get(
-    '/:namespace/:projectName/*',
+    '/:namespace/:name/*',
     async (
       req: OauthFastifyRequest<{
-        Params: { namespace: string; projectName: string };
+        Params: { namespace: string; name: string };
       }>,
       reply: FastifyReply,
     ) => {
-      return handleFeatureStoreProxy(fastify, req, reply);
+      const { namespace, name } = req.params;
+      const urlParts = req.url.split('/');
+      const namespaceIndex = urlParts.indexOf(namespace);
+      const pathAfterName = urlParts.slice(namespaceIndex + 2).join('/');
+      const path = pathAfterName || 'api/v1/projects';
+
+      const kubeHeaders = (await getDirectCallOptions(fastify, req, '')).headers as Record<
+        string,
+        string
+      >;
+      const token = getAccessToken({ headers: kubeHeaders });
+
+      if (!token) {
+        throw createCustomError('No access token', 'User authentication required', 401);
+      }
+
+      const crd = await getFeastFeatureStoreCRD(fastify, namespace, name, kubeHeaders);
+
+      if (!crd) {
+        throw createCustomError(
+          'FeatureStore not found',
+          `FeatureStore '${name}' not found in namespace '${namespace}' or access denied`,
+          404,
+        );
+      }
+
+      const { serviceName, namespace: svcNs } = getServiceFromCRD(crd);
+      const proxyUrl = constructRegistryProxyUrl(serviceName, svcNs, path, true);
+
+      try {
+        const { data, statusCode } = await makeAuthenticatedHttpRequest(fastify, proxyUrl, token, {
+          timeout: 60000,
+        });
+
+        reply.code(statusCode).type('application/json').send(data);
+      } catch (directError) {
+        const errorMessage = handleError(fastify, directError, 'Direct request error');
+        throw createCustomError('Registry request failed', errorMessage, 500);
+      }
     },
   );
 };

--- a/backend/src/routes/api/featurestores/featureStores.ts
+++ b/backend/src/routes/api/featurestores/featureStores.ts
@@ -160,8 +160,12 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       if (createError.isHttpError(error)) {
         throw error;
       }
-      const errorMessage = handleError(fastify, error, 'Failed to fetch feature stores');
-      throw createCustomError('Failed to fetch feature stores', errorMessage, 500);
+      handleError(fastify, error, 'Failed to fetch feature stores');
+      throw createCustomError(
+        'Failed to fetch feature stores',
+        'Unable to fetch feature stores at this time',
+        500,
+      );
     }
   });
 
@@ -223,8 +227,12 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
 
         reply.code(statusCode).type('application/json').send(data);
       } catch (directError) {
-        const errorMessage = handleError(fastify, directError, 'Direct request error');
-        throw createCustomError('Registry request failed', errorMessage, 500);
+        handleError(fastify, directError, 'Direct request error');
+        throw createCustomError(
+          'Registry request failed',
+          'Unable to contact the feature store registry',
+          500,
+        );
       }
     },
   );

--- a/backend/src/routes/api/featurestores/featureStores.ts
+++ b/backend/src/routes/api/featurestores/featureStores.ts
@@ -1,6 +1,7 @@
 import { FastifyReply } from 'fastify';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { getAccessToken, getDirectCallOptions } from '../../../utils/directCallUtils';
+import createError from 'http-errors';
 import { createCustomError } from '../../../utils/requestUtils';
 import {
   listFeastNamespaces,
@@ -89,37 +90,55 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             return [];
           }
 
-          const { serviceName, namespace: registryNamespace } = getServiceFromCRD(crd);
+          const {
+            serviceName,
+            namespace: registryNamespace,
+            protocol,
+            port,
+          } = getServiceFromCRD(crd);
           const registryUrl = constructRegistryProxyUrl(
             serviceName,
             registryNamespace,
             'api/v1/projects',
             true,
+            protocol,
+            port,
           );
           const baseRegistryUrl = constructRegistryProxyUrl(
             serviceName,
             registryNamespace,
             '',
             true,
+            protocol,
+            port,
           ).replace(/\/$/, '');
 
           try {
-            const { data } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+            const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
               fastify,
               registryUrl,
               token,
               {},
             );
 
+            if (statusCode < 200 || statusCode >= 300) {
+              throw new Error(`Registry returned ${statusCode}`);
+            }
+
+            const targetProject = crd.spec?.feastProject;
             const projects = data.projects || [];
             return projects
               .map((fs) => fs.spec?.name || fs.name)
-              .filter((n): n is string => !!n)
+              .filter((projectName): projectName is string => {
+                if (!projectName) return false;
+                if (targetProject) return projectName === targetProject;
+                return true;
+              })
               .map((projectName) =>
                 // name = CRD name for proxy lookup; project = Feast project name.
                 createFeatureStoreResponse(
                   crd.metadata.name,
-                  crd.spec?.feastProject || projectName,
+                  projectName,
                   baseRegistryUrl,
                   'True',
                   crd.metadata.namespace,
@@ -138,6 +157,9 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
 
       reply.send(buildFeatureStoreResponse(featureStoreResults.flat(), enabledCRDCount));
     } catch (error) {
+      if (createError.isHttpError(error)) {
+        throw error;
+      }
       const errorMessage = handleError(fastify, error, 'Failed to fetch feature stores');
       throw createCustomError('Failed to fetch feature stores', errorMessage, 500);
     }
@@ -154,15 +176,21 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
     '/:namespace/:name/*',
     async (
       req: OauthFastifyRequest<{
-        Params: { namespace: string; name: string };
+        Params: { namespace: string; name: string; '*': string };
       }>,
       reply: FastifyReply,
     ) => {
-      const { namespace, name } = req.params;
-      const urlParts = req.url.split('/');
-      const namespaceIndex = urlParts.indexOf(namespace);
-      const pathAfterName = urlParts.slice(namespaceIndex + 2).join('/');
-      const path = pathAfterName || 'api/v1/projects';
+      const { namespace, name, '*': wildcardPath } = req.params;
+      const path = wildcardPath || 'api/v1/projects';
+
+      const DNS1123_REGEX = /^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$/;
+      if (!DNS1123_REGEX.test(namespace) || !DNS1123_REGEX.test(name)) {
+        throw createCustomError(
+          'Invalid parameters',
+          'namespace and name must be valid DNS-1123 subdomains',
+          400,
+        );
+      }
 
       const kubeHeaders = (await getDirectCallOptions(fastify, req, '')).headers as Record<
         string,
@@ -184,8 +212,8 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         );
       }
 
-      const { serviceName, namespace: svcNs } = getServiceFromCRD(crd);
-      const proxyUrl = constructRegistryProxyUrl(serviceName, svcNs, path, true);
+      const { serviceName, namespace: svcNs, protocol, port } = getServiceFromCRD(crd);
+      const proxyUrl = constructRegistryProxyUrl(serviceName, svcNs, path, true, protocol, port);
 
       try {
         const { data, statusCode } = await makeAuthenticatedHttpRequest(fastify, proxyUrl, token, {

--- a/backend/src/routes/api/featurestores/featureStores.ts
+++ b/backend/src/routes/api/featurestores/featureStores.ts
@@ -181,7 +181,8 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
       reply: FastifyReply,
     ) => {
       const { namespace, name, '*': wildcardPath } = req.params;
-      const path = wildcardPath || 'api/v1/projects';
+      const path =
+        wildcardPath && wildcardPath.startsWith('api/v1/') ? wildcardPath : 'api/v1/projects';
 
       const DNS1123_REGEX = /^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$/;
       if (!DNS1123_REGEX.test(namespace) || !DNS1123_REGEX.test(name)) {

--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -2,72 +2,56 @@ import { FastifyReply } from 'fastify';
 import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
 import { getAccessToken, getDirectCallOptions } from '../../../utils/directCallUtils';
 import { secureRoute } from '../../../utils/route-security';
-import { getNamespaces } from '../../../utils/notebookUtils';
 import {
-  parseNamespacesData,
-  getClientConfigs,
-  fetchFromRegistry,
-  fetchConfigMap,
-  type ClientConfigInfo,
+  listFeastNamespaces,
+  listFeastFeatureStoreCRDs,
+  constructRegistryProxyUrl,
+  makeAuthenticatedHttpRequest,
   handleError,
+  isRegistryReady,
+  getServiceFromCRD,
+  type FeatureStoreCRD,
+  type FeastProjectsResponse,
 } from './featureStoreUtils';
+
+interface WorkbenchFeatureStoreConfig {
+  configName: string;
+  projectName: string;
+  hasAccessToFeatureStore: boolean;
+}
 
 interface WorkbenchResponse {
   namespaces: Array<{
     namespace: string;
-    clientConfigs: Array<{
-      configName: string;
-      projectName: string;
-      hasAccessToFeatureStore: boolean;
-    }>;
+    clientConfigs: WorkbenchFeatureStoreConfig[];
   }>;
 }
 
-async function checkFeatureStoreAccess(
+async function hasAccessToProject(
   fastify: KubeFastifyInstance,
-  registryUrl: string,
-  projectName: string,
-  userToken?: string,
+  crd: FeatureStoreCRD,
+  token: string,
 ): Promise<boolean> {
   try {
-    const projects = await fetchFromRegistry(fastify, registryUrl, userToken);
-    if (!projects || projects.length === 0) {
-      return false;
-    }
-    const hasAccess = projects.some((p) => p.name === projectName || p.project === projectName);
-    return hasAccess;
+    const { serviceName, namespace } = getServiceFromCRD(crd);
+    const registryUrl = constructRegistryProxyUrl(serviceName, namespace, 'api/v1/projects', true);
+    const { data } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+      fastify,
+      registryUrl,
+      token,
+      {},
+    );
+    const projectName = crd.spec?.feastProject || crd.metadata.name;
+    const projects = data.projects || [];
+    return projects.some((p) => (p.spec?.name || p.name) === projectName);
   } catch (error) {
     fastify.log.info(
-      `Access check for ${projectName}: DENIED (registry not accessible) - ${error.message}`,
+      `Access check for ${crd.metadata.namespace}/${crd.metadata.name}: DENIED ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     );
     return false;
   }
-}
-
-async function checkMultipleFeatureStoreAccess(
-  fastify: KubeFastifyInstance,
-  configs: ClientConfigInfo[],
-  userToken?: string,
-): Promise<Map<string, boolean>> {
-  const accessResults = new Map<string, boolean>();
-
-  const accessPromises = configs.map(async (config) => {
-    const hasAccess = await checkFeatureStoreAccess(
-      fastify,
-      config.registryUrl,
-      config.projectName,
-      userToken,
-    );
-    return { name: config.projectName, hasAccess };
-  });
-
-  const results = await Promise.all(accessPromises);
-
-  results.forEach(({ name, hasAccess }) => {
-    accessResults.set(name, hasAccess);
-  });
-
-  return accessResults;
 }
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
@@ -75,58 +59,52 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
     '/workbench-integration',
     secureRoute(fastify)(async (req: OauthFastifyRequest, reply: FastifyReply) => {
       try {
-        const { dashboardNamespace } = getNamespaces(fastify);
-        const feastConfig = await fetchConfigMap(
-          fastify,
-          dashboardNamespace,
-          'feast-configs-registry',
-        );
+        const kubeHeaders = (await getDirectCallOptions(fastify, req, '')).headers as Record<
+          string,
+          string
+        >;
+        const token = getAccessToken({ headers: kubeHeaders });
 
-        if (!feastConfig || !feastConfig.data?.namespaces) {
-          return reply.send({
-            namespaces: [],
-          });
+        if (!token) {
+          return reply.code(401).send({ error: 'User authentication required' });
         }
 
-        const parsedData = parseNamespacesData(feastConfig.data.namespaces);
-        const namespaces = Object.entries(parsedData.namespaces || {}).map(
-          ([ns, clientConfigs]) => ({
-            namespace: ns,
-            clientConfigs: clientConfigs as string[],
+        const namespaces = await listFeastNamespaces(fastify, kubeHeaders);
+
+        if (namespaces.length === 0) {
+          return reply.send({ namespaces: [] });
+        }
+
+        // Collect all enabled FeatureStore CRDs across user-accessible namespaces
+        const crdsByNamespace = await Promise.all(
+          namespaces.map(async (ns) => ({
+            ns,
+            crds: await listFeastFeatureStoreCRDs(fastify, ns, kubeHeaders),
+          })),
+        );
+
+        const namespaceResults = await Promise.all(
+          crdsByNamespace.map(async ({ ns, crds }) => {
+            const availableFeatureStores = crds.filter(isRegistryReady);
+
+            const configResults = await Promise.all(
+              availableFeatureStores.map(async (crd) => {
+                const projectName = crd.spec?.feastProject || crd.metadata.name;
+                const hasAccess = await hasAccessToProject(fastify, crd, token);
+                return {
+                  configName: crd.metadata.name,
+                  projectName,
+                  hasAccessToFeatureStore: hasAccess,
+                };
+              }),
+            );
+
+            return {
+              namespace: ns,
+              clientConfigs: configResults.filter((c) => c.hasAccessToFeatureStore),
+            };
           }),
         );
-
-        const token = await getAccessToken(await getDirectCallOptions(fastify, req, ''));
-
-        const allClientConfigsData = await getClientConfigs(
-          fastify,
-          Object.fromEntries(
-            namespaces.map(({ namespace, clientConfigs }) => [namespace, clientConfigs]),
-          ),
-        );
-
-        const accessResults = await checkMultipleFeatureStoreAccess(
-          fastify,
-          allClientConfigsData,
-          token,
-        );
-
-        const namespaceResults = namespaces.map(({ namespace }) => {
-          const namespaceConfigs = allClientConfigsData.filter(
-            (config) => config.namespace === namespace,
-          );
-          const accessibleConfigs = namespaceConfigs
-            .filter((config) => accessResults.get(config.projectName))
-            .map((config) => ({
-              configName: config.configName,
-              projectName: config.projectName,
-              hasAccessToFeatureStore: accessResults.get(config.projectName) ?? false,
-            }));
-          return {
-            namespace,
-            clientConfigs: accessibleConfigs,
-          };
-        });
 
         const response: WorkbenchResponse = {
           namespaces: namespaceResults.filter((ns) => ns.clientConfigs.length > 0),

--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -51,7 +51,7 @@ async function hasAccessToProject(
     if (statusCode < 200 || statusCode >= 300) {
       throw new Error(`Registry returned ${statusCode}`);
     }
-    const projectName = crd.spec?.feastProject || crd.metadata.name;
+    const projectName = crd.spec?.feastProject ?? crd.metadata.name;
     const projects = data.projects || [];
     return projects.some((p) => (p.spec?.name || p.name) === projectName);
   } catch (error) {
@@ -99,7 +99,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
 
             const configResults = await Promise.all(
               availableFeatureStores.map(async (crd) => {
-                const projectName = crd.spec?.feastProject || crd.metadata.name;
+                const projectName = crd.spec?.feastProject ?? crd.metadata.name;
                 const hasAccess = await hasAccessToProject(fastify, crd, token);
                 return {
                   configName: crd.metadata.name,

--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -33,14 +33,24 @@ async function hasAccessToProject(
   token: string,
 ): Promise<boolean> {
   try {
-    const { serviceName, namespace } = getServiceFromCRD(crd);
-    const registryUrl = constructRegistryProxyUrl(serviceName, namespace, 'api/v1/projects', true);
-    const { data } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+    const { serviceName, namespace, protocol, port } = getServiceFromCRD(crd);
+    const registryUrl = constructRegistryProxyUrl(
+      serviceName,
+      namespace,
+      'api/v1/projects',
+      true,
+      protocol,
+      port,
+    );
+    const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
       fastify,
       registryUrl,
       token,
       {},
     );
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Registry returned ${statusCode}`);
+    }
     const projectName = crd.spec?.feastProject || crd.metadata.name;
     const projects = data.projects || [];
     return projects.some((p) => (p.spec?.name || p.name) === projectName);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62428
https://issues.redhat.com/browse/RHOAIENG-62429
https://issues.redhat.com/browse/RHOAIENG-38042
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

- Removes the service account dependency from all Feature Store backend routes. Previously, the dashboard used a central `feast-configs-registry` ConfigMap (read via the SA) to discover Feature Store registries i.e. all users could see all Feature Stores regardless of their actual permissions.

- The backend now uses the user's own token for all Kubernetes API calls, so users only see Feature Stores in namespaces they have access to.

### [RHOAIENG-62428](https://redhat.atlassian.net/browse/RHOAIENG-62428) — Remove SA from Feature Store discovery and proxy

1. Previously the dashboard used a central `feast-configs-registry` ConfigMap (read via the SA) to discover Feature Store registries, meaning all users could see all Feature Stores regardless of their actual permissions.
2. Discovery (`GET /api/featurestores/`) now lists OpenShift Projects with `opendatahub.io/feast=true` and `FeatureStore` CRDs with `feature-store-ui=enabled` using the user's own token. The proxy (`GET /api/featurestores/:namespace/:name/*`) looks up the CRD directly by name using the user's token. All legacy ConfigMap helpers removed from `featureStoreUtils.ts`.

### [RHOAIENG-62429](https://redhat.atlassian.net/browse/RHOAIENG-62429) — Remove SA from workbench integration (partial)
`fsworkbenchIntegration.ts` now uses the same CRD-based discovery as the main feature store routes — lists namespaces and CRDs using the user's token instead of reading from the ConfigMap.
> **Note:** Permission level enforcement for the workbench integration (controlling which Feature Stores a user can select based on their role) is out of scope for this PR and will be addressed in a follow-up.
### [RHOAIENG-38042](https://redhat.atlassian.net/browse/RHOAIENG-38042) — Fix empty UI when registry runs without TLS
`constructRegistryProxyUrl` was hardcoding `https`/`443` for all registries. It now reads `tls.disable` from the CRD spec and picks `http`/`80` or `https`/`443` accordingly.

To test for this 
1. Deploy a `FeatureStore` CRD with `spec.services.registry.local.server.tls.disable: true`
2. Port-forward the registry REST service:
   ```bash
   kubectl port-forward svc/feast-credit-test-registry-rest 6570:80 -n dipanshu
3. Restart the backend and hit the discovery endpoint:
`curl -s http://localhost:4010/api/featurestores | jq '.featureStores[] | select(.name == "credit-test")'`
4. . Verify `registry.path` uses `http://` (not `https://`):
   **Dev mode (local port-forward):**
   ```json
   {
     "name": "credit-test",
     "project": "my_project",
     "registry": {
       "path": "http://localhost:6570"
     },
     "namespace": "dipanshu"
   }


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using DEV_MODE impersonation:
- User with no access to feast namespaces → `featureStores: []`


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated `featureStoreUtils.spec.ts` removed tests for deleted helpers, added coverage for `isRegistryReady`, `getServiceFromCRD`, `listFeastNamespaces`, `listFeastFeatureStoreCRDs`, and `getFeastFeatureStoreCRD`.


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Feature store discovery and registry proxying now use Kubernetes Custom Resources for more reliable discovery.
  * Registry readiness is validated before proxying; requests return clear errors when unavailable.
  * Workbench integration and access checks now derive configs directly from FeatureStore CRDs for more accurate permissions.

* **Tests**
  * Expanded coverage for feature store utilities, Kubernetes API interactions, registry readiness, and error/permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->