### PR TITLE
fix(autorag,automl): RHOAIENG-64768 - AutoRAG pipeline fails to pull hardcoded image SHA (manifest unknown) from registry.redhat.io

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -435,6 +435,9 @@
       - '--cert-file=/etc/tls/private/tls.crt'
       - '--key-file=/etc/tls/private/tls.key'
       - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+    env:
+      - name: RELATED_IMAGE_ODH_AUTOML_IMAGE
+        value: $(automl-pipeline-runtime-image)
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -505,6 +508,9 @@
       - '--cert-file=/etc/tls/private/tls.crt'
       - '--key-file=/etc/tls/private/tls.key'
       - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+    env:
+      - name: RELATED_IMAGE_ODH_AUTORAG_IMAGE
+        value: $(autorag-pipeline-runtime-image)
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -52,6 +52,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.automl-ui-image
+  - name: automl-pipeline-runtime-image
+    objref:
+      kind: ConfigMap
+      name: modular-architecture-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.automl-pipeline-runtime-image
   - name: autorag-ui-image
     objref:
       kind: ConfigMap
@@ -59,6 +66,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.autorag-ui-image
+  - name: autorag-pipeline-runtime-image
+    objref:
+      kind: ConfigMap
+      name: modular-architecture-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.autorag-pipeline-runtime-image
 configurations:
   - params.yaml
 patchesJson6902:

--- a/manifests/modular-architecture/params.env
+++ b/manifests/modular-architecture/params.env
@@ -10,5 +10,7 @@ mlflow-ui-image=quay.io/opendatahub/odh-mod-arch-mlflow:main
 eval-hub-ui-image=quay.io/opendatahub/odh-mod-arch-eval-hub:main
 
 automl-ui-image=quay.io/opendatahub/odh-mod-arch-automl:main
+automl-pipeline-runtime-image=
 
 autorag-ui-image=quay.io/opendatahub/odh-mod-arch-autorag:main
+autorag-pipeline-runtime-image=

--- a/manifests/modular-architecture/params.yaml
+++ b/manifests/modular-architecture/params.yaml
@@ -1,5 +1,7 @@
 varReference:
 - path: spec/template/spec/containers/image
   kind: Deployment
+- path: spec/template/spec/containers/env/value
+  kind: Deployment
 - path: spec/parentRefs/name
   kind: HTTPRoute

--- a/packages/automl/bff/internal/pipelines/embed.go
+++ b/packages/automl/bff/internal/pipelines/embed.go
@@ -1,12 +1,23 @@
 package pipelines
 
-import "embed"
+import (
+	"embed"
+	"regexp"
+)
 
 //go:embed */pipeline.yaml
 var pipelineFS embed.FS
+
+// AutoMLImagePattern matches the automl pipeline runtime image with any sha256 digest.
+var AutoMLImagePattern = regexp.MustCompile(`registry\.redhat\.io/rhoai/odh-automl-rhel9@sha256:[0-9a-f]{64}`)
 
 // GetPipelineYAML returns the embedded pipeline YAML for the given pipeline name.
 // The name corresponds to a directory under internal/pipelines/ (e.g. "autogluon_tabular_training_pipeline").
 func GetPipelineYAML(pipelineName string) ([]byte, error) {
 	return pipelineFS.ReadFile(pipelineName + "/pipeline.yaml")
+}
+
+// ReplaceImageRef replaces all image references matching pattern with newImage.
+func ReplaceImageRef(yamlBytes []byte, pattern *regexp.Regexp, newImage string) []byte {
+	return pattern.ReplaceAll(yamlBytes, []byte(newImage))
 }

