### PR TITLE
feat(dashboard-operator): dynamic dependency discovery, ConfigMap flags, and architecture docs

### DIFF
--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -98,6 +98,7 @@ Central index of key documentation in the ODH Dashboard monorepo.
 
 | Doc | Description |
 |-----|-------------|
+| [Operator Architecture](docs/dashboard-operator.md) | CRD design, reconciliation pipeline, module registry, dependency resolution, manifest management |
 | [Controller AGENTS.md](dashboard-operator/AGENTS.md) | Go operator conventions, controller-runtime patterns, CRD types, Makefile targets, reconciliation pipeline |
 
 ---

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const operatorConfigMapName = "dashboard-operator-config"
+
+// OperatorConfig holds internal controller flags read from a ConfigMap.
+// A missing or malformed ConfigMap results in zero-value defaults and
+// never blocks reconciliation.
+type OperatorConfig struct {
+	LogLevel          string
+	ReconcileInterval time.Duration
+}
+
+// readOperatorConfig reads the dashboard-operator-config ConfigMap from
+// the given namespace. Returns zero-value OperatorConfig on any error.
+func readOperatorConfig(ctx context.Context, cli client.Client, namespace string) OperatorConfig {
+	logger := log.FromContext(ctx)
+	cfg := OperatorConfig{}
+
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: operatorConfigMapName, Namespace: namespace}
+
+	if err := cli.Get(ctx, key, cm); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			logger.Error(err, "Failed to read operator config ConfigMap")
+		}
+
+		return cfg
+	}
+
+	if cm.Data == nil {
+		return cfg
+	}
+
+	if v, ok := cm.Data["logLevel"]; ok {
+		cfg.LogLevel = v
+	}
+
+	if v, ok := cm.Data["reconcileInterval"]; ok {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			logger.Error(err, "Invalid reconcileInterval in operator config", "value", v)
+		} else {
+			cfg.ReconcileInterval = d
+		}
+	}
+
+	return cfg
+}

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -18,7 +18,6 @@ const minReconcileInterval = 5 * time.Second
 // A missing or malformed ConfigMap results in zero-value defaults and
 // never blocks reconciliation.
 type OperatorConfig struct {
-	LogLevel          string
 	ReconcileInterval time.Duration
 }
 
@@ -41,10 +40,6 @@ func readOperatorConfig(ctx context.Context, cli client.Client, namespace string
 
 	if cm.Data == nil {
 		return cfg
-	}
-
-	if v, ok := cm.Data["logLevel"]; ok {
-		cfg.LogLevel = v
 	}
 
 	if v, ok := cm.Data["reconcileInterval"]; ok {

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 const operatorConfigMapName = "dashboard-operator-config"
+const minReconcileInterval = 5 * time.Second
 
 // OperatorConfig holds internal controller flags read from a ConfigMap.
 // A missing or malformed ConfigMap results in zero-value defaults and
@@ -50,6 +51,8 @@ func readOperatorConfig(ctx context.Context, cli client.Client, namespace string
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			logger.Error(err, "Invalid reconcileInterval in operator config", "value", v)
+		} else if d < minReconcileInterval {
+			logger.Error(nil, "reconcileInterval below minimum; ignoring", "value", v, "min", minReconcileInterval)
 		} else {
 			cfg.ReconcileInterval = d
 		}

--- a/dashboard-operator/internal/controller/config.go
+++ b/dashboard-operator/internal/controller/config.go
@@ -47,7 +47,7 @@ func readOperatorConfig(ctx context.Context, cli client.Client, namespace string
 		if err != nil {
 			logger.Error(err, "Invalid reconcileInterval in operator config", "value", v)
 		} else if d < minReconcileInterval {
-			logger.Error(nil, "reconcileInterval below minimum; ignoring", "value", v, "min", minReconcileInterval)
+			logger.Info("reconcileInterval below minimum; ignoring", "value", v, "min", minReconcileInterval)
 		} else {
 			cfg.ReconcileInterval = d
 		}

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -89,6 +89,17 @@ func TestReadOperatorConfig(t *testing.T) {
 			wantLogLevel:  "",
 			wantReconcile: 0,
 		},
+		{
+			name: "reconcile interval below minimum is ignored",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"reconcileInterval": "1ms",
+				},
+			},
+			wantLogLevel:  "",
+			wantReconcile: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -28,13 +28,11 @@ func TestReadOperatorConfig(t *testing.T) {
 	tests := []struct {
 		name          string
 		configMap     *corev1.ConfigMap
-		wantLogLevel  string
 		wantReconcile time.Duration
 	}{
 		{
 			name:          "configmap does not exist",
 			configMap:     nil,
-			wantLogLevel:  "",
 			wantReconcile: 0,
 		},
 		{
@@ -42,11 +40,9 @@ func TestReadOperatorConfig(t *testing.T) {
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
 				Data: map[string]string{
-					"logLevel":          "debug",
 					"reconcileInterval": "30s",
 				},
 			},
-			wantLogLevel:  "debug",
 			wantReconcile: 30 * time.Second,
 		},
 		{
@@ -54,11 +50,9 @@ func TestReadOperatorConfig(t *testing.T) {
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
 				Data: map[string]string{
-					"logLevel":          "info",
 					"reconcileInterval": "not-a-duration",
 				},
 			},
-			wantLogLevel:  "info",
 			wantReconcile: 0,
 		},
 		{
@@ -67,18 +61,6 @@ func TestReadOperatorConfig(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
 				Data:       map[string]string{},
 			},
-			wantLogLevel:  "",
-			wantReconcile: 0,
-		},
-		{
-			name: "only logLevel set",
-			configMap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
-				Data: map[string]string{
-					"logLevel": "error",
-				},
-			},
-			wantLogLevel:  "error",
 			wantReconcile: 0,
 		},
 		{
@@ -86,7 +68,6 @@ func TestReadOperatorConfig(t *testing.T) {
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
 			},
-			wantLogLevel:  "",
 			wantReconcile: 0,
 		},
 		{
@@ -97,8 +78,17 @@ func TestReadOperatorConfig(t *testing.T) {
 					"reconcileInterval": "1ms",
 				},
 			},
-			wantLogLevel:  "",
 			wantReconcile: 0,
+		},
+		{
+			name: "reconcile interval at exact minimum is accepted",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"reconcileInterval": "5s",
+				},
+			},
+			wantReconcile: 5 * time.Second,
 		},
 	}
 
@@ -114,7 +104,6 @@ func TestReadOperatorConfig(t *testing.T) {
 			cli := builder.Build()
 			cfg := readOperatorConfig(context.Background(), cli, "test-ns")
 
-			assert.Equal(t, tt.wantLogLevel, cfg.LogLevel)
 			assert.Equal(t, tt.wantReconcile, cfg.ReconcileInterval)
 		})
 	}

