### PR TITLE
RHOAIENG-62246: BFF body size configuration for multimodal payloads

### DIFF
--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -463,12 +463,12 @@ func (app *App) Routes() http.Handler {
 	appMux := http.NewServeMux()
 
 	// handler for api calls
-	appMux.Handle(constants.PathPrefix+constants.ApiPathPrefix+"/", http.StripPrefix(constants.PathPrefix, apiRouter))
+	appMux.Handle(constants.PathPrefix+constants.ApiPathPrefix+"/", app.MaxBodySize(http.StripPrefix(constants.PathPrefix, apiRouter)))
 
 	// file server for the frontend file and SPA routes
 	staticDir := http.Dir(app.config.StaticAssetsDir)
 	fileServer := http.FileServer(staticDir)
-	appMux.Handle(constants.ApiPathPrefix+"/", apiRouter)
+	appMux.Handle(constants.ApiPathPrefix+"/", app.MaxBodySize(apiRouter))
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 

--- a/packages/gen-ai/bff/internal/api/errors.go
+++ b/packages/gen-ai/bff/internal/api/errors.go
@@ -118,6 +118,19 @@ func (app *App) serviceUnavailableResponse(w http.ResponseWriter, r *http.Reques
 	app.errorResponse(w, r, httpError)
 }
 
+func (app *App) payloadTooLargeResponse(w http.ResponseWriter, r *http.Request, limit int64) {
+	limitMB := float64(limit) / (1 << 20)
+	app.LogError(r, fmt.Errorf("request body exceeds the %.0fMB limit", limitMB))
+	httpError := &integrations.HTTPError{
+		StatusCode: http.StatusRequestEntityTooLarge,
+		ErrorResponse: integrations.ErrorResponse{
+			Code:    strconv.Itoa(http.StatusRequestEntityTooLarge),
+			Message: fmt.Sprintf("request body exceeds the %.0fMB limit", limitMB),
+		},
+	}
+	app.errorResponse(w, r, httpError)
+}
+
 func (app *App) serverErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	app.LogError(r, err)
 

--- a/packages/gen-ai/bff/internal/api/lsd_files_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_files_handler.go
@@ -24,8 +24,15 @@ type FileUploadResponse = llamastack.APIResponse
 func (app *App) LlamaStackUploadFileHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
-	err := r.ParseMultipartForm(32 << 20) // 32MB max memory
+	r.Body = http.MaxBytesReader(w, r.Body, constants.FileUploadMaxBodySize)
+
+	err := r.ParseMultipartForm(constants.FileUploadMaxBodySize)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			app.payloadTooLargeResponse(w, r, maxBytesErr.Limit)
+			return
+		}
 		app.badRequestResponse(w, r, fmt.Errorf("failed to parse multipart form: %w", err))
 		return
 	}
@@ -282,8 +289,6 @@ func (app *App) LlamaStackFileUploadStatusHandler(w http.ResponseWriter, r *http
 	}
 }
 
-const visionMaxFileSize = 10 << 20 // 10MB
-
 var allowedVisionMIMETypes = map[string]bool{
 	"image/jpeg": true,
 	"image/png":  true,
@@ -294,17 +299,11 @@ var allowedVisionMIMETypes = map[string]bool{
 func (app *App) LlamaStackVisionFileUploadHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	start := time.Now()
 
-	r.Body = http.MaxBytesReader(w, r.Body, visionMaxFileSize)
-	if err := r.ParseMultipartForm(visionMaxFileSize); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, constants.VisionUploadMaxBodySize)
+	if err := r.ParseMultipartForm(constants.VisionUploadMaxBodySize); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusRequestEntityTooLarge)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"error": map[string]string{
-					"message": "file exceeds the 10MB limit for vision uploads",
-				},
-			})
+			app.payloadTooLargeResponse(w, r, maxBytesErr.Limit)
 			return
 		}
 		app.badRequestResponse(w, r, fmt.Errorf("failed to parse multipart form: %w", err))
@@ -329,14 +328,8 @@ func (app *App) LlamaStackVisionFileUploadHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if header.Size > visionMaxFileSize {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusRequestEntityTooLarge)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": map[string]string{
-				"message": fmt.Sprintf("file size %d bytes exceeds the 10MB limit for vision uploads", header.Size),
-			},
-		})
+	if header.Size > constants.VisionUploadMaxBodySize {
+		app.payloadTooLargeResponse(w, r, constants.VisionUploadMaxBodySize)
 		return
 	}
 

