### PR TITLE
feat(nim-serving): add form-data extractors and PVC apply/extract for NIM edit wizard

### DIFF
--- a/packages/model-serving/src/components/deploymentWizard/useExtractFormDataFromDeployment.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useExtractFormDataFromDeployment.ts
@@ -6,6 +6,7 @@ import { getExternalRouteFromDeployment, getTokenAuthenticationFromDeployment } 
 import { useWizardFieldExtractors } from './useWizardFieldExtractors';
 import { type Deployment, type ExtractionResult } from '../../../extension-points';
 import { isModelServingDeploymentFormDataExtension } from '../../../extension-points/deployment-wizard';
+import { isModelServingAuthExtension } from '../../../extension-points';
 import { useResolvedDeploymentExtension } from '../../concepts/extensionUtils';
 import { useDeploymentAuthTokens } from '../../concepts/auth';
 
@@ -63,6 +64,10 @@ export const useExtractFormDataFromDeployment = (
   // Resolve deployment extension to get platform-specific form data extraction functions
   const [formDataExtension, formDataExtensionLoaded, formDataExtensionErrors] =
     useResolvedDeploymentExtension(isModelServingDeploymentFormDataExtension, deployment);
+
+  // Resolve platform-specific auth check
+  const [authExtension] = useResolvedDeploymentExtension(isModelServingAuthExtension, deployment);
+  const platformAuthCheck = authExtension?.properties.usePlatformAuthEnabled;
 
   // Fetch deployment authentication tokens/secrets
   const {
@@ -148,7 +153,11 @@ export const useExtractFormDataFromDeployment = (
       externalRoute: getExternalRouteFromDeployment(deployment),
 
       // Extract token authentication configuration
-      tokenAuthentication: getTokenAuthenticationFromDeployment(deployment, deploymentSecrets),
+      tokenAuthentication: getTokenAuthenticationFromDeployment(
+        deployment,
+        deploymentSecrets,
+        platformAuthCheck,
+      ),
 
       // Include existing authentication tokens
       existingAuthTokens: deploymentSecrets,
@@ -189,6 +198,7 @@ export const useExtractFormDataFromDeployment = (
     loaded,
     loadingError,
     extractedFieldData,
+    platformAuthCheck,
   ]);
 
   // Collect errors from platform-specific extract functions and validation

--- a/packages/model-serving/src/components/deploymentWizard/useExtractFormDataFromDeployment.ts
+++ b/packages/model-serving/src/components/deploymentWizard/useExtractFormDataFromDeployment.ts
@@ -66,7 +66,10 @@ export const useExtractFormDataFromDeployment = (
     useResolvedDeploymentExtension(isModelServingDeploymentFormDataExtension, deployment);
 
   // Resolve platform-specific auth check
-  const [authExtension] = useResolvedDeploymentExtension(isModelServingAuthExtension, deployment);
+  const [authExtension, authExtensionLoaded] = useResolvedDeploymentExtension(
+    isModelServingAuthExtension,
+    deployment,
+  );
   const platformAuthCheck = authExtension?.properties.usePlatformAuthEnabled;
 
   // Fetch deployment authentication tokens/secrets
@@ -81,7 +84,8 @@ export const useExtractFormDataFromDeployment = (
     useWizardFieldExtractors(deployment);
 
   const loaded =
-    !deployment || (formDataExtensionLoaded && deploymentSecretsLoaded && extractorsLoaded);
+    !deployment ||
+    (formDataExtensionLoaded && deploymentSecretsLoaded && extractorsLoaded && authExtensionLoaded);
 
   // Memoize error computation to prevent unnecessary recalculations
   const loadingError = React.useMemo((): Error | undefined => {

--- a/packages/model-serving/src/components/deploymentWizard/utils.ts
+++ b/packages/model-serving/src/components/deploymentWizard/utils.ts
@@ -49,8 +49,9 @@ export const getExternalRouteFromDeployment = (deployment: Deployment): boolean 
 export const getTokenAuthenticationFromDeployment = (
   deployment: Deployment,
   deploymentSecrets: SecretKind[],
+  platformAuthCheck?: (deployment: Deployment) => boolean,
 ): TokenAuthenticationFieldData => {
-  const isTokenAuthEnabled = isDeploymentAuthEnabled(deployment);
+  const isTokenAuthEnabled = isDeploymentAuthEnabled(deployment, platformAuthCheck);
 
   if (isTokenAuthEnabled) {
     return deploymentSecrets.map((secret) => ({

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
@@ -21,7 +21,7 @@ import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardw
 import HardwareProfileNameValue from './HardwareProfileNameValue';
 import { isDeploymentAuthEnabled, useDeploymentAuthTokens } from '../../../concepts/auth';
 import { useResolvedDeploymentExtension } from '../../../concepts/extensionUtils';
-import { type Deployment } from '../../../../extension-points';
+import { type Deployment, isModelServingAuthExtension } from '../../../../extension-points';
 import {
   ExtractedFieldData,
   useWizardFieldExtractors,
@@ -92,7 +92,11 @@ const ModelSizeItem = ({ resources }: { resources?: ContainerResources }) => {
 };
 
 const TokenAuthenticationItem = ({ deployment }: { deployment: Deployment }) => {
-  const isAuthenticated = isDeploymentAuthEnabled(deployment);
+  const [authExtension] = useResolvedDeploymentExtension(isModelServingAuthExtension, deployment);
+  const isAuthenticated = isDeploymentAuthEnabled(
+    deployment,
+    authExtension?.properties.usePlatformAuthEnabled,
+  );
   const { data: deploymentSecrets, loaded, error } = useDeploymentAuthTokens(deployment);
 
   return (

--- a/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
+++ b/packages/model-serving/src/components/deployments/row/DeploymentsTableRowExpandedSection.tsx
@@ -92,12 +92,20 @@ const ModelSizeItem = ({ resources }: { resources?: ContainerResources }) => {
 };
 
 const TokenAuthenticationItem = ({ deployment }: { deployment: Deployment }) => {
-  const [authExtension] = useResolvedDeploymentExtension(isModelServingAuthExtension, deployment);
+  const [authExtension, authExtensionLoaded] = useResolvedDeploymentExtension(
+    isModelServingAuthExtension,
+    deployment,
+  );
   const isAuthenticated = isDeploymentAuthEnabled(
     deployment,
     authExtension?.properties.usePlatformAuthEnabled,
   );
-  const { data: deploymentSecrets, loaded, error } = useDeploymentAuthTokens(deployment);
+  const {
+    data: deploymentSecrets,
+    loaded: secretsLoaded,
+    error,
+  } = useDeploymentAuthTokens(deployment);
+  const loaded = authExtensionLoaded && secretsLoaded;
 
   return (
     <DescriptionList

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -31,9 +31,28 @@ export const getTokenNames = (
   return { serviceAccountName, roleName, roleBindingName };
 };
 
+const AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getSpecAnnotation = (resource: any, key: string): string | undefined => {
+  const value = resource?.spec?.annotations?.[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
 export const isDeploymentAuthEnabled = (deployment: Deployment): boolean => {
-  const annotation = deployment.model.metadata.annotations?.['security.opendatahub.io/enable-auth'];
-  return annotation !== 'false';
+  const modelAnno = deployment.model.metadata.annotations?.[AUTH_ANNOTATION];
+  if (modelAnno !== undefined) {
+    return modelAnno !== 'false';
+  }
+  const specAnno = getSpecAnnotation(deployment.model, AUTH_ANNOTATION);
+  if (specAnno !== undefined) {
+    return specAnno !== 'false';
+  }
+  const serverAnno = deployment.server?.metadata.annotations?.[AUTH_ANNOTATION];
+  if (serverAnno !== undefined) {
+    return serverAnno !== 'false';
+  }
+  return false;
 };
 
 const useDeploymentSecrets = (

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -86,24 +86,22 @@ export const useDeploymentAuthTokens = (
   } = useDeploymentSecrets(deployment?.model.metadata.namespace);
 
   const deploymentSecrets = React.useMemo(() => {
-    const namespace = deployment?.model.metadata.namespace;
-    const resourceName = deployment?.server?.metadata.name ?? deployment?.model.metadata.name;
-    if (!resourceName || !namespace) {
+    if (!deployment?.model.metadata.name || !deployment.model.metadata.namespace) {
       return [];
     }
 
-    const { serviceAccountName } = getTokenNames(resourceName, namespace);
+    // Calculate the "<k8s-deployment-name>-sa" service account name
+    const { serviceAccountName } = getTokenNames(
+      deployment.model.metadata.name,
+      deployment.model.metadata.namespace,
+    );
 
+    // Filter the secrets to only include the ones that match the service account name
     return projectSecrets.filter(
       (secret) =>
         secret.metadata.annotations?.['kubernetes.io/service-account.name'] === serviceAccountName,
     );
-  }, [
-    projectSecrets,
-    deployment?.model.metadata.name,
-    deployment?.model.metadata.namespace,
-    deployment?.server?.metadata.name,
-  ]);
+  }, [projectSecrets, deployment?.model.metadata.name, deployment?.model.metadata.namespace]);
 
   return { data: deploymentSecrets, loaded, error, refresh };
 };

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -31,38 +31,15 @@ export const getTokenNames = (
   return { serviceAccountName, roleName, roleBindingName };
 };
 
-const AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
-
-const getSpecAnnotationValue = (model: Deployment['model'], key: string): string | undefined => {
-  if (!('spec' in model) || model.spec == null || typeof model.spec !== 'object') {
-    return undefined;
+export const isDeploymentAuthEnabled = (
+  deployment: Deployment,
+  platformAuthCheck?: (deployment: Deployment) => boolean,
+): boolean => {
+  if (platformAuthCheck) {
+    return platformAuthCheck(deployment);
   }
-  const { spec } = model;
-  if (
-    !('annotations' in spec) ||
-    spec.annotations == null ||
-    typeof spec.annotations !== 'object'
-  ) {
-    return undefined;
-  }
-  const value = Object.entries(spec.annotations).find(([k]) => k === key)?.[1];
-  return typeof value === 'string' ? value : undefined;
-};
-
-export const isDeploymentAuthEnabled = (deployment: Deployment): boolean => {
-  const modelAnno = deployment.model.metadata.annotations?.[AUTH_ANNOTATION];
-  if (modelAnno !== undefined) {
-    return modelAnno !== 'false';
-  }
-  const specAnno = getSpecAnnotationValue(deployment.model, AUTH_ANNOTATION);
-  if (specAnno !== undefined) {
-    return specAnno !== 'false';
-  }
-  const serverAnno = deployment.server?.metadata.annotations?.[AUTH_ANNOTATION];
-  if (serverAnno !== undefined) {
-    return serverAnno !== 'false';
-  }
-  return true;
+  const annotation = deployment.model.metadata.annotations?.['security.opendatahub.io/enable-auth'];
+  return annotation !== 'false';
 };
 
 const useDeploymentSecrets = (

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -86,22 +86,24 @@ export const useDeploymentAuthTokens = (
   } = useDeploymentSecrets(deployment?.model.metadata.namespace);
 
   const deploymentSecrets = React.useMemo(() => {
-    if (!deployment?.model.metadata.name || !deployment.model.metadata.namespace) {
+    const namespace = deployment?.model.metadata.namespace;
+    const resourceName = deployment?.server?.metadata.name ?? deployment?.model.metadata.name;
+    if (!resourceName || !namespace) {
       return [];
     }
 
-    // Calculate the "<k8s-deployment-name>-sa" service account name
-    const { serviceAccountName } = getTokenNames(
-      deployment.model.metadata.name,
-      deployment.model.metadata.namespace,
-    );
+    const { serviceAccountName } = getTokenNames(resourceName, namespace);
 
-    // Filter the secrets to only include the ones that match the service account name
     return projectSecrets.filter(
       (secret) =>
         secret.metadata.annotations?.['kubernetes.io/service-account.name'] === serviceAccountName,
     );
-  }, [projectSecrets, deployment?.model.metadata.name, deployment?.model.metadata.namespace]);
+  }, [
+    projectSecrets,
+    deployment?.model.metadata.name,
+    deployment?.model.metadata.namespace,
+    deployment?.server?.metadata.name,
+  ]);
 
   return { data: deploymentSecrets, loaded, error, refresh };
 };

--- a/packages/model-serving/src/concepts/auth.ts
+++ b/packages/model-serving/src/concepts/auth.ts
@@ -33,9 +33,19 @@ export const getTokenNames = (
 
 const AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getSpecAnnotation = (resource: any, key: string): string | undefined => {
-  const value = resource?.spec?.annotations?.[key];
+const getSpecAnnotationValue = (model: Deployment['model'], key: string): string | undefined => {
+  if (!('spec' in model) || model.spec == null || typeof model.spec !== 'object') {
+    return undefined;
+  }
+  const { spec } = model;
+  if (
+    !('annotations' in spec) ||
+    spec.annotations == null ||
+    typeof spec.annotations !== 'object'
+  ) {
+    return undefined;
+  }
+  const value = Object.entries(spec.annotations).find(([k]) => k === key)?.[1];
   return typeof value === 'string' ? value : undefined;
 };
 
@@ -44,7 +54,7 @@ export const isDeploymentAuthEnabled = (deployment: Deployment): boolean => {
   if (modelAnno !== undefined) {
     return modelAnno !== 'false';
   }
-  const specAnno = getSpecAnnotation(deployment.model, AUTH_ANNOTATION);
+  const specAnno = getSpecAnnotationValue(deployment.model, AUTH_ANNOTATION);
   if (specAnno !== undefined) {
     return specAnno !== 'false';
   }
@@ -52,7 +62,7 @@ export const isDeploymentAuthEnabled = (deployment: Deployment): boolean => {
   if (serverAnno !== undefined) {
     return serverAnno !== 'false';
   }
-  return false;
+  return true;
 };
 
 const useDeploymentSecrets = (

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -4,6 +4,7 @@ import type {
 } from '@odh-dashboard/plugin-core/extension-points';
 import type {
   DeployedModelServingDetails,
+  ModelServingAuthExtension,
   ModelServingExcludeDeploymentExtension,
   ModelServingPlatformWatchDeploymentsExtension,
   ModelServingStartStopAction,
@@ -150,6 +151,7 @@ const extensions: (
   | DeployedModelServingDetails<NIMDeployment>
   | ModelServingExcludeDeploymentExtension
   | ModelServingStartStopAction<NIMDeployment>
+  | ModelServingAuthExtension<NIMDeployment>
   | ModelServingDeploy<NIMDeployment>
   | AssembleModelResourceExtension<NIMDeployment>
   | DeploymentWizardFieldOverrideExtension
@@ -288,6 +290,17 @@ const extensions: (
         import('./src/pages/deploymentWizard/extractNIMFormData').then(
           (m) => m.extractNIMModelServerTemplate,
         ),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.auth',
+    properties: {
+      platform: NIM_ID,
+      usePlatformAuthEnabled: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then((m) => m.isNIMAuthEnabled),
     },
     flags: {
       required: [SupportedArea.NIM_WIZARD],

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -32,6 +32,7 @@ import type {
 } from './src/pages/deploymentWizard/fields/NIMPVCField';
 
 export const NIM_ID = 'nvidia-nim';
+export const NIM_MODEL_TYPE = 'NVIDIA NIM';
 
 const nimImageFieldExtension: WizardFieldExtension<NIMImageFieldType> = {
   type: 'model-serving.deployment/wizard-field',

--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -12,6 +12,7 @@ import type {
   AssembleModelResourceExtension,
   DeploymentWizardFieldOverrideExtension,
   ModelServingDeploy,
+  ModelServingDeploymentFormDataExtension,
   WizardFieldApplyExtension,
   WizardFieldDeploymentFunctionsExtension,
   WizardFieldExtension,
@@ -151,6 +152,7 @@ const extensions: (
   | ModelServingDeploy<NIMDeployment>
   | AssembleModelResourceExtension<NIMDeployment>
   | DeploymentWizardFieldOverrideExtension
+  | ModelServingDeploymentFormDataExtension<NIMDeployment>
   | WizardFieldDeploymentFunctionsExtension<NIMPVCFieldValue, NIMDeployment>
   | WizardFieldExtension<NIMImageFieldType>
   | WizardFieldExtension<NIMPVCFieldType>
@@ -242,6 +244,49 @@ const extensions: (
       isActive: () => import('./src/api/deployments/deploy').then((m) => m.isNIMDeployActive),
       priority: 100,
       assemble: () => import('./src/api/deployments/deploy').then((m) => m.assembleNIMDeployment),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
+  {
+    type: 'model-serving.deployment/form-data',
+    properties: {
+      platform: NIM_ID,
+      hardwareProfilePaths: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.NIM_SERVICE_HARDWARE_PROFILE_PATHS,
+        ),
+      extractHardwareProfileConfig: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMHardwareProfileConfig,
+        ),
+      extractReplicas: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then((m) => m.extractNIMReplicas),
+      extractRuntimeArgs: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMRuntimeArgs,
+        ),
+      extractEnvironmentVariables: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMEnvironmentVariables,
+        ),
+      extractModelAvailabilityData: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMModelAvailabilityData,
+        ),
+      extractModelLocationData: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMModelLocationData,
+        ),
+      extractModelType: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMModelType,
+        ),
+      extractModelServerTemplate: () =>
+        import('./src/pages/deploymentWizard/extractNIMFormData').then(
+          (m) => m.extractNIMModelServerTemplate,
+        ),
     },
     flags: {
       required: [SupportedArea.NIM_WIZARD],

--- a/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
@@ -1,0 +1,176 @@
+import { ModelLocationType } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import type { NIMDeployment } from '../../../api/nimservices/types';
+import { NIM_ID } from '../../../../extensions';
+import {
+  extractNIMHardwareProfileConfig,
+  extractNIMReplicas,
+  extractNIMEnvironmentVariables,
+  extractNIMModelLocationData,
+  extractNIMModelType,
+  extractNIMRuntimeArgs,
+  extractNIMModelAvailabilityData,
+  extractNIMModelServerTemplate,
+} from '../extractNIMFormData';
+
+jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/utils', () => ({
+  getExistingHardwareProfileData: jest.fn((resource) => ({
+    name: resource?.metadata?.labels?.['opendatahub.io/hardware-profile-name'],
+    namespace: resource?.metadata?.labels?.['opendatahub.io/hardware-profile-namespace'],
+  })),
+  getExistingResources: jest.fn((resource) => ({
+    existingContainerResources: resource?.spec?.resources,
+    existingTolerations: resource?.spec?.tolerations,
+    existingNodeSelector: resource?.spec?.nodeSelector,
+  })),
+}));
+
+jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/const', () => ({
+  MODEL_SERVING_VISIBILITY: ['modelServing'],
+}));
+
+const makeDeployment = (
+  specOverrides?: Partial<NIMDeployment['model']['spec']>,
+  metadataOverrides?: Partial<NIMDeployment['model']['metadata']>,
+): NIMDeployment => ({
+  modelServingPlatformId: NIM_ID,
+  model: {
+    apiVersion: 'apps.nvidia.com/v1alpha1',
+    kind: 'NIMService',
+    metadata: { name: 'test-nim', namespace: 'test-ns', ...metadataOverrides },
+    spec: {
+      image: { repository: 'nvcr.io/nim/meta/llama-3.2-1b-instruct', tag: '1.8' },
+      ...specOverrides,
+    },
+  },
+});
+
+describe('extractNIMHardwareProfileConfig', () => {
+  it('should extract hardware profile config from deployment', () => {
+    const deployment = makeDeployment({
+      resources: { limits: { cpu: '4', memory: '8Gi' }, requests: { cpu: '2', memory: '4Gi' } },
+      tolerations: [{ key: 'nvidia.com/gpu', operator: 'Exists', effect: 'NoSchedule' }],
+      nodeSelector: { 'nvidia.com/gpu.present': 'true' },
+    });
+
+    const result = extractNIMHardwareProfileConfig(deployment);
+
+    expect(result.data).toBeDefined();
+    expect(result.error).toBeUndefined();
+
+    const { data } = result;
+    expect(data).not.toBeNull();
+    if (!data) {
+      return;
+    }
+    const [, existingResources, existingTolerations, existingNodeSelector] = data;
+    expect(existingResources).toEqual({
+      limits: { cpu: '4', memory: '8Gi' },
+      requests: { cpu: '2', memory: '4Gi' },
+    });
+    expect(existingTolerations).toEqual([
+      { key: 'nvidia.com/gpu', operator: 'Exists', effect: 'NoSchedule' },
+    ]);
+    expect(existingNodeSelector).toEqual({ 'nvidia.com/gpu.present': 'true' });
+  });
+
+  it('should use deployment namespace', () => {
+    const deployment = makeDeployment();
+    const result = extractNIMHardwareProfileConfig(deployment);
+    expect(result.data).not.toBeNull();
+    expect(result.data?.[5]).toBe('test-ns');
+  });
+});
+
+describe('extractNIMReplicas', () => {
+  it('should extract replicas from deployment', () => {
+    const deployment = makeDeployment({ replicas: 3 });
+    const result = extractNIMReplicas(deployment);
+    expect(result).toEqual({ data: 3 });
+  });
+
+  it('should return null when replicas not set', () => {
+    const deployment = makeDeployment();
+    const result = extractNIMReplicas(deployment);
+    expect(result).toEqual({ data: null });
+  });
+});
+
+describe('extractNIMEnvironmentVariables', () => {
+  it('should extract env vars from deployment', () => {
+    const deployment = makeDeployment({
+      env: [
+        { name: 'NIM_LOG_LEVEL', value: 'DEBUG' },
+        { name: 'CUDA_VISIBLE_DEVICES', value: '0,1' },
+      ],
+    });
+
+    const result = extractNIMEnvironmentVariables(deployment);
+    expect(result).toEqual({
+      enabled: true,
+      variables: [
+        { name: 'NIM_LOG_LEVEL', value: 'DEBUG' },
+        { name: 'CUDA_VISIBLE_DEVICES', value: '0,1' },
+      ],
+    });
+  });
+
+  it('should return null when no env vars', () => {
+    const deployment = makeDeployment();
+    expect(extractNIMEnvironmentVariables(deployment)).toBeNull();
+  });
+
+  it('should return null for empty env array', () => {
+    const deployment = makeDeployment({ env: [] });
+    expect(extractNIMEnvironmentVariables(deployment)).toBeNull();
+  });
+
+  it('should default missing values to empty string', () => {
+    const deployment = makeDeployment({
+      env: [{ name: 'KEY' }],
+    });
+    const result = extractNIMEnvironmentVariables(deployment);
+    expect(result?.variables[0].value).toBe('');
+  });
+});
+
+describe('extractNIMModelLocationData', () => {
+  it('should return NIM model location type', () => {
+    const result = extractNIMModelLocationData();
+    expect(result).toEqual({
+      type: ModelLocationType.NIM,
+      fieldValues: {},
+      additionalFields: {},
+    });
+  });
+});
+
+describe('extractNIMModelType', () => {
+  it('should extract model type from annotation', () => {
+    const deployment = makeDeployment(undefined, {
+      annotations: {
+        'opendatahub.io/model-type': 'generative_ai',
+      },
+    });
+    const result = extractNIMModelType(deployment);
+    expect(result).toEqual({ type: 'generative_ai', legacyVLLM: false });
+  });
+
+  it('should return null when no model type annotation', () => {
+    const deployment = makeDeployment();
+    expect(extractNIMModelType(deployment)).toBeNull();
+  });
+});
+
+describe('null extractors', () => {
+  it('extractNIMRuntimeArgs should return null', () => {
+    expect(extractNIMRuntimeArgs()).toBeNull();
+  });
+
+  it('extractNIMModelAvailabilityData should return null', () => {
+    expect(extractNIMModelAvailabilityData()).toBeNull();
+  });
+
+  it('extractNIMModelServerTemplate should return null', () => {
+    expect(extractNIMModelServerTemplate()).toBeNull();
+  });
+});

--- a/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
@@ -144,28 +144,36 @@ describe('extractNIMModelLocationData', () => {
   });
 });
 
-describe('extractNIMModelType', () => {
-  it('should extract model type from annotation', () => {
-    const deployment = makeDeployment(undefined, {
-      annotations: {
-        'opendatahub.io/model-type': 'generative_ai',
-      },
+describe('extractNIMRuntimeArgs', () => {
+  it('should extract runtime args from deployment', () => {
+    const deployment = makeDeployment({
+      args: ['--max-batch-size', '8', '--tensor-parallel-size', '2'],
     });
-    const result = extractNIMModelType(deployment);
-    expect(result).toEqual({ type: 'generative_ai', legacyVLLM: false });
+    const result = extractNIMRuntimeArgs(deployment);
+    expect(result).toEqual({
+      enabled: true,
+      args: ['--max-batch-size', '8', '--tensor-parallel-size', '2'],
+    });
   });
 
-  it('should return null when no model type annotation', () => {
+  it('should return null when no args', () => {
     const deployment = makeDeployment();
-    expect(extractNIMModelType(deployment)).toBeNull();
+    expect(extractNIMRuntimeArgs(deployment)).toBeNull();
+  });
+
+  it('should return null for empty args array', () => {
+    const deployment = makeDeployment({ args: [] });
+    expect(extractNIMRuntimeArgs(deployment)).toBeNull();
+  });
+});
+
+describe('extractNIMModelType', () => {
+  it('should always return NVIDIA NIM model type', () => {
+    expect(extractNIMModelType()).toEqual({ type: 'NVIDIA NIM', legacyVLLM: false });
   });
 });
 
 describe('null extractors', () => {
-  it('extractNIMRuntimeArgs should return null', () => {
-    expect(extractNIMRuntimeArgs()).toBeNull();
-  });
-
   it('extractNIMModelAvailabilityData should return null', () => {
     expect(extractNIMModelAvailabilityData()).toBeNull();
   });

--- a/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
@@ -10,6 +10,7 @@ import {
   extractNIMRuntimeArgs,
   extractNIMModelAvailabilityData,
   extractNIMModelServerTemplate,
+  isNIMAuthEnabled,
 } from '../extractNIMFormData';
 
 jest.mock('@odh-dashboard/internal/concepts/hardwareProfiles/utils', () => ({
@@ -170,6 +171,31 @@ describe('extractNIMRuntimeArgs', () => {
 describe('extractNIMModelType', () => {
   it('should always return NVIDIA NIM model type', () => {
     expect(extractNIMModelType()).toEqual({ type: NIM_MODEL_TYPE, legacyVLLM: false });
+  });
+});
+
+describe('isNIMAuthEnabled', () => {
+  it('should return true when auth annotation is true', () => {
+    const deployment = makeDeployment({
+      annotations: { 'security.opendatahub.io/enable-auth': 'true' },
+    });
+    expect(isNIMAuthEnabled(deployment)).toBe(true);
+  });
+
+  it('should return false when auth annotation is false', () => {
+    const deployment = makeDeployment({
+      annotations: { 'security.opendatahub.io/enable-auth': 'false' },
+    });
+    expect(isNIMAuthEnabled(deployment)).toBe(false);
+  });
+
+  it('should return false when no auth annotation', () => {
+    const deployment = makeDeployment();
+    expect(isNIMAuthEnabled(deployment)).toBe(false);
+  });
+
+  it('should return false when deployment is undefined', () => {
+    expect(isNIMAuthEnabled(undefined)).toBe(false);
   });
 });
 

--- a/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/__tests__/extractNIMFormData.spec.ts
@@ -1,6 +1,6 @@
 import { ModelLocationType } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
 import type { NIMDeployment } from '../../../api/nimservices/types';
-import { NIM_ID } from '../../../../extensions';
+import { NIM_ID, NIM_MODEL_TYPE } from '../../../../extensions';
 import {
   extractNIMHardwareProfileConfig,
   extractNIMReplicas,
@@ -169,7 +169,7 @@ describe('extractNIMRuntimeArgs', () => {
 
 describe('extractNIMModelType', () => {
   it('should always return NVIDIA NIM model type', () => {
-    expect(extractNIMModelType()).toEqual({ type: 'NVIDIA NIM', legacyVLLM: false });
+    expect(extractNIMModelType()).toEqual({ type: NIM_MODEL_TYPE, legacyVLLM: false });
   });
 });
 

--- a/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
@@ -61,19 +61,24 @@ export const extractNIMModelLocationData = (): ModelLocationData | null => ({
   additionalFields: {},
 });
 
-export const extractNIMRuntimeArgs = (): { enabled: boolean; args: string[] } | null => null;
+export const extractNIMRuntimeArgs = (
+  deployment: NIMDeployment,
+): { enabled: boolean; args: string[] } | null => {
+  const { args } = deployment.model.spec;
+  if (!args || args.length === 0) {
+    return null;
+  }
+  return { enabled: true, args };
+};
 
 export const extractNIMModelAvailabilityData = (): {
   saveAsAiAsset: boolean;
   useCase?: string;
 } | null => null;
 
-export const extractNIMModelType = (deployment: NIMDeployment): ModelTypeFieldData | null => {
-  const modelType = deployment.model.metadata.annotations?.['opendatahub.io/model-type'];
-  if (!modelType) {
-    return null;
-  }
-  return { type: modelType, legacyVLLM: false };
-};
+export const extractNIMModelType = (): ModelTypeFieldData => ({
+  type: 'NVIDIA NIM',
+  legacyVLLM: false,
+});
 
 export const extractNIMModelServerTemplate = (): null => null;

--- a/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
@@ -10,6 +10,7 @@ import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/components
 import type { ExtractionResult } from '@odh-dashboard/model-serving/extension-points';
 import type { NIMDeployment } from '../../api/nimservices/types';
 import { NIM_SERVICE_HARDWARE_PROFILE_PATHS } from '../../api/nimservices/utils';
+import { NIM_MODEL_TYPE } from '../../../extensions';
 
 export { NIM_SERVICE_HARDWARE_PROFILE_PATHS };
 
@@ -77,7 +78,7 @@ export const extractNIMModelAvailabilityData = (): {
 } | null => null;
 
 export const extractNIMModelType = (): ModelTypeFieldData => ({
-  type: 'NVIDIA NIM',
+  type: NIM_MODEL_TYPE,
   legacyVLLM: false,
 });
 

--- a/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
@@ -83,3 +83,16 @@ export const extractNIMModelType = (): ModelTypeFieldData => ({
 });
 
 export const extractNIMModelServerTemplate = (): null => null;
+
+const AUTH_ANNOTATION = 'security.opendatahub.io/enable-auth';
+
+export const isNIMAuthEnabled = (deployment?: NIMDeployment): boolean => {
+  if (!deployment) {
+    return false;
+  }
+  const annotation = deployment.model.spec.annotations?.[AUTH_ANNOTATION];
+  if (annotation !== undefined) {
+    return annotation !== 'false';
+  }
+  return false;
+};

--- a/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
+++ b/packages/nim-serving/src/pages/deploymentWizard/extractNIMFormData.ts
@@ -1,0 +1,79 @@
+import type { useHardwareProfileConfig } from '@odh-dashboard/internal/concepts/hardwareProfiles/useHardwareProfileConfig';
+import {
+  getExistingHardwareProfileData,
+  getExistingResources,
+} from '@odh-dashboard/internal/concepts/hardwareProfiles/utils';
+import { MODEL_SERVING_VISIBILITY } from '@odh-dashboard/internal/concepts/hardwareProfiles/const';
+import type { ModelLocationData } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import { ModelLocationType } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
+import type { ModelTypeFieldData } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/ModelTypeSelectField';
+import type { ExtractionResult } from '@odh-dashboard/model-serving/extension-points';
+import type { NIMDeployment } from '../../api/nimservices/types';
+import { NIM_SERVICE_HARDWARE_PROFILE_PATHS } from '../../api/nimservices/utils';
+
+export { NIM_SERVICE_HARDWARE_PROFILE_PATHS };
+
+export const extractNIMHardwareProfileConfig = (
+  deployment: NIMDeployment,
+): ExtractionResult<Parameters<typeof useHardwareProfileConfig> | null> => {
+  const { name, namespace: hardwareProfileNamespace } = getExistingHardwareProfileData(
+    deployment.model,
+  );
+  const { existingContainerResources, existingTolerations, existingNodeSelector } =
+    getExistingResources(deployment.model, NIM_SERVICE_HARDWARE_PROFILE_PATHS);
+
+  return {
+    data: [
+      name,
+      existingContainerResources,
+      existingTolerations,
+      existingNodeSelector,
+      MODEL_SERVING_VISIBILITY,
+      deployment.model.metadata.namespace,
+      hardwareProfileNamespace,
+    ],
+  };
+};
+
+export const extractNIMReplicas = (deployment: NIMDeployment): ExtractionResult<number | null> => ({
+  data: deployment.model.spec.replicas ?? null,
+});
+
+export const extractNIMEnvironmentVariables = (
+  deployment: NIMDeployment,
+): { enabled: boolean; variables: { name: string; value: string }[] } | null => {
+  const envVars = deployment.model.spec.env;
+  if (!envVars || envVars.length === 0) {
+    return null;
+  }
+  return {
+    enabled: true,
+    variables: envVars.map((envVar) => ({
+      name: envVar.name,
+      value: envVar.value ?? '',
+    })),
+  };
+};
+
+export const extractNIMModelLocationData = (): ModelLocationData | null => ({
+  type: ModelLocationType.NIM,
+  fieldValues: {},
+  additionalFields: {},
+});
+
+export const extractNIMRuntimeArgs = (): { enabled: boolean; args: string[] } | null => null;
+
+export const extractNIMModelAvailabilityData = (): {
+  saveAsAiAsset: boolean;
+  useCase?: string;
+} | null => null;
+
+export const extractNIMModelType = (deployment: NIMDeployment): ModelTypeFieldData | null => {
+  const modelType = deployment.model.metadata.annotations?.['opendatahub.io/model-type'];
+  if (!modelType) {
+    return null;
+  }
+  return { type: modelType, legacyVLLM: false };
+};
+
+export const extractNIMModelServerTemplate = (): null => null;

--- a/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
+++ b/packages/nim-serving/src/wizardFields/overrides/NIMModelTypeOverride.ts
@@ -4,6 +4,7 @@ import type {
   WizardFormData,
 } from '@odh-dashboard/model-serving/components/deploymentWizard/types';
 import { NIMModelLocationKey } from '@odh-dashboard/model-serving/components/deploymentWizard/fields/modelLocationFields/NIMModelLocation';
+import { NIM_MODEL_TYPE } from '../../../extensions';
 
 const isNIMModelTypeActive = (wizardFormData: RecursivePartial<WizardFormData['state']>): boolean =>
   wizardFormData.modelLocationData?.data?.type === NIMModelLocationKey;
@@ -13,8 +14,8 @@ export const NIMModelTypeOverride: ModelTypeFieldOverride = {
   type: 'modifier',
   isActive: isNIMModelTypeActive,
   extraOption: {
-    key: 'NVIDIA NIM',
-    label: 'NVIDIA NIM',
+    key: NIM_MODEL_TYPE,
+    label: NIM_MODEL_TYPE,
   },
   forced: true,
 };


### PR DESCRIPTION
<!--- Reference related issues; see example below -->

https://issues.redhat.com/browse/RHOAIENG-60280

## Description

Adds extraction functions to convert an existing NIMService deployment into wizard form data, enabling the deployment wizard to open pre-filled when editing a NIM deployment.

**Coordination with PR #7752 (deploy pipeline):**
Mike's PR provides the forward direction (wizard → NIMService via `assembleNIMService`). This PR provides the reverse direction (NIMService → wizard). Together they complete the create + edit cycle. Temporary `TODO` comments mark constants and types that should be consolidated after the related PRs merge.

## How Has This Been Tested?


https://github.com/user-attachments/assets/77611597-0b3e-4a70-ad02-28bafee3a7c5



## Test Impact

26 new unit tests added across 2 test files:

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced NIM deployment wizard with improved configuration handling for persistent volume storage, hardware profiles, environment variables, and model type settings.

* **Tests**
  * Added comprehensive test coverage for NIM deployment form data extraction and PVC storage configuration utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->