### PR TITLE
Show Active and Expired API Keys by Default

### DIFF
--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -72,7 +72,7 @@ describe('API Keys Page', () => {
     cy.interceptOdh(
       'POST /maas/api/v1/api-keys/search',
       mockSearchResponse(
-        mockAPIKeys().filter((k) => k.status === 'active'),
+        mockAPIKeys().filter((k) => k.status === 'active' || k.status === 'expired'),
         mockSubscriptionDetails,
       ),
     ).as('initialSearch');
@@ -89,7 +89,7 @@ describe('API Keys Page', () => {
     apiKeysPage.findApiKeysTab().should('not.exist');
   });
 
-  it('should display the API keys table page with active keys on initial load', () => {
+  it('should display the API keys table page with active and expired keys on initial load', () => {
     apiKeysPage.findTitle().should('contain.text', 'API keys');
     apiKeysPage
       .findDescription()
@@ -99,11 +99,11 @@ describe('API Keys Page', () => {
       );
 
     apiKeysPage.findTable().should('exist');
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     apiKeysPage.findStatusFilterToggle().click();
     apiKeysPage.findStatusFilterOptionCheckbox('Active').should('be.checked');
-    apiKeysPage.findStatusFilterOptionCheckbox('Expired').should('not.be.checked');
+    apiKeysPage.findStatusFilterOptionCheckbox('Expired').should('be.checked');
     apiKeysPage.findStatusFilterOptionCheckbox('Revoked').should('not.be.checked');
 
     const developmentTestingRow = apiKeysPage.getRow('development-testing');
@@ -146,7 +146,7 @@ describe('API Keys Page', () => {
     // Status filter defaults to Active
     apiKeysPage.findStatusFilterToggle().click();
     apiKeysPage.findStatusFilterOptionCheckbox('Active').should('be.checked');
-    apiKeysPage.findStatusFilterOptionCheckbox('Expired').should('not.be.checked');
+    apiKeysPage.findStatusFilterOptionCheckbox('Expired').should('be.checked');
     apiKeysPage.findStatusFilterOptionCheckbox('Revoked').should('not.be.checked');
     apiKeysPage.findStatusFilterToggle().click();
 
@@ -201,7 +201,7 @@ describe('API Keys Page', () => {
   });
 
   it('should display all API keys when the status filter is cleared', () => {
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(mockAPIKeys())).as(
       'clearAllFilters',
     );
@@ -243,7 +243,7 @@ describe('API Keys Page', () => {
 
   it('should filter api keys by username', () => {
     const aliceKeys = mockAPIKeys().filter((k) => k.username === 'alice');
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(aliceKeys)).as(
       'searchByUsername',
@@ -282,39 +282,31 @@ describe('API Keys Page', () => {
   });
 
   it('should filter api keys by status', () => {
-    const filteredKeys = mockAPIKeys().filter(
-      (k) => k.status === 'active' || k.status === 'expired',
-    );
-    apiKeysPage.findRows().should('have.length', 2);
+    const filteredKeys = mockAPIKeys().filter((k) => k.status === 'expired');
+    apiKeysPage.findRows().should('have.length', 3);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(filteredKeys)).as(
       'filterByStatus',
     );
 
     apiKeysPage.findStatusFilterToggle().click();
-    apiKeysPage.findStatusFilterOption('Expired').click();
+    apiKeysPage.findStatusFilterOption('Active').click();
 
-    // Keys are filtered to show active by default so here we're looking for active and expired since active was pre-selected
+    // Keys are filtered to show active and expired by default so here we're looking for just expired since active was pre-selected
     cy.wait('@filterByStatus').then((interception) => {
-      expect(interception.request.body.data.filters.status).to.deep.equal(['active', 'expired']);
+      expect(interception.request.body.data.filters.status).to.deep.equal(['expired']);
     });
 
-    apiKeysPage.findRows().should('have.length', 3);
+    apiKeysPage.findRows().should('have.length', 1);
 
     const oldServiceKeyRow = apiKeysPage.getRow('old-service-key');
     oldServiceKeyRow.findStatus().should('contain.text', 'Expired');
-
-    const productionBackendRow = apiKeysPage.getRow('production-backend');
-    productionBackendRow.findStatus().should('contain.text', 'Active');
-
-    const developmentTestingRow = apiKeysPage.getRow('development-testing');
-    developmentTestingRow.findStatus().should('contain.text', 'Active');
   });
 
   it('should sort api keys by name', () => {
     const keys = mockAPIKeys();
 
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortNameAsc',
@@ -345,7 +337,7 @@ describe('API Keys Page', () => {
   it('should sort api keys by creation date', () => {
     const keys = mockAPIKeys();
 
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     // Creation date is the default active sort (desc). First click toggles to asc.
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
@@ -376,7 +368,7 @@ describe('API Keys Page', () => {
   it('should sort api keys by expiration date', () => {
     const keys = mockAPIKeys();
 
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortExpirationAsc',
@@ -406,7 +398,7 @@ describe('API Keys Page', () => {
   it('should sort api keys by last used', () => {
     const keys = mockAPIKeys();
 
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     cy.interceptOdh('POST /maas/api/v1/api-keys/search', mockSearchResponse(keys)).as(
       'sortLastUsedAsc',
@@ -844,7 +836,7 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
     cy.interceptOdh(
       'POST /maas/api/v1/api-keys/search',
       mockSearchResponse(
-        mockAPIKeys().filter((k) => k.status === 'active'),
+        mockAPIKeys().filter((k) => k.status === 'active' || k.status === 'expired'),
         mockSubscriptionDetails,
       ),
     ).as('initialSearch');
@@ -864,7 +856,7 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
 
     apiKeysPage.findApiKeysTab().should('have.attr', 'aria-selected', 'true');
     apiKeysPage.findTable().should('exist');
-    apiKeysPage.findRows().should('have.length', 2);
+    apiKeysPage.findRows().should('have.length', 3);
 
     apiKeysPage.findSubscriptionsTab().click();
     cy.url().should('include', '/maas/keys-and-subs/subscriptions');

--- a/packages/maas/frontend/src/app/types/api-key.ts
+++ b/packages/maas/frontend/src/app/types/api-key.ts
@@ -70,7 +70,7 @@ export type ApiKeyFilterDataType = {
 
 export const initialApiKeyFilterData: ApiKeyFilterDataType = {
   username: '',
-  statuses: ['active'],
+  statuses: ['active', 'expired'],
 };
 
 export const emptyApiKeyFilterData: ApiKeyFilterDataType = {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-64753](https://redhat.atlassian.net/browse/RHOAIENG-64753)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Before only active keys would show on the API keys page but now expired keys will also show by default (revoked keys still behind the default filter)

Before showing only active keys:


https://github.com/user-attachments/assets/86e4ad34-2e5c-443b-8e23-9f6af358f0c1


Showing active and expired keys by default:

https://github.com/user-attachments/assets/db946819-c223-4f3d-bce0-678b5954df6f


Still works with the `mySubscriptions` flag flipped

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

To test:
- easiest to test on mock mode bc I couldn't find a cluster with expired keys, only revoked ones 🤷‍♀️ 
- go to the API key page and see if expired keys show up by default

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated some mock tests

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Default API keys filter now shows both active and expired keys on initial page load (previously active-only).

* **Tests**
  * End-to-end tests updated to reflect the new default filter behavior, including initial row counts, status checkbox defaults, and filtering/sorting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->