### PR TITLE
feat(RHOAIENG-64647): add shared ext toolkit to plugin-core

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -12,6 +12,7 @@
   },
   "exports": {
     ".": "./src/core/index.ts",
+    "./helpers/ui": "./src/core/helpers/ui.ts",
     "./extension-points": "./src/extension-points/index.ts",
     "./testing": "./src/testing/utils.ts"
   },

--- a/packages/plugin-core/src/core/helpers/ExtensibleActions.tsx
+++ b/packages/plugin-core/src/core/helpers/ExtensibleActions.tsx
@@ -3,6 +3,7 @@ import { DropdownItem } from '@patternfly/react-core';
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 import { LazyCodeRefComponent } from './LazyCodeRefComponent';
 import type { ActionProperties } from '../../extension-points/actions';
+import { sortExtensionsByGroup } from '../../extension-points/utils';
 
 type ExtensibleActionsProps<TExtension extends Extension<string, ActionProperties>> = {
   /** Loaded action extensions (from `useExtensions`). */
@@ -25,15 +26,7 @@ export const ExtensibleActions = <TExtension extends Extension<string, ActionPro
   actions,
   componentProps,
 }: ExtensibleActionsProps<TExtension>): React.ReactElement => {
-  const sorted = React.useMemo(
-    () =>
-      actions.toSorted((a, b) => {
-        const groupA = a.properties.group ?? '';
-        const groupB = b.properties.group ?? '';
-        return groupA.localeCompare(groupB);
-      }),
-    [actions],
-  );
+  const sorted = React.useMemo(() => sortExtensionsByGroup(actions), [actions]);
 
   return (
     <>

--- a/packages/plugin-core/src/core/helpers/ExtensibleActions.tsx
+++ b/packages/plugin-core/src/core/helpers/ExtensibleActions.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { DropdownItem } from '@patternfly/react-core';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import { LazyCodeRefComponent } from './LazyCodeRefComponent';
+import type { ActionProperties } from '../../extension-points/actions';
+
+type ExtensibleActionsProps<TExtension extends Extension<string, ActionProperties>> = {
+  /** Loaded action extensions (from `useExtensions`). */
+  actions: LoadedExtension<TExtension>[];
+  /** Extra props passed to each lazy-loaded action component. */
+  componentProps?: Record<string, unknown>;
+};
+
+/**
+ * Renders DropdownItems from action extensions, sorted by group.
+ *
+ * @example
+ * ```tsx
+ * <DropdownList>
+ *   <ExtensibleActions actions={actionExtensions} componentProps={{ resourceId }} />
+ * </DropdownList>
+ * ```
+ */
+export const ExtensibleActions = <TExtension extends Extension<string, ActionProperties>>({
+  actions,
+  componentProps,
+}: ExtensibleActionsProps<TExtension>): React.ReactElement => {
+  const sorted = React.useMemo(
+    () =>
+      actions.toSorted((a, b) => {
+        const groupA = a.properties.group ?? '';
+        const groupB = b.properties.group ?? '';
+        return groupA.localeCompare(groupB);
+      }),
+    [actions],
+  );
+
+  return (
+    <>
+      {sorted.map((action) => (
+        <DropdownItem key={action.properties.id} data-testid={`action-${action.properties.id}`}>
+          <LazyCodeRefComponent component={action.properties.component} props={componentProps} />
+        </DropdownItem>
+      ))}
+    </>
+  );
+};

--- a/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
+++ b/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { Tab, Tabs, TabTitleText, PageSection } from '@patternfly/react-core';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import { LazyCodeRefComponent } from './LazyCodeRefComponent';
+import type { DetailTabProperties } from '../../extension-points/detail-tabs';
+
+const DEFAULT_GROUP = '5_default';
+
+type StaticTab = {
+  id: string;
+  title: string;
+  content: React.ReactNode;
+};
+
+type ExtensibleDetailTabsProps<TExtension extends Extension<string, DetailTabProperties>> = {
+  /** The currently active tab key (typically from URL params). */
+  activeKey: string;
+  /** Callback fired when a tab is selected. Receives the new tab key. */
+  onSelect: (tabKey: string) => void;
+  /** Static (built-in) tabs rendered before extension tabs. */
+  staticTabs?: StaticTab[];
+  /** Loaded extension tabs (from `useExtensions`). */
+  extensionTabs: LoadedExtension<TExtension>[];
+  /** Extra props passed to each lazy-loaded extension component. */
+  componentProps?: Record<string, unknown>;
+  /** Accessible label for the Tabs component. */
+  ariaLabel?: string;
+  /** data-testid for the Tabs component. */
+  testId?: string;
+  /**
+   * Optional callback to filter extensions (e.g. hide certain tabs in archive mode).
+   * Return `true` to include the extension, `false` to exclude.
+   */
+  filterExtension?: (extension: LoadedExtension<TExtension>) => boolean;
+};
+
+/**
+ * Renders PatternFly Tabs from a combination of static (built-in) tabs and
+ * dynamic extension tabs.
+ *
+ * Features:
+ * - Sorts extension tabs by `group` (lexicographic, defaulting to `'5_default'`)
+ * - Supports `filterExtension` callback to hide tabs conditionally (e.g. archive mode)
+ * - Single-tab mode: when only one tab exists (static + extension), renders its content
+ *   directly without a tab bar
+ * - Tab content for extensions is loaded lazily via `LazyCodeRefComponent`
+ */
+export const ExtensibleDetailTabs = <TExtension extends Extension<string, DetailTabProperties>>({
+  activeKey,
+  onSelect,
+  staticTabs = [],
+  extensionTabs,
+  componentProps,
+  ariaLabel = 'Detail tabs',
+  testId,
+  filterExtension,
+}: ExtensibleDetailTabsProps<TExtension>): React.ReactElement | null => {
+  const filteredExtensions = React.useMemo(
+    () =>
+      (filterExtension ? extensionTabs.filter(filterExtension) : extensionTabs).toSorted((a, b) => {
+        const groupA = a.properties.group ?? DEFAULT_GROUP;
+        const groupB = b.properties.group ?? DEFAULT_GROUP;
+        return groupA.localeCompare(groupB);
+      }),
+    [extensionTabs, filterExtension],
+  );
+
+  const allTabs = React.useMemo(
+    () => [
+      ...staticTabs.map((tab) => ({ type: 'static' as const, ...tab })),
+      ...filteredExtensions.map((ext) => ({
+        type: 'extension' as const,
+        id: ext.properties.id,
+        title: ext.properties.title,
+        extension: ext,
+      })),
+    ],
+    [staticTabs, filteredExtensions],
+  );
+
+  if (allTabs.length === 0) {
+    return null;
+  }
+
+  if (allTabs.length === 1) {
+    const singleTab = allTabs[0];
+    if (singleTab.type === 'static') {
+      return <>{singleTab.content}</>;
+    }
+    return (
+      <LazyCodeRefComponent
+        component={singleTab.extension.properties.component}
+        props={componentProps}
+      />
+    );
+  }
+
+  return (
+    <Tabs
+      activeKey={activeKey}
+      aria-label={ariaLabel}
+      role="region"
+      data-testid={testId}
+      onSelect={(_event, eventKey) => onSelect(String(eventKey))}
+    >
+      {allTabs.map((tab) =>
+        tab.type === 'static' ? (
+          <Tab
+            key={tab.id}
+            eventKey={tab.id}
+            title={<TabTitleText>{tab.title}</TabTitleText>}
+            aria-label={`${tab.title} tab`}
+            data-testid={`${tab.id}-tab`}
+          >
+            <PageSection hasBodyWrapper={false} isFilled data-testid={`${tab.id}-tab-content`}>
+              {tab.content}
+            </PageSection>
+          </Tab>
+        ) : (
+          <Tab
+            key={tab.id}
+            eventKey={tab.id}
+            title={<TabTitleText>{tab.title}</TabTitleText>}
+            aria-label={`${tab.title} tab`}
+            data-testid={`${tab.id}-tab`}
+          >
+            <PageSection hasBodyWrapper={false} isFilled data-testid={`${tab.id}-tab-content`}>
+              <LazyCodeRefComponent
+                component={tab.extension.properties.component}
+                props={componentProps}
+              />
+            </PageSection>
+          </Tab>
+        ),
+      )}
+    </Tabs>
+  );
+};

--- a/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
+++ b/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Tab, Tabs, TabTitleText, PageSection } from '@patternfly/react-core';
+import { Badge, Tab, Tabs, TabTitleText, PageSection } from '@patternfly/react-core';
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 import { LazyCodeRefComponent } from './LazyCodeRefComponent';
 import type { DetailTabProperties } from '../../extension-points/detail-tabs';
+import { sortExtensionsByGroup } from '../../extension-points/utils';
 
 const DEFAULT_GROUP = '5_default';
 
@@ -57,11 +58,10 @@ export const ExtensibleDetailTabs = <TExtension extends Extension<string, Detail
 }: ExtensibleDetailTabsProps<TExtension>): React.ReactElement | null => {
   const filteredExtensions = React.useMemo(
     () =>
-      (filterExtension ? extensionTabs.filter(filterExtension) : extensionTabs).toSorted((a, b) => {
-        const groupA = a.properties.group ?? DEFAULT_GROUP;
-        const groupB = b.properties.group ?? DEFAULT_GROUP;
-        return groupA.localeCompare(groupB);
-      }),
+      sortExtensionsByGroup(
+        filterExtension ? extensionTabs.filter(filterExtension) : extensionTabs,
+        DEFAULT_GROUP,
+      ),
     [extensionTabs, filterExtension],
   );
 
@@ -72,6 +72,7 @@ export const ExtensibleDetailTabs = <TExtension extends Extension<string, Detail
         type: 'extension' as const,
         id: ext.properties.id,
         title: ext.properties.title,
+        label: ext.properties.label,
         extension: ext,
       })),
     ],
