### PR TITLE
feat(distributions): make base shell reusable

### DIFF
--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -1,119 +1,120 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { ModuleFederationPlugin } = require('@module-federation/enhanced/webpack');
-const deps = require('../package.json').dependencies;
 
-const RELATIVE_DIRNAME = path.resolve(__dirname, '..');
-const SRC_DIR = path.resolve(RELATIVE_DIRNAME, 'src');
-const DIST_DIR = path.resolve(RELATIVE_DIRNAME, 'public');
-const PLUGIN_CORE_DIR = path.resolve(RELATIVE_DIRNAME, '../../packages/plugin-core/src');
-// Allows the base shell to compile shared types/components from the main frontend source tree
-const INTERNAL_DIR = path.resolve(RELATIVE_DIRNAME, '../../frontend/src');
+const BASE_DIR = path.resolve(__dirname, '..');
+const BASE_SRC_DIR = path.resolve(BASE_DIR, 'src');
+const REPO_ROOT = path.resolve(BASE_DIR, '../..');
+const PLUGIN_CORE_DIR = path.resolve(REPO_ROOT, 'packages/plugin-core/src');
+const INTERNAL_DIR = path.resolve(REPO_ROOT, 'frontend/src');
 
-module.exports = () => ({
-  entry: {
-    app: path.join(SRC_DIR, 'index.tsx'),
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(tsx|ts|jsx|js)?$/,
-        exclude: /node_modules/,
-        include: [SRC_DIR, PLUGIN_CORE_DIR, INTERNAL_DIR],
-        use: [{ loader: 'swc-loader' }],
-      },
-      {
-        test: /\.(svg|ttf|eot|woff|woff2)$/,
-        include: [
-          path.resolve(RELATIVE_DIRNAME, '../../node_modules/@patternfly/patternfly/assets/fonts'),
-          path.resolve(RELATIVE_DIRNAME, '../../node_modules/@patternfly/patternfly/assets/pficon'),
-        ],
-        use: {
-          loader: 'file-loader',
-          options: {
-            outputPath: 'fonts',
-            name: '[name].[ext]',
+/**
+ * Shared webpack configuration factory for all distributions.
+ *
+ * Distributions use static imports (no Module Federation) — all extensions
+ * are bundled at build time via normal import statements.
+ *
+ * @param {object} [options]
+ * @param {string} [options.distributionSrcDir] - Source directory for the distribution. Defaults to base's src/.
+ * @param {string} [options.outputDir] - Output directory. Defaults to <distributionSrcDir>/../public.
+ * @param {string} [options.title] - HTML page title. Defaults to 'App Shell'.
+ * @param {string[]} [options.additionalIncludes] - Extra directories to compile with swc-loader.
+ */
+module.exports = ({
+  distributionSrcDir = BASE_SRC_DIR,
+  outputDir,
+  title = 'App Shell',
+  additionalIncludes = [],
+} = {}) => {
+  const resolvedOutputDir = outputDir || path.resolve(path.dirname(distributionSrcDir), 'public');
+
+  return {
+    entry: {
+      app: path.join(distributionSrcDir, 'index.tsx'),
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(tsx|ts|jsx|js)?$/,
+          exclude: /node_modules/,
+          include: [
+            distributionSrcDir,
+            BASE_SRC_DIR,
+            PLUGIN_CORE_DIR,
+            INTERNAL_DIR,
+            ...additionalIncludes,
+          ],
+          use: [{ loader: 'swc-loader' }],
+        },
+        {
+          test: /\.(svg|ttf|eot|woff|woff2)$/,
+          include: [
+            path.resolve(REPO_ROOT, 'node_modules/@patternfly/patternfly/assets/fonts'),
+            path.resolve(REPO_ROOT, 'node_modules/@patternfly/patternfly/assets/pficon'),
+          ],
+          use: {
+            loader: 'file-loader',
+            options: {
+              outputPath: 'fonts',
+              name: '[name].[ext]',
+            },
           },
         },
-      },
-      {
-        test: /\.svg$/,
-        include: (input) => input.indexOf('bgimages') > -1,
-        use: {
-          loader: 'svg-url-loader',
-          options: { limit: 10000 },
-        },
-      },
-      {
-        test: /\.svg$/,
-        include: (input) =>
-          input.indexOf('bgimages') === -1 &&
-          input.indexOf('fonts') === -1 &&
-          input.indexOf('pficon') === -1,
-        use: { loader: 'raw-loader' },
-      },
-      {
-        test: /\.(jpg|jpeg|png|gif)$/i,
-        include: [
-          SRC_DIR,
-          path.resolve(RELATIVE_DIRNAME, '../../node_modules/@patternfly/patternfly/assets/images'),
-        ],
-        use: [
-          {
-            loader: 'url-loader',
-            options: { limit: 5000, outputPath: 'images', name: '[name].[ext]' },
+        {
+          test: /\.svg$/,
+          include: (input) => input.indexOf('bgimages') > -1,
+          use: {
+            loader: 'svg-url-loader',
+            options: { limit: 10000 },
           },
-        ],
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-      {
-        test: /\.css$/i,
-        use: ['style-loader', 'css-loader'],
-      },
+        },
+        {
+          test: /\.svg$/,
+          include: (input) =>
+            input.indexOf('bgimages') === -1 &&
+            input.indexOf('fonts') === -1 &&
+            input.indexOf('pficon') === -1,
+          use: { loader: 'raw-loader' },
+        },
+        {
+          test: /\.(jpg|jpeg|png|gif)$/i,
+          include: [
+            distributionSrcDir,
+            BASE_SRC_DIR,
+            path.resolve(REPO_ROOT, 'node_modules/@patternfly/patternfly/assets/images'),
+          ],
+          use: [
+            {
+              loader: 'url-loader',
+              options: { limit: 5000, outputPath: 'images', name: '[name].[ext]' },
+            },
+          ],
+        },
+        {
+          test: /\.s[ac]ss$/i,
+          use: ['style-loader', 'css-loader', 'sass-loader'],
+        },
+        {
+          test: /\.css$/i,
+          use: ['style-loader', 'css-loader'],
+        },
+      ],
+    },
+    output: {
+      filename: '[name].bundle.js',
+      path: resolvedOutputDir,
+      publicPath: '/',
+      chunkFilename: '[name]-[chunkhash].js',
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.join(distributionSrcDir, 'index.html'),
+        title,
+      }),
     ],
-  },
-  output: {
-    filename: '[name].bundle.js',
-    path: DIST_DIR,
-    publicPath: '/',
-    chunkFilename: '[name]-[chunkhash].js',
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.join(SRC_DIR, 'index.html'),
-      title: 'App Shell',
-    }),
-    new ModuleFederationPlugin({
-      name: 'host',
-      filename: 'remoteEntry.js',
-      shared: {
-        react: { singleton: true, requiredVersion: deps.react, eager: true },
-        'react-dom': { singleton: true, requiredVersion: deps['react-dom'], eager: true },
-        'react-router': { singleton: true, requiredVersion: deps['react-router'], eager: true },
-        'react-router-dom': {
-          singleton: true,
-          requiredVersion: deps['react-router-dom'],
-          eager: true,
-        },
-        '@patternfly/react-core': {
-          singleton: true,
-          requiredVersion: deps['@patternfly/react-core'],
-        },
-        '@openshift/dynamic-plugin-sdk': {
-          singleton: true,
-          requiredVersion: deps['@openshift/dynamic-plugin-sdk'],
-          eager: true,
-        },
-      },
-      exposes: {},
-    }),
-  ],
-  resolve: {
-    extensions: ['.js', '.ts', '.tsx', '.jsx'],
-    symlinks: true,
-    cacheWithContext: false,
-  },
-});
+    resolve: {
+      extensions: ['.js', '.ts', '.tsx', '.jsx'],
+      symlinks: true,
+      cacheWithContext: false,
+    },
+  };
+};

