### PR TITLE
Add new Feature Store projects with connected workbenches and permiss…

### DIFF
--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -5,9 +5,14 @@ import {
   isRegistryReady,
   getServiceFromCRD,
   listFeastNamespaces,
+  listUserOpenShiftProjects,
+  listFeastIntegrationNotebooks,
   listFeastFeatureStoreCRDs,
   getFeastFeatureStoreCRD,
+  extractPermissionLevel,
+  buildWorkbenchesByFeastProjectMap,
   type FeatureStoreCRD,
+  type FeastIntegrationNotebook,
 } from '../routes/api/featurestores/featureStoreUtils';
 
 const NAMESPACE = {
@@ -442,6 +447,91 @@ describe('featureStoreUtils', () => {
     });
   });
 
+  describe('listUserOpenShiftProjects', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApi = createMockApi();
+      mockFastify = createMockKubeFastify(mockApi);
+    });
+
+    it('should return all user-accessible project names without a label filter', async () => {
+      mockApi.listClusterCustomObject.mockResolvedValue({
+        body: {
+          items: [{ metadata: { name: 'ds-project' } }, { metadata: { name: 'other-ns' } }],
+        },
+      });
+
+      const result = await listUserOpenShiftProjects(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual(['ds-project', 'other-ns']);
+      expect(mockApi.listClusterCustomObject).toHaveBeenCalledWith(
+        'project.openshift.io',
+        'v1',
+        'projects',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: KUBE_HEADERS },
+      );
+    });
+  });
+
+  describe('listFeastIntegrationNotebooks', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    let mockApi: ReturnType<typeof createMockApi>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockApi = createMockApi();
+      mockFastify = createMockKubeFastify(mockApi);
+    });
+
+    it('should list notebooks with feast-integration label in namespace', async () => {
+      const notebook = {
+        metadata: {
+          name: 'test-notebook',
+          namespace: NAMESPACE.VIEWER,
+          annotations: { 'opendatahub.io/feast-config': 'banking' },
+        },
+      };
+
+      mockApi.listNamespacedCustomObject.mockResolvedValue({
+        body: { items: [notebook] },
+      });
+
+      const result = await listFeastIntegrationNotebooks(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        KUBE_HEADERS,
+      );
+
+      expect(result).toEqual([notebook]);
+      expect(mockApi.listNamespacedCustomObject).toHaveBeenCalledWith(
+        'kubeflow.org',
+        'v1',
+        NAMESPACE.VIEWER,
+        'notebooks',
+        undefined,
+        undefined,
+        undefined,
+        'opendatahub.io/feast-integration=true',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: KUBE_HEADERS },
+      );
+    });
+  });
+
   describe('listFeastFeatureStoreCRDs', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
@@ -653,6 +743,111 @@ describe('featureStoreUtils', () => {
       );
 
       expect(result.namespace).toBeUndefined();
+    });
+  });
+
+  describe('extractPermissionLevel', () => {
+    it('should union spec.actions across all permissions', () => {
+      const result = extractPermissionLevel({
+        permissions: [
+          { spec: { actions: ['read', 'describe'] } },
+          { spec: { actions: ['read', 'write'] } },
+        ],
+      });
+
+      expect(result).toEqual(expect.arrayContaining(['read', 'describe', 'write']));
+      expect(result).toHaveLength(3);
+    });
+
+    it('should return empty array when permissions are missing', () => {
+      expect(extractPermissionLevel({})).toEqual([]);
+      expect(extractPermissionLevel({ permissions: [] })).toEqual([]);
+    });
+
+    it('should skip permissions without actions', () => {
+      const result = extractPermissionLevel({
+        permissions: [{ spec: {} }, { spec: { actions: ['read'] } }],
+      });
+
+      expect(result).toEqual(['read']);
+    });
+  });
+
+  describe('buildWorkbenchesByFeastProjectMap', () => {
+    const createNotebook = (
+      overrides: Partial<FeastIntegrationNotebook> & {
+        name: string;
+        namespace: string;
+        feastConfig?: string;
+      },
+    ): FeastIntegrationNotebook => ({
+      metadata: {
+        name: overrides.name,
+        namespace: overrides.namespace,
+        annotations: overrides.feastConfig
+          ? { 'opendatahub.io/feast-config': overrides.feastConfig }
+          : overrides.metadata?.annotations,
+        ...overrides.metadata,
+      },
+    });
+
+    it('should map feast project names to connected workbenches', () => {
+      const notebooks = [
+        createNotebook({
+          name: 'wb-1',
+          namespace: 'ds-project',
+          feastConfig: 'banking, retail',
+        }),
+        createNotebook({
+          name: 'wb-2',
+          namespace: 'other-project',
+          feastConfig: 'banking',
+        }),
+      ];
+
+      const map = buildWorkbenchesByFeastProjectMap(notebooks);
+
+      expect(map.get('banking')).toEqual([
+        {
+          workbenchName: 'wb-1',
+          workbenchNamespace: 'ds-project',
+          projectName: 'ds-project',
+        },
+        {
+          workbenchName: 'wb-2',
+          workbenchNamespace: 'other-project',
+          projectName: 'other-project',
+        },
+      ]);
+      expect(map.get('retail')).toEqual([
+        {
+          workbenchName: 'wb-1',
+          workbenchNamespace: 'ds-project',
+          projectName: 'ds-project',
+        },
+      ]);
+    });
+
+    it('should trim whitespace in feast-config project names', () => {
+      const map = buildWorkbenchesByFeastProjectMap([
+        createNotebook({
+          name: 'wb-1',
+          namespace: 'ds-project',
+          feastConfig: ' banking , retail ',
+        }),
+      ]);
+
+      expect(map.has('banking')).toBe(true);
+      expect(map.has('retail')).toBe(true);
+      expect(map.has(' banking ')).toBe(false);
+    });
+
+    it('should skip notebooks without feast-config annotation', () => {
+      const map = buildWorkbenchesByFeastProjectMap([
+        createNotebook({ name: 'wb-1', namespace: 'ds-project' }),
+      ]);
+
+      expect(map.size).toBe(0);
     });
   });
 });