@@ -103,36 +104,42 @@ export const ExtensibleDetailTabs = <TExtension extends Extension<string, Detail
       data-testid={testId}
       onSelect={(_event, eventKey) => onSelect(String(eventKey))}
     >
-      {allTabs.map((tab) =>
-        tab.type === 'static' ? (
+      {allTabs.map((tab) => {
+        const titleNode = (
+          <TabTitleText>
+            {tab.title}
+            {tab.type === 'extension' && tab.label != null && (
+              <>
+                {' '}
+                <Badge isRead>{tab.label}</Badge>
+              </>
+            )}
+          </TabTitleText>
+        );
+        const content =
+          tab.type === 'static' ? (
+            tab.content
+          ) : (
+            <LazyCodeRefComponent
+              component={tab.extension.properties.component}
+              props={componentProps}
+            />
+          );
+
+        return (
           <Tab
             key={tab.id}
             eventKey={tab.id}
-            title={<TabTitleText>{tab.title}</TabTitleText>}
+            title={titleNode}
             aria-label={`${tab.title} tab`}
             data-testid={`${tab.id}-tab`}
           >
             <PageSection hasBodyWrapper={false} isFilled data-testid={`${tab.id}-tab-content`}>
-              {tab.content}
+              {content}
             </PageSection>
           </Tab>
-        ) : (
-          <Tab
-            key={tab.id}
-            eventKey={tab.id}
-            title={<TabTitleText>{tab.title}</TabTitleText>}
-            aria-label={`${tab.title} tab`}
-            data-testid={`${tab.id}-tab`}
-          >
-            <PageSection hasBodyWrapper={false} isFilled data-testid={`${tab.id}-tab-content`}>
-              <LazyCodeRefComponent
-                component={tab.extension.properties.component}
-                props={componentProps}
-              />
-            </PageSection>
-          </Tab>
-        ),
-      )}
+        );
+      })}
     </Tabs>
   );
 };

--- a/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
+++ b/packages/plugin-core/src/core/helpers/ExtensibleDetailTabs.tsx
@@ -3,7 +3,7 @@ import { Badge, Tab, Tabs, TabTitleText, PageSection } from '@patternfly/react-c
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 import { LazyCodeRefComponent } from './LazyCodeRefComponent';
 import type { DetailTabProperties } from '../../extension-points/detail-tabs';
-import { sortExtensionsByGroup } from '../../extension-points/utils';
+import { isValidExtensionId, sortExtensionsByGroup } from '../../extension-points/utils';
 
 const DEFAULT_GROUP = '5_default';
 