--- a/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_files_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/openai/openai-go/v2"
@@ -947,3 +948,50 @@ var _ = Describe("LlamaStackVisionFileUploadHandler", func() {
 		assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
 	})
 })
+
+func TestLlamaStackUploadFileHandler_PayloadTooLarge(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	app := &App{
+		config: config.EnvConfig{
+			APIPathPrefix: "/api/v1",
+			AuthMethod:    config.AuthMethodDisabled,
+		},
+		logger: logger,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		app.LlamaStackUploadFileHandler(w, r, nil)
+	})
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", "large_doc.txt")
+	require.NoError(t, err)
+
+	oversizedContent := make([]byte, constants.FileUploadMaxBodySize+1)
+	for i := range oversizedContent {
+		oversizedContent[i] = 'x'
+	}
+	_, err = part.Write(oversizedContent)
+	require.NoError(t, err)
+
+	err = writer.WriteField("vector_store_id", "vs_test123")
+	require.NoError(t, err)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lsd/files/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+
+	var envelope map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &envelope)
+	assert.NoError(t, err)
+	errorObj, ok := envelope["error"].(map[string]interface{})
+	assert.True(t, ok, "response should contain 'error' object")
+	assert.Equal(t, "413", errorObj["code"])
+	assert.Contains(t, errorObj["message"], "10MB")
+}

--- a/packages/gen-ai/bff/internal/api/lsd_responses_handler.go
+++ b/packages/gen-ai/bff/internal/api/lsd_responses_handler.go
@@ -361,9 +361,16 @@ func calculateTTFT(startTime time.Time, firstTokenTime *time.Time) *int64 {
 func (app *App) LlamaStackCreateResponseHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
+	r.Body = http.MaxBytesReader(w, r.Body, constants.ResponsesMaxBodySize)
+
 	// Parse the request body
 	var createRequest CreateResponseRequest
 	if err := json.NewDecoder(r.Body).Decode(&createRequest); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			app.payloadTooLargeResponse(w, r, maxBytesErr.Limit)
+			return
+		}
 		app.badRequestResponse(w, r, err)
 		return
 	}

--- a/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/lsd_responses_handler_test.go
@@ -2694,3 +2694,48 @@ func TestAsyncModerationWithReasoning(t *testing.T) {
 		assert.Contains(t, eventTypes, "response.metrics", "metrics event should be emitted")
 	})
 }
+
+func TestLlamaStackCreateResponseHandler_PayloadTooLarge(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	app := &App{
+		config: config.EnvConfig{
+			APIPathPrefix: "/api/v1",
+			AuthMethod:    config.AuthMethodDisabled,
+		},
+		logger: logger,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		app.LlamaStackCreateResponseHandler(w, r, nil)
+	})
+
+	// Build a JSON body that forces the decoder to read past the limit.
+	// Wrapping in a JSON string ensures the decoder keeps reading.
+	prefix := []byte(`{"input":"`)
+	suffix := []byte(`"}`)
+	fillLen := constants.ResponsesMaxBodySize + 1 - len(prefix) - len(suffix)
+	fill := make([]byte, fillLen)
+	for i := range fill {
+		fill[i] = 'a'
+	}
+	oversizedBody := make([]byte, 0, constants.ResponsesMaxBodySize+1)
+	oversizedBody = append(oversizedBody, prefix...)
+	oversizedBody = append(oversizedBody, fill...)
+	oversizedBody = append(oversizedBody, suffix...)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/lsd/responses", bytes.NewReader(oversizedBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+
+	var envelope map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &envelope)
+	assert.NoError(t, err)
+	errorObj, ok := envelope["error"].(map[string]interface{})
+	assert.True(t, ok, "response should contain 'error' object")
+	assert.Equal(t, "413", errorObj["code"])
+	assert.Contains(t, errorObj["message"], "20MB")
+}

--- a/packages/gen-ai/bff/internal/api/middleware.go
+++ b/packages/gen-ai/bff/internal/api/middleware.go
@@ -564,3 +564,10 @@ func (app *App) AttachNemoClient(next func(http.ResponseWriter, *http.Request, h
 		next(w, r, ps)
 	}
 }
+
+// MaxBodySize wraps all API routes with a global body size safety net.
+// Individual handlers may apply tighter limits via http.MaxBytesReader.
+// The effective limit is min(global, handler).
+func (app *App) MaxBodySize(next http.Handler) http.Handler {
+	return http.MaxBytesHandler(next, constants.DefaultMaxBodySize)
+}

