### PR TITLE
feat(model-serving): add conditional "Preconfigure deployment" wizard step

### DIFF
--- a/packages/cypress/cypress/pages/modelServing.ts
+++ b/packages/cypress/cypress/pages/modelServing.ts
@@ -913,6 +913,18 @@ class ModelServingWizard extends Wizard {
     return cy.findByTestId('spinner');
   }
 
+  findPreconfigureStep() {
+    return this.findStep('preconfigure-step');
+  }
+
+  findPreconfigureProjectSelector() {
+    return cy.findByTestId('project-selector-toggle');
+  }
+
+  findPreconfigureProjectSelectorOption(name: string) {
+    return cy.findByTestId('project-selector-menuList').findByRole('menuitem', { name });
+  }
+
   findModelSourceStep() {
     return this.findStep('source-model-step');
   }

--- a/packages/cypress/cypress/tests/e2e/modelCatalog/testCatalogDeployModel.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelCatalog/testCatalogDeployModel.cy.ts
@@ -88,6 +88,15 @@ describe('Verify a model can be deployed from model catalog', () => {
 
       modelCatalog.clickDeployModelButtonWithRetry();
 
+      cy.step('Model deployment select project in preconfigure step');
+      modelServingWizard.findModelDeploymentProjectSelector().should('exist');
+      modelServingWizard.findModelDeploymentProjectSelector().click();
+      modelServingWizard
+        .findModelDeploymentProjectSelectorOption(projectName)
+        .should('exist')
+        .click();
+      modelServingWizard.findNextButton().should('be.enabled').click();
+
       cy.step('Verify model location gets prefilled');
       modelServingWizard.findModelSourceStep().click();
       modelServingWizard
@@ -100,12 +109,6 @@ describe('Verify a model can be deployed from model catalog', () => {
 
       cy.step('Model deployment step');
       modelServingWizard.findModelDeploymentNameInput().clear().type(modelName);
-      modelServingWizard.findModelDeploymentProjectSelector().should('exist');
-      modelServingWizard.findModelDeploymentProjectSelector().click();
-      modelServingWizard
-        .findModelDeploymentProjectSelectorOption(projectName)
-        .should('exist')
-        .click();
 
       modelServingWizard.findModelServerManualSelectRadio().click();
       modelServingWizard.findFirstServingRuntimeTemplateOption().should('exist').click();

--- a/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelServing/modelServingDeploy.cy.ts
@@ -1625,7 +1625,18 @@ describe('Model Serving Deploy Wizard', () => {
 
     modelServingWizard.visit();
 
-    // Step 1: Model source
+    // Step 1: Preconfigure deployment (shown because no project is pre-selected)
+    modelServingWizard.findPreconfigureStep().should('be.enabled');
+    modelServingWizard.findModelSourceStep().should('be.disabled');
+    modelServingWizard.findNextButton().should('be.disabled');
+    modelServingWizard.findPreconfigureProjectSelector().click();
+    modelServingWizard
+      .findPreconfigureProjectSelectorOption('Test Project')
+      .should('exist')
+      .click();
+    modelServingWizard.findNextButton().should('be.enabled').click();
+
+    // Step 2: Model source
     modelServingWizard.findModelSourceStep().should('be.enabled');
     modelServingWizard.findModelDeploymentStep().should('be.disabled');
     modelServingWizard.findNextButton().should('be.disabled');
@@ -1643,19 +1654,10 @@ describe('Model Serving Deploy Wizard', () => {
     modelServingWizard.findSaveConnectionCheckbox().should('not.be.checked');
     modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 2: Model deployment
+    // Step 3: Model deployment (project selector hidden, project was selected in preconfigure step)
     modelServingWizard.findModelDeploymentStep().should('be.enabled');
     modelServingWizard.findAdvancedOptionsStep().should('be.disabled');
     modelServingWizard.findNextButton().should('be.disabled');
-    modelServingWizard.findModelDeploymentProjectSelector().should('exist');
-    modelServingWizard
-      .findModelDeploymentProjectSelector()
-      .should('contain.text', 'Select target project');
-    modelServingWizard.findModelDeploymentProjectSelector().click();
-    modelServingWizard
-      .findModelDeploymentProjectSelectorOption('Test Project')
-      .should('exist')
-      .click();
     modelServingWizard.findModelDeploymentNameInput().type('test-model');
     hardwareProfileSection.findSelect().should('contain.text', 'Small');
 
@@ -1669,11 +1671,11 @@ describe('Model Serving Deploy Wizard', () => {
 
     modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 3: Advanced Options
+    // Step 4: Advanced Options
     modelServingWizard.findAdvancedOptionsStep().should('be.enabled');
     modelServingWizard.findNextButton().should('be.enabled').click();
 
-    // Step 4: Summary
+    // Step 5: Summary
     modelServingWizard.findSubmitButton().should('be.enabled').click();
 
     cy.wait('@createSecret').then((interception) => {

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -6,6 +6,7 @@ import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/conce
 import { ExternalDataLoader, type ExternalDataMap } from './ExternalDataLoader';
 import { useModelDeploymentWizard } from './useDeploymentWizard';
 import { useModelDeploymentWizardValidation } from './useDeploymentWizardValidation';
+import { PreconfigureDeploymentStepContent } from './steps/PreconfigureDeploymentStep';
 import { ModelSourceStepContent } from './steps/ModelSourceStep';
 import { AdvancedSettingsStepContent } from './steps/AdvancedOptionsStep';
 import { ModelDeploymentStepContent } from './steps/ModelDeploymentStep';
@@ -65,9 +66,14 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
     project?.metadata.name,
     externalData,
   );
+  // Whether to show the "Preconfigure deployment" step.
+  // Currently shown when no project was pre-selected.
+  const shouldShowPreconfigureStep = !project;
+
   const validation = useModelDeploymentWizardValidation(
     wizardFormData.state,
     wizardFormData.fields,
+    shouldShowPreconfigureStep,
   );
   const currentProjectName = wizardFormData.state.project.projectName ?? undefined;
 
@@ -182,7 +188,16 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
               lastStepIndex.current = currentStep.index;
             }}
           >
-            <WizardStep name={WizardStepTitle.MODEL_DETAILS} id="source-model-step">
+            {shouldShowPreconfigureStep && (
+              <WizardStep name={WizardStepTitle.PRECONFIGURE} id="preconfigure-step">
+                <PreconfigureDeploymentStepContent wizardState={wizardFormData} />
+              </WizardStep>
+            )}
+            <WizardStep
+              name={WizardStepTitle.MODEL_DETAILS}
+              id="source-model-step"
+              isDisabled={!validation.isPreconfigureStepValid}
+            >
               <ModelSourceStepContent
                 wizardState={wizardFormData}
                 validation={validation.modelSource}
@@ -198,6 +213,7 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
                 projectName={currentProjectName}
                 wizardState={wizardFormData}
                 externalData={externalData}
+                hideProjectSection={shouldShowPreconfigureStep}
               />
             </WizardStep>
             <WizardStep

--- a/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/ModelDeploymentWizard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PageSection, Wizard, WizardStep } from '@patternfly/react-core';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { ProjectKind } from '@odh-dashboard/internal/k8sTypes';
 import { SupportedArea, useIsAreaAvailable } from '@odh-dashboard/internal/concepts/areas';
@@ -207,7 +208,7 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
             <WizardStep
               name={WizardStepTitle.MODEL_DEPLOYMENT}
               id="model-deployment-step"
-              isDisabled={!validation.isModelSourceStepValid}
+              isDisabled={!validation.isPreconfigureStepValid || !validation.isModelSourceStepValid}
             >
               <ModelDeploymentStepContent
                 projectName={currentProjectName}
@@ -220,7 +221,9 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
               name={WizardStepTitle.ADVANCED_SETTINGS}
               id="advanced-options-step"
               isDisabled={
-                !validation.isModelSourceStepValid || !validation.isModelDeploymentStepValid
+                !validation.isPreconfigureStepValid ||
+                !validation.isModelSourceStepValid ||
+                !validation.isModelDeploymentStepValid
               }
             >
               <AdvancedSettingsStepContent
@@ -233,6 +236,7 @@ const ModelDeploymentWizard: React.FC<ModelDeploymentWizardProps> = ({
               name={WizardStepTitle.REVIEW}
               id="summary-step"
               isDisabled={
+                !validation.isPreconfigureStepValid ||
                 !validation.isModelSourceStepValid ||
                 !validation.isModelDeploymentStepValid ||
                 !validation.isAdvancedSettingsStepValid

--- a/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/ModelDeploymentStep.tsx
@@ -13,12 +13,14 @@ type ModelDeploymentStepProps = {
   projectName?: string;
   wizardState: UseModelDeploymentWizardState;
   externalData?: ExternalDataMap;
+  hideProjectSection?: boolean;
 };
 
 export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   projectName,
   wizardState,
   externalData,
+  hideProjectSection,
 }) => {
   const modelDeploymentExtensionFields = React.useMemo(
     () =>
@@ -33,11 +35,14 @@ export const ModelDeploymentStepContent: React.FC<ModelDeploymentStepProps> = ({
   return (
     <Form>
       <FormSection title="Model deployment">
-        <ProjectSection
-          initialProjectName={wizardState.state.project.initialProjectName}
-          projectName={wizardState.state.project.projectName}
-          setProjectName={wizardState.state.project.setProjectName}
-        />
+        {/* TODO remove ProjectSection and the hideProjectSection prop when PreconfigureDeploymentStep becomes unconditional */}
+        {!hideProjectSection && (
+          <ProjectSection
+            initialProjectName={wizardState.state.project.initialProjectName}
+            projectName={wizardState.state.project.projectName}
+            setProjectName={wizardState.state.project.setProjectName}
+          />
+        )}
         <K8sNameDescriptionField
           data={wizardState.state.k8sNameDesc.data}
           onDataChange={wizardState.state.k8sNameDesc.onDataChange}

--- a/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/PreconfigureDeploymentStep.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  Popover,
+  TextInput,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { ODH_PRODUCT_NAME } from '@odh-dashboard/internal/utilities/const';
+import ProjectSelector from '@odh-dashboard/internal/concepts/projects/ProjectSelector';
+import { UseModelDeploymentWizardState } from '../useDeploymentWizard';
+
+type PreconfigureDeploymentStepProps = {
+  wizardState: UseModelDeploymentWizardState;
+};
+
+const projectHelp = `This is the ${ODH_PRODUCT_NAME} project where the model will be deployed.`;
+
+export const PreconfigureDeploymentStepContent: React.FC<PreconfigureDeploymentStepProps> = ({
+  wizardState,
+}) => {
+  const { initialProjectName, projectName, setProjectName } = wizardState.state.project;
+
+  return (
+    <Form>
+      <HelperText>
+        <HelperTextItem>Choose from the below options to configure your deployment.</HelperTextItem>
+      </HelperText>
+      <FormGroup
+        label="Project"
+        fieldId="preconfigure-project-selector"
+        isRequired
+        labelHelp={
+          <Popover bodyContent={projectHelp}>
+            <OutlinedQuestionCircleIcon />
+          </Popover>
+        }
+      >
+        {initialProjectName ? (
+          <TextInput
+            id="preconfigure-project-name"
+            value={projectName}
+            isDisabled
+            data-testid="preconfigure-project-name"
+          />
+        ) : (
+          <ProjectSelector
+            onSelection={(name: string) => setProjectName(name)}
+            namespace={projectName ?? ''}
+            isFullWidth
+            placeholder="Select a project"
+          />
+        )}
+      </FormGroup>
+    </Form>
+  );
+};

--- a/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/steps/__tests__/PreconfigureDeploymentStep.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectsContext } from '@odh-dashboard/internal/concepts/projects/ProjectsContext';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { PreconfigureDeploymentStepContent } from '../PreconfigureDeploymentStep';
+import { mockDeploymentWizardState } from '../../../../__tests__/mockUtils';
+
+const mockProject = mockProjectK8sResource({
+  k8sName: 'test-project',
+  displayName: 'Test Project',
+});
+
+const createProjectsContextValue = () => ({
+  projects: [mockProject],
+  loaded: true,
+  preferredProject: null,
+  modelServingProjects: [],
+  nonActiveProjects: [],
+  updatePreferredProject: () => undefined,
+  waitForProject: () => Promise.resolve(),
+  loadError: undefined,
+});
+
+const mockWizardStateWithoutProject = (setProjectName = jest.fn()) => {
+  const state = mockDeploymentWizardState();
+  state.state.project = {
+    initialProjectName: undefined,
+    projectName: undefined,
+    setProjectName,
+  };
+  return state;
+};
+
+describe('PreconfigureDeploymentStep', () => {
+  it('should render the description text', () => {
+    const wizardState = mockWizardStateWithoutProject();
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText('Choose from the below options to configure your deployment.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a project selector when no initial project is set', () => {
+    const wizardState = mockWizardStateWithoutProject();
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('project-selector-toggle')).toBeInTheDocument();
+  });
+
+  it('should call setProjectName when a project is selected', () => {
+    const mockSetProjectName = jest.fn();
+    const wizardState = mockWizardStateWithoutProject(mockSetProjectName);
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByTestId('project-selector-toggle'));
+    fireEvent.click(screen.getByText('Test Project'));
+
+    expect(mockSetProjectName).toHaveBeenCalledWith('test-project');
+  });
+
+  it('should render a disabled text input when initial project is set', () => {
+    const wizardState = mockDeploymentWizardState();
+
+    render(
+      <MemoryRouter>
+        <ProjectsContext.Provider value={createProjectsContextValue()}>
+          <PreconfigureDeploymentStepContent wizardState={wizardState} />
+        </ProjectsContext.Provider>
+      </MemoryRouter>,
+    );
+
+    const input = screen.getByTestId('preconfigure-project-name');
+    expect(input).toBeDisabled();
+    expect(input).toHaveValue('test-project');
+  });
+});

--- a/packages/model-serving/src/components/deploymentWizard/types.ts
+++ b/packages/model-serving/src/components/deploymentWizard/types.ts
@@ -85,6 +85,7 @@ export enum ModelStateToggleLabel {
 }
 
 export enum WizardStepTitle {
+  PRECONFIGURE = 'Preconfigure deployment',
   MODEL_DETAILS = 'Model details',
   MODEL_DEPLOYMENT = 'Model deployment',
   ADVANCED_SETTINGS = 'Advanced settings',

--- a/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
+++ b/packages/model-serving/src/components/deploymentWizard/useDeploymentWizardValidation.tsx
@@ -22,6 +22,7 @@ import { getStateKey } from './dynamicFormUtils';
 export type ModelDeploymentWizardValidation = {
   modelSource: ReturnType<typeof useZodFormValidation<ModelSourceStepData>>;
   hardwareProfile: ReturnType<typeof useValidation>;
+  isPreconfigureStepValid: boolean;
   isModelSourceStepValid: boolean;
   isModelDeploymentStepValid: boolean;
   isAdvancedSettingsStepValid: boolean;
@@ -31,6 +32,7 @@ export type ModelDeploymentWizardValidation = {
 export const useModelDeploymentWizardValidation = (
   state: WizardFormData['state'],
   fields: WizardField<unknown>[] = [],
+  shouldShowPreconfigureStep = false,
 ): ModelDeploymentWizardValidation => {
   // Step 1: Model Source
   const step1Fields = fields.filter((field) => field.step === 'modelSource');
@@ -117,6 +119,9 @@ export const useModelDeploymentWizardValidation = (
   );
 
   // Step validation
+  const isPreconfigureStepValid =
+    !shouldShowPreconfigureStep ||
+    isValidProjectName(state.project.initialProjectName ?? state.project.projectName ?? undefined);
   const isModelSourceStepValid =
     modelSourceStepValidation.getFieldValidation(undefined, true).length === 0;
   const isModelDeploymentStepValid =
@@ -130,13 +135,17 @@ export const useModelDeploymentWizardValidation = (
     advancedOptionsValidation.getFieldValidation(undefined, true).length === 0;
 
   const isAllValid =
-    isModelSourceStepValid && isModelDeploymentStepValid && isAdvancedSettingsStepValid;
+    isPreconfigureStepValid &&
+    isModelSourceStepValid &&
+    isModelDeploymentStepValid &&
+    isAdvancedSettingsStepValid;
 
   return React.useMemo(
     () => ({
       modelSource: modelSourceStepValidation,
       hardwareProfile: hardwareProfileValidation,
       modelDeploymentStepValidation,
+      isPreconfigureStepValid,
       isModelSourceStepValid,
       isModelDeploymentStepValid,
       isAdvancedSettingsStepValid,
@@ -146,6 +155,7 @@ export const useModelDeploymentWizardValidation = (
       modelSourceStepValidation,
       hardwareProfileValidation,
       modelDeploymentStepValidation,
+      isPreconfigureStepValid,
       isModelSourceStepValid,
       isModelDeploymentStepValid,
       isAdvancedSettingsStepValid,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-60392

## Description
When deploying from the "All projects" view, the deployment wizard now shows a conditional **"Preconfigure deployment"** step as the first step, allowing the user to select a project before proceeding. When a project is already known (e.g. navigating from a specific project page or model catalog), the step is absent from the wizard entirely.

When the preconfigure step is shown, the duplicate `ProjectSection` on the "Model deployment" step is hidden (via `hideProjectSection` prop) since the project has already been selected.

Changes:
- **`PreconfigureDeploymentStep.tsx`** (new) — Wizard step with a project selector and help tooltip. Defensively renders a disabled text input when an initial project is already set.
- **`ModelDeploymentWizard.tsx`** — Adds `shouldShowPreconfigureStep` flag (based on whether a `project` prop was provided), conditionally renders the new step, passes `hideProjectSection` to the "Model deployment" step
- **`ModelDeploymentStep.tsx`** — Adds `hideProjectSection` prop to hide `ProjectSection` when the preconfigure step handles project selection
- **`useDeploymentWizardValidation.tsx`** — Accepts `shouldShowPreconfigureStep` param; adds `isPreconfigureStepValid` (always `true` when the step isn't shown), gates `isAllValid` on it
- **`types.ts`** — Adds `PRECONFIGURE` to `WizardStepTitle` enum
- **`modelServing.ts`** (page object) — Adds `findPreconfigureStep`, `findPreconfigureProjectSelector`, `findPreconfigureProjectSelectorOption` methods
- **`modelServingDeploy.cy.ts`** — Updates the "enter without a project" test to select a project in the preconfigure step before proceeding

### Screenshots
<img width="1200" height="997" alt="wizard-preconfigure-step" src="https://github.com/user-attachments/assets/0f4d78f3-c37f-46fa-bef5-8432f6c25e25" />

## How Has This Been Tested?
- Manually verified on a dev cluster: clicking Deploy from "All projects" opens the wizard with "Preconfigure deployment" as step 1, project selector works, selecting a project enables proceeding to "Model details"
- Manually verified: clicking Deploy from a specific project page skips the preconfigure step entirely — wizard starts at "Model details" as before
- Manually verified: when the preconfigure step is shown, the "Model deployment" step does not show a duplicate project selector
- All existing wizard unit tests pass (179 tests)
- Cypress mock test for "enter without a project" updated to exercise the preconfigure step flow

## Test Impact
- Added unit tests for `PreconfigureDeploymentStep` (4 tests: renders description, renders selector when no initial project, calls setProjectName on selection, renders disabled input when initial project is set)
- Updated Cypress mock test "Should create a new connection with a generated secret name and enter without a project" to select a project in the preconfigure step and verify the project selector is hidden on the "Model deployment" step
- Added page object methods for the preconfigure step (`findPreconfigureStep`, `findPreconfigureProjectSelector`, `findPreconfigureProjectSelectorOption`)

## Request review criteria:
Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`