--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -21,7 +21,6 @@ import {
   getFeastFeatureStoreCRD,
   fetchFeastProjectsFromRegistry,
   getFeastProjectRegistryInfo,
-  hasAccessToFeastProject,
   extractPermissionLevel,
   buildWorkbenchesByFeastProjectMap,
   type FeatureStoreCRD,
@@ -977,53 +976,6 @@ describe('featureStoreUtils', () => {
       );
 
       expect(result).toEqual({ hasAccess: false });
-    });
-  });
-
-  describe('hasAccessToFeastProject', () => {
-    let mockFastify: ReturnType<typeof createMockKubeFastify>;
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockFastify = createMockKubeFastify();
-      process.env = { ...originalEnv, NODE_ENV: 'development' };
-      delete process.env.KUBERNETES_SERVICE_HOST;
-    });
-
-    afterEach(() => {
-      process.env = originalEnv;
-      mockHttpsRequest.mockReset();
-    });
-
-    it('should return true when project is accessible in registry', async () => {
-      mockHttpsJsonResponse(200, {
-        projects: [{ spec: { name: PROJECT.BANKING } }],
-      });
-
-      const result = await hasAccessToFeastProject(
-        mockFastify,
-        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
-        PROJECT.BANKING,
-        USER_TOKEN,
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when project is not accessible in registry', async () => {
-      mockHttpsJsonResponse(200, {
-        projects: [{ spec: { name: PROJECT.RETAIL } }],
-      });
-
-      const result = await hasAccessToFeastProject(
-        mockFastify,
-        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
-        PROJECT.BANKING,
-        USER_TOKEN,
-      );
-
-      expect(result).toBe(false);
     });
   });
 

--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -1,3 +1,13 @@
+import { EventEmitter } from 'events';
+import * as https from 'https';
+
+jest.mock('https', () => {
+  const actual = jest.requireActual<typeof import('https')>('https');
+  return {
+    ...actual,
+    request: jest.fn(),
+  };
+});
 import {
   constructRegistryProxyUrl,
   createFeatureStoreResponse,
@@ -9,6 +19,9 @@ import {
   listFeastIntegrationNotebooks,
   listFeastFeatureStoreCRDs,
   getFeastFeatureStoreCRD,
+  fetchFeastProjectsFromRegistry,
+  getFeastProjectRegistryInfo,
+  hasAccessToFeastProject,
   extractPermissionLevel,
   buildWorkbenchesByFeastProjectMap,
   type FeatureStoreCRD,
@@ -88,6 +101,38 @@ const createMockKubeFastify = (mockApi = createMockApi()) =>
   } as any);
 
 const KUBE_HEADERS = { Authorization: 'Bearer test-token' } as Record<string, string>;
