### PR TITLE
fix(maas): use internal service URL for MaaS API instead of external route

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -312,6 +312,10 @@
       - '--key-file=/etc/tls/private/tls.key'
       - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
     env:
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
       - name: GATEWAY_DOMAIN
         value: ""
     securityContext:

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -116,15 +116,19 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		maasFakeServer = maas.CreateMaasFakeServer()
 		logger.Info("MaaS Fake API Server is running", "url", maasFakeServer.URL)
 		cfg.MaasApiUrl = maasFakeServer.URL
-	} else {
-		// Fallback to discovery of MaaS API url, when not provided via envvar, or cmd flags
-		if cfg.MaasApiUrl == "" {
-			clusterDomain, err := helper.GetClusterDomainUsingServiceAccount(context.Background(), logger)
-			if err != nil {
-				logger.Error("Failed to auto-discover cluster domain, MaaS API URL will be unavailable", "error", err)
+	} else if cfg.MaasApiUrl == "" {
+		ctx := context.Background()
+		if hostname, gwErr := helper.GetGatewayHostname(ctx, logger, cfg.GatewayName, cfg.GatewayNamespace); gwErr == nil {
+			cfg.MaasApiUrl = fmt.Sprintf("https://%s/maas-api", hostname)
+			logger.Info("Using Gateway hostname for MaaS API URL", "url", cfg.MaasApiUrl)
+		} else {
+			logger.Warn("Gateway hostname discovery failed, falling back to ingress domain", "error", gwErr)
+			clusterDomain, domainErr := helper.GetClusterDomainUsingServiceAccount(ctx, logger)
+			if domainErr != nil {
+				logger.Error("Failed to auto-discover MaaS API URL", "gatewayError", gwErr, "ingressError", domainErr)
 			} else {
 				cfg.MaasApiUrl = fmt.Sprintf("https://maas.%s/maas-api", clusterDomain)
-				logger.Info("Using automatically discovered MaaS URL", "url", cfg.MaasApiUrl)
+				logger.Info("Using ingress domain for MaaS API URL", "url", cfg.MaasApiUrl)
 			}
 		}
 	}

--- a/packages/maas/bff/internal/helpers/k8s.go
+++ b/packages/maas/bff/internal/helpers/k8s.go
@@ -63,3 +63,79 @@ func GetClusterDomainUsingServiceAccount(ctx context.Context, logger *slog.Logge
 
 	return domain, nil
 }
+
+// GetGatewayHostname reads the Gateway resource and returns a hostname for
+// reaching the gateway. It prefers the internal hostname from
+// status.addresses (keeps traffic in-cluster while still routing through
+// Envoy/Authorino), then falls back to spec.listeners[].hostname (external).
+func GetGatewayHostname(ctx context.Context, logger *slog.Logger, gatewayName, gatewayNamespace string) (string, error) {
+	cfg, err := clientRest.InClusterConfig()
+	if err != nil {
+		return "", fmt.Errorf("in-cluster config: %w", err)
+	}
+
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1",
+		Resource: "gateways",
+	}
+	gw, err := client.Resource(gvr).Namespace(gatewayNamespace).Get(ctx, gatewayName, v1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get gateway %s/%s: %w", gatewayNamespace, gatewayName, err)
+	}
+
+	if hostname := gatewayInternalHostname(gw); hostname != "" {
+		logger.Info("Resolved Gateway internal hostname from status.addresses", "gateway", gatewayNamespace+"/"+gatewayName, "hostname", hostname)
+		return hostname, nil
+	}
+
+	if hostname := gatewayListenerHostname(gw); hostname != "" {
+		logger.Info("Resolved Gateway external hostname from spec.listeners", "gateway", gatewayNamespace+"/"+gatewayName, "hostname", hostname)
+		return hostname, nil
+	}
+
+	return "", fmt.Errorf("gateway %s/%s has no hostname in status.addresses or spec.listeners", gatewayNamespace, gatewayName)
+}
+
+// gatewayInternalHostname returns the first Hostname-type address from status.addresses.
+func gatewayInternalHostname(gw *unstructured.Unstructured) string {
+	addresses, found, err := unstructured.NestedSlice(gw.Object, "status", "addresses")
+	if err != nil || !found {
+		return ""
+	}
+	for _, addr := range addresses {
+		addrMap, ok := addr.(map[string]any)
+		if !ok {
+			continue
+		}
+		if addrType, _ := addrMap["type"].(string); addrType == "Hostname" {
+			if value, _ := addrMap["value"].(string); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+// gatewayListenerHostname returns the first non-empty hostname from spec.listeners.
+func gatewayListenerHostname(gw *unstructured.Unstructured) string {
+	listeners, found, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil || !found {
+		return ""
+	}
+	for _, l := range listeners {
+		lMap, ok := l.(map[string]any)
+		if !ok {
+			continue
+		}
+		if hostname, _ := lMap["hostname"].(string); hostname != "" {
+			return hostname
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65143

## Description

The maas-ui BFF was constructing the MaaS API URL from the cluster's ingress domain (`https://maas.<domain>/maas-api`), routing through the external gateway. This fails when:
- The gateway uses a custom domain (not the default `maas.apps.<cluster-domain>`)
- The external route is unreachable from within the pod (e.g., disconnected clusters blocking egress)
- The external gateway requires OAuth, causing redirects instead of API responses for service-to-service calls

**Fix:** When `POD_NAMESPACE` env var is available (set via Kubernetes downward API in the deployment manifest), construct the URL using the internal Kubernetes service address: `https://maas-api.<ns>.svc.cluster.local:8443`. Fall back to external route discovery for backward compatibility in local dev.

**Why HTTPS port 8443 (not HTTP 8080):** The maas-api Service exposes only HTTPS on port 8443. The `/maas-api` path prefix is a gateway routing artifact — the HTTPRoute uses `ReplacePrefixMatch: /maas-api → /`, so the internal service serves at `/` not `/maas-api`. The BFF's `MaasClient` already has `InsecureSkipVerify: true` for TLS.

**Changes:**
- `packages/maas/bff/internal/api/app.go` — Prefer internal service URL via `POD_NAMESPACE` over external route auto-discovery
- `manifests/modular-architecture/deployment.yaml` — Add `POD_NAMESPACE` env var to the maas-ui container (same pattern as gen-ai container)

## How Has This Been Tested?

- Deployed on an OpenShift cluster with RHOAI 3.4.1 (`wenliang35-pool-69qnf`)
- Set `MAAS_API_URL=https://maas-api.redhat-ods-applications.svc.cluster.local:8443` to validate the internal URL
- Verified maas-api health endpoint returns `{"status":"healthy"}` via internal URL
- Verified BFF logs show `endpoint=https://maas-api.redhat-ods-applications.svc.cluster.local:8443/v1/models`
- Confirmed external gateway URL redirects to OAuth login (broken for BFF service-to-service calls), validating the need for internal routing
- Confirmed `/v1/models` and `/v1/subscriptions` are reachable through the internal service (auth errors expected without user token — confirms connectivity, not 404/connection refused)

## Test Impact

No new tests added. This is a configuration/wiring change in the BFF startup logic. The existing contract tests and e2e tests cover the API endpoints served by the BFF. The internal service URL is transparent to the frontend — same API, different backend routing.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MaaS API URL auto-discovery now tries gateway hostname resolution first, then falls back to cluster domain detection for more reliable service discovery in Kubernetes.
  * Pod environment now exposes the pod namespace via POD_NAMESPACE (downward API) to improve runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->