### PR TITLE
feat(nim-serving): deploy NIMService from wizard

### DIFF
--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -53,6 +53,10 @@ import {
 import type { CreatingInferenceServiceObject } from './deployModel';
 import type { KServeDeployment } from './deployments';
 
+export const KSERVE_AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
+export const KSERVE_VISIBILITY_LABEL = 'networking.kserve.io/visibility';
+export const KSERVE_DEPLOYMENT_MODE_ANNOTATION = 'serving.kserve.io/deploymentMode';
+
 const is404 = (error: unknown): boolean => {
   return getGenericErrorCode(error) === 404;
 };
@@ -195,16 +199,16 @@ export const applyAuth = (
   const result = structuredClone(inferenceService);
   result.metadata.annotations = {
     ...result.metadata.annotations,
-    'security.opendatahub.io/enable-auth': tokenAuth ? 'true' : 'false',
+    [KSERVE_AUTH_ANNOTATION]: tokenAuth ? 'true' : 'false',
   };
 
   result.metadata.labels = {
     ...result.metadata.labels,
-    ...(externalRoute && { 'networking.kserve.io/visibility': 'exposed' }),
+    ...(externalRoute && { [KSERVE_VISIBILITY_LABEL]: 'exposed' }),
   };
 
   if (!externalRoute) {
-    delete result.metadata.labels['networking.kserve.io/visibility'];
+    delete result.metadata.labels[KSERVE_VISIBILITY_LABEL];
   }
 
   return result;

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -57,6 +57,11 @@ export const KSERVE_AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
 export const KSERVE_VISIBILITY_LABEL = 'networking.kserve.io/visibility';
 export const KSERVE_DEPLOYMENT_MODE_ANNOTATION = 'serving.kserve.io/deploymentMode';
 
+export enum KServeVisibility {
+  Exposed = 'exposed',
+  ClusterLocal = 'cluster-local',
+}
+
 const is404 = (error: unknown): boolean => {
   return getGenericErrorCode(error) === 404;
 };
@@ -204,7 +209,7 @@ export const applyAuth = (
 
   result.metadata.labels = {
     ...result.metadata.labels,
-    ...(externalRoute && { [KSERVE_VISIBILITY_LABEL]: 'exposed' }),
+    ...(externalRoute && { [KSERVE_VISIBILITY_LABEL]: KServeVisibility.Exposed }),
   };
 
   if (!externalRoute) {

--- a/packages/kserve/src/deployUtils.ts
+++ b/packages/kserve/src/deployUtils.ts
@@ -62,6 +62,11 @@ export enum KServeVisibility {
   ClusterLocal = 'cluster-local',
 }
 
+export enum KServeDeploymentMode {
+  RawDeployment = 'RawDeployment',
+  Standard = 'Standard',
+}
+
 const is404 = (error: unknown): boolean => {
   return getGenericErrorCode(error) === 404;
 };

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -12,6 +12,7 @@ import type {
   DeploymentWizardFieldOverrideExtension,
   ModelServingDeploy,
   WizardFieldApplyExtension,
+  WizardFieldDeploymentFunctionsExtension,
   WizardFieldExtension,
   WizardFieldExtractorExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
@@ -117,6 +118,28 @@ const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, 
   },
 };
 
+const nimPVCDeployFunctionsExtension: WizardFieldDeploymentFunctionsExtension<
+  NIMPVCFieldValue,
+  NIMDeployment
+> = {
+  type: 'model-serving.deployment/wizard-field-deployment-functions',
+  properties: {
+    fieldId: 'nim-serving/pvcStorage',
+    platform: NIM_ID,
+    preDeploy: () =>
+      import('./src/pages/deploymentWizard/fields/nimPVCDeployFunctions').then(
+        (m) => m.nimPVCPreDeploy,
+      ),
+    postDeploy: () =>
+      import('./src/pages/deploymentWizard/fields/nimPVCDeployFunctions').then(
+        (m) => m.nimPVCPostDeploy,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
 const extensions: (
   | AreaExtension
   | ProjectDetailsSettingsCardExtension
@@ -126,6 +149,7 @@ const extensions: (
   | ModelServingDeploy<NIMDeployment>
   | AssembleModelResourceExtension<NIMDeployment>
   | DeploymentWizardFieldOverrideExtension
+  | WizardFieldDeploymentFunctionsExtension<NIMPVCFieldValue, NIMDeployment>
   | WizardFieldExtension<NIMImageFieldType>
   | WizardFieldExtension<NIMPVCFieldType>
   | WizardFieldApplyExtension<NIMImageFieldValue, NIMDeployment>
@@ -225,6 +249,7 @@ const extensions: (
   nimImageExtractorExtension,
   nimPVCApplyExtension,
   nimPVCExtractorExtension,
+  nimPVCDeployFunctionsExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -56,6 +56,67 @@ const nimPVCFieldExtension: WizardFieldExtension<NIMPVCFieldType> = {
   },
 };
 
+const nimImageApplyExtension: WizardFieldApplyExtension<NIMImageFieldValue, NIMDeployment> = {
+  type: 'model-serving.deployment/wizard-field-apply',
+  properties: {
+    fieldId: 'nim-serving/nimImage',
+    platform: NIM_ID,
+    apply: () =>
+      import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
+        (m) => m.applyNIMImageFieldData,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
+const nimImageExtractorExtension: WizardFieldExtractorExtension<NIMImageFieldValue, NIMDeployment> =
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'nim-serving/nimImage',
+      platform: NIM_ID,
+      extract: () =>
+        import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
+          (m) => m.extractNIMImageFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  };
+
+const nimPVCApplyExtension: WizardFieldApplyExtension<NIMPVCFieldValue, NIMDeployment> = {
+  type: 'model-serving.deployment/wizard-field-apply',
+  properties: {
+    fieldId: 'nim-serving/pvcStorage',
+    platform: NIM_ID,
+    apply: () =>
+      import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
+        (m) => m.applyNIMPVCFieldData,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
+const nimPVCExtractorExtension: WizardFieldExtractorExtension<NIMPVCFieldValue, NIMDeployment> = {
+  type: 'model-serving.deployment/wizard-field-extractor',
+  properties: {
+    fieldId: 'nim-serving/pvcStorage',
+    platform: NIM_ID,
+    extract: () =>
+      import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
+        (m) => m.extractNIMPVCFieldData,
+      ),
+  },
+  flags: {
+    required: [SupportedArea.NIM_WIZARD],
+  },
+};
+
 const extensions: (
   | AreaExtension
   | ProjectDetailsSettingsCardExtension
@@ -160,62 +221,10 @@ const extensions: (
       required: [SupportedArea.NIM_WIZARD],
     },
   },
-  {
-    type: 'model-serving.deployment/wizard-field-apply',
-    properties: {
-      fieldId: 'nim-serving/nimImage',
-      platform: NIM_ID,
-      apply: () =>
-        import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
-          (m) => m.applyNIMImageFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
-  {
-    type: 'model-serving.deployment/wizard-field-extractor',
-    properties: {
-      fieldId: 'nim-serving/nimImage',
-      platform: NIM_ID,
-      extract: () =>
-        import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
-          (m) => m.extractNIMImageFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
-  {
-    type: 'model-serving.deployment/wizard-field-apply',
-    properties: {
-      fieldId: 'nim-serving/pvcStorage',
-      platform: NIM_ID,
-      apply: () =>
-        import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
-          (m) => m.applyNIMPVCFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
-  {
-    type: 'model-serving.deployment/wizard-field-extractor',
-    properties: {
-      fieldId: 'nim-serving/pvcStorage',
-      platform: NIM_ID,
-      extract: () =>
-        import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
-          (m) => m.extractNIMPVCFieldData,
-        ),
-    },
-    flags: {
-      required: [SupportedArea.NIM_WIZARD],
-    },
-  },
+  nimImageApplyExtension,
+  nimImageExtractorExtension,
+  nimPVCApplyExtension,
+  nimPVCExtractorExtension,
 ];
 
 export default extensions;

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -8,15 +8,25 @@ import type {
   ModelServingPlatformWatchDeploymentsExtension,
 } from '@odh-dashboard/model-serving/extension-points';
 import type {
+  AssembleModelResourceExtension,
   DeploymentWizardFieldOverrideExtension,
+  ModelServingDeploy,
+  WizardFieldApplyExtension,
   WizardFieldExtension,
+  WizardFieldExtractorExtension,
 } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
 // Allow this import as it consists of types and enums only.
 // eslint-disable-next-line no-restricted-syntax
 import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import type { NIMDeployment } from './src/api/deployments/useWatchDeployments';
-import type { NIMImageFieldType } from './src/pages/deploymentWizard/fields/NIMImageField';
-import type { NIMPVCFieldType } from './src/pages/deploymentWizard/fields/NIMPVCField';
+import type {
+  NIMImageFieldType,
+  NIMImageFieldValue,
+} from './src/pages/deploymentWizard/fields/NIMImageField';
+import type {
+  NIMPVCFieldType,
+  NIMPVCFieldValue,
+} from './src/pages/deploymentWizard/fields/NIMPVCField';
 
 export const NIM_ID = 'nvidia-nim';
 
@@ -52,9 +62,15 @@ const extensions: (
   | ModelServingPlatformWatchDeploymentsExtension<NIMDeployment>
   | DeployedModelServingDetails<NIMDeployment>
   | ModelServingExcludeDeploymentExtension
+  | ModelServingDeploy<NIMDeployment>
+  | AssembleModelResourceExtension<NIMDeployment>
   | DeploymentWizardFieldOverrideExtension
   | WizardFieldExtension<NIMImageFieldType>
   | WizardFieldExtension<NIMPVCFieldType>
+  | WizardFieldApplyExtension<NIMImageFieldValue, NIMDeployment>
+  | WizardFieldApplyExtension<NIMPVCFieldValue, NIMDeployment>
+  | WizardFieldExtractorExtension<NIMImageFieldValue, NIMDeployment>
+  | WizardFieldExtractorExtension<NIMPVCFieldValue, NIMDeployment>
 )[] = [
   {
     type: 'app.area',
@@ -119,6 +135,87 @@ const extensions: (
   },
   nimImageFieldExtension,
   nimPVCFieldExtension,
+  {
+    type: 'model-serving.deployment/deploy',
+    properties: {
+      platform: NIM_ID,
+      isActive: () => import('./src/api/deployments/deploy').then((m) => m.isNIMDeployActive),
+      priority: 100,
+      supportsOverwrite: true,
+      deploy: () => import('./src/api/deployments/deploy').then((m) => m.deployNIMDeployment),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/assemble-model-resource',
+    properties: {
+      platform: NIM_ID,
+      isActive: () => import('./src/api/deployments/deploy').then((m) => m.isNIMDeployActive),
+      priority: 100,
+      assemble: () => import('./src/api/deployments/deploy').then((m) => m.assembleNIMDeployment),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'nim-serving/nimImage',
+      platform: NIM_ID,
+      apply: () =>
+        import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
+          (m) => m.applyNIMImageFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'nim-serving/nimImage',
+      platform: NIM_ID,
+      extract: () =>
+        import('./src/pages/deploymentWizard/fields/nimImageApplyExtract').then(
+          (m) => m.extractNIMImageFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-apply',
+    properties: {
+      fieldId: 'nim-serving/pvcStorage',
+      platform: NIM_ID,
+      apply: () =>
+        import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
+          (m) => m.applyNIMPVCFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/wizard-field-extractor',
+    properties: {
+      fieldId: 'nim-serving/pvcStorage',
+      platform: NIM_ID,
+      extract: () =>
+        import('./src/pages/deploymentWizard/fields/nimPVCApplyExtract').then(
+          (m) => m.extractNIMPVCFieldData,
+        ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
 ];
 
 export default extensions;

--- a/packages/nim-serving/src/api/deployments/__tests__/deploy.spec.ts
+++ b/packages/nim-serving/src/api/deployments/__tests__/deploy.spec.ts
@@ -1,0 +1,180 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
+import { isNIMDeployActive, deployNIMDeployment } from '../deploy';
+import { createNIMService, updateNIMService, patchNIMService } from '../../nimservices/k8s';
+import { getNIMAccount } from '../../accounts/k8s';
+import type { NIMServiceKind } from '../../nimservices/types';
+
+jest.mock('../../nimservices/k8s', () => ({
+  ...jest.requireActual('../../nimservices/k8s'),
+  createNIMService: jest.fn(),
+  updateNIMService: jest.fn(),
+  patchNIMService: jest.fn(),
+}));
+
+jest.mock('../../accounts/k8s', () => ({
+  ...jest.requireActual('../../accounts/k8s'),
+  getNIMAccount: jest.fn(),
+}));
+
+const mockCreate = jest.mocked(createNIMService);
+const mockUpdate = jest.mocked(updateNIMService);
+const mockPatch = jest.mocked(patchNIMService);
+const mockGetNIMAccount = jest.mocked(getNIMAccount);
+
+const mockNIMServiceResource: NIMServiceKind = {
+  apiVersion: 'apps.nvidia.com/v1alpha1',
+  kind: 'NIMService',
+  metadata: { name: 'test-nim', namespace: 'test-ns' },
+  spec: {
+    inferencePlatform: 'kserve',
+    image: { repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct', tag: '1.8' },
+  },
+};
+
+describe('isNIMDeployActive', () => {
+  it('should return true when model location type is nvidia-nim', () => {
+    const wizardData = {
+      modelLocationData: { data: { type: 'nvidia-nim' } },
+    } as unknown as WizardFormData['state'];
+
+    expect(isNIMDeployActive(wizardData)).toBe(true);
+  });
+
+  it('should return false when model location type is not nvidia-nim', () => {
+    const wizardData = {
+      modelLocationData: { data: { type: 'existing' } },
+    } as unknown as WizardFormData['state'];
+
+    expect(isNIMDeployActive(wizardData)).toBe(false);
+  });
+
+  it('should return false when model location data is undefined', () => {
+    const wizardData = {
+      modelLocationData: { data: undefined },
+    } as unknown as WizardFormData['state'];
+
+    expect(isNIMDeployActive(wizardData)).toBe(false);
+  });
+});
+
+describe('deployNIMDeployment', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const wizardState = {} as WizardFormData['state'];
+
+  it('should throw when modelResource is missing', async () => {
+    await expect(deployNIMDeployment(wizardState, 'test-ns')).rejects.toThrow(
+      'NIMService resource is required',
+    );
+  });
+
+  it('should create a new NIMService when no existing deployment', async () => {
+    const account = mockNimAccount({
+      namespace: 'test-ns',
+      apiKeySecretName: 'nvidia-nim-secrets',
+    });
+    account.status = {
+      ...account.status,
+      nimPullSecret: { name: 'ngc-secret' },
+    };
+    mockGetNIMAccount.mockResolvedValue(account);
+    mockCreate.mockResolvedValue(mockNIMServiceResource);
+
+    const result = await deployNIMDeployment(
+      wizardState,
+      'test-ns',
+      undefined,
+      mockNIMServiceResource,
+    );
+
+    expect(mockGetNIMAccount).toHaveBeenCalledWith('test-ns');
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          authSecret: 'nvidia-nim-secrets',
+          image: expect.objectContaining({
+            pullSecrets: ['ngc-secret'],
+          }),
+        }),
+      }),
+      { dryRun: undefined },
+    );
+    expect(result.modelServingPlatformId).toBe('nvidia-nim');
+    expect(result.model).toBe(mockNIMServiceResource);
+  });
+
+  it('should update an existing NIMService deployment', async () => {
+    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue(mockNIMServiceResource);
+
+    const existingDeployment = {
+      modelServingPlatformId: 'nvidia-nim' as const,
+      model: mockNIMServiceResource,
+    };
+
+    await deployNIMDeployment(wizardState, 'test-ns', existingDeployment, mockNIMServiceResource);
+
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('should patch when overwrite is true and existing deployment exists', async () => {
+    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockPatch.mockResolvedValue(mockNIMServiceResource);
+
+    const existingDeployment = {
+      modelServingPlatformId: 'nvidia-nim' as const,
+      model: mockNIMServiceResource,
+    };
+
+    await deployNIMDeployment(
+      wizardState,
+      'test-ns',
+      existingDeployment,
+      mockNIMServiceResource,
+      undefined,
+      undefined,
+      false,
+      undefined,
+      true,
+    );
+
+    expect(mockPatch).toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to NIM_SECRET_NAME when no NIM account exists', async () => {
+    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockCreate.mockResolvedValue(mockNIMServiceResource);
+
+    await deployNIMDeployment(wizardState, 'test-ns', undefined, mockNIMServiceResource);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          authSecret: 'nvidia-nim-secrets',
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('should pass dryRun option', async () => {
+    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockCreate.mockResolvedValue(mockNIMServiceResource);
+
+    await deployNIMDeployment(
+      wizardState,
+      'test-ns',
+      undefined,
+      mockNIMServiceResource,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.any(Object), { dryRun: true });
+  });
+});

--- a/packages/nim-serving/src/api/deployments/__tests__/deploy.spec.ts
+++ b/packages/nim-serving/src/api/deployments/__tests__/deploy.spec.ts
@@ -105,7 +105,9 @@ describe('deployNIMDeployment', () => {
   });
 
   it('should update an existing NIMService deployment', async () => {
-    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockGetNIMAccount.mockResolvedValue(
+      mockNimAccount({ namespace: 'test-ns', apiKeySecretName: 'nvidia-nim-secrets' }),
+    );
     mockUpdate.mockResolvedValue(mockNIMServiceResource);
 
     const existingDeployment = {
@@ -120,7 +122,9 @@ describe('deployNIMDeployment', () => {
   });
 
   it('should patch when overwrite is true and existing deployment exists', async () => {
-    mockGetNIMAccount.mockResolvedValue(undefined);
+    mockGetNIMAccount.mockResolvedValue(
+      mockNimAccount({ namespace: 'test-ns', apiKeySecretName: 'nvidia-nim-secrets' }),
+    );
     mockPatch.mockResolvedValue(mockNIMServiceResource);
 
     const existingDeployment = {
@@ -145,24 +149,21 @@ describe('deployNIMDeployment', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it('should fall back to NIM_SECRET_NAME when no NIM account exists', async () => {
+  it('should throw when no NIM account exists in the project', async () => {
     mockGetNIMAccount.mockResolvedValue(undefined);
-    mockCreate.mockResolvedValue(mockNIMServiceResource);
 
-    await deployNIMDeployment(wizardState, 'test-ns', undefined, mockNIMServiceResource);
-
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        spec: expect.objectContaining({
-          authSecret: 'nvidia-nim-secrets',
-        }),
-      }),
-      expect.any(Object),
-    );
+    await expect(
+      deployNIMDeployment(wizardState, 'test-ns', undefined, mockNIMServiceResource),
+    ).rejects.toThrow('NIM Account not found');
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it('should pass dryRun option', async () => {
-    mockGetNIMAccount.mockResolvedValue(undefined);
+    const account = mockNimAccount({
+      namespace: 'test-ns',
+      apiKeySecretName: 'nvidia-nim-secrets',
+    });
+    mockGetNIMAccount.mockResolvedValue(account);
     mockCreate.mockResolvedValue(mockNIMServiceResource);
 
     await deployNIMDeployment(

--- a/packages/nim-serving/src/api/deployments/deploy.ts
+++ b/packages/nim-serving/src/api/deployments/deploy.ts
@@ -9,7 +9,6 @@ import {
   patchNIMService,
 } from '../nimservices/k8s';
 import { getNIMAccount } from '../accounts/k8s';
-import { NIM_SECRET_NAME } from '../accounts/constants';
 import { NIM_ID } from '../../../extensions';
 
 export const isNIMDeployActive = (wizardData: WizardFormData['state']): boolean =>
@@ -80,13 +79,14 @@ export const deployNIMDeployment = async (
   const nimServiceWithSecrets = structuredClone(modelResource);
 
   const nimAccount = await getNIMAccount(projectName);
-  if (nimAccount) {
-    nimServiceWithSecrets.spec.authSecret = nimAccount.spec.apiKeySecret.name;
-    if (nimAccount.status?.nimPullSecret?.name) {
-      nimServiceWithSecrets.spec.image.pullSecrets = [nimAccount.status.nimPullSecret.name];
-    }
-  } else {
-    nimServiceWithSecrets.spec.authSecret = NIM_SECRET_NAME;
+  if (!nimAccount) {
+    throw new Error(
+      'NIM Account not found in this project. Configure NVIDIA NIM in the project settings first.',
+    );
+  }
+  nimServiceWithSecrets.spec.authSecret = nimAccount.spec.apiKeySecret.name;
+  if (nimAccount.status?.nimPullSecret?.name) {
+    nimServiceWithSecrets.spec.image.pullSecrets = [nimAccount.status.nimPullSecret.name];
   }
 
   const nimService = await deployNIMServiceResource(

--- a/packages/nim-serving/src/api/deployments/deploy.ts
+++ b/packages/nim-serving/src/api/deployments/deploy.ts
@@ -33,6 +33,7 @@ export const assembleNIMDeployment = (
       replicas: wizardData.state.numReplicas.data,
       externalRoute: wizardData.state.externalRoute.data,
       tokenAuth,
+      runtimeArgs: wizardData.state.runtimeArgs.data,
       environmentVariables: wizardData.state.environmentVariables.data,
       hardwareProfile: wizardData.state.hardwareProfileConfig.formData,
     },

--- a/packages/nim-serving/src/api/deployments/deploy.ts
+++ b/packages/nim-serving/src/api/deployments/deploy.ts
@@ -20,6 +20,11 @@ export const assembleNIMDeployment = (
   existingDeployment?: NIMDeployment,
   applyFieldData?: DeploymentAssemblyFn<NIMDeployment>,
 ): NIMDeployment => {
+  const tokenAuth =
+    (wizardData.state.tokenAuthentication.data &&
+      wizardData.state.tokenAuthentication.data.length > 0) ??
+    false;
+
   const nimService = assembleNIMService(
     {
       projectName: wizardData.state.project.projectName ?? '',
@@ -28,6 +33,7 @@ export const assembleNIMDeployment = (
       description: wizardData.state.k8sNameDesc.data.description,
       replicas: wizardData.state.numReplicas.data,
       externalRoute: wizardData.state.externalRoute.data,
+      tokenAuth,
       environmentVariables: wizardData.state.environmentVariables.data,
       hardwareProfile: wizardData.state.hardwareProfileConfig.formData,
     },

--- a/packages/nim-serving/src/api/deployments/deploy.ts
+++ b/packages/nim-serving/src/api/deployments/deploy.ts
@@ -1,0 +1,96 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
+import type { DeploymentAssemblyFn } from '@odh-dashboard/model-serving/extension-points/deployment-wizard';
+import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
+import { type NIMServiceKind, type NIMDeployment } from '../nimservices/types';
+import {
+  assembleNIMService,
+  createNIMService,
+  updateNIMService,
+  patchNIMService,
+} from '../nimservices/k8s';
+import { getNIMAccount } from '../accounts/k8s';
+import { NIM_SECRET_NAME } from '../accounts/constants';
+import { NIM_ID } from '../../../extensions';
+
+export const isNIMDeployActive = (wizardData: WizardFormData['state']): boolean =>
+  wizardData.modelLocationData.data?.type === NIMModelLocationKey;
+
+export const assembleNIMDeployment = (
+  wizardData: WizardFormData,
+  existingDeployment?: NIMDeployment,
+  applyFieldData?: DeploymentAssemblyFn<NIMDeployment>,
+): NIMDeployment => {
+  const nimService = assembleNIMService(
+    {
+      projectName: wizardData.state.project.projectName ?? '',
+      k8sName: wizardData.state.k8sNameDesc.data.k8sName.value,
+      displayName: wizardData.state.k8sNameDesc.data.name,
+      description: wizardData.state.k8sNameDesc.data.description,
+      replicas: wizardData.state.numReplicas.data,
+      externalRoute: wizardData.state.externalRoute.data,
+      environmentVariables: wizardData.state.environmentVariables.data,
+      hardwareProfile: wizardData.state.hardwareProfileConfig.formData,
+    },
+    existingDeployment?.model,
+  );
+
+  let result: NIMDeployment = {
+    modelServingPlatformId: NIM_ID,
+    model: nimService,
+  };
+  result = applyFieldData?.(result) ?? result;
+  return result;
+};
+
+const deployNIMServiceResource = async (
+  nimService: NIMServiceKind,
+  existingNimService?: NIMServiceKind,
+  opts?: { dryRun?: boolean; overwrite?: boolean },
+): Promise<NIMServiceKind> => {
+  if (!existingNimService) {
+    return createNIMService(nimService, { dryRun: opts?.dryRun });
+  }
+  if (opts?.overwrite) {
+    return patchNIMService(existingNimService, nimService, { dryRun: opts.dryRun });
+  }
+  return updateNIMService(nimService, { dryRun: opts?.dryRun });
+};
+
+export const deployNIMDeployment = async (
+  _wizardData: WizardFormData['state'],
+  projectName: string,
+  existingDeployment?: NIMDeployment,
+  modelResource?: NIMDeployment['model'],
+  _serverResource?: NIMDeployment['server'],
+  _serverResourceTemplateName?: string,
+  dryRun?: boolean,
+  _secretName?: string,
+  overwrite?: boolean,
+): Promise<NIMDeployment> => {
+  if (!modelResource) {
+    throw new Error('NIMService resource is required');
+  }
+
+  const nimServiceWithSecrets = structuredClone(modelResource);
+
+  const nimAccount = await getNIMAccount(projectName);
+  if (nimAccount) {
+    nimServiceWithSecrets.spec.authSecret = nimAccount.spec.apiKeySecret.name;
+    if (nimAccount.status?.nimPullSecret?.name) {
+      nimServiceWithSecrets.spec.image.pullSecrets = [nimAccount.status.nimPullSecret.name];
+    }
+  } else {
+    nimServiceWithSecrets.spec.authSecret = NIM_SECRET_NAME;
+  }
+
+  const nimService = await deployNIMServiceResource(
+    nimServiceWithSecrets,
+    existingDeployment?.model,
+    { dryRun, overwrite },
+  );
+
+  return {
+    modelServingPlatformId: NIM_ID,
+    model: nimService,
+  };
+};

--- a/packages/nim-serving/src/api/deployments/deploy.ts
+++ b/packages/nim-serving/src/api/deployments/deploy.ts
@@ -20,9 +20,8 @@ export const assembleNIMDeployment = (
   applyFieldData?: DeploymentAssemblyFn<NIMDeployment>,
 ): NIMDeployment => {
   const tokenAuth =
-    (wizardData.state.tokenAuthentication.data &&
-      wizardData.state.tokenAuthentication.data.length > 0) ??
-    false;
+    Array.isArray(wizardData.state.tokenAuthentication.data) &&
+    wizardData.state.tokenAuthentication.data.length > 0;
 
   const nimService = assembleNIMService(
     {

--- a/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
+++ b/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
@@ -1,0 +1,265 @@
+import {
+  k8sCreateResource,
+  k8sUpdateResource,
+  k8sPatchResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import { createNIMService, updateNIMService, patchNIMService, assembleNIMService } from '../k8s';
+import { NIMServiceModel, type NIMServiceKind } from '../types';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sCreateResource: jest.fn(),
+  k8sUpdateResource: jest.fn(),
+  k8sPatchResource: jest.fn(),
+}));
+
+jest.mock('@odh-dashboard/internal/api/apiMergeUtils', () => ({
+  applyK8sAPIOptions: jest.fn((opts, apiOpts) => ({
+    ...opts,
+    ...(apiOpts?.dryRun && { queryOptions: { queryParams: { dryRun: 'All' } } }),
+  })),
+}));
+
+jest.mock('@odh-dashboard/internal/api/k8sUtils', () => ({
+  createPatchesFromDiff: jest.fn((a, b) => {
+    if (JSON.stringify(a) === JSON.stringify(b)) {
+      return [];
+    }
+    return [{ op: 'replace', path: '/spec/replicas', value: b.spec?.replicas }];
+  }),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/utils', () => ({
+  applyHardwareProfileConfig: jest.fn((resource) => resource),
+}));
+
+const mockK8sCreate = jest.mocked(k8sCreateResource);
+const mockK8sUpdate = jest.mocked(k8sUpdateResource);
+const mockK8sPatch = jest.mocked(k8sPatchResource);
+const mockApplyHardwareProfile = jest.mocked(applyHardwareProfileConfig);
+
+const mockNIMService: NIMServiceKind = {
+  apiVersion: 'apps.nvidia.com/v1alpha1',
+  kind: 'NIMService',
+  metadata: { name: 'test-nim', namespace: 'test-ns' },
+  spec: {
+    inferencePlatform: 'kserve',
+    image: { repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct', tag: '1.8' },
+  },
+};
+
+const emptyHardwareProfile: HardwareProfileConfig = {
+  selectedProfile: undefined,
+  useExistingSettings: false,
+  resources: { requests: {}, limits: {} },
+};
+
+describe('createNIMService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should call k8sCreateResource with NIMServiceModel', async () => {
+    mockK8sCreate.mockResolvedValue(mockNIMService);
+    await createNIMService(mockNIMService);
+    expect(mockK8sCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: NIMServiceModel, resource: mockNIMService }),
+    );
+  });
+
+  it('should pass dryRun option', async () => {
+    mockK8sCreate.mockResolvedValue(mockNIMService);
+    await createNIMService(mockNIMService, { dryRun: true });
+    expect(mockK8sCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ queryOptions: { queryParams: { dryRun: 'All' } } }),
+    );
+  });
+});
+
+describe('updateNIMService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should call k8sUpdateResource with NIMServiceModel', async () => {
+    mockK8sUpdate.mockResolvedValue(mockNIMService);
+    await updateNIMService(mockNIMService);
+    expect(mockK8sUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: NIMServiceModel, resource: mockNIMService }),
+    );
+  });
+});
+
+describe('patchNIMService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should return the new resource when no patches are needed', async () => {
+    const result = await patchNIMService(mockNIMService, mockNIMService);
+    expect(result).toBe(mockNIMService);
+    expect(mockK8sPatch).not.toHaveBeenCalled();
+  });
+
+  it('should call k8sPatchResource when patches exist', async () => {
+    const updated = { ...mockNIMService, spec: { ...mockNIMService.spec, replicas: 3 } };
+    mockK8sPatch.mockResolvedValue(updated);
+    await patchNIMService(mockNIMService, updated);
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: NIMServiceModel,
+        queryOptions: expect.objectContaining({ name: 'test-nim', ns: 'test-ns' }),
+      }),
+    );
+  });
+});
+
+describe('assembleNIMService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should create a base NIMService with required fields', () => {
+    const result = assembleNIMService({
+      projectName: 'my-project',
+      k8sName: 'my-nim',
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.apiVersion).toBe('apps.nvidia.com/v1alpha1');
+    expect(result.kind).toBe('NIMService');
+    expect(result.metadata.name).toBe('my-nim');
+    expect(result.metadata.namespace).toBe('my-project');
+    expect(result.spec.inferencePlatform).toBe('kserve');
+    expect(result.spec.image.pullPolicy).toBe('IfNotPresent');
+    expect(result.spec.expose?.service?.type).toBe('ClusterIP');
+    expect(result.spec.expose?.service?.port).toBe(8000);
+    expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBe('Standard');
+    expect(result.spec.replicas).toBe(1);
+    expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');
+  });
+
+  it('should set display name and description in annotations', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      displayName: 'My Model',
+      description: 'A test model',
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.metadata.annotations?.['openshift.io/display-name']).toBe('My Model');
+    expect(result.metadata.annotations?.['openshift.io/description']).toBe('A test model');
+  });
+
+  it('should set replicas', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      replicas: 3,
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.replicas).toBe(3);
+  });
+
+  it('should set visibility label when externalRoute is true', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      externalRoute: true,
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.labels?.['networking.kserve.io/visibility']).toBe('exposed');
+  });
+
+  it('should remove visibility label when externalRoute is false', () => {
+    const existing: NIMServiceKind = {
+      ...mockNIMService,
+      spec: {
+        ...mockNIMService.spec,
+        labels: { 'networking.kserve.io/visibility': 'exposed' },
+      },
+    };
+
+    const result = assembleNIMService(
+      {
+        projectName: 'ns',
+        k8sName: 'test',
+        externalRoute: false,
+        hardwareProfile: emptyHardwareProfile,
+      },
+      existing,
+    );
+
+    expect(result.spec.labels?.['networking.kserve.io/visibility']).toBeUndefined();
+  });
+
+  it('should set environment variables when enabled', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      environmentVariables: {
+        enabled: true,
+        variables: [
+          { name: 'FOO', value: 'bar' },
+          { name: 'BAZ', value: 'qux' },
+        ],
+      },
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.env).toEqual([
+      { name: 'FOO', value: 'bar' },
+      { name: 'BAZ', value: 'qux' },
+    ]);
+  });
+
+  it('should clear environment variables when disabled', () => {
+    const existing: NIMServiceKind = {
+      ...mockNIMService,
+      spec: {
+        ...mockNIMService.spec,
+        env: [{ name: 'OLD', value: 'val' }],
+      },
+    };
+
+    const result = assembleNIMService(
+      {
+        projectName: 'ns',
+        k8sName: 'test',
+        environmentVariables: { enabled: false, variables: [] },
+        hardwareProfile: emptyHardwareProfile,
+      },
+      existing,
+    );
+
+    expect(result.spec.env).toBeUndefined();
+  });
+
+  it('should set authSecret and pullSecrets', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      authSecret: 'my-secret',
+      pullSecrets: ['ngc-secret'],
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.authSecret).toBe('my-secret');
+    expect(result.spec.image.pullSecrets).toEqual(['ngc-secret']);
+  });
+
+  it('should apply hardware profile config', () => {
+    assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(mockApplyHardwareProfile).toHaveBeenCalledWith(
+      expect.any(Object),
+      emptyHardwareProfile,
+      expect.objectContaining({
+        containerResourcesPath: 'spec.resources',
+        tolerationsPath: 'spec.tolerations',
+        nodeSelectorPath: 'spec.nodeSelector',
+      }),
+    );
+  });
+});

--- a/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
+++ b/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
@@ -6,6 +6,7 @@ import {
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import { KServeDeploymentMode } from '@odh-dashboard/kserve/deployUtils';
 import { createNIMService, updateNIMService, patchNIMService, assembleNIMService } from '../k8s';
 import { NIMServiceModel, type NIMServiceKind } from '../types';
 
@@ -128,7 +129,9 @@ describe('assembleNIMService', () => {
     expect(result.spec.image.pullPolicy).toBe('IfNotPresent');
     expect(result.spec.expose?.service?.type).toBe('ClusterIP');
     expect(result.spec.expose?.service?.port).toBe(8000);
-    expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBe('Standard');
+    expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBe(
+      KServeDeploymentMode.Standard,
+    );
     expect(result.spec.annotations?.['security.opendatahub.io/enable-auth']).toBe('false');
     expect(result.spec.replicas).toBe(1);
     expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');
@@ -253,6 +256,42 @@ describe('assembleNIMService', () => {
     );
 
     expect(result.spec.env).toBeUndefined();
+  });
+
+  it('should set runtime args when enabled', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      runtimeArgs: {
+        enabled: true,
+        args: ['--max-batch-size', '8', '--tensor-parallel-size', '2'],
+      },
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.args).toEqual(['--max-batch-size', '8', '--tensor-parallel-size', '2']);
+  });
+
+  it('should clear runtime args when disabled', () => {
+    const existing: NIMServiceKind = {
+      ...mockNIMService,
+      spec: {
+        ...mockNIMService.spec,
+        args: ['--old-arg'],
+      },
+    };
+
+    const result = assembleNIMService(
+      {
+        projectName: 'ns',
+        k8sName: 'test',
+        runtimeArgs: { enabled: false, args: [] },
+        hardwareProfile: emptyHardwareProfile,
+      },
+      existing,
+    );
+
+    expect(result.spec.args).toBeUndefined();
   });
 
   it('should set authSecret and pullSecrets', () => {

--- a/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
+++ b/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
@@ -6,7 +6,6 @@ import {
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
-import { KServeDeploymentMode } from '@odh-dashboard/kserve/deployUtils';
 import { createNIMService, updateNIMService, patchNIMService, assembleNIMService } from '../k8s';
 import { NIMServiceModel, type NIMServiceKind } from '../types';
 
@@ -129,9 +128,7 @@ describe('assembleNIMService', () => {
     expect(result.spec.image.pullPolicy).toBe('IfNotPresent');
     expect(result.spec.expose?.service?.type).toBe('ClusterIP');
     expect(result.spec.expose?.service?.port).toBe(8000);
-    expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBe(
-      KServeDeploymentMode.Standard,
-    );
+    expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBeUndefined();
     expect(result.spec.annotations?.['security.opendatahub.io/enable-auth']).toBe('false');
     expect(result.spec.replicas).toBe(1);
     expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');

--- a/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
+++ b/packages/nim-serving/src/api/nimservices/__tests__/k8s.spec.ts
@@ -129,8 +129,31 @@ describe('assembleNIMService', () => {
     expect(result.spec.expose?.service?.type).toBe('ClusterIP');
     expect(result.spec.expose?.service?.port).toBe(8000);
     expect(result.spec.annotations?.['serving.kserve.io/deploymentMode']).toBe('Standard');
+    expect(result.spec.annotations?.['security.opendatahub.io/enable-auth']).toBe('false');
     expect(result.spec.replicas).toBe(1);
     expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');
+  });
+
+  it('should set auth annotation to true when tokenAuth is true', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      tokenAuth: true,
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.annotations?.['security.opendatahub.io/enable-auth']).toBe('true');
+  });
+
+  it('should set auth annotation to false when tokenAuth is false', () => {
+    const result = assembleNIMService({
+      projectName: 'ns',
+      k8sName: 'test',
+      tokenAuth: false,
+      hardwareProfile: emptyHardwareProfile,
+    });
+
+    expect(result.spec.annotations?.['security.opendatahub.io/enable-auth']).toBe('false');
   });
 
   it('should set display name and description in annotations', () => {

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -7,13 +7,17 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
 import { createPatchesFromDiff } from '@odh-dashboard/internal/api/k8sUtils';
-import type { EnvironmentVariablesFieldData } from '@odh-dashboard/model-serving/types/form-data';
+import type {
+  EnvironmentVariablesFieldData,
+  RuntimeArgsFieldData,
+} from '@odh-dashboard/model-serving/types/form-data';
 import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import {
   KSERVE_AUTH_ANNOTATION,
   KSERVE_DEPLOYMENT_MODE_ANNOTATION,
   KSERVE_VISIBILITY_LABEL,
+  KServeDeploymentMode,
   KServeVisibility,
 } from '@odh-dashboard/kserve/deployUtils';
 import { NIMServiceModel, type NIMServiceKind } from './types';
@@ -108,6 +112,7 @@ type AssembleNIMServiceParams = {
   replicas?: number;
   externalRoute?: boolean;
   tokenAuth?: boolean;
+  runtimeArgs?: RuntimeArgsFieldData;
   environmentVariables?: EnvironmentVariablesFieldData;
   hardwareProfile: HardwareProfileConfig;
   authSecret?: string;
@@ -126,6 +131,7 @@ export const assembleNIMService = (
     replicas = 1,
     externalRoute,
     tokenAuth,
+    runtimeArgs,
     environmentVariables,
     hardwareProfile,
     authSecret,
@@ -171,7 +177,7 @@ export const assembleNIMService = (
   if (!nimService.spec.annotations) {
     nimService.spec.annotations = {};
   }
-  nimService.spec.annotations[KSERVE_DEPLOYMENT_MODE_ANNOTATION] = 'Standard';
+  nimService.spec.annotations[KSERVE_DEPLOYMENT_MODE_ANNOTATION] = KServeDeploymentMode.Standard;
   nimService.spec.annotations[KSERVE_AUTH_ANNOTATION] = tokenAuth ? 'true' : 'false';
 
   if (environmentVariables?.enabled) {
@@ -181,6 +187,12 @@ export const assembleNIMService = (
     }));
   } else {
     delete nimService.spec.env;
+  }
+
+  if (runtimeArgs?.enabled && runtimeArgs.args.length > 0) {
+    nimService.spec.args = runtimeArgs.args;
+  } else {
+    delete nimService.spec.args;
   }
 
   if (authSecret) {

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -91,9 +91,6 @@ const baseNIMService = (
         port: 8000,
       },
     },
-    annotations: {
-      'serving.kserve.io/deploymentMode': 'Standard',
-    },
   },
 });
 
@@ -104,6 +101,7 @@ type AssembleNIMServiceParams = {
   description?: string;
   replicas?: number;
   externalRoute?: boolean;
+  tokenAuth?: boolean;
   environmentVariables?: EnvironmentVariablesFieldData;
   hardwareProfile: HardwareProfileConfig;
   authSecret?: string;
@@ -121,6 +119,7 @@ export const assembleNIMService = (
     description,
     replicas = 1,
     externalRoute,
+    tokenAuth,
     environmentVariables,
     hardwareProfile,
     authSecret,
@@ -162,6 +161,12 @@ export const assembleNIMService = (
   } else if (nimService.spec.labels) {
     delete nimService.spec.labels['networking.kserve.io/visibility'];
   }
+
+  if (!nimService.spec.annotations) {
+    nimService.spec.annotations = {};
+  }
+  nimService.spec.annotations['serving.kserve.io/deploymentMode'] = 'Standard';
+  nimService.spec.annotations['security.opendatahub.io/enable-auth'] = tokenAuth ? 'true' : 'false';
 
   if (environmentVariables?.enabled) {
     nimService.spec.env = environmentVariables.variables.map((v) => ({

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -14,6 +14,7 @@ import {
   KSERVE_AUTH_ANNOTATION,
   KSERVE_DEPLOYMENT_MODE_ANNOTATION,
   KSERVE_VISIBILITY_LABEL,
+  KServeVisibility,
 } from '@odh-dashboard/kserve/deployUtils';
 import { NIMServiceModel, type NIMServiceKind } from './types';
 import { NIM_SERVICE_HARDWARE_PROFILE_PATHS } from './utils';
@@ -161,7 +162,7 @@ export const assembleNIMService = (
   if (externalRoute) {
     nimService.spec.labels = {
       ...nimService.spec.labels,
-      [KSERVE_VISIBILITY_LABEL]: 'exposed',
+      [KSERVE_VISIBILITY_LABEL]: KServeVisibility.Exposed,
     };
   } else if (nimService.spec.labels) {
     delete nimService.spec.labels[KSERVE_VISIBILITY_LABEL];

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -1,0 +1,189 @@
+import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { KnownLabels } from '@odh-dashboard/internal/k8sTypes';
+import {
+  k8sCreateResource,
+  k8sPatchResource,
+  k8sUpdateResource,
+} from '@openshift/dynamic-plugin-sdk-utils';
+import { applyK8sAPIOptions } from '@odh-dashboard/internal/api/apiMergeUtils';
+import { createPatchesFromDiff } from '@odh-dashboard/internal/api/k8sUtils';
+import type { EnvironmentVariablesFieldData } from '@odh-dashboard/model-serving/types/form-data';
+import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import { NIMServiceModel, type NIMServiceKind } from './types';
+import { NIM_SERVICE_HARDWARE_PROFILE_PATHS } from './utils';
+
+export const createNIMService = (
+  nimService: NIMServiceKind,
+  opts?: K8sAPIOptions,
+): Promise<NIMServiceKind> =>
+  k8sCreateResource<NIMServiceKind>(
+    applyK8sAPIOptions(
+      {
+        model: NIMServiceModel,
+        resource: nimService,
+      },
+      opts,
+    ),
+  );
+
+export const updateNIMService = (
+  nimService: NIMServiceKind,
+  opts?: K8sAPIOptions,
+): Promise<NIMServiceKind> =>
+  k8sUpdateResource<NIMServiceKind>(
+    applyK8sAPIOptions(
+      {
+        model: NIMServiceModel,
+        resource: nimService,
+      },
+      opts,
+    ),
+  );
+
+export const patchNIMService = (
+  existingNimService: NIMServiceKind,
+  newNimService: NIMServiceKind,
+  opts?: K8sAPIOptions,
+): Promise<NIMServiceKind> => {
+  const patches = createPatchesFromDiff(existingNimService, newNimService);
+
+  if (patches.length === 0) {
+    return Promise.resolve(newNimService);
+  }
+
+  return k8sPatchResource<NIMServiceKind>(
+    applyK8sAPIOptions(
+      {
+        model: NIMServiceModel,
+        queryOptions: {
+          name: newNimService.metadata.name,
+          ns: newNimService.metadata.namespace,
+        },
+        patches,
+      },
+      opts,
+    ),
+  );
+};
+
+const baseNIMService = (
+  name: string,
+  namespace: string,
+  annotations?: Record<string, string>,
+): NIMServiceKind => ({
+  apiVersion: 'apps.nvidia.com/v1alpha1',
+  kind: 'NIMService',
+  metadata: {
+    name,
+    namespace,
+    annotations: annotations ?? {},
+  },
+  spec: {
+    inferencePlatform: 'kserve',
+    image: {
+      repository: '',
+      pullPolicy: 'IfNotPresent',
+    },
+    expose: {
+      service: {
+        type: 'ClusterIP',
+        port: 8000,
+      },
+    },
+    annotations: {
+      'serving.kserve.io/deploymentMode': 'Standard',
+    },
+  },
+});
+
+type AssembleNIMServiceParams = {
+  projectName: string;
+  k8sName: string;
+  displayName?: string;
+  description?: string;
+  replicas?: number;
+  externalRoute?: boolean;
+  environmentVariables?: EnvironmentVariablesFieldData;
+  hardwareProfile: HardwareProfileConfig;
+  authSecret?: string;
+  pullSecrets?: string[];
+};
+
+export const assembleNIMService = (
+  params: AssembleNIMServiceParams,
+  existingNimService?: NIMServiceKind,
+): NIMServiceKind => {
+  const {
+    projectName,
+    k8sName,
+    displayName,
+    description,
+    replicas = 1,
+    externalRoute,
+    environmentVariables,
+    hardwareProfile,
+    authSecret,
+    pullSecrets,
+  } = params;
+
+  let nimService: NIMServiceKind = existingNimService
+    ? structuredClone(existingNimService)
+    : baseNIMService(k8sName, projectName, {
+        ...(displayName && { 'openshift.io/display-name': displayName }),
+        ...(description && { 'openshift.io/description': description }),
+      });
+
+  nimService.metadata.name = k8sName;
+  nimService.metadata.namespace = projectName;
+
+  if (!nimService.metadata.annotations) {
+    nimService.metadata.annotations = {};
+  }
+  if (displayName) {
+    nimService.metadata.annotations['openshift.io/display-name'] = displayName;
+  }
+  if (description !== undefined) {
+    nimService.metadata.annotations['openshift.io/description'] = description;
+  }
+
+  if (!nimService.metadata.labels) {
+    nimService.metadata.labels = {};
+  }
+  nimService.metadata.labels[KnownLabels.DASHBOARD_RESOURCE] = 'true';
+
+  nimService.spec.replicas = replicas;
+
+  if (externalRoute) {
+    nimService.spec.labels = {
+      ...nimService.spec.labels,
+      'networking.kserve.io/visibility': 'exposed',
+    };
+  } else if (nimService.spec.labels) {
+    delete nimService.spec.labels['networking.kserve.io/visibility'];
+  }
+
+  if (environmentVariables?.enabled) {
+    nimService.spec.env = environmentVariables.variables.map((v) => ({
+      name: v.name,
+      value: v.value,
+    }));
+  } else {
+    delete nimService.spec.env;
+  }
+
+  if (authSecret) {
+    nimService.spec.authSecret = authSecret;
+  }
+  if (pullSecrets && pullSecrets.length > 0) {
+    nimService.spec.image.pullSecrets = pullSecrets;
+  }
+
+  nimService = applyHardwareProfileConfig(
+    nimService,
+    hardwareProfile,
+    NIM_SERVICE_HARDWARE_PROFILE_PATHS,
+  );
+
+  return nimService;
+};

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -10,6 +10,11 @@ import { createPatchesFromDiff } from '@odh-dashboard/internal/api/k8sUtils';
 import type { EnvironmentVariablesFieldData } from '@odh-dashboard/model-serving/types/form-data';
 import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import {
+  KSERVE_AUTH_ANNOTATION,
+  KSERVE_DEPLOYMENT_MODE_ANNOTATION,
+  KSERVE_VISIBILITY_LABEL,
+} from '@odh-dashboard/kserve/deployUtils';
 import { NIMServiceModel, type NIMServiceKind } from './types';
 import { NIM_SERVICE_HARDWARE_PROFILE_PATHS } from './utils';
 
@@ -156,17 +161,17 @@ export const assembleNIMService = (
   if (externalRoute) {
     nimService.spec.labels = {
       ...nimService.spec.labels,
-      'networking.kserve.io/visibility': 'exposed',
+      [KSERVE_VISIBILITY_LABEL]: 'exposed',
     };
   } else if (nimService.spec.labels) {
-    delete nimService.spec.labels['networking.kserve.io/visibility'];
+    delete nimService.spec.labels[KSERVE_VISIBILITY_LABEL];
   }
 
   if (!nimService.spec.annotations) {
     nimService.spec.annotations = {};
   }
-  nimService.spec.annotations['serving.kserve.io/deploymentMode'] = 'Standard';
-  nimService.spec.annotations['security.opendatahub.io/enable-auth'] = tokenAuth ? 'true' : 'false';
+  nimService.spec.annotations[KSERVE_DEPLOYMENT_MODE_ANNOTATION] = 'Standard';
+  nimService.spec.annotations[KSERVE_AUTH_ANNOTATION] = tokenAuth ? 'true' : 'false';
 
   if (environmentVariables?.enabled) {
     nimService.spec.env = environmentVariables.variables.map((v) => ({

--- a/packages/nim-serving/src/api/nimservices/k8s.ts
+++ b/packages/nim-serving/src/api/nimservices/k8s.ts
@@ -15,9 +15,7 @@ import type { HardwareProfileConfig } from '@odh-dashboard/internal/concepts/har
 import { applyHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
 import {
   KSERVE_AUTH_ANNOTATION,
-  KSERVE_DEPLOYMENT_MODE_ANNOTATION,
   KSERVE_VISIBILITY_LABEL,
-  KServeDeploymentMode,
   KServeVisibility,
 } from '@odh-dashboard/kserve/deployUtils';
 import { NIMServiceModel, type NIMServiceKind } from './types';
@@ -177,7 +175,6 @@ export const assembleNIMService = (
   if (!nimService.spec.annotations) {
     nimService.spec.annotations = {};
   }
-  nimService.spec.annotations[KSERVE_DEPLOYMENT_MODE_ANNOTATION] = KServeDeploymentMode.Standard;
   nimService.spec.annotations[KSERVE_AUTH_ANNOTATION] = tokenAuth ? 'true' : 'false';
 
   if (environmentVariables?.enabled) {

--- a/packages/nim-serving/src/api/nimservices/types.ts
+++ b/packages/nim-serving/src/api/nimservices/types.ts
@@ -56,6 +56,8 @@ export type NIMServiceKind = K8sResourceCommon & {
         size?: string;
         storageClassName?: string;
         subPath?: string;
+        volumeAccessMode?: string;
+        annotations?: Record<string, string>;
       };
       nimCache?: {
         name?: string;

--- a/packages/nim-serving/src/api/nimservices/types.ts
+++ b/packages/nim-serving/src/api/nimservices/types.ts
@@ -25,6 +25,8 @@ export type NIMServiceKind = K8sResourceCommon & {
   };
   spec: {
     inferencePlatform?: string;
+    command?: string[];
+    args?: string[];
     image: {
       repository: string;
       tag?: string;

--- a/packages/nim-serving/src/api/nimservices/types.ts
+++ b/packages/nim-serving/src/api/nimservices/types.ts
@@ -24,11 +24,24 @@ export type NIMServiceKind = K8sResourceCommon & {
     };
   };
   spec: {
+    inferencePlatform?: string;
     image: {
       repository: string;
       tag?: string;
       pullPolicy?: string;
       pullSecrets?: string[];
+    };
+    model?: {
+      engine?: string;
+      quantization?: string;
+      profiles?: string[];
+      lora?: {
+        enabled?: boolean;
+        models?: Array<{
+          name?: string;
+          source?: string;
+        }>;
+      };
     };
     authSecret?: string;
     replicas?: number;
@@ -55,9 +68,42 @@ export type NIMServiceKind = K8sResourceCommon & {
     }>;
     expose?: {
       service?: {
+        type?: string;
         port?: number;
         openaiPort?: number;
       };
+    };
+    scale?: {
+      enabled?: boolean;
+      minReplicas?: number;
+      maxReplicas?: number;
+      metrics?: Array<{
+        type?: string;
+        resource?: {
+          name?: string;
+          target?: {
+            type?: string;
+            averageUtilization?: number;
+            averageValue?: string;
+          };
+        };
+      }>;
+    };
+    metrics?: {
+      enabled?: boolean;
+      port?: number;
+    };
+    livenessProbe?: {
+      enabled?: boolean;
+      probe?: Record<string, unknown>;
+    };
+    readinessProbe?: {
+      enabled?: boolean;
+      probe?: Record<string, unknown>;
+    };
+    startupProbe?: {
+      enabled?: boolean;
+      probe?: Record<string, unknown>;
     };
     annotations?: Record<string, string>;
     labels?: Record<string, string>;
@@ -68,6 +114,8 @@ export type NIMServiceKind = K8sResourceCommon & {
       effect?: string;
     }>;
     nodeSelector?: Record<string, string>;
+    userID?: number;
+    groupID?: number;
   };
   status?: {
     state?: string;

--- a/packages/nim-serving/src/api/nimservices/types.ts
+++ b/packages/nim-serving/src/api/nimservices/types.ts
@@ -63,7 +63,14 @@ export type NIMServiceKind = K8sResourceCommon & {
       };
       nimCache?: {
         name?: string;
+        profile?: string;
       };
+      emptyDir?: {
+        sizeLimit?: string;
+      };
+      hostPath?: string;
+      readOnly?: boolean;
+      sharedMemorySizeLimit?: string;
     };
     env?: Array<{
       name: string;
@@ -75,6 +82,12 @@ export type NIMServiceKind = K8sResourceCommon & {
         type?: string;
         port?: number;
         openaiPort?: number;
+      };
+      router?: {
+        annotations?: Record<string, string>;
+        eppConfig?: Record<string, unknown>;
+        enabled?: boolean;
+        type?: string;
       };
     };
     scale?: {
@@ -118,6 +131,28 @@ export type NIMServiceKind = K8sResourceCommon & {
       effect?: string;
     }>;
     nodeSelector?: Record<string, string>;
+    affinity?: Record<string, unknown>;
+    initContainers?: Array<Record<string, unknown>>;
+    sidecarContainers?: Array<Record<string, unknown>>;
+    multiNode?: {
+      backendType?: string;
+      computeDomain?: {
+        create?: boolean;
+        name?: string;
+      };
+      parallelism?: string;
+      mpi?: Record<string, unknown>;
+      ray?: Record<string, unknown>;
+    };
+    proxy?: {
+      httpProxy?: string;
+      httpsProxy?: string;
+      noProxy?: string;
+      certConfigMap?: string;
+    };
+    draResources?: Array<Record<string, unknown>>;
+    runtimeClassName?: string;
+    schedulerName?: string;
     userID?: number;
     groupID?: number;
   };
@@ -125,6 +160,9 @@ export type NIMServiceKind = K8sResourceCommon & {
     state?: string;
     conditions?: K8sCondition[];
     availableReplicas?: number;
+    model?: Record<string, unknown>;
+    computeDomainStatus?: Record<string, unknown>;
+    draResourceStatuses?: Array<Record<string, unknown>>;
   };
 };
 

--- a/packages/nim-serving/src/api/nimservices/utils.ts
+++ b/packages/nim-serving/src/api/nimservices/utils.ts
@@ -1,5 +1,6 @@
 import type { InferenceServiceKind } from '@odh-dashboard/internal/k8sTypes';
 import type { Deployment } from '@odh-dashboard/model-serving/extension-points';
+import type { CrPathConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/types';
 import { NIMServiceModel, type NIMDeployment } from './types';
 import { NIM_ID } from '../../../extensions';
 
@@ -12,3 +13,9 @@ export const isNIMServiceRef = (ref: { kind: string; apiVersion: string }): bool
 
 export const isNIMOwned = (inferenceService: InferenceServiceKind): boolean =>
   inferenceService.metadata.ownerReferences?.some(isNIMServiceRef) ?? false;
+
+export const NIM_SERVICE_HARDWARE_PROFILE_PATHS: CrPathConfig = {
+  containerResourcesPath: 'spec.resources',
+  tolerationsPath: 'spec.tolerations',
+  nodeSelectorPath: 'spec.nodeSelector',
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -68,26 +68,37 @@ type StorageClassOption = {
   displayName: string;
 };
 
+type ExistingPVCOption = {
+  name: string;
+  subPath?: string;
+};
+
 type NIMPVCExternalData = {
   storageClasses: StorageClassOption[];
   defaultStorageClassName: string;
-  existingPVCs: string[];
+  existingPVCs: ExistingPVCOption[];
 };
 
 export const NIM_PVC_ANNOTATION = 'dashboard.opendatahub.io/nim-pvc';
+export const NIM_PVC_SUBPATH_ANNOTATION = 'dashboard.opendatahub.io/nim-subpath';
 
 const isNIMPVC = (pvc: PersistentVolumeClaimKind): boolean =>
   pvc.metadata.annotations?.[NIM_PVC_ANNOTATION] === 'true';
 
-const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
-  const nimPVCs: string[] = [];
-  const otherPVCs: string[] = [];
+const toPVCOption = (pvc: PersistentVolumeClaimKind): ExistingPVCOption => ({
+  name: pvc.metadata.name,
+  subPath: pvc.metadata.annotations?.[NIM_PVC_SUBPATH_ANNOTATION],
+});
+
+const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): ExistingPVCOption[] => {
+  const nimPVCs: ExistingPVCOption[] = [];
+  const otherPVCs: ExistingPVCOption[] = [];
 
   for (const pvc of pvcs) {
     if (isNIMPVC(pvc)) {
-      nimPVCs.push(pvc.metadata.name);
+      nimPVCs.push(toPVCOption(pvc));
     } else {
-      otherPVCs.push(pvc.metadata.name);
+      otherPVCs.push(toPVCOption(pvc));
     }
   }
 
@@ -96,7 +107,7 @@ const sortPVCsNIMFirst = (pvcs: PersistentVolumeClaimKind[]): string[] => {
 
 type FetchedStorageData = {
   storageClasses: StorageClassOption[];
-  existingPVCs: string[];
+  existingPVCs: ExistingPVCOption[];
 };
 
 const DEFAULT_FETCHED_DATA: FetchedStorageData = { storageClasses: [], existingPVCs: [] };
@@ -218,8 +229,16 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
 
   const storageClasses = externalData?.data.storageClasses ?? [];
   const defaultStorageClassName = externalData?.data.defaultStorageClassName ?? '';
-  const existingPVCs = externalData?.data.existingPVCs ?? [];
+  const existingPVCs = React.useMemo(
+    () => externalData?.data.existingPVCs ?? [],
+    [externalData?.data.existingPVCs],
+  );
   const hasExistingPVCs = existingPVCs.length > 0;
+
+  const existingPVCMap = React.useMemo(
+    () => new Map(existingPVCs.map((pvc) => [pvc.name, pvc])),
+    [existingPVCs],
+  );
 
   if (!externalData || !externalData.loaded) {
     return (
@@ -250,8 +269,8 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
   }));
 
   const existingPVCOptions: SimpleSelectOption[] = existingPVCs.map((pvc) => ({
-    key: pvc,
-    label: pvc,
+    key: pvc.name,
+    label: pvc.name,
   }));
 
   return (
@@ -269,6 +288,7 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             updateField({
               storageMode: mode,
               pvcName: '',
+              subPath: DEFAULT_SUBPATH,
               storageClassName:
                 mode === NIMPVCStorageMode.NEW
                   ? defaultStorageClassName || storageClasses[0]?.name || ''
@@ -352,7 +372,13 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
               dataTestId="nim-existing-pvc-select"
               options={existingPVCOptions}
               value={fieldValue.pvcName}
-              onChange={(val) => updateField({ pvcName: val })}
+              onChange={(val) => {
+                const selectedPVC = existingPVCMap.get(val);
+                updateField({
+                  pvcName: val,
+                  subPath: selectedPVC?.subPath ?? DEFAULT_SUBPATH,
+                });
+              }}
               isDisabled={isDisabled}
               isFullWidth
               placeholder="Select..."

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -37,7 +37,7 @@ export type NIMPVCFieldValue = {
   storageSizeGi: number;
 };
 
-const DEFAULT_SUBPATH = '/';
+const DEFAULT_SUBPATH = '';
 const DEFAULT_STORAGE_SIZE_GI = 50;
 const MIN_STORAGE_SIZE_GI = 1;
 
@@ -440,7 +440,7 @@ export const NIMPVCFieldWizardField: NIMPVCFieldType = {
           label: 'Subpath',
           value: () => value.subPath || '-',
           optional: true,
-          isVisible: () => !!value.subPath && value.subPath !== '/',
+          isVisible: () => !!value.subPath,
         },
         {
           key: 'storageClass',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/NIMPVCField.tsx
@@ -32,13 +32,11 @@ export enum NIMPVCStorageMode {
 export type NIMPVCFieldValue = {
   storageMode: NIMPVCStorageMode;
   pvcName: string;
-  modelPath: string;
   subPath: string;
   storageClassName: string;
   storageSizeGi: number;
 };
 
-const DEFAULT_MODEL_PATH = '/model-store';
 const DEFAULT_SUBPATH = '/';
 const DEFAULT_STORAGE_SIZE_GI = 50;
 const MIN_STORAGE_SIZE_GI = 1;
@@ -47,7 +45,6 @@ const nimPVCFieldSchema = z
   .object({
     storageMode: z.nativeEnum(NIMPVCStorageMode),
     pvcName: z.string().min(1, 'Cluster storage name is required'),
-    modelPath: z.string().min(1, 'Model path is required'),
     subPath: z.string(),
     storageClassName: z.string(),
     storageSizeGi: z.number().min(MIN_STORAGE_SIZE_GI, 'Storage size must be at least 1 GiB'),
@@ -161,7 +158,6 @@ const useNIMPVCExternalData = (dependencies?: {
 const getDefaultFieldValue = (): NIMPVCFieldValue => ({
   storageMode: NIMPVCStorageMode.NEW,
   pvcName: '',
-  modelPath: DEFAULT_MODEL_PATH,
   subPath: DEFAULT_SUBPATH,
   storageClassName: '',
   storageSizeGi: DEFAULT_STORAGE_SIZE_GI,
@@ -174,57 +170,35 @@ type NIMPVCFieldComponentProps = {
   isDisabled?: boolean;
 };
 
-type ModelPathFieldsProps = {
-  modelPath: string;
+type SubPathFieldProps = {
   subPath: string;
-  onModelPathChange: (val: string) => void;
   onSubPathChange: (val: string) => void;
   isDisabled?: boolean;
   idSuffix?: string;
 };
 
-const ModelPathFields: React.FC<ModelPathFieldsProps> = ({
-  modelPath,
+const SubPathField: React.FC<SubPathFieldProps> = ({
   subPath,
-  onModelPathChange,
   onSubPathChange,
   isDisabled,
   idSuffix = '',
 }) => (
-  <>
-    <FormGroup label="Model path" fieldId={`nim-model-path${idSuffix}`} isRequired>
-      <TextInput
-        id={`nim-model-path${idSuffix}`}
-        data-testid={`nim-model-path${idSuffix}-input`}
-        value={modelPath}
-        onChange={(_event, val) => onModelPathChange(val)}
-        placeholder={DEFAULT_MODEL_PATH}
-        isDisabled={isDisabled}
-      />
-      <HelperText>
-        <HelperTextItem>
-          Path within the container where model files will be mounted.
-        </HelperTextItem>
-      </HelperText>
-    </FormGroup>
-
-    <FormGroup label="Subpath" fieldId={`nim-subpath${idSuffix}`}>
-      <TextInput
-        id={`nim-subpath${idSuffix}`}
-        data-testid={`nim-subpath${idSuffix}-input`}
-        value={subPath}
-        onChange={(_event, val) => onSubPathChange(val)}
-        placeholder="/"
-        isDisabled={isDisabled}
-      />
-      <HelperText>
-        <HelperTextItem>
-          Optional: Subdirectory within the PVC. Use this if you have multiple models stored in the
-          same PVC. Leave blank to use the root of the PVC.
-        </HelperTextItem>
-      </HelperText>
-    </FormGroup>
-  </>
+  <FormGroup label="Subpath" fieldId={`nim-subpath${idSuffix}`}>
+    <TextInput
+      id={`nim-subpath${idSuffix}`}
+      data-testid={`nim-subpath${idSuffix}-input`}
+      value={subPath}
+      onChange={(_event, val) => onSubPathChange(val)}
+      placeholder="/"
+      isDisabled={isDisabled}
+    />
+    <HelperText>
+      <HelperTextItem>
+        Optional: Subdirectory within the PVC. Use this if you have multiple models stored in the
+        same PVC. Leave blank to use the root of the PVC.
+      </HelperTextItem>
+    </HelperText>
+  </FormGroup>
 );
 
 const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
@@ -331,10 +305,8 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             </HelperText>
           </FormGroup>
 
-          <ModelPathFields
-            modelPath={fieldValue.modelPath}
+          <SubPathField
             subPath={fieldValue.subPath}
-            onModelPathChange={(val) => updateField({ modelPath: val })}
             onSubPathChange={(val) => updateField({ subPath: val })}
             isDisabled={isDisabled}
           />
@@ -387,10 +359,8 @@ const NIMPVCFieldComponent: React.FC<NIMPVCFieldComponentProps> = ({
             />
           </FormGroup>
 
-          <ModelPathFields
-            modelPath={fieldValue.modelPath}
+          <SubPathField
             subPath={fieldValue.subPath}
-            onModelPathChange={(val) => updateField({ modelPath: val })}
             onSubPathChange={(val) => updateField({ subPath: val })}
             isDisabled={isDisabled}
             idSuffix="-existing"
@@ -438,11 +408,6 @@ export const NIMPVCFieldWizardField: NIMPVCFieldType = {
           key: 'pvcName',
           label: 'Cluster storage name',
           value: () => value.pvcName || '-',
-        },
-        {
-          key: 'modelPath',
-          label: 'Model path',
-          value: () => value.modelPath || '-',
         },
         {
           key: 'subPath',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimImageApplyExtract.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimImageApplyExtract.spec.ts
@@ -1,0 +1,95 @@
+import type { NIMDeployment } from '../../../../api/nimservices/types';
+import type { NIMImageFieldValue } from '../NIMImageField';
+import { applyNIMImageFieldData, extractNIMImageFieldData } from '../nimImageApplyExtract';
+
+const makeDeployment = (repository: string, tag?: string): NIMDeployment => ({
+  modelServingPlatformId: 'nvidia-nim',
+  model: {
+    apiVersion: 'apps.nvidia.com/v1alpha1',
+    kind: 'NIMService',
+    metadata: { name: 'test', namespace: 'ns' },
+    spec: {
+      image: { repository, ...(tag !== undefined && { tag }) },
+    },
+  },
+});
+
+describe('applyNIMImageFieldData', () => {
+  it('should set image repository and tag on the deployment', () => {
+    const deployment = makeDeployment('', '');
+    const fieldData: NIMImageFieldValue = {
+      repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct',
+      tag: '1.8',
+    };
+
+    const result = applyNIMImageFieldData(deployment, fieldData);
+
+    expect(result.model.spec.image.repository).toBe('nvcr.io/nim/meta/llama-3.2-1b-instruct');
+    expect(result.model.spec.image.tag).toBe('1.8');
+  });
+
+  it('should preserve other spec fields', () => {
+    const deployment = makeDeployment('old-repo', 'old-tag');
+    deployment.model.spec.replicas = 3;
+    deployment.model.spec.authSecret = 'my-secret';
+
+    const result = applyNIMImageFieldData(deployment, {
+      repository: 'new-repo',
+      tag: 'new-tag',
+    });
+
+    expect(result.model.spec.replicas).toBe(3);
+    expect(result.model.spec.authSecret).toBe('my-secret');
+    expect(result.model.spec.image.repository).toBe('new-repo');
+  });
+
+  it('should not mutate the original deployment', () => {
+    const deployment = makeDeployment('original', '1.0');
+    applyNIMImageFieldData(deployment, { repository: 'changed', tag: '2.0' });
+
+    expect(deployment.model.spec.image.repository).toBe('original');
+    expect(deployment.model.spec.image.tag).toBe('1.0');
+  });
+});
+
+describe('extractNIMImageFieldData', () => {
+  it('should extract repository and tag from the deployment', () => {
+    const deployment = makeDeployment('nvcr.io/nim/meta/llama-3.2-1b-instruct', '1.8');
+    const result = extractNIMImageFieldData(deployment);
+
+    expect(result).toEqual({
+      repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct',
+      tag: '1.8',
+    });
+  });
+
+  it('should return undefined when repository is empty', () => {
+    const deployment = makeDeployment('');
+    expect(extractNIMImageFieldData(deployment)).toBeUndefined();
+  });
+
+  it('should default tag to empty string when undefined', () => {
+    const deployment = makeDeployment('nvcr.io/nim/meta/llama');
+    const result = extractNIMImageFieldData(deployment);
+
+    expect(result).toEqual({
+      repository: 'nvcr.io/nim/meta/llama',
+      tag: '',
+    });
+  });
+});
+
+describe('applyNIMImageFieldData + extractNIMImageFieldData round-trip', () => {
+  it('should round-trip correctly', () => {
+    const original: NIMImageFieldValue = {
+      repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct',
+      tag: '1.8',
+    };
+
+    const deployment = makeDeployment('', '');
+    const applied = applyNIMImageFieldData(deployment, original);
+    const extracted = extractNIMImageFieldData(applied);
+
+    expect(extracted).toEqual(original);
+  });
+});

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
@@ -56,6 +56,11 @@ describe('applyNIMPVCFieldData', () => {
     expect(result.model.spec.storage?.pvc?.subPath).toBe('models/llama');
   });
 
+  it('should strip multiple leading slashes from subPath', () => {
+    const result = applyNIMPVCFieldData(makeDeployment(), makeFieldValue({ subPath: '//models' }));
+    expect(result.model.spec.storage?.pvc?.subPath).toBe('models');
+  });
+
   it('should keep relative subPath as-is', () => {
     const result = applyNIMPVCFieldData(
       makeDeployment(),
@@ -85,6 +90,27 @@ describe('extractNIMPVCFieldData', () => {
 
   it('should return undefined when no PVC is configured', () => {
     expect(extractNIMPVCFieldData(makeDeployment())).toBeUndefined();
+  });
+
+  it('should parse size with Gi unit', () => {
+    const deployment = makeDeployment('my-pvc');
+    deployment.model.spec.storage = { pvc: { name: 'my-pvc', size: '64Gi' } };
+    const result = extractNIMPVCFieldData(deployment);
+    expect(result?.storageSizeGi).toBe(64);
+  });
+
+  it('should treat plain number as GiB', () => {
+    const deployment = makeDeployment('my-pvc');
+    deployment.model.spec.storage = { pvc: { name: 'my-pvc', size: '100' } };
+    const result = extractNIMPVCFieldData(deployment);
+    expect(result?.storageSizeGi).toBe(100);
+  });
+
+  it('should fall back to default for malformed size', () => {
+    const deployment = makeDeployment('my-pvc');
+    deployment.model.spec.storage = { pvc: { name: 'my-pvc', size: 'abc' } };
+    const result = extractNIMPVCFieldData(deployment);
+    expect(result?.storageSizeGi).toBe(50);
   });
 
   it('should default subPath to empty string when not set', () => {

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/__tests__/nimPVCApplyExtract.spec.ts
@@ -1,0 +1,94 @@
+import { NIMPVCStorageMode } from '../NIMPVCField';
+import type { NIMDeployment } from '../../../../api/nimservices/types';
+import type { NIMPVCFieldValue } from '../NIMPVCField';
+import { applyNIMPVCFieldData, extractNIMPVCFieldData } from '../nimPVCApplyExtract';
+
+const makeDeployment = (pvcName?: string, subPath?: string): NIMDeployment => ({
+  modelServingPlatformId: 'nvidia-nim',
+  model: {
+    apiVersion: 'apps.nvidia.com/v1alpha1',
+    kind: 'NIMService',
+    metadata: { name: 'test', namespace: 'ns' },
+    spec: {
+      image: { repository: 'nvcr.io/nim/test' },
+      ...(pvcName && {
+        storage: {
+          pvc: {
+            name: pvcName,
+            ...(subPath && { subPath }),
+          },
+        },
+      }),
+    },
+  },
+});
+
+const makeFieldValue = (overrides?: Partial<NIMPVCFieldValue>): NIMPVCFieldValue => ({
+  storageMode: NIMPVCStorageMode.NEW,
+  pvcName: 'test-pvc',
+  subPath: '',
+  storageClassName: 'gp3-csi',
+  storageSizeGi: 50,
+  ...overrides,
+});
+
+describe('applyNIMPVCFieldData', () => {
+  it('should set PVC name on the deployment', () => {
+    const result = applyNIMPVCFieldData(makeDeployment(), makeFieldValue({ pvcName: 'my-pvc' }));
+    expect(result.model.spec.storage?.pvc?.name).toBe('my-pvc');
+  });
+
+  it('should omit subPath when it is empty (default)', () => {
+    const result = applyNIMPVCFieldData(makeDeployment(), makeFieldValue({ subPath: '' }));
+    expect(result.model.spec.storage?.pvc?.subPath).toBeUndefined();
+  });
+
+  it('should strip leading slash from "/" leaving it omitted', () => {
+    const result = applyNIMPVCFieldData(makeDeployment(), makeFieldValue({ subPath: '/' }));
+    expect(result.model.spec.storage?.pvc?.subPath).toBeUndefined();
+  });
+
+  it('should strip leading slash from subPath', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(),
+      makeFieldValue({ subPath: '/models/llama' }),
+    );
+    expect(result.model.spec.storage?.pvc?.subPath).toBe('models/llama');
+  });
+
+  it('should keep relative subPath as-is', () => {
+    const result = applyNIMPVCFieldData(
+      makeDeployment(),
+      makeFieldValue({ subPath: 'models/llama' }),
+    );
+    expect(result.model.spec.storage?.pvc?.subPath).toBe('models/llama');
+  });
+
+  it('should not mutate the original deployment', () => {
+    const deployment = makeDeployment();
+    applyNIMPVCFieldData(deployment, makeFieldValue({ pvcName: 'changed' }));
+    expect(deployment.model.spec.storage).toBeUndefined();
+  });
+});
+
+describe('extractNIMPVCFieldData', () => {
+  it('should extract PVC data from deployment', () => {
+    const result = extractNIMPVCFieldData(makeDeployment('my-pvc', 'models'));
+    expect(result).toEqual({
+      storageMode: NIMPVCStorageMode.EXISTING,
+      pvcName: 'my-pvc',
+      subPath: 'models',
+      storageClassName: '',
+      storageSizeGi: 50,
+    });
+  });
+
+  it('should return undefined when no PVC is configured', () => {
+    expect(extractNIMPVCFieldData(makeDeployment())).toBeUndefined();
+  });
+
+  it('should default subPath to empty string when not set', () => {
+    const result = extractNIMPVCFieldData(makeDeployment('my-pvc'));
+    expect(result?.subPath).toBe('');
+  });
+});

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimImageApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimImageApplyExtract.ts
@@ -1,0 +1,30 @@
+import type { NIMImageFieldValue } from './NIMImageField';
+import type { NIMDeployment } from '../../../api/nimservices/types';
+
+export const applyNIMImageFieldData = (
+  deployment: NIMDeployment,
+  fieldData: NIMImageFieldValue,
+): NIMDeployment => ({
+  ...deployment,
+  model: {
+    ...deployment.model,
+    spec: {
+      ...deployment.model.spec,
+      image: {
+        ...deployment.model.spec.image,
+        repository: fieldData.repository,
+        tag: fieldData.tag,
+      },
+    },
+  },
+});
+
+export const extractNIMImageFieldData = (
+  deployment: NIMDeployment,
+): NIMImageFieldValue | undefined => {
+  const { repository, tag } = deployment.model.spec.image;
+  if (!repository) {
+    return undefined;
+  }
+  return { repository, tag: tag ?? '' };
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,5 +1,5 @@
+import { NIM_PVC_ANNOTATION, NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
 import type { NIMDeployment } from '../../../api/nimservices/types';
-import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
 
 export const applyNIMPVCFieldData = (
   deployment: NIMDeployment,
@@ -18,6 +18,9 @@ export const applyNIMPVCFieldData = (
             create: true,
             size: `${fieldData.storageSizeGi}Gi`,
             storageClassName: fieldData.storageClassName || undefined,
+            annotations: {
+              [NIM_PVC_ANNOTATION]: 'true',
+            },
           }),
         },
       },
@@ -25,9 +28,7 @@ export const applyNIMPVCFieldData = (
   },
 });
 
-export const extractNIMPVCFieldData = (
-  deployment: NIMDeployment,
-): NIMPVCFieldValue | undefined => {
+export const extractNIMPVCFieldData = (deployment: NIMDeployment): NIMPVCFieldValue | undefined => {
   const pvc = deployment.model.spec.storage?.pvc;
   if (!pvc?.name) {
     return undefined;

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -28,7 +28,6 @@ export const extractNIMPVCFieldData = (deployment: NIMDeployment): NIMPVCFieldVa
   return {
     storageMode: NIMPVCStorageMode.EXISTING,
     pvcName: pvc.name,
-    modelPath: '/model-store',
     subPath: pvc.subPath ?? '/',
     storageClassName: pvc.storageClassName ?? '',
     storageSizeGi: pvc.size ? parseInt(pvc.size, 10) : 50,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,0 +1,43 @@
+import type { NIMDeployment } from '../../../api/nimservices/types';
+import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
+
+export const applyNIMPVCFieldData = (
+  deployment: NIMDeployment,
+  fieldData: NIMPVCFieldValue,
+): NIMDeployment => ({
+  ...deployment,
+  model: {
+    ...deployment.model,
+    spec: {
+      ...deployment.model.spec,
+      storage: {
+        pvc: {
+          name: fieldData.pvcName,
+          subPath: fieldData.subPath || undefined,
+          ...(fieldData.storageMode === NIMPVCStorageMode.NEW && {
+            create: true,
+            size: `${fieldData.storageSizeGi}Gi`,
+            storageClassName: fieldData.storageClassName || undefined,
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const extractNIMPVCFieldData = (
+  deployment: NIMDeployment,
+): NIMPVCFieldValue | undefined => {
+  const pvc = deployment.model.spec.storage?.pvc;
+  if (!pvc?.name) {
+    return undefined;
+  }
+  return {
+    storageMode: pvc.create ? NIMPVCStorageMode.NEW : NIMPVCStorageMode.EXISTING,
+    pvcName: pvc.name,
+    modelPath: '/model-store',
+    subPath: pvc.subPath ?? '/',
+    storageClassName: pvc.storageClassName ?? '',
+    storageSizeGi: pvc.size ? parseInt(pvc.size, 10) : 50,
+  };
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,9 +1,27 @@
+import {
+  convertToUnit,
+  MEMORY_UNITS_FOR_PARSING,
+} from '@odh-dashboard/internal/utilities/valueUnits';
 import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
 import type { NIMDeployment } from '../../../api/nimservices/types';
 
 const normalizeSubPath = (subPath: string): string | undefined => {
-  const stripped = subPath.replace(/^\//, '');
+  const stripped = subPath.replace(/^\/+/, '');
   return stripped || undefined;
+};
+
+const DEFAULT_STORAGE_SIZE_GI = 50;
+
+const parseSizeToGi = (size: string): number => {
+  const parsed = Number(size);
+  if (!Number.isNaN(parsed) && parsed > 0) {
+    return Math.round(parsed);
+  }
+  if (!/^\d/.test(size)) {
+    return DEFAULT_STORAGE_SIZE_GI;
+  }
+  const [value] = convertToUnit(size, MEMORY_UNITS_FOR_PARSING, 'Gi');
+  return Math.round(value) || DEFAULT_STORAGE_SIZE_GI;
 };
 
 export const applyNIMPVCFieldData = (
@@ -35,6 +53,6 @@ export const extractNIMPVCFieldData = (deployment: NIMDeployment): NIMPVCFieldVa
     pvcName: pvc.name,
     subPath: pvc.subPath ?? '',
     storageClassName: pvc.storageClassName ?? '',
-    storageSizeGi: pvc.size ? parseInt(pvc.size, 10) : 50,
+    storageSizeGi: pvc.size ? parseSizeToGi(pvc.size) : DEFAULT_STORAGE_SIZE_GI,
   };
 };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,4 +1,4 @@
-import { NIM_PVC_ANNOTATION, NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
+import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
 import type { NIMDeployment } from '../../../api/nimservices/types';
 
 export const applyNIMPVCFieldData = (
@@ -14,14 +14,6 @@ export const applyNIMPVCFieldData = (
         pvc: {
           name: fieldData.pvcName,
           subPath: fieldData.subPath || undefined,
-          ...(fieldData.storageMode === NIMPVCStorageMode.NEW && {
-            create: true,
-            size: `${fieldData.storageSizeGi}Gi`,
-            storageClassName: fieldData.storageClassName || undefined,
-            annotations: {
-              [NIM_PVC_ANNOTATION]: 'true',
-            },
-          }),
         },
       },
     },
@@ -34,7 +26,7 @@ export const extractNIMPVCFieldData = (deployment: NIMDeployment): NIMPVCFieldVa
     return undefined;
   }
   return {
-    storageMode: pvc.create ? NIMPVCStorageMode.NEW : NIMPVCStorageMode.EXISTING,
+    storageMode: NIMPVCStorageMode.EXISTING,
     pvcName: pvc.name,
     modelPath: '/model-store',
     subPath: pvc.subPath ?? '/',

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCApplyExtract.ts
@@ -1,6 +1,11 @@
 import { NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
 import type { NIMDeployment } from '../../../api/nimservices/types';
 
+const normalizeSubPath = (subPath: string): string | undefined => {
+  const stripped = subPath.replace(/^\//, '');
+  return stripped || undefined;
+};
+
 export const applyNIMPVCFieldData = (
   deployment: NIMDeployment,
   fieldData: NIMPVCFieldValue,
@@ -13,7 +18,7 @@ export const applyNIMPVCFieldData = (
       storage: {
         pvc: {
           name: fieldData.pvcName,
-          subPath: fieldData.subPath || undefined,
+          subPath: normalizeSubPath(fieldData.subPath),
         },
       },
     },
@@ -28,7 +33,7 @@ export const extractNIMPVCFieldData = (deployment: NIMDeployment): NIMPVCFieldVa
   return {
     storageMode: NIMPVCStorageMode.EXISTING,
     pvcName: pvc.name,
-    subPath: pvc.subPath ?? '/',
+    subPath: pvc.subPath ?? '',
     storageClassName: pvc.storageClassName ?? '',
     storageSizeGi: pvc.size ? parseInt(pvc.size, 10) : 50,
   };

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -1,6 +1,11 @@
 import type { WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
 import { createPvc } from '@odh-dashboard/internal/api';
-import { NIM_PVC_ANNOTATION, NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
+import {
+  NIM_PVC_ANNOTATION,
+  NIM_PVC_SUBPATH_ANNOTATION,
+  NIMPVCStorageMode,
+  type NIMPVCFieldValue,
+} from './NIMPVCField';
 import type { NIMDeployment } from '../../../api/nimservices/types';
 
 export const nimPVCPreDeploy = async (
@@ -27,7 +32,11 @@ export const nimPVCPreDeploy = async (
     projectName,
     undefined,
     false,
-    { [NIM_PVC_ANNOTATION]: 'true' },
+    {
+      [NIM_PVC_ANNOTATION]: 'true',
+      ...(fieldData.subPath &&
+        fieldData.subPath !== '/' && { [NIM_PVC_SUBPATH_ANNOTATION]: fieldData.subPath }),
+    },
     { 'opendatahub.io/managed': 'true' },
   );
 

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -49,7 +49,9 @@ export const nimPVCPreDeploy = async (
         storage: {
           pvc: {
             name: pvc.metadata.name,
-            subPath: fieldData.subPath || undefined,
+            subPath: fieldData.subPath
+              ? fieldData.subPath.replace(/^\//, '') || undefined
+              : undefined,
           },
         },
       },

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -1,0 +1,53 @@
+import type { WizardFormData } from '@odh-dashboard/model-serving/types/form-data';
+import { createPvc } from '@odh-dashboard/internal/api';
+import { NIM_PVC_ANNOTATION, NIMPVCStorageMode, type NIMPVCFieldValue } from './NIMPVCField';
+import type { NIMDeployment } from '../../../api/nimservices/types';
+
+export const nimPVCPreDeploy = async (
+  fieldData: NIMPVCFieldValue,
+  wizardState: WizardFormData['state'],
+  deployment: NIMDeployment,
+): Promise<NIMDeployment> => {
+  const { projectName } = wizardState.project;
+  if (!projectName) {
+    throw new Error('Project is required to create PVC storage');
+  }
+
+  if (fieldData.storageMode !== NIMPVCStorageMode.NEW) {
+    return deployment;
+  }
+
+  const pvc = await createPvc(
+    {
+      name: fieldData.pvcName,
+      description: '',
+      size: `${fieldData.storageSizeGi}Gi`,
+      storageClassName: fieldData.storageClassName,
+    },
+    projectName,
+    undefined,
+    false,
+    { [NIM_PVC_ANNOTATION]: 'true' },
+    { 'opendatahub.io/managed': 'true' },
+  );
+
+  return {
+    ...deployment,
+    model: {
+      ...deployment.model,
+      spec: {
+        ...deployment.model.spec,
+        storage: {
+          pvc: {
+            name: pvc.metadata.name,
+            subPath: fieldData.subPath || undefined,
+          },
+        },
+      },
+    },
+  };
+};
+
+export const nimPVCPostDeploy = async (): Promise<void> => {
+  // No-op: PVC persists independently of the NIMService for reuse
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -23,6 +23,7 @@ export const nimPVCPreDeploy = async (
       description: '',
       size: `${fieldData.storageSizeGi}Gi`,
       storageClassName: fieldData.storageClassName,
+      modelPath: fieldData.modelPath,
     },
     projectName,
     undefined,

--- a/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/fields/nimPVCDeployFunctions.ts
@@ -23,7 +23,6 @@ export const nimPVCPreDeploy = async (
       description: '',
       size: `${fieldData.storageSizeGi}Gi`,
       storageClassName: fieldData.storageClassName,
-      modelPath: fieldData.modelPath,
     },
     projectName,
     undefined,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-60281

## Description

Adds the deploy pipeline for NIM models in the new deployment wizard. When a user selects NVIDIA NIM as the model location and submits the wizard, the system now creates a **NIMService** CR (`apps.nvidia.com/v1alpha1`) instead of directly creating a ServingRuntime + InferenceService. The NIM operator handles creating the SR+IS downstream when `inferencePlatform: kserve` is set.

### Deploy pipeline

- `model-serving.deployment/deploy` extension — routes NIM deployments to `deployNIMDeployment`, which creates/updates/patches NIMService resources via the K8s API
- `model-serving.deployment/assemble-model-resource` extension — builds the NIMServiceKind from wizard form data (name, replicas, hardware profile, env vars, runtime args, external route, token auth)
- NIM account secrets (`authSecret`, `pullSecrets`) are fetched from the namespace's NIMAccount CR at deploy time; throws if no NIM Account is configured in the project
- Runtime args from the wizard are mapped to `spec.args` on the NIMService
- `NIM_SERVICE_HARDWARE_PROFILE_PATHS` for hardware profile integration
- `priority: 100` so NIM deploy wins over KServe's `priority: 0` when both are active

### NIM image field

- `wizard-field-apply` / `wizard-field-extractor` for `nim-serving/nimImage` — maps the NIM image selection (repository + tag) into `spec.image` on the NIMService

### PVC storage field

- `wizard-field-apply` / `wizard-field-extractor` for `nim-serving/pvcStorage` — maps PVC name and subPath into `spec.storage.pvc` on the NIMService
- `wizard-field-deployment-functions` (`preDeploy`) for `nim-serving/pvcStorage` — when storage mode is "new", creates the PVC via `createPvc` **before** the NIMService is created, with `dashboard.opendatahub.io/nim-pvc: 'true'` annotation, `dashboard.opendatahub.io/nim-subpath` annotation (if subpath is set), and `opendatahub.io/managed: 'true'` label
- PVCs are created independently (not via `spec.storage.pvc.create: true`) so the NIM operator does **not** delete them when the NIMService is deleted — they can be reused for future deployments as the UI promises
- When selecting an existing PVC, the `nim-subpath` annotation prefills the subpath field (user can still override)
- Removed `modelPath` field from the NIM PVC form — the NIMService CRD has no mount path configuration field; the operator manages container mount paths internally. `subPath` (path inside the PVC) is retained.

### Annotation propagation via `spec.annotations`

- Sets `security.opendatahub.io/enable-auth` so the NIM operator propagates it to the downstream InferenceService, enabling the auth proxy sidecar when token auth is configured
- Sets `networking.kserve.io/visibility: 'exposed'` via `spec.labels` when external route is enabled

### KServe shared constants

- Exported `KSERVE_AUTH_ANNOTATION`, `KSERVE_VISIBILITY_LABEL`, `KSERVE_DEPLOYMENT_MODE_ANNOTATION` as named constants from `@odh-dashboard/kserve/deployUtils`
- Exported `KServeVisibility` enum (`Exposed`, `ClusterLocal`) and `KServeDeploymentMode` enum (`RawDeployment`, `Standard`)
- Both kserve and nim-serving packages now use these shared constants instead of magic strings

### NIMServiceKind type

- Fields actively used in the wizard flow: `inferencePlatform`, `image`, `args`, `authSecret`, `replicas`, `resources`, `storage.pvc`, `env`, `expose.service`, `annotations`, `labels`, `tolerations`, `nodeSelector`
- All remaining non-deprecated fields from the [NIMService CRD](https://github.com/NVIDIA/k8s-nim-operator/blob/main/config/crd/bases/apps.nvidia.com_nimservices.yaml) are also included for completeness

### Other

- NIMService K8s CRUD functions (`createNIMService`, `updateNIMService`, `patchNIMService`)
- Unit tests covering assembly, deploy routing, activation logic, image and PVC apply/extract (30 tests added, 108 total in nim-serving)

**No changes to the legacy NIM modal** (`frontend/src/.../nim/NIMServiceModal/`) — all new code is in `packages/nim-serving/`.

### Follow-ups

- `model-serving.deployment/form-data` extension for editing existing NIM deployments (separate story [RHOAIENG-60280](https://redhat.atlassian.net/browse/RHOAIENG-60280))
- Cypress mock tests for the NIM wizard deploy flow
- Cluster testing

## How Has This Been Tested?

- `tsc --noEmit` passes on nim-serving and full monorepo
- `eslint` passes with 0 errors on all changed files
- 119/119 unit tests pass in nim-serving (39 new)
- Manual test via Playwright on GPU cluster (`zaffre-nim-gpu-pool`):
  - Impersonated as `ldap-user2` in project `mturley` with NIM Account configured
  - Wizard: selected NVIDIA NIM location → `phi-4-mini-instruct:latest` → `nvidia-gpu-profile` (1x GPU) → new PVC `phi4-nim-pvc` (50 GiB) → Deploy
  - PVC created with `dashboard.opendatahub.io/nim-pvc` annotation and `opendatahub.io/managed` label
  - NIMService created with correct spec: image, auth secret, pull secrets from NIM Account, GPU resources, `inferencePlatform: kserve`
  - NIM operator created downstream InferenceService with ownerReference to NIMService
  - Pod scheduled on GPU node, image pulled, model initializing successfully
  - PVC survives NIMService deletion (confirmed independently)

## Test Impact

Unit tests added for:
- `assembleNIMService` — base resource creation, display name/description, replicas, external route visibility, token auth annotation, env vars, auth/pull secrets, hardware profile application
- `deployNIMDeployment` — create/update/patch routing, NIM account required (throws if missing), dryRun passthrough, error on missing model resource
- `isNIMDeployActive` — activates for NIM model location, inactive for other types
- `applyNIMImageFieldData` / `extractNIMImageFieldData` — apply sets image data, extract reads it back, round-trip, immutability
- `applyNIMPVCFieldData` / `extractNIMPVCFieldData` — PVC name and subPath mapping

Cypress mock tests for the full NIM wizard deploy flow are a follow-up.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end NIM model deployment: assemble/create/update/patch flows with account-based auth, image pull handling, and hardware-profile-aware manifests.
  * Wizard storage improvements: PVC subpath support, sizing, storage class, creation hooks, and review updates.
  * Wizard field enhancements: image and PVC apply/extract handlers and new deployment extension points.
  * KServe metadata handling standardized for auth and visibility.

* **Tests**
  * Expanded unit tests covering NIM services, deployments, PVC and image field logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

