### PR TITLE
feat(RHOAIENG-63600): update project selector to match Projects page

### DIFF
--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -21,6 +21,7 @@ type ProjectSelectorProps = {
   placeholder?: string;
   isLoading?: boolean;
   namespacesOverride?: Namespace[];
+  toggleContent?: React.ReactNode;
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
@@ -36,6 +37,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   placeholder = undefined,
   isLoading = false,
   namespacesOverride,
+  toggleContent: customToggleContent,
 }) => {
   const { projects } = React.useContext(ProjectsContext);
   const namespaces =
@@ -73,7 +75,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       searchValue={searchText}
       isLoading={isLoading}
       isDisabled={isLoading}
-      toggleContent={toggleLabel}
+      toggleContent={customToggleContent ?? toggleLabel}
       toggleVariant={primary ? 'primary' : undefined}
     >
       <>

--- a/packages/gen-ai/frontend/src/app/GenAiCoreHeader.tsx
+++ b/packages/gen-ai/frontend/src/app/GenAiCoreHeader.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { Content, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
-import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
-import { IconSize } from '@odh-dashboard/internal/types';
 import GenAiCoreProjectSelector from '~/app/GenAiCoreProjectSelector';
 import HeaderIcon from '~/app/HeaderIcon';
 import { IconType } from '~/app/types';
@@ -32,15 +30,7 @@ const GenAiCoreHeader: React.FC<GenAiCoreHeaderProps> = ({ title, getRedirectPat
         </Flex>
       </FlexItem>
       <FlexItem>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-          <ProjectIconWithSize size={IconSize.LG} />
-          <FlexItem>
-            <Content component="p">Project</Content>
-          </FlexItem>
-          <FlexItem>
-            <GenAiCoreProjectSelector namespace={namespace} getRedirectPath={getRedirectPath} />
-          </FlexItem>
-        </Flex>
+        <GenAiCoreProjectSelector namespace={namespace} getRedirectPath={getRedirectPath} />
       </FlexItem>
     </Flex>
   );

--- a/packages/gen-ai/frontend/src/app/GenAiCoreProjectSelector.tsx
+++ b/packages/gen-ai/frontend/src/app/GenAiCoreProjectSelector.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
-import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
-import { useNamespaceSelector } from 'mod-arch-core';
+import { Badge, Flex, FlexItem, Label } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
+import { useNamespaceSelector } from 'mod-arch-core';
+import AiExperienceIcon from '@odh-dashboard/internal/images/icons/AiExperienceIcon';
+import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 
 type PipelineCoreProjectSelectorProps = {
   namespace?: string;
   getRedirectPath: (namespace: string) => string;
-} & Omit<React.ComponentProps<typeof ProjectSelector>, 'onSelection' | 'namespace'>;
+} & Omit<
+  React.ComponentProps<typeof ProjectSelector>,
+  'onSelection' | 'namespace' | 'toggleContent'
+>;
 
 const GenAiCoreProjectSelector: React.FC<PipelineCoreProjectSelectorProps> = ({
   getRedirectPath,
@@ -16,6 +22,28 @@ const GenAiCoreProjectSelector: React.FC<PipelineCoreProjectSelectorProps> = ({
 }) => {
   const navigate = useNavigate();
   const { namespaces, updatePreferredNamespace, namespacesLoaded } = useNamespaceSelector();
+
+  const toggleContent = (
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+      <FlexItem>
+        <FilterIcon />
+      </FlexItem>
+      <FlexItem>A.I. projects</FlexItem>
+      <FlexItem>
+        <Badge isRead>{namespaces.length}</Badge>
+      </FlexItem>
+      <FlexItem>
+        <Label
+          icon={<AiExperienceIcon />}
+          variant="outline"
+          data-testid="ai-project-label"
+          isCompact
+        >
+          AI
+        </Label>
+      </FlexItem>
+    </Flex>
+  );
 
   return (
     <ProjectSelector
@@ -33,6 +61,7 @@ const GenAiCoreProjectSelector: React.FC<PipelineCoreProjectSelectorProps> = ({
       namespace={namespace ?? ''}
       isLoading={!namespacesLoaded}
       namespacesOverride={namespaces}
+      toggleContent={namespacesLoaded ? toggleContent : undefined}
     />
   );
 };


### PR DESCRIPTION
Replace folder icon + "Project" label with a filter-style toggle matching the Projects page: FilterIcon, "A.I. projects" label, count badge, and AI sparkle label.

https://redhat.atlassian.net/browse/RHOAIENG-63600

## Description

The project selector in the GenAI Playground and AI Asset Endpoints headers used a plain folder icon with a "Project" label and a dropdown showing the selected project name. This looked inconsistent with the Projects page which uses a filter-style toggle with a FilterIcon, "A.I. projects" label, project count badge, and AI sparkle label.

This change updates the GenAI project selector toggle to match the Projects page style:
- Added an optional `toggleContent` prop to the shared `ProjectSelector` component (backward-compatible) to allow callers to override the default toggle rendering
- `GenAiCoreProjectSelector` now builds the filter-style toggle content with FilterIcon, "A.I. projects" label, namespace count badge, and AI sparkle label
- Removed the folder icon and "Project" text from `GenAiCoreHeader`, since the context is now self-contained in the selector toggle

## How Has This Been Tested?

- Ran type-check (`tsc --noEmit`) across all 17 packages — all pass
- Ran ESLint across all 25 packages — 0 errors
- Ran unit tests across all 11 test suites — all pass
- The toggle content is only rendered when namespaces have loaded, falling back to the default label during loading

## Test Impact

No existing tests broken. The shared `ProjectSelector` change is backward-compatible (new optional prop). The toggle content is pure presentational markup using PatternFly components.
No new test added as the change is a thin presentational wiring of existing components (FilterIcon, Badge, Label from PatternFly).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<img width="1221" height="725" alt="Screenshot 2026-05-28 at 11 50 53" src="https://github.com/user-attachments/assets/ef2c210c-1901-483f-923e-7bedb363d0d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project selector now displays an enhanced header with a filter icon and a badge showing the count of loaded namespaces.

* **Refactor**
  * Updated header layout structure for improved component organization and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->