### PR TITLE
RHOAIENG-63152: Add dev feature flag and Roles tab with routing

### DIFF
--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -61,6 +61,7 @@ export type MockDashboardConfigType = {
   nimWizard?: boolean;
   mySubscriptions?: boolean;
   agentOps?: boolean;
+  roleManagement?: boolean;
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
       externalProviders?: boolean;
@@ -121,6 +122,7 @@ export const mockDashboardConfig = ({
   nimWizard = false,
   mySubscriptions = false,
   agentOps = false,
+  roleManagement = false,
   hardwareProfileOrder = ['test-hardware-profile'],
   genAiStudioConfig = {
     aiAssetCustomEndpoints: {
@@ -304,6 +306,7 @@ export const mockDashboardConfig = ({
       nimWizard,
       mySubscriptions,
       agentOps,
+      roleManagement,
     },
     notebookController: {
       enabled: !disableNotebookController,

--- a/frontend/src/concepts/areas/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/areas/__tests__/utils.spec.ts
@@ -346,4 +346,42 @@ describe('isAreaAvailable', () => {
       });
     });
   });
+
+  describe('ROLE_MANAGEMENT area', () => {
+    it('should be available when roleManagement flag is true', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.ROLE_MANAGEMENT,
+        mockDashboardConfig({ roleManagement: true }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(true);
+      expect(isAvailable.featureFlags).toEqual({ roleManagement: 'on' });
+    });
+
+    it('should not be available when roleManagement flag is false', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.ROLE_MANAGEMENT,
+        mockDashboardConfig({ roleManagement: false }).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ roleManagement: 'off' });
+    });
+
+    it('should not be available by default (flag defaults to false)', () => {
+      const isAvailable = isAreaAvailable(
+        SupportedArea.ROLE_MANAGEMENT,
+        mockDashboardConfig({}).spec,
+        null,
+        null,
+      );
+
+      expect(isAvailable.status).toBe(false);
+      expect(isAvailable.featureFlags).toEqual({ roleManagement: 'off' });
+    });
+  });
 });

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -26,6 +26,7 @@ export const devTemporaryFeatureFlags = {
   mlflowPipelines: false,
   nimWizard: false,
   agentOps: false,
+  roleManagement: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features
@@ -233,6 +234,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.PROJECT_RBAC_SETTINGS]: {
     featureFlags: ['projectRBAC'],
+  },
+  [SupportedArea.ROLE_MANAGEMENT]: {
+    featureFlags: ['roleManagement'],
   },
   [SupportedArea.YAML_VIEWER]: {
     featureFlags: ['deploymentWizardYAMLViewer'],

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -106,6 +106,9 @@ export enum SupportedArea {
 
   /* Project RBAC Settings */
   PROJECT_RBAC_SETTINGS = 'project-rbac-settings',
+
+  /* Role Management */
+  ROLE_MANAGEMENT = 'role-management',
 }
 
 export type SupportedAreaType = SupportedArea | string;

--- a/frontend/src/concepts/projects/accessChecks.tsx
+++ b/frontend/src/concepts/projects/accessChecks.tsx
@@ -50,6 +50,20 @@ export const useProjectPermissionsTabVisible = (
     shouldRunCheck,
   );
 
+export const useProjectRolesTabVisible = (
+  projectName: string,
+  shouldRunCheck?: boolean,
+): ReturnType<typeof useAccessReview> =>
+  useAccessReview(
+    {
+      group: 'rbac.authorization.k8s.io',
+      resource: 'roles',
+      namespace: projectName,
+      verb: 'list',
+    },
+    shouldRunCheck,
+  );
+
 // TODO: expand this out to meet future needs
 export const useProjectSettingsTabVisible = (): boolean =>
   useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1337,6 +1337,7 @@ export type DashboardCommonConfig = {
   nimWizard?: boolean;
   mySubscriptions?: boolean;
   agentOps?: boolean;
+  roleManagement?: boolean;
 };
 
 // [1] Intentionally disjointed fields from the CRD in this type definition

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -29,7 +29,11 @@ const ProjectViewRoutes: React.FC = () => {
         <Route path="spawner/:notebookName" element={<EditSpawnerPage />} />
         <Route path="permissions" element={<Navigate to="..?section=permissions" replace />} />
         <Route path="permissions/assign" element={<ProjectPermissionsAssignRoles />} />
-        {roleManagementEnabled && <Route path="roles/create" element={<CreateRolePage />} />}
+        {roleManagementEnabled ? (
+          <Route path="roles/create" element={<CreateRolePage />} />
+        ) : (
+          <Route path="roles/*" element={<Navigate to=".." replace />} />
+        )}
         {modelMetricsEnabled && (
           <>
             <Route path="metrics/model" element={<ProjectInferenceExplainabilityWrapper />}>

--- a/frontend/src/pages/projects/ProjectViewRoutes.tsx
+++ b/frontend/src/pages/projects/ProjectViewRoutes.tsx
@@ -13,10 +13,12 @@ import ProjectDetailsContextProvider from './ProjectDetailsContext';
 import SpawnerPage from './screens/spawner/SpawnerPage';
 import EditSpawnerPage from './screens/spawner/EditSpawnerPage';
 import ProjectPermissionsAssignRoles from './projectPermissions/ProjectPermissionsAssignRoles';
+import CreateRolePage from './projectRoles/CreateRolePage';
 
 const ProjectViewRoutes: React.FC = () => {
   const [modelMetricsEnabled] = useModelMetricsEnabled();
   const biasMetricsAreaAvailable = useIsAreaAvailable(SupportedArea.BIAS_METRICS).status;
+  const roleManagementEnabled = useIsAreaAvailable(SupportedArea.ROLE_MANAGEMENT).status;
 
   return (
     <ProjectsRoutes>
@@ -27,6 +29,7 @@ const ProjectViewRoutes: React.FC = () => {
         <Route path="spawner/:notebookName" element={<EditSpawnerPage />} />
         <Route path="permissions" element={<Navigate to="..?section=permissions" replace />} />
         <Route path="permissions/assign" element={<ProjectPermissionsAssignRoles />} />
+        {roleManagementEnabled && <Route path="roles/create" element={<CreateRolePage />} />}
         {modelMetricsEnabled && (
           <>
             <Route path="metrics/model" element={<ProjectInferenceExplainabilityWrapper />}>

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -57,7 +57,11 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({
                 <>
                   {section.icon && <TabTitleIcon>{section.icon}</TabTitleIcon>}
                   <TabTitleText>{section.title}</TabTitleText>
-                  {section.label && <Label isCompact>{section.label}</Label>}
+                  {section.label && (
+                    <Label isCompact color="yellow" variant="outline">
+                      {section.label}
+                    </Label>
+                  )}
                 </>
               }
             />

--- a/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
+++ b/frontend/src/pages/projects/components/GenericHorizontalBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tabs, Tab, TabTitleIcon, TabTitleText, PageSection, Label } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleIcon, TabTitleText, PageSection } from '@patternfly/react-core';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 export type SectionDefinition = {
@@ -8,7 +8,7 @@ export type SectionDefinition = {
   icon?: React.ReactElement<React.ComponentClass<SVGIconProps>>;
   id: string;
   actions?: React.ReactNode[];
-  label?: string;
+  label?: React.ReactNode;
 };
 
 type GenericHorizontalBarProps = {
@@ -57,11 +57,7 @@ const GenericHorizontalBar: React.FC<GenericHorizontalBarProps> = ({
                 <>
                   {section.icon && <TabTitleIcon>{section.icon}</TabTitleIcon>}
                   <TabTitleText>{section.title}</TabTitleText>
-                  {section.label && (
-                    <Label isCompact color="yellow" variant="outline">
-                      {section.label}
-                    </Label>
-                  )}
+                  {section.label}
                 </>
               }
             />

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -2,15 +2,37 @@ import * as React from 'react';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Bullseye,
   PageSection,
   EmptyState,
   EmptyStateBody,
+  Spinner,
 } from '@patternfly/react-core';
-import { Link, useParams } from 'react-router-dom';
+import { Link, Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
+import { useAccessReview } from '#~/api/useAccessReview';
 
 const CreateRolePage: React.FC = () => {
   const { namespace = '' } = useParams<{ namespace: string }>();
+
+  const [allowCreate, loaded] = useAccessReview({
+    group: 'rbac.authorization.k8s.io',
+    resource: 'roles',
+    namespace,
+    verb: 'create',
+  });
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (!allowCreate) {
+    return <Navigate to={`/projects/${namespace}?section=roles`} replace />;
+  }
 
   return (
     <ApplicationsPage

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  PageSection,
+  EmptyState,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { Link, useParams } from 'react-router-dom';
+import ApplicationsPage from '#~/pages/ApplicationsPage';
+
+const CreateRolePage: React.FC = () => {
+  const { namespace = '' } = useParams<{ namespace: string }>();
+
+  return (
+    <ApplicationsPage
+      title="Create role"
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem render={() => <Link to="/projects">Projects</Link>} />
+          <BreadcrumbItem
+            render={() => <Link to={`/projects/${namespace}?section=roles`}>{namespace}</Link>}
+          />
+          <BreadcrumbItem isActive>Create role</BreadcrumbItem>
+        </Breadcrumb>
+      }
+      loaded
+      empty={false}
+    >
+      <PageSection hasBodyWrapper={false} data-testid="create-role-page">
+        <EmptyState headingLevel="h2" titleText="Create role">
+          <EmptyStateBody>Role creation form will be implemented here.</EmptyStateBody>
+        </EmptyState>
+      </PageSection>
+    </ApplicationsPage>
+  );
+};
+
+export default CreateRolePage;

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -11,9 +11,13 @@ import {
 import { Link, Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { useAccessReview } from '#~/api/useAccessReview';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
 
 const CreateRolePage: React.FC = () => {
   const { namespace = '' } = useParams<{ namespace: string }>();
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const displayName = getDisplayNameFromK8sResource(currentProject);
 
   const [allowCreate, loaded] = useAccessReview({
     group: 'rbac.authorization.k8s.io',
@@ -41,7 +45,7 @@ const CreateRolePage: React.FC = () => {
         <Breadcrumb>
           <BreadcrumbItem render={() => <Link to="/projects">Projects</Link>} />
           <BreadcrumbItem
-            render={() => <Link to={`/projects/${namespace}?section=roles`}>{namespace}</Link>}
+            render={() => <Link to={`/projects/${namespace}?section=roles`}>{displayName}</Link>}
           />
           <BreadcrumbItem isActive>Create role</BreadcrumbItem>
         </Breadcrumb>

--- a/frontend/src/pages/projects/projectRoles/ProjectRoles.tsx
+++ b/frontend/src/pages/projects/projectRoles/ProjectRoles.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Button,
+  PageSection,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
+
+const ProjectRoles: React.FC = () => {
+  const { currentProject } = React.useContext(ProjectDetailsContext);
+  const namespace = currentProject.metadata.name;
+
+  return (
+    <PageSection hasBodyWrapper={false} data-testid="project-roles-tab">
+      <EmptyState headingLevel="h2" icon={PlusCircleIcon} titleText="No custom roles">
+        <EmptyStateBody>
+          Custom roles allow you to define fine-grained permissions for project members.
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button
+              variant="primary"
+              component={(props) => <Link {...props} to={`/projects/${namespace}/roles/create`} />}
+              data-testid="create-role-button"
+            >
+              Create role
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
+  );
+};
+
+export default ProjectRoles;

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   ListItem,
   List,
+  Label,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Link, useSearchParams } from 'react-router-dom';
@@ -195,7 +196,11 @@ const ProjectDetails: React.FC = () => {
                   {
                     id: ProjectSectionID.ROLES,
                     title: 'Roles',
-                    label: 'Dev preview',
+                    label: (
+                      <Label isCompact color="yellow" variant="outline">
+                        Dev preview
+                      </Label>
+                    ),
                     component: <ProjectRoles />,
                   },
                 ]

--- a/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
+++ b/frontend/src/pages/projects/screens/detail/ProjectDetails.tsx
@@ -22,6 +22,7 @@ import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import GenericHorizontalBar from '#~/pages/projects/components/GenericHorizontalBar';
 import ProjectSharing from '#~/pages/projects/projectSharing/ProjectSharing';
 import ProjectPermissions from '#~/pages/projects/projectPermissions/ProjectPermissions';
+import ProjectRoles from '#~/pages/projects/projectRoles/ProjectRoles';
 import ProjectSettingsPage from '#~/pages/projects/projectSettings/ProjectSettingsPage';
 import { SupportedArea, useIsAreaAvailable } from '#~/concepts/areas';
 import { ProjectObjectType, SectionType } from '#~/concepts/design/utils';
@@ -32,7 +33,10 @@ import {
 } from '#~/concepts/k8s/utils';
 import ResourceNameTooltip from '#~/components/ResourceNameTooltip';
 import HeaderIcon from '#~/concepts/design/HeaderIcon';
-import { useProjectPermissionsTabVisible } from '#~/concepts/projects/accessChecks';
+import {
+  useProjectPermissionsTabVisible,
+  useProjectRolesTabVisible,
+} from '#~/concepts/projects/accessChecks';
 import { useKueueConfiguration } from '#~/concepts/hardwareProfiles/kueueUtils';
 import { PermissionsContextProvider } from '#~/concepts/permissions/PermissionsContext';
 import useCheckLogoutParams from './useCheckLogoutParams';
@@ -53,6 +57,7 @@ const ProjectDetails: React.FC = () => {
   const projectSharingEnabled = useIsAreaAvailable(SupportedArea.DS_PROJECTS_PERMISSIONS).status;
   const pipelinesEnabled = useIsAreaAvailable(SupportedArea.DS_PIPELINES).status;
   const projectRBACEnabled = useIsAreaAvailable(SupportedArea.PROJECT_RBAC_SETTINGS).status;
+  const roleManagementEnabled = useIsAreaAvailable(SupportedArea.ROLE_MANAGEMENT).status;
   const settingsCardExtensions = useExtensions(isProjectDetailsSettingsCardExtension);
   const hasSettingsCards = settingsCardExtensions.length > 0;
   const deploymentsTab = useDeploymentsTab();
@@ -60,6 +65,10 @@ const ProjectDetails: React.FC = () => {
   const state = searchParams.get('section');
 
   const [allowCreate, rbacLoaded] = useProjectPermissionsTabVisible(currentProject.metadata.name);
+  const [allowRoles, rolesRbacLoaded] = useProjectRolesTabVisible(
+    currentProject.metadata.name,
+    roleManagementEnabled,
+  );
 
   const workbenchEnabled = useIsAreaAvailable(SupportedArea.WORKBENCHES).status;
 
@@ -94,7 +103,7 @@ const ProjectDetails: React.FC = () => {
           </BreadcrumbItem>
         </Breadcrumb>
       }
-      loaded={rbacLoaded}
+      loaded={rbacLoaded && (!roleManagementEnabled || rolesRbacLoaded)}
       empty={false}
       headerAction={<ProjectActions project={currentProject} />}
     >
@@ -181,6 +190,16 @@ const ProjectDetails: React.FC = () => {
               title: 'Connections',
               component: <ConnectionsList />,
             },
+            ...(roleManagementEnabled && allowRoles
+              ? [
+                  {
+                    id: ProjectSectionID.ROLES,
+                    title: 'Roles',
+                    label: 'Dev preview',
+                    component: <ProjectRoles />,
+                  },
+                ]
+              : []),
             ...(projectSharingEnabled && allowCreate
               ? [
                   {
@@ -213,6 +232,8 @@ const ProjectDetails: React.FC = () => {
             projectSharingEnabled,
             allowCreate,
             projectRBACEnabled,
+            roleManagementEnabled,
+            allowRoles,
             currentProject.metadata.name,
             biasMetricsAreaAvailable,
             hasSettingsCards,

--- a/frontend/src/pages/projects/screens/detail/const.ts
+++ b/frontend/src/pages/projects/screens/detail/const.ts
@@ -8,6 +8,7 @@ export const ProjectSectionTitles: ProjectSectionTitlesType = {
   [ProjectSectionID.MODEL_SERVER]: 'Deployments',
   [ProjectSectionID.PIPELINES]: 'Pipelines',
   [ProjectSectionID.PERMISSIONS]: 'Permissions',
+  [ProjectSectionID.ROLES]: 'Roles',
   [ProjectSectionID.SETTINGS]: 'Settings',
   [ProjectSectionID.FEATURE_STORE]: 'Feature Store',
 };

--- a/frontend/src/pages/projects/screens/detail/types.ts
+++ b/frontend/src/pages/projects/screens/detail/types.ts
@@ -6,6 +6,7 @@ export enum ProjectSectionID {
   MODEL_SERVER = 'model-server',
   PIPELINES = 'pipelines-projects',
   PERMISSIONS = 'permissions',
+  ROLES = 'roles',
   SETTINGS = 'settings',
   FEATURE_STORE = 'feature-store-integration',
 }

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -1,0 +1,34 @@
+class ProjectRolesTab {
+  visit(namespace: string) {
+    cy.visitWithLogin(`/projects/${namespace}?section=roles`);
+    this.wait();
+  }
+
+  visitOverview(namespace: string) {
+    cy.visitWithLogin(`/projects/${namespace}?section=overview`);
+    this.wait();
+  }
+
+  visitCreateRole(namespace: string) {
+    cy.visitWithLogin(`/projects/${namespace}/roles/create`);
+  }
+
+  private wait() {
+    cy.findByTestId('app-page-title');
+    cy.testA11y();
+  }
+
+  findRolesTab() {
+    return cy.findByTestId('roles-tab');
+  }
+
+  findCreateRoleButton() {
+    return cy.findByTestId('create-role-button');
+  }
+
+  findCreateRolePage() {
+    return cy.findByTestId('create-role-page');
+  }
+}
+
+export const projectRoles = new ProjectRolesTab();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the Roles tab feature flag gating.
+ * Verifies that the Roles tab is visible only when the roleManagement feature flag is enabled
+ * and the user has SSAR access to list roles.
+ */
+import {
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockProjectK8sResource,
+} from '@odh-dashboard/internal/__mocks__';
+import { ProjectModel } from '../../../../utils/models';
+import { asProjectAdminUser, asProjectEditUser } from '../../../../utils/mockUsers';
+
+const NAMESPACE = 'test-project';
+
+const initIntercepts = ({ roleManagement = false }: { roleManagement?: boolean } = {}) => {
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      roleManagement,
+    }),
+  );
+
+  cy.interceptK8s(ProjectModel, mockProjectK8sResource({ k8sName: NAMESPACE }));
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: NAMESPACE })]),
+  );
+};
+
+describe('Roles tab feature flag gating', () => {
+  describe('with roleManagement flag disabled (default)', () => {
+    beforeEach(() => {
+      asProjectAdminUser();
+      initIntercepts({ roleManagement: false });
+    });
+
+    it('should not show the Roles tab', () => {
+      cy.visit(`/projects/${NAMESPACE}?section=overview`);
+      cy.findByTestId('project-roles-tab').should('not.exist');
+      cy.findByRole('tab', { name: 'Roles' }).should('not.exist');
+    });
+  });
+
+  describe('with roleManagement flag enabled', () => {
+    beforeEach(() => {
+      asProjectAdminUser();
+      initIntercepts({ roleManagement: true });
+    });
+
+    it('should show the Roles tab', () => {
+      cy.visit(`/projects/${NAMESPACE}?section=roles`);
+      cy.findByTestId('project-roles-tab').should('exist');
+    });
+
+    it('should show the Create role button in the Roles tab', () => {
+      cy.visit(`/projects/${NAMESPACE}?section=roles`);
+      cy.findByTestId('create-role-button').should('exist');
+    });
+  });
+
+  describe('with roleManagement flag enabled but non-admin user', () => {
+    beforeEach(() => {
+      asProjectEditUser();
+      initIntercepts({ roleManagement: true });
+    });
+
+    it('should show the Roles tab for users with list access to roles', () => {
+      cy.visit(`/projects/${NAMESPACE}?section=roles`);
+      cy.findByTestId('project-roles-tab').should('exist');
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -11,6 +11,7 @@ import {
 import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
 import { ProjectModel, SelfSubjectAccessReviewModel } from '../../../../utils/models';
 import { asProjectAdminUser, asProjectEditUser } from '../../../../utils/mockUsers';
+import { projectRoles } from '../../../../pages/projectRoles';
 
 const NAMESPACE = 'test-project';
 
@@ -37,13 +38,12 @@ describe('Roles tab feature flag gating', () => {
     });
 
     it('should not show the Roles tab', () => {
-      cy.visit(`/projects/${NAMESPACE}?section=overview`);
-      cy.findByTestId('project-roles-tab').should('not.exist');
-      cy.findByRole('tab', { name: 'Roles' }).should('not.exist');
+      projectRoles.visitOverview(NAMESPACE);
+      projectRoles.findRolesTab().should('not.exist');
     });
 
     it('should redirect from /roles/create to the project page when flag is disabled', () => {
-      cy.visit(`/projects/${NAMESPACE}/roles/create`);
+      projectRoles.visitCreateRole(NAMESPACE);
       cy.url().should('not.include', '/roles/create');
       cy.url().should('include', `/projects/${NAMESPACE}`);
     });
@@ -56,18 +56,18 @@ describe('Roles tab feature flag gating', () => {
     });
 
     it('should show the Roles tab', () => {
-      cy.visit(`/projects/${NAMESPACE}?section=roles`);
-      cy.findByTestId('project-roles-tab').should('exist');
+      projectRoles.visit(NAMESPACE);
+      projectRoles.findRolesTab().should('exist');
     });
 
     it('should show the Create role button in the Roles tab', () => {
-      cy.visit(`/projects/${NAMESPACE}?section=roles`);
-      cy.findByTestId('create-role-button').should('exist');
+      projectRoles.visit(NAMESPACE);
+      projectRoles.findCreateRoleButton().should('exist');
     });
 
     it('should render the Create role page when user has permission', () => {
-      cy.visit(`/projects/${NAMESPACE}/roles/create`);
-      cy.findByTestId('create-role-page').should('exist');
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findCreateRolePage().should('exist');
     });
   });
 
@@ -75,7 +75,6 @@ describe('Roles tab feature flag gating', () => {
     beforeEach(() => {
       asProjectEditUser();
       initIntercepts({ roleManagement: true });
-      // Override SSAR to deny 'create' on 'roles'
       cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
         const { resourceAttributes } = req.body.spec;
         if (
@@ -100,16 +99,49 @@ describe('Roles tab feature flag gating', () => {
       });
     });
 
-    it('should show the Roles tab for users with list access to roles', () => {
-      cy.visit(`/projects/${NAMESPACE}?section=roles`);
-      cy.findByTestId('project-roles-tab').should('exist');
+    it('should show the Roles tab when user has list access to roles', () => {
+      projectRoles.visit(NAMESPACE);
+      projectRoles.findRolesTab().should('exist');
     });
 
     it('should redirect from /roles/create when user lacks create permission', () => {
-      cy.visit(`/projects/${NAMESPACE}/roles/create`);
+      projectRoles.visitCreateRole(NAMESPACE);
       cy.url().should('not.include', '/roles/create');
       cy.url().should('include', `/projects/${NAMESPACE}`);
       cy.url().should('include', 'section=roles');
+    });
+  });
+
+  describe('with roleManagement flag enabled but user lacks list permission on roles', () => {
+    beforeEach(() => {
+      asProjectEditUser();
+      initIntercepts({ roleManagement: true });
+      cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
+        const { resourceAttributes } = req.body.spec;
+        if (
+          resourceAttributes.resource === 'roles' &&
+          resourceAttributes.group === 'rbac.authorization.k8s.io'
+        ) {
+          req.reply(
+            mockSelfSubjectAccessReview({
+              ...resourceAttributes,
+              allowed: false,
+            }),
+          );
+        } else {
+          req.reply(
+            mockSelfSubjectAccessReview({
+              ...resourceAttributes,
+              allowed: true,
+            }),
+          );
+        }
+      });
+    });
+
+    it('should not show the Roles tab when user lacks list access to roles', () => {
+      projectRoles.visitOverview(NAMESPACE);
+      projectRoles.findRolesTab().should('not.exist');
     });
   });
 });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -8,7 +8,8 @@ import {
   mockK8sResourceList,
   mockProjectK8sResource,
 } from '@odh-dashboard/internal/__mocks__';
-import { ProjectModel } from '../../../../utils/models';
+import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
+import { ProjectModel, SelfSubjectAccessReviewModel } from '../../../../utils/models';
 import { asProjectAdminUser, asProjectEditUser } from '../../../../utils/mockUsers';
 
 const NAMESPACE = 'test-project';
@@ -40,6 +41,12 @@ describe('Roles tab feature flag gating', () => {
       cy.findByTestId('project-roles-tab').should('not.exist');
       cy.findByRole('tab', { name: 'Roles' }).should('not.exist');
     });
+
+    it('should redirect from /roles/create to the project page when flag is disabled', () => {
+      cy.visit(`/projects/${NAMESPACE}/roles/create`);
+      cy.url().should('not.include', '/roles/create');
+      cy.url().should('include', `/projects/${NAMESPACE}`);
+    });
   });
 
   describe('with roleManagement flag enabled', () => {
@@ -57,17 +64,52 @@ describe('Roles tab feature flag gating', () => {
       cy.visit(`/projects/${NAMESPACE}?section=roles`);
       cy.findByTestId('create-role-button').should('exist');
     });
+
+    it('should render the Create role page when user has permission', () => {
+      cy.visit(`/projects/${NAMESPACE}/roles/create`);
+      cy.findByTestId('create-role-page').should('exist');
+    });
   });
 
-  describe('with roleManagement flag enabled but non-admin user', () => {
+  describe('with roleManagement flag enabled but user lacks create permission', () => {
     beforeEach(() => {
       asProjectEditUser();
       initIntercepts({ roleManagement: true });
+      // Override SSAR to deny 'create' on 'roles'
+      cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
+        const { resourceAttributes } = req.body.spec;
+        if (
+          resourceAttributes.resource === 'roles' &&
+          resourceAttributes.verb === 'create' &&
+          resourceAttributes.group === 'rbac.authorization.k8s.io'
+        ) {
+          req.reply(
+            mockSelfSubjectAccessReview({
+              ...resourceAttributes,
+              allowed: false,
+            }),
+          );
+        } else {
+          req.reply(
+            mockSelfSubjectAccessReview({
+              ...resourceAttributes,
+              allowed: true,
+            }),
+          );
+        }
+      });
     });
 
     it('should show the Roles tab for users with list access to roles', () => {
       cy.visit(`/projects/${NAMESPACE}?section=roles`);
       cy.findByTestId('project-roles-tab').should('exist');
+    });
+
+    it('should redirect from /roles/create when user lacks create permission', () => {
+      cy.visit(`/projects/${NAMESPACE}/roles/create`);
+      cy.url().should('not.include', '/roles/create');
+      cy.url().should('include', `/projects/${NAMESPACE}`);
+      cy.url().should('include', 'section=roles');
     });
   });
 });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-63152

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds scaffolding for a project-level "Roles" tab behind the `roleManagement` temporary developer feature flag ([RHOAIENG-63152](https://redhat.atlassian.net/browse/RHOAIENG-63152)). This is preparatory work for fine-grained role management within projects.

**What's included:**
- New `roleManagement` feature flag in `devTemporaryFeatureFlags` (not in CRD — hidden from users until dev is complete)
- New `ROLE_MANAGEMENT` supported area with feature flag mapping
- "Roles" tab in project details, gated by:
  1. Feature flag enabled (`roleManagement: true`)
  2. SSAR check — user must have `list` permission on `roles` in `rbac.authorization.k8s.io`
- Tab displays "Dev preview" label (yellow outline, matching existing label styling)
- Placeholder `ProjectRoles` empty state with a "Create role" button
- Placeholder `CreateRolePage` with breadcrumb navigation
- Route for `/projects/:namespace/roles/create` (conditional on feature flag)

**Visibility:** The tab is invisible by default. To enable locally, set `roleManagement: true` on the `OdhDashboardConfig` CR. A follow-up ticket ([RHOAIENG-63227](https://redhat.atlassian.net/browse/RHOAIENG-63227)) tracks promotion to Tech Preview.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified the tab does **not** appear when the feature flag is disabled (default)
- Verified the tab appears with "Dev preview" label when `roleManagement: true` is set on the CR
- Verified the loading spinner does not hang when the flag is disabled (conditional SSAR logic)
- Verified the "Create role" button navigates to the create page with correct breadcrumbs
- Ran `tsc --noEmit` on frontend and backend — no type errors
- Ran ESLint on all changed/new files — no lint errors
- Ran unit tests (14 suites, 152 tests pass) including new `isAreaAvailable` tests for `ROLE_MANAGEMENT`

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- **Unit tests:** Added 3 test cases in `frontend/src/concepts/areas/__tests__/utils.spec.ts` verifying `ROLE_MANAGEMENT` area availability based on feature flag state
- **Cypress mock tests:** Added `packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts` covering:
  - Tab hidden when `roleManagement` flag is disabled
  - Tab visible with "Create role" button when flag is enabled (admin)
  - Tab visible for non-admin users with appropriate RBAC permissions

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role management to projects (feature-flag gated).
  * Introduced a Roles tab in project details with a "Create role" page (access-controlled; placeholder UI).
  * Routing updated so role creation routes are available only when permitted.

* **Tests**
  * Unit tests for area availability with roleManagement flag.
  * End-to-end tests covering feature-flag gating and create-role permission flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->