### PR TITLE
feat(observability): use RBAC check for cluster metrics access instea…

### DIFF
--- a/frontend/src/__mocks__/mockSelfSubjectAccessReview.ts
+++ b/frontend/src/__mocks__/mockSelfSubjectAccessReview.ts
@@ -1,17 +1,15 @@
-import { K8sVerb, SelfSubjectAccessReviewKind } from '#~/k8sTypes';
+import { AccessReviewResourceAttributes, SelfSubjectAccessReviewKind } from '#~/k8sTypes';
 
-type MockResourceConfigType = {
-  verb?: K8sVerb;
-  group?: string;
-  resource?: string;
+type MockResourceConfigType = Partial<AccessReviewResourceAttributes> & {
   allowed?: boolean;
-  namespace?: string;
 };
 
 export const mockSelfSubjectAccessReview = ({
   verb = 'list',
   group = 'serving.kserve.io',
   resource = 'servingruntimes',
+  subresource,
+  name,
   namespace = 'opendatahub',
   allowed = false,
 }: MockResourceConfigType): SelfSubjectAccessReviewKind => ({
@@ -21,7 +19,9 @@ export const mockSelfSubjectAccessReview = ({
     resourceAttributes: {
       group,
       resource,
+      subresource,
       verb,
+      name,
       namespace,
     },
   },

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -65,7 +65,9 @@ const initIntercepts = ({
     mockSelfSubjectAccessReview({
       group: 'monitoring.coreos.com',
       resource: 'prometheuses',
+      subresource: 'api',
       verb: 'get',
+      name: 'k8s',
       namespace: 'openshift-monitoring',
       allowed: hasClusterMetricsAccess,
     }),

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -59,19 +59,27 @@ const initIntercepts = ({
 
   cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin: false }));
 
-  cy.interceptK8s(
-    'POST',
-    SelfSubjectAccessReviewModel,
-    mockSelfSubjectAccessReview({
+  cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
+    expect(req.body?.spec?.resourceAttributes).to.deep.include({
       group: 'monitoring.coreos.com',
       resource: 'prometheuses',
       subresource: 'api',
       verb: 'get',
       name: 'k8s',
       namespace: 'openshift-monitoring',
-      allowed: hasClusterMetricsAccess,
-    }),
-  );
+    });
+    req.reply(
+      mockSelfSubjectAccessReview({
+        group: 'monitoring.coreos.com',
+        resource: 'prometheuses',
+        subresource: 'api',
+        verb: 'get',
+        name: 'k8s',
+        namespace: 'openshift-monitoring',
+        allowed: hasClusterMetricsAccess,
+      }),
+    );
+  });
 
   cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({ conditions: dsciConditions }));
 

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -2,6 +2,8 @@ import type { DashboardResource } from '@perses-dev/core';
 import type { K8sCondition } from '@odh-dashboard/internal/k8sTypes';
 import { mockDashboardConfig, mockStatus } from '@odh-dashboard/internal/__mocks__';
 import { mockDsciStatus } from '@odh-dashboard/internal/__mocks__/mockDsciStatus';
+import { mockSelfSubjectAccessReview } from '@odh-dashboard/internal/__mocks__/mockSelfSubjectAccessReview';
+import { SelfSubjectAccessReviewModel } from '@odh-dashboard/internal/api/models';
 import { observabilityDashboardPage } from '../../pages/observabilityDashboard';
 
 // Minimal test fixtures following the naming pattern from packages/observability/setup
@@ -21,8 +23,9 @@ const createMockPersesDashboard = (name: string, displayName: string): Dashboard
   return dashboard;
 };
 
-const mockAdminDashboard = createMockPersesDashboard('dashboard-0-cluster-admin', 'Cluster');
-const mockNonAdminDashboard = createMockPersesDashboard('dashboard-1-model', 'Model');
+const mockClusterDashboard = createMockPersesDashboard('dashboard-0-cluster-admin', 'Cluster');
+const mockModelDashboard = createMockPersesDashboard('dashboard-1-model', 'Model');
+const mockTenancyDashboard = createMockPersesDashboard('dashboard-2-tenancy', 'Tenancy');
 
 const HEALTHY_DSCI_CONDITIONS: K8sCondition[] = [
   {
@@ -43,18 +46,30 @@ const HEALTHY_DSCI_CONDITIONS: K8sCondition[] = [
 
 type InitInterceptsOptions = {
   dashboards?: DashboardResource[];
-  isAdmin?: boolean;
+  hasClusterMetricsAccess?: boolean;
   dsciConditions?: K8sCondition[];
 };
 
 const initIntercepts = ({
   dashboards = [],
-  isAdmin = false,
+  hasClusterMetricsAccess = false,
   dsciConditions = HEALTHY_DSCI_CONDITIONS,
 }: InitInterceptsOptions = {}) => {
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ observabilityDashboard: true }));
 
-  cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin }));
+  cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin: false }));
+
+  cy.interceptK8s(
+    'POST',
+    SelfSubjectAccessReviewModel,
+    mockSelfSubjectAccessReview({
+      group: 'monitoring.coreos.com',
+      resource: 'prometheuses',
+      verb: 'get',
+      namespace: 'openshift-monitoring',
+      allowed: hasClusterMetricsAccess,
+    }),
+  );
 
   cy.interceptOdh('GET /api/dsci/status', mockDsciStatus({ conditions: dsciConditions }));
 
