### PR TITLE
feat(dashboard-operator): status reporting, singleton webhook, and unit tests

### DIFF
--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -31,9 +31,11 @@ test: fmt vet ## Run tests.
 
 ##@ Build
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+
 .PHONY: build
 build: fmt vet ## Build manager binary.
-	go build -o bin/manager ./cmd/manager
+	go build -ldflags "-X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=$(VERSION)" -o bin/manager ./cmd/manager
 
 .PHONY: run
 run: fmt vet ## Run the controller from your host.

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -32,7 +32,7 @@ test: fmt vet ## Run tests.
 ##@ Build
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
-SAFE_VERSION := $(shell printf '%s' '$(VERSION)' | tr -cd '[:alnum:]_.-')
+SAFE_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | tr -cd '[:alnum:]_.-' || echo "unknown")
 
 .PHONY: build
 build: fmt vet ## Build manager binary.

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -31,7 +31,6 @@ test: fmt vet ## Run tests.
 
 ##@ Build
 
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
 SAFE_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null | tr -cd '[:alnum:]_.-' || echo "unknown")
 
 .PHONY: build

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -32,10 +32,11 @@ test: fmt vet ## Run tests.
 ##@ Build
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+SAFE_VERSION := $(shell printf '%s' '$(VERSION)' | tr -cd '[:alnum:]_.-')
 
 .PHONY: build
 build: fmt vet ## Build manager binary.
-	go build -ldflags "-X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=$(VERSION)" -o bin/manager ./cmd/manager
+	go build -ldflags "-X github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller.Version=$(SAFE_VERSION)" -o bin/manager ./cmd/manager
 
 .PHONY: run
 run: fmt vet ## Run the controller from your host.

--- a/dashboard-operator/api/v1alpha1/dashboard_types_test.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types_test.go
@@ -1,0 +1,75 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// Compile-time assertion: Dashboard must implement PlatformObject.
+var _ common.PlatformObject = &v1alpha1.Dashboard{}
+
+func TestDashboard_GetStatus(t *testing.T) {
+	d := &v1alpha1.Dashboard{}
+	d.Status.Phase = common.PhaseReady
+
+	s := d.GetStatus()
+	require.NotNil(t, s)
+	assert.Equal(t, common.PhaseReady, s.Phase)
+
+	s.Phase = common.PhaseNotReady
+	assert.Equal(t, common.PhaseNotReady, d.Status.Phase, "GetStatus must return a pointer to the actual status")
+}
+
+func TestDashboard_GetSetConditions(t *testing.T) {
+	d := &v1alpha1.Dashboard{}
+	assert.Empty(t, d.GetConditions())
+
+	conds := []common.Condition{
+		{
+			Type:   string(common.ConditionTypeReady),
+			Status: metav1.ConditionTrue,
+			Reason: "AllGood",
+		},
+		{
+			Type:   string(common.ConditionTypeProvisioningSucceeded),
+			Status: metav1.ConditionTrue,
+			Reason: "Applied",
+		},
+	}
+
+	d.SetConditions(conds)
+	got := d.GetConditions()
+	require.Len(t, got, 2)
+	assert.Equal(t, string(common.ConditionTypeReady), got[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, got[0].Status)
+}
+
+func TestDashboard_GetSetReleaseStatus(t *testing.T) {
+	d := &v1alpha1.Dashboard{}
+	assert.Empty(t, d.GetReleaseStatus().Releases)
+
+	rs := common.ComponentReleaseStatus{
+		Releases: []common.ComponentRelease{
+			{Name: "dashboard", Version: "1.0.0"},
+		},
+	}
+
+	d.SetReleaseStatus(rs)
+	got := d.GetReleaseStatus()
+	require.Len(t, got.Releases, 1)
+	assert.Equal(t, "dashboard", got.Releases[0].Name)
+	assert.Equal(t, "1.0.0", got.Releases[0].Version)
+}
+
+func TestDashboard_Constants(t *testing.T) {
+	assert.Equal(t, "default-dashboard", v1alpha1.DashboardInstanceName)
+	assert.Equal(t, "Dashboard", v1alpha1.DashboardKind)
+	assert.Equal(t, "dashboard", v1alpha1.DashboardComponentName)
+}

--- a/dashboard-operator/cmd/manager/main.go
+++ b/dashboard-operator/cmd/manager/main.go
@@ -95,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr.GetWebhookServer().Register("/validate-dashboard", webhook.NewSingletonHandler(mgr.GetClient()))
+	mgr.GetWebhookServer().Register("/validate-dashboard", webhook.NewSingletonHandler(mgr.GetAPIReader()))
 	setupLog.Info("Registered singleton validation webhook", "path", "/validate-dashboard")
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/dashboard-operator/cmd/manager/main.go
+++ b/dashboard-operator/cmd/manager/main.go
@@ -15,11 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 	"github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+	"github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/webhook"
 )
 
 var scheme = runtime.NewScheme()
@@ -38,6 +40,7 @@ func main() {
 		healthProbeAddr   string
 		leaderElect       bool
 		operatorNamespace string
+		webhookPort       int
 	)
 
 	flag.StringVar(&manifestsBasePath, "manifests-base-path", "/opt/manifests/dashboard", "Base path for dashboard manifests")