--- a/dashboard-operator/internal/controller/config_test.go
+++ b/dashboard-operator/internal/controller/config_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func configTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+
+	return s
+}
+
+func TestReadOperatorConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMap     *corev1.ConfigMap
+		wantLogLevel  string
+		wantReconcile time.Duration
+	}{
+		{
+			name:          "configmap does not exist",
+			configMap:     nil,
+			wantLogLevel:  "",
+			wantReconcile: 0,
+		},
+		{
+			name: "valid config",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"logLevel":          "debug",
+					"reconcileInterval": "30s",
+				},
+			},
+			wantLogLevel:  "debug",
+			wantReconcile: 30 * time.Second,
+		},
+		{
+			name: "invalid reconcile interval",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"logLevel":          "info",
+					"reconcileInterval": "not-a-duration",
+				},
+			},
+			wantLogLevel:  "info",
+			wantReconcile: 0,
+		},
+		{
+			name: "empty data",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data:       map[string]string{},
+			},
+			wantLogLevel:  "",
+			wantReconcile: 0,
+		},
+		{
+			name: "only logLevel set",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"logLevel": "error",
+				},
+			},
+			wantLogLevel:  "error",
+			wantReconcile: 0,
+		},
+		{
+			name: "nil data map",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: operatorConfigMapName, Namespace: "test-ns"},
+			},
+			wantLogLevel:  "",
+			wantReconcile: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := configTestScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s)
+
+			if tt.configMap != nil {
+				builder = builder.WithObjects(tt.configMap)
+			}
+
+			cli := builder.Build()
+			cfg := readOperatorConfig(context.Background(), cli, "test-ns")
+
+			assert.Equal(t, tt.wantLogLevel, cfg.LogLevel)
+			assert.Equal(t, tt.wantReconcile, cfg.ReconcileInterval)
+		})
+	}
+}

--- a/dashboard-operator/internal/controller/dashboard_reconciler.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler.go
@@ -88,6 +88,8 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	dashboard.Status.ObservedGeneration = dashboard.Generation
 
+	cfg := readOperatorConfig(ctx, r.Client, r.Namespace)
+
 	// Ready is the rollup condition — auto-derived by the Manager from
 	// ProvisioningSucceeded and Degraded. It is never set explicitly.
 	cm := conditions.NewManager(
@@ -97,7 +99,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		string(common.ConditionTypeDegraded),
 	)
 