--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -25,11 +25,13 @@ module.exports = ({
   title = 'App Shell',
   additionalIncludes = [],
 } = {}) => {
-  const resolvedOutputDir = outputDir || path.resolve(path.dirname(distributionSrcDir), 'public');
+  const normalizedDistDir = path.resolve(distributionSrcDir);
+  const normalizedIncludes = additionalIncludes.map((p) => path.resolve(p));
+  const resolvedOutputDir = outputDir || path.resolve(path.dirname(normalizedDistDir), 'public');
 
   return {
     entry: {
-      app: path.join(distributionSrcDir, 'index.tsx'),
+      app: path.join(normalizedDistDir, 'index.tsx'),
     },
     module: {
       rules: [
@@ -37,11 +39,11 @@ module.exports = ({
           test: /\.(tsx|ts|jsx|js)?$/,
           exclude: /node_modules/,
           include: [
-            distributionSrcDir,
+            normalizedDistDir,
             BASE_SRC_DIR,
             PLUGIN_CORE_DIR,
             INTERNAL_DIR,
-            ...additionalIncludes,
+            ...normalizedIncludes,
           ],
           use: [{ loader: 'swc-loader' }],
         },
@@ -78,7 +80,7 @@ module.exports = ({
         {
           test: /\.(jpg|jpeg|png|gif)$/i,
           include: [
-            distributionSrcDir,
+            normalizedDistDir,
             BASE_SRC_DIR,
             path.resolve(REPO_ROOT, 'node_modules/@patternfly/patternfly/assets/images'),
           ],
@@ -107,7 +109,7 @@ module.exports = ({
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: path.join(distributionSrcDir, 'index.html'),
+        template: path.join(normalizedDistDir, 'index.html'),
         title,
       }),
     ],

--- a/distributions/base/config/webpack.dev.js
+++ b/distributions/base/config/webpack.dev.js
@@ -8,7 +8,7 @@ const DIST_DIR = path.resolve(RELATIVE_DIRNAME, 'public');
 const PORT = process.env.SHELL_PORT || 4010;
 const BFF_PORT = process.env.BFF_PORT || 4000;
 
-module.exports = merge(webpackCommon('development'), {
+module.exports = merge(webpackCommon(), {
   mode: 'development',
   devtool: 'eval-source-map',
   optimization: {

--- a/distributions/base/config/webpack.dev.js
+++ b/distributions/base/config/webpack.dev.js
@@ -31,10 +31,6 @@ module.exports = merge(webpackCommon(), {
         target: `ws://localhost:${BFF_PORT}`,
         ws: true,
       },
-      {
-        context: ['/_mf'],
-        target: `http://localhost:${BFF_PORT}`,
-      },
     ],
     client: {
       overlay: false,

--- a/distributions/base/config/webpack.prod.js
+++ b/distributions/base/config/webpack.prod.js
@@ -1,7 +1,7 @@
 const { merge } = require('webpack-merge');
 const webpackCommon = require('./webpack.common.js');
 
-module.exports = merge(webpackCommon('production'), {
+module.exports = merge(webpackCommon(), {
   mode: 'production',
   devtool: 'source-map',
 });

--- a/distributions/base/package.json
+++ b/distributions/base/package.json
@@ -4,6 +4,10 @@
   "description": "Base app shell distribution framework",
   "license": "Apache-2.0",
   "private": true,
+  "main": "./src/lib.ts",
+  "exports": {
+    ".": "./src/lib.ts"
+  },
   "engines": {
     "node": ">=22.0.0"
   },
@@ -28,7 +32,6 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@module-federation/enhanced": "^0.18.0",
     "@odh-dashboard/eslint-config": "*",
     "@odh-dashboard/tsconfig": "*",
     "@swc/core": "^1.13.3",

--- a/distributions/base/src/lib.ts
+++ b/distributions/base/src/lib.ts
@@ -1,0 +1,6 @@
+export { default as Shell } from './Shell';
+export { default as ShellHeader } from './ShellHeader';
+export { default as ShellNav } from './ShellNav';
+export { default as ShellRoutes } from './ShellRoutes';
+export { ThemeProvider, useThemeContext } from './ThemeContext';
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65797

## Description

Foundation for the multi-distribution architecture. Makes the base app shell shareable so downstream distributions (rhaii, etc.) can compose their own dashboard variant from shared components without duplicating build config or reaching into internal file paths.

Enables the distributions workstream by parameterizing the base webpack config as a factory and adding barrel exports for shell components.

**Changes:**

- **Webpack factory** — `webpack.common.js` now accepts `{ distributionSrcDir, title, additionalIncludes }` so a new distribution is just a thin config file that calls the factory with its own source directory.
- **Barrel export** — added `src/lib.ts` and package.json `exports` so distributions import shell components via `@odh-dashboard/base-distribution` instead of fragile relative paths.
- **Removed Module Federation dependency** — distributions use static imports and bundle everything at build time.

## How Has This Been Tested?

- `npm install` from root is unaffected (no workspace or dependency changes)
- Base distribution builds successfully with factory defaults: `npx webpack --config distributions/base/config/webpack.prod.js`
- `npx tsc --noEmit` passes with no type errors
- Dev server boots and base app renders at `http://localhost:4010`

## Test Impact

No new tests — this is a build config refactor with no runtime behavior change. The factory defaults are validated by the existing base build continuing to work identically.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API expanded with Shell layout components, theme utilities, and ErrorBoundary.
  * Build output and HTML title made configurable for distributions.

* **Chores**
  * Simplified build configuration by consolidating common settings and removing Module Federation.
  * Dev server proxy for legacy module-federation route removed.
* **Packaging**
  * Package entrypoint/export map added to expose library surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->