@@ -45,6 +48,7 @@ func main() {
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "Address the health probe endpoint binds to")
 	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager")
 	flag.StringVar(&operatorNamespace, "namespace", "", "Namespace where the operator is deployed")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server binds to")
 
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -67,6 +71,7 @@ func main() {
 		HealthProbeBindAddress: healthProbeAddr,
 		LeaderElection:         leaderElect,
 		LeaderElectionID:       "dashboard.opendatahub.io",
+		WebhookServer:          ctrlwebhook.NewServer(ctrlwebhook.Options{Port: webhookPort}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create manager")
@@ -89,6 +94,9 @@ func main() {
 		setupLog.Error(err, "unable to create Dashboard controller")
 		os.Exit(1)
 	}
+
+	mgr.GetWebhookServer().Register("/validate-dashboard", webhook.NewSingletonHandler(mgr.GetClient()))
+	setupLog.Info("Registered singleton validation webhook", "path", "/validate-dashboard")
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/dashboard-operator/config/default/kustomization.yaml
+++ b/dashboard-operator/config/default/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ../crd
   - ../rbac
   - ../manager
+  - ../webhook

--- a/dashboard-operator/config/default/kustomization.yaml
+++ b/dashboard-operator/config/default/kustomization.yaml
@@ -7,3 +7,16 @@ resources:
   - ../rbac
   - ../manager
   - ../webhook
+replacements:
+  - source:
+      kind: Certificate
+      name: dashboard-operator-webhook-cert
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: /
+          index: 0

--- a/dashboard-operator/config/default/kustomization.yaml
+++ b/dashboard-operator/config/default/kustomization.yaml
@@ -20,3 +20,7 @@ replacements:
         options:
           delimiter: /
           index: 0
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.0.clientConfig.service.namespace

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -35,12 +35,19 @@ spec:
               drop:
                 - ALL
           ports:
+            - containerPort: 9443
+              name: webhook
+              protocol: TCP
             - containerPort: 8080
               name: metrics
               protocol: TCP
             - containerPort: 8081
               name: health
               protocol: TCP
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -60,5 +67,9 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: dashboard-operator-webhook-tls
       serviceAccountName: dashboard-operator
       terminationGracePeriodSeconds: 10

--- a/dashboard-operator/config/webhook/kustomization.yaml
+++ b/dashboard-operator/config/webhook/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manifests.yaml

--- a/dashboard-operator/config/webhook/manifests.yaml
+++ b/dashboard-operator/config/webhook/manifests.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: dashboard-validating-webhook
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/dashboard-operator-webhook-cert
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/dashboard-operator-webhook-cert
 webhooks:
   - name: validate.dashboard.opendatahub.io
     admissionReviewVersions:
@@ -24,6 +24,7 @@ webhooks:
           - dashboards
     sideEffects: None
     failurePolicy: Fail
+    timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Service

--- a/dashboard-operator/config/webhook/manifests.yaml
+++ b/dashboard-operator/config/webhook/manifests.yaml
@@ -1,0 +1,61 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: dashboard-validating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/dashboard-operator-webhook-cert
+webhooks:
+  - name: validate.dashboard.opendatahub.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: dashboard-operator-webhook-service
+        namespace: system
+        path: /validate-dashboard
+    rules:
+      - apiGroups:
+          - dashboard.opendatahub.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - dashboards
+    sideEffects: None
+    failurePolicy: Fail
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard-operator-webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/name: dashboard-operator
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dashboard-operator-webhook-cert
+  namespace: system
+spec:
+  dnsNames:
+    - dashboard-operator-webhook-service.system.svc
+    - dashboard-operator-webhook-service.system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: dashboard-operator-webhook-tls

--- a/dashboard-operator/go.mod
+++ b/dashboard-operator/go.mod
@@ -5,6 +5,8 @@ go 1.25.7
 require (
 	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/stretchr/testify v1.11.1
+	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.2
@@ -92,7 +94,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v4 v4.1.1 // indirect
-	k8s.io/api v0.35.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -6,21 +6,16 @@ import (
 	"fmt"
 	"maps"
 	"strings"
-	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/render"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
-
-const conditionTypeReady = "Ready"
 
 var ErrDashboardRouteNotReady = errors.New("dashboard route not yet ready")
 
@@ -75,31 +70,4 @@ func extractDashboardURL(ctx context.Context, cli client.Client, namespace strin
 	}
 
 	return "", ErrDashboardRouteNotReady
-}
-
-func setReadyCondition(dashboard *v1alpha1.Dashboard, status metav1.ConditionStatus, reason, message string) {
-	now := metav1.NewTime(time.Now())
-	conditions := dashboard.GetConditions()
-
-	for i := range conditions {
-		if conditions[i].Type == conditionTypeReady {
-			if conditions[i].Status != status {
-				conditions[i].LastTransitionTime = now
-			}
-			conditions[i].Status = status
-			conditions[i].Reason = reason
-			conditions[i].Message = message
-			dashboard.SetConditions(conditions)
-
-			return
-		}
-	}
-
-	dashboard.SetConditions(append(conditions, common.Condition{
-		Type:               conditionTypeReady,
-		Status:             status,
-		LastTransitionTime: now,
-		Reason:             reason,
-		Message:            message,
-	}))
 }

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -1,0 +1,170 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+func TestManifestSets(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform cluster.Platform
+	}{
+		{name: "SelfManagedRhoai", platform: cluster.SelfManagedRhoai},
+		{name: "ManagedRhoai", platform: cluster.ManagedRhoai},
+		{name: "OpenDataHub", platform: cluster.OpenDataHub},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sets := manifestSets("/base", tt.platform)
+			require.Len(t, sets, 1)
+			assert.Equal(t, "/base", sets[0].Path)
+		})
+	}
+}
+
+func TestApplyKustomizeParams(t *testing.T) {
+	dir := t.TempDir()
+	overlay := filepath.Join(dir, "rhoai")
+	require.NoError(t, os.MkdirAll(overlay, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "params.env"), []byte("existing-key=existing-value\n"), 0644))
+
+	dashboard := &v1alpha1.Dashboard{
+		Spec: v1alpha1.DashboardSpec{
+			Gateway: &v1alpha1.GatewaySpec{Domain: "apps.test.com"},
+		},
+	}
+
+	manifests := manifestSets(dir, cluster.SelfManagedRhoai)
+	require.NoError(t, applyKustomizeParams(dashboard, manifests, cluster.SelfManagedRhoai))
+
+	data, err := os.ReadFile(filepath.Join(overlay, "params.env"))
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.Contains(t, content, "gateway-domain=apps.test.com")
+	assert.Contains(t, content, "dashboard-url=https://odh-dashboard-apps.test.com")
+	assert.Contains(t, content, "section-title=OpenShift Self Managed Services")
+	assert.Contains(t, content, "existing-key=existing-value")
+}
+
+func TestExtractDashboardURL(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, routev1.AddToScheme(scheme))
+
+	namespace := "test-ns"
+	partOfLabel := map[string]string{labels.PlatformPartOf: "dashboard"}
+
+	tests := []struct {
+		name      string
+		routes    []routev1.Route
+		wantURL   string
+		wantErr   error
+		wantErrIs bool
+	}{
+		{
+			name:      "no routes",
+			routes:    nil,
+			wantErr:   ErrDashboardRouteNotReady,
+			wantErrIs: true,
+		},
+		{
+			name: "route without ingress",
+			routes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
+				},
+			},
+			wantErr:   ErrDashboardRouteNotReady,
+			wantErrIs: true,
+		},
+		{
+			name: "route with admitted ingress",
+			routes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Host: "dashboard.apps.example.com",
+								Conditions: []routev1.RouteIngressCondition{
+									{Type: routev1.RouteAdmitted, Status: "True"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantURL: "https://dashboard.apps.example.com",
+		},
+		{
+			name: "route with non-admitted ingress",
+			routes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Host: "dashboard.apps.example.com",
+								Conditions: []routev1.RouteIngressCondition{
+									{Type: routev1.RouteAdmitted, Status: "False"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:   ErrDashboardRouteNotReady,
+			wantErrIs: true,
+		},
+		{
+			name: "multiple routes",
+			routes: []routev1.Route{
+				{ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: namespace, Labels: partOfLabel}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "r2", Namespace: namespace, Labels: partOfLabel}},
+			},
+			wantErr:   ErrDashboardRouteNotReady,
+			wantErrIs: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, len(tt.routes))
+			for i := range tt.routes {
+				objs = append(objs, &tt.routes[i])
+			}
+
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			url, err := extractDashboardURL(context.Background(), cli, namespace)
+			if tt.wantErrIs {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Empty(t, url)
+			} else if tt.wantErr != nil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantURL, url)
+			}
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -59,6 +59,8 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	dashboard.Status.ObservedGeneration = dashboard.Generation
 
