### PR TITLE
feat: add Cache-Control headers and content hashes for static assets

### DIFF
--- a/backend/src/__tests__/cacheHeaders.spec.ts
+++ b/backend/src/__tests__/cacheHeaders.spec.ts
@@ -1,0 +1,83 @@
+import {
+  isHashedAsset,
+  isStaticAsset,
+  getCacheControlForStaticFile,
+  CACHE_HEADER_IMMUTABLE,
+  CACHE_HEADER_SHORT,
+  CACHE_HEADER_NO_CACHE,
+} from '../utils/cacheHeaders';
+
+describe('isHashedAsset', () => {
+  it.each([
+    'app.a1b2c3d4e5f6.bundle.js',
+    'chunk-vendors-abcdef0123456789.js',
+    'app.1234abcd5678.css',
+    'some-chunk.a1b2c3d4e5f6.bundle.css',
+    '1013-4cee0676a66ac829f875.js',
+  ])('should detect hashed filename: %s', (name) => {
+    expect(isHashedAsset(name)).toBe(true);
+  });
+
+  it.each([
+    'index.html',
+    'favicon.ico',
+    'manifest.json',
+    'robots.txt',
+    'remoteEntry.js',
+    'images/logo.png',
+    'fonts/RedHatDisplay-Regular.woff2',
+    'locales/en/translation.json',
+    'app.bundle.js',
+    'app.css',
+  ])('should detect non-hashed filename: %s', (name) => {
+    expect(isHashedAsset(name)).toBe(false);
+  });
+});
+
+describe('isStaticAsset', () => {
+  it.each([
+    'favicon.ico',
+    'images/logo.png',
+    'images/photo.jpg',
+    'images/photo.jpeg',
+    'images/icon.svg',
+    'images/banner.webp',
+    'images/bg.gif',
+    'fonts/RedHatDisplay-Regular.woff2',
+    'fonts/RedHatText.woff',
+    'fonts/mono.ttf',
+    'fonts/legacy.eot',
+  ])('should detect static asset: %s', (name) => {
+    expect(isStaticAsset(name)).toBe(true);
+  });
+
+  it.each([
+    'app.bundle.js',
+    'app.css',
+    'index.html',
+    'remoteEntry.js',
+    'manifest.json',
+    'robots.txt',
+    'locales/en/translation.json',
+  ])('should not detect non-static-asset: %s', (name) => {
+    expect(isStaticAsset(name)).toBe(false);
+  });
+});
+
+describe('getCacheControlForStaticFile', () => {
+  it('should return immutable for hashed files', () => {
+    expect(getCacheControlForStaticFile('app.a1b2c3d4.bundle.js')).toBe(CACHE_HEADER_IMMUTABLE);
+  });
+
+  it('should return short cache for non-hashed images and fonts', () => {
+    expect(getCacheControlForStaticFile('favicon.ico')).toBe(CACHE_HEADER_SHORT);
+    expect(getCacheControlForStaticFile('fonts/RedHatDisplay.woff2')).toBe(CACHE_HEADER_SHORT);
+    expect(getCacheControlForStaticFile('images/logo.png')).toBe(CACHE_HEADER_SHORT);
+  });
+
+  it('should return no-cache for non-hashed code files', () => {
+    expect(getCacheControlForStaticFile('remoteEntry.js')).toBe(CACHE_HEADER_NO_CACHE);
+    expect(getCacheControlForStaticFile('locales/en/translation.json')).toBe(CACHE_HEADER_NO_CACHE);
+    expect(getCacheControlForStaticFile('manifest.json')).toBe(CACHE_HEADER_NO_CACHE);
+  });
+});

--- a/backend/src/__tests__/cacheHeaders.spec.ts
+++ b/backend/src/__tests__/cacheHeaders.spec.ts
@@ -29,6 +29,8 @@ describe('isHashedAsset', () => {
     'locales/en/translation.json',
     'app.bundle.js',
     'app.css',
+    'images/logo-20240608.png',
+    'fonts/asset-20240608.woff2',
   ])('should detect non-hashed filename: %s', (name) => {
     expect(isHashedAsset(name)).toBe(false);
   });
