### PR TITLE
fix: gate model catalog settings behind disableModelCatalog feature flag

### DIFF
--- a/frontend/src/plugins/extensions/routes.ts
+++ b/frontend/src/plugins/extensions/routes.ts
@@ -384,7 +384,7 @@ const extensions: RouteExtension[] = [
   {
     type: 'app.route',
     flags: {
-      required: [ADMIN_USER],
+      required: [SupportedArea.MODEL_REGISTRY, ADMIN_USER],
     },
     properties: {
       path: '/settings/model-resources-operations/model-registry/*',
@@ -394,7 +394,7 @@ const extensions: RouteExtension[] = [
   {
     type: 'app.route',
     flags: {
-      required: [ADMIN_USER],
+      required: [SupportedArea.MODEL_REGISTRY, ADMIN_USER],
     },
     properties: {
       path: '/modelRegistrySettings/*',

--- a/packages/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -2,11 +2,12 @@
 import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
 import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
 import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import type { DashboardCommonConfig } from '@odh-dashboard/internal/k8sTypes';
 import { modelCatalogSettings } from '../../../pages/modelCatalogSettings';
 import { pageNotfound } from '../../../pages/pageNotFound';
 import { asProductAdminUser, asProjectAdminUser } from '../../../utils/mockUsers';
 
-const setupMocksForMCSettingAccess = () => {
+const setupAdminMocks = (configOverrides: Partial<DashboardCommonConfig> = {}) => {
   asProductAdminUser();
   cy.interceptOdh(
     'GET /api/dsc/status',
@@ -25,6 +26,7 @@ const setupMocksForMCSettingAccess = () => {
     mockDashboardConfig({
       disableModelRegistry: false,
       disableModelCatalog: false,
+      ...configOverrides,
     }),
   );
   cy.interceptOdh(
@@ -42,9 +44,14 @@ it('Model catalog settings should not be available for non product admins', () =
 });
 
 it('Model catalog settings should be available for product admins with capabilities', () => {
-  setupMocksForMCSettingAccess();
-  // check page is accessible
+  setupAdminMocks();
   modelCatalogSettings.visit(true);
-  // check nav item exists
   modelCatalogSettings.findNavItem().should('exist');
+});
+
+it('Model catalog settings should not be available when model catalog is disabled', () => {
+  setupAdminMocks({ disableModelCatalog: true });
+  modelCatalogSettings.visit(false);
+  pageNotfound.findPage().should('exist');
+  modelCatalogSettings.findNavItem().should('not.exist');
 });

--- a/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelRegistrySettings/modelRegistrySettings.cy.ts
@@ -310,10 +310,33 @@ it('Model registry settings should not be available for non product admins', () 
 
 it('Model registry settings should be available for product admins with capabilities', () => {
   setupMocksForMRSettingAccess({});
-  // check page is accessible
   modelRegistrySettings.visit(true);
-  // check nav item exists
   modelRegistrySettings.findNavItem().should('exist');
+});
+
+it('Model registry settings should not be available when model registry is disabled', () => {
+  asProductAdminUser();
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({
+      disableModelRegistry: true,
+    }),
+  );
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.MODEL_REGISTRY]: {
+          managementState: 'Managed',
+          registriesNamespace: MODEL_REGISTRIES_NAMESPACE,
+        },
+      },
+    }),
+  );
+  cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({}));
+  modelRegistrySettings.visit(false);
+  pageNotfound.findPage().should('exist');
+  modelRegistrySettings.findNavItem().should('not.exist');
 });
 
 it('Shows empty state when there are no registries', () => {

--- a/packages/model-registry/upstream/frontend/src/odh/extensions.ts
+++ b/packages/model-registry/upstream/frontend/src/odh/extensions.ts
@@ -186,11 +186,11 @@ const extensions: (
       }),
     },
   },
-  // Settings (unchanged)
+  // Settings
   {
     type: 'app.navigation/href',
     flags: {
-      required: [ADMIN_USER],
+      required: [ADMIN_USER, SupportedArea.MODEL_CATALOG],
     },
     properties: {
       id: 'settings-model-catalog',
@@ -204,7 +204,7 @@ const extensions: (
   {
     type: 'app.route',
     flags: {
-      required: [ADMIN_USER],
+      required: [ADMIN_USER, SupportedArea.MODEL_CATALOG],
     },
     properties: {
       path: `${catalogSettingsUrl()}/*`,


### PR DESCRIPTION
## Description

The model catalog settings navigation item and route in the model-registry plugin extensions were only gated by `ADMIN_USER`, not `SupportedArea.MODEL_CATALOG`. This meant admin users could still see and access model catalog settings even when the `disableModelCatalog` feature flag was set to `true` (disabled).

This is a follow-up to #7583 which decoupled Model Catalog from Model Registry — that PR correctly gated the catalog **tab** behind `MODEL_CATALOG`, but the **settings** extensions were missed.


https://github.com/user-attachments/assets/103b96d4-6a91-4e07-a2dc-32398dacae75


### What changed

- **`packages/model-registry/upstream/frontend/src/odh/extensions.ts`** — added `SupportedArea.MODEL_CATALOG` to `flags.required` for both the settings `app.navigation/href` and `app.route` extensions, matching the pattern used by model registry settings (`SupportedArea.MODEL_REGISTRY` + `ADMIN_USER`)
- **`packages/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts`** — added a test verifying settings are hidden when `disableModelCatalog: true`; refactored setup to reduce intercept duplication with a parameterized helper

## How Has This Been Tested?

- Added Cypress mock test: "Model catalog settings should not be available when model catalog is disabled"
- Verified existing tests still pass (non-admin access denied, admin access with capabilities)
- Check whether model catalog settings is hidden behind `disableModelCatalog` feature flag


## Test Impact

Added a Cypress mock test covering the previously-untested scenario of admin user with `disableModelCatalog: true`. Refactored existing test setup into a reusable `setupAdminMocks(configOverrides)` helper to reduce duplication.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added configurable test helper and coverage to verify model catalog and model registry settings are hidden when their feature flags are disabled.
* **Bug Fixes**
  * Adjusted access checks so model registry settings respect the model-registry feature flag and are removed from navigation when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->