+	// Ready is the rollup condition — auto-derived by the Manager from
+	// ProvisioningSucceeded and Degraded. It is never set explicitly.
 	cm := conditions.NewManager(
 		dashboard,
 		string(common.ConditionTypeReady),

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -86,7 +86,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
 		logger.Error(statusErr, "Failed to update status")
 
-		return ctrl.Result{}, statusErr
+		return result, statusErr
 	}
 
 	return result, err

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -98,6 +98,7 @@ func (r *DashboardReconciler) reconcile(
 	cm *conditions.Manager,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	dashboard.Status.URL = ""
 
 	manifests := manifestSets(r.ManifestsBasePath, r.Platform)
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -85,8 +85,6 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
 		logger.Error(statusErr, "Failed to update status")
-
-		return result, statusErr
 	}
 
 	return result, err

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -145,13 +145,8 @@ func (r *DashboardReconciler) reconcile(
 	}
 
 	cm.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
-		conditions.WithReason("ReconcileSuccess"),
+		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard manifests applied successfully"))
-
-	cm.MarkFalse(string(common.ConditionTypeDegraded),
-		conditions.WithReason("NoDegradation"),
-		conditions.WithMessage("All sub-modules healthy"),
-		conditions.WithSeverity(common.ConditionSeverityInfo))
 
 	url, err := extractDashboardURL(ctx, r.Client, r.Namespace)
 
@@ -159,13 +154,33 @@ func (r *DashboardReconciler) reconcile(
 
 	switch {
 	case errors.Is(err, ErrDashboardRouteNotReady):
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("RouteNotReady"),
+			conditions.WithMessage("Dashboard route is not yet admitted"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("RouteNotReady"),
+			conditions.WithMessage("Dashboard route is not yet admitted"))
+		dashboard.Status.URL = ""
 		logger.Info("Dashboard route not yet available, requeuing")
 		requeueAfter = 10 * time.Second
 	case err != nil:
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("URLExtractionFailed"),
+			conditions.WithError(err),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
+		cm.MarkFalse(string(common.ConditionTypeReady),
+			conditions.WithReason("URLExtractionFailed"),
+			conditions.WithError(err))
+		dashboard.Status.URL = ""
 		logger.Error(err, "Failed to extract dashboard URL")
 
 		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", err)
 	default:
+		cm.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithReason("NoDegradation"),
+			conditions.WithMessage("All sub-modules healthy"),
+			conditions.WithSeverity(common.ConditionSeverityInfo))
 		dashboard.Status.URL = url
 	}
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -8,20 +8,24 @@ import (
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
+
+// Version is set at build time via -ldflags.
+var Version = "unknown"
 
 // Options configures the dashboard controller.
 type Options struct {
@@ -53,14 +57,54 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	logger.Info("Reconciling Dashboard", "name", dashboard.Name)
 
+	dashboard.Status.ObservedGeneration = dashboard.Generation
+
+	cm := conditions.NewManager(
+		dashboard,
+		string(common.ConditionTypeReady),
+		string(common.ConditionTypeProvisioningSucceeded),
+		string(common.ConditionTypeDegraded),
+	)
+
+	result, err := r.reconcile(ctx, dashboard, cm)
+
+	dashboard.SetReleaseStatus(common.ComponentReleaseStatus{
+		Releases: []common.ComponentRelease{{
+			Name:    v1alpha1.DashboardComponentName,
+			Version: Version,
+		}},
+	})
+
+	if cm.IsHappy() {
+		dashboard.Status.Phase = common.PhaseReady
+	} else {
+		dashboard.Status.Phase = common.PhaseNotReady
+	}
+
+	cm.Sort()
+
+	if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
+		logger.Error(statusErr, "Failed to update status")
+
+		return ctrl.Result{}, statusErr
+	}
+
+	return result, err
+}
+
+func (r *DashboardReconciler) reconcile(
+	ctx context.Context,
+	dashboard *v1alpha1.Dashboard,
+	cm *conditions.Manager,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
 	manifests := manifestSets(r.ManifestsBasePath, r.Platform)
 
 	if err := applyKustomizeParams(dashboard, manifests, r.Platform); err != nil {
-		setReadyCondition(dashboard, metav1.ConditionFalse, "KustomizeParamsFailed", err.Error())
-
-		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status after kustomize params failure")
-		}
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("KustomizeParamsFailed"),
+			conditions.WithError(err))
 
 		return ctrl.Result{}, fmt.Errorf("failed to apply kustomize params: %w", err)
 	}
