### PR TITLE
 fix(feature-store): remove duplicate store memo and  alias

### DIFF
--- a/packages/feature-store/src/FeatureStoreContext.tsx
+++ b/packages/feature-store/src/FeatureStoreContext.tsx
@@ -76,11 +76,12 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
     refresh: refreshRegistry,
   } = useRegistryFeatureStores();
 
+  // Reserved for future multi-store UI selection. GA currently defaults to first discovered store.
   const [selectedFeatureStoreName, setSelectedFeatureStoreName] = React.useState<string | null>(
     null,
   );
 
-  const apiActiveFeatureStore = React.useMemo(() => {
+  const activeFeatureStore = React.useMemo(() => {
     // Use the selected feature store, or fall back to the first one
     if (selectedFeatureStoreName) {
       return registryFeatureStores.find((fs) => fs.name === selectedFeatureStoreName) || null;
@@ -90,10 +91,8 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
   }, [registryFeatureStores, selectedFeatureStoreName]);
 
   // Use backend proxy to access registry services
-  const hostPath = apiActiveFeatureStore
-    ? `/api/featurestores/${apiActiveFeatureStore.namespace || 'default'}/${
-        apiActiveFeatureStore.name
-      }`
+  const hostPath = activeFeatureStore
+    ? `/api/featurestores/${activeFeatureStore.namespace || 'default'}/${activeFeatureStore.name}`
     : null;
 
   const [apiState, refreshAPIState] = useFeatureStoreAPIState(hostPath);
@@ -138,13 +137,6 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
     [setSelectedFeatureStoreName],
   );
 
-  const filteredFeatureStores = registryFeatureStores;
-
-  const activeFeatureStore = React.useMemo(() => {
-    //INFO: For GA we are only allowing one FeatureStore and hence we are picking the first one
-    return filteredFeatureStores.length > 0 ? filteredFeatureStores[0] : null;
-  }, [filteredFeatureStores]);
-
   const refreshFeatureStores = React.useCallback(async () => {
     await refreshRegistry();
   }, [refreshRegistry]);
@@ -152,7 +144,7 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
   const contextValue = React.useMemo(
     () => ({
       // Registry-based discovery
-      featureStores: filteredFeatureStores,
+      featureStores: registryFeatureStores,
       enabledCRDCount,
       activeFeatureStore,
       loaded: registryLoaded && featureStoreProjectsLoaded,
@@ -172,7 +164,7 @@ const FeatureStoreContextProviderComponent: React.FC<FeatureStoreContextProvider
       refreshFeatureStoreProjects,
     }),
     [
-      filteredFeatureStores,
+      registryFeatureStores,
       enabledCRDCount,
       activeFeatureStore,
       registryLoaded,
@@ -239,6 +231,7 @@ export const useFeatureStoreProject = (): {
   };
 };
 
+// Multi-store selection hook (currently unused in GA).
 export const useFeatureStoreSelection = (): {
   selectedFeatureStoreName: string | null;
   setCurrentFeatureStore: (featureStoreName?: string) => void;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58680

## Description

- Duplicate apiActiveFeatureStore + activeFeatureStore useMemos consolidated into one
- Removed redundant alias (`filteredFeatureStores`)
- Kept multi-store selection state/hook for future work, with clarifying comments

## How Has This Been Tested?
Ran in `packages/feature-store`:

- `npm run lint`
- `npm run type-check`
- `npm run test-unit`

All passed (lint has existing warnings in unrelated files, no new errors).

## Test Impact
- Existing unit tests pass: 35 suites, 473 tests
- No new tests added; change is refactor/cleanup with behavior preserved

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-store selection support so users can choose among available feature stores.

* **Improvements**
  * Improved active store determination with better fallback to a discovered store when none is selected.
  * Made available store listings and selection state more consistently exposed for UI use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->