@@ -73,6 +75,11 @@ describe('getCacheControlForStaticFile', () => {
     expect(getCacheControlForStaticFile('favicon.ico')).toBe(CACHE_HEADER_SHORT);
     expect(getCacheControlForStaticFile('fonts/RedHatDisplay.woff2')).toBe(CACHE_HEADER_SHORT);
     expect(getCacheControlForStaticFile('images/logo.png')).toBe(CACHE_HEADER_SHORT);
+  });
+
+  it('should return short cache for numeric-suffix assets, not immutable', () => {
+    expect(getCacheControlForStaticFile('images/logo-20240608.png')).toBe(CACHE_HEADER_SHORT);
+    expect(getCacheControlForStaticFile('fonts/asset-20240608.woff2')).toBe(CACHE_HEADER_SHORT);
   });
 
   it('should return no-cache for non-hashed code files', () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import fastifyWebsocket from '@fastify/websocket';
 import fastifyAccepts from '@fastify/accepts';
 import type { FastifyInstance, FastifyRegisterOptions } from 'fastify';
 import ejs from 'ejs';
+import { getCacheControlForStaticFile } from './utils/cacheHeaders';
 
 const publicDir = path.join(__dirname, '../../frontend/public');
 
@@ -30,6 +31,9 @@ export const initializeApp = async (
     wildcard: false,
     // Do not auto-serve index.html for '/'; let the view route render it
     index: false,
+    setHeaders: (res, filePath) => {
+      res.setHeader('Cache-Control', getCacheControlForStaticFile(filePath));
+    },
   });
 
   // Configure EJS to use a non-conflicting delimiter

--- a/backend/src/routes/root.ts
+++ b/backend/src/routes/root.ts
@@ -21,6 +21,6 @@ export default async (fastify: FastifyInstance): Promise<void> => {
   }
 
   fastify.get('/*', async (_: FastifyRequest, reply: FastifyReply) =>
-    reply.view('index.html', { mfRemotesJson }),
+    reply.header('Cache-Control', 'no-cache').view('index.html', { mfRemotesJson }),
   );
 };

--- a/backend/src/utils/cacheHeaders.ts
+++ b/backend/src/utils/cacheHeaders.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+
+const HASH_PATTERN = /[.-][0-9a-f]{8,}/;
+const STATIC_ASSET_PATTERN = /\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$/i;
+
+export const isHashedAsset = (filePath: string): boolean =>
+  HASH_PATTERN.test(path.basename(filePath));
+
+export const isStaticAsset = (filePath: string): boolean => STATIC_ASSET_PATTERN.test(filePath);
+
+export const CACHE_HEADER_IMMUTABLE = 'public, max-age=31536000, immutable';
+export const CACHE_HEADER_SHORT = 'public, max-age=86400';
+export const CACHE_HEADER_NO_CACHE = 'no-cache';
+
+export const getCacheControlForStaticFile = (filePath: string): string => {
+  if (isHashedAsset(filePath)) {
+    return CACHE_HEADER_IMMUTABLE;
+  }
+  if (isStaticAsset(filePath)) {
+    return CACHE_HEADER_SHORT;
+  }
+  return CACHE_HEADER_NO_CACHE;
+};

--- a/backend/src/utils/cacheHeaders.ts
+++ b/backend/src/utils/cacheHeaders.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-const HASH_PATTERN = /[.-][0-9a-f]{8,}/;
+const HASH_PATTERN = /[.-](?=[0-9a-f]*[a-f])[0-9a-f]{8,}/;
 const STATIC_ASSET_PATTERN = /\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$/i;
 
 export const isHashedAsset = (filePath: string): boolean =>

--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -102,10 +102,9 @@ module.exports = ({
       ],
     },
     output: {
-      filename: '[name].bundle.js',
+      filename: '[name].js',
       path: resolvedOutputDir,
       publicPath: '/',
-      chunkFilename: '[name]-[chunkhash].js',
     },
     plugins: [
       new HtmlWebpackPlugin({

--- a/distributions/core-bff/frontend/config/webpack.common.js
+++ b/distributions/core-bff/frontend/config/webpack.common.js
@@ -180,7 +180,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/distributions/core-bff/frontend/config/webpack.prod.js
+++ b/distributions/core-bff/frontend/config/webpack.prod.js
@@ -35,13 +35,16 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
+        filename: '[name].[contenthash].css',
         ignoreOrder: true,
       }),
     ],