@@ -71,11 +115,9 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	for _, m := range manifests {
 		rendered, err := engine.Render(m.String(), kustomize.WithNamespace(r.Namespace))
 		if err != nil {
-			setReadyCondition(dashboard, metav1.ConditionFalse, "RenderFailed", err.Error())
-
-			if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
-				logger.Error(statusErr, "Failed to update status after render failure")
-			}
+			cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+				conditions.WithReason("RenderFailed"),
+				conditions.WithError(err))
 
 			return ctrl.Result{}, fmt.Errorf("failed to render manifests from %s: %w", m, err)
 		}
@@ -95,14 +137,21 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Release:   deploy.ReleaseInfo{Type: string(r.Platform)},
 		Resources: allResources,
 	}); err != nil {
-		setReadyCondition(dashboard, metav1.ConditionFalse, "DeployFailed", err.Error())
-
-		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status after deploy failure")
-		}
+		cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("DeployFailed"),
+			conditions.WithError(err))
 
 		return ctrl.Result{}, fmt.Errorf("failed to deploy resources: %w", err)
 	}
+
+	cm.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
+		conditions.WithReason("ReconcileSuccess"),
+		conditions.WithMessage("Dashboard manifests applied successfully"))
+
+	cm.MarkFalse(string(common.ConditionTypeDegraded),
+		conditions.WithReason("NoDegradation"),
+		conditions.WithMessage("All sub-modules healthy"),
+		conditions.WithSeverity(common.ConditionSeverityInfo))
 
 	url, err := extractDashboardURL(ctx, r.Client, r.Namespace)
 
@@ -114,22 +163,10 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		requeueAfter = 10 * time.Second
 	case err != nil:
 		logger.Error(err, "Failed to extract dashboard URL")
-		setReadyCondition(dashboard, metav1.ConditionFalse, "URLExtractionFailed", err.Error())
-
-		if statusErr := r.Status().Update(ctx, dashboard); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status after URL extraction failure")
-		}
 
 		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", err)
 	default:
 		dashboard.Status.URL = url
-	}
-
-	dashboard.Status.ObservedGeneration = dashboard.Generation
-	setReadyCondition(dashboard, metav1.ConditionTrue, "ReconcileSuccess", "Dashboard reconciled successfully")
-
-	if err := r.Status().Update(ctx, dashboard); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 	}
 
 	logger.Info("Dashboard reconciled successfully", "url", url)

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -224,7 +224,10 @@ func TestReconcile_RouteNotReady(t *testing.T) {
 	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
 
 	assert.Equal(t, int64(2), updated.Status.ObservedGeneration)
+	assert.Equal(t, common.PhaseNotReady, updated.Status.Phase)
+	assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeReady)))
 	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
+	assert.Empty(t, updated.Status.URL)
 }
 
 func TestReconcile_ObservedGenerationSetEarly(t *testing.T) {

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
@@ -23,7 +24,7 @@ import (
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
 
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
-	"github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+	ctrlpkg "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
 )
 
 const testNamespace = "test-ns"
@@ -65,13 +66,31 @@ data:
 	return base
 }
 
+func admittedRoute(namespace string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard",
+			Namespace: namespace,
+			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Host: "dashboard.apps.example.com",
+					Conditions: []routev1.RouteIngressCondition{
+						{Type: routev1.RouteAdmitted, Status: "True"},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestReconcile_NotFound(t *testing.T) {
 	s := testScheme(t)
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		Build()
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
 
-	r := &controller.DashboardReconciler{
+	r := &ctrlpkg.DashboardReconciler{
 		Client:            cli,
 		Scheme:            s,
 		ManifestsBasePath: t.TempDir(),
@@ -87,182 +106,144 @@ func TestReconcile_NotFound(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
-func TestReconcile_Success(t *testing.T) {
-	s := testScheme(t)
-	manifestsBase := createMinimalManifests(t)
-
-	dashboard := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       v1alpha1.DashboardInstanceName,
-			Generation: 3,
-		},
-	}
-
-	route := &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dashboard",
-			Namespace: testNamespace,
-			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
-		},
-		Status: routev1.RouteStatus{
-			Ingress: []routev1.RouteIngress{
-				{
-					Host: "dashboard.apps.example.com",
-					Conditions: []routev1.RouteIngressCondition{
-						{Type: routev1.RouteAdmitted, Status: "True"},
-					},
-				},
+func TestReconcile(t *testing.T) {
+	tests := []struct {
+		name            string
+		generation      int64
+		manifestsBase   func(t *testing.T) string
+		extraObjects    func(t *testing.T) []client.Object
+		wantErr         bool
+		wantRequeue     time.Duration
+		wantPhase       common.Phase
+		wantReady       *bool
+		wantProvisioned *bool
+		wantURL         string
+		wantGeneration  int64
+	}{
+		{
+			name:       "success with admitted route",
+			generation: 3,
+			manifestsBase: func(t *testing.T) string {
+				return createMinimalManifests(t)
 			},
+			extraObjects: func(t *testing.T) []client.Object {
+				return []client.Object{admittedRoute(testNamespace)}
+			},
+			wantPhase:       common.PhaseReady,
+			wantReady:       boolPtr(true),
+			wantProvisioned: boolPtr(true),
+			wantURL:         "https://dashboard.apps.example.com",
+			wantGeneration:  3,
+		},
+		{
+			name:       "kustomize failure",
+			generation: 1,
+			manifestsBase: func(t *testing.T) string {
+				return "/nonexistent/path"
+			},
+			wantErr:         true,
+			wantPhase:       common.PhaseNotReady,
+			wantProvisioned: boolPtr(false),
+			wantGeneration:  1,
+		},
+		{
+			name:       "route not ready requeues",
+			generation: 2,
+			manifestsBase: func(t *testing.T) string {
+				return createMinimalManifests(t)
+			},
+			wantRequeue:     10 * time.Second,
+			wantPhase:       common.PhaseNotReady,
+			wantReady:       boolPtr(false),
+			wantProvisioned: boolPtr(true),
+			wantGeneration:  2,
+		},
+		{
+			name:       "observed generation matches CR",
+			generation: 42,
+			manifestsBase: func(t *testing.T) string {
+				return createMinimalManifests(t)
+			},
+			wantRequeue:    10 * time.Second,
+			wantGeneration: 42,
 		},
 	}
 
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(dashboard, route).
-		WithStatusSubresource(dashboard).
-		Build()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testScheme(t)
 
-	r := &controller.DashboardReconciler{
-		Client:            cli,
-		Scheme:            s,
-		ManifestsBasePath: manifestsBase,
-		Platform:          cluster.OpenDataHub,
-		Namespace:         testNamespace,
+			dashboard := &v1alpha1.Dashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       v1alpha1.DashboardInstanceName,
+					Generation: tt.generation,
+				},
+			}
+
+			builder := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(dashboard).
+				WithStatusSubresource(dashboard)
+
+			if tt.extraObjects != nil {
+				builder = builder.WithObjects(tt.extraObjects(t)...)
+			}
+
+			cli := builder.Build()
+
+			r := &ctrlpkg.DashboardReconciler{
+				Client:            cli,
+				Scheme:            s,
+				ManifestsBasePath: tt.manifestsBase(t),
+				Platform:          cluster.OpenDataHub,
+				Namespace:         testNamespace,
+			}
+
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+			})
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRequeue, result.RequeueAfter)
+
+			updated := &v1alpha1.Dashboard{}
+			require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+			assert.Equal(t, tt.wantGeneration, updated.Status.ObservedGeneration)
+
+			if tt.wantPhase != "" {
+				assert.Equal(t, tt.wantPhase, updated.Status.Phase)
+			}
+			if tt.wantReady != nil {
+				if *tt.wantReady {
+					assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeReady)))
+				} else {
+					assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeReady)))
+				}
+			}
+			if tt.wantProvisioned != nil {
+				if *tt.wantProvisioned {
+					assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
+				} else {
+					assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeProvisioningSucceeded)))
+				}
+			}
+			if tt.wantURL != "" {
+				assert.Equal(t, tt.wantURL, updated.Status.URL)
+			} else {
+				assert.Empty(t, updated.Status.URL)
+			}
+
+			require.NotEmpty(t, updated.GetReleaseStatus().Releases)
+			assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
+		})
 	}
