### PR TITLE
Add AI harness for dashboard-operator

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,11 +1,12 @@
 ---
-description: ODH Dashboard monorepo architecture, package boundaries, and BFF structure
-globs: "packages/**,frontend/**,backend/**"
+description: ODH Dashboard monorepo architecture, package boundaries, BFF structure, and operator controller
+globs: "packages/**,frontend/**,backend/**,dashboard-operator/**"
 alwaysApply: false
 paths:
   - "packages/**"
   - "frontend/**"
   - "backend/**"
+  - "dashboard-operator/**"
 ---
 
 # ODH Dashboard Architecture
@@ -73,6 +74,18 @@ These packages export extensions but have **no** `module-federation` config. The
 - Feature packages MUST NOT import directly from other feature packages' internal modules.
 - Feature packages MUST use exported APIs from `plugin-core` or `app-config` for shared functionality.
 - Changes to infrastructure packages (`eslint-config`, `jest-config`, `tsconfig`) affect ALL packages — review with extra care.
+
+## Dashboard Module Controller (`dashboard-operator/`)
+
+A standalone Kubernetes operator that manages the full lifecycle of the Dashboard application. Co-located in the monorepo (not a separate repository) because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
+
+- **Language**: Go 1.25+ with controller-runtime v0.23
+- **CRD**: `Dashboard` (cluster-scoped, singleton `default-dashboard`) in group `dashboard.opendatahub.io`
+- **Key dependencies**: `odh-platform-utilities` (Tier 1 packages for manifest rendering, SSA deployment, platform detection, status conditions)
+- **CI**: `.github/workflows/dashboard-operator-tests.yml` — lint, build, test on `dashboard-operator/**` changes
+- **Container**: `quay.io/opendatahub/dashboard-operator:latest` built from `dashboard-operator/Dockerfile`
+
+The controller is **not** part of the npm workspace or Turbo pipeline. It has its own `go.mod`, `Makefile`, and CI workflow. See `dashboard-operator/AGENTS.md` and `.claude/rules/operator-controller.md` for detailed conventions.
 
 ## BFF (Backend-for-Frontend) Architecture
 