--- a/packages/automl/bff/internal/pipelines/embed_test.go
+++ b/packages/automl/bff/internal/pipelines/embed_test.go
@@ -1,0 +1,35 @@
+package pipelines
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceImageRef(t *testing.T) {
+	oldDigest := "77d5222d8b4f10828bfeafb692de7348e28c711b45ca3f70854e407bf651a6fd"
+	newDigest := "1b6a063cdde3bf91cd10f5a2be999bd171d76892617444c49384828e326ae9ce"
+
+	t.Run("replaces all occurrences matching the pattern", func(t *testing.T) {
+		yaml := []byte("image: registry.redhat.io/rhoai/odh-automl-rhel9@sha256:" + oldDigest + "\nother: stuff\nimage: registry.redhat.io/rhoai/odh-automl-rhel9@sha256:" + oldDigest + "\n")
+		newImage := "registry.redhat.io/rhoai/odh-automl-rhel9@sha256:" + newDigest
+		result := ReplaceImageRef(yaml, AutoMLImagePattern, newImage)
+		assert.NotContains(t, string(result), oldDigest)
+		assert.Equal(t, 2, strings.Count(string(result), newImage))
+	})
+
+	t.Run("matches any 64-char hex digest", func(t *testing.T) {
+		yaml := []byte("image: registry.redhat.io/rhoai/odh-automl-rhel9@sha256:" + oldDigest + "\n")
+		newImage := "registry.redhat.io/rhoai/odh-automl-rhel9@sha256:" + newDigest
+		result := ReplaceImageRef(yaml, AutoMLImagePattern, newImage)
+		assert.Contains(t, string(result), newDigest)
+		assert.NotContains(t, string(result), oldDigest)
+	})
+
+	t.Run("no match returns YAML unchanged", func(t *testing.T) {
+		yaml := []byte("image: some-other-image@sha256:" + oldDigest + "\n")
+		result := ReplaceImageRef(yaml, AutoMLImagePattern, "new-image@sha256:"+newDigest)
+		assert.Equal(t, string(yaml), string(result))
+	})
+}

--- a/packages/automl/bff/internal/repositories/pipeline.go
+++ b/packages/automl/bff/internal/repositories/pipeline.go
@@ -450,6 +450,12 @@ func (r *PipelineRepository) ensurePipelineAndVersion(
 		return nil, fmt.Errorf("failed to load embedded pipeline YAML %q: %w", def.PipelineDir, err)
 	}
 
+	if override := os.Getenv("RELATED_IMAGE_ODH_AUTOML_IMAGE"); override != "" {
+		yamlBytes = pipelines.ReplaceImageRef(yamlBytes, pipelines.AutoMLImagePattern, override)
+		logger.Info("Replaced pipeline image with RELATED_IMAGE_ODH_AUTOML_IMAGE",
+			"pipelineDir", def.PipelineDir, "overrideImage", override)
+	}
+
 	// Step 1: Find or create the pipeline shell
 	pipelineID, err := r.findOrCreatePipeline(client, ctx, namespace, pipelineName)
 	if err != nil {

--- a/packages/automl/bff/internal/repositories/pipeline_test.go
+++ b/packages/automl/bff/internal/repositories/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	ps "github.com/opendatahub-io/automl-library/bff/internal/integrations/pipelineserver"
 	"github.com/opendatahub-io/automl-library/bff/internal/integrations/pipelineserver/psmocks"
 	"github.com/opendatahub-io/automl-library/bff/internal/models"
+	"github.com/opendatahub-io/automl-library/bff/internal/pipelines"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,6 +42,18 @@ func (m *conflictVersionMockClient) ListPipelineVersions(_ context.Context, pipe
 		}, nil
 	}
 	return m.MockPipelineServerClient.ListPipelineVersions(context.Background(), pipelineID)