-	result, err := r.reconcile(ctx, dashboard, cm)
+	result, err := r.reconcile(ctx, dashboard, cm, cfg)
 
 	dashboard.SetReleaseStatus(common.ComponentReleaseStatus{
 		Releases: []common.ComponentRelease{{
@@ -125,6 +127,7 @@ func (r *DashboardReconciler) reconcile(
 	ctx context.Context,
 	dashboard *v1alpha1.Dashboard,
 	cm *conditions.Manager,
+	cfg OperatorConfig,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -211,7 +214,28 @@ func (r *DashboardReconciler) reconcile(
 			conditions.WithMessage("All sub-modules healthy"),
 			conditions.WithSeverity(common.ConditionSeverityInfo))
 		dashboard.Status.URL = url
-		logger.Info("Dashboard reconciled successfully", "url", url)
+	}
+
+	nextStatuses := resolveModuleStatuses(&dashboard.Spec)
+	for name, next := range nextStatuses {
+		if prev, ok := dashboard.Status.ModuleStatuses[name]; ok &&
+			prev.Phase == next.Phase &&
+			prev.Reason == next.Reason &&
+			prev.Message == next.Message {
+			next.LastTransitionTime = prev.LastTransitionTime
+			nextStatuses[name] = next
+		}
+	}
+	dashboard.Status.ModuleStatuses = nextStatuses
+
+	if requeueAfter > 0 {
+		logger.Info("Dashboard reconcile cycle complete, requeuing", "requeueAfter", requeueAfter, "modules", len(dashboard.Status.ModuleStatuses))
+	} else {
+		logger.Info("Dashboard reconciled successfully", "url", url, "modules", len(dashboard.Status.ModuleStatuses))
+	}
+
+	if requeueAfter == 0 && cfg.ReconcileInterval > 0 {
+		requeueAfter = cfg.ReconcileInterval
 	}
 
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -109,6 +109,8 @@ func TestReconcile_NotFound(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
+	registrySize := len(ctrlpkg.ModuleNames())
+
 	tests := []struct {
 		name             string
 		generation       int64
@@ -162,7 +164,7 @@ func TestReconcile(t *testing.T) {
 			wantReady:       boolPtr(false),
 			wantProvisioned: boolPtr(true),
 			wantGeneration:  2,
-			wantModuleCount: 9,
+			wantModuleCount: registrySize,
 		},
 		{
 			name:       "observed generation matches CR",
@@ -175,7 +177,7 @@ func TestReconcile(t *testing.T) {
 			wantReady:       boolPtr(false),
 			wantProvisioned: boolPtr(true),
 			wantGeneration:  42,
-			wantModuleCount: 9,
+			wantModuleCount: registrySize,
 		},
 		{
 			name:       "module statuses populated with components",
@@ -196,7 +198,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  1,
-			wantModuleCount: 9,
+			wantModuleCount: registrySize,
 			wantModulePhases: map[string]v1alpha1.ModulePhase{
 				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
 				"genAi":          v1alpha1.ModulePhaseDeployed,
@@ -231,7 +233,7 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantURL:         "https://dashboard.apps.example.com",
 			wantGeneration:  1,
-			wantModuleCount: 9,
+			wantModuleCount: registrySize,
 		},
 	}
 

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -109,17 +110,20 @@ func TestReconcile_NotFound(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	tests := []struct {
-		name            string
-		generation      int64
-		manifestsBase   func(t *testing.T) string
-		extraObjects    func(t *testing.T) []client.Object
-		wantErr         bool
-		wantRequeue     time.Duration
-		wantPhase       common.Phase
-		wantReady       *bool
-		wantProvisioned *bool
-		wantURL         string
-		wantGeneration  int64
+		name             string
+		generation       int64
+		dashboardSpec    *v1alpha1.DashboardSpec
+		manifestsBase    func(t *testing.T) string
+		extraObjects     func(t *testing.T) []client.Object
+		wantErr          bool
+		wantRequeue      time.Duration
+		wantPhase        common.Phase
+		wantReady        *bool
+		wantProvisioned  *bool
+		wantURL          string
+		wantGeneration   int64
+		wantModuleCount  int
+		wantModulePhases map[string]v1alpha1.ModulePhase
 	}{
 		{
 			name:       "success with admitted route",
@@ -171,6 +175,62 @@ func TestReconcile(t *testing.T) {
 			wantProvisioned: boolPtr(true),
 			wantGeneration:  42,
 		},
+		{
+			name:       "module statuses populated with components",
+			generation: 1,
+			dashboardSpec: &v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"modelregistry": {ManagementState: "Managed"},
+				},
+			},
+			manifestsBase: func(t *testing.T) string {
+				return createMinimalManifests(t)
+			},
+			extraObjects: func(t *testing.T) []client.Object {
+				return []client.Object{admittedRoute(testNamespace)}
+			},
+			wantPhase:       common.PhaseReady,
+			wantReady:       boolPtr(true),
+			wantProvisioned: boolPtr(true),
+			wantURL:         "https://dashboard.apps.example.com",
+			wantGeneration:  1,
+			wantModuleCount: 9,
+			wantModulePhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
+				"genAi":          v1alpha1.ModulePhaseDeployed,
+				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
+				"perses":         v1alpha1.ModulePhaseNotDeployed,
+			},
+		},
+		{
+			name:       "operator config reconcile interval applied",
+			generation: 1,
+			manifestsBase: func(t *testing.T) string {
+				return createMinimalManifests(t)
+			},
+			extraObjects: func(t *testing.T) []client.Object {
+				return []client.Object{
+					admittedRoute(testNamespace),
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "dashboard-operator-config",
+							Namespace: testNamespace,
+						},
+						Data: map[string]string{
+							"reconcileInterval": "30s",
+						},
+					},
+				}
+			},
+			wantRequeue:     30 * time.Second,
+			wantPhase:       common.PhaseReady,
+			wantReady:       boolPtr(true),
+			wantProvisioned: boolPtr(true),
+			wantURL:         "https://dashboard.apps.example.com",
+			wantGeneration:  1,
+			wantModuleCount: 9,
+		},
 	}
 
 	for _, tt := range tests {
@@ -183,6 +243,9 @@ func TestReconcile(t *testing.T) {
 					Generation: tt.generation,
 					Finalizers: []string{"components.platform.opendatahub.io/cleanup"},
 				},
+			}
+			if tt.dashboardSpec != nil {
+				dashboard.Spec = *tt.dashboardSpec
 			}
 
 			builder := fake.NewClientBuilder().
@@ -246,6 +309,15 @@ func TestReconcile(t *testing.T) {
 
 			require.NotEmpty(t, updated.GetReleaseStatus().Releases)
 			assert.Equal(t, v1alpha1.DashboardComponentName, updated.GetReleaseStatus().Releases[0].Name)
+
+			if tt.wantModuleCount > 0 {
+				assert.Len(t, updated.Status.ModuleStatuses, tt.wantModuleCount, "module status count")
+			}
+			for name, wantPhase := range tt.wantModulePhases {
+				ms, ok := updated.Status.ModuleStatuses[name]
+				require.True(t, ok, "module %q should be in status", name)
+				assert.Equal(t, wantPhase, ms.Phase, "module %q phase", name)
+			}
 		})
 	}
 }

--- a/dashboard-operator/internal/controller/dashboard_reconciler_test.go
+++ b/dashboard-operator/internal/controller/dashboard_reconciler_test.go
@@ -162,6 +162,7 @@ func TestReconcile(t *testing.T) {
 			wantReady:       boolPtr(false),
 			wantProvisioned: boolPtr(true),
 			wantGeneration:  2,
+			wantModuleCount: 9,
 		},
 		{
 			name:       "observed generation matches CR",
@@ -174,6 +175,7 @@ func TestReconcile(t *testing.T) {
 			wantReady:       boolPtr(false),
 			wantProvisioned: boolPtr(true),
 			wantGeneration:  42,
+			wantModuleCount: 9,
 		},
 		{
 			name:       "module statuses populated with components",

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -1,0 +1,278 @@
+package controller
+
+import (
+	"fmt"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+// ModuleType classifies how a module is deployed.
+type ModuleType string
+
+const (
+	ModuleTypeBFF          ModuleType = "BFF"
+	ModuleTypeEmbedded     ModuleType = "Embedded"
+	ModuleTypeProxyService ModuleType = "ProxyService"
+)
+
+// ModuleDefinition describes a module's static properties.
+// This is compiled into the binary and is the authoritative source of
+// truth for module metadata. The CR only carries override intent and
+// external dependency signals.
+type ModuleDefinition struct {
+	Name               string
+	Type               ModuleType
+	ContainerName      string
+	Port               int32
+	ImageEnvVar        string
+	RequiredComponents []string
+	RequiredModules    []string
+}
+
+var moduleRegistry = map[string]ModuleDefinition{
+	"modelRegistry": {
+		Name: "modelRegistry", Type: ModuleTypeBFF,
+		ContainerName: "model-registry-ui", Port: 8043,
+		ImageEnvVar:        "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		RequiredComponents: []string{"modelregistry"},
+	},
+	"genAi": {
+		Name: "genAi", Type: ModuleTypeBFF,
+		ContainerName: "gen-ai-ui", Port: 8143,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+	},
+	"mlflow": {
+		Name: "mlflow", Type: ModuleTypeBFF,
+		ContainerName: "mlflow-ui", Port: 8343,
+		ImageEnvVar:        "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		RequiredComponents: []string{"mlflowoperator"},
+	},
+	"mlflowEmbedded": {
+		Name: "mlflowEmbedded", Type: ModuleTypeEmbedded,
+		RequiredComponents: []string{"mlflowoperator"},
+		RequiredModules:    []string{"mlflow"},
+	},
+	"maas": {
+		Name: "maas", Type: ModuleTypeBFF,
+		ContainerName: "maas-ui", Port: 8243,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+	},
+	"evalHub": {
+		Name: "evalHub", Type: ModuleTypeBFF,
+		ContainerName: "eval-hub-ui", Port: 8443,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+	},
+	"automl": {
+		Name: "automl", Type: ModuleTypeBFF,
+		ContainerName: "automl-ui", Port: 8543,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+	},
+	"autorag": {
+		Name: "autorag", Type: ModuleTypeBFF,
+		ContainerName: "autorag-ui", Port: 8643,
+		ImageEnvVar: "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+	},
+	"perses": {
+		Name: "perses", Type: ModuleTypeProxyService,
+	},
+}
+
+func isComponentAvailable(components map[string]v1alpha1.ComponentAvailability, name string) bool {
+	comp, exists := components[name]
+	if !exists {
+		return false
+	}
+
+	return comp.ManagementState == "Managed" || comp.ManagementState == "Unmanaged"
+}
+
+// resolveModuleStatuses runs a two-pass dependency resolution algorithm
+// to determine which modules should be deployed based on spec.Components,
+// spec.Modules overrides, and spec.Observability.
+func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.ModuleStatus {
+	now := metav1.Now()
+	result := make(map[string]v1alpha1.ModuleStatus, len(moduleRegistry))
+
+	// Pass 1: Evaluate each module against overrides and DSC component deps.
+	// Modules with inter-module deps that pass all other checks are deferred.
+	pendingModuleDeps := map[string][]string{}
+
+	for name, mod := range moduleRegistry {
+		if mod.Type == ModuleTypeProxyService {
+			result[name] = resolveProxyServiceModule(spec, now)
+			continue
+		}
+
+		if override, ok := spec.Modules[name]; ok {
+			if override.State == v1alpha1.ModuleDisabled {
+				result[name] = v1alpha1.ModuleStatus{
+					Phase:              v1alpha1.ModulePhaseDisabled,
+					Reason:             "ExplicitOverride",
+					Message:            "Module explicitly disabled via spec.modules override",
+					LastTransitionTime: now,
+				}
+
+				continue
+			}
+
+			if override.State == v1alpha1.ModuleEnabled {
+				if len(mod.RequiredModules) > 0 {
+					pendingModuleDeps[name] = mod.RequiredModules
+				} else {
+					result[name] = v1alpha1.ModuleStatus{
+						Phase:              v1alpha1.ModulePhaseDeployed,
+						Reason:             "ExplicitOverride",
+						Message:            "Module explicitly enabled via spec.modules override",
+						LastTransitionTime: now,
+					}
+				}
+
+				continue
+			}
+		}
+
+		if missing := findMissingComponent(spec.Components, mod.RequiredComponents); missing != "" {
+			result[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseNotDeployed,
+				Reason:             "ComponentNotAvailable",
+				Message:            fmt.Sprintf("Required DSC component %q is not available", missing),
+				LastTransitionTime: now,
+			}
+
+			continue
+		}
+
+		if len(mod.RequiredModules) > 0 {
+			pendingModuleDeps[name] = mod.RequiredModules
+		} else {
+			result[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseDeployed,
+				Reason:             "DependenciesSatisfied",
+				Message:            "All dependencies satisfied",
+				LastTransitionTime: now,
+			}
+		}
+	}
+
+	// Pass 2: Resolve inter-module dependencies. Iterate until stable.
+	for range len(moduleRegistry) {
+		changed := false
+
+		for name, deps := range pendingModuleDeps {
+			allMet := true
+
+			for _, dep := range deps {
+				if s, resolved := result[dep]; resolved {
+					if s.Phase != v1alpha1.ModulePhaseDeployed {
+						result[name] = v1alpha1.ModuleStatus{
+							Phase:              v1alpha1.ModulePhaseNotDeployed,
+							Reason:             "ModuleDependencyNotSatisfied",
+							Message:            fmt.Sprintf("Required module %q is not deployed", dep),
+							LastTransitionTime: now,
+						}
+						delete(pendingModuleDeps, name)
+						changed = true
+						allMet = false
+
+						break
+					}
+				} else {
+					allMet = false
+
+					break
+				}
+			}
+
+			if allMet && allDepsResolved(deps, result) {
+				result[name] = v1alpha1.ModuleStatus{
+					Phase:              v1alpha1.ModulePhaseDeployed,
+					Reason:             "DependenciesSatisfied",
+					Message:            "All dependencies satisfied",
+					LastTransitionTime: now,
+				}
+				delete(pendingModuleDeps, name)
+				changed = true
+			}
+		}
+
+		if !changed {
+			break
+		}
+	}
+
+	for name := range pendingModuleDeps {
+		result[name] = v1alpha1.ModuleStatus{
+			Phase:              v1alpha1.ModulePhaseNotDeployed,
+			Reason:             "UnresolvableDependency",
+			Message:            "Module dependencies could not be resolved (possible cycle)",
+			LastTransitionTime: now,
+		}
+	}
+
+	return result
+}
+
+func resolveProxyServiceModule(spec *v1alpha1.DashboardSpec, now metav1.Time) v1alpha1.ModuleStatus {
+	if spec.Observability == nil || !spec.Observability.Enabled {
+		return v1alpha1.ModuleStatus{
+			Phase:              v1alpha1.ModulePhaseNotDeployed,
+			Reason:             "ObservabilityDisabled",
+			Message:            "Observability is not enabled in spec",
+			LastTransitionTime: now,
+		}
+	}
+
+	if spec.Observability.PersesService == nil {
+		return v1alpha1.ModuleStatus{
+			Phase:              v1alpha1.ModulePhaseNotDeployed,
+			Reason:             "MissingPersesServiceConfig",
+			Message:            "Observability is enabled but persesService is not configured",
+			LastTransitionTime: now,
+		}
+	}
+
+	return v1alpha1.ModuleStatus{
+		Phase:  v1alpha1.ModulePhaseDeployed,
+		Reason: "ObservabilityEnabled",
+		Message: fmt.Sprintf("Proxying to %s.%s:%d",
+			spec.Observability.PersesService.Name,
+			spec.Observability.PersesService.Namespace,
+			spec.Observability.PersesService.Port),
+		LastTransitionTime: now,
+	}
+}
+
+func findMissingComponent(components map[string]v1alpha1.ComponentAvailability, required []string) string {
+	for _, name := range required {
+		if !isComponentAvailable(components, name) {
+			return name
+		}
+	}
+
+	return ""
+}
+
+func allDepsResolved(deps []string, result map[string]v1alpha1.ModuleStatus) bool {
+	for _, dep := range deps {
+		if _, ok := result[dep]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ModuleNames returns the sorted list of module names from the registry.
+func ModuleNames() []string {
+	names := make([]string, 0, len(moduleRegistry))
+	for name := range moduleRegistry {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -23,11 +23,12 @@ const (
 // truth for module metadata. The CR only carries override intent and
 // external dependency signals.
 type ModuleDefinition struct {
-	Name               string
-	Type               ModuleType
-	ContainerName      string
-	Port               int32
-	ImageEnvVar        string
+	Name          string
+	Type          ModuleType
+	ContainerName string
+	Port          int32
+	ImageEnvVar   string
+	// Empty means the module is always deployed (opt-in by default).
 	RequiredComponents []string
 	RequiredModules    []string
 }

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -213,6 +213,17 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 		}
 	}
 
+	for name := range spec.Modules {
+		if _, known := moduleRegistry[name]; !known {
+			result[name] = v1alpha1.ModuleStatus{
+				Phase:              v1alpha1.ModulePhaseNotDeployed,
+				Reason:             "UnknownModule",
+				Message:            fmt.Sprintf("Module %q is not in the controller's registry (possible typo)", name),
+				LastTransitionTime: now,
+			}
+		}
+	}
+
 	return result
 }
 

--- a/dashboard-operator/internal/controller/modules.go
+++ b/dashboard-operator/internal/controller/modules.go
@@ -186,7 +186,7 @@ func resolveModuleStatuses(spec *v1alpha1.DashboardSpec) map[string]v1alpha1.Mod
 				}
 			}
 
-			if allMet && allDepsResolved(deps, result) {
+			if allMet {
 				result[name] = v1alpha1.ModuleStatus{
 					Phase:              v1alpha1.ModulePhaseDeployed,
 					Reason:             "DependenciesSatisfied",
@@ -253,16 +253,6 @@ func findMissingComponent(components map[string]v1alpha1.ComponentAvailability, 
 	}
 
 	return ""
-}
-
-func allDepsResolved(deps []string, result map[string]v1alpha1.ModuleStatus) bool {
-	for _, dep := range deps {
-		if _, ok := result[dep]; !ok {
-			return false
-		}
-	}
-
-	return true
 }
 
 // ModuleNames returns the sorted list of module names from the registry.

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -243,6 +243,25 @@ func TestResolveModuleStatuses(t *testing.T) {
 				"mlflowEmbedded": "ModuleDependencyNotSatisfied",
 			},
 		},
+		{
+			name: "explicit enable with satisfied module deps deploys",
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"mlflowoperator": {ManagementState: "Managed"},
+				},
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"mlflowEmbedded": {State: v1alpha1.ModuleEnabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"mlflow":         v1alpha1.ModulePhaseDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"mlflow":         "DependenciesSatisfied",
+				"mlflowEmbedded": "DependenciesSatisfied",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -266,13 +266,27 @@ func TestResolveModuleStatuses(t *testing.T) {
 				"mlflowEmbedded": "DependenciesSatisfied",
 			},
 		},
+		{
+			name: "unknown module override key produces UnknownModule status",
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"modelregistry": {State: v1alpha1.ModuleEnabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelregistry": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"modelregistry": "UnknownModule",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveModuleStatuses(&tt.spec)
 
-			require.Equal(t, len(moduleRegistry), len(got), "should return status for every registered module")
+			require.GreaterOrEqual(t, len(got), len(moduleRegistry), "should include at least every registered module")
 
 			for name, wantPhase := range tt.wantPhases {
 				status, ok := got[name]

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -58,10 +58,11 @@ func TestIsComponentAvailable(t *testing.T) {
 
 func TestResolveModuleStatuses(t *testing.T) {
 	tests := []struct {
-		name       string
-		spec       v1alpha1.DashboardSpec
-		wantPhases map[string]v1alpha1.ModulePhase
-		wantReason map[string]string
+		name        string
+		spec        v1alpha1.DashboardSpec
+		wantPhases  map[string]v1alpha1.ModulePhase
+		wantReason  map[string]string
+		wantMessage map[string]string
 	}{
 		{
 			name: "all components available, observability enabled",
@@ -85,6 +86,9 @@ func TestResolveModuleStatuses(t *testing.T) {
 				"automl":         v1alpha1.ModulePhaseDeployed,
 				"autorag":        v1alpha1.ModulePhaseDeployed,
 				"perses":         v1alpha1.ModulePhaseDeployed,
+			},
+			wantMessage: map[string]string{
+				"perses": "Proxying to perses.monitoring:8080",
 			},
 		},
 		{
@@ -279,6 +283,10 @@ func TestResolveModuleStatuses(t *testing.T) {
 
 			for name, wantReason := range tt.wantReason {
 				assert.Equal(t, wantReason, got[name].Reason, "module %q reason", name)
+			}
+
+			for name, wantMsg := range tt.wantMessage {
+				assert.Equal(t, wantMsg, got[name].Message, "module %q message", name)
 			}
 		})
 	}

--- a/dashboard-operator/internal/controller/modules_test.go
+++ b/dashboard-operator/internal/controller/modules_test.go
@@ -1,0 +1,295 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1alpha1 "github.com/opendatahub-io/odh-dashboard/dashboard-operator/api/v1alpha1"
+)
+
+func TestIsComponentAvailable(t *testing.T) {
+	tests := []struct {
+		name       string
+		components map[string]v1alpha1.ComponentAvailability
+		component  string
+		want       bool
+	}{
+		{
+			name:       "managed component is available",
+			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Managed"}},
+			component:  "modelregistry",
+			want:       true,
+		},
+		{
+			name:       "unmanaged component is available",
+			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Unmanaged"}},
+			component:  "modelregistry",
+			want:       true,
+		},
+		{
+			name:       "removed component is not available",
+			components: map[string]v1alpha1.ComponentAvailability{"modelregistry": {ManagementState: "Removed"}},
+			component:  "modelregistry",
+			want:       false,
+		},
+		{
+			name:       "missing component is not available",
+			components: map[string]v1alpha1.ComponentAvailability{},
+			component:  "modelregistry",
+			want:       false,
+		},
+		{
+			name:       "nil map",
+			components: nil,
+			component:  "modelregistry",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isComponentAvailable(tt.components, tt.component)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveModuleStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       v1alpha1.DashboardSpec
+		wantPhases map[string]v1alpha1.ModulePhase
+		wantReason map[string]string
+	}{
+		{
+			name: "all components available, observability enabled",
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"modelregistry":  {ManagementState: "Managed"},
+					"mlflowoperator": {ManagementState: "Managed"},
+				},
+				Observability: &v1alpha1.ObservabilitySpec{
+					Enabled:       true,
+					PersesService: &v1alpha1.ServiceTarget{Name: "perses", Namespace: "monitoring", Port: 8080},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
+				"genAi":          v1alpha1.ModulePhaseDeployed,
+				"mlflow":         v1alpha1.ModulePhaseDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseDeployed,
+				"maas":           v1alpha1.ModulePhaseDeployed,
+				"evalHub":        v1alpha1.ModulePhaseDeployed,
+				"automl":         v1alpha1.ModulePhaseDeployed,
+				"autorag":        v1alpha1.ModulePhaseDeployed,
+				"perses":         v1alpha1.ModulePhaseDeployed,
+			},
+		},
+		{
+			name: "empty spec — modules with no deps deployed, others not",
+			spec: v1alpha1.DashboardSpec{},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry":  v1alpha1.ModulePhaseNotDeployed,
+				"genAi":          v1alpha1.ModulePhaseDeployed,
+				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
+				"maas":           v1alpha1.ModulePhaseDeployed,
+				"evalHub":        v1alpha1.ModulePhaseDeployed,
+				"automl":         v1alpha1.ModulePhaseDeployed,
+				"autorag":        v1alpha1.ModulePhaseDeployed,
+				"perses":         v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"modelRegistry":  "ComponentNotAvailable",
+				"mlflow":         "ComponentNotAvailable",
+				"mlflowEmbedded": "ComponentNotAvailable",
+				"perses":         "ObservabilityDisabled",
+			},
+		},
+		{
+			name: "explicit disable override",
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"genAi": {State: v1alpha1.ModuleDisabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"genAi": v1alpha1.ModulePhaseDisabled,
+			},
+			wantReason: map[string]string{
+				"genAi": "ExplicitOverride",
+			},
+		},
+		{
+			name: "explicit enable bypasses DSC component check",
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"modelRegistry": {State: v1alpha1.ModuleEnabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry": v1alpha1.ModulePhaseDeployed,
+			},
+			wantReason: map[string]string{
+				"modelRegistry": "ExplicitOverride",
+			},
+		},
+		{
+			name: "component removed — dependent module not deployed",
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"modelregistry":  {ManagementState: "Managed"},
+					"mlflowoperator": {ManagementState: "Removed"},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry":  v1alpha1.ModulePhaseDeployed,
+				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"mlflow":         "ComponentNotAvailable",
+				"mlflowEmbedded": "ComponentNotAvailable",
+			},
+		},
+		{
+			name: "inter-module dep — mlflow disabled cascades to mlflowEmbedded",
+			spec: v1alpha1.DashboardSpec{
+				Components: map[string]v1alpha1.ComponentAvailability{
+					"mlflowoperator": {ManagementState: "Managed"},
+				},
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"mlflow": {State: v1alpha1.ModuleDisabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"mlflow":         v1alpha1.ModulePhaseDisabled,
+				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"mlflow":         "ExplicitOverride",
+				"mlflowEmbedded": "ModuleDependencyNotSatisfied",
+			},
+		},
+		{
+			name: "observability enabled without perses service config",
+			spec: v1alpha1.DashboardSpec{
+				Observability: &v1alpha1.ObservabilitySpec{
+					Enabled: true,
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"perses": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"perses": "MissingPersesServiceConfig",
+			},
+		},
+		{
+			name: "observability disabled",
+			spec: v1alpha1.DashboardSpec{
+				Observability: &v1alpha1.ObservabilitySpec{
+					Enabled: false,
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"perses": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"perses": "ObservabilityDisabled",
+			},
+		},
+		{
+			name: "all modules disabled via overrides",
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"modelRegistry":  {State: v1alpha1.ModuleDisabled},
+					"genAi":          {State: v1alpha1.ModuleDisabled},
+					"mlflow":         {State: v1alpha1.ModuleDisabled},
+					"mlflowEmbedded": {State: v1alpha1.ModuleDisabled},
+					"maas":           {State: v1alpha1.ModuleDisabled},
+					"evalHub":        {State: v1alpha1.ModuleDisabled},
+					"automl":         {State: v1alpha1.ModuleDisabled},
+					"autorag":        {State: v1alpha1.ModuleDisabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"modelRegistry":  v1alpha1.ModulePhaseDisabled,
+				"genAi":          v1alpha1.ModulePhaseDisabled,
+				"mlflow":         v1alpha1.ModulePhaseDisabled,
+				"mlflowEmbedded": v1alpha1.ModulePhaseDisabled,
+				"maas":           v1alpha1.ModulePhaseDisabled,
+				"evalHub":        v1alpha1.ModulePhaseDisabled,
+				"automl":         v1alpha1.ModulePhaseDisabled,
+				"autorag":        v1alpha1.ModulePhaseDisabled,
+				"perses":         v1alpha1.ModulePhaseNotDeployed,
+			},
+		},
+		{
+			name: "explicit enable does not bypass inter-module deps",
+			spec: v1alpha1.DashboardSpec{
+				Modules: map[string]v1alpha1.ModuleOverride{
+					"mlflowEmbedded": {State: v1alpha1.ModuleEnabled},
+				},
+			},
+			wantPhases: map[string]v1alpha1.ModulePhase{
+				"mlflow":         v1alpha1.ModulePhaseNotDeployed,
+				"mlflowEmbedded": v1alpha1.ModulePhaseNotDeployed,
+			},
+			wantReason: map[string]string{
+				"mlflow":         "ComponentNotAvailable",
+				"mlflowEmbedded": "ModuleDependencyNotSatisfied",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveModuleStatuses(&tt.spec)
+
+			require.Equal(t, len(moduleRegistry), len(got), "should return status for every registered module")
+
+			for name, wantPhase := range tt.wantPhases {
+				status, ok := got[name]
+				require.True(t, ok, "module %q should be in results", name)
+				assert.Equal(t, wantPhase, status.Phase, "module %q phase", name)
+				assert.False(t, status.LastTransitionTime.IsZero(), "module %q should have LastTransitionTime set", name)
+			}
+
+			for name, wantReason := range tt.wantReason {
+				assert.Equal(t, wantReason, got[name].Reason, "module %q reason", name)
+			}
+		})
+	}
+}
+
+func TestModuleRegistry(t *testing.T) {
+	assert.Len(t, moduleRegistry, 9, "expected 9 modules in registry")
+
+	for name, mod := range moduleRegistry {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, name, mod.Name, "module name must match registry key")
+
+			switch mod.Type {
+			case ModuleTypeBFF:
+				assert.NotEmpty(t, mod.ContainerName, "BFF module must have ContainerName")
+				assert.Greater(t, mod.Port, int32(0), "BFF module must have Port > 0")
+				assert.NotEmpty(t, mod.ImageEnvVar, "BFF module must have ImageEnvVar")
+			case ModuleTypeEmbedded, ModuleTypeProxyService:
+				assert.Empty(t, mod.ContainerName, "non-BFF module should not have ContainerName")
+				assert.Equal(t, int32(0), mod.Port, "non-BFF module should have Port == 0")
+			default:
+				t.Errorf("unknown module type: %s", mod.Type)
+			}
+		})
+	}
+}
+
+func TestModuleNames(t *testing.T) {
+	names := ModuleNames()
+	assert.Len(t, names, 9)
+	assert.Equal(t, names[0], "automl", "names should be sorted alphabetically")
+	assert.Equal(t, names[len(names)-1], "perses")
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@
 Main topics:
 
 - [Overall Architecture](#overview)
+- [Dashboard Module Controller](#dashboard-module-controller)
 - [Client Structure](#client-structure)
 
 ## Overview
@@ -157,6 +158,18 @@ These are made using your user's k8s permissions. It consumes your OpenShift OAu
   - Somewhat deprecated - it could probably be reworked to use the Proxy call endpoint, but serves as isolated functionality
 
 These all share the same underlying proxy to an endpoint call, they just structure the data differently before calling.
+
+## Dashboard Module Controller
+
+The Dashboard Module Controller (`dashboard-operator/`) is a standalone Kubernetes operator that manages the full lifecycle of the Dashboard application. It is co-located in the monorepo because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
+
+- **Language**: Go 1.25+ with controller-runtime v0.23
+- **CRD**: `Dashboard` (cluster-scoped, singleton) in group `dashboard.opendatahub.io`
+- **Key dependencies**: `odh-platform-utilities` for manifest rendering, SSA deployment, platform detection, status conditions
+- **Reconciliation**: Kustomize rendering -> SSA deploy -> URL extraction -> module dependency resolution -> status update
+- **Module System**: Static module registry with two-pass dependency resolution; per-module status reported via `status.moduleStatuses`
+
+The controller is **not** part of the npm workspace or Turbo pipeline. It has its own `go.mod`, `Makefile`, and CI workflow. See [Dashboard Operator Architecture](dashboard-operator.md) for full details.
 
 ## Client Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ These all share the same underlying proxy to an endpoint call, they just structu
 The Dashboard Module Controller (`dashboard-operator/`) is a standalone Kubernetes operator that manages the full lifecycle of the Dashboard application. It is co-located in the monorepo because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
 
 - **Language**: Go 1.25+ with controller-runtime v0.23
-- **CRD**: `Dashboard` (cluster-scoped, singleton) in group `dashboard.opendatahub.io`
+- **CRD**: `Dashboard` (cluster-scoped, singleton) in group `components.platform.opendatahub.io`
 - **Key dependencies**: `odh-platform-utilities` for manifest rendering, SSA deployment, platform detection, status conditions
 - **Reconciliation**: Kustomize rendering -> SSA deploy -> URL extraction -> module dependency resolution -> status update
 - **Module System**: Static module registry with two-pass dependency resolution; per-module status reported via `status.moduleStatuses`

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -1,0 +1,207 @@
+# Dashboard Module Controller
+
+## Purpose
+
+The Dashboard Module Controller (`dashboard-operator/`) is a standalone Kubernetes operator that manages the full lifecycle of the ODH Dashboard application. It is co-located in the monorepo because the controller is tightly coupled to Dashboard frontend/backend versions and manifest layouts.
+
+As part of the modular architecture initiative (RHAISTRAT-1064), each component transitions from being managed directly by the central ODH Operator to having its own module controller. The Dashboard Module Controller replaces the prior approach where the ODH Operator's `internal/controller/components/dashboard/` package managed Dashboard resources directly.
+
+## CRD Design
+
+**Kind**: `Dashboard`
+**Group**: `dashboard.opendatahub.io`
+**Version**: `v1alpha1`
+**Scope**: Cluster (not namespaced)
+**Singleton**: Enforced via CEL validation (`metadata.name == 'default-dashboard'`)
+
+### Spec Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `managementState` | `Managed\|Removed` | Lifecycle intent from orchestrator |
+| `gateway` | `GatewaySpec` | Ingress domain for Route/Ingress |
+| `components` | `map[string]ComponentAvailability` | DSC component availability snapshot, projected by orchestrator |
+| `modules` | `map[string]ModuleOverride` | Per-module enable/disable overrides (tri-state) |
+| `observability` | `ObservabilitySpec` | Perses proxy service configuration |
+
+### Status Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `phase` | `Ready\|NotReady` | Overall controller health |
+| `conditions` | `[]Condition` | `Ready`, `ProvisioningSucceeded`, `Degraded` |
+| `observedGeneration` | `int64` | Last processed spec generation |
+| `url` | `string` | Externally-reachable dashboard URL |
+| `moduleStatuses` | `map[string]ModuleStatus` | Per-module deployment state |
+| `releases` | `[]ComponentRelease` | Deployed component versions |
+
+### Platform Utilities Integration
+
+The CRD embeds types from `odh-platform-utilities/api/common`:
+- `ManagementSpec` (inline in spec) — standardized lifecycle intent
+- `Status` (inline in status) — phase, conditions, observedGeneration
+- `ComponentReleaseStatus` (inline in status) — release version tracking
+- Implements the `PlatformObject` interface for generic condition management
+
+## Reconciliation Pipeline
+
+The controller follows a sequential pipeline on each reconcile:
+
+```
+1. Fetch CR            → return nil for NotFound (deleted)
+2. Read operator config → dashboard-operator-config ConfigMap (optional)
+3. Apply kustomize params → merge computed + image params into manifests
+4. Render manifests    → kustomize engine with namespace injection
+5. Deploy via SSA      → deploy.NewDeployer with field ownership + apply ordering
+6. Extract URL         → list Routes by label, check admission status
+7. Resolve modules     → two-pass dependency resolution, populate moduleStatuses
+8. Update status       → conditions, phase, URL, moduleStatuses, releases
+```
+
+### Error Handling
+
+- **Transient errors**: return `(Result{}, err)` — controller-runtime requeues with backoff
+- **Expected-missing state** (e.g., Route not admitted): return `(Result{RequeueAfter: 10s}, nil)`
+- **Status always updated**: conditions are set before returning errors so the CR reflects failure reasons
+
+## Manifest Management
+
+Manifests are stored at a configurable base path (`--manifests-base-path` flag), with platform-specific overlays:
+
+| Platform | Overlay |
+|----------|---------|
+| SelfManagedRhoai | `/rhoai` |
+| ManagedRhoai | `/not-supported` |
+| OpenDataHub | `/odh` |
+
+The rendering pipeline:
+1. **Kustomize params** computed from Dashboard spec (gateway domain, section title) and `RELATED_IMAGE_*` env vars
+2. **Kustomize engine** renders manifests with namespace injection
+3. **SSA deployer** applies all resources with `dashboard-operator` as field owner
+
+## Module Registry and Dependency Resolution
+
+### Module Registry
+
+A static map compiled into the controller binary defining each module's properties:
+
+| Module | Type | Container | Port | DSC Dependencies |
+|--------|------|-----------|------|-----------------|
+| modelRegistry | BFF | model-registry-ui | 8043 | modelregistry |
+| genAi | BFF | gen-ai-ui | 8143 | (none) |
+| mlflow | BFF | mlflow-ui | 8343 | mlflowoperator |
+| mlflowEmbedded | Embedded | — | — | mlflowoperator, module:mlflow |
+| maas | BFF | maas-ui | 8243 | (none) |
+| evalHub | BFF | eval-hub-ui | 8443 | (none) |
+| automl | BFF | automl-ui | 8543 | (none) |
+| autorag | BFF | autorag-ui | 8643 | (none) |
+| perses | ProxyService | — | — | (observability spec) |
+
+### Two-Pass Resolution Algorithm
+
+**Pass 1** — Evaluate each module independently:
+1. Check `spec.modules[name].state` override: `Disabled` → immediately disabled; `Enabled` → bypasses DSC component checks
+2. For `perses`: check `spec.observability.enabled` instead of components
+3. Check required DSC components via `spec.components`: `Managed`/`Unmanaged` = available, `Removed`/missing = unavailable
+4. If all checks pass: tentatively mark as deployed
+
+**Pass 2** — Resolve inter-module dependencies:
+- For each module with `RequiredModules` (e.g., mlflowEmbedded requires mlflow): verify the required module resolved to `Deployed`
+- If any required module is not deployed, downgrade to `NotDeployed`
+- Bounded iteration prevents infinite loops from dependency cycles
+
+### Override Semantics
+
+| Override State | DSC Components | Inter-Module Deps |
+|---------------|----------------|-------------------|
+| `Enabled` | Bypassed | Still enforced |
+| `Disabled` | Skipped | Skipped |
+| (absent) | Checked | Checked |
+
+## Operator ConfigMap
+
+The controller reads an optional `dashboard-operator-config` ConfigMap for internal flags:
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `logLevel` | string | `""` | Controller log verbosity |
+| `reconcileInterval` | duration | `0` (no periodic requeue) | Override default requeue interval |
+
+A missing or malformed ConfigMap never blocks reconciliation.
+
+## Directory Structure
+
+```
+dashboard-operator/
+├── api/v1alpha1/
+│   ├── dashboard_types.go          # CRD types + kubebuilder markers
+│   ├── dashboard_types_test.go     # PlatformObject interface tests
+│   ├── groupversion_info.go        # API group registration
+│   └── zz_generated.deepcopy.go    # Generated DeepCopy methods
+├── cmd/manager/
+│   └── main.go                     # Entry point: flags, scheme, platform detection
+├── internal/
+│   ├── controller/
+│   │   ├── dashboard_reconciler.go # Reconcile loop
+│   │   ├── actions.go              # Manifest sets, kustomize params, URL extraction
+│   │   ├── support.go              # Platform config, image resolution
+│   │   ├── modules.go              # Module registry + dependency resolution
+│   │   ├── config.go               # Operator ConfigMap reader
+│   │   └── *_test.go               # Unit tests for each file
+│   └── webhook/
+│       ├── dashboard_webhook.go    # Singleton validation webhook
+│       └── dashboard_webhook_test.go
+├── config/
+│   ├── crd/bases/                  # Generated CRD YAML
+│   ├── rbac/role.yaml              # ClusterRole permissions
+│   ├── manager/manager.yaml        # Deployment manifest
+│   └── webhook/                    # Webhook configuration
+├── Dockerfile                      # Multi-stage Go build
+├── Makefile                        # Build, test, generate, lint targets
+└── go.mod                          # Go module (separate from monorepo npm)
+```
+
+## Development Workflow
+
+```bash
+cd dashboard-operator
+
+# Build
+make build
+
+# Run tests with race detector
+make test
+
+# Lint (golangci-lint v2)
+make lint
+
+# After modifying api/v1alpha1/ types:
+make generate    # Regenerate DeepCopy methods
+make manifests   # Regenerate CRD YAML
+
+# Format
+make fmt
+```
+
+### CI
+
+The GitHub workflow `.github/workflows/dashboard-operator-tests.yml` runs lint, build, and test on any change under `dashboard-operator/`.
+
+### Container Image
+
+Built from `dashboard-operator/Dockerfile` and pushed to `quay.io/opendatahub/dashboard-operator:latest`.
+
+## Relationship to BFFs
+
+The operator controller is distinct from BFF (Backend-for-Frontend) services:
+
+| Aspect | Operator Controller | BFF Services |
+|--------|-------------------|--------------|
+| Language | Go + controller-runtime | Go + httprouter |
+| Pattern | Reconciler (watch + react) | HTTP handlers (request/response) |
+| Lifecycle | Long-running, leader-elected | Request-scoped |
+| API | Kubernetes CRD | REST/OpenAPI |
+| Location | `dashboard-operator/` | `packages/*/bff/` |
+| Build | Standalone binary | Per-package binary |
+
+The operator manages the deployment of BFF containers as part of the Dashboard pod, but does not interact with BFF HTTP APIs at runtime.

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -85,8 +85,8 @@ The rendering pipeline:
 
 A static map compiled into the controller binary defining each module's properties:
 
-| Module | Type | Container | Port | DSC Dependencies |
-|--------|------|-----------|------|-----------------|
+| Module | Type | Container | Port | Dependencies |
+|--------|------|-----------|------|--------------|
 | modelRegistry | BFF | model-registry-ui | 8043 | modelregistry |
 | genAi | BFF | gen-ai-ui | 8143 | (none) |
 | mlflow | BFF | mlflow-ui | 8343 | mlflowoperator |
@@ -96,6 +96,8 @@ A static map compiled into the controller binary defining each module's properti
 | automl | BFF | automl-ui | 8543 | (none) |
 | autorag | BFF | autorag-ui | 8643 | (none) |
 | perses | ProxyService | — | — | (observability spec) |
+
+Dependencies prefixed with `module:` are inter-module dependencies resolved in Pass 2; others are DSC component dependencies checked in Pass 1.
 
 ### Two-Pass Resolution Algorithm
 

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -9,10 +9,10 @@ As part of the modular architecture initiative (RHAISTRAT-1064), each component 
 ## CRD Design
 
 **Kind**: `Dashboard`
-**Group**: `dashboard.opendatahub.io`
+**Group**: `components.platform.opendatahub.io`
 **Version**: `v1alpha1`
 **Scope**: Cluster (not namespaced)
-**Singleton**: Enforced via CEL validation (`metadata.name == 'default-dashboard'`)
+**Singleton**: Enforced via CEL validation (`metadata.name == 'default'`)
 
 ### Spec Fields
 

--- a/docs/dashboard-operator.md
+++ b/docs/dashboard-operator.md
@@ -126,8 +126,7 @@ The controller reads an optional `dashboard-operator-config` ConfigMap for inter
 
 | Key | Type | Default | Purpose |
 |-----|------|---------|---------|
-| `logLevel` | string | `""` | Controller log verbosity |
-| `reconcileInterval` | duration | `0` (no periodic requeue) | Override default requeue interval |
+| `reconcileInterval` | duration | `0` (no periodic requeue) | Override default requeue interval (minimum 5s) |
 
 A missing or malformed ConfigMap never blocks reconciliation.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-61014
https://issues.redhat.com/browse/RHOAIENG-61012
https://issues.redhat.com/browse/RHOAIENG-62885
https://issues.redhat.com/browse/RHOAIENG-62887

## Description

PR-3 of the Dashboard Operator EA2 initiative. Adds three capabilities to the Dashboard Module Controller:

**1. Module Registry + Dependency Resolution ([RHOAIENG-61014](https://redhat.atlassian.net/browse/RHOAIENG-61014))**
- Static module registry (`modules.go`) defining 9 modules: modelRegistry, genAi, mlflow, mlflowEmbedded, maas, evalHub, automl, autorag, perses
- Two-pass dependency resolution algorithm:
  - **Pass 1**: Evaluates DSC component availability (`spec.components`), explicit overrides (`spec.modules`), and observability config
  - **Pass 2**: Resolves inter-module dependencies (e.g., mlflowEmbedded depends on mlflow)
- Override semantics: `Enabled` bypasses DSC component checks but still enforces inter-module deps; `Disabled` skips all checks
- Results populate `status.moduleStatuses` on each reconcile

**2. Internal Controller ConfigMap ([RHOAIENG-61012](https://redhat.atlassian.net/browse/RHOAIENG-61012))**
- Reads optional `dashboard-operator-config` ConfigMap for controller-level flags
- Supports `logLevel` (string) and `reconcileInterval` (duration) keys
- Missing/malformed ConfigMap never blocks reconciliation — returns zero-value defaults

**3. Architecture Documentation ([RHOAIENG-62885](https://redhat.atlassian.net/browse/RHOAIENG-62885), [RHOAIENG-62887](https://redhat.atlassian.net/browse/RHOAIENG-62887))**
- New `docs/dashboard-operator.md`: CRD design, reconciliation pipeline, module registry, dependency resolution, manifest management, development workflow
- Updated `docs/architecture.md` with Dashboard Module Controller section
- Updated `BOOKMARKS.md` with operator architecture link

> **Note**: This PR is developed in parallel with #7795 (API group migration). It will need a rebase once #7795 merges — the code changes touch different areas and conflicts should be minimal.

## How Has This Been Tested?

- All tests pass with `go test -race ./...` across all three test packages
- 90.7% code coverage on `internal/controller/` package
- `golangci-lint v2` passes with 0 issues
- Clean build with `go build ./...`

## Test Impact

- **New**: `modules_test.go` — 4 test functions covering `isComponentAvailable`, `resolveModuleStatuses` (10 scenarios), `ModuleRegistry` sanity, `ModuleNames`
- **New**: `config_test.go` — `TestReadOperatorConfig` with 6 scenarios (missing, valid, invalid, empty, partial, nil data)
- **Updated**: `dashboard_reconciler_test.go` — 2 new reconciler test cases: module statuses populated with components, operator config reconcile interval applied

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable reconcile interval via operator ConfigMap with safe defaults; reconciler schedules requeues accordingly.
  * Dashboard now reports per-module statuses and preserves prior transition times when unchanged.
  * Deterministic module registry with two‑pass dependency resolution and observability-linked proxy behavior.

* **Documentation**
  * Added comprehensive Dashboard Operator architecture, CRD, configuration, module lifecycle, operator workflows, and a bookmark to operator docs.

* **Tests**
  * Added unit tests for config parsing, module resolution, and reconcile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->