-
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, time.Duration(0), result.RequeueAfter)
-
-	updated := &v1alpha1.Dashboard{}
-	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
-
-	assert.Equal(t, int64(3), updated.Status.ObservedGeneration)
-	assert.Equal(t, common.PhaseReady, updated.Status.Phase)
-	assert.Equal(t, "https://dashboard.apps.example.com", updated.Status.URL)
-
-	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeReady)))
-	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
-
-	require.NotEmpty(t, updated.GetReleaseStatus().Releases)
-	assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
 }
 
-func TestReconcile_KustomizeFailure(t *testing.T) {
-	s := testScheme(t)
-
-	dashboard := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       v1alpha1.DashboardInstanceName,
-			Generation: 1,
-		},
-	}
-
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(dashboard).
-		WithStatusSubresource(dashboard).
-		Build()
-
-	r := &controller.DashboardReconciler{
-		Client:            cli,
-		Scheme:            s,
-		ManifestsBasePath: "/nonexistent/path",
-		Platform:          cluster.OpenDataHub,
-		Namespace:         testNamespace,
-	}
-
-	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
-	})
-
-	assert.Error(t, err)
-
-	updated := &v1alpha1.Dashboard{}
-	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
-
-	assert.Equal(t, common.PhaseNotReady, updated.Status.Phase)
-	assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeProvisioningSucceeded)))
-}
-
-func TestReconcile_RouteNotReady(t *testing.T) {
-	s := testScheme(t)
-	manifestsBase := createMinimalManifests(t)
-
-	dashboard := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       v1alpha1.DashboardInstanceName,
-			Generation: 2,
-		},
-	}
-
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(dashboard).
-		WithStatusSubresource(dashboard).
-		Build()
-
-	r := &controller.DashboardReconciler{
-		Client:            cli,
-		Scheme:            s,
-		ManifestsBasePath: manifestsBase,
-		Platform:          cluster.OpenDataHub,
-		Namespace:         testNamespace,
-	}
-
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
-	})
-
-	require.NoError(t, err)
-	assert.Equal(t, 10*time.Second, result.RequeueAfter)
-
-	updated := &v1alpha1.Dashboard{}
-	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
-
-	assert.Equal(t, int64(2), updated.Status.ObservedGeneration)
-	assert.Equal(t, common.PhaseNotReady, updated.Status.Phase)
-	assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeReady)))
-	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
-	assert.Empty(t, updated.Status.URL)
-}
-
-func TestReconcile_ObservedGenerationSetEarly(t *testing.T) {
-	s := testScheme(t)
-	manifestsBase := createMinimalManifests(t)
-
-	dashboard := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       v1alpha1.DashboardInstanceName,
-			Generation: 42,
-		},
-	}
-
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(dashboard).
-		WithStatusSubresource(dashboard).
-		Build()
-
-	r := &controller.DashboardReconciler{
-		Client:            cli,
-		Scheme:            s,
-		ManifestsBasePath: manifestsBase,
-		Platform:          cluster.OpenDataHub,
-		Namespace:         testNamespace,
-	}
-
-	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
-	})
-	require.NoError(t, err)
-
-	updated := &v1alpha1.Dashboard{}
-	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
-
-	assert.Equal(t, int64(42), updated.Status.ObservedGeneration,
-		"ObservedGeneration must match the CR's metadata.generation")
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -1,0 +1,265 @@
+package controller_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	"github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/controller"
+)
+
+const testNamespace = "test-ns"
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, routev1.AddToScheme(s))
+
+	return s
+}
+
+func createMinimalManifests(t *testing.T) string {
+	t.Helper()
+
+	base := t.TempDir()
+	overlay := filepath.Join(base, "odh")
+	require.NoError(t, os.MkdirAll(overlay, 0755))
+
+	kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+`
+	configmap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+`
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(kustomization), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "configmap.yaml"), []byte(configmap), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "params.env"), []byte(""), 0644))
+
+	return base
+}
+
+func TestReconcile_NotFound(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		Build()
+
+	r := &controller.DashboardReconciler{
+		Client:            cli,
+		Scheme:            s,
+		ManifestsBasePath: t.TempDir(),
+		Platform:          cluster.OpenDataHub,
+		Namespace:         testNamespace,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nonexistent"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcile_Success(t *testing.T) {
+	s := testScheme(t)
+	manifestsBase := createMinimalManifests(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Generation: 3,
+		},
+	}
+
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard",
+			Namespace: testNamespace,
+			Labels:    map[string]string{labels.PlatformPartOf: "dashboard"},
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Host: "dashboard.apps.example.com",
+					Conditions: []routev1.RouteIngressCondition{
+						{Type: routev1.RouteAdmitted, Status: "True"},
+					},
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard, route).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &controller.DashboardReconciler{
+		Client:            cli,
+		Scheme:            s,
+		ManifestsBasePath: manifestsBase,
+		Platform:          cluster.OpenDataHub,
+		Namespace:         testNamespace,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+	assert.Equal(t, int64(3), updated.Status.ObservedGeneration)
+	assert.Equal(t, common.PhaseReady, updated.Status.Phase)
+	assert.Equal(t, "https://dashboard.apps.example.com", updated.Status.URL)
+
+	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeReady)))
+	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
+
+	require.NotEmpty(t, updated.GetReleaseStatus().Releases)
+	assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
+}
+
+func TestReconcile_KustomizeFailure(t *testing.T) {
+	s := testScheme(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Generation: 1,
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &controller.DashboardReconciler{
+		Client:            cli,
+		Scheme:            s,
+		ManifestsBasePath: "/nonexistent/path",
+		Platform:          cluster.OpenDataHub,
+		Namespace:         testNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	assert.Error(t, err)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+	assert.Equal(t, common.PhaseNotReady, updated.Status.Phase)
+	assert.True(t, conditions.IsStatusConditionFalse(updated, string(common.ConditionTypeProvisioningSucceeded)))
+}
+
+func TestReconcile_RouteNotReady(t *testing.T) {
+	s := testScheme(t)
+	manifestsBase := createMinimalManifests(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Generation: 2,
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &controller.DashboardReconciler{
+		Client:            cli,
+		Scheme:            s,
+		ManifestsBasePath: manifestsBase,
+		Platform:          cluster.OpenDataHub,
+		Namespace:         testNamespace,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+	assert.Equal(t, int64(2), updated.Status.ObservedGeneration)
+	assert.True(t, conditions.IsStatusConditionTrue(updated, string(common.ConditionTypeProvisioningSucceeded)))
+}
+
+func TestReconcile_ObservedGenerationSetEarly(t *testing.T) {
+	s := testScheme(t)
+	manifestsBase := createMinimalManifests(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Generation: 42,
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &controller.DashboardReconciler{
+		Client:            cli,
+		Scheme:            s,
+		ManifestsBasePath: manifestsBase,
+		Platform:          cluster.OpenDataHub,
+		Namespace:         testNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+	require.NoError(t, err)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+
+	assert.Equal(t, int64(42), updated.Status.ObservedGeneration,
+		"ObservedGeneration must match the CR's metadata.generation")
+}

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -164,8 +164,11 @@ func TestReconcile(t *testing.T) {
 			manifestsBase: func(t *testing.T) string {
 				return createMinimalManifests(t)
 			},
-			wantRequeue:    10 * time.Second,
-			wantGeneration: 42,
+			wantRequeue:     10 * time.Second,
+			wantPhase:       common.PhaseNotReady,
+			wantReady:       boolPtr(false),
+			wantProvisioned: boolPtr(true),
+			wantGeneration:  42,
 		},
 	}
 

--- a/dashboard-operator/internal/controller/support_test.go
+++ b/dashboard-operator/internal/controller/support_test.go
@@ -1,0 +1,155 @@
+package controller
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+func TestDefaultManifestInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		platform   cluster.Platform
+		wantSource string
+	}{
+		{name: "SelfManagedRhoai", platform: cluster.SelfManagedRhoai, wantSource: "/rhoai"},
+		{name: "ManagedRhoai", platform: cluster.ManagedRhoai, wantSource: "/not-supported"},
+		{name: "OpenDataHub", platform: cluster.OpenDataHub, wantSource: "/odh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := defaultManifestInfo("/base", tt.platform)
+			assert.Equal(t, "/base", info.Path)
+			assert.Equal(t, "", info.ContextDir)
+			assert.Equal(t, tt.wantSource, info.SourcePath)
+		})
+	}
+}
+
+func TestComputeKustomizeVariables(t *testing.T) {
+	tests := []struct {
+		name      string
+		dashboard *v1alpha1.Dashboard
+		platform  cluster.Platform
+		want      map[string]string
+	}{
+		{
+			name:      "minimal spec, SelfManagedRhoai",
+			dashboard: &v1alpha1.Dashboard{},
+			platform:  cluster.SelfManagedRhoai,
+			want: map[string]string{
+				"section-title": "OpenShift Self Managed Services",
+			},
+		},
+		{
+			name: "with gateway domain",
+			dashboard: &v1alpha1.Dashboard{
+				Spec: v1alpha1.DashboardSpec{
+					Gateway: &v1alpha1.GatewaySpec{Domain: "apps.example.com"},
+				},
+			},
+			platform: cluster.OpenDataHub,
+			want: map[string]string{
+				"section-title":  "OpenShift Open Data Hub",
+				"gateway-domain": "apps.example.com",
+				"dashboard-url":  "https://odh-dashboard-apps.example.com",
+			},
+		},
+		{
+			name:      "unknown platform",
+			dashboard: &v1alpha1.Dashboard{},
+			platform:  cluster.Platform("Unknown"),
+			want:      map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeKustomizeVariables(tt.dashboard, tt.platform)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReadExistingParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    map[string]string
+	}{
+		{
+			name:    "empty file",
+			content: "",
+			want:    map[string]string{},
+		},
+		{
+			name:    "comments and blanks",
+			content: "# comment\n\n# another comment\n",
+			want:    map[string]string{},
+		},
+		{
+			name:    "key=value pairs",
+			content: "key1=value1\nkey2=value2\n",
+			want:    map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:    "value with equals sign",
+			content: "key=val=ue\n",
+			want:    map[string]string{"key": "val=ue"},
+		},
+		{
+			name:    "mixed content",
+			content: "# header\nfoo=bar\n\n# comment\nbaz=qux\n",
+			want:    map[string]string{"foo": "bar", "baz": "qux"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "params.env")
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0644))
+			got := readExistingParams(path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		got := readExistingParams("/nonexistent/params.env")
+		assert.Empty(t, got)
+	})
+}
+
+func TestResolveImageParams(t *testing.T) {
+	t.Setenv("RELATED_IMAGE_ODH_DASHBOARD_IMAGE", "quay.io/dashboard:latest")
+	t.Setenv("RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE", "quay.io/mr:v1")
+
+	got := resolveImageParams()
+	assert.Equal(t, "quay.io/dashboard:latest", got["odh-dashboard-image"])
+	assert.Equal(t, "quay.io/mr:v1", got["model-registry-ui-image"])
+	assert.NotContains(t, got, "gen-ai-ui-image", "unset env vars should not appear")
+}
+
+func TestWriteParamsEnv(t *testing.T) {
+	dir := t.TempDir()
+	params := map[string]string{
+		"zebra": "z",
+		"alpha": "a",
+		"mid":   "m",
+	}
+
+	require.NoError(t, writeParamsEnv(dir, params))
+
+	data, err := os.ReadFile(filepath.Join(dir, "params.env"))
+	require.NoError(t, err)
+
+	expected := "alpha=a\nmid=m\nzebra=z\n"
+	assert.Equal(t, expected, string(data), "params must be sorted alphabetically")
+}

--- a/dashboard-operator/internal/webhook/dashboard_webhook.go
+++ b/dashboard-operator/internal/webhook/dashboard_webhook.go
@@ -1,0 +1,30 @@
+package webhook
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	platformwebhook "github.com/opendatahub-io/odh-platform-utilities/pkg/webhook"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// DashboardGVK is the GroupVersionKind for the Dashboard resource.
+var DashboardGVK = schema.GroupVersionKind{
+	Group:   v1alpha1.GroupVersion.Group,
+	Version: v1alpha1.GroupVersion.Version,
+	Kind:    v1alpha1.DashboardKind,
+}
+
+// NewSingletonHandler returns an admission.Webhook that enforces the singleton
+// constraint for Dashboard resources using the platform utilities library.
+func NewSingletonHandler(reader client.Reader) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
+			return platformwebhook.ValidateSingletonCreation(ctx, reader, &req, DashboardGVK)
+		}),
+	}
+}

