### PR TITLE
fix(gen-ai): Fix flaky mcpTab.cy.ts test - ambiguous close button selector

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts
@@ -84,7 +84,10 @@ class MCPTab {
   }
 
   findModalCloseButton(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('button', { name: /close/i, timeout: 10000 });
+    // Scope to success modal to avoid clicking drawer close button
+    return cy
+      .findByTestId('mcp-server-success-modal')
+      .findByRole('button', { name: /^close$/i, timeout: 10000 });
   }
 
   verifySuccessModalVisible(): void {


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/RHOAIENG-65544
## Description

Fixes a flaky Cypress test that fails intermittently in CI.

**Root Cause:**
The test method `playgroundPage.mcpTab.closeSuccessModal()` used an ambiguous selector:
```typescript
cy.findByRole('button', { name: /close/i })
```

This matched **two buttons**:
- Modal close button: accessible name = "Close"
- Drawer close button: accessible name = "Close settings panel"

In CI, Cypress sometimes clicked the drawer close button instead of the modal close button, causing the settings panel to close unexpectedly. The test then failed looking for the MCP servers table inside a closed drawer.

**The Fix:**
Scoped the selector to only search within the success modal and use exact matching:
```typescript
return cy
  .findByTestId('mcp-server-success-modal')
  .findByRole('button', { name: /^close$/i, timeout: 10000 });
```

## How Has This Been Tested?

- Tested locally to verify the selector now only finds the modal close button
- Verified lint checks pass
- CI pipeline will validate the fix resolves the flake

## Test Impact

- Updated page object method in `packages/gen-ai/frontend/src/__tests__/cypress/cypress/pages/playgroundPage/mcpTab.ts`
- No changes to test assertions or test flow
- Follows project convention to use data-testid for scoping selectors

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] N/A - Test-only change

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for modal interactions by enhancing element detection specificity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->