### PR TITLE
feat: add agent-ops BFF to mod-arch manifests [RHOAIENG-62588]

### DIFF
--- a/manifests/modular-architecture/deployment.yaml
+++ b/manifests/modular-architecture/deployment.yaml
@@ -619,3 +619,76 @@
       capabilities:
         drop:
           - ALL
+
+- op: add
+  path: /spec/template/spec/containers/-
+  value:
+    name: agent-ops-ui
+    image: $(agent-ops-ui-image)
+    imagePullPolicy: Always
+    livenessProbe:
+      httpGet:
+        path: /healthcheck
+        port: 8843
+        scheme: HTTPS
+      initialDelaySeconds: 30
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /healthcheck
+        port: 8843
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 3
+    resources:
+      requests:
+        cpu: 300m
+        memory: 512Mi
+        ephemeral-storage: 10Mi
+      limits:
+        memory: 512Mi
+    ports:
+      - containerPort: 8843
+        name: agent-ops-ui
+    volumeMounts:
+      - name: proxy-tls
+        mountPath: /etc/tls/private
+        readOnly: true
+      - name: odh-trusted-ca-cert
+        mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+        subPath: odh-trusted-ca-bundle.crt
+        readOnly: true
+      - name: odh-trusted-ca-cert
+        mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+        subPath: odh-trusted-ca-bundle.crt
+        readOnly: true
+      - name: odh-ca-cert
+        mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+        subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: odh-ca-cert
+        mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+        subPath: odh-ca-bundle.crt
+        readOnly: true
+      - name: modules-sa-token
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
+    args:
+      - '--auth-method=user_token'
+      - '--auth-token-header=x-forwarded-access-token'
+      - '--auth-token-prefix='
+      - '--port=8843'
+      - '--cert-file=/etc/tls/private/tls.crt'
+      - '--key-file=/etc/tls/private/tls.key'
+      - '--bundle-paths=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem,/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt,/etc/pki/tls/certs/odh-ca-bundle.crt,/etc/pki/tls/certs/odh-trusted-ca-bundle.crt'
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL

--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -153,6 +153,31 @@ data:
         }
       },
       {
+          "name": "agentOps",
+          "remoteEntry": "/remoteEntry.js",
+          "authorize": true,
+          "tls": true,
+          "proxy": [
+            {
+              "path": "/agent-ops/api",
+              "pathRewrite": "/api"
+            },
+            {
+              "path": "/agent-ops/healthcheck",
+              "pathRewrite": "/healthcheck"
+            }
+          ],
+          "local": {
+            "host": "localhost",
+            "port": 8080
+          },
+          "service": {
+            "name": "odh-dashboard",
+            "namespace": "opendatahub",
+            "port": 8843
+        }
+      },
+      {
         "name": "perses",
         "proxyService": [
           {

--- a/manifests/modular-architecture/kustomization.yaml
+++ b/manifests/modular-architecture/kustomization.yaml
@@ -77,6 +77,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.autorag-pipeline-runtime-image
+  - name: agent-ops-ui-image
+    objref:
+      kind: ConfigMap
+      name: modular-architecture-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.agent-ops-ui-image
 configurations:
   - params.yaml
 patchesJson6902:

--- a/manifests/modular-architecture/networkpolicy.yaml
+++ b/manifests/modular-architecture/networkpolicy.yaml
@@ -28,6 +28,8 @@ spec:
           protocol: TCP
         - port: 8743
           protocol: TCP
+        - port: 8843
+          protocol: TCP
       from:
         # Allow traffic from OpenShift ingress controller
         - namespaceSelector:

--- a/manifests/modular-architecture/params.env
+++ b/manifests/modular-architecture/params.env
@@ -14,3 +14,5 @@ automl-pipeline-runtime-image=
 
 autorag-ui-image=quay.io/opendatahub/odh-mod-arch-autorag:main
 autorag-pipeline-runtime-image=
+
+agent-ops-ui-image=quay.io/opendatahub/odh-mod-arch-agent-ops:main

--- a/manifests/modular-architecture/service.yaml
+++ b/manifests/modular-architecture/service.yaml
@@ -47,3 +47,10 @@
     protocol: TCP
     port: 8743
     targetPort: 8743
+- op: add
+  path: /spec/ports/-
+  value:
+    name: agent-ops-ui
+    protocol: TCP
+    port: 8843
+    targetPort: 8843

--- a/manifests/rhoai/base/federation-configmap.yaml
+++ b/manifests/rhoai/base/federation-configmap.yaml
@@ -153,6 +153,31 @@ data:
         }
       },
       {
+          "name": "agentOps",
+          "remoteEntry": "/remoteEntry.js",
+          "authorize": true,
+          "tls": true,
+          "proxy": [
+            {
+              "path": "/agent-ops/api",
+              "pathRewrite": "/api"
+            },
+            {
+              "path": "/agent-ops/healthcheck",
+              "pathRewrite": "/healthcheck"
+            }
+          ],
+          "local": {
+            "host": "localhost",
+            "port": 8080
+          },
+          "service": {
+            "name": "rhods-dashboard",
+            "namespace": "redhat-ods-applications",
+            "port": 8843
+        }
+      },
+      {
         "name": "perses",
         "proxyService": [
           {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-62588

## Summary
Adds the agent-ops BFF module to the modular architecture deployment manifests, enabling the container to be deployed by the operator alongside the main dashboard.

## Changes
- **deployment.yaml** — adds `agent-ops-ui` container with healthcheck probes, TLS, service account token mount (port 8843)
- **service.yaml** — adds port 8843 for agent-ops
- **federation-configmap.yaml** — adds `agentOps` module federation entry (both ODH + RHOAI)
- **networkpolicy.yaml** — opens port 8843
- **kustomization.yaml** — adds image param for agent-ops
- **params.env** — adds `agent-ops-ui-image` parameter

## Why federation-configmap is included
PR #7789 previously added the configmap without the deployment, causing a 10s page load timeout ([RHOAIENG-66735](https://redhat.atlassian.net/browse/RHOAIENG-66735)). This PR adds the deployment AND configmap together, so Module Federation can load `remoteEntry.js` from the running container.

## Test plan
- [ ] Operator deploys agent-ops container with the new manifests
- [ ] Module Federation loads `agentOps` remote entry without timeout
- [ ] Feature flag `agentOps` gates visibility (disabled by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Agent Operations UI component with federated module integration.
  * Added new service endpoints accessible via `/agent-ops` path with dedicated routing and health monitoring.
  * Configured secure service communication on port 8843 with network policies, TLS encryption, and security hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->