### PR TITLE
RHOAIENG-63154: Implement Create Custom Role form - role configuration section

### DIFF
--- a/frontend/src/concepts/k8s/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/k8s/__tests__/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   getDescriptionFromK8sResource,
   getDisplayNameFromK8sResource,
   isValidK8sName,
+  isValidK8sLabelKeyValue,
   kindApiVersion,
   translateDisplayNameForK8s,
   translateDisplayNameForK8sAndReport,
@@ -216,5 +217,58 @@ describe('kindApiVersion', () => {
     expect(
       kindApiVersion({ kind: 'bar', apiVersion: 'v1', apiGroup: 'foo.bar.baz.io', plural: 'bars' }),
     ).toBe('foo.bar.baz.io/v1');
+  });
+});
+
+describe('isValidK8sLabelKeyValue', () => {
+  it('should accept valid simple key and value', () => {
+    expect(isValidK8sLabelKeyValue('team', 'platform')).toBe(true);
+  });
+
+  it('should accept key with DNS prefix', () => {
+    expect(isValidK8sLabelKeyValue('app.kubernetes.io/name', 'my-app')).toBe(true);
+  });
+
+  it('should accept empty value', () => {
+    expect(isValidK8sLabelKeyValue('team', '')).toBe(true);
+  });
+
+  it('should accept key/value with dots, dashes, and underscores', () => {
+    expect(isValidK8sLabelKeyValue('my_key.name', 'my-value_1.0')).toBe(true);
+  });
+
+  it('should reject empty key', () => {
+    expect(isValidK8sLabelKeyValue('', 'value')).toBe(false);
+  });
+
+  it('should reject key with spaces', () => {
+    expect(isValidK8sLabelKeyValue('Team Name', 'platform')).toBe(false);
+  });
+
+  it('should reject key starting with a dash', () => {
+    expect(isValidK8sLabelKeyValue('-invalid', 'value')).toBe(false);
+  });
+
+  it('should reject value starting with a dash', () => {
+    expect(isValidK8sLabelKeyValue('key', '-invalid')).toBe(false);
+  });
+
+  it('should reject key with multiple slashes', () => {
+    expect(isValidK8sLabelKeyValue('bad/key/extra', 'value')).toBe(false);
+  });
+
+  it('should reject value longer than 63 characters', () => {
+    const longValue = 'a'.repeat(64);
+    expect(isValidK8sLabelKeyValue('key', longValue)).toBe(false);
+  });
+
+  it('should reject key name longer than 63 characters', () => {
+    const longName = 'a'.repeat(64);
+    expect(isValidK8sLabelKeyValue(longName, 'value')).toBe(false);
+  });
+
+  it('should reject prefix longer than 253 characters', () => {
+    const longPrefix = `${'a'.repeat(251)}.io`;
+    expect(isValidK8sLabelKeyValue(`${longPrefix}/name`, 'value')).toBe(false);
   });
 });

--- a/frontend/src/concepts/k8s/__tests__/utils.spec.ts
+++ b/frontend/src/concepts/k8s/__tests__/utils.spec.ts
@@ -267,6 +267,11 @@ describe('isValidK8sLabelKeyValue', () => {
     expect(isValidK8sLabelKeyValue(longName, 'value')).toBe(false);
   });
 