--- a/distributions/core-bff/frontend/config/webpack.prod.js
+++ b/distributions/core-bff/frontend/config/webpack.prod.js
@@ -42,7 +42,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -218,10 +218,9 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: PUBLIC_PATH,
-    chunkFilename: '[name].js',
   },
   optimization: {
     splitChunks: {

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -218,7 +218,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: PUBLIC_PATH,
     chunkFilename: '[name]-[chunkhash].js',

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -221,7 +221,7 @@ module.exports = (env) => ({
     filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: PUBLIC_PATH,
-    chunkFilename: '[name]-[chunkhash].js',
+    chunkFilename: '[name].js',
   },
   optimization: {
     splitChunks: {

--- a/frontend/config/webpack.common.js
+++ b/frontend/config/webpack.common.js
@@ -218,7 +218,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: PUBLIC_PATH,
     chunkFilename: '[name]-[chunkhash].js',

--- a/frontend/config/webpack.prod.js
+++ b/frontend/config/webpack.prod.js
@@ -40,8 +40,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
-      chunkFilename: '[name]-[contenthash].js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -50,7 +49,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/frontend/config/webpack.prod.js
+++ b/frontend/config/webpack.prod.js
@@ -41,6 +41,7 @@ module.exports = merge(
     devtool: 'source-map',
     output: {
       filename: '[name].[contenthash].bundle.js',
+      chunkFilename: '[name]-[contenthash].js',
     },
     optimization: {
       minimize: true,

--- a/frontend/config/webpack.prod.js
+++ b/frontend/config/webpack.prod.js
@@ -39,6 +39,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/frontend/config/webpack.prod.js
+++ b/frontend/config/webpack.prod.js
@@ -45,8 +45,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -212,7 +212,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/bffclient"
@@ -33,6 +34,27 @@ const (
 	UserPath      = ApiPathPrefix + "/user"
 	NamespacePath = ApiPathPrefix + "/namespaces"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                  config.EnvConfig
@@ -193,12 +215,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/agent-ops/bff/internal/api/app.go
+++ b/packages/agent-ops/bff/internal/api/app.go
@@ -39,7 +39,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/agent-ops/bff/internal/api/cache_test.go
+++ b/packages/agent-ops/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/agent-ops/bff/internal/api/cache_test.go
+++ b/packages/agent-ops/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/agent-ops/frontend/config/webpack.prod.js
+++ b/packages/agent-ops/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/agent-ops/frontend/config/webpack.prod.js
+++ b/packages/agent-ops/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/agent-ops/frontend/config/webpack.prod.js
+++ b/packages/agent-ops/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/packages/automl/bff/internal/api/app.go
+++ b/packages/automl/bff/internal/api/app.go
@@ -52,7 +52,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/automl/bff/internal/api/app.go
+++ b/packages/automl/bff/internal/api/app.go
@@ -310,7 +310,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/automl/bff/internal/api/app.go
+++ b/packages/automl/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	k8s "github.com/opendatahub-io/automl-library/bff/internal/integrations/kubernetes"
@@ -46,6 +47,27 @@ const (
 // modelRegistryHTTPClientFactory builds a client for Model Registry register calls.
 // If nil, modelregistry.NewHTTPClient is used. Set by tests only.
 type modelRegistryHTTPClientFactory func(*slog.Logger, string, http.Header, bool, *x509.CertPool) (modelregistry.HTTPClientInterface, error)
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                      config.EnvConfig
@@ -291,12 +313,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/automl/bff/internal/api/cache_test.go
+++ b/packages/automl/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/automl/bff/internal/api/cache_test.go
+++ b/packages/automl/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/automl/frontend/config/webpack.common.js
+++ b/packages/automl/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/automl/frontend/config/webpack.common.js
+++ b/packages/automl/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/automl/frontend/config/webpack.common.js
+++ b/packages/automl/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/automl/frontend/config/webpack.prod.js
+++ b/packages/automl/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/automl/frontend/config/webpack.prod.js
+++ b/packages/automl/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/automl/frontend/config/webpack.prod.js
+++ b/packages/automl/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/packages/autorag/bff/internal/api/app.go
+++ b/packages/autorag/bff/internal/api/app.go
@@ -49,7 +49,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/autorag/bff/internal/api/app.go
+++ b/packages/autorag/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	k8s "github.com/opendatahub-io/autorag-library/bff/internal/integrations/kubernetes"
@@ -43,6 +44,27 @@ const (
 	OGXVectorStoresPath = ApiPathPrefix + "/ogx/vector-stores"
 	PipelineRunsPath    = ApiPathPrefix + "/pipeline-runs"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                      config.EnvConfig
@@ -293,12 +315,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/autorag/bff/internal/api/app.go
+++ b/packages/autorag/bff/internal/api/app.go
@@ -312,7 +312,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/autorag/bff/internal/api/cache_test.go
+++ b/packages/autorag/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/autorag/bff/internal/api/cache_test.go
+++ b/packages/autorag/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/autorag/frontend/config/webpack.common.js
+++ b/packages/autorag/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/autorag/frontend/config/webpack.common.js
+++ b/packages/autorag/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/autorag/frontend/config/webpack.common.js
+++ b/packages/autorag/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/autorag/frontend/config/webpack.prod.js
+++ b/packages/autorag/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/autorag/frontend/config/webpack.prod.js
+++ b/packages/autorag/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/autorag/frontend/config/webpack.prod.js
+++ b/packages/autorag/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -46,7 +46,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -231,7 +231,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/evalhub"
@@ -40,6 +41,27 @@ const (
 	EvalHubCRStatusPath      = ApiPathPrefix + "/evalhub/status"
 	EvalHubServiceHealthPath = ApiPathPrefix + "/evalhub/health"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                  config.EnvConfig
@@ -212,12 +234,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/eval-hub/bff/internal/api/cache_test.go
+++ b/packages/eval-hub/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/eval-hub/bff/internal/api/cache_test.go
+++ b/packages/eval-hub/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/eval-hub/frontend/config/webpack.common.js
+++ b/packages/eval-hub/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/eval-hub/frontend/config/webpack.common.js
+++ b/packages/eval-hub/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/eval-hub/frontend/config/webpack.common.js
+++ b/packages/eval-hub/frontend/config/webpack.common.js
@@ -185,7 +185,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/eval-hub/frontend/config/webpack.prod.js
+++ b/packages/eval-hub/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/eval-hub/frontend/config/webpack.prod.js
+++ b/packages/eval-hub/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/eval-hub/frontend/config/webpack.prod.js
+++ b/packages/eval-hub/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -500,7 +500,8 @@ func (app *App) Routes() http.Handler {
 
 			// Check if the requested file exists
 			cleanPath := path.Clean(r.URL.Path)
-			if _, err := staticDir.Open(cleanPath); err == nil {
+			if f, err := staticDir.Open(cleanPath); err == nil {
+				f.Close()
 				ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 				w.Header().Set("Cache-Control", cacheControlForStaticFile(cleanPath))
 				fileServer.ServeHTTP(w, r)

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/opendatahub-io/gen-ai/internal/integrations/bffclient"
@@ -36,6 +37,27 @@ import (
 	helper "github.com/opendatahub-io/gen-ai/internal/helpers"
 	"github.com/opendatahub-io/gen-ai/internal/services"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                  config.EnvConfig
@@ -480,13 +502,14 @@ func (app *App) Routes() http.Handler {
 			cleanPath := path.Clean(r.URL.Path)
 			if _, err := staticDir.Open(cleanPath); err == nil {
 				ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
-				// Serve the file if it exists
+				w.Header().Set("Cache-Control", cacheControlForStaticFile(cleanPath))
 				fileServer.ServeHTTP(w, r)
 				return
 			}
 
 			// Fallback to index.html for SPA routes
 			ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+			w.Header().Set("Cache-Control", "no-cache")
 			http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 			return
 		}

--- a/packages/gen-ai/bff/internal/api/app.go
+++ b/packages/gen-ai/bff/internal/api/app.go
@@ -42,7 +42,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/gen-ai/bff/internal/api/cache_test.go
+++ b/packages/gen-ai/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/gen-ai/bff/internal/api/cache_test.go
+++ b/packages/gen-ai/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/gen-ai/frontend/config/webpack.common.js
+++ b/packages/gen-ai/frontend/config/webpack.common.js
@@ -141,7 +141,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/gen-ai/frontend/config/webpack.common.js
+++ b/packages/gen-ai/frontend/config/webpack.common.js
@@ -141,7 +141,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/gen-ai/frontend/config/webpack.common.js
+++ b/packages/gen-ai/frontend/config/webpack.common.js
@@ -141,7 +141,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/gen-ai/frontend/config/webpack.prod.js
+++ b/packages/gen-ai/frontend/config/webpack.prod.js
@@ -32,7 +32,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimizer: [
@@ -47,7 +47,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
       }),
     ],
     module: {

--- a/packages/gen-ai/frontend/config/webpack.prod.js
+++ b/packages/gen-ai/frontend/config/webpack.prod.js
@@ -43,8 +43,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
       }),
     ],
     module: {

--- a/packages/gen-ai/frontend/config/webpack.prod.js
+++ b/packages/gen-ai/frontend/config/webpack.prod.js
@@ -31,6 +31,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimizer: [
         new TerserJSPlugin({}),

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -41,7 +41,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"k8s.io/client-go/dynamic"
@@ -35,6 +36,27 @@ const (
 	UserPath        = constants.ApiPathPrefix + "/user"
 	NamespacePath   = constants.ApiPathPrefix + "/namespaces"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                  config.EnvConfig
@@ -219,12 +241,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/maas/bff/internal/api/app.go
+++ b/packages/maas/bff/internal/api/app.go
@@ -238,7 +238,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/maas/bff/internal/api/cache_test.go
+++ b/packages/maas/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/maas/bff/internal/api/cache_test.go
+++ b/packages/maas/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/maas/frontend/config/webpack.common.js
+++ b/packages/maas/frontend/config/webpack.common.js
@@ -186,7 +186,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/maas/frontend/config/webpack.common.js
+++ b/packages/maas/frontend/config/webpack.common.js
@@ -186,7 +186,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/maas/frontend/config/webpack.common.js
+++ b/packages/maas/frontend/config/webpack.common.js
@@ -186,7 +186,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/maas/frontend/config/webpack.prod.js
+++ b/packages/maas/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/maas/frontend/config/webpack.prod.js
+++ b/packages/maas/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/maas/frontend/config/webpack.prod.js
+++ b/packages/maas/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],

--- a/packages/mlflow/bff/internal/api/app.go
+++ b/packages/mlflow/bff/internal/api/app.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -39,6 +40,27 @@ const (
 	PromptVersionsPath = APIPathPrefix + "/prompts/:name/versions"
 	PromptVersionPath  = APIPathPrefix + "/prompts/:name/versions/:version"
 )
+
+var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
+var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
+
+func isHashedAsset(filePath string) bool {
+	return hashPattern.MatchString(path.Base(filePath))
+}
+
+func isStaticAsset(filePath string) bool {
+	return staticAssetPattern.MatchString(filePath)
+}
+
+func cacheControlForStaticFile(filePath string) string {
+	if isHashedAsset(filePath) {
+		return "public, max-age=31536000, immutable"
+	}
+	if isStaticAsset(filePath) {
+		return "public, max-age=86400"
+	}
+	return "no-cache"
+}
 
 type App struct {
 	config                  config.EnvConfig
@@ -241,12 +263,14 @@ func (app *App) Routes() http.Handler {
 		if _, err := staticDir.Open(r.URL.Path); err == nil {
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
+			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
 		// Fallback to index.html for SPA routes
 		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
 	})
 

--- a/packages/mlflow/bff/internal/api/app.go
+++ b/packages/mlflow/bff/internal/api/app.go
@@ -45,7 +45,8 @@ var hashPattern = regexp.MustCompile(`[.\-][0-9a-f]{8,}`)
 var staticAssetPattern = regexp.MustCompile(`(?i)\.(woff2?|ttf|eot|png|jpe?g|gif|svg|ico|webp|avif|bmp)$`)
 
 func isHashedAsset(filePath string) bool {
-	return hashPattern.MatchString(path.Base(filePath))
+	match := hashPattern.FindString(path.Base(filePath))
+	return match != "" && strings.ContainsAny(match, "abcdef")
 }
 
 func isStaticAsset(filePath string) bool {

--- a/packages/mlflow/bff/internal/api/app.go
+++ b/packages/mlflow/bff/internal/api/app.go
@@ -260,7 +260,8 @@ func (app *App) Routes() http.Handler {
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helper.GetContextLoggerFromReq(r)
 		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			// Serve the file if it exists
 			w.Header().Set("Cache-Control", cacheControlForStaticFile(r.URL.Path))

--- a/packages/mlflow/bff/internal/api/cache_test.go
+++ b/packages/mlflow/bff/internal/api/cache_test.go
@@ -20,6 +20,8 @@ func TestIsHashedAsset(t *testing.T) {
 		{"font", "fonts/RedHatDisplay.woff2", false},
 		{"non-hashed bundle", "app.bundle.js", false},
 		{"non-hashed CSS", "app.css", false},
+		{"numeric suffix image", "images/logo-20240608.png", false},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +75,8 @@ func TestCacheControlForStaticFile(t *testing.T) {
 		{"favicon", "favicon.ico", "public, max-age=86400"},
 		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
 		{"image", "images/logo.png", "public, max-age=86400"},
+		{"numeric suffix image", "images/logo-20240608.png", "public, max-age=86400"},
+		{"numeric suffix font", "fonts/asset-20240608.woff2", "public, max-age=86400"},
 		{"remoteEntry", "remoteEntry.js", "no-cache"},
 		{"locale JSON", "locales/en/translation.json", "no-cache"},
 		{"manifest", "manifest.json", "no-cache"},

--- a/packages/mlflow/bff/internal/api/cache_test.go
+++ b/packages/mlflow/bff/internal/api/cache_test.go
@@ -1,0 +1,87 @@
+package api
+
+import "testing"
+
+func TestIsHashedAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"hashed JS bundle", "app.a1b2c3d4e5f6.bundle.js", true},
+		{"hashed CSS", "app.1234abcd5678.css", true},
+		{"chunkhash JS", "1013-4cee0676a66ac829f875.js", true},
+		{"hashed chunk CSS", "some-chunk.abcdef01.bundle.css", true},
+		{"index.html", "index.html", false},
+		{"favicon", "favicon.ico", false},
+		{"remoteEntry", "remoteEntry.js", false},
+		{"manifest", "manifest.json", false},
+		{"image", "images/logo.png", false},
+		{"font", "fonts/RedHatDisplay.woff2", false},
+		{"non-hashed bundle", "app.bundle.js", false},
+		{"non-hashed CSS", "app.css", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHashedAsset(tt.path); got != tt.expected {
+				t.Errorf("isHashedAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"ico", "favicon.ico", true},
+		{"png", "images/logo.png", true},
+		{"jpg", "images/photo.jpg", true},
+		{"jpeg", "images/photo.jpeg", true},
+		{"svg", "images/icon.svg", true},
+		{"gif", "images/anim.gif", true},
+		{"webp", "images/banner.webp", true},
+		{"woff2", "fonts/RedHatDisplay.woff2", true},
+		{"woff", "fonts/RedHatText.woff", true},
+		{"ttf", "fonts/mono.ttf", true},
+		{"eot", "fonts/legacy.eot", true},
+		{"JS file", "app.bundle.js", false},
+		{"CSS file", "app.css", false},
+		{"HTML file", "index.html", false},
+		{"JSON file", "manifest.json", false},
+		{"locale JSON", "locales/en/translation.json", false},
+		{"remoteEntry", "remoteEntry.js", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaticAsset(tt.path); got != tt.expected {
+				t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCacheControlForStaticFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"hashed JS", "app.a1b2c3d4.bundle.js", "public, max-age=31536000, immutable"},
+		{"favicon", "favicon.ico", "public, max-age=86400"},
+		{"font", "fonts/RedHatDisplay.woff2", "public, max-age=86400"},
+		{"image", "images/logo.png", "public, max-age=86400"},
+		{"remoteEntry", "remoteEntry.js", "no-cache"},
+		{"locale JSON", "locales/en/translation.json", "no-cache"},
+		{"manifest", "manifest.json", "no-cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cacheControlForStaticFile(tt.path); got != tt.expected {
+				t.Errorf("cacheControlForStaticFile(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}

--- a/packages/mlflow/frontend/config/webpack.common.js
+++ b/packages/mlflow/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/mlflow/frontend/config/webpack.common.js
+++ b/packages/mlflow/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].[contenthash].bundle.js',
+    filename: '[name].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/mlflow/frontend/config/webpack.common.js
+++ b/packages/mlflow/frontend/config/webpack.common.js
@@ -179,7 +179,7 @@ module.exports = (env) => ({
     ],
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     path: DIST_DIR,
     publicPath: 'auto',
     uniqueName: name,

--- a/packages/mlflow/frontend/config/webpack.prod.js
+++ b/packages/mlflow/frontend/config/webpack.prod.js
@@ -41,8 +41,8 @@ module.exports = merge(
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].css',
-        chunkFilename: '[name].bundle.css',
+        filename: '[name].[contenthash].css',
+        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/mlflow/frontend/config/webpack.prod.js
+++ b/packages/mlflow/frontend/config/webpack.prod.js
@@ -36,7 +36,7 @@ module.exports = merge(
     mode: 'production',
     devtool: 'source-map',
     output: {
-      filename: '[name].[contenthash].bundle.js',
+      filename: '[name].[contenthash].js',
     },
     optimization: {
       minimize: true,
@@ -45,7 +45,6 @@ module.exports = merge(
     plugins: [
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].bundle.css',
         ignoreOrder: true,
       }),
     ],

--- a/packages/mlflow/frontend/config/webpack.prod.js
+++ b/packages/mlflow/frontend/config/webpack.prod.js
@@ -35,6 +35,9 @@ module.exports = merge(
   {
     mode: 'production',
     devtool: 'source-map',
+    output: {
+      filename: '[name].[contenthash].bundle.js',
+    },
     optimization: {
       minimize: true,
       minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-2576

## Description

Adds Cache-Control headers to all static file serving paths (Fastify backend and all 7 Go BFF instances) and adds content hashes to webpack output filenames to enable safe long-term caching.

**Three-tier caching strategy:**

| File Type | Cache-Control | Rationale |
|-----------|--------------|-----------|
| Content-hashed JS/CSS (e.g. `app.a1b2c3d4.bundle.js`) | `public, max-age=31536000, immutable` | Filename changes on content change; cache forever |
| Non-hashed images/fonts (e.g. `favicon.ico`, `.woff2`) | `public, max-age=86400` | Rarely change; 1-day cache with revalidation |
| Code/config files (`index.html`, `remoteEntry.js`, `locales/*.json`) | `no-cache` | Must always revalidate to pick up new deployments |

**Changes across 34 files:**

- **Webpack**: Added `[contenthash]` to `output.filename` in `webpack.common.js` and to `MiniCssExtractPlugin` filenames in `webpack.prod.js` for the main dashboard and all 7 MF packages (gen-ai, maas, automl, autorag, eval-hub, mlflow, agent-ops). `HtmlWebpackPlugin` automatically injects the new hashed filenames into `index.html`.
- **Fastify backend**: Created `backend/src/utils/cacheHeaders.ts` with hash/static-asset detection utilities. Added `setHeaders` callback to `@fastify/static` in `app.ts`. Added `Cache-Control: no-cache` to the root route `index.html` response in `root.ts`.
- **Go BFFs**: Added `isHashedAsset()`, `isStaticAsset()`, and `cacheControlForStaticFile()` to all 7 BFF `app.go` files. Cache headers are set before `fileServer.ServeHTTP()` and before the `index.html` SPA fallback.

**Why `no-cache` for non-hashed code files instead of long cache:**
- `remoteEntry.js` (Module Federation entry) changes every build but keeps the same filename
- `locales/*.json` translation files change between deployments
- `manifest.json` can change with branding updates
- `no-cache` still allows 304 responses via ETag/Last-Modified, so no wasted bandwidth

## How Has This Been Tested?

- Backend unit tests: 36 tests covering `isHashedAsset`, `isStaticAsset`, and `getCacheControlForStaticFile` with hashed filenames, static assets, and code files
- Go BFF unit tests: Table-driven tests for `isHashedAsset`, `isStaticAsset`, and `cacheControlForStaticFile` in all 7 BFF packages
- Verified gen-ai and maas BFF tests pass with `go test ./internal/api/ -run TestIsHashedAsset|TestIsStaticAsset|TestCacheControlForStaticFile`
- Backend lint and type-check pass cleanly

## Test Impact

- New file: `backend/src/__tests__/cacheHeaders.spec.ts` — 36 Jest test cases
- New files: `packages/*/bff/internal/api/cache_test.go` — table-driven Go tests in all 7 BFFs
- All tests are automatically discovered by existing CI pipelines (`go test ./...` and Jest)

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static file responses now set Cache-Control: immutable long-lived for fingerprinted assets, shorter caching for images/fonts, and no-cache for SPA HTML/metadata.
  * Production builds emit content-hashed asset filenames and normalize bundle naming to improve cache invalidation.

* **Tests**
  * Added unit tests across services verifying asset classification and the resulting Cache-Control behaviors (hashed vs. non-hashed assets, images/fonts, and metadata).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->