--- a/dashboard-operator/internal/webhook/dashboard_webhook_test.go
+++ b/dashboard-operator/internal/webhook/dashboard_webhook_test.go
@@ -1,0 +1,115 @@
+package webhook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+	dashwebhook "github.com/opendatahub-io/odh-dashboard/dashboard-operator/internal/webhook"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+
+	return s
+}
+
+func TestDashboardGVK(t *testing.T) {
+	assert.Equal(t, "dashboard.opendatahub.io", dashwebhook.DashboardGVK.Group)
+	assert.Equal(t, "v1alpha1", dashwebhook.DashboardGVK.Version)
+	assert.Equal(t, "Dashboard", dashwebhook.DashboardGVK.Kind)
+}
+
+func TestSingletonHandler_AllowFirstCreate(t *testing.T) {
+	s := testScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	handler := dashwebhook.NewSingletonHandler(cli)
+	resp := handler.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
+		},
+	})
+
+	assert.True(t, resp.Allowed, "first CREATE should be allowed")
+}
+
+func TestSingletonHandler_DenySecondCreate(t *testing.T) {
+	s := testScheme(t)
+
+	existing := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(existing).
+		Build()
+
+	handler := dashwebhook.NewSingletonHandler(cli)
+	resp := handler.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
+		},
+	})
+
+	assert.False(t, resp.Allowed, "second CREATE should be denied")
+	assert.Contains(t, resp.Result.Message, "only one instance")
+}
+
+func TestSingletonHandler_AllowUpdate(t *testing.T) {
+	s := testScheme(t)
+
+	existing := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(existing).
+		Build()
+
+	handler := dashwebhook.NewSingletonHandler(cli)
+	resp := handler.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+		},
+	})
+
+	assert.True(t, resp.Allowed, "UPDATE should always be allowed")
+}
+
+func TestSingletonHandler_AllowDelete(t *testing.T) {
+	s := testScheme(t)
+
+	existing := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(existing).
+		Build()
+
+	handler := dashwebhook.NewSingletonHandler(cli)
+	resp := handler.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Delete,
+		},
+	})
+
+	assert.True(t, resp.Allowed, "DELETE should always be allowed")
+}