+
+const USER_TOKEN = 'user-registry-token';
+
+const mockHttpsRequest = https.request as jest.Mock;
+
+const mockHttpsJsonResponse = (
+  statusCode: number,
+  body: unknown,
+  options: { requestError?: Error } = {},
+) => {
+  mockHttpsRequest.mockImplementation((_options, callback) => {
+    const req = new EventEmitter() as any;
+    req.end = jest.fn();
+    req.setTimeout = jest.fn();
+    req.destroy = jest.fn();
+
+    if (options.requestError) {
+      process.nextTick(() => req.emit('error', options.requestError));
+      return req;
+    }
+
+    const res = new EventEmitter() as any;
+    res.statusCode = statusCode;
+    process.nextTick(() => {
+      callback?.(res);
+      res.emit('data', JSON.stringify(body));
+      res.emit('end');
+    });
+
+    return req;
+  });
+};
 
 const createFeatureStoreCRD = (overrides: Partial<FeatureStoreCRD> = {}): FeatureStoreCRD => ({
   apiVersion: 'feast.dev/v1',
@@ -482,6 +527,26 @@ describe('featureStoreUtils', () => {
         { headers: KUBE_HEADERS },
       );
     });
+
+    it('should return empty array on 403 without throwing', async () => {
+      mockApi.listClusterCustomObject.mockRejectedValue({ statusCode: 403 });
+
+      const result = await listUserOpenShiftProjects(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array and log on non-403 errors', async () => {
+      mockApi.listClusterCustomObject.mockRejectedValue(new Error('network failure'));
+
+      const result = await listUserOpenShiftProjects(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to list OpenShift projects for user'),
+      );
+    });
   });
 
   describe('listFeastIntegrationNotebooks', () => {
@@ -528,6 +593,34 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         { headers: KUBE_HEADERS },
+      );
+    });
+
+    it('should return empty array on 403 without throwing', async () => {
+      mockApi.listNamespacedCustomObject.mockRejectedValue({ statusCode: 403 });
+
+      const result = await listFeastIntegrationNotebooks(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        KUBE_HEADERS,
+      );
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array and log on non-403 errors', async () => {
+      mockApi.listNamespacedCustomObject.mockRejectedValue(new Error('network failure'));
+
+      const result = await listFeastIntegrationNotebooks(
+        mockFastify,
+        NAMESPACE.VIEWER,
+        KUBE_HEADERS,
+      );
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to list feast-integrated notebooks in ${NAMESPACE.VIEWER}`),
       );
     });
   });
@@ -743,6 +836,194 @@ describe('featureStoreUtils', () => {
       );
 
       expect(result.namespace).toBeUndefined();
+    });
+  });
+
+  describe('fetchFeastProjectsFromRegistry', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockFastify = createMockKubeFastify();
+      process.env = { ...originalEnv, NODE_ENV: 'development' };
+      delete process.env.KUBERNETES_SERVICE_HOST;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      mockHttpsRequest.mockReset();
+    });
+
+    it('should return projects from registry on success', async () => {
+      const projectsResponse = {
+        projects: [{ spec: { name: PROJECT.BANKING, description: 'Banking project' } }],
+      };
+      mockHttpsJsonResponse(200, projectsResponse);
+
+      const result = await fetchFeastProjectsFromRegistry(
+        mockFastify,
+        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
+        USER_TOKEN,
+      );
+
+      expect(result).toEqual(projectsResponse);
+    });
+
+    it('should return null when registry returns non-2xx status', async () => {
+      mockHttpsJsonResponse(503, { error: 'unavailable' });
+
+      const result = await fetchFeastProjectsFromRegistry(
+        mockFastify,
+        createFeatureStoreCRD(),
+        USER_TOKEN,
+      );
+
+      expect(result).toBeNull();
+      expect(mockFastify.log.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Projects list for ${NAMESPACE.VIEWER}/${PROJECT.BANKING}: unavailable`,
+        ),
+      );
+    });
+
+    it('should return null and log when registry request fails', async () => {
+      mockHttpsJsonResponse(200, {}, { requestError: new Error('network failure') });
+
+      const result = await fetchFeastProjectsFromRegistry(
+        mockFastify,
+        createFeatureStoreCRD(),
+        USER_TOKEN,
+      );
+
+      expect(result).toBeNull();
+      expect(mockFastify.log.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Projects list for ${NAMESPACE.VIEWER}/${PROJECT.BANKING}: unavailable`,
+        ),
+      );
+    });
+  });
+
+  describe('getFeastProjectRegistryInfo', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockFastify = createMockKubeFastify();
+      process.env = { ...originalEnv, NODE_ENV: 'development' };
+      delete process.env.KUBERNETES_SERVICE_HOST;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      mockHttpsRequest.mockReset();
+    });
+
+    it('should return access and trimmed description when project is listed', async () => {
+      mockHttpsJsonResponse(200, {
+        projects: [{ spec: { name: PROJECT.BANKING, description: '  Banking DS  ' } }],
+      });
+
+      const result = await getFeastProjectRegistryInfo(
+        mockFastify,
+        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
+        PROJECT.BANKING,
+        USER_TOKEN,
+      );
+
+      expect(result).toEqual({ hasAccess: true, description: 'Banking DS' });
+    });
+
+    it('should use top-level description when spec description is missing', async () => {
+      mockHttpsJsonResponse(200, {
+        projects: [{ name: PROJECT.RETAIL, description: 'Retail project' }],
+      });
+
+      const result = await getFeastProjectRegistryInfo(
+        mockFastify,
+        createFeatureStoreCRD({ metadata: { name: PROJECT.RETAIL, namespace: NAMESPACE.VIEWER } }),
+        PROJECT.RETAIL,
+        USER_TOKEN,
+      );
+
+      expect(result).toEqual({ hasAccess: true, description: 'Retail project' });
+    });
+
+    it('should return hasAccess false when project is not in registry list', async () => {
+      mockHttpsJsonResponse(200, {
+        projects: [{ spec: { name: PROJECT.RETAIL } }],
+      });
+
+      const result = await getFeastProjectRegistryInfo(
+        mockFastify,
+        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
+        PROJECT.BANKING,
+        USER_TOKEN,
+      );
+
+      expect(result).toEqual({ hasAccess: false });
+    });
+
+    it('should return hasAccess false when registry fetch fails', async () => {
+      mockHttpsJsonResponse(500, { error: 'unavailable' });
+
+      const result = await getFeastProjectRegistryInfo(
+        mockFastify,
+        createFeatureStoreCRD(),
+        PROJECT.BANKING,
+        USER_TOKEN,
+      );
+
+      expect(result).toEqual({ hasAccess: false });
+    });
+  });
+
+  describe('hasAccessToFeastProject', () => {
+    let mockFastify: ReturnType<typeof createMockKubeFastify>;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockFastify = createMockKubeFastify();
+      process.env = { ...originalEnv, NODE_ENV: 'development' };
+      delete process.env.KUBERNETES_SERVICE_HOST;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+      mockHttpsRequest.mockReset();
+    });
+
+    it('should return true when project is accessible in registry', async () => {
+      mockHttpsJsonResponse(200, {
+        projects: [{ spec: { name: PROJECT.BANKING } }],
+      });
+
+      const result = await hasAccessToFeastProject(
+        mockFastify,
+        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
+        PROJECT.BANKING,
+        USER_TOKEN,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when project is not accessible in registry', async () => {
+      mockHttpsJsonResponse(200, {
+        projects: [{ spec: { name: PROJECT.RETAIL } }],
+      });
+
+      const result = await hasAccessToFeastProject(
+        mockFastify,
+        createFeatureStoreCRD({ spec: { feastProject: PROJECT.BANKING } }),
+        PROJECT.BANKING,
+        USER_TOKEN,
+      );
+
+      expect(result).toBe(false);
     });
   });
 

--- a/backend/src/routes/api/featurestores/connectedWorkbenches.ts
+++ b/backend/src/routes/api/featurestores/connectedWorkbenches.ts
@@ -1,0 +1,165 @@
+import { FastifyReply } from 'fastify';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
+import { getAccessToken, getDirectCallOptions } from '../../../utils/directCallUtils';
+import { secureRoute } from '../../../utils/route-security';
+import {
+  listFeastNamespaces,
+  listFeastFeatureStoreCRDs,
+  listUserOpenShiftProjects,
+  listFeastIntegrationNotebooks,
+  constructRegistryProxyUrl,
+  makeAuthenticatedHttpRequest,
+  handleError,
+  isRegistryReady,
+  getServiceFromCRD,
+  extractPermissionLevel,
+  buildWorkbenchesByFeastProjectMap,
+  getFeastProjectRegistryInfo,
+  type FeatureStoreCRD,
+  type FeastPermissionsResponse,
+  type ConnectedWorkbenchEntry,
+} from './featureStoreUtils';
+
+interface FeastProjectWithWorkbenches {
+  feastProjectName: string;
+  namespace: string;
+  description?: string;
+  permissionLevel: string[];
+  connectedWorkbenches: ConnectedWorkbenchEntry[];
+}
+
+interface ConnectedWorkbenchesResponse {
+  connectedWorkbenches: FeastProjectWithWorkbenches[];
+}
+
+async function fetchPermissionLevel(
+  fastify: KubeFastifyInstance,
+  crd: FeatureStoreCRD,
+  feastProjectName: string,
+  token: string,
+): Promise<string[]> {
+  try {
+    const { serviceName, namespace, protocol, port } = getServiceFromCRD(crd);
+    const permissionsPath = `api/v1/permissions?project=${encodeURIComponent(feastProjectName)}`;
+    const registryUrl = constructRegistryProxyUrl(
+      serviceName,
+      namespace,
+      permissionsPath,
+      true,
+      protocol,
+      port,
+    );
+    const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastPermissionsResponse>(
+      fastify,
+      registryUrl,
+      token,
+      {},
+    );
+
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Registry permissions returned ${statusCode}`);
+    }
+
+    return extractPermissionLevel(data);
+  } catch (error) {
+    fastify.log.info(
+      `Permissions check for ${crd.metadata.namespace}/${feastProjectName}: unavailable ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return [];
+  }
+}
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.get(
+    '/projects-with-workbenches',
+    secureRoute(fastify)(async (req: OauthFastifyRequest, reply: FastifyReply) => {
+      try {
+        const kubeHeaders = (await getDirectCallOptions(fastify, req, '')).headers as Record<
+          string,
+          string
+        >;
+        const token = getAccessToken({ headers: kubeHeaders });
+
+        if (!token) {
+          return reply.code(401).send({ error: 'User authentication required' });
+        }
+
+        const feastNamespaces = await listFeastNamespaces(fastify, kubeHeaders);
+
+        if (feastNamespaces.length === 0) {
+          return reply.send({ connectedWorkbenches: [] });
+        }
+
+        const crdsByNamespace = await Promise.all(
+          feastNamespaces.map(async (ns) => ({
+            crds: await listFeastFeatureStoreCRDs(fastify, ns, kubeHeaders),
+          })),
+        );
+
+        const userProjectNamespaces = await listUserOpenShiftProjects(fastify, kubeHeaders);
+        const notebooksByNamespace = await Promise.all(
+          userProjectNamespaces.map((ns) =>
+            listFeastIntegrationNotebooks(fastify, ns, kubeHeaders),
+          ),
+        );
+        const workbenchMap = buildWorkbenchesByFeastProjectMap(notebooksByNamespace.flat());
+
+        const projectResults = await Promise.all(
+          crdsByNamespace.map(async ({ crds }) => {
+            const availableFeatureStores = crds.filter(isRegistryReady);
+
+            const projectRows = await Promise.all(
+              availableFeatureStores.map(async (crd) => {
+                const feastProjectName = crd.spec?.feastProject ?? crd.metadata.name;
+                const { hasAccess, description } = await getFeastProjectRegistryInfo(
+                  fastify,
+                  crd,
+                  feastProjectName,
+                  token,
+                );
+
+                if (!hasAccess) {
+                  return null;
+                }
+
+                const permissionLevel = await fetchPermissionLevel(
+                  fastify,
+                  crd,
+                  feastProjectName,
+                  token,
+                );
+                const row: FeastProjectWithWorkbenches = {
+                  feastProjectName,
+                  namespace: crd.metadata.namespace,
+                  permissionLevel,
+                  connectedWorkbenches: workbenchMap.get(feastProjectName) ?? [],
+                };
+                if (description) {
+                  row.description = description;
+                }
+                return row;
+              }),
+            );
+
+            return projectRows.filter((row) => row !== null);
+          }),
+        );
+
+        const response: ConnectedWorkbenchesResponse = {
+          connectedWorkbenches: projectResults.flat(),
+        };
+
+        return reply.send(response);
+      } catch (error) {
+        const errorMessage = handleError(fastify, error, 'projects-with-workbenches');
+        return reply.code(500).send({
+          error: 'Failed to fetch projects with connected workbenches',
+          message: errorMessage,
+          status_code: 500,
+        });
+      }
+    }),
+  );
+};

--- a/backend/src/routes/api/featurestores/connectedWorkbenches.ts
+++ b/backend/src/routes/api/featurestores/connectedWorkbenches.ts
@@ -93,9 +93,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         }
 
         const crdsByNamespace = await Promise.all(
-          feastNamespaces.map(async (ns) => ({
-            crds: await listFeastFeatureStoreCRDs(fastify, ns, kubeHeaders),
-          })),
+          feastNamespaces.map((ns) => listFeastFeatureStoreCRDs(fastify, ns, kubeHeaders)),
         );
 
         const userProjectNamespaces = await listUserOpenShiftProjects(fastify, kubeHeaders);
@@ -107,7 +105,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         const workbenchMap = buildWorkbenchesByFeastProjectMap(notebooksByNamespace.flat());
 
         const projectResults = await Promise.all(
-          crdsByNamespace.map(async ({ crds }) => {
+          crdsByNamespace.map(async (crds) => {
             const availableFeatureStores = crds.filter(isRegistryReady);
 
             const projectRows = await Promise.all(

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -268,17 +268,6 @@ export async function getFeastProjectRegistryInfo(
   };
 }
 
-/** Whether the Feast project appears in the registry projects list for this user. */
-export async function hasAccessToFeastProject(
-  fastify: KubeFastifyInstance,
-  crd: FeatureStoreCRD,
-  feastProjectName: string,
-  token: string,
-): Promise<boolean> {
-  const { hasAccess } = await getFeastProjectRegistryInfo(fastify, crd, feastProjectName, token);
-  return hasAccess;
-}
-
 export function extractPermissionLevel(data: FeastPermissionsResponse): string[] {
   const actions = new Set<string>();
   for (const permission of data.permissions ?? []) {

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -37,13 +37,39 @@ export interface FeatureStoreCRD {
 
 export interface FeastProject {
   name?: string;
+  description?: string;
   spec?: {
     name?: string;
+    description?: string;
   };
 }
 
 export interface FeastProjectsResponse {
   projects?: FeastProject[];
+}
+
+export interface FeastIntegrationNotebook {
+  metadata: {
+    name: string;
+    namespace: string;
+    annotations?: Record<string, string>;
+  };
+}
+
+export interface FeastPermission {
+  spec?: {
+    actions?: string[];
+  };
+}
+
+export interface FeastPermissionsResponse {
+  permissions?: FeastPermission[];
+}
+
+export interface ConnectedWorkbenchEntry {
+  workbenchName: string;
+  workbenchNamespace: string;
+  projectName: string;
 }
 
 export function handleError(fastify: KubeFastifyInstance, error: unknown, context: string): string {
@@ -140,6 +166,162 @@ export async function listFeastNamespaces(
     errorContext: 'Failed to list Feast namespaces for user',
   });
   return items.map((p) => p.metadata.name).filter(Boolean);
+}
+
+/**
+ * Lists all OpenShift projects accessible to the user (no label filter).
+ * Used to discover feast-integrated workbenches across namespaces the user can see.
+ */
+export async function listUserOpenShiftProjects(
+  fastify: KubeFastifyInstance,
+  kubeHeaders: Record<string, string>,
+): Promise<string[]> {
+  const items = await listCustomObjects<{ metadata: { name: string } }>(fastify, kubeHeaders, {
+    group: 'project.openshift.io',
+    version: 'v1',
+    plural: 'projects',
+    errorContext: 'Failed to list OpenShift projects for user',
+  });
+  return items.map((p) => p.metadata.name).filter(Boolean);
+}
+
+/**
+ * Lists Notebook CRs with `opendatahub.io/feast-integration=true` in a namespace.
+ * Returns [] on 403.
+ */
+export async function listFeastIntegrationNotebooks(
+  fastify: KubeFastifyInstance,
+  namespace: string,
+  kubeHeaders: Record<string, string>,
+): Promise<FeastIntegrationNotebook[]> {
+  return listCustomObjects<FeastIntegrationNotebook>(fastify, kubeHeaders, {
+    group: 'kubeflow.org',
+    version: 'v1',
+    plural: 'notebooks',
+    namespace,
+    labelSelector: 'opendatahub.io/feast-integration=true',
+    errorContext: `Failed to list feast-integrated notebooks in ${namespace}`,
+  });
+}
+
+/**
+ * Lists Feast projects from the registry for a FeatureStore CRD. Returns null on failure.
+ */
+export async function fetchFeastProjectsFromRegistry(
+  fastify: KubeFastifyInstance,
+  crd: FeatureStoreCRD,
+  token: string,
+): Promise<FeastProjectsResponse | null> {
+  try {
+    const { serviceName, namespace, protocol, port } = getServiceFromCRD(crd);
+    const registryUrl = constructRegistryProxyUrl(
+      serviceName,
+      namespace,
+      'api/v1/projects',
+      true,
+      protocol,
+      port,
+    );
+    const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+      fastify,
+      registryUrl,
+      token,
+      {},
+    );
+
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Registry returned ${statusCode}`);
+    }
+
+    return data;
+  } catch (error) {
+    fastify.log.info(
+      `Projects list for ${crd.metadata.namespace}/${crd.metadata.name}: unavailable ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Returns whether the user can see the Feast project and its description (one registry call).
+ */
+export async function getFeastProjectRegistryInfo(
+  fastify: KubeFastifyInstance,
+  crd: FeatureStoreCRD,
+  feastProjectName: string,
+  token: string,
+): Promise<{ hasAccess: boolean; description?: string }> {
+  const data = await fetchFeastProjectsFromRegistry(fastify, crd, token);
+  if (!data) {
+    return { hasAccess: false };
+  }
+
+  const project = (data.projects ?? []).find((p) => (p.spec?.name || p.name) === feastProjectName);
+  const rawDescription = project?.spec?.description ?? project?.description;
+  const description = rawDescription?.trim() || undefined;
+
+  return {
+    hasAccess: !!project,
+    description,
+  };
+}
+
+/** Whether the Feast project appears in the registry projects list for this user. */
+export async function hasAccessToFeastProject(
+  fastify: KubeFastifyInstance,
+  crd: FeatureStoreCRD,
+  feastProjectName: string,
+  token: string,
+): Promise<boolean> {
+  const { hasAccess } = await getFeastProjectRegistryInfo(fastify, crd, feastProjectName, token);
+  return hasAccess;
+}
+
+export function extractPermissionLevel(data: FeastPermissionsResponse): string[] {
+  const actions = new Set<string>();
+  for (const permission of data.permissions ?? []) {
+    for (const action of permission.spec?.actions ?? []) {
+      actions.add(action);
+    }
+  }
+  return [...actions];
+}
+
+/**
+ * Maps feast project name → workbenches that reference it via the feast-config annotation.
+ */
+export function buildWorkbenchesByFeastProjectMap(
+  notebooks: FeastIntegrationNotebook[],
+): Map<string, ConnectedWorkbenchEntry[]> {
+  const map = new Map<string, ConnectedWorkbenchEntry[]>();
+
+  for (const notebook of notebooks) {
+    const feastConfig = notebook.metadata.annotations?.['opendatahub.io/feast-config'];
+    if (!feastConfig) {
+      continue;
+    }
+
+    const workbenchNamespace = notebook.metadata.namespace;
+    const entry: ConnectedWorkbenchEntry = {
+      workbenchName: notebook.metadata.name,
+      workbenchNamespace,
+      projectName: workbenchNamespace,
+    };
+
+    feastConfig
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean)
+      .forEach((feastProjectName) => {
+        const existing = map.get(feastProjectName) ?? [];
+        existing.push(entry);
+        map.set(feastProjectName, existing);
+      });
+  }
+
+  return map;
 }
 
 /**

--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -5,13 +5,9 @@ import { secureRoute } from '../../../utils/route-security';
 import {
   listFeastNamespaces,
   listFeastFeatureStoreCRDs,
-  constructRegistryProxyUrl,
-  makeAuthenticatedHttpRequest,
   handleError,
   isRegistryReady,
-  getServiceFromCRD,
-  type FeatureStoreCRD,
-  type FeastProjectsResponse,
+  hasAccessToFeastProject,
 } from './featureStoreUtils';
 
 interface WorkbenchFeatureStoreConfig {
@@ -25,43 +21,6 @@ interface WorkbenchResponse {
     namespace: string;
     clientConfigs: WorkbenchFeatureStoreConfig[];
   }>;
-}
-
-async function hasAccessToProject(
-  fastify: KubeFastifyInstance,
-  crd: FeatureStoreCRD,
-  token: string,
-): Promise<boolean> {
-  try {
-    const { serviceName, namespace, protocol, port } = getServiceFromCRD(crd);
-    const registryUrl = constructRegistryProxyUrl(
-      serviceName,
-      namespace,
-      'api/v1/projects',
-      true,
-      protocol,
-      port,
-    );
-    const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
-      fastify,
-      registryUrl,
-      token,
-      {},
-    );
-    if (statusCode < 200 || statusCode >= 300) {
-      throw new Error(`Registry returned ${statusCode}`);
-    }
-    const projectName = crd.spec?.feastProject ?? crd.metadata.name;
-    const projects = data.projects || [];
-    return projects.some((p) => (p.spec?.name || p.name) === projectName);
-  } catch (error) {
-    fastify.log.info(
-      `Access check for ${crd.metadata.namespace}/${crd.metadata.name}: DENIED ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return false;
-  }
 }
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
@@ -100,7 +59,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             const configResults = await Promise.all(
               availableFeatureStores.map(async (crd) => {
                 const projectName = crd.spec?.feastProject ?? crd.metadata.name;
-                const hasAccess = await hasAccessToProject(fastify, crd, token);
+                const hasAccess = await hasAccessToFeastProject(fastify, crd, projectName, token);
                 return {
                   configName: crd.metadata.name,
                   projectName,

--- a/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
+++ b/backend/src/routes/api/featurestores/fsworkbenchIntegration.ts
@@ -5,9 +5,13 @@ import { secureRoute } from '../../../utils/route-security';
 import {
   listFeastNamespaces,
   listFeastFeatureStoreCRDs,
+  constructRegistryProxyUrl,
+  makeAuthenticatedHttpRequest,
   handleError,
   isRegistryReady,
-  hasAccessToFeastProject,
+  getServiceFromCRD,
+  type FeatureStoreCRD,
+  type FeastProjectsResponse,
 } from './featureStoreUtils';
 
 interface WorkbenchFeatureStoreConfig {
@@ -21,6 +25,43 @@ interface WorkbenchResponse {
     namespace: string;
     clientConfigs: WorkbenchFeatureStoreConfig[];
   }>;
+}
+
+async function hasAccessToProject(
+  fastify: KubeFastifyInstance,
+  crd: FeatureStoreCRD,
+  token: string,
+): Promise<boolean> {
+  try {
+    const { serviceName, namespace, protocol, port } = getServiceFromCRD(crd);
+    const registryUrl = constructRegistryProxyUrl(
+      serviceName,
+      namespace,
+      'api/v1/projects',
+      true,
+      protocol,
+      port,
+    );
+    const { data, statusCode } = await makeAuthenticatedHttpRequest<FeastProjectsResponse>(
+      fastify,
+      registryUrl,
+      token,
+      {},
+    );
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Registry returned ${statusCode}`);
+    }
+    const projectName = crd.spec?.feastProject ?? crd.metadata.name;
+    const projects = data.projects || [];
+    return projects.some((p) => (p.spec?.name || p.name) === projectName);
+  } catch (error) {
+    fastify.log.info(
+      `Access check for ${crd.metadata.namespace}/${crd.metadata.name}: DENIED ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
 }
 
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
@@ -59,7 +100,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
             const configResults = await Promise.all(
               availableFeatureStores.map(async (crd) => {
                 const projectName = crd.spec?.feastProject ?? crd.metadata.name;
-                const hasAccess = await hasAccessToFeastProject(fastify, crd, projectName, token);
+                const hasAccess = await hasAccessToProject(fastify, crd, token);
                 return {
                   configName: crd.metadata.name,
                   projectName,

--- a/backend/src/routes/api/featurestores/index.ts
+++ b/backend/src/routes/api/featurestores/index.ts
@@ -3,4 +3,5 @@ import { KubeFastifyInstance } from '../../../types';
 export default async (fastify: KubeFastifyInstance): Promise<void> => {
   await fastify.register(require('./featureStores'));
   await fastify.register(require('./fsworkbenchIntegration'));
+  await fastify.register(require('./connectedWorkbenches'));
 };

--- a/packages/feature-store/docs/overview.md
+++ b/packages/feature-store/docs/overview.md
@@ -56,13 +56,14 @@ The workbench API endpoint is defined in [`frontend/src/api/featureStore/custom.
 
 ### Backend Proxy Architecture
 
-Located in [`backend/src/routes/api/featurestores/`](../../../backend/src/routes/api/featurestores/), the backend provides three endpoints:
+Located in [`backend/src/routes/api/featurestores/`](../../../backend/src/routes/api/featurestores/), the backend provides four endpoints:
 
 | Endpoint | File | Purpose |
 |----------|------|---------|
 | `GET /api/featurestores/` | `featureStores.ts` | Discovery -- lists all available Feast instances |
 | `GET /api/featurestores/:namespace/:projectName/*` | `featureStores.ts` | Proxy -- forwards requests to the Feast REST API |
 | `GET /api/featurestores/workbench-integration` | `fsworkbenchIntegration.ts` | Returns accessible Feature Stores for the workbench spawner (filtered by user RBAC) |
+| `GET /api/featurestores/projects-with-workbenches` | `connectedWorkbenches.ts` | Merged view of accessible Feast projects, user permissions, and connected workbenches |
 
 **Discovery flow:**
 1. Reads `feast-configs-registry` ConfigMap from the dashboard namespace


### PR DESCRIPTION
…ions API endpoint
https://redhat.atlassian.net/browse/RHOAIENG-62430

## Description

The workbench spawner (“Select feature stores”) and Feature Store “Connected Workbenches” modals both need one payload: every Feast project the user can access, which workbenches are tied to each project, and that user’s permission level per project.

This PR adds GET /api/featurestores/projects-with-workbenches on the dashboard backend to return that merged view. 

## How Has This Been Tested?
GET /api/featurestores/projects-with-workbenches merges accessible Feast projects, permissions, and notebooks with opendatahub.io/feast-config.

<img width="1112" height="1058" alt="SCR-20260604-qsns" src="https://github.com/user-attachments/assets/a4998c0b-351d-46f2-be76-b788545cf562" />


## Test Impact
Extended backend/src/__tests__/featureStoreUtils.spec.ts for listUserOpenShiftProjects, listFeastIntegrationNotebooks, extractPermissionLevel, buildWorkbenchesByFeastProjectMap, and related helpers.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to list feature store projects with connected workbenches, registry access status, optional descriptions, and permission levels.

* **Tests**
  * Expanded test coverage for OpenShift/project discovery, notebook discovery, registry project fetching, permission extraction, and workbench-to-project mapping; includes simulated registry responses and error cases.

* **Documentation**
  * Updated feature store overview to document the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->