@@ -59,7 +59,9 @@ export const ExtensibleDetailTabs = <TExtension extends Extension<string, Detail
   const filteredExtensions = React.useMemo(
     () =>
       sortExtensionsByGroup(
-        filterExtension ? extensionTabs.filter(filterExtension) : extensionTabs,
+        (filterExtension ? extensionTabs.filter(filterExtension) : extensionTabs).filter((ext) =>
+          isValidExtensionId(ext.properties.id),
+        ),
         DEFAULT_GROUP,
       ),
     [extensionTabs, filterExtension],

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
@@ -16,8 +16,9 @@ describe('ExtensibleActions', () => {
 
     render(<ExtensibleActions actions={actions} />);
 
-    expect(await screen.findByTestId('action-deploy')).toBeInTheDocument();
-    expect(screen.getByTestId('action-deploy').className).toContain('pf-v6-c-menu__list-item');
+    const element = await screen.findByTestId('action-deploy');
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass('pf-v6-c-menu__list-item');
   });
 
   it('should render multiple actions as DropdownItems', async () => {

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
@@ -1,31 +1,8 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
-import type { ActionProperties } from '../../../extension-points/actions';
+import { createMockActionExtension } from './mockExtensions';
 import { ExtensibleActions } from '../ExtensibleActions';
-
-type TestActionExtension = Extension<'test.header/action', ActionProperties>;
-
-const MockActionComponent: React.FC = () => <span data-testid="mock-action">Action</span>;
-
-const createMockAction = (
-  id: string,
-  label: string,
-  group?: string,
-): LoadedExtension<TestActionExtension> =>
-  ({
-    type: 'test.header/action',
-    properties: {
-      id,
-      label,
-      component: () => Promise.resolve({ default: MockActionComponent }),
-      group,
-    },
-    uid: `uid-${id}`,
-    pluginID: 'test-plugin',
-    pluginName: 'test-plugin',
-  } as unknown as LoadedExtension<TestActionExtension>);
 
 describe('ExtensibleActions', () => {
   it('should render nothing for empty actions', () => {
@@ -35,7 +12,7 @@ describe('ExtensibleActions', () => {
   });
 
   it('should wrap each action in a DropdownItem', async () => {
-    const actions = [createMockAction('deploy', 'Deploy')];
+    const actions = [createMockActionExtension('deploy', 'Deploy')];
 
     render(<ExtensibleActions actions={actions} />);
 
@@ -44,7 +21,10 @@ describe('ExtensibleActions', () => {
   });
 
   it('should render multiple actions as DropdownItems', async () => {
-    const actions = [createMockAction('deploy', 'Deploy'), createMockAction('archive', 'Archive')];
+    const actions = [
+      createMockActionExtension('deploy', 'Deploy'),
+      createMockActionExtension('archive', 'Archive'),
+    ];
 
     render(<ExtensibleActions actions={actions} />);
 
@@ -54,9 +34,9 @@ describe('ExtensibleActions', () => {
 
   it('should sort actions by group', () => {
     const actions = [
-      createMockAction('third', 'Third', '3_late'),
-      createMockAction('first', 'First', '1_early'),
-      createMockAction('second', 'Second', '2_middle'),
+      createMockActionExtension('third', 'Third', { group: '3_late' }),
+      createMockActionExtension('first', 'First', { group: '1_early' }),
+      createMockActionExtension('second', 'Second', { group: '2_middle' }),
     ];
 
     const { container } = render(<ExtensibleActions actions={actions} />);
@@ -69,7 +49,7 @@ describe('ExtensibleActions', () => {
   });
 
   it('should render lazy component content inside DropdownItem', async () => {
-    const actions = [createMockAction('deploy', 'Deploy')];
+    const actions = [createMockActionExtension('deploy', 'Deploy')];
 
     render(<ExtensibleActions actions={actions} />);
 

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleActions.spec.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { ActionProperties } from '../../../extension-points/actions';
+import { ExtensibleActions } from '../ExtensibleActions';
+
+type TestActionExtension = Extension<'test.header/action', ActionProperties>;
+
+const MockActionComponent: React.FC = () => <span data-testid="mock-action">Action</span>;
+
+const createMockAction = (
+  id: string,
+  label: string,
+  group?: string,
+): LoadedExtension<TestActionExtension> =>
+  ({
+    type: 'test.header/action',
+    properties: {
+      id,
+      label,
+      component: () => Promise.resolve({ default: MockActionComponent }),
+      group,
+    },
+    uid: `uid-${id}`,
+    pluginID: 'test-plugin',
+    pluginName: 'test-plugin',
+  } as unknown as LoadedExtension<TestActionExtension>);
+
+describe('ExtensibleActions', () => {
+  it('should render nothing for empty actions', () => {
+    const { container } = render(<ExtensibleActions actions={[]} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should wrap each action in a DropdownItem', async () => {
+    const actions = [createMockAction('deploy', 'Deploy')];
+
+    render(<ExtensibleActions actions={actions} />);
+
+    expect(await screen.findByTestId('action-deploy')).toBeInTheDocument();
+    expect(screen.getByTestId('action-deploy').className).toContain('pf-v6-c-menu__list-item');
+  });
+
+  it('should render multiple actions as DropdownItems', async () => {
+    const actions = [createMockAction('deploy', 'Deploy'), createMockAction('archive', 'Archive')];
+
+    render(<ExtensibleActions actions={actions} />);
+
+    expect(await screen.findByTestId('action-deploy')).toBeInTheDocument();
+    expect(screen.getByTestId('action-archive')).toBeInTheDocument();
+  });
+
+  it('should sort actions by group', () => {
+    const actions = [
+      createMockAction('third', 'Third', '3_late'),
+      createMockAction('first', 'First', '1_early'),
+      createMockAction('second', 'Second', '2_middle'),
+    ];
+
+    const { container } = render(<ExtensibleActions actions={actions} />);
+
+    const items = container.querySelectorAll('[data-testid^="action-"]');
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveAttribute('data-testid', 'action-first');
+    expect(items[1]).toHaveAttribute('data-testid', 'action-second');
+    expect(items[2]).toHaveAttribute('data-testid', 'action-third');
+  });
+
+  it('should render lazy component content inside DropdownItem', async () => {
+    const actions = [createMockAction('deploy', 'Deploy')];
+
+    render(<ExtensibleActions actions={actions} />);
+
+    const actionContent = await screen.findByTestId('mock-action');
+    expect(actionContent).toBeInTheDocument();
+    expect(actionContent.closest('[data-testid="action-deploy"]')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { DetailTabProperties } from '../../../extension-points/detail-tabs';
+import { ExtensibleDetailTabs } from '../ExtensibleDetailTabs';
+
+type TestTabExtension = Extension<'test.details/tab', DetailTabProperties>;
+
+const MockTabContent: React.FC = () => <div data-testid="mock-tab-content">Tab Content</div>;
+
+const createMockTabExtension = (
+  id: string,
+  title: string,
+  group?: string,
+): LoadedExtension<TestTabExtension> =>
+  ({
+    type: 'test.details/tab',
+    properties: {
+      id,
+      title,
+      component: () => Promise.resolve({ default: MockTabContent }),
+      group,
+    },
+    uid: `uid-${id}`,
+    pluginID: 'test-plugin',
+    pluginName: 'test-plugin',
+  } as unknown as LoadedExtension<TestTabExtension>);
+
+describe('ExtensibleDetailTabs', () => {
+  const defaultOnSelect = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null when no tabs exist', () => {
+    const { container } = render(
+      <ExtensibleDetailTabs activeKey="overview" onSelect={defaultOnSelect} extensionTabs={[]} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render single static tab content directly without tab bar', () => {
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div data-testid="overview-content">Overview Content</div>,
+          },
+        ]}
+        extensionTabs={[]}
+      />,
+    );
+
+    expect(screen.getByTestId('overview-content')).toBeInTheDocument();
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+  });
+
+  it('should render tab bar with multiple static tabs', () => {
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div data-testid="overview-inner">Overview content</div>,
+          },
+          {
+            id: 'versions',
+            title: 'Versions',
+            content: <div data-testid="versions-inner">Versions content</div>,
+          },
+        ]}
+        extensionTabs={[]}
+        testId="test-tabs"
+      />,
+    );
+
+    expect(screen.getByTestId('test-tabs')).toBeInTheDocument();
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('versions-tab')).toBeInTheDocument();
+  });
+
+  it('should render extension tabs alongside static tabs', () => {
+    const extensionTabs = [createMockTabExtension('deployments', 'Deployments')];
+
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div data-testid="overview-inner">Overview content</div>,
+          },
+        ]}
+        extensionTabs={extensionTabs}
+        testId="test-tabs"
+      />,
+    );
+
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('deployments-tab')).toBeInTheDocument();
+  });
+
+  it('should call onSelect when a tab is clicked', () => {
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div data-testid="overview-inner">Overview content</div>,
+          },
+          {
+            id: 'versions',
+            title: 'Versions',
+            content: <div data-testid="versions-inner">Versions content</div>,
+          },
+        ]}
+        extensionTabs={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('versions-tab'));
+    expect(defaultOnSelect).toHaveBeenCalledWith('versions');
+  });
+
+  it('should filter extension tabs using filterExtension callback', () => {
+    const extensionTabs = [
+      createMockTabExtension('deployments', 'Deployments'),
+      createMockTabExtension('hidden', 'Hidden'),
+    ];
+
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div data-testid="overview-inner">Overview content</div>,
+          },
+        ]}
+        extensionTabs={extensionTabs}
+        filterExtension={(ext) => ext.properties.id !== 'hidden'}
+        testId="test-tabs"
+      />,
+    );
+
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('deployments-tab')).toBeInTheDocument();
+    expect(screen.queryByTestId('hidden-tab')).not.toBeInTheDocument();
+  });
+
+  it('should apply custom ariaLabel', () => {
+    render(
+      <ExtensibleDetailTabs
+        activeKey="tab-1"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          { id: 'tab-1', title: 'Tab 1', content: <div>Content 1</div> },
+          { id: 'tab-2', title: 'Tab 2', content: <div>Content 2</div> },
+        ]}
+        extensionTabs={[]}
+        ariaLabel="Model details tabs"
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: 'Model details tabs' })).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
@@ -39,6 +39,21 @@ describe('ExtensibleDetailTabs', () => {
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
   });
 