--- a/.claude/rules/operator-controller.md
+++ b/.claude/rules/operator-controller.md
@@ -1,0 +1,264 @@
+---
+description: Go operator/controller-runtime patterns for the Dashboard Module Controller
+globs: "dashboard-operator/**"
+alwaysApply: false
+paths:
+  - "dashboard-operator/**"
+---
+
+# Operator Controller Patterns
+
+Conventions for Go code in `dashboard-operator/`. This rule covers controller-runtime, kubebuilder, and CRD patterns. For Go BFF (HTTP handler) patterns, see `bff-go.md` — the two are distinct.
+
+## Directory layout
+
+```text
+dashboard-operator/
+├── api/v1alpha1/         # CRD types + kubebuilder markers
+├── cmd/manager/          # Entry point (scheme, flags, manager setup)
+├── internal/controller/  # Reconciler, actions, support utilities
+└── config/               # Generated CRD, RBAC, manager manifests
+```
+
+- `api/` is the public contract — changes here require `make generate && make manifests`
+- `internal/` is private implementation — no external consumers
+- `config/` is generated output — never hand-edit `config/crd/bases/`
+
+## CRD types (`api/v1alpha1/`)
+
+### Kubebuilder markers
+
+Use kubebuilder markers for validation, defaults, and print columns:
+
+```go
+// +kubebuilder:validation:Enum=Managed;Unmanaged;Removed
+// +kubebuilder:default=Removed
+// +kubebuilder:validation:Required
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^regex$`
+```
+
+CEL validation for cross-field rules:
+
+```go
+// +kubebuilder:validation:XValidation:rule="...",message="..."
+```
+
+### Platform utilities embedding
+
+The `Dashboard` CRD embeds shared types from `odh-platform-utilities/api/common`:
+
+```go
+type DashboardSpec struct {
+    common.ManagementSpec `json:",inline"`
+    // ...
+}
+
+type DashboardStatus struct {
+    common.Status                 `json:",inline"`
+    common.ComponentReleaseStatus `json:",inline"`
+    // ...
+}
+```
+
+Implement the `PlatformObject` interface:
+
+```go
+func (d *Dashboard) GetStatus() *common.Status
+func (d *Dashboard) GetConditions() []common.Condition
+func (d *Dashboard) SetConditions(conditions []common.Condition)
+func (d *Dashboard) GetReleaseStatus() *common.ComponentReleaseStatus
+func (d *Dashboard) SetReleaseStatus(status common.ComponentReleaseStatus)
+```
+
+### After modifying types
+
+Always regenerate after changing `api/` files:
+
+```bash
+cd dashboard-operator
+make generate    # DeepCopy methods
+make manifests   # CRD YAML
+```
+
+Verify no drift: `git status` must show only your intentional changes in `api/`. If `zz_generated.deepcopy.go` or `config/crd/bases/` changed, commit them alongside the type changes.
+
+## Reconciler pattern
+
+### Structure
+
+```go
+type DashboardReconciler struct {
+    client.Client
+    Scheme            *runtime.Scheme
+    ManifestsBasePath string
+    Platform          cluster.Platform
+    Namespace         string
+}
+```
+
+Embed `client.Client` — this gives direct access to `r.Get()`, `r.List()`, `r.Status().Update()`, etc.
+
+### Reconcile method
+
+Follow this pipeline order:
+
+1. **Fetch the CR** — return `nil` error for `IsNotFound` (resource was deleted)
+2. **Compute state** — kustomize params, image resolution
+3. **Render manifests** — `kustomize.NewEngine().Render()`
+4. **Deploy** — `deploy.NewDeployer()` with SSA
+5. **Post-deploy actions** — URL extraction, dependency checks
+6. **Update status** — set conditions, observedGeneration, then `r.Status().Update()`
+
+### Error handling in Reconcile
+
+- On transient errors: return `ctrl.Result{}, err` — controller-runtime will requeue with backoff
+- On expected-missing state (e.g., Route not yet ready): return `ctrl.Result{RequeueAfter: duration}, nil`
+- Always update status before returning errors so the CR reflects the failure reason
+
+```go
+if err != nil {
+    setReadyCondition(dashboard, metav1.ConditionFalse, "ReasonCode", err.Error())
+    if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+        logger.Error(statusErr, "Failed to update status")
+    }
+    return ctrl.Result{}, fmt.Errorf("context: %w", err)
+}
+```
+
+### SetupWithManager
+
+Register watches and predicates:
+
+```go
+func SetupWithManager(mgr ctrl.Manager, opts Options) error {
+    r := &DashboardReconciler{...}
+    return ctrl.NewControllerManagedBy(mgr).
+        For(&v1alpha1.Dashboard{}).
+        Complete(r)
+}
+```
+
+Add `Owns()` for resources the controller creates. Add `Watches()` for external resources that should trigger reconciliation.
+
+## Platform utilities usage
+
+### Manifest rendering
+
+```go
+engine := kustomize.NewEngine()
+rendered, err := engine.Render(manifestPath, kustomize.WithNamespace(namespace))
+```
+
+### Deployment (SSA)
+
+```go
+deployer := deploy.NewDeployer(
+    deploy.WithFieldOwner("dashboard-operator"),
+    deploy.WithLabel(labels.PlatformPartOf, strings.ToLower(v1alpha1.DashboardKind)),
+    deploy.WithApplyOrder(),
+)
+err := deployer.Deploy(ctx, deploy.DeployInput{
+    Client:    r.Client,
+    Owner:     dashboard,
+    Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
+    Resources: allResources,
+})
+```
+
+### Platform detection
+
+```go
+platform, err := cluster.DetectPlatform(ctx, client, envOverride, namespace)
+```
+
+Called once at startup, injected into the reconciler. Do not re-detect per reconciliation.
+
+### Status conditions
+
+Use `common.Condition` from platform utilities. The `Ready` condition is mandatory. Future conditions: `ProvisioningSucceeded`, `Degraded`.
+
+## Logging
+
+Use controller-runtime's structured logger:
+
+```go
+logger := log.FromContext(ctx)
+logger.Info("Reconciling Dashboard", "name", dashboard.Name)
+logger.Error(err, "Failed to deploy", "resource", name)
+```
+
+Never use `fmt.Println` or `log.Printf`. Always include key-value pairs for structured fields.
+
+## Testing
+
+### Unit tests
+
+Place `*_test.go` files adjacent to implementation. Use table-driven tests:
+
+```go
+func TestComputeKustomizeVariables(t *testing.T) {
+    tests := []struct {
+        name     string
+        dashboard *v1alpha1.Dashboard
+        platform  cluster.Platform
+        want      map[string]string
+    }{...}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := computeKustomizeVariables(tt.dashboard, tt.platform)
+            if !reflect.DeepEqual(got, tt.want) {
+                t.Errorf("got %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+### envtest (integration tests)
+
+For testing the full reconcile loop:
+
+```go
+testEnv = &envtest.Environment{
+    CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+}
+cfg, err := testEnv.Start()
+```
+
+### Running tests
+
+```bash
+make test    # fmt + vet + go test -race -coverprofile=cover.out ./...
+```
+
+## Linting
+
+golangci-lint v2 with the `standard` preset. Key disabled linters: `depguard`. Excluded dirs: `bin`, `config`.
+
+```bash
+make lint       # Check
+make lint-fix   # Auto-fix
+```
+
+## Image conventions
+
+Container images use the `RELATED_IMAGE_*` env var pattern (required by Konflux/operator-framework). Map param keys to env vars in `support.go:imagesMap`. Never hardcode image references.
+
+## RBAC
+
+RBAC manifests are in `config/rbac/`. When adding new resource types to the reconciler, update the RBAC rules. Use kubebuilder RBAC markers on the `Reconcile` method if adopting marker-based RBAC generation:
+
+```go
+// +kubebuilder:rbac:groups=dashboard.opendatahub.io,resources=dashboards,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=dashboard.opendatahub.io,resources=dashboards/status,verbs=get;update;patch
+```
+
+## Common mistakes to avoid
+
+- **Forgetting `make generate && make manifests`** after CRD type changes — CI will catch uncommitted generated files
+- **Hand-editing `config/crd/bases/`** — always generate from markers
+- **Blocking in Reconcile** — use `RequeueAfter` for polling, not `time.Sleep`
+- **Ignoring status updates on error paths** — always set a condition before returning an error
+- **Using `fmt.Errorf` without `%w`** — wrap errors for `errors.Is()` / `errors.As()` compatibility
+- **Creating resources without ownership** — use `deployer.Deploy()` with `Owner` set for garbage collection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ odh-dashboard/
 │       └── __mocks__/          # Shared mock data (@odh-dashboard/internal/__mocks__)
 ├── backend/                     # Main dashboard backend (Node.js/Express)
 │   └── src/
+├── dashboard-operator/          # Dashboard Module Controller (Go, controller-runtime)
+│   ├── api/v1alpha1/           # CRD types (Dashboard kind)
+│   ├── cmd/manager/            # Controller entry point
+│   ├── internal/controller/    # Reconciler, actions, support utilities
+│   └── config/                 # Generated CRD, RBAC, manager manifests
 ├── packages/                    # Feature packages
 │   ├── cypress/                # Cypress test framework and shared tests
 │   ├── gen-ai/                 # Gen AI / LLM features (has BFF)
@@ -31,7 +36,7 @@ odh-dashboard/
 
 - **Node.js**: >= 22.0.0
 - **npm**: >= 10.0.0
-- **Go**: >= 1.24 (for packages with BFF)
+- **Go**: >= 1.24 (for packages with BFF), >= 1.25 (for dashboard-operator)
 
 ## Key Technologies
 
@@ -98,6 +103,7 @@ Rules live in `.claude/rules/`. Read the relevant rule file before starting the 
 | **Modular Architecture**    | `modular-architecture.md`     | When working on the plugin/extension system or package integration              |
 | **Module Federation**       | `module-federation.md`        | When configuring Module Federation, webpack remotes, or shared dependencies    |
 | **Module Onboarding**       | `module-onboarding.md`        | When creating a new package/module in the monorepo                             |
+| **Operator Controller**     | `operator-controller.md`      | When working on Go operator/controller-runtime code in `dashboard-operator/`   |
 | **Pull Requests**           | `pull-requests.md`            | When creating a pull request — must follow `.github/pull_request_template.md`  |
 | **React**                   | `react.md`                    | When writing React components, hooks, or pages                                 |
 | **Security**                | `security.md`                 | When working on auth, secrets, input validation, or K8s API interactions        |

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -94,6 +94,14 @@ Central index of key documentation in the ODH Dashboard monorepo.
 
 ---
 
+## Dashboard Module Controller
+
+| Doc | Description |
+|-----|-------------|
+| [Controller AGENTS.md](dashboard-operator/AGENTS.md) | Go operator conventions, controller-runtime patterns, CRD types, Makefile targets, reconciliation pipeline |
+
+---
+
 ## Packages
 
 ### Full Docs

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -139,7 +139,7 @@ The controller detects three platforms via `cluster.DetectPlatform()`:
 | Platform | Manifest Overlay | Section Title |
 |---|---|---|
 | `OpenDataHub` | `/odh` | OpenShift Open Data Hub |
-| `SelfManagedRhoai` | `/rhoai` | OpenShift Self Managed Services |
+| `SelfManagedRhoai` | `/rhoai` | OpenShift Self-Managed Services |
 | `ManagedRhoai` | `/not-supported` | OpenShift Managed Services |
 
 Platform is determined at startup and injected into the reconciler.

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -139,7 +139,7 @@ The controller detects three platforms via `cluster.DetectPlatform()`:
 | Platform | Manifest Overlay | Section Title |
 |---|---|---|
 | `OpenDataHub` | `/odh` | OpenShift Open Data Hub |
-| `SelfManagedRhoai` | `/rhoai` | OpenShift Self-Managed Services |
+| `SelfManagedRhoai` | `/rhoai` | OpenShift Self Managed Services |
 | `ManagedRhoai` | `/not-supported` | OpenShift Managed Services |
 
 Platform is determined at startup and injected into the reconciler.
@@ -158,6 +158,7 @@ Container images are resolved from environment variables following the `RELATED_
 | `eval-hub-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE` |
 | `automl-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE` |
 | `autorag-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE` |
+| `images-jobs-async-upload` | `RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE` |
 | `kube-rbac-proxy` | `RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE` |
 
 ## CLI Flags

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -1,0 +1,232 @@
+# AGENTS.md — Dashboard Module Controller
+
+This document provides guidance for AI agents working on the Dashboard Module Controller (`dashboard-operator/`).
+
+## Overview
+
+The Dashboard Module Controller is a standalone Kubernetes operator that manages the full lifecycle of the ODH Dashboard application. It reconciles a cluster-scoped `Dashboard` CRD, rendering and deploying manifests via SSA (Server-Side Apply), detecting the cluster platform (ODH, RHOAI self-managed, RHOAI managed), and reporting granular health status.
+
+This is **not** a BFF — it is a controller-runtime operator. For Go BFF conventions, see `.claude/rules/bff-go.md`. For operator/controller-runtime patterns, see `.claude/rules/operator-controller.md`.
+
+## Project Structure
+
+```text
+dashboard-operator/
+├── api/
+│   └── v1alpha1/
+│       ├── dashboard_types.go          # CRD types (Dashboard kind)
+│       ├── groupversion_info.go        # GVK registration
+│       └── zz_generated.deepcopy.go    # Generated DeepCopy methods
+├── cmd/
+│   └── manager/
+│       └── main.go                     # Controller entry point
+├── config/
+│   ├── crd/
+│   │   ├── bases/                      # Generated CRD YAML
+│   │   └── kustomization.yaml
+│   ├── default/
+│   │   └── kustomization.yaml
+│   ├── manager/
+│   │   ├── manager.yaml                # Deployment manifest
+│   │   └── kustomization.yaml
+│   └── rbac/
+│       ├── role.yaml
+│       ├── role_binding.yaml
+│       ├── service_account.yaml
+│       └── kustomization.yaml
+├── internal/
+│   └── controller/
+│       ├── dashboard_reconciler.go     # Reconcile loop and SetupWithManager
+│       ├── actions.go                  # Manifest rendering, URL extraction, status helpers
+│       └── support.go                  # Kustomize params, image resolution, platform config
+├── Dockerfile                          # Container build (run from repo root)
+├── Dockerfile.dockerignore
+├── Makefile                            # All build/test/generate targets
+├── go.mod
+├── go.sum
+└── .golangci.yml                       # Linter config (golangci-lint v2)
+```
+
+## Development Requirements
+
+- **Go**: >= 1.25 (see `go.mod` for exact toolchain version)
+- **controller-gen**: v0.17.2 (auto-installed by Makefile)
+- **golangci-lint**: v2.1.0 (auto-installed by Makefile)
+
+## Key Technologies
+
+| Technology | Purpose |
+|---|---|
+| controller-runtime v0.23 | Kubernetes controller framework |
+| controller-gen | CRD and DeepCopy code generation |
+| odh-platform-utilities | Shared platform libraries (Tier 1) |
+| kustomize (via platform-utilities) | Manifest rendering |
+| SSA (Server-Side Apply) | Resource deployment via `pkg/deploy` |
+| OpenShift Route API | Dashboard URL extraction |
+| golangci-lint v2 | Go linting |
+
+## Common Commands
+
+All commands run from the `dashboard-operator/` directory:
+
+```bash
+# Development
+make fmt              # Run go fmt
+make vet              # Run go vet
+make lint             # Run golangci-lint
+make lint-fix         # Run golangci-lint with auto-fix
+make test             # Run tests with race detector + coverage
+
+# Build
+make build            # Build manager binary to bin/manager
+make run              # Run controller locally (requires --namespace and --manifests-base-path)
+
+# Code generation (run after modifying api/ types)
+make generate         # Generate DeepCopy methods
+make manifests        # Generate CRD YAML from kubebuilder markers
+
+# Container
+make docker-build     # Build container image (run from repo root)
+make docker-push      # Push container image
+
+# Clean
+make clean            # Remove build artifacts
+```
+
+## CRD Design
+
+The `Dashboard` CRD is **cluster-scoped** and **singleton** (enforced by CEL validation: `metadata.name` must be `default-dashboard`).
+
+### Key Types
+
+| Type | Purpose |
+|---|---|
+| `Dashboard` | Root CRD type |
+| `DashboardSpec` | Desired state: management state, gateway, components, modules, observability |
+| `DashboardStatus` | Observed state: conditions, URL, module statuses, releases |
+| `GatewaySpec` | Ingress configuration (Route on OpenShift, Ingress on K8s) |
+| `ComponentAvailability` | DSC component availability snapshot |
+| `ModuleOverride` | Per-module enablement override |
+| `ObservabilitySpec` | Perses proxy configuration |
+| `ModuleStatus` | Per-module deployment state |
+
+### Platform Utilities Integration
+
+The CRD embeds types from `odh-platform-utilities/api/common`:
+
+- `common.ManagementSpec` — `Managed` / `Removed` state
+- `common.Status` — `observedGeneration`, `conditions`, `phase`
+- `common.ComponentReleaseStatus` — `releases` array
+- `common.Condition` — standard Kubernetes conditions
+
+## Reconciliation Pipeline
+
+The `Reconcile()` method follows this flow:
+
+1. **Fetch** — Get the `Dashboard` CR
+2. **Kustomize params** — Compute variables from spec (gateway domain, platform title, images) and write `params.env`
+3. **Render** — Use `kustomize.NewEngine().Render()` with namespace injection
+4. **Deploy** — Use `deploy.NewDeployer()` with SSA, field ownership, labels, and apply ordering
+5. **URL extraction** — List Routes by label, extract admitted host
+6. **Status update** — Set `Ready` condition, `observedGeneration`, and `url`
+
+If the Route is not yet admitted, the controller requeues after 10 seconds.
+
+## Platform Detection
+
+The controller detects three platforms via `cluster.DetectPlatform()`:
+
+| Platform | Manifest Overlay | Section Title |
+|---|---|---|
+| `OpenDataHub` | `/odh` | OpenShift Open Data Hub |
+| `SelfManagedRhoai` | `/rhoai` | OpenShift Self Managed Services |
+| `ManagedRhoai` | `/not-supported` | OpenShift Managed Services |
+
+Platform is determined at startup and injected into the reconciler.
+
+## Image Resolution
+
+Container images are resolved from environment variables following the `RELATED_IMAGE_*` convention (required by Konflux/operator-framework):
+
+| Param Key | Environment Variable |
+|---|---|
+| `odh-dashboard-image` | `RELATED_IMAGE_ODH_DASHBOARD_IMAGE` |
+| `model-registry-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE` |
+| `gen-ai-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE` |
+| `mlflow-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE` |
+| `maas-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE` |
+| `eval-hub-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE` |
+| `automl-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE` |
+| `autorag-ui-image` | `RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE` |
+| `kube-rbac-proxy` | `RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE` |
+
+## CLI Flags
+
+| Flag | Env Var | Default | Purpose |
+|---|---|---|---|
+| `--manifests-base-path` | — | `/opt/manifests/dashboard` | Base path for kustomize manifests |
+| `--metrics-bind-address` | — | `:8080` | Metrics endpoint |
+| `--health-probe-bind-address` | — | `:8081` | Health/ready probes |
+| `--leader-elect` | — | `false` | Leader election for HA |
+| `--namespace` | `OPERATOR_NAMESPACE` | (required) | Operator deployment namespace |
+| — | `ODH_PLATFORM_TYPE` | (auto-detect) | Override platform detection |
+
+## CI/CD
+
+CI workflow at `.github/workflows/dashboard-operator-tests.yml` triggers on changes to `dashboard-operator/**` or `manifests/**`:
+
+1. Setup Go (version from `go.mod`)
+2. `make lint`
+3. `make build`
+4. `make test`
+5. Check for uncommitted changes (catches stale generated code)
+
+## Testing
+
+Tests use `*_test.go` files adjacent to implementation:
+
+```go
+func TestMyFunction(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   InputType
+        want    OutputType
+        wantErr bool
+    }{...}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) { ... })
+    }
+}
+```
+
+For controller tests, use controller-runtime's `envtest` package:
+
+```go
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+
+testEnv = &envtest.Environment{
+    CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+}
+```
+
+Run tests: `make test` (includes `fmt`, `vet`, race detector, coverage report).
+
+## Agent Rules
+
+When working on dashboard-operator code, read these rules:
+
+| Rule | File | When |
+|---|---|---|
+| **Operator Controller** | `.claude/rules/operator-controller.md` | Writing controller, reconciler, CRD, or action code |
+| **Architecture** | `.claude/rules/architecture.md` | Making structural changes to the operator |
+| **Security** | `.claude/rules/security.md` | Working on RBAC, secrets, or K8s API interactions |
+| **Pull Requests** | `.claude/rules/pull-requests.md` | Creating a PR |
+
+## Dev Workflow
+
+When implementing changes in `dashboard-operator/`:
+
+1. **Implement** — Write the code following operator conventions
+2. **Generate** — If CRD types changed: `make generate && make manifests`
+3. **Validate** — Run `make lint && make test`
+4. **Verify no drift** — `git diff` should show no untracked generated file changes


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62883

## Description

Adds comprehensive AI agent infrastructure for the Dashboard Module Controller (`dashboard-operator/`) to reach parity with the rest of the monorepo. This enables effective AI-assisted development on Go operator/controller-runtime code, per the harness engineering requirements in [RHOAIENG-60566](https://issues.redhat.com/browse/RHOAIENG-60566).

**New files:**
- `dashboard-operator/AGENTS.md` — Operator conventions, CRD design, reconciliation pipeline, platform detection, CLI flags, testing, CI, and dev workflow guidance
- `.claude/rules/operator-controller.md` — Agent rule for controller-runtime/kubebuilder patterns (distinct from `bff-go.md` which covers BFF HTTP handlers): CRD types with markers, reconciler structure, error handling, SSA deployment, envtest, platform utilities, RBAC, common mistakes

**Updated files:**
- `.claude/rules/architecture.md` — Documents `dashboard-operator/` as a monorepo component (Go 1.25+, controller-runtime v0.23, separate CI workflow, own `go.mod`)
- `AGENTS.md` (+ `CLAUDE.md` symlink) — Adds `dashboard-operator/` to the repo structure tree, updates Go version note, adds Operator Controller row to the rules table
- `BOOKMARKS.md` — Adds "Dashboard Module Controller" section with link to the controller AGENTS.md

## How Has This Been Tested?

Documentation-only change. Verified all file paths and cross-references are correct. CLAUDE.md symlink pattern matches the root-level approach (CLAUDE.md → AGENTS.md).

## Test Impact

No tests needed — this is AI harness configuration (agent rules, documentation, bookmarks). No runtime code changed.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture guidance to cover the Dashboard Module Controller.
  * Added comprehensive operator/controller guidance: CRD authoring, reconciler patterns, deployment and testing workflows.
  * New agent-oriented docs for end-to-end reconciliation, platform detection, image resolution, CLI flags, and CI/dev workflows.
  * Updated Go requirement for the Dashboard Module Controller to >= 1.25 and added bookmarks/references to the new guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->