### PR TITLE
fix: enable MLflow tracing in preflight GHA

### DIFF
--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -12,7 +12,7 @@ name: ODH Dashboard Agent
 # Required Secrets:
 #   CLAUDE_APP_ID, CLAUDE_APP_PRIVATE_KEY, GCP_CREDENTIALS_JSON,
 #   GCP_PROJECT_ID, MLFLOW_TRACKING_URI, MLFLOW_TRACKING_TOKEN,
-#   MLFLOW_EXPERIMENT_NAME
+#   MLFLOW_EXPERIMENT_NAME, MLFLOW_WORKSPACE
 
 on:
   issue_comment:
@@ -166,9 +166,9 @@ jobs:
       ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       CLOUD_ML_REGION: us-east5
       MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
-      MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
       MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
-      MLFLOW_CLAUDE_TRACING_ENABLED: "true"
+      MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
+      CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS: "30000"
 
     steps:
       - name: Generate GitHub App token (managed)
@@ -231,41 +231,6 @@ jobs:
       - name: Install MLflow
         run: pip install "mlflow==3.12.0"
 
-      - name: Verify MLflow connection
-        continue-on-error: true
-        run: |
-          # Uses ajax-api because /api/2.0/ requires workspace headers that
-          # mlflow 3.12.0 doesn't support. ajax-api bypasses workspace auth.
-          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer $MLFLOW_TRACKING_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{"max_results": 1}' \
-            "$MLFLOW_TRACKING_URI/ajax-api/2.0/mlflow/experiments/search")
-          echo "MLflow API: HTTP $CODE"
-          if [ "$CODE" != "200" ]; then
-            echo "::warning::MLflow returned $CODE — tracing may not work"
-          fi
-
-      - name: Configure MLflow tracing
-        run: |
-          mkdir -p ~/.claude
-          cat > ~/.claude/settings.local.json << 'SETTINGS'
-          {
-            "env": { "MLFLOW_CLAUDE_TRACING_ENABLED": "true" },
-            "hooks": {
-              "Stop": [{
-                "matcher": "",
-                "hooks": [{ "type": "command", "command": "which mlflow >/dev/null 2>&1 && mlflow autolog claude stop-hook || true" }]
-              }],
-              "StopFailure": [{
-                "matcher": "",
-                "hooks": [{ "type": "command", "command": "which mlflow >/dev/null 2>&1 && mlflow autolog claude stop-hook || true" }]
-              }]
-            }
-          }
-          SETTINGS
-
       # ── Check (read-only) ──
       - name: Preflight check
         if: matrix.mode == 'check-only'
@@ -273,6 +238,19 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
+          settings: |
+            {
+              "env": {
+                "MLFLOW_CLAUDE_TRACING_ENABLED": "true",
+                "MLFLOW_TRACKING_URI": "${{ secrets.MLFLOW_TRACKING_URI }}",
+                "MLFLOW_TRACKING_TOKEN": "${{ secrets.MLFLOW_TRACKING_TOKEN }}",
+                "MLFLOW_EXPERIMENT_NAME": "${{ secrets.MLFLOW_EXPERIMENT_NAME }}",
+                "MLFLOW_WORKSPACE": "${{ secrets.MLFLOW_WORKSPACE }}"
+              },
+              "hooks": {
+                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
+              }
+            }
           claude_args: >-
             --max-turns 120
             --model "claude-sonnet-4-6[1m]"
@@ -291,6 +269,19 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
+          settings: |
+            {
+              "env": {
+                "MLFLOW_CLAUDE_TRACING_ENABLED": "true",
+                "MLFLOW_TRACKING_URI": "${{ secrets.MLFLOW_TRACKING_URI }}",
+                "MLFLOW_TRACKING_TOKEN": "${{ secrets.MLFLOW_TRACKING_TOKEN }}",
+                "MLFLOW_EXPERIMENT_NAME": "${{ secrets.MLFLOW_EXPERIMENT_NAME }}",
+                "MLFLOW_WORKSPACE": "${{ secrets.MLFLOW_WORKSPACE }}"
+              },
+              "hooks": {
+                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
+              }
+            }
           claude_args: >-
             --max-turns 200
             --model "claude-sonnet-4-6[1m]"

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -165,9 +165,6 @@ jobs:
       HEAD_REPO: ${{ matrix.head_repo }}
       ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       CLOUD_ML_REGION: us-east5
-      MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
-      MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
-      MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
       CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS: "30000"
 
     steps:
@@ -248,7 +245,8 @@ jobs:
                 "MLFLOW_WORKSPACE": "${{ secrets.MLFLOW_WORKSPACE }}"
               },
               "hooks": {
-                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
+                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}],
+                "StopFailure": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
               }
             }
           claude_args: >-
@@ -279,7 +277,8 @@ jobs:
                 "MLFLOW_WORKSPACE": "${{ secrets.MLFLOW_WORKSPACE }}"
               },
               "hooks": {
-                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
+                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}],
+                "StopFailure": [{"matcher": "", "hooks": [{"type": "command", "command": "mlflow autolog claude stop-hook"}]}]
               }
             }
           claude_args: >-


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65758

## Summary
Fixes MLflow tracing so preflight sessions are captured as traces in our RHOAI MLflow instance.

Three issues were preventing traces from landing:

1. **Settings delivery** — env vars and Stop hooks were written to `~/.claude/settings.local.json`, but `claude-code-action` overwrites `~/.claude/settings.json` and the local file gets ignored. Fix: pass config via the action's `settings` input, which merges into the settings the action creates.

2. **Hook timeout** — the default `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` is 1.5s, which is too short for the mlflow stop-hook to parse the transcript and flush traces. Fix: set to 30s.

3. **Workspace context** — the RHOAI MLflow server requires `MLFLOW_WORKSPACE` on all API calls. Fix: add it to the settings env block.

Also removes the old `Verify MLflow connection` and `Configure MLflow tracing` steps that are no longer needed.

## Required secrets
Set `MLFLOW_WORKSPACE` in the repo secrets (value: the K8s namespace for the MLflow workspace, e.g. `odh-dashboard-tracing`).

## Test plan
- [x] Verified traces land in MLflow from GHA preflight runs on fork
- [ ] Verify traces appear after merge on upstream

Upstream tracking: https://github.com/mlflow/mlflow/issues/23744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration: now requires the workspace secret and streamlines preflight checks.
  * Simplified preflight behavior by inlining tracing/config settings and adding a timeout for code session end hooks.
  * Consolidated verification and fix paths to use the new inline settings and stop-hook flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->