### PR TITLE
fix(e2e): clear test timeout timer between tests

### DIFF
--- a/packages/cypress/cypress/support/e2e.ts
+++ b/packages/cypress/cypress/support/e2e.ts
@@ -91,6 +91,7 @@ Cypress.testsExecuted = false;
 
 // Get global tests timeout from --env argument
 const timeoutSeconds = Cypress.env('CY_TEST_TIMEOUT_SECONDS');
+let testTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Configure global settings
 chai.use(chaiSubset);
@@ -322,9 +323,14 @@ beforeEach(function beforeEachHook(this: Mocha.Context) {
     return;
   }
 
+  if (testTimeoutTimer) {
+    clearTimeout(testTimeoutTimer);
+    testTimeoutTimer = null;
+  }
   if (timeoutSeconds) {
-    this._testTimeoutTimer = setTimeout(() => {
-      throw new Error(`Test exceeded ${timeoutSeconds}s`);
+    cy.task('log', `Starting ${timeoutSeconds}s timeout for: ${this.currentTest.title}`);
+    testTimeoutTimer = setTimeout(() => {
+      throw new Error(`Test exceeded ${timeoutSeconds}s timeout`);
     }, Number(timeoutSeconds) * 1000);
   }
 
@@ -426,6 +432,11 @@ beforeEach(function beforeEachHook(this: Mocha.Context) {
 
 // Handle skipped suites in afterEach hook
 afterEach(function afterEachHook(this: Mocha.Context) {
+  if (testTimeoutTimer) {
+    clearTimeout(testTimeoutTimer);
+    testTimeoutTimer = null;
+  }
+
   if (!this.currentTest) {
     return;
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65431

## Description

The `CY_TEST_TIMEOUT_SECONDS` timer (default 480s) was set in `beforeEach` but never
cleared in `afterEach`. When a spec file contains multiple tests, the first test's timer
persists and fires during the second test — killing it before its own timeout expires.

For example, if test 1 takes 330s and test 2 needs 300s, test 2 gets killed at ~150s
because the leftover timer from test 1 fires at 480s total elapsed time.

## How Has This Been Tested?
Job: dashboard-e2e-tests/1039 

One Spec with 3 different tests:

<img width="965" height="218" alt="image" src="https://github.com/user-attachments/assets/949936d5-8093-473d-a408-1ad78edd1f14" />

<img width="940" height="40" alt="image" src="https://github.com/user-attachments/assets/bf390682-65db-45e1-b474-c5d7b65888a9" />

<img width="946" height="42" alt="image" src="https://github.com/user-attachments/assets/80459705-b26d-450d-9bc9-fb9a77ab56c7" />

<img width="923" height="41" alt="image" src="https://github.com/user-attachments/assets/25aa1e65-7a48-4fc5-8322-87010d962f29" />

## Test Impact
Fix timeout issue

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced per-test timeout enforcement with improved error messages displaying test titles for better debugging visibility
  * Optimized timeout cleanup mechanisms to prevent resource leaks between test executions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->