+}
+
+// capturingMockClient wraps MockPipelineServerClient and captures the YAML bytes passed to UploadPipelineVersion.
+type capturingMockClient struct {
+	*psmocks.MockPipelineServerClient
+	capturedYAML []byte
+}
+
+func (m *capturingMockClient) UploadPipelineVersion(ctx context.Context, pipelineID string, versionName string, fileContent []byte) (*models.KFPipelineVersion, error) {
+	m.capturedYAML = make([]byte, len(fileContent))
+	copy(m.capturedYAML, fileContent)
+	return m.MockPipelineServerClient.UploadPipelineVersion(ctx, pipelineID, versionName, fileContent)
 }
 
 func TestDiscoverNamedPipelines(t *testing.T) {
@@ -532,5 +545,53 @@ func TestEnsurePipeline(t *testing.T) {
 		assert.NotNil(t, discovered)
 		assert.True(t, mockClient.uploaded, "UploadPipelineVersion should have been called")
 		assert.Equal(t, "autogluon-tabular-training-pipeline", discovered.PipelineName)
+	})
+
+	t.Run("should replace image when RELATED_IMAGE_ODH_AUTOML_IMAGE is set", func(t *testing.T) {
+		overrideImage := "registry.redhat.io/rhoai/odh-automl-rhel9@sha256:overridden"
+		t.Setenv("RELATED_IMAGE_ODH_AUTOML_IMAGE", overrideImage)
+
+		namespace := "test-ns-ensure-image-override"
+		baseMock := psmocks.NewMockPipelineServerClient("http://mock-ps")
+		baseMock.PipelineNames = []string{"unrelated-pipeline"}
+		mockClient := &capturingMockClient{MockPipelineServerClient: baseMock}
+
+		def := PipelineDefinition{
+			Name:        "autogluon-tabular-training-pipeline",
+			PipelineDir: "autogluon_tabular_training_pipeline",
+		}
+
+		repo.InvalidateCache("http://mock-ps", namespace)
+
+		discovered, err := repo.EnsurePipeline(mockClient, ctx, namespace, "http://mock-ps", def)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, discovered)
+		assert.NotNil(t, mockClient.capturedYAML, "UploadPipelineVersion should have been called with YAML bytes")
+		assert.Contains(t, string(mockClient.capturedYAML), overrideImage)
+		assert.False(t, pipelines.AutoMLImagePattern.Match(mockClient.capturedYAML), "original image pattern should not remain after override")
+	})
+
+	t.Run("should use default image when RELATED_IMAGE_ODH_AUTOML_IMAGE is unset", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_ODH_AUTOML_IMAGE", "")
+
+		namespace := "test-ns-ensure-default-image"
+		baseMock := psmocks.NewMockPipelineServerClient("http://mock-ps")
+		baseMock.PipelineNames = []string{"unrelated-pipeline"}
+		mockClient := &capturingMockClient{MockPipelineServerClient: baseMock}
+
+		def := PipelineDefinition{
+			Name:        "autogluon-tabular-training-pipeline",
+			PipelineDir: "autogluon_tabular_training_pipeline",
+		}
+
+		repo.InvalidateCache("http://mock-ps", namespace)
+
+		discovered, err := repo.EnsurePipeline(mockClient, ctx, namespace, "http://mock-ps", def)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, discovered)
+		assert.NotNil(t, mockClient.capturedYAML, "UploadPipelineVersion should have been called with YAML bytes")
+		assert.True(t, pipelines.AutoMLImagePattern.Match(mockClient.capturedYAML), "embedded default image should be preserved")
 	})
 }

--- a/packages/autorag/bff/internal/pipelines/embed.go
+++ b/packages/autorag/bff/internal/pipelines/embed.go
@@ -1,12 +1,23 @@
 package pipelines
 
-import "embed"
+import (
+	"embed"
+	"regexp"
+)
 
 //go:embed */pipeline.yaml
 var pipelineFS embed.FS
+
+// AutoRAGImagePattern matches the autorag pipeline runtime image with any sha256 digest.
+var AutoRAGImagePattern = regexp.MustCompile(`registry\.redhat\.io/rhoai/odh-autorag-rhel9@sha256:[0-9a-f]{64}`)
 
 // GetPipelineYAML returns the embedded pipeline YAML for the given pipeline name.
 // The name corresponds to a directory under internal/pipelines/ (e.g. "documents_rag_optimization_pipeline").
 func GetPipelineYAML(pipelineName string) ([]byte, error) {
 	return pipelineFS.ReadFile(pipelineName + "/pipeline.yaml")
+}
+
+// ReplaceImageRef replaces all image references matching pattern with newImage.
+func ReplaceImageRef(yamlBytes []byte, pattern *regexp.Regexp, newImage string) []byte {
+	return pattern.ReplaceAll(yamlBytes, []byte(newImage))
 }