+  it('should render single extension tab content directly without tab bar', async () => {
+    const extensionTabs = [createMockTabExtension('deployments', 'Deployments')];
+
+    render(
+      <ExtensibleDetailTabs
+        activeKey="deployments"
+        onSelect={defaultOnSelect}
+        extensionTabs={extensionTabs}
+      />,
+    );
+
+    expect(await screen.findByTestId('mock-tab-content')).toBeInTheDocument();
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+  });
+
   it('should render tab bar with multiple static tabs', () => {
     render(
       <ExtensibleDetailTabs

--- a/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/ExtensibleDetailTabs.spec.tsx
@@ -1,31 +1,8 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
-import type { DetailTabProperties } from '../../../extension-points/detail-tabs';
+import { createMockTabExtension } from './mockExtensions';
 import { ExtensibleDetailTabs } from '../ExtensibleDetailTabs';
-
-type TestTabExtension = Extension<'test.details/tab', DetailTabProperties>;
-
-const MockTabContent: React.FC = () => <div data-testid="mock-tab-content">Tab Content</div>;
-
-const createMockTabExtension = (
-  id: string,
-  title: string,
-  group?: string,
-): LoadedExtension<TestTabExtension> =>
-  ({
-    type: 'test.details/tab',
-    properties: {
-      id,
-      title,
-      component: () => Promise.resolve({ default: MockTabContent }),
-      group,
-    },
-    uid: `uid-${id}`,
-    pluginID: 'test-plugin',
-    pluginName: 'test-plugin',
-  } as unknown as LoadedExtension<TestTabExtension>);
 
 describe('ExtensibleDetailTabs', () => {
   const defaultOnSelect = jest.fn();
@@ -180,5 +157,51 @@ describe('ExtensibleDetailTabs', () => {
     );
 
     expect(screen.getByRole('region', { name: 'Model details tabs' })).toBeInTheDocument();
+  });
+
+  it('should render Badge when extension has a label', () => {
+    const extensionTabs = [createMockTabExtension('metrics', 'Metrics', { label: '3' })];
+
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div>Overview</div>,
+          },
+        ]}
+        extensionTabs={extensionTabs}
+        testId="test-tabs"
+      />,
+    );
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('3').closest('.pf-v6-c-badge')).toBeInTheDocument();
+  });
+
+  it('should not render Badge when extension label is undefined', () => {
+    const extensionTabs = [createMockTabExtension('metrics', 'Metrics')];
+
+    render(
+      <ExtensibleDetailTabs
+        activeKey="overview"
+        onSelect={defaultOnSelect}
+        staticTabs={[
+          {
+            id: 'overview',
+            title: 'Overview',
+            content: <div>Overview</div>,
+          },
+        ]}
+        extensionTabs={extensionTabs}
+        testId="test-tabs"
+      />,
+    );
+
+    expect(screen.getByTestId('metrics-tab')).toBeInTheDocument();
+    expect(document.querySelector('.pf-v6-c-badge')).toBeNull();
   });
 });

