### PR TITLE
fix(e2e): clean up registered model on retry in testRetainCustomProperties

### DIFF
--- a/packages/cypress/cypress/tests/e2e/modelRegistry/testRetainCustomProperties.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelRegistry/testRetainCustomProperties.cy.ts
@@ -75,9 +75,11 @@ describe('Verify custom properties and labels are retained during Model Registry
   });
 
   retryableBeforeEach(() => {
-    // TODO: RHOAIENG-65075 - 'Cannot read properties of null (reading postMessage)' error is suppressed globally in e2e.ts
     cy.clearCookies();
     cy.clearLocalStorage();
+    if (modelName && databaseName) {
+      cleanupRegisteredModelsFromDatabase([modelName], databaseName);
+    }
   });
 
   it(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65608

## Description
When `testRetainCustomProperties` fails and retries, the model registered by the
previous attempt is still in the database. The retry then fails again because the
model already exists.

Add `cleanupRegisteredModelsFromDatabase` to the `retryableBeforeEach` hook so any
model from a failed attempt is deleted before the next attempt starts. The function
is already imported and is idempotent — the SQL DELETE is a no-op if no model exists.
A guard on `modelName && databaseName` handles the first attempt where `before()` may
not have set them yet.

## How Has This Been Tested?
Locally: I've forced a retry after the model registration and it worked:
<img width="517" height="149" alt="image" src="https://github.com/user-attachments/assets/dce0e5c8-412e-4895-bd95-dd3e4aa164d6" />

dashboard-e2e-tests/1050/ :
<img width="1174" height="170" alt="image" src="https://github.com/user-attachments/assets/31403827-b16e-48b2-8e92-26e64aa497bf" />


## Test Impact
No new tests — this fixes retry reliability for an existing test.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to enhance test isolation by clearing database state between test runs, ensuring more reliable and consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->