--- a/packages/autorag/bff/internal/pipelines/embed_test.go
+++ b/packages/autorag/bff/internal/pipelines/embed_test.go
@@ -1,0 +1,35 @@
+package pipelines
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceImageRef(t *testing.T) {
+	oldDigest := "a10e28c36726add59cce2e59435c57bab22795baf979bdc531fd7b40f06cc9d6"
+	newDigest := "7f481301e8a2a5142aaf3a7d757886b936641342fed0cbd16a4b3d44692f4987"
+
+	t.Run("replaces all occurrences matching the pattern", func(t *testing.T) {
+		yaml := []byte("image: registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:" + oldDigest + "\nother: stuff\nimage: registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:" + oldDigest + "\n")
+		newImage := "registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:" + newDigest
+		result := ReplaceImageRef(yaml, AutoRAGImagePattern, newImage)
+		assert.NotContains(t, string(result), oldDigest)
+		assert.Equal(t, 2, strings.Count(string(result), newImage))
+	})
+
+	t.Run("matches any 64-char hex digest", func(t *testing.T) {
+		yaml := []byte("image: registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:" + oldDigest + "\n")
+		newImage := "registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:" + newDigest
+		result := ReplaceImageRef(yaml, AutoRAGImagePattern, newImage)
+		assert.Contains(t, string(result), newDigest)
+		assert.NotContains(t, string(result), oldDigest)
+	})
+
+	t.Run("no match returns YAML unchanged", func(t *testing.T) {
+		yaml := []byte("image: some-other-image@sha256:" + oldDigest + "\n")
+		result := ReplaceImageRef(yaml, AutoRAGImagePattern, "new-image@sha256:"+newDigest)
+		assert.Equal(t, string(yaml), string(result))
+	})
+}

--- a/packages/autorag/bff/internal/repositories/pipeline.go
+++ b/packages/autorag/bff/internal/repositories/pipeline.go
@@ -442,6 +442,12 @@ func (r *PipelineRepository) ensurePipelineAndVersion(
 		return nil, fmt.Errorf("failed to load embedded pipeline YAML %q: %w", def.PipelineDir, err)
 	}
 
+	if override := os.Getenv("RELATED_IMAGE_ODH_AUTORAG_IMAGE"); override != "" {
+		yamlBytes = pipelines.ReplaceImageRef(yamlBytes, pipelines.AutoRAGImagePattern, override)
+		logger.Info("Replaced pipeline image with RELATED_IMAGE_ODH_AUTORAG_IMAGE",
+			"pipelineDir", def.PipelineDir, "overrideImage", override)
+	}
+
 	// Step 1: Find or create the pipeline shell
 	pipelineID, err := r.findOrCreatePipeline(client, ctx, namespace, pipelineName)
 	if err != nil {

--- a/packages/autorag/bff/internal/repositories/pipeline_test.go
+++ b/packages/autorag/bff/internal/repositories/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	ps "github.com/opendatahub-io/autorag-library/bff/internal/integrations/pipelineserver"
 	"github.com/opendatahub-io/autorag-library/bff/internal/integrations/pipelineserver/psmocks"
 	"github.com/opendatahub-io/autorag-library/bff/internal/models"
+	"github.com/opendatahub-io/autorag-library/bff/internal/pipelines"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,6 +40,18 @@ func (m *conflictVersionMockClient) ListPipelineVersions(_ context.Context, pipe
 		}, nil
 	}
 	return m.MockPipelineServerClient.ListPipelineVersions(context.Background(), pipelineID)
