### PR TITLE
feat(dashboard-operator): migrate CRD API group and add platform contract

### DIFF
--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -140,7 +140,9 @@ type DashboardStatus struct {
 	common.Status                 `json:",inline"`
 	common.ComponentReleaseStatus `json:",inline"`
 
-	// URL is the externally-reachable dashboard URL.
+	// URL is the externally-reachable dashboard URL (last known good).
+	// This value persists across transient route failures — consumers must
+	// check the Ready condition before relying on this endpoint.
 	// +optional
 	URL string `json:"url,omitempty"`
 

--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	DashboardComponentName = "dashboard"
-	DashboardInstanceName  = "default-dashboard"
+	DashboardInstanceName  = "default"
 	DashboardKind          = "Dashboard"
 )
 
@@ -158,7 +158,7 @@ type DashboardStatus struct {
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-dashboard'",message="Dashboard name must be default-dashboard"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="Dashboard name must be default"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.observability) || !self.spec.observability.enabled || has(self.spec.observability.persesService)",message="persesService must be specified when observability is enabled"
 
 // Dashboard is the Schema for the dashboards API.

--- a/dashboard-operator/api/v1alpha1/dashboard_types_test.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types_test.go
@@ -69,7 +69,7 @@ func TestDashboard_GetSetReleaseStatus(t *testing.T) {
 }
 
 func TestDashboard_Constants(t *testing.T) {
-	assert.Equal(t, "default-dashboard", v1alpha1.DashboardInstanceName)
+	assert.Equal(t, "default", v1alpha1.DashboardInstanceName)
 	assert.Equal(t, "Dashboard", v1alpha1.DashboardKind)
 	assert.Equal(t, "dashboard", v1alpha1.DashboardComponentName)
 }

--- a/dashboard-operator/api/v1alpha1/groupversion_info.go
+++ b/dashboard-operator/api/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// +groupName=dashboard.opendatahub.io
+// +groupName=components.platform.opendatahub.io
 
 package v1alpha1
 
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	GroupVersion = schema.GroupVersion{Group: "dashboard.opendatahub.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "components.platform.opendatahub.io", Version: "v1alpha1"}
 
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/dashboard-operator/cmd/manager/main.go
+++ b/dashboard-operator/cmd/manager/main.go
@@ -75,7 +75,7 @@ func main() {
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: healthProbeAddr,
 		LeaderElection:         leaderElect,
-		LeaderElectionID:       "components.platform.opendatahub.io",
+		LeaderElectionID:       "dashboard.components.platform.opendatahub.io",
 		WebhookServer:          ctrlwebhook.NewServer(ctrlwebhook.Options{Port: webhookPort}),
 	})
 	if err != nil {

--- a/dashboard-operator/cmd/manager/main.go
+++ b/dashboard-operator/cmd/manager/main.go
@@ -65,12 +65,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	applicationsNamespace := os.Getenv("APPLICATIONS_NAMESPACE")
+	if applicationsNamespace == "" {
+		applicationsNamespace = operatorNamespace
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: healthProbeAddr,
 		LeaderElection:         leaderElect,
-		LeaderElectionID:       "dashboard.opendatahub.io",
+		LeaderElectionID:       "components.platform.opendatahub.io",
 		WebhookServer:          ctrlwebhook.NewServer(ctrlwebhook.Options{Port: webhookPort}),
 	})
 	if err != nil {
@@ -87,9 +92,10 @@ func main() {
 	setupLog.Info("Detected platform", "platform", platform)
 
 	if err := controller.SetupWithManager(mgr, controller.Options{
-		ManifestsBasePath: manifestsBasePath,
-		Platform:          platform,
-		Namespace:         operatorNamespace,
+		ManifestsBasePath:     manifestsBasePath,
+		Platform:              platform,
+		Namespace:             operatorNamespace,
+		ApplicationsNamespace: applicationsNamespace,
 	}); err != nil {
 		setupLog.Error(err, "unable to create Dashboard controller")
 		os.Exit(1)

--- a/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  name: dashboards.dashboard.opendatahub.io
+  name: dashboards.components.platform.opendatahub.io
 spec:
-  group: dashboard.opendatahub.io
+  group: components.platform.opendatahub.io
   names:
     kind: Dashboard
     listKind: DashboardList
@@ -278,8 +278,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: Dashboard name must be default-dashboard
-          rule: self.metadata.name == 'default-dashboard'
+        - message: Dashboard name must be default
+          rule: self.metadata.name == 'default'
         - message: persesService must be specified when observability is enabled
           rule: '!has(self.spec.observability) || !self.spec.observability.enabled
             || has(self.spec.observability.persesService)'

--- a/dashboard-operator/config/crd/kustomization.yaml
+++ b/dashboard-operator/config/crd/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - bases/dashboard.opendatahub.io_dashboards.yaml
+  - bases/components.platform.opendatahub.io_dashboards.yaml

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -29,6 +29,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: APPLICATIONS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -47,6 +51,9 @@ spec:
           volumeMounts:
             - name: webhook-certs
               mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+            - name: odh-trusted-ca-bundle
+              mountPath: /etc/pki/tls/custom-certs
               readOnly: true
           livenessProbe:
             httpGet:
@@ -71,5 +78,12 @@ spec:
         - name: webhook-certs
           secret:
             secretName: dashboard-operator-webhook-tls
+        - name: odh-trusted-ca-bundle
+          configMap:
+            name: odh-trusted-ca-bundle
+            optional: true
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
       serviceAccountName: dashboard-operator
       terminationGracePeriodSeconds: 10

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -29,6 +29,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Override point: the ODH Operator sets this to the target
+            # namespace for operand resources (may differ from operator namespace).
             - name: APPLICATIONS_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/dashboard-operator/config/manager/manager.yaml
+++ b/dashboard-operator/config/manager/manager.yaml
@@ -33,6 +33,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/custom-certs/tls-ca-bundle.pem
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/dashboard-operator/config/rbac/role.yaml
+++ b/dashboard-operator/config/rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   # Dashboard CR access
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards
     verbs:
@@ -17,7 +17,7 @@ rules:
       - patch
       - delete
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards/status
     verbs:
@@ -25,7 +25,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards/finalizers
     verbs:

--- a/dashboard-operator/config/webhook/manifests.yaml
+++ b/dashboard-operator/config/webhook/manifests.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/dashboard-operator-webhook-cert
 webhooks:
-  - name: validate.dashboard.opendatahub.io
+  - name: validate.dashboards.components.platform.opendatahub.io
     admissionReviewVersions:
       - v1
     clientConfig:
@@ -15,7 +15,7 @@ webhooks:
         path: /validate-dashboard
     rules:
       - apiGroups:
-          - dashboard.opendatahub.io
+          - components.platform.opendatahub.io
         apiVersions:
           - v1alpha1
         operations:

--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -41,7 +41,11 @@ func applyKustomizeParams(dashboard *v1alpha1.Dashboard, manifests []render.Mani
 	return nil
 }
 
-func extractDashboardURL(ctx context.Context, cli client.Client, namespace string) (string, error) {
+func extractDashboardURL(ctx context.Context, cli client.Client, namespace string, platform cluster.Platform) (string, error) {
+	if platform == cluster.XKS {
+		return "", ErrDashboardRouteNotReady
+	}
+
 	rl := &routev1.RouteList{}
 	if err := cli.List(ctx, rl,
 		client.InNamespace(namespace),

--- a/dashboard-operator/internal/controller/actions.go
+++ b/dashboard-operator/internal/controller/actions.go
@@ -43,7 +43,7 @@ func applyKustomizeParams(dashboard *v1alpha1.Dashboard, manifests []render.Mani
 
 func extractDashboardURL(ctx context.Context, cli client.Client, namespace string, platform cluster.Platform) (string, error) {
 	if platform == cluster.XKS {
-		return "", ErrDashboardRouteNotReady
+		return "", nil
 	}
 
 	rl := &routev1.RouteList{}

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -79,10 +79,8 @@ func TestExtractDashboardURL(t *testing.T) {
 		wantErrIs bool
 	}{
 		{
-			name:      "xKS platform returns not ready",
-			platform:  cluster.XKS,
-			wantErr:   ErrDashboardRouteNotReady,
-			wantErrIs: true,
+			name:     "xKS platform returns empty URL without error",
+			platform: cluster.XKS,
 		},
 		{
 			name:      "no routes",

--- a/dashboard-operator/internal/controller/actions_test.go
+++ b/dashboard-operator/internal/controller/actions_test.go
@@ -72,19 +72,28 @@ func TestExtractDashboardURL(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		platform  cluster.Platform
 		routes    []routev1.Route
 		wantURL   string
 		wantErr   error
 		wantErrIs bool
 	}{
 		{
+			name:      "xKS platform returns not ready",
+			platform:  cluster.XKS,
+			wantErr:   ErrDashboardRouteNotReady,
+			wantErrIs: true,
+		},
+		{
 			name:      "no routes",
+			platform:  cluster.OpenDataHub,
 			routes:    nil,
 			wantErr:   ErrDashboardRouteNotReady,
 			wantErrIs: true,
 		},
 		{
-			name: "route without ingress",
+			name:     "route without ingress",
+			platform: cluster.OpenDataHub,
 			routes: []routev1.Route{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
@@ -94,7 +103,8 @@ func TestExtractDashboardURL(t *testing.T) {
 			wantErrIs: true,
 		},
 		{
-			name: "route with admitted ingress",
+			name:     "route with admitted ingress",
+			platform: cluster.OpenDataHub,
 			routes: []routev1.Route{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
@@ -113,7 +123,8 @@ func TestExtractDashboardURL(t *testing.T) {
 			wantURL: "https://dashboard.apps.example.com",
 		},
 		{
-			name: "route with non-admitted ingress",
+			name:     "route with non-admitted ingress",
+			platform: cluster.SelfManagedRhoai,
 			routes: []routev1.Route{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "dashboard", Namespace: namespace, Labels: partOfLabel},
@@ -133,7 +144,8 @@ func TestExtractDashboardURL(t *testing.T) {
 			wantErrIs: true,
 		},
 		{
-			name: "multiple routes",
+			name:     "multiple routes",
+			platform: cluster.OpenDataHub,
 			routes: []routev1.Route{
 				{ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: namespace, Labels: partOfLabel}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "r2", Namespace: namespace, Labels: partOfLabel}},
@@ -155,7 +167,7 @@ func TestExtractDashboardURL(t *testing.T) {
 				WithRuntimeObjects(objs...).
 				Build()
 
-			url, err := extractDashboardURL(context.Background(), cli, namespace)
+			url, err := extractDashboardURL(context.Background(), cli, namespace, tt.platform)
 			if tt.wantErrIs {
 				assert.ErrorIs(t, err, tt.wantErr)
 				assert.Empty(t, url)

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -82,6 +82,8 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Update(ctx, dashboard); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
+
+		return ctrl.Result{}, nil
 	}
 
 	dashboard.Status.ObservedGeneration = dashboard.Generation

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -127,7 +127,6 @@ func (r *DashboardReconciler) reconcile(
 	cm *conditions.Manager,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	dashboard.Status.URL = ""
 
 	manifests := manifestSets(r.ManifestsBasePath, r.Platform)
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -182,6 +182,8 @@ func (r *DashboardReconciler) reconcile(
 
 	var requeueAfter time.Duration
 
+	// URL is intentionally not cleared on error — "last known good" semantic.
+	// Conditions (Ready, Degraded) communicate the actual state.
 	switch {
 	case errors.Is(err, ErrDashboardRouteNotReady):
 		cm.MarkFalse(string(common.ConditionTypeDegraded),

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -191,7 +191,6 @@ func (r *DashboardReconciler) reconcile(
 		cm.MarkFalse(string(common.ConditionTypeReady),
 			conditions.WithReason("RouteNotReady"),
 			conditions.WithMessage("Dashboard route is not yet admitted"))
-		dashboard.Status.URL = ""
 		logger.Info("Dashboard route not yet available, requeuing")
 		requeueAfter = 10 * time.Second
 	case err != nil:
@@ -202,7 +201,6 @@ func (r *DashboardReconciler) reconcile(
 		cm.MarkFalse(string(common.ConditionTypeReady),
 			conditions.WithReason("URLExtractionFailed"),
 			conditions.WithError(err))
-		dashboard.Status.URL = ""
 		logger.Error(err, "Failed to extract dashboard URL")
 
 		return ctrl.Result{}, fmt.Errorf("failed to extract dashboard URL: %w", err)
@@ -212,13 +210,14 @@ func (r *DashboardReconciler) reconcile(
 			conditions.WithMessage("All sub-modules healthy"),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		dashboard.Status.URL = url
+		logger.Info("Dashboard reconciled successfully", "url", url)
 	}
-
-	logger.Info("Dashboard reconciled successfully", "url", url)
 
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
+// TODO(RHOAIENG-59938): delete Perses monitoring resources in the observability namespace
+// and any SSA-adopted resources not covered by ownerReference GC.
 func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context, _ *v1alpha1.Dashboard) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Cleaning up cross-namespace resources")

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
@@ -24,23 +25,27 @@ import (
 	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
 )
 
+const dashboardFinalizer = "components.platform.opendatahub.io/cleanup"
+
 // Version is set at build time via -ldflags.
 var Version = "unknown"
 
 // Options configures the dashboard controller.
 type Options struct {
-	ManifestsBasePath string
-	Platform          cluster.Platform
-	Namespace         string
+	ManifestsBasePath     string
+	Platform              cluster.Platform
+	Namespace             string
+	ApplicationsNamespace string
 }
 
 // DashboardReconciler reconciles a Dashboard object.
 type DashboardReconciler struct {
 	client.Client
-	Scheme            *runtime.Scheme
-	ManifestsBasePath string
-	Platform          cluster.Platform
-	Namespace         string
+	Scheme                *runtime.Scheme
+	ManifestsBasePath     string
+	Platform              cluster.Platform
+	Namespace             string
+	ApplicationsNamespace string
 }
 
 func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -56,6 +61,28 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	logger.Info("Reconciling Dashboard", "name", dashboard.Name)
+
+	if !dashboard.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(dashboard, dashboardFinalizer) {
+			if err := r.cleanupCrossNamespaceResources(ctx, dashboard); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to cleanup cross-namespace resources: %w", err)
+			}
+
+			controllerutil.RemoveFinalizer(dashboard, dashboardFinalizer)
+			if err := r.Update(ctx, dashboard); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(dashboard, dashboardFinalizer) {
+		controllerutil.AddFinalizer(dashboard, dashboardFinalizer)
+		if err := r.Update(ctx, dashboard); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
+		}
+	}
 
 	dashboard.Status.ObservedGeneration = dashboard.Generation
 
@@ -114,7 +141,7 @@ func (r *DashboardReconciler) reconcile(
 
 	var allResources []unstructured.Unstructured
 	for _, m := range manifests {
-		rendered, err := engine.Render(m.String(), kustomize.WithNamespace(r.Namespace))
+		rendered, err := engine.Render(m.String(), kustomize.WithNamespace(r.ApplicationsNamespace))
 		if err != nil {
 			cm.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
 				conditions.WithReason("RenderFailed"),
@@ -149,7 +176,7 @@ func (r *DashboardReconciler) reconcile(
 		conditions.WithReason("ResourcesApplied"),
 		conditions.WithMessage("Dashboard manifests applied successfully"))
 
-	url, err := extractDashboardURL(ctx, r.Client, r.Namespace)
+	url, err := extractDashboardURL(ctx, r.Client, r.ApplicationsNamespace, r.Platform)
 
 	var requeueAfter time.Duration
 
@@ -190,14 +217,22 @@ func (r *DashboardReconciler) reconcile(
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
+func (r *DashboardReconciler) cleanupCrossNamespaceResources(ctx context.Context, _ *v1alpha1.Dashboard) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Cleaning up cross-namespace resources")
+
+	return nil
+}
+
 // SetupWithManager registers the dashboard controller with the manager.
 func SetupWithManager(mgr ctrl.Manager, opts Options) error {
 	r := &DashboardReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		ManifestsBasePath: opts.ManifestsBasePath,
-		Platform:          opts.Platform,
-		Namespace:         opts.Namespace,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		ManifestsBasePath:     opts.ManifestsBasePath,
+		Platform:              opts.Platform,
+		Namespace:             opts.Namespace,
+		ApplicationsNamespace: opts.ApplicationsNamespace,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -91,11 +91,12 @@ func TestReconcile_NotFound(t *testing.T) {
 	cli := fake.NewClientBuilder().WithScheme(s).Build()
 
 	r := &ctrlpkg.DashboardReconciler{
-		Client:            cli,
-		Scheme:            s,
-		ManifestsBasePath: t.TempDir(),
-		Platform:          cluster.OpenDataHub,
-		Namespace:         testNamespace,
+		Client:                cli,
+		Scheme:                s,
+		ManifestsBasePath:     t.TempDir(),
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
 	}
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -195,11 +196,12 @@ func TestReconcile(t *testing.T) {
 			cli := builder.Build()
 
 			r := &ctrlpkg.DashboardReconciler{
-				Client:            cli,
-				Scheme:            s,
-				ManifestsBasePath: tt.manifestsBase(t),
-				Platform:          cluster.OpenDataHub,
-				Namespace:         testNamespace,
+				Client:                cli,
+				Scheme:                s,
+				ManifestsBasePath:     tt.manifestsBase(t),
+				Platform:              cluster.OpenDataHub,
+				Namespace:             testNamespace,
+				ApplicationsNamespace: testNamespace,
 			}
 
 			result, err := r.Reconcile(context.Background(), ctrl.Request{

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -181,6 +181,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       v1alpha1.DashboardInstanceName,
 					Generation: tt.generation,
+					Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
 				},
 			}
 
@@ -301,6 +302,7 @@ func TestReconcile_DistinctNamespaces(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       v1alpha1.DashboardInstanceName,
 			Generation: 1,
+			Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
 		},
 	}
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -249,6 +249,110 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestReconcile_Deletion(t *testing.T) {
+	s := testScheme(t)
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
+			DeletionTimestamp: &metav1.Time{
+				Time: time.Now(),
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		ManifestsBasePath:     t.TempDir(),
+		Platform:              cluster.OpenDataHub,
+		Namespace:             testNamespace,
+		ApplicationsNamespace: testNamespace,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &v1alpha1.Dashboard{}
+	err = cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated)
+	if err == nil {
+		assert.Empty(t, updated.Finalizers, "finalizer should be removed after deletion")
+	}
+}
+
+func TestReconcile_DistinctNamespaces(t *testing.T) {
+	s := testScheme(t)
+
+	operatorNS := "operator-ns"
+	appNS := "application-ns"
+
+	dashboard := &v1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       v1alpha1.DashboardInstanceName,
+			Generation: 1,
+		},
+	}
+
+	builder := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		WithObjects(admittedRoute(appNS))
+
+	cli := builder.Build()
+
+	base := t.TempDir()
+	overlay := filepath.Join(base, "odh")
+	require.NoError(t, os.MkdirAll(overlay, 0755))
+
+	kustomization := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+`
+	configmap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+data:
+  key: value
+`
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(kustomization), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "configmap.yaml"), []byte(configmap), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "params.env"), []byte(""), 0644))
+
+	r := &ctrlpkg.DashboardReconciler{
+		Client:                cli,
+		Scheme:                s,
+		ManifestsBasePath:     base,
+		Platform:              cluster.OpenDataHub,
+		Namespace:             operatorNS,
+		ApplicationsNamespace: appNS,
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: v1alpha1.DashboardInstanceName},
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	updated := &v1alpha1.Dashboard{}
+	require.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: v1alpha1.DashboardInstanceName}, updated))
+	assert.Equal(t, "https://dashboard.apps.example.com", updated.Status.URL)
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -38,10 +38,15 @@ var imagesMap = map[string]string{
 }
 
 func defaultManifestInfo(basePath string, platform cluster.Platform) render.ManifestInfo {
+	sourcePath, ok := overlaysSourcePaths[platform]
+	if !ok {
+		sourcePath = overlaysSourcePaths[cluster.OpenDataHub]
+	}
+
 	return render.ManifestInfo{
 		Path:       basePath,
 		ContextDir: "",
-		SourcePath: overlaysSourcePaths[platform],
+		SourcePath: sourcePath,
 	}
 }
 

--- a/dashboard-operator/internal/controller/support.go
+++ b/dashboard-operator/internal/controller/support.go
@@ -108,5 +108,5 @@ func writeParamsEnv(manifestPath string, params map[string]string) error {
 		sb.WriteString(params[k])
 		sb.WriteString("\n")
 	}
-	return os.WriteFile(manifestPath+"/params.env", []byte(sb.String()), 0664)
+	return os.WriteFile(manifestPath+"/params.env", []byte(sb.String()), 0600)
 }

--- a/dashboard-operator/internal/controller/support_test.go
+++ b/dashboard-operator/internal/controller/support_test.go
@@ -32,6 +32,11 @@ func TestDefaultManifestInfo(t *testing.T) {
 			assert.Equal(t, tt.wantSource, info.SourcePath)
 		})
 	}
+
+	t.Run("unknown platform falls back to ODH", func(t *testing.T) {
+		info := defaultManifestInfo("/base", cluster.XKS)
+		assert.Equal(t, "/odh", info.SourcePath)
+	})
 }
 
 func TestComputeKustomizeVariables(t *testing.T) {

--- a/dashboard-operator/internal/controller/support_test.go
+++ b/dashboard-operator/internal/controller/support_test.go
@@ -22,6 +22,7 @@ func TestDefaultManifestInfo(t *testing.T) {
 		{name: "SelfManagedRhoai", platform: cluster.SelfManagedRhoai, wantSource: "/rhoai"},
 		{name: "ManagedRhoai", platform: cluster.ManagedRhoai, wantSource: "/not-supported"},
 		{name: "OpenDataHub", platform: cluster.OpenDataHub, wantSource: "/odh"},
+		{name: "unknown platform falls back to ODH", platform: cluster.XKS, wantSource: "/odh"},
 	}
 
 	for _, tt := range tests {
@@ -32,11 +33,6 @@ func TestDefaultManifestInfo(t *testing.T) {
 			assert.Equal(t, tt.wantSource, info.SourcePath)
 		})
 	}
-
-	t.Run("unknown platform falls back to ODH", func(t *testing.T) {
-		info := defaultManifestInfo("/base", cluster.XKS)
-		assert.Equal(t, "/odh", info.SourcePath)
-	})
 }
 
 func TestComputeKustomizeVariables(t *testing.T) {

--- a/dashboard-operator/internal/webhook/dashboard_webhook_test.go
+++ b/dashboard-operator/internal/webhook/dashboard_webhook_test.go
@@ -26,7 +26,7 @@ func testScheme(t *testing.T) *runtime.Scheme {
 }
 
 func TestDashboardGVK(t *testing.T) {
-	assert.Equal(t, "dashboard.opendatahub.io", dashwebhook.DashboardGVK.Group)
+	assert.Equal(t, "components.platform.opendatahub.io", dashwebhook.DashboardGVK.Group)
 	assert.Equal(t, "v1alpha1", dashwebhook.DashboardGVK.Version)
 	assert.Equal(t, "Dashboard", dashwebhook.DashboardGVK.Kind)
 }
@@ -38,7 +38,7 @@ func TestSingletonHandler_AllowFirstCreate(t *testing.T) {
 	resp := handler.Handle(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			Operation: admissionv1.Create,
-			Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
+			Resource:  metav1.GroupVersionResource{Group: "components.platform.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
 		},
 	})
 
@@ -69,7 +69,7 @@ func TestSingletonHandler_WithExistingInstance(t *testing.T) {
 			resp := handler.Handle(context.Background(), admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: tt.operation,
-					Resource:  metav1.GroupVersionResource{Group: "dashboard.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
+					Resource:  metav1.GroupVersionResource{Group: "components.platform.opendatahub.io", Version: "v1alpha1", Resource: "dashboards"},
 				},
 			})
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65723

## Description

Migrate the Dashboard Module CRD from `dashboard.opendatahub.io/v1alpha1` to the platform-required `components.platform.opendatahub.io/v1alpha1` as mandated by the upstream [Onboarding Guide for ODH Operator Modules](https://gitlab.cee.redhat.com/data-hub/odh-modularisation-docs). This is a critical path blocker for ModuleHandler registration in the ODH Operator ([RHOAIENG-61029](https://redhat.atlassian.net/browse/RHOAIENG-61029)).

### API migration
- **API group**: `dashboard.opendatahub.io` → `components.platform.opendatahub.io`
- **Singleton name**: `default-dashboard` → `default` (CEL rule updated)
- **Leader election ID**: updated to `components.platform.opendatahub.io`
- **Webhook**: API group reference updated in ValidatingWebhookConfiguration
- **RBAC**: All ClusterRole rules updated for new API group
- **CRD**: Regenerated via `make manifests`, old CRD file removed

### Platform contract additions
- **`APPLICATIONS_NAMESPACE`** env var consumed with fallback to operator namespace — separates where the operator runs from where operand resources are deployed
- **Trusted CA bundle** volume mount (`odh-trusted-ca-bundle` ConfigMap, `optional: true`) — standard ODH pattern for custom CAs
- **Finalizer** (`components.platform.opendatahub.io/cleanup`) — registered on Dashboard CR for cross-namespace resource cleanup; placeholder cleanup logic for now, real cleanup added when Perses monitoring namespace resources land
- **xKS platform guard** — `extractDashboardURL` skips Route listing on vanilla Kubernetes (XKS platform)
- **Platform overlay fallback** — `defaultManifestInfo` falls back to ODH overlay for unknown platforms

## How Has This Been Tested?

### Unit tests
- `make generate` — deepcopy regenerated successfully
- `make manifests` — CRD regenerated with new API group and CEL rule verified
- `make lint` — passes with 0 issues
- `make test` — all test packages pass:
  - `api/v1alpha1` — OK (5.3% coverage)
  - `internal/controller` — OK (81.6% coverage)
  - `internal/webhook` — OK (100% coverage)

### Cluster testing (ROSA `ui-monarch-rosa`)

Image `quay.io/lferrnan/odh-dashboard-operator:pr-7795` deployed and validated on a ROSA cluster:

1. **CRD applied** — `dashboards.components.platform.opendatahub.io` with new CEL validation rule
2. **Singleton name enforcement** — `default` accepted, `default-dashboard` rejected by CEL:
   ```
   The Dashboard "default-dashboard" is invalid: Dashboard name must be default
   ```
3. **Controller watches correct API group** — logs show `controllerGroup: "components.platform.opendatahub.io"`
4. **Reconciliation succeeds** — `ProvisioningSucceeded: True`, all dashboard manifests applied via SSA
5. **Finalizer registered** — `components.platform.opendatahub.io/cleanup` present on CR
6. **Status conditions populated correctly**:
   - `ProvisioningSucceeded: True` (reason: ResourcesApplied)
   - `Ready: False` (reason: RouteNotReady — expected, Route label depends on manifests)
   - `Degraded: False` (severity: Info)
7. **ObservedGeneration** set correctly (matches `metadata.generation`)
8. **Leader election** uses new ID `components.platform.opendatahub.io`

#### Cluster testing instructions (for reviewer)

```bash
# Build and push (from repo root, M1 Mac → x86 cluster)
docker buildx build --platform linux/amd64 --no-cache \
  -t quay.io/lferrnan/odh-dashboard-operator:pr-7795 \
  -f dashboard-operator/Dockerfile --push .

# Apply updated CRD
oc apply -f dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml

# Apply updated RBAC
oc apply -f dashboard-operator/config/rbac/role.yaml

# Scale down, update image, add volumes, scale up
oc scale deployment dashboard-operator -n opendatahub --replicas=0
oc set image deployment/dashboard-operator -n opendatahub \
  manager=quay.io/lferrnan/odh-dashboard-operator:pr-7795
oc set env deployment/dashboard-operator -n opendatahub \
  APPLICATIONS_NAMESPACE=opendatahub

# Ensure webhook TLS secret exists (cert-manager or manual)
oc get secret dashboard-operator-webhook-tls -n opendatahub || \
  (openssl req -x509 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt \
   -days 365 -nodes -subj '/CN=dashboard-operator-webhook-service.opendatahub.svc' && \
   oc create secret tls dashboard-operator-webhook-tls -n opendatahub \
   --cert=/tmp/tls.crt --key=/tmp/tls.key)

# Patch volumes if not present
oc patch deployment dashboard-operator -n opendatahub --type='json' -p='[
  {"op": "add", "path": "/spec/template/spec/volumes", "value": [
    {"name": "webhook-certs", "secret": {"secretName": "dashboard-operator-webhook-tls"}},
    {"name": "odh-trusted-ca-bundle", "configMap": {"name": "odh-trusted-ca-bundle", "optional": true, "items": [{"key": "ca-bundle.crt", "path": "tls-ca-bundle.pem"}]}}
  ]},
  {"op": "add", "path": "/spec/template/spec/containers/0/volumeMounts", "value": [
    {"name": "webhook-certs", "mountPath": "/tmp/k8s-webhook-server/serving-certs", "readOnly": true},
    {"name": "odh-trusted-ca-bundle", "mountPath": "/etc/pki/tls/custom-certs", "readOnly": true}
  ]}
]'

oc scale deployment dashboard-operator -n opendatahub --replicas=1

# Delete old CRs, create new one with singleton name "default"
oc delete dashboards.dashboard.opendatahub.io --all 2>/dev/null
oc delete dashboards.components.platform.opendatahub.io --all 2>/dev/null
cat <<EOF | oc apply -f -
apiVersion: components.platform.opendatahub.io/v1alpha1
kind: Dashboard
metadata:
  name: default
spec:
  managementState: Managed
EOF

# Verify
oc logs deployment/dashboard-operator -n opendatahub --tail=10
oc get dashboards.components.platform.opendatahub.io default -o yaml

# Verify CEL rejects old name
cat <<EOF | oc apply -f - 2>&1 | grep "must be default"
apiVersion: components.platform.opendatahub.io/v1alpha1
kind: Dashboard
metadata:
  name: default-dashboard
spec:
  managementState: Managed
EOF
```

## Test Impact

Updated existing tests to cover new behavior:
- `dashboard_types_test.go` — updated `DashboardInstanceName` assertion to `"default"`
- `actions_test.go` — added platform parameter to `extractDashboardURL` tests, added xKS platform test case
- `dashboard_reconciler_test.go` — added `ApplicationsNamespace` field to all test reconciler instances
- `support_test.go` — added test for unknown platform fallback to ODH overlay

Finalizer add/remove is exercised indirectly through the reconciler tests; dedicated finalizer unit tests can be added once the cleanup logic has concrete resource types.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure a separate applications namespace via env var.
  * Finalizer-based cleanup when deleting dashboards.
  * Improved handling for additional cluster platform types.

* **Improvements**
  * Dashboard URL now persists across transient route failures (check Ready condition).
  * Manifest rendering and URL extraction use the applications namespace when configured.

* **Chores**
  * Dashboard API group renamed to platform-aligned naming.
  * Default dashboard name normalized to "default".
  * RBAC and webhook manifests updated to match API group change.

* **Ops**
  * SSL certificate bundle mount added for the manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->