--- a/packages/plugin-core/src/core/helpers/__tests__/generateExtensionTabRoutes.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/generateExtensionTabRoutes.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { DetailTabProperties } from '../../../extension-points/detail-tabs';
+import { generateExtensionTabRoutes } from '../generateExtensionTabRoutes';
+
+type TestTabExtension = Extension<'test.details/tab', DetailTabProperties>;
+
+const createMockTabExtension = (id: string, title: string): LoadedExtension<TestTabExtension> =>
+  ({
+    type: 'test.details/tab',
+    properties: {
+      id,
+      title,
+      component: () => Promise.resolve({ default: () => null }),
+    },
+    uid: `uid-${id}`,
+    pluginID: 'test-plugin',
+    pluginName: 'test-plugin',
+  } as unknown as LoadedExtension<TestTabExtension>);
+
+describe('generateExtensionTabRoutes', () => {
+  it('should generate a route for each tab extension', () => {
+    const tabExtensions = [
+      createMockTabExtension('overview', 'Overview'),
+      createMockTabExtension('details', 'Details'),
+    ];
+
+    const routes = generateExtensionTabRoutes({
+      tabExtensions,
+      renderElement: (tabId) => <div data-testid={`content-${tabId}`} />,
+    });
+
+    expect(routes).toHaveLength(2);
+    expect(routes[0].key).toBe('overview');
+    expect(routes[1].key).toBe('details');
+  });
+
+  it('should use extension id as the route path', () => {
+    const tabExtensions = [createMockTabExtension('deployments', 'Deployments')];
+
+    const routes = generateExtensionTabRoutes({
+      tabExtensions,
+      renderElement: (tabId) => <div>{tabId}</div>,
+    });
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0].props.path).toBe('deployments');
+  });
+
+  it('should pass the tab id to renderElement', () => {
+    const renderElement = jest.fn((tabId: string) => <div>{tabId}</div>);
+    const tabExtensions = [createMockTabExtension('metrics', 'Metrics')];
+
+    generateExtensionTabRoutes({
+      tabExtensions,
+      renderElement,
+    });
+
+    expect(renderElement).toHaveBeenCalledWith('metrics');
+  });
+
+  it('should return empty array for empty extensions', () => {
+    const routes = generateExtensionTabRoutes({
+      tabExtensions: [],
+      renderElement: () => <div />,
+    });
+
+    expect(routes).toHaveLength(0);
+  });
+});

--- a/packages/plugin-core/src/core/helpers/__tests__/generateExtensionTabRoutes.spec.tsx
+++ b/packages/plugin-core/src/core/helpers/__tests__/generateExtensionTabRoutes.spec.tsx
@@ -1,22 +1,6 @@
 import * as React from 'react';
-import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
-import type { DetailTabProperties } from '../../../extension-points/detail-tabs';
+import { createMockTabExtension } from './mockExtensions';
 import { generateExtensionTabRoutes } from '../generateExtensionTabRoutes';
-
-type TestTabExtension = Extension<'test.details/tab', DetailTabProperties>;
-
-const createMockTabExtension = (id: string, title: string): LoadedExtension<TestTabExtension> =>
-  ({
-    type: 'test.details/tab',
-    properties: {
-      id,
-      title,
-      component: () => Promise.resolve({ default: () => null }),
-    },
-    uid: `uid-${id}`,
-    pluginID: 'test-plugin',
-    pluginName: 'test-plugin',
-  } as unknown as LoadedExtension<TestTabExtension>);
 
 describe('generateExtensionTabRoutes', () => {
   it('should generate a route for each tab extension', () => {
@@ -66,5 +50,22 @@ describe('generateExtensionTabRoutes', () => {
     });
 
     expect(routes).toHaveLength(0);
+  });
+
+  it('should skip extensions with route-unsafe IDs', () => {
+    const tabExtensions = [
+      createMockTabExtension('valid-tab', 'Valid'),
+      createMockTabExtension(':param', 'Param'),
+      createMockTabExtension('path/nested', 'Nested'),
+      createMockTabExtension('wild*', 'Wild'),
+    ];
+
+    const routes = generateExtensionTabRoutes({
+      tabExtensions,
+      renderElement: (tabId) => <div>{tabId}</div>,
+    });
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0].key).toBe('valid-tab');
   });
 });

--- a/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
+++ b/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
@@ -16,34 +16,38 @@ export const createMockTabExtension = (
   id: string,
   title: string,
   overrides?: Partial<DetailTabProperties>,
-): LoadedExtension<TestTabExtension> =>
-  ({
+): LoadedExtension<TestTabExtension> => {
+  const properties: DetailTabProperties = {
+    id,
+    title,
+    component: () => Promise.resolve({ default: MockTabContent }),
+    ...overrides,
+  };
+  return {
     type: 'test.details/tab',
-    properties: {
-      id,
-      title,
-      component: () => Promise.resolve({ default: MockTabContent }),
-      ...overrides,
-    },
+    properties,
     uid: `uid-${id}`,
     pluginID: 'test-plugin',
     pluginName: 'test-plugin',
-  } as unknown as LoadedExtension<TestTabExtension>);
+  } as LoadedExtension<TestTabExtension>;
+};
 
 export const createMockActionExtension = (
   id: string,
   label: string,
   overrides?: Partial<ActionProperties>,
-): LoadedExtension<TestActionExtension> =>
-  ({
+): LoadedExtension<TestActionExtension> => {
+  const properties: ActionProperties = {
+    id,
+    label,
+    component: () => Promise.resolve({ default: MockActionComponent }),
+    ...overrides,
+  };
+  return {
     type: 'test.header/action',
-    properties: {
-      id,
-      label,
-      component: () => Promise.resolve({ default: MockActionComponent }),
-      ...overrides,
-    },
+    properties,
     uid: `uid-${id}`,
     pluginID: 'test-plugin',
     pluginName: 'test-plugin',
-  } as unknown as LoadedExtension<TestActionExtension>);
+  } as LoadedExtension<TestActionExtension>;
+};

--- a/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
+++ b/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
@@ -27,9 +27,8 @@ export const createMockTabExtension = (
     type: 'test.details/tab',
     properties,
     uid: `uid-${id}`,
-    pluginID: 'test-plugin',
     pluginName: 'test-plugin',
-  } as LoadedExtension<TestTabExtension>;
+  } satisfies LoadedExtension<TestTabExtension>;
 };
 
 export const createMockActionExtension = (
@@ -47,7 +46,6 @@ export const createMockActionExtension = (
     type: 'test.header/action',
     properties,
     uid: `uid-${id}`,
-    pluginID: 'test-plugin',
     pluginName: 'test-plugin',
-  } as LoadedExtension<TestActionExtension>;
+  } satisfies LoadedExtension<TestActionExtension>;
 };

--- a/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
+++ b/packages/plugin-core/src/core/helpers/__tests__/mockExtensions.ts
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { DetailTabProperties } from '../../../extension-points/detail-tabs';
+import type { ActionProperties } from '../../../extension-points/actions';
+
+type TestTabExtension = Extension<'test.details/tab', DetailTabProperties>;
+type TestActionExtension = Extension<'test.header/action', ActionProperties>;
+
+const MockTabContent: React.FC = () =>
+  React.createElement('div', { 'data-testid': 'mock-tab-content' }, 'Tab Content');
+
+const MockActionComponent: React.FC = () =>
+  React.createElement('span', { 'data-testid': 'mock-action' }, 'Action');
+
+export const createMockTabExtension = (
+  id: string,
+  title: string,
+  overrides?: Partial<DetailTabProperties>,
+): LoadedExtension<TestTabExtension> =>
+  ({
+    type: 'test.details/tab',
+    properties: {
+      id,
+      title,
+      component: () => Promise.resolve({ default: MockTabContent }),
+      ...overrides,
+    },
+    uid: `uid-${id}`,
+    pluginID: 'test-plugin',
+    pluginName: 'test-plugin',
+  } as unknown as LoadedExtension<TestTabExtension>);
+
+export const createMockActionExtension = (
+  id: string,
+  label: string,
+  overrides?: Partial<ActionProperties>,
+): LoadedExtension<TestActionExtension> =>
+  ({
+    type: 'test.header/action',
+    properties: {
+      id,
+      label,
+      component: () => Promise.resolve({ default: MockActionComponent }),
+      ...overrides,
+    },
+    uid: `uid-${id}`,
+    pluginID: 'test-plugin',
+    pluginName: 'test-plugin',
+  } as unknown as LoadedExtension<TestActionExtension>);