--- a/packages/gen-ai/bff/internal/constants/limits.go
+++ b/packages/gen-ai/bff/internal/constants/limits.go
@@ -1,0 +1,20 @@
+package constants
+
+const (
+	// DefaultMaxBodySize is the global safety-net body limit applied via middleware
+	// to all API routes. Individual handlers set tighter limits as needed.
+	DefaultMaxBodySize = 50 << 20 // 50MB
+
+	// ResponsesMaxBodySize caps the request body for POST /lsd/responses.
+	// With the file_id architecture, payloads contain JSON with small file_id
+	// references (not base64), chat_context text, and MCP tool schemas.
+	ResponsesMaxBodySize = 20 << 20 // 20MB
+
+	// FileUploadMaxBodySize caps multipart uploads for vector store documents.
+	// Matches frontend FILE_UPLOAD_CONFIG.MAX_FILE_SIZE.
+	FileUploadMaxBodySize = 10 << 20 // 10MB
+
+	// VisionUploadMaxBodySize caps multipart uploads for vision image files.
+	// Matches frontend VISION_UPLOAD_CONFIG.MAX_FILE_SIZE.
+	VisionUploadMaxBodySize = 10 << 20 // 10MB
+)

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -1481,6 +1481,12 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: File size exceeds 10MB limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalServerError'
       operationId: uploadFile
@@ -1787,6 +1793,12 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '413':
+          description: Request body exceeds 20MB limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalServerError'
       operationId: createResponse
@@ -2057,6 +2069,21 @@ components:
         type: string
         example: 'demo'
   schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: HTTP status code as string
+              example: '413'
+            message:
+              type: string
+              description: Human-readable error message
+              example: 'request body exceeds the 20MB limit'
+
     HealthCheckModel:
       type: object
       required:
@@ -2707,7 +2734,7 @@ components:
         file:
           type: string
           format: binary
-          description: File to upload (max 512MB, supports PDF, TXT, CSV)
+          description: File to upload (max 10MB, supports PDF, TXT, CSV)
         vector_store_id:
           type: string
           example: 'vs_abc123-def456'


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62246

## Description

Adds body size enforcement across the Gen AI BFF so that oversized payloads are rejected with clear, structured JSON 413 responses instead of generic errors or unbounded memory consumption.

### Architecture: Two-layer defense

- **Global middleware** (`MaxBodySize`): wraps all API routes with a 50MB `http.MaxBytesHandler` safety net. No handler can accidentally skip body size limits.
- **Per-handler `MaxBytesReader`**: each handler sets its own tighter limit. The effective limit is `min(global, handler)`.
- **Shared 413 helper** (`payloadTooLargeResponse`): consistent structured JSON `{"error": {"code": "413", "message": "request body exceeds the NMB limit"}}` with logging, matching the existing `errors.go` pattern.

### Changes

| File | Change |
|------|--------|
| `internal/constants/limits.go` | **New** — centralized body size constants (50MB global, 20MB responses, 10MB uploads, 10MB vision) |
| `internal/api/errors.go` | Add `payloadTooLargeResponse` helper with `LogError` + `integrations.HTTPError` |
| `internal/api/middleware.go` | Add `MaxBodySize` middleware using `http.MaxBytesHandler` |
| `internal/api/app.go` | Wrap both API router mounts with `MaxBodySize` |
| `internal/api/lsd_responses_handler.go` | Add `MaxBytesReader(20MB)` + `MaxBytesError` handling before JSON decode |
| `internal/api/lsd_files_handler.go` | Add `MaxBytesReader(10MB)` to upload handler; refactor vision handler to use shared constants and 413 helper |
| `internal/api/lsd_responses_handler_test.go` | Add `TestLlamaStackCreateResponseHandler_PayloadTooLarge` |
| `internal/api/lsd_files_handler_test.go` | Add `TestLlamaStackUploadFileHandler_PayloadTooLarge` |
| `openapi/src/gen-ai.yaml` | Add `ErrorResponse` schema, 413 responses for `/lsd/responses` and `/lsd/files/upload`, fix stale "512MB" description |

### AC Reconciliation

