### PR TITLE
fix(e2e): null-safe jq in cleanupTemplates and fix serving runtime test

### DIFF
--- a/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/settings/servingRuntimes/testSingleServingRuntimeCreation.cy.ts
@@ -23,6 +23,12 @@ retryableBefore(() => {
       return cleanupTemplates(metadataSingleDisplayName);
     });
 });
+after(() => {
+  if (metadataSingleDisplayName) {
+    cleanupTemplates(metadataSingleDisplayName);
+  }
+});
+
 describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runtime Template By Uploading A YAML file', () => {
   it(
     'Admin should access serving runtimes, import a yaml file and then delete',
@@ -61,10 +67,7 @@ describe('Verify Admins Can Import and Delete a Custom Single-Model Serving Runt
         .should('be.enabled')
         .click()
         .then(() => {
-          // Wait for URL to change, indicating page transition
-          cy.url().should('include', '/settings/model-resources-operations/serving-runtimes', {
-            timeout: 30000,
-          });
+          cy.url().should('match', /\/serving-runtimes$/, { timeout: 30000 });
         });
 
       // Edit the created model serving platform and delete

--- a/packages/cypress/cypress/utils/oc_commands/templates.ts
+++ b/packages/cypress/cypress/utils/oc_commands/templates.ts
@@ -12,7 +12,7 @@ const applicationNamespace = Cypress.env('APPLICATIONS_NAMESPACE');
  *          the original command execution result if no matching template is found.
  */
 export const cleanupTemplates = (displayName: string): Cypress.Chainable<CommandLineResult> => {
-  const ocCommand = `oc get templates -ojson -n ${applicationNamespace} | jq '.items[] | select(.objects[].metadata.annotations."openshift.io/display-name" | contains("${displayName}")) | .metadata.name' | tr -d '"'`;
+  const ocCommand = `oc get templates -ojson -n ${applicationNamespace} | jq '.items[] | select(.objects[]?.metadata?.annotations?."openshift.io/display-name"? // "" | contains("${displayName}")) | .metadata.name' | tr -d '"'`;
   cy.log(`Executing command: ${ocCommand}`);
 
   return cy.exec(ocCommand, { failOnNonZeroExit: false }).then((result) => {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65341
## Description
  - Add ? operators and // "" fallback to the jq query in cleanupTemplates()
    so templates without openshift.io/display-name (e.g. batch/v1 Jobs from
    model-registry-operator) are skipped instead of crashing the pipeline
  - Fix URL assertion in testSingleServingRuntimeCreation to match end of
    path so it waits for the redirect to the list page, not the /add page
  - Add after() cleanup hook so the template is always deleted regardless
    of test outcome

## How Has This Been Tested?
Locally:
<img width="2467" height="904" alt="Greenshot 2026-06-01 11 05 09" src="https://github.com/user-attachments/assets/acd3f77d-b195-4fe3-aa7c-9b05fd9317c2" />

Jenkins:
job/dashboard-e2e-tests/1037
<img width="964" height="200" alt="image" src="https://github.com/user-attachments/assets/5d81be38-5f4a-42d6-9556-a089e5469696" />


## Test Impact
Test fixes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced serving runtime creation test with improved cleanup procedures
  * Refined navigation route verification for serving runtime paths

* **Chores**
  * Improved robustness of template handling to gracefully manage missing metadata scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->