+  it('should reject prefix with a DNS segment longer than 63 characters', () => {
+    const segment64 = 'a'.repeat(64);
+    expect(isValidK8sLabelKeyValue(`${segment64}.io/name`, 'value')).toBe(false);
+  });
+
   it('should reject prefix longer than 253 characters', () => {
     const longPrefix = `${'a'.repeat(251)}.io`;
     expect(isValidK8sLabelKeyValue(`${longPrefix}/name`, 'value')).toBe(false);

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -121,6 +121,32 @@ export const isValidK8sName = (
   regExp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/,
 ): boolean => name === undefined || (name.length > 0 && regExp.test(name));
 
+const K8S_LABEL_NAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
+const K8S_LABEL_VALUE_REGEX = /^([a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?)?$/;
+const K8S_DNS_SUBDOMAIN_REGEX = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+
+export const isValidK8sLabelKeyValue = (key: string, value: string): boolean => {
+  if (value.length > 63 || !K8S_LABEL_VALUE_REGEX.test(value)) {
+    return false;
+  }
+  const parts = key.split('/');
+  if (parts.length > 2) {
+    return false;
+  }
+  if (parts.length === 2) {
+    const [prefix, name] = parts;
+    return (
+      prefix.length <= 253 &&
+      K8S_DNS_SUBDOMAIN_REGEX.test(prefix) &&
+      name.length > 0 &&
+      name.length <= 63 &&
+      K8S_LABEL_NAME_REGEX.test(name)
+    );
+  }
+  const name = parts[0];
+  return name.length > 0 && name.length <= 63 && K8S_LABEL_NAME_REGEX.test(name);
+};
+
 type ResourceWithConditions = K8sResourceCommon & { status?: { conditions?: K8sCondition[] } };
 
 export const getConditionForType = (

--- a/frontend/src/concepts/k8s/utils.ts
+++ b/frontend/src/concepts/k8s/utils.ts
@@ -135,13 +135,11 @@ export const isValidK8sLabelKeyValue = (key: string, value: string): boolean => 
   }
   if (parts.length === 2) {
     const [prefix, name] = parts;
-    return (
+    const isPrefixValid =
       prefix.length <= 253 &&
       K8S_DNS_SUBDOMAIN_REGEX.test(prefix) &&
-      name.length > 0 &&
-      name.length <= 63 &&
-      K8S_LABEL_NAME_REGEX.test(name)
-    );
+      prefix.split('.').every((segment) => segment.length > 0 && segment.length <= 63);
+    return isPrefixValid && name.length > 0 && name.length <= 63 && K8S_LABEL_NAME_REGEX.test(name);
   }
   const name = parts[0];
   return name.length > 0 && name.length <= 63 && K8S_LABEL_NAME_REGEX.test(name);

--- a/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ActionList, ActionListItem, Button, Stack, StackItem } from '@patternfly/react-core';
+import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
 
 type CreateRoleFooterProps = {
   namespace: string;
@@ -15,31 +15,23 @@ const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
 }) => {
   const navigate = useNavigate();
 
-  const handleCancel = React.useCallback(() => {
-    navigate(`/projects/${namespace}?section=roles`);
-  }, [navigate, namespace]);
-
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <ActionList>
-          <ActionListItem>
-            <Button
-              isDisabled={isSubmitDisabled}
-              variant="primary"
-              data-testid="create-role-submit"
-            >
-              {isEdit ? 'Save changes' : 'Create role'}
-            </Button>
-          </ActionListItem>
-          <ActionListItem>
-            <Button variant="link" data-testid="create-role-cancel" onClick={handleCancel}>
-              Cancel
-            </Button>
-          </ActionListItem>
-        </ActionList>
-      </StackItem>
-    </Stack>
+    <ActionList>
+      <ActionListItem>
+        <Button isDisabled={isSubmitDisabled} variant="primary" data-testid="create-role-submit">
+          {isEdit ? 'Save changes' : 'Create role'}
+        </Button>
+      </ActionListItem>
+      <ActionListItem>
+        <Button
+          variant="link"
+          data-testid="create-role-cancel"
+          onClick={() => navigate(`/projects/${namespace}?section=roles`)}
+        >
+          Cancel
+        </Button>
+      </ActionListItem>
+    </ActionList>
   );
 };
 

