### PR TITLE
Show MaaS API Errors in the UI

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -25,6 +25,10 @@ class APIKeysPage {
     cy.testA11y();
   }
 
+  findErrorState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('error-empty-state-body');
+  }
+
   findTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('app-page-title');
   }
@@ -377,6 +381,10 @@ class SubscriptionsPage {
   private wait(): void {
     cy.findByTestId('app-page-title').should('exist');
     cy.testA11y();
+  }
+
+  findErrorState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('error-empty-state-body');
   }
 
   findTable(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -841,6 +849,10 @@ class AuthPoliciesPage {
   private wait(): void {
     cy.findByTestId('app-page-title').should('exist');
     cy.testA11y();
+  }
+
+  findErrorState(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('error-empty-state-body');
   }
 
   findTitle(): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -178,6 +178,28 @@ describe('API Keys Page', () => {
     apiKeysPage.findCreateApiKeyButton().should('exist').and('be.enabled');
   });
 
+  it('should display a useful error state when the API keys search fails', () => {
+    cy.intercept('POST', '/maas/api/v1/api-keys/search', {
+      statusCode: 500,
+      body: {
+        error: {
+          code: '500',
+          message:
+            'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/api-keys/search',
+        },
+      },
+    }).as('searchError');
+    apiKeysPage.visit();
+    cy.wait('@searchError');
+    apiKeysPage.findErrorState().should('exist');
+    apiKeysPage
+      .findErrorState()
+      .should(
+        'contain.text',
+        'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/api-keys/search',
+      );
+  });
+
   it('should display all API keys when the status filter is cleared', () => {
     apiKeysPage.findRows().should('have.length', 2);
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasAuthPolicies.cy.ts
@@ -90,6 +90,28 @@ describe('MaaS Auth Policies', () => {
     authPoliciesPage.findCreateAuthPolicyButton().should('exist');
   });
 
+  it('should display a useful error state when the auth policies search fails', () => {
+    cy.intercept('GET', '/maas/api/v1/all-policies', {
+      statusCode: 500,
+      body: {
+        error: {
+          code: '500',
+          message:
+            'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/all-policies',
+        },
+      },
+    }).as('searchError');
+    authPoliciesPage.visit();
+    cy.wait('@searchError');
+    authPoliciesPage.findErrorState().should('exist');
+    authPoliciesPage
+      .findErrorState()
+      .should(
+        'contain.text',
+        'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/all-policies',
+      );
+  });
+
   it('should display the auth policies table with correct page content', () => {
     authPoliciesPage.findTitle().should('contain.text', 'Authorization policies');
     authPoliciesPage.findTable().should('exist');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptions.cy.ts
@@ -51,6 +51,28 @@ describe('Subscriptions Page', () => {
     subscriptionsPage.findCreateSubscriptionButton().should('exist');
   });
 
+  it('should display a useful error state when the subscriptions search fails', () => {
+    cy.intercept('GET', '/maas/api/v1/all-subscriptions', {
+      statusCode: 500,
+      body: {
+        error: {
+          code: '500',
+          message:
+            'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/all-subscriptions',
+        },
+      },
+    }).as('searchError');
+    subscriptionsPage.visit();
+    cy.wait('@searchError');
+    subscriptionsPage.findErrorState().should('exist');
+    subscriptionsPage
+      .findErrorState()
+      .should(
+        'contain.text',
+        'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/all-subscriptions',
+      );
+  });
+
   it('should display the subscriptions table with correct page content', () => {
     subscriptionsPage.findTitle().should('contain.text', 'Subscriptions');
     subscriptionsPage

--- a/packages/maas/bff/internal/api/errors.go
+++ b/packages/maas/bff/internal/api/errors.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/opendatahub-io/maas-library/bff/internal/integrations/maas"
 )
 
 type HTTPError struct {
@@ -50,7 +53,27 @@ func (app *App) errorResponse(w http.ResponseWriter, r *http.Request, httpErr *H
 func (app *App) serverErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	app.LogError(r, err)
 
-	httpError := &HTTPError{StatusCode: http.StatusInternalServerError, Error: ErrorPayload{Code: strconv.Itoa(http.StatusInternalServerError), Message: "the server encountered a problem and could not process your request"}}
+	statusCode := http.StatusInternalServerError
+	message := err.Error()
+
+	var upstreamErr *maas.MaasUpstreamError
+	if errors.As(err, &upstreamErr) {
+		message = upstreamErr.Error()
+		switch {
+		case upstreamErr.StatusCode == 0, upstreamErr.StatusCode >= http.StatusInternalServerError:
+			statusCode = http.StatusServiceUnavailable
+		default:
+			statusCode = http.StatusBadGateway
+		}
+	}
+
+	httpError := &HTTPError{
+		StatusCode: statusCode,
+		Error: ErrorPayload{
+			Code:    strconv.Itoa(statusCode),
+			Message: message,
+		},
+	}
 	app.errorResponse(w, r, httpError)
 }
 

--- a/packages/maas/frontend/src/app/api/__tests__/subscriptions.spec.ts
+++ b/packages/maas/frontend/src/app/api/__tests__/subscriptions.spec.ts
@@ -63,7 +63,7 @@ describe('getSubscriptionInfo', () => {
   });
 
   it('should resolve with subscription info for a valid response', async () => {
-    mockRestGET.mockResolvedValue(validSubscriptionInfoResponse);
+    mockRestGET.mockResolvedValue({ data: validSubscriptionInfoResponse });
 
     const result = await getSubscriptionInfo('test-sub')({} as never);
     expect(result).toStrictEqual(validSubscriptionInfoResponse);
@@ -104,7 +104,7 @@ describe('getSubscriptionInfo', () => {
 
   it('should accept an empty authPolicies array', async () => {
     const emptyPolicies = { ...validSubscriptionInfoResponse, authPolicies: [] };
-    mockRestGET.mockResolvedValue(emptyPolicies);
+    mockRestGET.mockResolvedValue({ data: emptyPolicies });
 
     const result = await getSubscriptionInfo('test-sub')({} as never);
     expect(result.authPolicies).toHaveLength(0);
@@ -134,7 +134,7 @@ describe('getSubscriptionInfo', () => {
         description: 'High-priority subscription for the premium team.',
       },
     };
-    mockRestGET.mockResolvedValue(withAnnotations);
+    mockRestGET.mockResolvedValue({ data: withAnnotations });
 
     const result = await getSubscriptionInfo('test-sub')({} as never);
     expect(result.subscription.displayName).toBe('Premium Team Subscription');
@@ -154,7 +154,7 @@ describe('getSubscriptionInfo', () => {
         },
       ],
     };
-    mockRestGET.mockResolvedValue(noOptionals);
+    mockRestGET.mockResolvedValue({ data: noOptionals });
 
     const result = await getSubscriptionInfo('test-sub')({} as never);
     expect(result.modelRefs[0].phase).toBeUndefined();

--- a/packages/maas/frontend/src/app/hooks/useApiKeysPageLoad.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysPageLoad.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useFetchApiKeys } from '~/app/hooks/useFetchApiKeys';
+import { useIsMaasAdmin } from '~/app/hooks/useIsMaasAdmin';
+import {
+  useApiKeysTableState,
+  type UseApiKeysTableStateReturn,
+} from '~/app/hooks/useApiKeysTableState';
+import { APIKeySearchRequest } from '~/app/types/api-key';
+
+const EXISTENCE_CHECK_REQUEST: APIKeySearchRequest = { pagination: { limit: 1, offset: 0 } };
+
+export type UseApiKeysPageLoadReturn = UseApiKeysTableStateReturn & {
+  isMaasAdmin: boolean;
+  isMaasAdminLoaded: boolean;
+  loadError: Error | undefined;
+  loaded: boolean;
+  hasAnyApiKeys: boolean;
+  existenceLoaded: boolean;
+  refreshAll: () => void;
+};
+
+export const useApiKeysPageLoad = (): UseApiKeysPageLoadReturn => {
+  const [isMaasAdmin, isMaasAdminLoaded, isMaasAdminError] = useIsMaasAdmin();
+  const tableState = useApiKeysTableState();
+  const [existenceResponse, existenceLoaded, existenceError, refreshExistence] =
+    useFetchApiKeys(EXISTENCE_CHECK_REQUEST);
+
+  const loadError = tableState.error ?? existenceError ?? isMaasAdminError;
+
+  const hasAnyApiKeys = tableState.response.data.length > 0 || existenceResponse.data.length > 0;
+
+  const loaded =
+    isMaasAdminLoaded && tableState.loaded && (existenceLoaded || !!existenceError) && !loadError;
+
+  const refreshAll = React.useCallback(() => {
+    tableState.refresh();
+    refreshExistence();
+  }, [tableState, refreshExistence]);
+
+  return {
+    ...tableState,
+    isMaasAdmin,
+    isMaasAdminLoaded,
+    loadError,
+    loaded,
+    hasAnyApiKeys,
+    existenceLoaded,
+    refreshAll,
+  };
+};

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -16,9 +16,10 @@ const DEFAULT_SORT_FIELD: ApiKeySortField = 'created_at';
 const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
 const DEFAULT_PER_PAGE = 50;
 
-type UseApiKeysTableStateReturn = {
+export type UseApiKeysTableStateReturn = {
   response: APIKeyListResponse;
   loaded: boolean;
+  error: Error | undefined;
   refresh: () => void;
   filterData: ApiKeyFilterDataType;
   localUsername: string;
@@ -58,7 +59,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     [filterData, sortField, sortDirection, page, perPage],
   );
 
-  const [response, loaded, , refresh] = useFetchApiKeys(searchRequest);
+  const [response, loaded, error, refresh] = useFetchApiKeys(searchRequest);
 
   React.useEffect(() => {
     setIsFetching(false);
@@ -121,6 +122,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
   return {
     response,
     loaded,
+    error,
     refresh,
     filterData,
     localUsername,

--- a/packages/maas/frontend/src/app/pages/api-keys/AllApiKeysPage.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/AllApiKeysPage.tsx
@@ -1,16 +1,24 @@
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import React from 'react';
+import { useApiKeysPageLoad } from '~/app/hooks/useApiKeysPageLoad';
 import ApiKeysTab from './ApiKeysTab';
 
-const AllApiKeysPage: React.FC = () => (
-  <ApplicationsPage
-    title="API keys"
-    description="Manage API keys that can be used to authenticate with model endpoints."
-    loaded
-    empty={false}
-  >
-    <ApiKeysTab />
-  </ApplicationsPage>
-);
+const AllApiKeysPage: React.FC = () => {
+  const pageState = useApiKeysPageLoad();
+  const { loadError, loaded } = pageState;
+
+  return (
+    <ApplicationsPage
+      title="API keys"
+      description="Manage API keys that can be used to authenticate with model endpoints."
+      loaded={loaded || !!loadError}
+      empty={false}
+      loadError={loadError}
+      errorMessage="Error loading API keys"
+    >
+      {!loadError && <ApiKeysTab pageState={pageState} />}
+    </ApplicationsPage>
+  );
+};
 
 export default AllApiKeysPage;

--- a/packages/maas/frontend/src/app/pages/api-keys/ApiKeysAndSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/ApiKeysAndSubscriptionsPage.tsx
@@ -4,6 +4,7 @@ import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useApiKeysPageLoad } from '~/app/hooks/useApiKeysPageLoad';
 import { URL_PREFIX } from '~/app/utilities/const';
 import ApiKeysTab from './ApiKeysTab';
 import SubscriptionsTab from './SubscriptionsTab';
@@ -15,8 +16,11 @@ const VALID_TABS = [API_KEYS_TAB, SUBSCRIPTIONS_TAB];
 const ApiKeysAndSubscriptionsPage: React.FC = () => {
   const { tab } = useParams<{ tab: string }>();
   const navigate = useNavigate();
+  const apiKeysPageState = useApiKeysPageLoad();
+  const { loadError: apiKeysLoadError } = apiKeysPageState;
 
   const activeTab = tab && VALID_TABS.includes(tab) ? tab : API_KEYS_TAB;
+  const showApiKeysLoadError = activeTab === API_KEYS_TAB && !!apiKeysLoadError;
 
   const onSelectTab = React.useCallback(
     (_event: React.MouseEvent, tabKey: string | number) => {
@@ -31,8 +35,10 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
         <TitleWithIcon title="API keys and subscriptions" objectType={ProjectObjectType.apiKeys} />
       }
       description="Manage your API keys and view your subscription access."
-      loaded
+      loaded={activeTab === SUBSCRIPTIONS_TAB || apiKeysPageState.loaded || !!apiKeysLoadError}
       empty={false}
+      loadError={showApiKeysLoadError ? apiKeysLoadError : undefined}
+      errorMessage="Error loading API keys"
     >
       <Tabs
         activeKey={activeTab}
@@ -47,7 +53,7 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
           data-testid="api-keys-tab"
         >
           <PageSection isFilled>
-            <ApiKeysTab />
+            {!showApiKeysLoadError && <ApiKeysTab pageState={apiKeysPageState} />}
           </PageSection>
         </Tab>
         <Tab

--- a/packages/maas/frontend/src/app/pages/api-keys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/ApiKeysTab.tsx
@@ -1,27 +1,29 @@
 import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import React from 'react';
-import { useFetchApiKeys } from '~/app/hooks/useFetchApiKeys';
-import { useIsMaasAdmin } from '~/app/hooks/useIsMaasAdmin';
-import { useApiKeysTableState } from '~/app/hooks/useApiKeysTableState';
-import { APIKey, APIKeySearchRequest } from '~/app/types/api-key';
+import { type UseApiKeysPageLoadReturn } from '~/app/hooks/useApiKeysPageLoad';
+import { APIKey } from '~/app/types/api-key';
 import CreateApiKeyModal from './CreateApiKeyModal';
 import EmptyApiKeysPage from './EmptyApiKeysPage';
 import ApiKeysTable from './allKeys/ApiKeysTable';
 import RevokeApiKeyModal from './RevokeApiKeyModal';
 import ApiKeysToolbar from './allKeys/ApiKeysToolbar';
 
-const EXISTENCE_CHECK_REQUEST: APIKeySearchRequest = { pagination: { limit: 1, offset: 0 } };
+type ApiKeysTabProps = {
+  pageState: UseApiKeysPageLoadReturn;
+};
 
-const ApiKeysTab: React.FC = () => {
+const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [revokeApiKey, setRevokeApiKey] = React.useState<APIKey | undefined>(undefined);
 
-  const [isMaasAdmin, isMaasAdminLoaded] = useIsMaasAdmin();
-
   const {
+    isMaasAdmin,
+    isMaasAdminLoaded,
     response,
+    hasAnyApiKeys,
+    existenceLoaded,
     loaded,
-    refresh,
+    refreshAll,
     filterData,
     localUsername,
     setLocalUsername,
@@ -37,16 +39,7 @@ const ApiKeysTab: React.FC = () => {
     onSetPage,
     onPerPageSelect,
     onClearFilters,
-  } = useApiKeysTableState();
-
-  const [existenceResponse, existenceLoaded, , refreshExistence] =
-    useFetchApiKeys(EXISTENCE_CHECK_REQUEST);
-  const hasAnyApiKeys = response.data.length > 0 || existenceResponse.data.length > 0;
-
-  const refreshAll = React.useCallback(() => {
-    refresh();
-    refreshExistence();
-  }, [refresh, refreshExistence]);
+  } = pageState;
 
   const apiKeys = response.data;
   const hasMore = response.has_more;

--- a/packages/maas/frontend/src/app/pages/api-keys/__tests__/ApiKeysAndSubscriptionsPage.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/api-keys/__tests__/ApiKeysAndSubscriptionsPage.spec.tsx
@@ -12,6 +12,35 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ tab: mockTab }),
 }));
 
+jest.mock('~/app/hooks/useApiKeysPageLoad', () => ({
+  useApiKeysPageLoad: () => ({
+    loadError: undefined,
+    loaded: true,
+    hasAnyApiKeys: true,
+    existenceLoaded: true,
+    isMaasAdmin: false,
+    isMaasAdminLoaded: true,
+    // eslint-disable-next-line camelcase
+    response: { data: [], has_more: false, object: 'list' },
+    refreshAll: jest.fn(),
+    filterData: { username: '', statuses: [] },
+    localUsername: '',
+    setLocalUsername: jest.fn(),
+    page: 1,
+    perPage: 50,
+    sortField: 'created_at',
+    sortDirection: 'desc',
+    isFetching: false,
+    onUsernameChange: jest.fn(),
+    onStatusToggle: jest.fn(),
+    onStatusClear: jest.fn(),
+    onSort: jest.fn(),
+    onSetPage: jest.fn(),
+    onPerPageSelect: jest.fn(),
+    onClearFilters: jest.fn(),
+  }),
+}));
+
 jest.mock('~/app/pages/api-keys/ApiKeysTab', () => {
   const MockApiKeysTab = () => <div data-testid="mock-api-keys-tab">ApiKeysTab</div>;
   MockApiKeysTab.displayName = 'MockApiKeysTab';

--- a/packages/maas/frontend/src/app/pages/auth-policies/AllAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/AllAuthPoliciesPage.tsx
@@ -51,8 +51,9 @@ const AllAuthPoliciesPage: React.FC = () => {
       description="Authorization policies, in combination with subscriptions, enable users to consume model endpoints through the API gateway."
       empty={loaded && !error && authPolicies.length === 0}
       emptyStatePage={<EmptyAuthPoliciesPage />}
-      loaded={loaded}
+      loaded={loaded || !!error}
       loadError={error}
+      errorMessage="Error loading authorization policies"
     >
       {loaded && (
         <PageSection isFilled>

--- a/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
@@ -21,7 +21,7 @@ const CreateAuthPolicyPage: React.FC = () => {
           <BreadcrumbItem isActive>Create authorization policy</BreadcrumbItem>
         </Breadcrumb>
       }
-      loaded={loaded}
+      loaded={loaded || !!loadError}
       empty={false}
       loadError={loadError}
     >

--- a/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
@@ -28,7 +28,7 @@ const EditAuthPolicyPage: React.FC = () => {
           <BreadcrumbItem isActive>{displayName || authPolicyName}</BreadcrumbItem>
         </Breadcrumb>
       }
-      loaded={loaded}
+      loaded={loaded || !!loadError}
       empty={false}
       loadError={loadError}
       errorMessage="Unable to load policy."

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -103,7 +103,7 @@ const ViewAuthPoliciesPage: React.FC = () => {
       breadcrumb={breadcrumb}
       headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} />}
       empty={false}
-      loaded={loaded}
+      loaded={loaded || !!loadError}
       loadError={loadError}
       errorMessage="Unable to load policy details."
     >

--- a/packages/maas/frontend/src/app/pages/subscriptions/AllSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/AllSubscriptionsPage.tsx
@@ -49,8 +49,9 @@ const AllSubscriptionsPage: React.FC = () => {
       description="Create subscriptions to manage group access to MaaS endpoints, and to set token limits for each model."
       empty={loaded && !error && subscriptions.length === 0}
       emptyStatePage={<EmptySubscriptionsPage />}
-      loaded={loaded}
+      loaded={loaded || !!error}
       loadError={error}
+      errorMessage="Error loading subscriptions"
     >
       {loaded && (
         <PageSection isFilled>

--- a/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
@@ -20,7 +20,7 @@ const CreateSubscriptionPage: React.FC = () => {
           <BreadcrumbItem isActive>Create subscription</BreadcrumbItem>
         </Breadcrumb>
       }
-      loaded={loaded}
+      loaded={loaded || !!error}
       empty={false}
       loadError={error}
     >

--- a/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
@@ -42,7 +42,7 @@ const EditSubscriptionPage: React.FC = () => {
           <BreadcrumbItem isActive>Edit subscription</BreadcrumbItem>
         </Breadcrumb>
       }
-      loaded={loaded}
+      loaded={loaded || !!error}
       empty={false}
       loadError={error}
       errorMessage="Unable to load subscription details."

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -111,7 +111,7 @@ const ViewSubscriptionPage: React.FC = () => {
         subscriptionInfo && <SubscriptionActions subscription={subscriptionInfo.subscription} />
       }
       empty={false}
-      loaded={loaded}
+      loaded={loaded || !!loadError}
       loadError={loadError}
       errorMessage="Unable to load subscription details."
     >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-63607](https://redhat.atlassian.net/browse/RHOAIENG-63607)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Makes it so on MaaS pages if there are any errors, the error will show in the UI instead of an unhelpful generic message

Now:
<img width="765" height="350" alt="Screenshot 2026-05-28 at 12 00 07 PM" src="https://github.com/user-attachments/assets/6a217fd5-19e2-48f9-95bd-a910047e50f9" />

Previously:
<img width="650" height="279" alt="Screenshot 2026-05-28 at 12 18 49 PM" src="https://github.com/user-attachments/assets/1809d83c-42fe-40da-8c7a-9f51609c8e67" />


----------------
Some hard coded errors to show how they would appear in the subscriptions and policies pages (they're harder to break)
<img width="675" height="312" alt="Screenshot 2026-05-28 at 2 41 29 PM" src="https://github.com/user-attachments/assets/a7c6a83d-b04d-4f38-9211-f20f1acf3ae7" />

<img width="694" height="337" alt="Screenshot 2026-05-28 at 2 41 32 PM" src="https://github.com/user-attachments/assets/1a2b46d6-f952-4434-9c27-ced65bf1f569" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on the `onyx` cluster

- Log into that cluster, I broke the API keys page on purpose by changing the `maas-default-gateway`'s `gatewayClassName` from `openshift-default` to `openshift-default123` which doesn't exist

Just add this to the list handler in the subs and policies files to see those errors:
```
	err = errors.New("test error - here's a bunch of info to help you debug it: " + r.URL.Path)
```


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Some tests updated and added some mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate error handling and clearer server error messages on API Keys, Auth Policies, and Subscriptions pages
  * Pages now surface load errors so error states render reliably

* **New Features / Refactor**
  * API Keys tab and related pages consolidated around a single page-state model for more consistent loading and refresh behavior

* **Tests**
  * Added end-to-end tests covering error scenarios for API Keys, Auth Policies, and Subscriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->