--- a/packages/plugin-core/src/core/helpers/generateExtensionTabRoutes.tsx
+++ b/packages/plugin-core/src/core/helpers/generateExtensionTabRoutes.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Route } from 'react-router-dom';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { DetailTabProperties } from '../../extension-points/detail-tabs';
+
+type GenerateExtensionTabRoutesOptions<TExtension extends Extension<string, DetailTabProperties>> =
+  {
+    /** Loaded tab extensions (from `useExtensions`). */
+    tabExtensions: LoadedExtension<TExtension>[];
+    /**
+     * A React element to render as the route content for each tab.
+     * Receives the extension's `id` as the `tab` prop and `empty` set to `false`.
+     */
+    renderElement: (tabId: string) => React.ReactElement;
+  };
+
+/**
+ * Generates `<Route>` elements for tab extensions.
+ *
+ * Each route uses the extension's `id` as the URL path segment.
+ * The `renderElement` callback controls what is rendered for each tab route.
+ *
+ * This replaces bespoke route generators like `DetailsTabExtensionRoutes.tsx`
+ * and `VersionDetailsTabExtensionRoutes.tsx` with a single generic utility.
+ *
+ * @example
+ * ```tsx
+ * <Routes>
+ *   <Route path="overview" element={<OverviewPage />} />
+ *   {generateExtensionTabRoutes({
+ *     tabExtensions,
+ *     renderElement: (tabId) => <DetailsPage tab={tabId} empty={false} />,
+ *   })}
+ * </Routes>
+ * ```
+ */
+export const generateExtensionTabRoutes = <
+  TExtension extends Extension<string, DetailTabProperties>,
+>({
+  tabExtensions,
+  renderElement,
+}: GenerateExtensionTabRoutesOptions<TExtension>): React.ReactElement[] =>
+  tabExtensions.map((extension) => (
+    <Route
+      key={extension.properties.id}
+      path={extension.properties.id}
+      element={renderElement(extension.properties.id)}
+    />
+  ));

--- a/packages/plugin-core/src/core/helpers/generateExtensionTabRoutes.tsx
+++ b/packages/plugin-core/src/core/helpers/generateExtensionTabRoutes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Route } from 'react-router-dom';
 import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
 import type { DetailTabProperties } from '../../extension-points/detail-tabs';
+import { isValidExtensionId } from '../../extension-points/utils';
 
 type GenerateExtensionTabRoutesOptions<TExtension extends Extension<string, DetailTabProperties>> =
   {
@@ -18,6 +19,8 @@ type GenerateExtensionTabRoutesOptions<TExtension extends Extension<string, Deta
  * Generates `<Route>` elements for tab extensions.
  *
  * Each route uses the extension's `id` as the URL path segment.
+ * IDs containing route-significant characters (`:`, `*`, `/`) are
+ * skipped to prevent unintended React Router matching semantics.
  * The `renderElement` callback controls what is rendered for each tab route.
  *
  * This replaces bespoke route generators like `DetailsTabExtensionRoutes.tsx`
@@ -40,10 +43,12 @@ export const generateExtensionTabRoutes = <
   tabExtensions,
   renderElement,
 }: GenerateExtensionTabRoutesOptions<TExtension>): React.ReactElement[] =>
-  tabExtensions.map((extension) => (
-    <Route
-      key={extension.properties.id}
-      path={extension.properties.id}
-      element={renderElement(extension.properties.id)}
-    />
-  ));
+  tabExtensions
+    .filter((extension) => isValidExtensionId(extension.properties.id))
+    .map((extension) => (
+      <Route
+        key={extension.properties.id}
+        path={extension.properties.id}
+        element={renderElement(extension.properties.id)}
+      />
+    ));

--- a/packages/plugin-core/src/core/helpers/index.ts
+++ b/packages/plugin-core/src/core/helpers/index.ts
@@ -1,2 +1,5 @@
 export * from './HookNotify';
 export * from './LazyCodeRefComponent';
+export * from './ExtensibleDetailTabs';
+export * from './ExtensibleActions';
+export * from './generateExtensionTabRoutes';

--- a/packages/plugin-core/src/core/helpers/index.ts
+++ b/packages/plugin-core/src/core/helpers/index.ts
@@ -1,5 +1,3 @@
 export * from './HookNotify';
 export * from './LazyCodeRefComponent';
-export * from './ExtensibleDetailTabs';
-export * from './ExtensibleActions';
 export * from './generateExtensionTabRoutes';

--- a/packages/plugin-core/src/core/helpers/ui.ts
+++ b/packages/plugin-core/src/core/helpers/ui.ts
@@ -1,0 +1,2 @@
+export * from './ExtensibleDetailTabs';
+export * from './ExtensibleActions';

--- a/packages/plugin-core/src/extension-points/__tests__/utils.spec.ts
+++ b/packages/plugin-core/src/extension-points/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 import type { Extension } from '@openshift/dynamic-plugin-sdk';
-import { createExtensionGuard } from '../utils';
+import { createExtensionGuard, isValidExtensionId } from '../utils';
 
 type FakeTabExtension = Extension<
   'test.details/tab',
@@ -71,4 +71,44 @@ describe('createExtensionGuard', () => {
 
     expect(guard(extension)).toBe(false);
   });
+
+  it('should return false when properties is null or undefined', () => {
+    const guard = createExtensionGuard<FakeTabExtension>('test.details/tab');
+
+    expect(guard({ type: 'test.details/tab', properties: null } as unknown as Extension)).toBe(
+      false,
+    );
+    expect(guard({ type: 'test.details/tab', properties: undefined } as unknown as Extension)).toBe(
+      false,
+    );
+  });
+
+  it('should accept a propertiesValidator and reject invalid properties', () => {
+    const guard = createExtensionGuard<FakeTabExtension>(
+      'test.details/tab',
+      (p): p is FakeTabExtension['properties'] =>
+        typeof (p as Record<string, unknown>).id === 'string' &&
+        typeof (p as Record<string, unknown>).title === 'string',
+    );
+
+    expect(guard({ type: 'test.details/tab', properties: { id: 'tab-1', title: 'Tab 1' } })).toBe(
+      true,
+    );
+    expect(
+      guard({ type: 'test.details/tab', properties: { id: 123 } } as unknown as Extension),
+    ).toBe(false);
+  });
+});
+
+describe('isValidExtensionId', () => {
+  it.each(['foo', 'my-tab', 'tab_1'])('should return true for safe id "%s"', (id) => {
+    expect(isValidExtensionId(id)).toBe(true);
+  });
+
+  it.each(['foo/bar', ':param', '*', 'tab with spaces', ''])(
+    'should return false for unsafe id "%s"',
+    (id) => {
+      expect(isValidExtensionId(id)).toBe(false);
+    },
+  );
 });

