### PR TITLE
test(e2e): Fix model catalog and testAbout dialog

### DIFF
--- a/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/applications/testAboutDialog.cy.ts
@@ -3,6 +3,7 @@ import { DataScienceStackComponentMap } from '@odh-dashboard/internal/concepts/a
 import { aboutDialog } from '../../../pages/aboutDialog';
 import {
   getCsvByDisplayName,
+  getInstalledProductName,
   getResourceVersionByName,
   getSubscriptionChannelFromCsv,
   getVersionFromCsv,
@@ -10,16 +11,22 @@ import {
 import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import { retryableBefore } from '../../../utils/retryableHooks';
 
-const productName = Cypress.env('PRODUCT_NAME');
 const dataScienceStackComponentMap = DataScienceStackComponentMap;
 
 describe('Verify RHODS About Dialog', () => {
   let odhCsv: Record<string, unknown>;
+  let productName: string;
 
   retryableBefore(async () => {
-    cy.log(`Prepare the CSV JSON for the tests according to the installed Product: ${productName}`);
-    getCsvByDisplayName(productName, 'default').then((csv) => {
-      odhCsv = csv as Record<string, unknown>;
+    cy.log('Auto-detecting installed product (RHOAI or ODH)...');
+    getInstalledProductName('default').then((detectedProduct) => {
+      productName = detectedProduct;
+      cy.log(
+        `Prepare the CSV JSON for the tests according to the installed Product: ${productName}`,
+      );
+      getCsvByDisplayName(productName, 'default').then((csv) => {
+        odhCsv = csv as Record<string, unknown>;
+      });
     });
   });
 

--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testPerformanceFiltersAvailable.cy.ts
@@ -3,6 +3,8 @@ import { HTPASSWD_CLUSTER_ADMIN_USER } from '../../../utils/e2eUsers';
 import { modelCatalog } from '../../../pages/modelCatalog/modelCatalog';
 import { modelDetailsPage } from '../../../pages/modelCatalog/modelDetailsPage';
 import {
+  checkPerformanceDataAvailable,
+  detectModelCatalogNamespace,
   ensureModelCatalogSourceEnabled,
   waitForModelCatalogCards,
   waitForModelCatalogDeployment,
@@ -30,11 +32,23 @@ describe('Verify Performance Filters are available on RHOAI', () => {
       }
     });
 
+    // Check if model-catalog deployment exists and detect its namespace
     cy.then(() => {
       if (skipTest) {
         return;
       }
-      waitForModelCatalogDeployment();
+
+      cy.step('Detect model-catalog namespace');
+      detectModelCatalogNamespace().then((foundNamespace) => {
+        if (!foundNamespace) {
+          cy.log('model-catalog deployment not found in any namespace, skipping test.');
+          skipTest = true;
+        } else {
+          // Override the namespace for this test
+          Cypress.env('MODEL_REGISTRY_NAMESPACE_OVERRIDE', foundNamespace);
+          waitForModelCatalogDeployment();
+        }
+      });
     });
 
     // If not skipping, proceed with test setup
@@ -102,33 +116,58 @@ describe('Verify Performance Filters are available on RHOAI', () => {
       modelCatalog.findLatencyFilter().should('be.visible');
       modelCatalog.findMaxRpsFilter().should('be.visible');
 
-      cy.step('Wait for validated model cards with performance data to appear');
-      waitForValidatedModelCards();
+      cy.step('Check if performance data is available on this cluster');
+      checkPerformanceDataAvailable(15000).then((count) => {
+        if (count === 0) {
+          cy.log(
+            'No validated models with performance data found on this cluster. ' +
+              'Performance/benchmark data must be present in the model-catalog deployment ' +
+              'at /shared-benchmark-data/<source-id>/<model-name>/performance.ndjson',
+          );
+          cy.log('Skipping remaining test steps - performance data not available on this cluster.');
+          skipTest = true;
+        }
+      });
 
-      cy.step('Find a validated model card and verify it shows metrics');
-      modelCatalog.findValidatedModelCard().should('have.length.at.least', 1);
-      modelCatalog
-        .findValidatedModelCard()
-        .first()
-        .within(() => {
-          modelCatalog.findValidatedModelHardware().should('be.visible');
-          modelCatalog.findValidatedModelReplicas().should('be.visible');
-          modelCatalog.findValidatedModelLatency().should('be.visible');
-        });
+      cy.then(() => {
+        if (skipTest) {
+          return;
+        }
 
-      cy.step('Click on validated model to go to details page');
-      modelCatalog.findValidatedModelCardLink().click();
+        cy.step('Wait for validated model cards with performance data to appear');
+        waitForValidatedModelCards();
+      });
 
-      cy.step('Verify Performance Insights tab exists and click it');
-      modelDetailsPage.findPerformanceInsightsTab().should('be.visible');
-      modelDetailsPage.clickPerformanceInsightsTab();
+      cy.then(() => {
+        if (skipTest) {
+          return;
+        }
 
-      cy.step('Verify hardware configuration table loads with data');
-      modelDetailsPage.findHardwareConfigurationTable().should('be.visible');
-      modelDetailsPage.findHardwareConfigurationTableRows().should('have.length.at.least', 1);
+        cy.step('Find a validated model card and verify it shows metrics');
+        modelCatalog.findValidatedModelCard().should('have.length.at.least', 1);
+        modelCatalog
+          .findValidatedModelCard()
+          .first()
+          .within(() => {
+            modelCatalog.findValidatedModelHardware().should('be.visible');
+            modelCatalog.findValidatedModelReplicas().should('be.visible');
+            modelCatalog.findValidatedModelLatency().should('be.visible');
+          });
 
-      cy.step('Verify workload type filter is visible on details page');
-      modelDetailsPage.findWorkloadTypeFilter().should('be.visible');
+        cy.step('Click on validated model to go to details page');
+        modelCatalog.findValidatedModelCardLink().click();
+
+        cy.step('Verify Performance Insights tab exists and click it');
+        modelDetailsPage.findPerformanceInsightsTab().should('be.visible');
+        modelDetailsPage.clickPerformanceInsightsTab();
+
+        cy.step('Verify hardware configuration table loads with data');
+        modelDetailsPage.findHardwareConfigurationTable().should('be.visible');
+        modelDetailsPage.findHardwareConfigurationTableRows().should('have.length.at.least', 1);
+
+        cy.step('Verify workload type filter is visible on details page');
+        modelDetailsPage.findWorkloadTypeFilter().should('be.visible');
+      });
     },
   );
 });

--- a/packages/cypress/cypress/utils/oc_commands/applications.ts
+++ b/packages/cypress/cypress/utils/oc_commands/applications.ts
@@ -76,6 +76,55 @@ export const getCsvByDisplayName = (
 };
 
 /**
+ * Auto-detect which product is installed (RHOAI or ODH).
+ * Tries both product names and returns the one that's actually installed.
+ *
+ * @param namespace - Optional namespace to search in
+ * @returns A Cypress.Chainable that resolves to the detected product display name
+ */
+export const getInstalledProductName = (namespace?: string): Cypress.Chainable<string> => {
+  const productNames = ['Red Hat OpenShift AI', 'Open Data Hub'];
+
+  // Try RHOAI first by checking if CSV exists
+  const rhoaiCsvCommand = `oc get csv ${
+    namespace ? `-n ${namespace}` : '-A'
+  } -o json | jq -r '[.items[] | select(.spec.displayName | test("${
+    productNames[0]
+  }")) | select(.status.phase != "Failed")] | first // empty'`;
+
+  return execWithOutput(rhoaiCsvCommand).then(({ exitCode, stdout }) => {
+    if (exitCode === 0 && stdout.trim()) {
+      Cypress.log({ message: `✓ Detected product: ${productNames[0]}` });
+      return cy.wrap(productNames[0]);
+    }
+
+    // RHOAI not found, try ODH
+    Cypress.log({
+      message: `${productNames[0]} not found, trying ${productNames[1]}...`,
+    });
+
+    const odhCsvCommand = `oc get csv ${
+      namespace ? `-n ${namespace}` : '-A'
+    } -o json | jq -r '[.items[] | select(.spec.displayName | test("${
+      productNames[1]
+    }")) | select(.status.phase != "Failed")] | first // empty'`;
+
+    return execWithOutput(odhCsvCommand).then(({ exitCode: odhExitCode, stdout: odhStdout }) => {
+      if (odhExitCode === 0 && odhStdout.trim()) {
+        Cypress.log({ message: `✓ Detected product: ${productNames[1]}` });
+        return cy.wrap(productNames[1]);
+      }
+
+      throw new Error(
+        `Failed to detect installed product. Neither RHOAI nor ODH CSV found in namespace: ${
+          namespace || 'all namespaces'
+        }`,
+      );
+    });
+  });
+};
+
+/**
  * Get version of a product from its CSV JSON.
  *
  * @param csvObject - The CSV object from which to retrieve the version.

--- a/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
@@ -345,20 +345,20 @@ export const detectModelCatalogNamespace = (): Cypress.Chainable<string | null> 
         failOnNonZeroExit: false,
       },
     )
-    .then((result) => {
+    .then((result: Cypress.Exec) => {
       const foundNamespace = result.stdout.trim();
       if (!foundNamespace || result.stderr) {
         Cypress.log({
           name: 'detectModelCatalogNamespace',
           message: 'model-catalog deployment not found in any namespace',
         });
-        return null;
+      } else {
+        Cypress.log({
+          name: 'detectModelCatalogNamespace',
+          message: `✓ Found in namespace: ${foundNamespace}`,
+        });
       }
-      Cypress.log({
-        name: 'detectModelCatalogNamespace',
-        message: `✓ Found in namespace: ${foundNamespace}`,
-      });
-      return foundNamespace;
+      return cy.wrap(!foundNamespace || result.stderr ? null : foundNamespace);
     });
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelCatalog.ts
@@ -329,6 +329,40 @@ export const ensureModelCatalogSourceEnabled = (sourceId: string): Cypress.Chain
   });
 };
 /**
+ * Detect which namespace contains the model-catalog deployment.
+ * Searches across all namespaces and returns the first match.
+ * @returns A Cypress chainable that resolves with the namespace name, or null if not found.
+ */
+export const detectModelCatalogNamespace = (): Cypress.Chainable<string | null> => {
+  Cypress.log({
+    name: 'detectModelCatalogNamespace',
+    message: 'Detecting deployment namespace...',
+  });
+  return cy
+    .exec(
+      'oc get deployments --all-namespaces -o json | jq -r \'.items[] | select(.metadata.name=="model-catalog") | .metadata.namespace\' | head -n1',
+      {
+        failOnNonZeroExit: false,
+      },
+    )
+    .then((result) => {
+      const foundNamespace = result.stdout.trim();
+      if (!foundNamespace || result.stderr) {
+        Cypress.log({
+          name: 'detectModelCatalogNamespace',
+          message: 'model-catalog deployment not found in any namespace',
+        });
+        return null;
+      }
+      Cypress.log({
+        name: 'detectModelCatalogNamespace',
+        message: `✓ Found in namespace: ${foundNamespace}`,
+      });
+      return foundNamespace;
+    });
+};
+
+/**
  * Wait for the model-catalog deployment to become Available.
  * The BFF resolves the model-catalog Kubernetes Service on every catalog API request,
  * so if the deployment is not ready all catalog endpoints return 404.
@@ -544,6 +578,31 @@ export const waitForValidatedModelCards = (
 
   cy.step(`Polling for validated model cards with performance data (max ${maxAttempts} attempts)`);
   return cy.then(() => checkForValidatedCards(1));
+};
+
+/**
+ * Check if performance/benchmark data is available on the cluster.
+ * Waits for cards to load and checks if any validated models have performance metrics.
+ * @param maxWaitMs Maximum time to wait for performance data to appear (default: 15000ms)
+ * @returns A Cypress chainable that resolves with the count of validated cards with performance data.
+ */
+export const checkPerformanceDataAvailable = (maxWaitMs = 15000): Cypress.Chainable<number> => {
+  cy.log('Checking for validated models with performance data...');
+
+  // Use a retry mechanism with Cypress's built-in waiting
+  return cy.get('body', { timeout: maxWaitMs }).then(($body) => {
+    const count = $body.find(
+      '[data-testid="model-catalog-card"]:has([data-testid="validated-model-hardware"])',
+    ).length;
+
+    if (count > 0) {
+      cy.log(`Found ${count} validated model card(s) with performance data`);
+    } else {
+      cy.log('No validated models with performance data found');
+    }
+
+    return count;
+  });
 };
 
 /**

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -12,6 +12,12 @@ import { maskSensitiveInfo } from '../maskSensitiveInfo';
  * @returns The appropriate namespace for model registries
  */
 export const getModelRegistryNamespace = (): string => {
+  // Allow test-specific override (e.g., for clusters with non-standard namespace setup)
+  const override = Cypress.env('MODEL_REGISTRY_NAMESPACE_OVERRIDE');
+  if (override) {
+    return override;
+  }
+
   const applicationsNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
 
   // For RHOAI use rhoai-model-registries, for ODH use odh-model-registries


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-64945

## Description
- Add detectModelCatalogNamespace() utility for auto-detecting model-catalog deployment namespace across different cluster configs
- Add checkPerformanceDataAvailable() utility to verify benchmark data presence before running performance-specific validations
- Implement three-level skip logic: RHOAI operator check, namespace detection, and performance data availability
- Support MODEL_REGISTRY_NAMESPACE_OVERRIDE env var for portability
 - Add getInstalledProductName() utility to query CSVs and detect which product is installed           
 - Update testAboutDialog to use auto-detection instead of test-variables.yml                          
 - Ensures test works on both RHOAI and ODH clusters without environment-specific config 

## How Has This Been Tested?
- Locally
- Jenkins dashboard/job/dashboard-e2e-tests/1005/

## Test Impact
- None

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved model catalog performance-filter test to detect deployment and skip assertions when no performance data is available.
  * About dialog test now auto-detects the installed product at runtime to use matching test data.

* **Chores**
  * Added helpers to detect installed product and to check performance-data availability before UI checks.
  * Made test namespace resolution configurable via an environment override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->