### PR TITLE
feat(cypress) add mocked Cypress tests for Feature Store lineage graph

### DIFF
--- a/frontend/src/components/lineage/Lineage.tsx
+++ b/frontend/src/components/lineage/Lineage.tsx
@@ -91,7 +91,7 @@ const LineageInner: React.FC<LineageProps> = ({
   });
 
   React.useEffect(() => {
-    if (controller && nodes.length > 0) {
+    if (controller) {
       try {
         controller.fromModel(
           {

--- a/frontend/src/components/lineage/Lineage.tsx
+++ b/frontend/src/components/lineage/Lineage.tsx
@@ -188,7 +188,12 @@ const LineageInner: React.FC<LineageProps> = ({
   if (error) {
     return (
       <div className={className} style={{ height, padding: '1rem' }}>
-        <Alert variant="danger" isInline title="Error loading lineage data">
+        <Alert
+          variant="danger"
+          isInline
+          title="Error loading lineage data"
+          data-testid="lineage-error-alert"
+        >
           {error}
         </Alert>
       </div>
@@ -223,7 +228,10 @@ const LineageInner: React.FC<LineageProps> = ({
       }}
     >
       {ToolbarComponent && <ToolbarComponent />}
-      <div style={{ flex: 1, overflow: 'hidden', position: 'relative', borderRadius: 16 }}>
+      <div
+        data-testid="lineage-graph-surface"
+        style={{ flex: 1, overflow: 'hidden', position: 'relative', borderRadius: 16 }}
+      >
         <TopologyView
           controlBar={
             <TopologyControlBar controlButtons={createLineageTopologyControls(controller)} />

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -61,7 +61,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   selectFilterType(filterLabel: string) {
     this.findLineageFilterDropdown().then(($toggle) => {
       if ($toggle.text().trim() !== filterLabel) {
-        cy.wrap($toggle).click({ force: true });
+        cy.wrap($toggle).should('be.visible').click();
         cy.findByRole('menuitem', { name: filterLabel }).click();
       }
     });
@@ -79,7 +79,9 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   toggleHideNodesWithoutRelationships() {
-    cy.findByLabelText('Toggle visibility of nodes without relationships').click({ force: true });
+    cy.findByLabelText('Toggle visibility of nodes without relationships')
+      .should('be.visible')
+      .click();
     return this;
   }
 

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -70,6 +70,9 @@ class FeatureLineage extends Contextual<HTMLElement> {
 
   applyEntityFilter(entityName: string) {
     this.selectFilterType('Entity');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
+    cy.findByPlaceholderText('Filter by entity name').should('not.be.disabled').click();
     cy.findByPlaceholderText('Filter by entity name').type(entityName);
     cy.findByTestId(`select-multi-typeahead-${entityName}`).click();
     return this;

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -59,13 +59,17 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   selectFilterType(filterLabel: string) {
-    this.findLineageFilterDropdown().click();
-    cy.findByRole('menuitem', { name: filterLabel }).should('be.visible').click();
+    this.findLineageFilterDropdown().then(($toggle) => {
+      if ($toggle.text().trim() !== filterLabel) {
+        cy.wrap($toggle).click({ force: true });
+        cy.findByRole('menuitem', { name: filterLabel }).click();
+      }
+    });
     return this;
   }
 
   selectMultiSelectionOption(ariaLabel: string, optionName: string) {
-    cy.findByLabelText(ariaLabel).click();
+    cy.findByLabelText(ariaLabel).should('be.enabled').click();
     cy.findByTestId(`select-multi-typeahead-${optionName.replace(/ /g, '-')}`).click();
     return this;
   }

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -68,15 +68,10 @@ class FeatureLineage extends Contextual<HTMLElement> {
     return this;
   }
 
-  selectMultiSelectionOption(ariaLabel: string, optionName: string) {
-    cy.findByLabelText(ariaLabel).should('be.enabled').click();
-    cy.findByTestId(`select-multi-typeahead-${optionName.replace(/ /g, '-')}`).click();
-    return this;
-  }
-
   applyEntityFilter(entityName: string) {
     this.selectFilterType('Entity');
-    this.selectMultiSelectionOption('Search entities', entityName);
+    cy.findByPlaceholderText('Filter by entity name').type(entityName);
+    cy.findByTestId(`select-multi-typeahead-${entityName}`).click();
     return this;
   }
 
@@ -86,7 +81,10 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   clickNodeByLabel(nodeLabel: string) {
-    this.findLineageGraphSurface().contains(nodeLabel).closest('[data-kind="node"]').click();
+    this.findLineageGraphSurface()
+      .contains(new RegExp(`\\b${nodeLabel}\\b`))
+      .closest('[data-kind="node"]')
+      .click();
     return this;
   }
 
@@ -107,7 +105,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   findNodeLabel(nodeLabel: string) {
-    return this.findLineageGraphSurface().contains(nodeLabel);
+    return this.findLineageGraphSurface().contains(new RegExp(`\\b${nodeLabel}\\b`));
   }
 
   shouldNodeLabelExist(nodeLabel: string) {

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -1,0 +1,125 @@
+import { Contextual } from '../components/Contextual';
+
+class FeatureLineage extends Contextual<HTMLElement> {
+  findFeatureStorePage() {
+    return cy.findByTestId('feature-store-page');
+  }
+
+  findLineageTab() {
+    return cy.findByTestId('lineage-tab');
+  }
+
+  findLineageTabContent() {
+    return cy.findByTestId('tabContent-Lineage');
+  }
+
+  findFeatureViewLineageTab() {
+    return cy.findByTestId('lineage-feature-views-tab');
+  }
+
+  findFeatureViewLineageSection() {
+    return cy.findByTestId('feature-view-lineage');
+  }
+
+  findLineageToolbar() {
+    return cy.findByTestId('lineage-search-filter');
+  }
+
+  findLineageFilterDropdown() {
+    return cy.findByTestId('lineage-search-filter-dropdown');
+  }
+
+  findLineageGraphSurface() {
+    return cy.get('.pf-topology-visualization-surface__svg');
+  }
+
+  visitFeatureViewDetails(project: string, featureViewName: string) {
+    cy.visitWithLogin(
+      `/develop-train/feature-store/feature-views/${project}/${featureViewName}?devFeatureFlags=Feature+store+plugin%3Dtrue`,
+    );
+    cy.findByTestId('app-page-title').should('contain.text', featureViewName);
+    cy.testA11y({ exclude: [['.pf-v6-c-tabs']] });
+    return this;
+  }
+
+  waitForLineageLoaded() {
+    cy.findByRole('heading', { name: 'Loading lineage data...' }).should('not.exist');
+    cy.findByRole('heading', { name: 'Initializing visualization...' }).should('not.exist');
+    return this;
+  }
+
+  openOverviewLineageTab() {
+    this.findLineageTab().click();
+    return this;
+  }
+
+  openFeatureViewLineageTab() {
+    this.findFeatureViewLineageTab().click();
+    return this;
+  }
+
+  selectFilterType(filterLabel: string) {
+    this.findLineageFilterDropdown().click();
+    cy.findByRole('menuitem', { name: filterLabel }).should('be.visible').click();
+    return this;
+  }
+
+  selectMultiSelectionOption(ariaLabel: string, optionName: string) {
+    cy.findByLabelText(ariaLabel).click();
+    cy.findByTestId(`select-multi-typeahead-${optionName.replace(/ /g, '-')}`).click();
+    return this;
+  }
+
+  applyEntityFilter(entityName: string) {
+    this.selectFilterType('Entity');
+    this.selectMultiSelectionOption('Search entities', entityName);
+    return this;
+  }
+
+  toggleHideNodesWithoutRelationships() {
+    cy.findByLabelText('Toggle visibility of nodes without relationships').click({ force: true });
+    return this;
+  }
+
+  clickNodeByLabel(nodeLabel: string) {
+    this.findLineageGraphSurface().contains(nodeLabel).closest('[data-kind="node"]').click();
+    return this;
+  }
+
+  shouldShowPopoverWithName(name: string) {
+    cy.get('.pf-v6-c-popover').should('be.visible').and('contain.text', name);
+    return this;
+  }
+
+  findViewDetailsPageLink(detailsLabel: string) {
+    return cy.findByRole('link', { name: new RegExp(detailsLabel, 'i') });
+  }
+
+  shouldShowLineageError() {
+    cy.get('.pf-v6-c-alert.pf-m-danger')
+      .should('be.visible')
+      .and('contain.text', 'Error loading lineage data');
+    return this;
+  }
+
+  findNodeLabel(nodeLabel: string) {
+    return this.findLineageGraphSurface().contains(nodeLabel);
+  }
+
+  shouldNodeLabelExist(nodeLabel: string) {
+    this.findNodeLabel(nodeLabel).should('exist');
+    return this;
+  }
+
+  shouldNodeLabelNotExist(nodeLabel: string) {
+    this.findNodeLabel(nodeLabel).should('not.exist');
+    return this;
+  }
+
+  shouldShowEmptyLineageGraph() {
+    this.findLineageGraphSurface().should('exist');
+    return this;
+  }
+}
+
+export const featureLineage = new FeatureLineage(() => cy.findByTestId('feature-store-page'));

--- a/packages/cypress/cypress/pages/featureStore/featureLineage.ts
+++ b/packages/cypress/cypress/pages/featureStore/featureLineage.ts
@@ -30,7 +30,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   findLineageGraphSurface() {
-    return cy.get('.pf-topology-visualization-surface__svg');
+    return cy.findByTestId('lineage-graph-surface');
   }
 
   visitFeatureViewDetails(project: string, featureViewName: string) {
@@ -45,6 +45,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   waitForLineageLoaded() {
     cy.findByRole('heading', { name: 'Loading lineage data...' }).should('not.exist');
     cy.findByRole('heading', { name: 'Initializing visualization...' }).should('not.exist');
+    this.findLineageGraphSurface().should('exist');
     return this;
   }
 
@@ -70,8 +71,6 @@ class FeatureLineage extends Contextual<HTMLElement> {
 
   applyEntityFilter(entityName: string) {
     this.selectFilterType('Entity');
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
     cy.findByPlaceholderText('Filter by entity name').should('not.be.disabled').click();
     cy.findByPlaceholderText('Filter by entity name').type(entityName);
     cy.findByTestId(`select-multi-typeahead-${entityName}`).click();
@@ -94,7 +93,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   shouldShowPopoverWithName(name: string) {
-    cy.get('.pf-v6-c-popover').should('be.visible').and('contain.text', name);
+    cy.findByTestId('lineage-node-popover').should('be.visible').and('contain.text', name);
     return this;
   }
 
@@ -103,9 +102,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
   }
 
   shouldShowLineageError() {
-    cy.get('.pf-v6-c-alert.pf-m-danger')
-      .should('be.visible')
-      .and('contain.text', 'Error loading lineage data');
+    cy.findByTestId('lineage-error-alert').should('be.visible');
     return this;
   }
 
@@ -125,6 +122,7 @@ class FeatureLineage extends Contextual<HTMLElement> {
 
   shouldShowEmptyLineageGraph() {
     this.findLineageGraphSurface().should('exist');
+    this.findLineageGraphSurface().find('[data-kind="node"]').should('have.length', 0);
     return this;
   }
 }

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts
@@ -14,7 +14,7 @@ import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashb
 import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
 import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
 import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
-import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { DataScienceStackComponent } from '@odh-dashboard/k8s-core';
 import { ProjectModel, ServiceModel } from '../../../utils/models';
 import { asClusterAdminUser } from '../../../utils/mockUsers';
 import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';

--- a/packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts
@@ -1,0 +1,396 @@
+/* eslint-disable camelcase */
+
+import { mockFeatureStoreService } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreService';
+import { mockFeatureStoreProject } from '@odh-dashboard/feature-store/mocks/mockFeatureStoreProject';
+import { mockEntity } from '@odh-dashboard/feature-store/mocks/mockEntities';
+import { mockDataSource } from '@odh-dashboard/feature-store/mocks/mockDataSources';
+import { mockFeatureView } from '@odh-dashboard/feature-store/mocks/mockFeatureViews';
+import { mockFeatureService } from '@odh-dashboard/feature-store/mocks/mockFeatureServices';
+import type {
+  FeatureStoreLineage,
+  FeatureViewLineage,
+} from '@odh-dashboard/feature-store/types/lineage';
+import { mockDashboardConfig } from '@odh-dashboard/internal/__mocks__/mockDashboardConfig';
+import { mockDscStatus } from '@odh-dashboard/internal/__mocks__/mockDscStatus';
+import { mockK8sResourceList } from '@odh-dashboard/internal/__mocks__/mockK8sResourceList';
+import { mockProjectK8sResource } from '@odh-dashboard/internal/__mocks__/mockProjectK8sResource';
+import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { ProjectModel, ServiceModel } from '../../../utils/models';
+import { asClusterAdminUser } from '../../../utils/mockUsers';
+import { featureStoreGlobal } from '../../../pages/featureStore/featureStoreGlobal';
+import { featureLineage } from '../../../pages/featureStore/featureLineage';
+
+const k8sNamespace = 'default';
+const fsName = 'demo';
+const fsProjectName = 'rbac';
+const alternateProjectName = 'new-project';
+
+const ENTITY_NAME = 'driver';
+const DISCONNECTED_ENTITY_NAME = 'passenger';
+const DATA_SOURCE_NAME = 'driver_source';
+const FEATURE_VIEW_NAME = 'driver_stats';
+const FEATURE_SERVICE_NAME = 'driver_activity';
+
+const paginationInfo = {
+  totalCount: 1,
+  totalPages: 1,
+};
+
+const emptyPagination = {
+  totalCount: 0,
+  totalPages: 0,
+};
+
+const buildRelationship = (
+  sourceType: string,
+  sourceName: string,
+  targetType: string,
+  targetName: string,
+) => ({
+  source: { type: sourceType, name: sourceName },
+  target: { type: targetType, name: targetName },
+});
+
+const initCommonIntercepts = () => {
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+      },
+    }),
+  );
+
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ disableFeatureStore: false }));
+
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: k8sNamespace })]),
+  );
+
+  cy.intercept('GET', '/api/featurestores', {
+    featureStores: [
+      {
+        name: fsName,
+        project: fsName,
+        registry: {
+          path: `feast-${fsName}-${k8sNamespace}-registry.${k8sNamespace}.svc.cluster.local:443`,
+        },
+        namespace: k8sNamespace,
+        status: {
+          conditions: [
+            {
+              type: 'Registry',
+              status: 'True',
+              lastTransitionTime: '2025-10-08T21:13:38.158Z',
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  cy.interceptK8sList(
+    ServiceModel,
+    mockK8sResourceList([
+      mockFeatureStoreService({
+        name: 'feast-demo-registry-rest',
+        namespace: 'default',
+        featureStoreName: fsName,
+      }),
+    ]),
+  );
+
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/projects',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+    },
+    {
+      projects: [
+        mockFeatureStoreProject({ spec: { name: fsProjectName } }),
+        mockFeatureStoreProject({ spec: { name: alternateProjectName } }),
+      ],
+      pagination: {
+        total_count: 2,
+        total_pages: 1,
+        has_next: false,
+        has_previous: false,
+        page: 1,
+        limit: 10,
+      },
+    },
+  );
+};
+
+const buildStoreLineageMock = (
+  project: string,
+  includeDisconnectedEntity = false,
+): FeatureStoreLineage => {
+  const driverEntity = mockEntity({
+    spec: {
+      name: ENTITY_NAME,
+      valueType: 'INT64',
+      joinKey: 'driver_id',
+      description: 'Driver entity',
+    },
+  });
+
+  const entities = includeDisconnectedEntity
+    ? [
+        driverEntity,
+        mockEntity({
+          spec: {
+            name: DISCONNECTED_ENTITY_NAME,
+            valueType: 'INT64',
+            joinKey: 'passenger_id',
+            description: 'Unconnected entity for filter tests',
+          },
+        }),
+      ]
+    : [driverEntity];
+
+  const featureView = mockFeatureView({
+    spec: {
+      ...mockFeatureView().spec,
+      name: FEATURE_VIEW_NAME,
+      entities: [ENTITY_NAME],
+    },
+  });
+
+  return {
+    project,
+    objects: {
+      entities,
+      dataSources: [
+        mockDataSource({
+          name: DATA_SOURCE_NAME,
+          description: 'Driver batch data source',
+        }),
+      ],
+      featureViews: [
+        {
+          featureView: {
+            spec: featureView.spec,
+            meta: featureView.meta,
+          },
+        },
+      ],
+      featureServices: [mockFeatureService({ name: FEATURE_SERVICE_NAME })],
+      features: [],
+    },
+    relationships: [
+      buildRelationship('entity', ENTITY_NAME, 'featureView', FEATURE_VIEW_NAME),
+      buildRelationship('dataSource', DATA_SOURCE_NAME, 'featureView', FEATURE_VIEW_NAME),
+      buildRelationship('featureView', FEATURE_VIEW_NAME, 'featureService', FEATURE_SERVICE_NAME),
+    ],
+    indirectRelationships: [],
+    pagination: {
+      entities: paginationInfo,
+      dataSources: paginationInfo,
+      featureViews: paginationInfo,
+      featureServices: paginationInfo,
+      features: emptyPagination,
+      relationships: { totalCount: 3, totalPages: 1 },
+      indirectRelationships: emptyPagination,
+    },
+  };
+};
+
+const buildEmptyStoreLineageMock = (project: string): FeatureStoreLineage => ({
+  project,
+  objects: {
+    entities: [],
+    dataSources: [],
+    featureViews: [],
+    featureServices: [],
+    features: [],
+  },
+  relationships: [],
+  indirectRelationships: [],
+  pagination: {
+    entities: emptyPagination,
+    dataSources: emptyPagination,
+    featureViews: emptyPagination,
+    featureServices: emptyPagination,
+    features: emptyPagination,
+    relationships: emptyPagination,
+    indirectRelationships: emptyPagination,
+  },
+});
+
+const buildFeatureViewLineageMock = (): FeatureViewLineage => ({
+  relationships: [
+    buildRelationship('entity', ENTITY_NAME, 'featureView', FEATURE_VIEW_NAME),
+    buildRelationship('dataSource', DATA_SOURCE_NAME, 'featureView', FEATURE_VIEW_NAME),
+    buildRelationship('feature', 'conv_rate', 'featureView', FEATURE_VIEW_NAME),
+    buildRelationship('featureView', FEATURE_VIEW_NAME, 'featureService', FEATURE_SERVICE_NAME),
+  ],
+  pagination: { totalCount: 4, totalPages: 1 },
+});
+
+const mockLineageCompleteIntercept = (project: string, body: FeatureStoreLineage) => {
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/lineage/complete',
+    {
+      path: { namespace: k8sNamespace, projectName: fsName, apiVersion: 'v1' },
+      query: { project },
+    },
+    body,
+  ).as('getLineageComplete');
+};
+
+const mockFeatureViewLineageIntercept = (
+  project: string,
+  featureViewName: string,
+  body: FeatureViewLineage,
+) => {
+  cy.interceptOdh(
+    'GET /api/featurestores/:namespace/:projectName/api/:apiVersion/lineage/objects/featureView/:featureViewName',
+    {
+      path: {
+        namespace: k8sNamespace,
+        projectName: fsName,
+        apiVersion: 'v1',
+        featureViewName,
+      },
+      query: { project },
+    },
+    body,
+  ).as('getFeatureViewLineage');
+};
+
+const mockFeatureViewDetailsIntercept = () => {
+  cy.intercept(
+    'GET',
+    `**/api/featurestores/${k8sNamespace}/${fsName}/api/v1/feature_views/${FEATURE_VIEW_NAME}?project=${fsProjectName}&include_relationships=true*`,
+    mockFeatureView({
+      spec: {
+        ...mockFeatureView().spec,
+        name: FEATURE_VIEW_NAME,
+        entities: [ENTITY_NAME],
+      },
+    }),
+  ).as('getFeatureViewDetails');
+};
+
+const openOverviewLineage = (project = fsProjectName) => {
+  featureStoreGlobal.visitOverview(project);
+  featureLineage.openOverviewLineageTab();
+  cy.wait('@getLineageComplete');
+  featureLineage.waitForLineageLoaded();
+};
+
+describe('Feature Store Lineage', () => {
+  beforeEach(() => {
+    asClusterAdminUser();
+    initCommonIntercepts();
+  });
+
+  it('should render project-wide lineage graph on overview Lineage tab', () => {
+    mockLineageCompleteIntercept(fsProjectName, buildStoreLineageMock(fsProjectName));
+
+    openOverviewLineage();
+
+    featureLineage.findLineageGraphSurface().should('exist');
+    featureLineage.shouldNodeLabelExist(ENTITY_NAME);
+    featureLineage.shouldNodeLabelExist(DATA_SOURCE_NAME);
+    featureLineage.shouldNodeLabelExist(FEATURE_VIEW_NAME);
+    featureLineage.shouldNodeLabelExist(FEATURE_SERVICE_NAME);
+    featureLineage.findLineageToolbar().should('be.visible');
+  });
+
+  it('should render scoped lineage graph on feature view detail Lineage tab', () => {
+    mockFeatureViewDetailsIntercept();
+    mockFeatureViewLineageIntercept(
+      fsProjectName,
+      FEATURE_VIEW_NAME,
+      buildFeatureViewLineageMock(),
+    );
+
+    featureLineage.visitFeatureViewDetails(fsProjectName, FEATURE_VIEW_NAME);
+    featureLineage.openFeatureViewLineageTab();
+    cy.wait('@getFeatureViewLineage');
+    featureLineage.waitForLineageLoaded();
+
+    featureLineage.findFeatureViewLineageSection().should('be.visible');
+    featureLineage.findLineageGraphSurface().should('exist');
+    featureLineage.shouldNodeLabelExist(FEATURE_VIEW_NAME);
+    featureLineage.shouldNodeLabelExist(FEATURE_SERVICE_NAME);
+  });
+
+  it('should show popover with object details and navigate from node interaction', () => {
+    mockLineageCompleteIntercept(fsProjectName, buildStoreLineageMock(fsProjectName));
+
+    openOverviewLineage();
+
+    featureLineage.clickNodeByLabel(ENTITY_NAME);
+    featureLineage.shouldShowPopoverWithName(ENTITY_NAME);
+
+    featureLineage.findViewDetailsPageLink('Entity details').click();
+    cy.url().should(
+      'include',
+      `/develop-train/feature-store/entities/${fsProjectName}/${ENTITY_NAME}`,
+    );
+  });
+
+  it('should update graph when toolbar entity filter is applied', () => {
+    mockLineageCompleteIntercept(fsProjectName, buildStoreLineageMock(fsProjectName, true));
+
+    openOverviewLineage();
+
+    featureLineage.shouldNodeLabelExist(DISCONNECTED_ENTITY_NAME);
+
+    featureLineage.applyEntityFilter(ENTITY_NAME);
+
+    featureLineage.shouldNodeLabelExist(ENTITY_NAME);
+    featureLineage.shouldNodeLabelNotExist(DISCONNECTED_ENTITY_NAME);
+  });
+
+  it('should reload lineage graph when project is switched on overview Lineage tab', () => {
+    mockLineageCompleteIntercept(fsProjectName, buildStoreLineageMock(fsProjectName));
+
+    openOverviewLineage();
+    featureLineage.shouldNodeLabelExist(FEATURE_VIEW_NAME);
+
+    mockLineageCompleteIntercept(
+      alternateProjectName,
+      buildEmptyStoreLineageMock(alternateProjectName),
+    );
+
+    featureStoreGlobal.selectProject(alternateProjectName);
+    cy.wait('@getLineageComplete');
+    featureLineage.waitForLineageLoaded();
+
+    featureStoreGlobal.findProjectSelector().should('contain.text', alternateProjectName);
+    featureLineage.shouldShowEmptyLineageGraph();
+    featureLineage.shouldNodeLabelNotExist(FEATURE_VIEW_NAME);
+  });
+
+  it('should handle empty lineage response', () => {
+    mockLineageCompleteIntercept(fsProjectName, buildEmptyStoreLineageMock(fsProjectName));
+
+    openOverviewLineage();
+
+    featureLineage.shouldShowEmptyLineageGraph();
+    featureLineage.shouldNodeLabelNotExist(FEATURE_VIEW_NAME);
+    featureLineage.shouldNodeLabelNotExist(FEATURE_SERVICE_NAME);
+  });
+
+  it('should handle API error on lineage endpoint', () => {
+    cy.intercept(
+      'GET',
+      `/api/featurestores/${k8sNamespace}/${fsName}/api/v1/lineage/complete?project=${fsProjectName}*`,
+      {
+        statusCode: 500,
+        body: { detail: 'Internal server error' },
+      },
+    ).as('getLineageCompleteError');
+
+    featureStoreGlobal.visitOverview(fsProjectName);
+    featureLineage.openOverviewLineageTab();
+    cy.wait('@getLineageCompleteError');
+
+    featureLineage.shouldShowLineageError();
+  });
+});

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -43,17 +43,9 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
   const [currentFilterType, setCurrentFilterType] =
     useState<keyof FeatureStoreLineageSearchFilters>('entity');
   const [conversionError, setConversionError] = useState<string | null>(null);
-  const { triggerCenter, forceCenter } = useLineageCenter();
-  const [lineageKey, setLineageKey] = useState(0);
+  const { triggerCenter } = useLineageCenter();
   const featureViewLineageState = useFeatureViewLineage(project, featureViewName);
   const featureStoreLineageState = useFeatureStoreLineage(featureViewName ? undefined : project);
-
-  // Force re-render when forceCenter is triggered (tab switch)
-  useEffect(() => {
-    if (forceCenter) {
-      setLineageKey((prev) => prev + 1);
-    }
-  }, [forceCenter]);
 
   const {
     data: lineageData,
@@ -188,7 +180,6 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
       style={{ height, display: 'flex', flexDirection: 'column' }}
     >
       <Lineage
-        key={lineageKey}
         data={visualizationData}
         loading={!lineageDataLoaded && !error}
         error={

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -190,7 +190,7 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
       <Lineage
         key={lineageKey}
         data={visualizationData}
-        loading={!lineageDataLoaded}
+        loading={!lineageDataLoaded && !error}
         error={
           error ? `Failed to load lineage data: ${String(error)}` : conversionError || undefined
         }

--- a/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
+++ b/packages/feature-store/src/screens/lineage/node/FeatureStoreLineageNodePopover.tsx
@@ -84,6 +84,7 @@ const FeatureStoreLineageNodePopover: React.FC<FeatureStoreLineageNodePopoverPro
 
   const popoverContent = (
     <Popover
+      data-testid="lineage-node-popover"
       isVisible={isVisible}
       shouldClose={() => {
         onClose();


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-58682

## Description

packages/cypress/cypress/pages/featureStore/featureLineage.ts — New page object with helpers for navigating lineage tabs, interacting with graph nodes, applying filters, and asserting graph state.

packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts — New test file with 7 mocked tests covering all lineage tab interactions 

frontend/src/components/lineage/Lineage.tsx — Removed nodes.length > 0 guard from fromModel call so the graph properly clears when data becomes empty (project switch / empty response).

packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx — Changed loading prop from !lineageDataLoaded to !lineageDataLoaded && !error so the error alert renders instead of a perpetual loading spinner on API 500.


## How Has This Been Tested?

Ran the spec 3 times locally 7/7 passing consistently

npm run cypress:run:mock -- --spec "packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts"

<img width="2539" height="1277" alt="SCR-20260602-kdue" src="https://github.com/user-attachments/assets/14aedc9b-a695-4a6a-9bdf-caa864860915" />

## Test Impact

New files: 
packages/cypress/cypress/tests/mocked/featureStore/featureLineage.cy.ts (7 tests) 
packages/cypress/cypress/pages/featureStore/featureLineage.ts (page object)




## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop showing a loading indicator when lineage responses fail.
  * Ensure the lineage graph updates correctly for empty results, including proper topology initialization so empty-node views render as expected.
* **Tests**
  * Added end-to-end coverage for Feature Store Lineage UI (overview and feature-view), including graph rendering, filtering, tab switching, empty and error states, and node click/navigation behavior.
  * Added reusable Cypress page-object helpers and a dedicated lineage Cypress spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->