--- a/dashboard-operator/internal/webhook/dashboard_webhook_test.go
+++ b/dashboard-operator/internal/webhook/dashboard_webhook_test.go
@@ -67,7 +67,10 @@ func TestSingletonHandler_WithExistingInstance(t *testing.T) {
 
 			handler := dashwebhook.NewSingletonHandler(cli)
 			resp := handler.Handle(context.Background(), admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{Operation: tt.operation},
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: tt.operation,
+					Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
+				},
 			})
 
 			assert.Equal(t, tt.wantAllow, resp.Allowed)

--- a/dashboard-operator/internal/webhook/dashboard_webhook_test.go
+++ b/dashboard-operator/internal/webhook/dashboard_webhook_test.go
@@ -32,8 +32,7 @@ func TestDashboardGVK(t *testing.T) {
 }
 
 func TestSingletonHandler_AllowFirstCreate(t *testing.T) {
-	s := testScheme(t)
-	cli := fake.NewClientBuilder().WithScheme(s).Build()
+	cli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
 
 	handler := dashwebhook.NewSingletonHandler(cli)
 	resp := handler.Handle(context.Background(), admission.Request{
@@ -46,70 +45,32 @@ func TestSingletonHandler_AllowFirstCreate(t *testing.T) {
 	assert.True(t, resp.Allowed, "first CREATE should be allowed")
 }
 
-func TestSingletonHandler_DenySecondCreate(t *testing.T) {
-	s := testScheme(t)
-
-	existing := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+func TestSingletonHandler_WithExistingInstance(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation admissionv1.Operation
+		wantAllow bool
+	}{
+		{name: "deny second create", operation: admissionv1.Create, wantAllow: false},
+		{name: "allow update", operation: admissionv1.Update, wantAllow: true},
+		{name: "allow delete", operation: admissionv1.Delete, wantAllow: true},
 	}
 
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(existing).
-		Build()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().
+				WithScheme(testScheme(t)).
+				WithObjects(&v1alpha1.Dashboard{
+					ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+				}).
+				Build()
 
-	handler := dashwebhook.NewSingletonHandler(cli)
-	resp := handler.Handle(context.Background(), admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: admissionv1.Create,
-			Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
-		},
-	})
+			handler := dashwebhook.NewSingletonHandler(cli)
+			resp := handler.Handle(context.Background(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{Operation: tt.operation},
+			})
 
-	assert.False(t, resp.Allowed, "second CREATE should be denied")
-	assert.Contains(t, resp.Result.Message, "only one instance")
-}
-
-func TestSingletonHandler_AllowUpdate(t *testing.T) {
-	s := testScheme(t)
-
-	existing := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
+			assert.Equal(t, tt.wantAllow, resp.Allowed)
+		})
 	}