The original Jira ACs referenced base64-encoded 13.3MB payloads on `/lsd/responses`. The implemented architecture uses stateless `file_id` references (PRs #7613/#7621) — images upload via `/lsd/files/vision` (10MB, already capped), and only small `file_id` strings flow through `/lsd/responses`. Limits are set based on actual payload sizes.

### Effective limits after this PR

| Endpoint | Limit | Enforcement |
|----------|-------|-------------|
| `POST /lsd/responses` | **20MB** | `MaxBytesReader` (chat_context + MCP tools, no base64 with file_id arch) |
| `POST /lsd/files/upload` | **10MB** | `MaxBytesReader` (matches frontend `FILE_UPLOAD_CONFIG`) |
| `POST /lsd/files/vision` | **10MB** | `MaxBytesReader` (existing, refactored to shared constant) |
| `ReadJSON` endpoints | **1MB** | Existing `ReadJSON` helper (unchanged) |
| All API routes | **50MB** | Global `MaxBytesHandler` middleware (safety net) |

### Proxy chain documentation

| Hop | Component | Limit | Notes |
|-----|-----------|-------|-------|
| 1 | Browser (frontend) | 10MB per file | Client-side only |
| 2 | Envoy (data-science-gateway) | Cluster default | **Needs validation by Platform/Ops** |
| 3 | kube-rbac-proxy | Passthrough | No body limit config |
| 4 | Fastify (dashboard backend) | 32MB | `Content-Length` pre-check |
| 5 | Gen AI BFF | 20MB / 10MB | **Authoritative enforcement** |
| 6 | OGX | 100MB | BFF caps first |

### Related PRs

- #7613 — BFF multimodal + thinking models (Story 1.1)
- #7621 — Frontend image upload + inline UX (Stories 1.2 + 1.3)

## How Has This Been Tested?

### Unit tests

- `TestLlamaStackCreateResponseHandler_PayloadTooLarge` — sends 20MB+1 JSON body, verifies 413 with `{"error":{"code":"413","message":"...20MB..."}}`
- `TestLlamaStackUploadFileHandler_PayloadTooLarge` — sends 10MB+1 multipart body, verifies 413 with structured JSON
- All existing tests pass (`go build ./...`, `go vet ./...`, `go test ./internal/api/`)

### API stress test (against running BFF on localhost:8080)

| Test | Payload | Expected | Result |
|------|---------|----------|--------|
| Normal text request | ~100B | 201 | PASS |
| Multimodal with file_id | ~500B | 201 | PASS |
| Just over 20MB (responses) | 20MB+100B | 413 | PASS |
| 30MB (responses) | 30MB | 413 | PASS |
| Empty body (responses) | 0B | 400 | PASS |
| Chunked 21MB (no Content-Length) | 21MB | 413 | PASS |
| Small document upload | 1KB | 202 | PASS |
| Just over 10MB (upload) | 10MB+1KB | 413 | PASS |
| 20MB (upload) | 20MB | 413 | PASS |
| Small valid PNG (vision) | 69B | 200 | PASS |
| Just over 10MB (vision) | 10MB+1KB | 413 | PASS |
| Wrong MIME type (vision) | txt as image | 400 | PASS |
| 413 body has `code` field | oversized | yes | PASS |

### Browser QA (gstack browse against Playground UI)

| Test | Result |
|------|--------|
| Upload small image via Playground | PASS — image chip visible, file_id returned |
| Send image + text to Gemini | PASS — model responded "solid, uniform red color" |
| Upload document to vector store | PASS — toast notification, Knowledge tab On |
| Combined image + document + Gemini | PASS — RAG retrieved doc, model cited test_document.txt |
| One-image-per-conversation guard | PASS — BFF returned clear error on second image |

### E2E validation (Gemini 2.5 Flash + qwen-vl-3b)

Full multimodal flow validated via `curl` and browser: image upload → file_id → responses API with `input_image` + `input_text` + RAG vector store → model processes both image and document → correct response with source citation.

## Test Impact

- 2 new Go unit tests for 413 body limit enforcement
- No existing tests modified (all pass unchanged)
- Stress test script at `/tmp/stress-test-body-limits.sh` (not committed — manual verification tool)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision file upload endpoint supporting JPEG and PNG images

* **Improvements**
  * Enforced request body size limits: 50MB global, 10MB file uploads, 20MB responses, 10MB vision uploads
  * Added 413 error responses for oversized requests with clear messaging

* **Documentation**
  * Updated API specification with 413 error handling and corrected file upload size constraint from 512MB to 10MB

<!-- end of auto-generated comment: release notes by coderabbit.ai -->