--- a/packages/plugin-core/src/extension-points/__tests__/utils.spec.ts
+++ b/packages/plugin-core/src/extension-points/__tests__/utils.spec.ts
@@ -1,0 +1,74 @@
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import { createExtensionGuard } from '../utils';
+
+type FakeTabExtension = Extension<
+  'test.details/tab',
+  {
+    id: string;
+    title: string;
+  }
+>;
+
+type FakeActionExtension = Extension<
+  'test.header/action',
+  {
+    id: string;
+    label: string;
+  }
+>;
+
+describe('createExtensionGuard', () => {
+  it('should return true for matching extension type', () => {
+    const isFakeTab = createExtensionGuard<FakeTabExtension>('test.details/tab');
+    const extension: Extension = {
+      type: 'test.details/tab',
+      properties: { id: 'tab-1', title: 'Tab 1' },
+    };
+
+    expect(isFakeTab(extension)).toBe(true);
+  });
+
+  it('should return false for non-matching extension type', () => {
+    const isFakeTab = createExtensionGuard<FakeTabExtension>('test.details/tab');
+    const extension: Extension = {
+      type: 'other.extension/type',
+      properties: { id: 'other', title: 'Other' },
+    };
+
+    expect(isFakeTab(extension)).toBe(false);
+  });
+
+  it('should narrow the type when used as a predicate', () => {
+    const isFakeAction = createExtensionGuard<FakeActionExtension>('test.header/action');
+    const extensions: Extension[] = [
+      { type: 'test.header/action', properties: { id: 'a1', label: 'Action 1' } },
+      { type: 'test.details/tab', properties: { id: 'tab-1', title: 'Tab 1' } },
+      { type: 'test.header/action', properties: { id: 'a2', label: 'Action 2' } },
+    ];
+
+    const filtered = extensions.filter(isFakeAction);
+    expect(filtered).toHaveLength(2);
+    expect(filtered[0].properties.id).toBe('a1');
+    expect(filtered[1].properties.id).toBe('a2');
+  });
+
+  it('should return false for empty type string', () => {
+    const guard = createExtensionGuard<FakeTabExtension>('');
+    const extension: Extension = {
+      type: 'test.details/tab',
+      properties: { id: 'tab-1', title: 'Tab 1' },
+    };
+
+    expect(guard(extension)).toBe(false);
+  });
+
+  it('should handle case-sensitive type matching', () => {
+    const guard = createExtensionGuard<FakeTabExtension>('test.details/tab');
+    const extension: Extension = {
+      type: 'Test.Details/Tab',
+      properties: { id: 'tab-1', title: 'Tab 1' },
+    };
+
+    expect(guard(extension)).toBe(false);
+  });
+});

--- a/packages/plugin-core/src/extension-points/actions.ts
+++ b/packages/plugin-core/src/extension-points/actions.ts
@@ -1,0 +1,24 @@
+import type { ComponentCodeRef } from '../core/types';
+
+/**
+ * Reusable base properties for any action extension point
+ * (header actions, table row actions, etc.).
+ *
+ * @example
+ * ```ts
+ * type MyActionExtension = Extension<
+ *   'my-package.header/action',
+ *   ActionProperties & { customField?: boolean }
+ * >;
+ * ```
+ */
+export type ActionProperties = {
+  /** A unique identifier for this action. */
+  id: string;
+  /** The display label for the action. */
+  label: string;
+  /** The component to render for this action. */
+  component: ComponentCodeRef;
+  /** Group used to sort actions lexicographically. */
+  group?: string;
+};

--- a/packages/plugin-core/src/extension-points/detail-cards.ts
+++ b/packages/plugin-core/src/extension-points/detail-cards.ts
@@ -1,0 +1,17 @@
+import type { ComponentCodeRef } from '../core/types';
+
+/**
+ * Reusable base properties for any detail-card extension point.
+ *
+ * @example
+ * ```ts
+ * type MyDetailCardExtension = Extension<
+ *   'my-package.details/card',
+ *   DetailCardProperties
+ * >;
+ * ```
+ */
+export type DetailCardProperties = {
+  /** The component to render as the detail card content. */
+  component: ComponentCodeRef;
+};

--- a/packages/plugin-core/src/extension-points/detail-tabs.ts
+++ b/packages/plugin-core/src/extension-points/detail-tabs.ts
@@ -1,0 +1,28 @@
+import type { ComponentCodeRef } from '../core/types';
+
+/**
+ * Reusable base properties for any tab extension point.
+ *
+ * Packages define their own tab extensions by intersecting these properties
+ * with any extra fields specific to their domain.
+ *
+ * @example
+ * ```ts
+ * type MyDetailsTabExtension = Extension<
+ *   'my-package.details/tab',
+ *   DetailTabProperties & { extraProp?: string }
+ * >;
+ * ```
+ */
+export type DetailTabProperties = {
+  /** A unique identifier for this tab. */
+  id: string;
+  /** The display title for the tab. */
+  title: string;
+  /** The component to render as tab content. */
+  component: ComponentCodeRef;
+  /** Group used to sort tabs lexicographically. Unspecified tabs are placed in `'5_default'`. */
+  group?: string;
+  /** Optional label badge displayed alongside the tab title. */
+  label?: string;
+};

--- a/packages/plugin-core/src/extension-points/index.ts
+++ b/packages/plugin-core/src/extension-points/index.ts
@@ -11,6 +11,15 @@ export * from './tasks';
 // RHAII app-shell — consumed by distributions/base only (convergence with RHOAI is a future goal)
 export * from './masthead';
 
+// Shared base property types — reusable building blocks for package-level extension points
+export * from './detail-tabs';
+export * from './actions';
+export * from './detail-cards';
+export * from './table-columns';
+
+// Utilities
+export * from './utils';
+
 /**
  * ## Extension Point Definitions
  *

--- a/packages/plugin-core/src/extension-points/table-columns.ts
+++ b/packages/plugin-core/src/extension-points/table-columns.ts
@@ -1,0 +1,17 @@
+import type { ComponentCodeRef } from '../core/types';
+
+/**
+ * Reusable base properties for any table-column extension point.
+ *
+ * @example
+ * ```ts
+ * type MyTableColumnExtension = Extension<
+ *   'my-package.table/column',
+ *   TableColumnProperties
+ * >;
+ * ```
+ */
+export type TableColumnProperties = {
+  /** The component to render as the column cell content. */
+  component: ComponentCodeRef;
+};