-
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(existing).
-		Build()
-
-	handler := dashwebhook.NewSingletonHandler(cli)
-	resp := handler.Handle(context.Background(), admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: admissionv1.Update,
-		},
-	})
-
-	assert.True(t, resp.Allowed, "UPDATE should always be allowed")
-}
-
-func TestSingletonHandler_AllowDelete(t *testing.T) {
-	s := testScheme(t)
-
-	existing := &v1alpha1.Dashboard{
-		ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.DashboardInstanceName},
-	}
-
-	cli := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(existing).
-		Build()
-
-	handler := dashwebhook.NewSingletonHandler(cli)
-	resp := handler.Handle(context.Background(), admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: admissionv1.Delete,
-		},
-	})
-
-	assert.True(t, resp.Allowed, "DELETE should always be allowed")
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-59935
https://issues.redhat.com/browse/RHOAIENG-61030
https://issues.redhat.com/browse/RHOAIENG-62884
Epic: https://issues.redhat.com/browse/RHOAIENG-60566

## Description

Bundles three controller enhancements for the Dashboard Module Operator (`dashboard-operator/`) into a single PR since they touch overlapping files (`internal/controller/`, `api/v1alpha1/`, `cmd/manager/main.go`):

### Status Reporting ([RHOAIENG-59935](https://redhat.atlassian.net/browse/RHOAIENG-59935))
- Replaced the manual `setReadyCondition()` helper with `conditions.Manager` from `odh-platform-utilities/pkg/controller/conditions`
- Registers 3 mandatory PlatformObject conditions: **Ready** (happy/aggregated), **ProvisioningSucceeded** (manifest deployment), **Degraded** (sub-module health, Info severity when healthy)
- Moved `ObservedGeneration` to the **start** of reconciliation (was at the end) per platform contract
- Added `Phase` field (`PhaseReady`/`PhaseNotReady`) derived from the Ready condition
- Added `releases` field with `ComponentReleaseStatus` populated from a build-time `Version` variable via ldflags
- Refactored reconciler into `Reconcile()` (status bookkeeping, single status update path) + `reconcile()` (business logic)

### Singleton Webhook ([RHOAIENG-61030](https://redhat.atlassian.net/browse/RHOAIENG-61030))
- Created `internal/webhook/dashboard_webhook.go` — thin wrapper around `webhook.ValidateSingletonCreation` from `odh-platform-utilities`
- Registered webhook handler in `cmd/manager/main.go` with configurable `--webhook-port` flag (default 9443)
- Added `config/webhook/` kustomize overlay with `ValidatingWebhookConfiguration`, webhook `Service`, cert-manager `Issuer` + `Certificate`
- Updated `config/manager/manager.yaml` with webhook port and TLS volume mount
- CEL validation rule (`metadata.name == 'default-dashboard'`) was already in the CRD from the scaffold PR; this adds the belt-and-suspenders admission webhook

### Unit Tests ([RHOAIENG-62884](https://redhat.atlassian.net/browse/RHOAIENG-62884))
- 5 new test files covering all packages:
  - `api/v1alpha1/dashboard_types_test.go` — PlatformObject interface compliance, accessor round-trips, constants
  - `internal/controller/support_test.go` — pure functions (params parsing, image resolution, kustomize variables, file writing)
  - `internal/controller/actions_test.go` — manifest sets, kustomize params merge, URL extraction with fake Route objects
  - `internal/controller/dashboard_reconciler_test.go` — reconciler with fake client (not-found, success, kustomize failure, route-not-ready, observed generation)
  - `internal/webhook/dashboard_webhook_test.go` — singleton enforcement (allow first create, deny second, allow update/delete)

## How Has This Been Tested?

### Automated tests
- `make test` — all 4 test packages pass:
  - `api/v1alpha1` — OK (5.3% coverage — small types file)
  - `internal/controller` — OK (89.1% coverage)
  - `internal/webhook` — OK (100% coverage)
  - `cmd/manager` — no test files (entry point only)
- `make lint` — 0 issues (golangci-lint v2)
- `make build` — compiles successfully with version ldflags

### Test approach
- **Reconciler tests** use `sigs.k8s.io/controller-runtime/pkg/client/fake` with `WithStatusSubresource()` for proper status subresource behavior
- **Webhook tests** use fake client to simulate empty cluster (allow CREATE) and existing Dashboard (deny CREATE)
- **Support/actions tests** use `t.TempDir()` for filesystem isolation and `t.Setenv()` for environment variable testing
- All tests follow table-driven patterns with `testify/assert` and `testify/require`

### Manual verification
- Confirmed `make build` produces a working binary with version ldflags injected (e.g., `v3.4.0-308-g25a07fb80`)
- Cluster deployment testing deferred to CI image build

## Test Impact

Added 5 new test files with comprehensive coverage of all controller, webhook, and CRD type code. Coverage breakdown:
- Controller package: 89.1% statement coverage
- Webhook package: 100% statement coverage
- API types package: 5.3% (accessor methods only; deepcopy is auto-generated)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission webhook enforcing a single Dashboard instance; operator now exposes a webhook port and includes TLS-backed manifests for deployment.
  * Operator binaries embed a sanitized build-time version identifier.

* **Bug Fixes / Improvements**
  * Centralized, more robust status and condition management with clearer phases, URL handling, and requeue behavior.

* **Tests**
  * Expanded unit tests covering reconciliation, webhook behavior, kustomize/manifest handling, and controller helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->