--- a/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ActionList, ActionListItem, Button, Stack, StackItem } from '@patternfly/react-core';
+
+type CreateRoleFooterProps = {
+  namespace: string;
+  isSubmitDisabled: boolean;
+  isEdit?: boolean;
+};
+
+const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
+  namespace,
+  isSubmitDisabled,
+  isEdit = false,
+}) => {
+  const navigate = useNavigate();
+
+  const handleCancel = React.useCallback(() => {
+    navigate(`/projects/${namespace}?section=roles`);
+  }, [navigate, namespace]);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <ActionList>
+          <ActionListItem>
+            <Button
+              isDisabled={isSubmitDisabled}
+              variant="primary"
+              data-testid="create-role-submit"
+            >
+              {isEdit ? 'Save changes' : 'Create role'}
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="link" data-testid="create-role-cancel" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </ActionListItem>
+        </ActionList>
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default CreateRoleFooter;

--- a/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
@@ -76,7 +76,7 @@ const CreateRoleForm: React.FC<CreateRoleFormProps> = ({
       </Title>
       <Content component="p">Define the permissions that this role grants by adding rules.</Content>
       <Content component="p" data-testid="permissions-empty-state">
-        <em>No permissions set for this role.</em>
+        No permissions set for this role.
       </Content>
       <Flex>
         <FlexItem>

--- a/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  TextArea,
+  Title,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import K8sNameDescriptionField from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import FieldGroupHelpLabelIcon from '#~/components/FieldGroupHelpLabelIcon';
+import { UseK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/types';
+import RoleLabelsSection from './RoleLabelsSection';
+
+type LabelEntry = {
+  key: string;
+  value: string;
+};
+
+type CreateRoleFormProps = {
+  nameDescriptionData: UseK8sNameDescriptionFieldData;
+  description: string;
+  onDescriptionChange: (value: string) => void;
+  labels: LabelEntry[];
+  onLabelsChange: (labels: LabelEntry[]) => void;
+};
+
+const CreateRoleForm: React.FC<CreateRoleFormProps> = ({
+  nameDescriptionData,
+  description,
+  onDescriptionChange,
+  labels,
+  onLabelsChange,
+}) => {
+  const handleDescriptionChange = React.useCallback(
+    (_event: React.FormEvent<HTMLTextAreaElement>, value: string) => {
+      onDescriptionChange(value);
+    },
+    [onDescriptionChange],
+  );
+
+  return (
+    <Form data-testid="create-role-form">
+      <Title headingLevel="h2" size="md">
+        Role configuration
+      </Title>
+      <Content component="p">
+        Define the basic properties for this custom role, including its name, description, and
+        labels.
+      </Content>
+
+      <K8sNameDescriptionField
+        dataTestId="role"
+        data={nameDescriptionData.data}
+        onDataChange={nameDescriptionData.onDataChange}
+        nameLabel="Name"
+        autoFocusName
+        hideDescription
+      />
+
+      <FormGroup label="Description" fieldId="role-description">
+        <TextArea
+          id="role-description"
+          data-testid="role-description"
+          value={description}
+          onChange={handleDescriptionChange}
+          placeholder="Describe what this role is for and who should use it"
+          resizeOrientation="vertical"
+        />
+      </FormGroup>
+
+      <RoleLabelsSection labels={labels} onLabelsChange={onLabelsChange} />
+
+      <Title headingLevel="h2" size="md">
+        Permissions rules (verbs){' '}
+        <FieldGroupHelpLabelIcon content="Define the permissions that this role grants. Each rule specifies which actions (verbs) are allowed on which resources." />
+      </Title>
+      <Content component="p">Define the permissions that this role grants by adding rules.</Content>
+      <Content component="p" data-testid="permissions-empty-state">
+        <i>No permissions set for this rule.</i>
+      </Content>
+      <Flex>
+        <FlexItem>
+          {/* TODO: Enable when permission rules are implemented (RHOAIENG-63157) */}
+          <Button variant="link" icon={<PlusCircleIcon />} data-testid="role-add-rule" isDisabled>
+            Add rule
+          </Button>
+        </FlexItem>
+        <FlexItem>
+          {/* TODO: Enable when template import is implemented (RHOAIENG-63156) */}
+          <Button variant="link" data-testid="role-import-template" isDisabled>
+            Import rules from template
+          </Button>
+        </FlexItem>
+      </Flex>
+    </Form>
+  );
+};
+
+export default CreateRoleForm;

--- a/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleForm.tsx
@@ -14,11 +14,7 @@ import K8sNameDescriptionField from '#~/concepts/k8s/K8sNameDescriptionField/K8s
 import FieldGroupHelpLabelIcon from '#~/components/FieldGroupHelpLabelIcon';
 import { UseK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/types';
 import RoleLabelsSection from './RoleLabelsSection';
-
-type LabelEntry = {
-  key: string;
-  value: string;
-};
+import type { LabelEntry } from './types';
 
 type CreateRoleFormProps = {
   nameDescriptionData: UseK8sNameDescriptionFieldData;
@@ -80,7 +76,7 @@ const CreateRoleForm: React.FC<CreateRoleFormProps> = ({
       </Title>
       <Content component="p">Define the permissions that this role grants by adding rules.</Content>
       <Content component="p" data-testid="permissions-empty-state">
-        <i>No permissions set for this rule.</i>
+        <em>No permissions set for this role.</em>
       </Content>
       <Flex>
         <FlexItem>

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -55,9 +55,12 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     setLabels(newLabels);
   }, []);
 
-  const hasInvalidLabels = labels.some(
-    (label) => !label.key || !label.value || !isValidK8sLabelKeyValue(label.key, label.value),
-  );
+  const hasDuplicateLabelKeys = new Set(labels.map((l) => l.key)).size !== labels.length;
+
+  const hasInvalidLabels =
+    labels.some(
+      (label) => !label.key || !label.value || !isValidK8sLabelKeyValue(label.key, label.value),
+    ) || hasDuplicateLabelKeys;
 
   const isSubmitDisabled =
     !k8sNameDescriptionData.data.k8sName.value ||

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   PageSection,
   Spinner,
+  getUniqueId,
 } from '@patternfly/react-core';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
@@ -16,6 +17,7 @@ import { useK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescripti
 import { RoleKind } from '#~/k8sTypes';
 import CreateRoleForm from './CreateRoleForm';
 import CreateRoleFooter from './CreateRoleFooter';
+import type { LabelEntry } from './types';
 
 type CreateRolePageProps = {
   existingRole?: RoleKind;
@@ -40,22 +42,29 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
   const [description, setDescription] = React.useState(
     () => existingRole?.metadata.annotations?.['openshift.io/description'] ?? '',
   );
-  const [labels, setLabels] = React.useState<{ key: string; value: string }[]>(() => {
+  const [labels, setLabels] = React.useState<LabelEntry[]>(() => {
     if (!existingRole?.metadata.labels) {
       return [];
     }
-    return Object.entries(existingRole.metadata.labels).map(([key, value]) => ({ key, value }));
+    return Object.entries(existingRole.metadata.labels).map(([key, value]) => ({
+      id: getUniqueId('label'),
+      key,
+      value,
+    }));
   });
 
   const handleDescriptionChange = React.useCallback((value: string) => {
     setDescription(value);
   }, []);
 
-  const handleLabelsChange = React.useCallback((newLabels: { key: string; value: string }[]) => {
+  const handleLabelsChange = React.useCallback((newLabels: LabelEntry[]) => {
     setLabels(newLabels);
   }, []);
 
-  const hasDuplicateLabelKeys = new Set(labels.map((l) => l.key)).size !== labels.length;
+  const hasDuplicateLabelKeys = React.useMemo(
+    () => new Set(labels.map((l) => l.key)).size !== labels.length,
+    [labels],
+  );
 
   const hasInvalidLabels =
     labels.some(
@@ -80,7 +89,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     return <Navigate to={`/projects/${namespace}?section=roles`} replace />;
   }
 
-  const pageTitle = isEdit ? 'Edit custom role' : 'Create custom roles';
+  const pageTitle = isEdit ? 'Edit custom role' : 'Create custom role';
 
   return (
     <ApplicationsPage

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -11,7 +11,7 @@ import { Link, Navigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { useAccessReview } from '#~/api/useAccessReview';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
-import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
+import { getDisplayNameFromK8sResource, isValidK8sLabelKeyValue } from '#~/concepts/k8s/utils';
 import { useK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { RoleKind } from '#~/k8sTypes';
 import CreateRoleForm from './CreateRoleForm';
@@ -55,7 +55,9 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     setLabels(newLabels);
   }, []);
 
-  const hasInvalidLabels = labels.some((label) => !label.key || !label.value);
+  const hasInvalidLabels = labels.some(
+    (label) => !label.key || !label.value || !isValidK8sLabelKeyValue(label.key, label.value),
+  );
 
   const isSubmitDisabled =
     !k8sNameDescriptionData.data.k8sName.value ||

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -3,9 +3,8 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Bullseye,
+  Button,
   PageSection,
-  EmptyState,
-  EmptyStateBody,
   Spinner,
 } from '@patternfly/react-core';
 import { Link, Navigate, useParams } from 'react-router-dom';
@@ -13,18 +12,56 @@ import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { useAccessReview } from '#~/api/useAccessReview';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { getDisplayNameFromK8sResource } from '#~/concepts/k8s/utils';
+import { useK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { RoleKind } from '#~/k8sTypes';
+import CreateRoleForm from './CreateRoleForm';
+import CreateRoleFooter from './CreateRoleFooter';
 
-const CreateRolePage: React.FC = () => {
+type CreateRolePageProps = {
+  existingRole?: RoleKind;
+};
+
+const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
   const { namespace = '' } = useParams<{ namespace: string }>();
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const displayName = getDisplayNameFromK8sResource(currentProject);
+  const isEdit = !!existingRole;
 
-  const [allowCreate, loaded] = useAccessReview({
+  const [allowAccess, loaded] = useAccessReview({
     group: 'rbac.authorization.k8s.io',
     resource: 'roles',
     namespace,
-    verb: 'create',
+    verb: isEdit ? 'update' : 'create',
   });
+
+  const k8sNameDescriptionData = useK8sNameDescriptionFieldData({
+    initialData: existingRole,
+  });
+  const [description, setDescription] = React.useState(
+    () => existingRole?.metadata.annotations?.['openshift.io/description'] ?? '',
+  );
+  const [labels, setLabels] = React.useState<{ key: string; value: string }[]>(() => {
+    if (!existingRole?.metadata.labels) {
+      return [];
+    }
+    return Object.entries(existingRole.metadata.labels).map(([key, value]) => ({ key, value }));
+  });
+
+  const handleDescriptionChange = React.useCallback((value: string) => {
+    setDescription(value);
+  }, []);
+
+  const handleLabelsChange = React.useCallback((newLabels: { key: string; value: string }[]) => {
+    setLabels(newLabels);
+  }, []);
+
+  const hasInvalidLabels = labels.some((label) => !label.key || !label.value);
+
+  const isSubmitDisabled =
+    !k8sNameDescriptionData.data.k8sName.value ||
+    k8sNameDescriptionData.data.k8sName.state.invalidCharacters ||
+    k8sNameDescriptionData.data.k8sName.state.invalidLength ||
+    hasInvalidLabels;
 
   if (!loaded) {
     return (
@@ -34,29 +71,49 @@ const CreateRolePage: React.FC = () => {
     );
   }
 
-  if (!allowCreate) {
+  if (!allowAccess) {
     return <Navigate to={`/projects/${namespace}?section=roles`} replace />;
   }
 
+  const pageTitle = isEdit ? 'Edit custom role' : 'Create custom roles';
+
   return (
     <ApplicationsPage
-      title="Create role"
+      title={pageTitle}
       breadcrumb={
         <Breadcrumb>
           <BreadcrumbItem render={() => <Link to="/projects">Projects</Link>} />
           <BreadcrumbItem
             render={() => <Link to={`/projects/${namespace}?section=roles`}>{displayName}</Link>}
           />
-          <BreadcrumbItem isActive>Create role</BreadcrumbItem>
+          <BreadcrumbItem isActive>{pageTitle}</BreadcrumbItem>
         </Breadcrumb>
+      }
+      description="Create a custom role to control what users can see and do across your cluster resources. Define permissions, navigation access, and resource scopes to implement fine-grained access control."
+      headerAction={
+        // TODO: Enable when template selection modal is implemented (RHOAIENG-63156)
+        <Button variant="secondary" data-testid="select-role-template-button" isDisabled>
+          Select role template
+        </Button>
       }
       loaded
       empty={false}
     >
-      <PageSection hasBodyWrapper={false} data-testid="create-role-page">
-        <EmptyState headingLevel="h2" titleText="Create role">
-          <EmptyStateBody>Role creation form will be implemented here.</EmptyStateBody>
-        </EmptyState>
+      <PageSection hasBodyWrapper={false} isFilled data-testid="create-role-page">
+        <CreateRoleForm
+          nameDescriptionData={k8sNameDescriptionData}
+          description={description}
+          onDescriptionChange={handleDescriptionChange}
+          labels={labels}
+          onLabelsChange={handleLabelsChange}
+        />
+      </PageSection>
+      <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
+        <CreateRoleFooter
+          namespace={namespace}
+          isSubmitDisabled={isSubmitDisabled}
+          isEdit={isEdit}
+        />
       </PageSection>
     </ApplicationsPage>
   );

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { Button, Content, Flex, FlexItem, FormGroup, TextInput } from '@patternfly/react-core';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+
+type LabelEntry = {
+  key: string;
+  value: string;
+};
+
+type RoleLabelsSectionProps = {
+  labels: LabelEntry[];
+  onLabelsChange: (labels: LabelEntry[]) => void;
+};
+
+const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsChange }) => {
+  const handleLabelChange = React.useCallback(
+    (index: number, field: 'key' | 'value', newValue: string) => {
+      const updated = labels.map((label, i) =>
+        i === index ? { ...label, [field]: newValue } : label,
+      );
+      onLabelsChange(updated);
+    },
+    [labels, onLabelsChange],
+  );
+
+  const handleAddLabel = React.useCallback(() => {
+    onLabelsChange([...labels, { key: '', value: '' }]);
+  }, [labels, onLabelsChange]);
+
+  const handleRemoveLabel = React.useCallback(
+    (index: number) => {
+      onLabelsChange(labels.filter((_, i) => i !== index));
+    },
+    [labels, onLabelsChange],
+  );
+
+  return (
+    <FormGroup label="Labels" fieldId="role-labels">
+      <Content component="p">
+        Add key/value labels to organize and filter roles (for example by organization, category or
+        team).
+      </Content>
+      {labels.map((label, index) => (
+        <Flex
+          key={index}
+          spaceItems={{ default: 'spaceItemsSm' }}
+          className="pf-v6-u-mb-sm"
+          data-testid={`role-label-${index}`}
+        >
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <TextInput
+              aria-label={`Label key ${index + 1}`}
+              data-testid={`role-label-key-${index}`}
+              value={label.key}
+              onChange={(_event, value) => handleLabelChange(index, 'key', value)}
+              placeholder="Key"
+            />
+          </FlexItem>
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <TextInput
+              aria-label={`Label value ${index + 1}`}
+              data-testid={`role-label-value-${index}`}
+              value={label.value}
+              onChange={(_event, value) => handleLabelChange(index, 'value', value)}
+              placeholder="Value"
+            />
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="plain"
+              aria-label={`Remove label ${index + 1}`}
+              data-testid={`role-label-remove-${index}`}
+              onClick={() => handleRemoveLabel(index)}
+            >
+              <MinusCircleIcon />
+            </Button>
+          </FlexItem>
+        </Flex>
+      ))}
+      <Button
+        variant="link"
+        icon={<PlusCircleIcon />}
+        onClick={handleAddLabel}
+        data-testid="role-add-label"
+      >
+        Add label
+      </Button>
+    </FormGroup>
+  );
+};
+
+export default RoleLabelsSection;

--- a/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
+++ b/frontend/src/pages/projects/projectRoles/RoleLabelsSection.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { Button, Content, Flex, FlexItem, FormGroup, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  FormGroup,
+  TextInput,
+  getUniqueId,
+} from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
-
-type LabelEntry = {
-  key: string;
-  value: string;
-};
+import type { LabelEntry } from './types';
 
 type RoleLabelsSectionProps = {
   labels: LabelEntry[];
@@ -24,7 +28,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
   );
 
   const handleAddLabel = React.useCallback(() => {
-    onLabelsChange([...labels, { key: '', value: '' }]);
+    onLabelsChange([...labels, { id: getUniqueId('label'), key: '', value: '' }]);
   }, [labels, onLabelsChange]);
 
   const handleRemoveLabel = React.useCallback(
@@ -42,7 +46,7 @@ const RoleLabelsSection: React.FC<RoleLabelsSectionProps> = ({ labels, onLabelsC
       </Content>
       {labels.map((label, index) => (
         <Flex
-          key={index}
+          key={label.id}
           spaceItems={{ default: 'spaceItemsSm' }}
           className="pf-v6-u-mb-sm"
           data-testid={`role-label-${index}`}

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -20,8 +20,8 @@ describe('RoleLabelsSection', () => {
 
     it('should render existing label rows', () => {
       const labels = [
-        { key: 'team', value: 'platform' },
-        { key: 'env', value: 'production' },
+        { id: 'l-1', key: 'team', value: 'platform' },
+        { id: 'l-2', key: 'env', value: 'production' },
       ];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
@@ -46,18 +46,20 @@ describe('RoleLabelsSection', () => {
 
       fireEvent.click(screen.getByTestId('role-add-label'));
 
-      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: '', value: '' }]);
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([
+        expect.objectContaining({ key: '', value: '' }),
+      ]);
     });
 
     it('should append to existing labels when Add label is clicked', () => {
-      const labels = [{ key: 'team', value: 'platform' }];
+      const labels = [{ id: 'l-1', key: 'team', value: 'platform' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.click(screen.getByTestId('role-add-label'));
 
       expect(mockOnLabelsChange).toHaveBeenCalledWith([
-        { key: 'team', value: 'platform' },
-        { key: '', value: '' },
+        { id: 'l-1', key: 'team', value: 'platform' },
+        expect.objectContaining({ key: '', value: '' }),
       ]);
     });
   });
@@ -65,18 +67,20 @@ describe('RoleLabelsSection', () => {
   describe('removing labels', () => {
     it('should remove the correct label row', () => {
       const labels = [
-        { key: 'team', value: 'platform' },
-        { key: 'env', value: 'production' },
+        { id: 'l-1', key: 'team', value: 'platform' },
+        { id: 'l-2', key: 'env', value: 'production' },
       ];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.click(screen.getByTestId('role-label-remove-0'));
 
-      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'env', value: 'production' }]);
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([
+        { id: 'l-2', key: 'env', value: 'production' },
+      ]);
     });
 
     it('should remove the last remaining label', () => {
-      const labels = [{ key: 'team', value: 'platform' }];
+      const labels = [{ id: 'l-1', key: 'team', value: 'platform' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.click(screen.getByTestId('role-label-remove-0'));
@@ -87,29 +91,31 @@ describe('RoleLabelsSection', () => {
 
   describe('editing labels', () => {
     it('should update the key of a label', () => {
-      const labels = [{ key: '', value: '' }];
+      const labels = [{ id: 'l-1', key: '', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.change(screen.getByTestId('role-label-key-0'), { target: { value: 'team' } });
 
-      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'team', value: '' }]);
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ id: 'l-1', key: 'team', value: '' }]);
     });
 
     it('should update the value of a label', () => {
-      const labels = [{ key: 'team', value: '' }];
+      const labels = [{ id: 'l-1', key: 'team', value: '' }];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
       fireEvent.change(screen.getByTestId('role-label-value-0'), {
         target: { value: 'platform' },
       });
 
-      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'team', value: 'platform' }]);
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([
+        { id: 'l-1', key: 'team', value: 'platform' },
+      ]);
     });
 
     it('should only update the targeted label row', () => {
       const labels = [
-        { key: 'team', value: 'platform' },
-        { key: 'env', value: 'prod' },
+        { id: 'l-1', key: 'team', value: 'platform' },
+        { id: 'l-2', key: 'env', value: 'prod' },
       ];
       render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
 
@@ -118,8 +124,8 @@ describe('RoleLabelsSection', () => {
       });
 
       expect(mockOnLabelsChange).toHaveBeenCalledWith([
-        { key: 'team', value: 'platform' },
-        { key: 'env', value: 'staging' },
+        { id: 'l-1', key: 'team', value: 'platform' },
+        { id: 'l-2', key: 'env', value: 'staging' },
       ]);
     });
   });

--- a/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RoleLabelsSection from '#~/pages/projects/projectRoles/RoleLabelsSection';
+
+describe('RoleLabelsSection', () => {
+  const mockOnLabelsChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render with no label rows when labels is empty', () => {
+      render(<RoleLabelsSection labels={[]} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-add-label')).toBeInTheDocument();
+      expect(screen.queryByTestId('role-label-key-0')).not.toBeInTheDocument();
+    });
+
+    it('should render existing label rows', () => {
+      const labels = [
+        { key: 'team', value: 'platform' },
+        { key: 'env', value: 'production' },
+      ];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(screen.getByTestId('role-label-key-0')).toHaveValue('team');
+      expect(screen.getByTestId('role-label-value-0')).toHaveValue('platform');
+      expect(screen.getByTestId('role-label-key-1')).toHaveValue('env');
+      expect(screen.getByTestId('role-label-value-1')).toHaveValue('production');
+    });
+
+    it('should render description text', () => {
+      render(<RoleLabelsSection labels={[]} onLabelsChange={mockOnLabelsChange} />);
+
+      expect(
+        screen.getByText(/Add key\/value labels to organize and filter roles/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('adding labels', () => {
+    it('should call onLabelsChange with a new empty row when Add label is clicked', () => {
+      render(<RoleLabelsSection labels={[]} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.click(screen.getByTestId('role-add-label'));
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: '', value: '' }]);
+    });
+
+    it('should append to existing labels when Add label is clicked', () => {
+      const labels = [{ key: 'team', value: 'platform' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.click(screen.getByTestId('role-add-label'));
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([
+        { key: 'team', value: 'platform' },
+        { key: '', value: '' },
+      ]);
+    });
+  });
+
+  describe('removing labels', () => {
+    it('should remove the correct label row', () => {
+      const labels = [
+        { key: 'team', value: 'platform' },
+        { key: 'env', value: 'production' },
+      ];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.click(screen.getByTestId('role-label-remove-0'));
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'env', value: 'production' }]);
+    });
+
+    it('should remove the last remaining label', () => {
+      const labels = [{ key: 'team', value: 'platform' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.click(screen.getByTestId('role-label-remove-0'));
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('editing labels', () => {
+    it('should update the key of a label', () => {
+      const labels = [{ key: '', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.change(screen.getByTestId('role-label-key-0'), { target: { value: 'team' } });
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'team', value: '' }]);
+    });
+
+    it('should update the value of a label', () => {
+      const labels = [{ key: 'team', value: '' }];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.change(screen.getByTestId('role-label-value-0'), {
+        target: { value: 'platform' },
+      });
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([{ key: 'team', value: 'platform' }]);
+    });
+
+    it('should only update the targeted label row', () => {
+      const labels = [
+        { key: 'team', value: 'platform' },
+        { key: 'env', value: 'prod' },
+      ];
+      render(<RoleLabelsSection labels={labels} onLabelsChange={mockOnLabelsChange} />);
+
+      fireEvent.change(screen.getByTestId('role-label-value-1'), {
+        target: { value: 'staging' },
+      });
+
+      expect(mockOnLabelsChange).toHaveBeenCalledWith([
+        { key: 'team', value: 'platform' },
+        { key: 'env', value: 'staging' },
+      ]);
+    });
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/types.ts
+++ b/frontend/src/pages/projects/projectRoles/types.ts
@@ -1,0 +1,5 @@
+export type LabelEntry = {
+  id: string;
+  key: string;
+  value: string;
+};

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -29,6 +29,58 @@ class ProjectRolesTab {
   findCreateRolePage() {
     return cy.findByTestId('create-role-page');
   }
+
+  findCreateRoleForm() {
+    return cy.findByTestId('create-role-form');
+  }
+
+  findRoleNameInput() {
+    return cy.findByTestId('role-name');
+  }
+
+  findDescriptionTextarea() {
+    return cy.findByTestId('role-description');
+  }
+
+  findAddLabelButton() {
+    return cy.findByTestId('role-add-label');
+  }
+
+  findLabelKeyInput(index: number) {
+    return cy.findByTestId(`role-label-key-${index}`);
+  }
+
+  findLabelValueInput(index: number) {
+    return cy.findByTestId(`role-label-value-${index}`);
+  }
+
+  findLabelRemoveButton(index: number) {
+    return cy.findByTestId(`role-label-remove-${index}`);
+  }
+
+  findPermissionsEmptyState() {
+    return cy.findByTestId('permissions-empty-state');
+  }
+
+  findAddRuleButton() {
+    return cy.findByTestId('role-add-rule');
+  }
+
+  findImportTemplateButton() {
+    return cy.findByTestId('role-import-template');
+  }
+
+  findSelectRoleTemplateButton() {
+    return cy.findByTestId('select-role-template-button');
+  }
+
+  findSubmitButton() {
+    return cy.findByTestId('create-role-submit');
+  }
+
+  findCancelButton() {
+    return cy.findByTestId('create-role-cancel');
+  }
 }
 
 export const projectRoles = new ProjectRolesTab();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -69,6 +69,70 @@ describe('Roles tab feature flag gating', () => {
       projectRoles.visitCreateRole(NAMESPACE);
       projectRoles.findCreateRolePage().should('exist');
     });
+
+    it('should render the create role form with all fields and placeholder states', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findCreateRoleForm().should('exist');
+      projectRoles.findRoleNameInput().should('exist');
+      projectRoles
+        .findDescriptionTextarea()
+        .should('have.attr', 'placeholder', 'Describe what this role is for and who should use it');
+      projectRoles.findAddLabelButton().should('exist');
+      projectRoles.findPermissionsEmptyState().should('contain.text', 'No permissions set');
+      projectRoles.findSelectRoleTemplateButton().should('be.disabled');
+      projectRoles.findAddRuleButton().should('be.disabled');
+      projectRoles.findImportTemplateButton().should('be.disabled');
+    });
+
+    it('should have the submit button disabled when name is empty', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findSubmitButton().should('be.disabled');
+    });
+
+    it('should enable the submit button when name is filled', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findRoleNameInput().type('my-test-role');
+      projectRoles.findSubmitButton().should('be.enabled');
+    });
+
+    it('should disable submit when a label row has empty key or value', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findRoleNameInput().type('my-test-role');
+      projectRoles.findSubmitButton().should('be.enabled');
+
+      projectRoles.findAddLabelButton().click();
+      projectRoles.findSubmitButton().should('be.disabled');
+
+      projectRoles.findLabelKeyInput(0).type('team');
+      projectRoles.findSubmitButton().should('be.disabled');
+
+      projectRoles.findLabelValueInput(0).type('platform');
+      projectRoles.findSubmitButton().should('be.enabled');
+    });
+
+    it('should add and remove label rows', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findLabelKeyInput(0).should('not.exist');
+
+      projectRoles.findAddLabelButton().click();
+      projectRoles.findLabelKeyInput(0).should('exist');
+
+      projectRoles.findAddLabelButton().click();
+      projectRoles.findLabelKeyInput(1).should('exist');
+
+      projectRoles.findLabelRemoveButton(1).click();
+      projectRoles.findLabelKeyInput(1).should('not.exist');
+
+      projectRoles.findLabelRemoveButton(0).click();
+      projectRoles.findLabelKeyInput(0).should('not.exist');
+    });
+
+    it('should navigate back to roles tab on cancel', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findCancelButton().click();
+      cy.url().should('include', `/projects/${NAMESPACE}`);
+      cy.url().should('include', 'section=roles');
+    });
   });
 
   describe('with roleManagement flag enabled but user lacks create permission', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -110,6 +110,21 @@ describe('Roles tab feature flag gating', () => {
       projectRoles.findSubmitButton().should('be.enabled');
     });
 
+    it('should disable submit when duplicate label keys exist', () => {
+      projectRoles.visitCreateRole(NAMESPACE);
+      projectRoles.findRoleNameInput().type('my-test-role');
+
+      projectRoles.findAddLabelButton().click();
+      projectRoles.findLabelKeyInput(0).type('team');
+      projectRoles.findLabelValueInput(0).type('platform');
+      projectRoles.findSubmitButton().should('be.enabled');
+
+      projectRoles.findAddLabelButton().click();
+      projectRoles.findLabelKeyInput(1).type('team');
+      projectRoles.findLabelValueInput(1).type('other');
+      projectRoles.findSubmitButton().should('be.disabled');
+    });
+
     it('should add and remove label rows', () => {
       projectRoles.visitCreateRole(NAMESPACE);
       projectRoles.findLabelKeyInput(0).should('not.exist');


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-63154

## Description

Implements the Create Custom Role form page with the role configuration (metadata) section. This replaces the placeholder page from Story 1 ([RHOAIENG-63152](https://redhat.atlassian.net/browse/RHOAIENG-63152)) with the full form matching the [Figma design](https://www.figma.com/design/1ofcEqlUlbfdZu10NTta0Z/RBAC-feature-in-Project?node-id=3273-31943&m=dev&focus-id=3273-31940).

https://github.com/user-attachments/assets/81cd2c24-9986-4de9-9171-2298df405832

**What's included:**
- **Page header**: Breadcrumb (`Projects > {project name} > Create custom roles`), title, description text, and disabled "Select role template" secondary button (placeholder for Story 5)
- **Role name field**: Reuses `K8sNameDescriptionField` with K8s-compatible name validation (auto-generated resource name, "Edit resource name" link)
- **Description**: Textarea with placeholder text
- **Labels**: Extracted `RoleLabelsSection` component with repeatable key/value rows (add/remove), validation that blocks submit if any row has empty key or value
- **Permissions rules section**: Placeholder with empty state text and disabled "Add rule" / "Import rules from template" buttons (Story 4 & 5)
- **Sticky footer**: "Create role" button (disabled until valid) + "Cancel" link
- **Edit-ready**: Page accepts optional `existingRole?: RoleKind` prop following the `SpawnerPage`/`EditSpawnerPage` pattern — access review verb switches between `create`/`update`, state initializes from existing resource

## How Has This Been Tested?

- TypeScript compilation: 0 errors
- ESLint: 0 errors, 0 warnings (all files including Cypress)
- Unit tests: 10/10 pass (`RoleLabelsSection.spec.tsx`)
- Cypress mock tests: 14/14 pass (`rolesTab.cy.ts`) — built frontend, started server, ran headless Chrome

## Test Impact

**Unit tests added:**
- `frontend/src/pages/projects/projectRoles/__tests__/RoleLabelsSection.spec.tsx` — 10 tests covering rendering (empty, existing labels, description text), adding labels, removing labels (including last row), editing key/value (including isolation check)

**Cypress mock tests added (in existing `rolesTab.cy.ts`):**
- Form renders with all fields and placeholder states (disabled buttons, placeholder text)
- Submit button disabled when name is empty
- Submit button enabled when name is filled
- Submit disabled when a label row has empty key or value (validates full key+value flow)
- Add and remove label rows (including removing all rows)
- Cancel navigates back to roles tab

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create/edit custom roles UI: full form, sticky footer, edit mode, pre-filled data, cancel returns to roles.

* **Labels**
  * Editable key/value rows with add/remove controls, duplicate-key prevention, and inline validation.

* **Permissions**
  * Permissions rules section with descriptive empty state and disabled add/import actions.

* **Validation**
  * Kubernetes-style label key/value validation; submit enabled/disabled based on name and label validity.

* **Tests**
  * Unit and E2E tests plus test helpers covering create-role flow and label validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->