+}
+
+// capturingMockClient wraps MockPipelineServerClient and captures the YAML bytes passed to UploadPipelineVersion.
+type capturingMockClient struct {
+	*psmocks.MockPipelineServerClient
+	capturedYAML []byte
+}
+
+func (m *capturingMockClient) UploadPipelineVersion(ctx context.Context, pipelineID string, versionName string, fileContent []byte) (*models.KFPipelineVersion, error) {
+	m.capturedYAML = make([]byte, len(fileContent))
+	copy(m.capturedYAML, fileContent)
+	return m.MockPipelineServerClient.UploadPipelineVersion(ctx, pipelineID, versionName, fileContent)
 }
 
 func TestDiscoverNamedPipelines(t *testing.T) {
@@ -528,5 +541,53 @@ func TestEnsurePipeline(t *testing.T) {
 		assert.NotNil(t, discovered)
 		assert.True(t, mockClient.uploaded, "UploadPipelineVersion should have been called")
 		assert.Equal(t, "documents-rag-optimization-pipeline", discovered.PipelineName)
+	})
+
+	t.Run("should replace image when RELATED_IMAGE_ODH_AUTORAG_IMAGE is set", func(t *testing.T) {
+		overrideImage := "registry.redhat.io/rhoai/odh-autorag-rhel9@sha256:overridden"
+		t.Setenv("RELATED_IMAGE_ODH_AUTORAG_IMAGE", overrideImage)
+
+		namespace := "test-ns-ensure-image-override"
+		baseMock := psmocks.NewMockPipelineServerClient("http://mock-ps")
+		baseMock.PipelineNames = []string{"unrelated-pipeline"}
+		mockClient := &capturingMockClient{MockPipelineServerClient: baseMock}
+
+		def := PipelineDefinition{
+			Name:        "documents-rag-optimization-pipeline",
+			PipelineDir: "documents_rag_optimization_pipeline",
+		}
+
+		repo.InvalidateCache("http://mock-ps", namespace)
+
+		discovered, err := repo.EnsurePipeline(mockClient, ctx, namespace, "http://mock-ps", def)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, discovered)
+		assert.NotNil(t, mockClient.capturedYAML, "UploadPipelineVersion should have been called with YAML bytes")
+		assert.Contains(t, string(mockClient.capturedYAML), overrideImage)
+		assert.False(t, pipelines.AutoRAGImagePattern.Match(mockClient.capturedYAML), "original image pattern should not remain after override")
+	})
+
+	t.Run("should use default image when RELATED_IMAGE_ODH_AUTORAG_IMAGE is unset", func(t *testing.T) {
+		t.Setenv("RELATED_IMAGE_ODH_AUTORAG_IMAGE", "")
+
+		namespace := "test-ns-ensure-default-image"
+		baseMock := psmocks.NewMockPipelineServerClient("http://mock-ps")
+		baseMock.PipelineNames = []string{"unrelated-pipeline"}
+		mockClient := &capturingMockClient{MockPipelineServerClient: baseMock}
+
+		def := PipelineDefinition{
+			Name:        "documents-rag-optimization-pipeline",
+			PipelineDir: "documents_rag_optimization_pipeline",
+		}
+
+		repo.InvalidateCache("http://mock-ps", namespace)
+
+		discovered, err := repo.EnsurePipeline(mockClient, ctx, namespace, "http://mock-ps", def)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, discovered)
+		assert.NotNil(t, mockClient.capturedYAML, "UploadPipelineVersion should have been called with YAML bytes")
+		assert.True(t, pipelines.AutoRAGImagePattern.Match(mockClient.capturedYAML), "embedded default image should be preserved")
 	})
 }


### PR DESCRIPTION
Cherry pick to resolve 3.4.0 blocking issue in AutoRAG / AutoML

3.4.1 issue: https://redhat.atlassian.net/browse/RHOAIENG-64768

Original PR: https://github.com/opendatahub-io/odh-dashboard/pull/7743