--- a/packages/plugin-core/src/extension-points/utils.ts
+++ b/packages/plugin-core/src/extension-points/utils.ts
@@ -1,5 +1,24 @@
 import type { Extension, ExtensionPredicate } from '@openshift/dynamic-plugin-sdk';
 
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Returns `true` when `id` contains only URL-safe literal characters
+ * (`A-Z`, `a-z`, `0-9`, `_`, `-`) and is therefore safe to use as a
+ * React Router `<Route path>` segment without altering matching semantics.
+ */
+export const isValidExtensionId = (id: string): boolean => SAFE_PATH_SEGMENT.test(id);
+
+export const sortExtensionsByGroup = <T extends { properties: { group?: string } }>(
+  extensions: readonly T[],
+  defaultGroup = '',
+): T[] =>
+  extensions.toSorted((a, b) => {
+    const groupA = a.properties.group ?? defaultGroup;
+    const groupB = b.properties.group ?? defaultGroup;
+    return groupA.localeCompare(groupB);
+  });
+
 /**
  * Creates a type-guard function for a given extension type string.
  *
@@ -12,14 +31,35 @@ import type { Extension, ExtensionPredicate } from '@openshift/dynamic-plugin-sd
  * Usage:
  * ```ts
  * export const isFooExtension = createExtensionGuard<FooExtension>('namespace.foo/bar');
+ *
+ * // With runtime properties validation:
+ * export const isFooExtension = createExtensionGuard<FooExtension>(
+ *   'namespace.foo/bar',
+ *   (p): p is FooProperties => typeof p.id === 'string' && typeof p.title === 'string',
+ * );
  * ```
  *
  * @param type - The extension type string to match.
+ * @param propertiesValidator - Optional runtime validator for `e.properties`.
+ *   When omitted the guard still verifies that `properties` is a non-null object.
  * @returns A type-guard (predicate) function compatible with `useExtensions` / `useResolvedExtensions`.
  */
 export const createExtensionGuard = <TExtension extends Extension>(
   type: string,
+  propertiesValidator?: (properties: unknown) => properties is TExtension['properties'],
 ): ExtensionPredicate<TExtension> => {
-  const guard = (e: Extension): e is TExtension => e.type === type;
+  const guard = (e: Extension): e is TExtension => {
+    if (e.type !== type) {
+      return false;
+    }
+    const props: unknown = e.properties;
+    if (typeof props !== 'object' || props == null) {
+      return false;
+    }
+    if (propertiesValidator && !propertiesValidator(props)) {
+      return false;
+    }
+    return true;
+  };
   return guard;
 };

--- a/packages/plugin-core/src/extension-points/utils.ts
+++ b/packages/plugin-core/src/extension-points/utils.ts
@@ -1,0 +1,25 @@
+import type { Extension, ExtensionPredicate } from '@openshift/dynamic-plugin-sdk';
+
+/**
+ * Creates a type-guard function for a given extension type string.
+ *
+ * Eliminates the repetitive pattern:
+ * ```ts
+ * export const isFooExtension = (e: Extension): e is FooExtension =>
+ *   e.type === 'namespace.foo/bar';
+ * ```
+ *
+ * Usage:
+ * ```ts
+ * export const isFooExtension = createExtensionGuard<FooExtension>('namespace.foo/bar');
+ * ```
+ *
+ * @param type - The extension type string to match.
+ * @returns A type-guard (predicate) function compatible with `useExtensions` / `useResolvedExtensions`.
+ */
+export const createExtensionGuard = <TExtension extends Extension>(
+  type: string,
+): ExtensionPredicate<TExtension> => {
+  const guard = (e: Extension): e is TExtension => e.type === type;
+  return guard;
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-64647

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Adds a shared extension toolkit to `plugin-core` so packages can define and consume extension points without duplicating boilerplate.

**What was added:**
- **Base property types** (`DetailTabProperties`, `ActionProperties`, `DetailCardProperties`, `TableColumnProperties`) — reusable type building blocks that packages intersect with their own domain-specific fields when defining extension points.
- **`createExtensionGuard` factory** — a one-liner that replaces the repetitive `(e: Extension): e is T => e.type === '...'` pattern with a generic, type-safe guard compatible with `useExtensions` / `useResolvedExtensions`.
- **`ExtensibleDetailTabs`** — a PatternFly Tabs consumer component that merges static (built-in) tabs with dynamic extension tabs, supports group-based sorting, a `filterExtension` callback, and single-tab mode (renders content directly without the tab bar when only one tab exists).
- **`ExtensibleActions`** — renders action extensions as sorted `DropdownItem` elements with lazy-loaded content via `LazyCodeRefComponent`.
- **`generateExtensionTabRoutes`** — generates `<Route>` elements from tab extensions using a caller-provided `renderElement` factory, replacing bespoke route generators.

All new code lives in `packages/plugin-core/src/extension-points/` (types + utils) and `packages/plugin-core/src/core/helpers/` (consumer components). Barrel exports were updated in both `index.ts` files. No existing consuming code was changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 21 new unit tests across 4 test files covering all new modules
- All 29 plugin-core tests pass (8 suites)
- TypeScript compiles without errors on production files
- `createExtensionGuard`: type matching, non-matching, filtering arrays, empty string, case sensitivity
- `ExtensibleDetailTabs`: empty state, single-tab mode, multi-tab rendering, extension + static tabs, onSelect callback, filterExtension, custom ariaLabel
- `ExtensibleActions`: empty state, DropdownItem wrapping, multiple actions, group sorting, lazy component loading
- `generateExtensionTabRoutes`: route generation, path correctness, renderElement callback, empty extensions

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
- 21 new unit tests added (4 new spec files)
- No existing tests modified
- Full plugin-core suite: 8 suites, 29 tests — all passing

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
**N/A — this is an infrastructure/toolkit change with no direct UI impact.**

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loadable, sortable extension actions and detail tabs with optional badges, single-tab inline rendering, accessible tablists, and a helper to generate routes for extension tabs.

* **Utilities**
  * ID validation, stable grouping/sorting, and a factory for type-safe extension guards/filters.

* **Types**
  * Shared base property types for actions, detail tabs, detail cards, and table columns.

* **Tests**
  * Comprehensive tests and mocks for components, routing helper, utilities, and guards.

* **Chores**
  * New public UI re-exports and package export for helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->