@@ -67,7 +82,7 @@ const initIntercepts = ({
 
 describe('Observability Dashboard', () => {
   it('should show empty state when no dashboards exist', () => {
-    initIntercepts({ dashboards: [], isAdmin: true });
+    initIntercepts({ dashboards: [], hasClusterMetricsAccess: true });
 
     observabilityDashboardPage.visit();
 
@@ -79,7 +94,7 @@ describe('Observability Dashboard', () => {
   it('should hide nav and route when DSCI reports monitoring is not ready', () => {
     initIntercepts({
       dashboards: [],
-      isAdmin: true,
+      hasClusterMetricsAccess: true,
       dsciConditions: [
         {
           lastTransitionTime: '2023-10-20T11:45:04Z',
@@ -98,7 +113,7 @@ describe('Observability Dashboard', () => {
   it('should hide nav and route when MonitoringReady is True but PersesAvailable is False', () => {
     initIntercepts({
       dashboards: [],
-      isAdmin: true,
+      hasClusterMetricsAccess: true,
       dsciConditions: [
         {
           lastTransitionTime: '2023-10-20T11:45:04Z',
@@ -122,7 +137,7 @@ describe('Observability Dashboard', () => {
   });
 
   it('should show a load error when the Perses dashboards API is unreachable', () => {
-    initIntercepts({ isAdmin: true });
+    initIntercepts({ hasClusterMetricsAccess: true });
 
     cy.intercept('GET', '/perses/api/api/v1/dashboards', {
       statusCode: 503,
@@ -136,47 +151,29 @@ describe('Observability Dashboard', () => {
     observabilityDashboardPage.shouldHavePersesLoadError();
   });
 
-  it('should show both admin and non-admin dashboard tabs when user is admin', () => {
+  it('should show all dashboard tabs when user has cluster metrics access', () => {
     initIntercepts({
-      dashboards: [mockAdminDashboard, mockNonAdminDashboard],
-      isAdmin: true,
+      dashboards: [mockClusterDashboard, mockModelDashboard, mockTenancyDashboard],
+      hasClusterMetricsAccess: true,
     });
 
     observabilityDashboardPage.visit();
 
-    // Admin users should see both dashboards
     observabilityDashboardPage.shouldHaveTab('Cluster');
     observabilityDashboardPage.shouldHaveTab('Model');
-    observabilityDashboardPage.shouldHaveTabCount(2);
+    observabilityDashboardPage.shouldHaveTab('Tenancy');
+    observabilityDashboardPage.shouldHaveTabCount(3);
   });
 
-  // it('should show only non-admin dashboard tabs when user is not admin', () => {
-  //   // Non-admin users should only see the non-admin dashboard
-  //   // The filtering happens on the frontend, so we still return all dashboards
-  //   // but the usePersesDashboards hook filters based on user admin status
-  //   initIntercepts({
-  //     dashboards: [mockAdminDashboard, mockNonAdminDashboard],
-  //     isAdmin: false,
-  //   });
-
-  //   observabilityDashboardPage.visit();
-
-  //   // Non-admin users should only see non-admin dashboards
-  //   observabilityDashboardPage.shouldHaveTab('Model');
-  //   observabilityDashboardPage.shouldHaveTabCount(1);
-  // });
-
-  // FIXME This is a temporary test to ensure that the dashboard tabs are only available for admins
-  it('should show only dashboard tabs for admins', () => {
-    // Non-admin users should only see the non-admin dashboard
-    // The filtering happens on the frontend, so we still return all dashboards
-    // but the usePersesDashboards hook filters based on user admin status
+  it('should show only tenancy dashboard tabs when user does not have cluster metrics access', () => {
     initIntercepts({
-      dashboards: [mockAdminDashboard, mockNonAdminDashboard],
-      isAdmin: false,
+      dashboards: [mockClusterDashboard, mockModelDashboard, mockTenancyDashboard],
+      hasClusterMetricsAccess: false,
     });
 
-    cy.visitWithLogin('/observe-and-monitor/dashboard');
-    cy.findByTestId('not-found-page').should('exist');
+    observabilityDashboardPage.visit();
+
+    observabilityDashboardPage.shouldHaveTab('Tenancy');
+    observabilityDashboardPage.shouldHaveTabCount(1);
   });
 });

--- a/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
+++ b/packages/observability/cypress/tests/mocked/observabilityDashboard.cy.ts
@@ -60,7 +60,17 @@ const initIntercepts = ({
   cy.interceptOdh('GET /api/status', mockStatus({ isAllowed: true, isAdmin: false }));
 
   cy.interceptK8s('POST', SelfSubjectAccessReviewModel, (req) => {
-    expect(req.body?.spec?.resourceAttributes).to.deep.include({
+    const attrs = req.body?.spec?.resourceAttributes;
+    if (attrs?.group !== 'monitoring.coreos.com') {
+      req.reply(
+        mockSelfSubjectAccessReview({
+          ...attrs,
+          allowed: true,
+        }),
+      );
+      return;
+    }
+    expect(attrs).to.deep.include({
       group: 'monitoring.coreos.com',
       resource: 'prometheuses',
       subresource: 'api',

--- a/packages/observability/extensions.ts
+++ b/packages/observability/extensions.ts
@@ -6,7 +6,6 @@ import type {
 // eslint-disable-next-line no-restricted-syntax -- customCondition is a runtime function, not a CodeRef
 import { isMonitoringStackAvailable } from './src/utils/monitoringStackStatus';
 
-const ADMIN_USER = 'ADMIN_USER';
 const PLUGIN_OBSERVABILITY = 'plugin-observability';
 
 const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
@@ -21,7 +20,7 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
   {
     type: 'app.navigation/href',
     flags: {
-      required: [PLUGIN_OBSERVABILITY, ADMIN_USER],
+      required: [PLUGIN_OBSERVABILITY],
     },
     properties: {
       id: 'observability-dashboard',
@@ -40,7 +39,7 @@ const extensions: (AreaExtension | HrefNavItemExtension | RouteExtension)[] = [
       component: () => import('./src/pages/DashboardPage'),
     },
     flags: {
-      required: [PLUGIN_OBSERVABILITY, ADMIN_USER],
+      required: [PLUGIN_OBSERVABILITY],
     },
   },
 ];

--- a/packages/observability/src/api/usePersesDashboards.ts
+++ b/packages/observability/src/api/usePersesDashboards.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { DashboardResource } from '@perses-dev/core';
 import { useAccessReview } from '@odh-dashboard/internal/api/useAccessReview';
 import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
-import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import useFetch, { type FetchStateObject } from '@odh-dashboard/internal/utilities/useFetch';
 import { fetchPersesDashboardsMetadata } from '../perses/perses-client';
 import {
@@ -29,7 +28,6 @@ export const usePersesDashboards = (
   options?: UsePersesDashboardsOptions,
 ): UsePersesDashboardsResult => {
   const fetchDashboardList = options?.fetchDashboardList ?? true;
-  const { isAdmin } = useUser();
   const [canAccessThanosNonTenancy, thanosNonTenancyAccessLoaded] = useAccessReview(
     THANOS_QUERIER_NON_TENANCY_ACCESS,
   );
@@ -53,9 +51,9 @@ export const usePersesDashboards = (
   } = useFetch(fetchDashboards, [], { initialPromisePurity: true });
 
   const dashboards = React.useMemo(() => {
-    const afterAdminFilter = filterDashboards(allDashboards, isAdmin);
+    const afterAdminFilter = filterDashboards(allDashboards, canAccessThanosNonTenancy);
     return filterDashboardsByThanosNonTenancyAccess(afterAdminFilter, canAccessThanosNonTenancy);
-  }, [allDashboards, isAdmin, canAccessThanosNonTenancy]);
+  }, [allDashboards, canAccessThanosNonTenancy]);
 
   return {
     dashboards,

--- a/packages/observability/src/utils/__tests__/dashboardUtils.spec.ts
+++ b/packages/observability/src/utils/__tests__/dashboardUtils.spec.ts
@@ -70,7 +70,7 @@ describe('dashboardUtils', () => {
     });
 
     describe('admin suffix filtering', () => {
-      it('should exclude admin dashboards for non-admin users', () => {
+      it('should exclude admin dashboards for users without cluster metrics access', () => {
         const dashboards = [
           createMockDashboard('dashboard-model'),
           createMockDashboard('dashboard-cluster-admin'),
@@ -83,7 +83,7 @@ describe('dashboardUtils', () => {
         expect(result[0].metadata.name).toBe('dashboard-model');
       });
 
-      it('should include admin dashboards for admin users', () => {
+      it('should include admin dashboards for users with cluster metrics access', () => {
         const dashboards = [
           createMockDashboard('dashboard-model'),
           createMockDashboard('dashboard-cluster-admin'),
@@ -217,7 +217,7 @@ describe('dashboardUtils', () => {
     });
 
     describe('combined filtering and sorting', () => {
-      it('should filter by prefix, filter by admin status, and sort results', () => {
+      it('should filter by prefix, filter by cluster metrics access, and sort results', () => {
         const dashboards = [
           createMockDashboard('dashboard-zebra'),
           createMockDashboard('other-panel'),

--- a/packages/observability/src/utils/dashboardUtils.ts
+++ b/packages/observability/src/utils/dashboardUtils.ts
@@ -52,24 +52,25 @@ export const filterDashboardsByThanosNonTenancyAccess = (
 };
 
 /**
- * Filters and sorts dashboards according to user admin status.
+ * Filters and sorts dashboards according to cluster metrics access.
  * - Only includes dashboards with names starting with PERSES_DASHBOARD_PREFIX
- * - Non-admin users are excluded from dashboards ending with PERSES_DASHBOARD_ADMIN_SUFFIX
- * - Admin users see the `-admin` variant when both `X` and `X-admin` exist
+ * - Users without cluster metrics access are excluded from dashboards ending with
+ *   PERSES_DASHBOARD_ADMIN_SUFFIX
+ * - Users with cluster metrics access see the `-admin` variant when both `X` and `X-admin` exist
  * - Results are sorted lexicographically by metadata.name
  * @param dashboards - List of dashboard resources
- * @param isAdminUser - Boolean flag indicating if the user is an admin
+ * @param hasClusterMetricsAccess - Whether the user has cluster-scoped metrics access
  * @returns Filtered and sorted dashboards
  */
 export function filterDashboards(
   dashboards: DashboardResource[],
-  isAdminUser: boolean,
+  hasClusterMetricsAccess: boolean,
 ): DashboardResource[] {
   const prefixed = dashboards.filter(({ metadata: { name } }) =>
     name.startsWith(PERSES_DASHBOARD_PREFIX),
   );
 
-  if (!isAdminUser) {
+  if (!hasClusterMetricsAccess) {
     return prefixed
       .filter(({ metadata: { name } }) => !name.endsWith(PERSES_DASHBOARD_ADMIN_SUFFIX))
       .toSorted(({ metadata: { name: a } }, { metadata: { name: b } }) => a.localeCompare(b));


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-51666

## Description

The observability dashboard previously used the `ADMIN_USER` flag to control visibility, which blocked all non-admin users from accessing the page — including users who should be able to see tenancy dashboards.

This PR replaces the admin check with a proper RBAC approach:

- **Removed `ADMIN_USER` flag** from the observability nav item and route extensions. Visibility is now gated only by the `observabilityDashboard` feature flag, so non-admin users can reach the page.
- **Replaced `isAdmin` with a SelfSubjectAccessReview** in `usePersesDashboards`. Dashboard filtering now uses the Thanos non-tenancy SSAR (`prometheuses/api` GET on `k8s` in `openshift-monitoring`) instead of the dashboard admin status. This correctly gates cluster-scoped dashboards (e.g., `dashboard-0-cluster-admin`, `dashboard-1-model`) while leaving tenancy dashboards accessible to all users.
- **Updated Cypress mocked tests** to use SSAR intercepts instead of `isAdmin`, added a tenancy dashboard fixture, and removed the temporary `not-found-page` test that was blocking non-admin access.

### Access behavior after this change

| User type | Cluster dashboards (-admin suffix / non-tenancy gated) | Tenancy dashboards |
|-----------|----------------------------------------------------------|-------------------|
| Cluster admin / cluster-monitoring-view | Visible | Visible |
| Regular user (no cluster metrics access) | Hidden | Visible |

## How Has This Been Tested?

- Unit tests: all 79 observability tests pass (npx jest in packages/observability)
- Type-check: tsc --noEmit passes for the observability package
- Lint: all changed files pass ESLint
- Verified Thanos querier proxy configuration on a live cluster (oc get secret -n openshift-monitoring thanos-querier-kube-rbac-proxy-web) confirms the SSAR attributes match the actual proxy rules

## Test Impact

- Updated existing Cypress mocked tests in observabilityDashboard.cy.ts to use SSAR intercepts (SelfSubjectAccessReviewModel) instead of isAdmin
- Added tenancy dashboard fixture to test that users without cluster metrics access still see tenancy dashboards
- Updated unit test descriptions in dashboardUtils.spec.ts to reflect RBAC semantics
- Renamed filterDashboards parameter from isAdminUser to hasClusterMetricsAccess

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability dashboards, navigation and routes now rely on cluster metrics access checks instead of admin-role gating.

* **Tests**
  * Dashboard tab visibility tests updated to validate behavior when cluster metrics access is present (three tabs) vs absent (one tab).

* **Chores**
  * Mocks, test fixtures, and dashboard filtering/terminology updated to use access-review-driven flags and "cluster metrics access" naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->