### PR TITLE
feat(distributions): scaffold RHAII distribution

### DIFF
--- a/distributions/base/config/webpack.common.js
+++ b/distributions/base/config/webpack.common.js
@@ -27,7 +27,9 @@ module.exports = ({
 } = {}) => {
   const normalizedDistDir = path.resolve(distributionSrcDir);
   const normalizedIncludes = additionalIncludes.map((p) => path.resolve(p));
-  const resolvedOutputDir = outputDir || path.resolve(path.dirname(normalizedDistDir), 'public');
+  const resolvedOutputDir = outputDir
+    ? path.resolve(outputDir)
+    : path.resolve(path.dirname(normalizedDistDir), 'public');
 
   return {
     entry: {

--- a/distributions/base/src/ShellHeader.tsx
+++ b/distributions/base/src/ShellHeader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Content,
   Masthead,
   MastheadBrand,
   MastheadContent,
@@ -13,27 +12,13 @@ import {
   ToolbarItem,
   ToggleGroup,
   ToggleGroupItem,
-  Dropdown,
-  DropdownList,
-  DropdownItem,
-  MenuToggle,
-  Spinner,
-  Button,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports -- shell has no ContentModal wrapper
-  Modal,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
-  ModalBody,
-  // eslint-disable-next-line @odh-dashboard/no-restricted-imports
-  ModalHeader,
 } from '@patternfly/react-core';
-import { MoonIcon, SunIcon, QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
+import { MoonIcon, SunIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { LazyCodeRefComponent, useExtensions } from '@odh-dashboard/plugin-core';
 import {
   isMastheadBrandExtension,
   isMastheadToolbarItemExtension,
-  isMastheadUserMenuExtension,
-  isMastheadAboutExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import { useThemeContext } from './ThemeContext';
 import logoLight from './images/red-hat-ai-light.svg';
@@ -68,97 +53,6 @@ const ShellBrand: React.FC = () => {
         />
       </Link>
     </MastheadBrand>
-  );
-};
-
-const ShellAbout: React.FC = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const aboutExtensions = useExtensions(isMastheadAboutExtension);
-
-  return (
-    <>
-      <ToolbarItem>
-        <Button
-          aria-label="About"
-          variant="plain"
-          icon={<QuestionCircleIcon />}
-          onClick={() => setIsOpen(true)}
-        />
-      </ToolbarItem>
-      {isOpen ? (
-        aboutExtensions.length > 0 ? (
-          <LazyCodeRefComponent
-            component={aboutExtensions[0].properties.component}
-            props={{ onClose: () => setIsOpen(false) }}
-            fallback={<Spinner size="lg" />}
-          />
-        ) : (
-          <Modal
-            isOpen
-            onClose={() => setIsOpen(false)}
-            aria-label="About Red Hat AI"
-            variant="small"
-          >
-            <ModalHeader title="About" />
-            <ModalBody>
-              <Content>
-                <p>No product information available.</p>
-              </Content>
-            </ModalBody>
-          </Modal>
-        )
-      ) : null}
-    </>
-  );
-};
-
-const ShellUserMenu: React.FC = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const userMenuExtensions = useExtensions(isMastheadUserMenuExtension);
-
-  if (userMenuExtensions.length === 0) {
-    return (
-      <ToolbarItem>
-        <MenuToggle aria-label="User menu" isDisabled>
-          No user authenticated
-        </MenuToggle>
-      </ToolbarItem>
-    );
-  }
-
-  const { usernameRef, logoutRef, menuItemsRef } = userMenuExtensions[0].properties;
-
-  return (
-    <ToolbarItem>
-      <Dropdown
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        toggle={(toggleRef) => (
-          <MenuToggle
-            ref={toggleRef}
-            aria-label="User menu"
-            variant="plain"
-            onClick={() => setIsOpen((prev) => !prev)}
-            isExpanded={isOpen}
-            icon={<UserIcon />}
-          >
-            <LazyCodeRefComponent component={usernameRef} />
-          </MenuToggle>
-        )}
-        popperProps={{ position: 'right' }}
-      >
-        <DropdownList>
-          {menuItemsRef ? (
-            <DropdownItem key="user-menu-extra">
-              <LazyCodeRefComponent component={menuItemsRef} />
-            </DropdownItem>
-          ) : null}
-          <DropdownItem key="user-menu-logout">
-            <LazyCodeRefComponent component={logoutRef} />
-          </DropdownItem>
-        </DropdownList>
-      </Dropdown>
-    </ToolbarItem>
   );
 };
 
@@ -220,8 +114,6 @@ const ShellHeader: React.FC = () => {
                   />
                 </ToggleGroup>
               </ToolbarItem>
-              <ShellAbout />
-              <ShellUserMenu />
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/distributions/base/src/ShellHeader.tsx
+++ b/distributions/base/src/ShellHeader.tsx
@@ -97,7 +97,6 @@ const ShellHeader: React.FC = () => {
         <Toolbar isFullHeight>
           <ToolbarContent>
             <ToolbarGroup variant="action-group-plain" align={{ default: 'alignEnd' }}>
-              <ShellToolbarItems />
               <ToolbarItem>
                 <ToggleGroup aria-label="Theme toggle">
                   <ToggleGroupItem
@@ -114,6 +113,7 @@ const ShellHeader: React.FC = () => {
                   />
                 </ToggleGroup>
               </ToolbarItem>
+              <ShellToolbarItems />
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/distributions/base/src/ShellHeader.tsx
+++ b/distributions/base/src/ShellHeader.tsx
@@ -24,8 +24,6 @@ import { useThemeContext } from './ThemeContext';
 import logoLight from './images/red-hat-ai-light.svg';
 import logoDark from './images/red-hat-ai-dark.svg';
 
-const DEFAULT_GROUP = '5_default';
-
 const ShellBrand: React.FC = () => {
   const brandExtensions = useExtensions(isMastheadBrandExtension);
   const { theme } = useThemeContext();
@@ -56,29 +54,30 @@ const ShellBrand: React.FC = () => {
   );
 };
 
-const ShellToolbarItems: React.FC = () => {
+const useToolbarExtensions = () => {
   const toolbarExtensions = useExtensions(isMastheadToolbarItemExtension);
-  const sorted = React.useMemo(
-    () =>
-      [...toolbarExtensions].toSorted((a, b) =>
-        (a.properties.group || DEFAULT_GROUP).localeCompare(b.properties.group || DEFAULT_GROUP),
-      ),
-    [toolbarExtensions],
-  );
-
-  return (
-    <>
-      {sorted.map((ext) => (
-        <ToolbarItem key={ext.uid}>
-          <LazyCodeRefComponent component={ext.properties.component} />
-        </ToolbarItem>
-      ))}
-    </>
-  );
+  return React.useMemo(() => {
+    const leading = toolbarExtensions.filter((ext) => ext.properties.position !== 'trailing');
+    const trailing = toolbarExtensions.filter((ext) => ext.properties.position === 'trailing');
+    return { leading, trailing };
+  }, [toolbarExtensions]);
 };
+
+const ToolbarItems: React.FC<{
+  extensions: ReturnType<typeof useToolbarExtensions>['leading'];
+}> = ({ extensions }) => (
+  <>
+    {extensions.map((ext) => (
+      <ToolbarItem key={ext.uid}>
+        <LazyCodeRefComponent component={ext.properties.component} />
+      </ToolbarItem>
+    ))}
+  </>
+);
 
 const ShellHeader: React.FC = () => {
   const { theme, setTheme } = useThemeContext();
+  const { leading, trailing } = useToolbarExtensions();
 
   return (
     <Masthead role="banner" aria-label="page masthead">
@@ -97,6 +96,7 @@ const ShellHeader: React.FC = () => {
         <Toolbar isFullHeight>
           <ToolbarContent>
             <ToolbarGroup variant="action-group-plain" align={{ default: 'alignEnd' }}>
+              <ToolbarItems extensions={leading} />
               <ToolbarItem>
                 <ToggleGroup aria-label="Theme toggle">
                   <ToggleGroupItem
@@ -113,7 +113,7 @@ const ShellHeader: React.FC = () => {
                   />
                 </ToggleGroup>
               </ToolbarItem>
-              <ShellToolbarItems />
+              <ToolbarItems extensions={trailing} />
             </ToolbarGroup>
           </ToolbarContent>
         </Toolbar>

--- a/distributions/base/src/ShellNav.tsx
+++ b/distributions/base/src/ShellNav.tsx
@@ -149,17 +149,6 @@ const ShellNavItem: React.FC<{ extension: LoadedExtension<NavExtension> }> = ({ 
   return null;
 };
 
-const HomeNavItem: React.FC = () => {
-  const { pathname } = useLocation();
-  const isActive = pathname === '/';
-
-  return (
-    <NavItem isActive={isActive}>
-      <Link to="/">Home</Link>
-    </NavItem>
-  );
-};
-
 const ShellNav: React.FC = () => {
   const navExtensions = useExtensions<NavExtension>(isNavExtension);
   const topLevelExtensions = React.useMemo(
@@ -172,7 +161,6 @@ const ShellNav: React.FC = () => {
       <PageSidebarBody>
         <Nav aria-label="Navigation">
           <NavList>
-            <HomeNavItem />
             {topLevelExtensions.map((extension) => (
               <ShellNavItem key={extension.uid} extension={extension} />
             ))}

--- a/distributions/rhaii/.eslintrc.js
+++ b/distributions/rhaii/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@odh-dashboard/eslint-config').recommendedReactTypescript(__dirname);

--- a/distributions/rhaii/.gitignore
+++ b/distributions/rhaii/.gitignore
@@ -1,0 +1,3 @@
+public/
+dist/
+node_modules/

--- a/distributions/rhaii/config/webpack.common.js
+++ b/distributions/rhaii/config/webpack.common.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const createWebpackCommon = require('../../base/config/webpack.common.js');
+
+const SRC_DIR = path.resolve(__dirname, '../src');
+
+module.exports = (overrides = {}) =>
+  createWebpackCommon({ distributionSrcDir: SRC_DIR, title: 'RHAII', ...overrides });

--- a/distributions/rhaii/config/webpack.common.js
+++ b/distributions/rhaii/config/webpack.common.js
@@ -2,6 +2,7 @@ const path = require('path');
 const createWebpackCommon = require('../../base/config/webpack.common.js');
 
 const SRC_DIR = path.resolve(__dirname, '../src');
+const TITLE = 'RHAII';
 
 module.exports = (overrides = {}) =>
-  createWebpackCommon({ distributionSrcDir: SRC_DIR, title: 'RHAII', ...overrides });
+  createWebpackCommon({ distributionSrcDir: SRC_DIR, title: TITLE, ...overrides });

--- a/distributions/rhaii/config/webpack.dev.js
+++ b/distributions/rhaii/config/webpack.dev.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const { merge } = require('webpack-merge');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const webpackCommon = require('./webpack.common.js');
+
+const RELATIVE_DIRNAME = path.resolve(__dirname, '..');
+const DIST_DIR = path.resolve(RELATIVE_DIRNAME, 'public');
+const PORT = process.env.SHELL_PORT || 4020;
+const BFF_PORT = process.env.BFF_PORT || 4000;
+
+module.exports = merge(webpackCommon(), {
+  mode: 'development',
+  devtool: 'eval-source-map',
+  optimization: {
+    runtimeChunk: 'single',
+    removeEmptyChunks: true,
+  },
+  devServer: {
+    host: 'localhost',
+    port: PORT,
+    compress: true,
+    historyApiFallback: true,
+    hot: true,
+    proxy: [
+      {
+        context: ['/api'],
+        target: `http://localhost:${BFF_PORT}`,
+      },
+      {
+        context: ['/wss'],
+        target: `ws://localhost:${BFF_PORT}`,
+        ws: true,
+      },
+    ],
+    client: {
+      overlay: true,
+    },
+    static: {
+      directory: DIST_DIR,
+    },
+    onListening: (devServer) => {
+      const addr = devServer?.server?.address();
+      if (addr) {
+        console.log(
+          `\x1b[32m✓ RHAII distribution available at: \x1b[4mhttp://localhost:${addr.port}\x1b[0m`,
+        );
+      }
+    },
+  },
+  plugins: [new ForkTsCheckerWebpackPlugin()],
+});

--- a/distributions/rhaii/config/webpack.dev.js
+++ b/distributions/rhaii/config/webpack.dev.js
@@ -41,9 +41,13 @@ module.exports = merge(webpackCommon(), {
     onListening: (devServer) => {
       const addr = devServer?.server?.address();
       if (addr) {
-        console.log(
-          `\x1b[32m✓ RHAII distribution available at: \x1b[4mhttp://localhost:${addr.port}\x1b[0m`,
-        );
+        const green = '\x1b[32m';
+        const underline = '\x1b[4m';
+        const reset = '\x1b[0m';
+        const url = `http://localhost:${addr.port}`;
+        console.log(`${green}✓ RHAII distribution available at: ${underline}${url}${reset}`);
+      } else {
+        console.warn('RHAII dev server started but could not determine address');
       }
     },
   },

--- a/distributions/rhaii/config/webpack.prod.js
+++ b/distributions/rhaii/config/webpack.prod.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+const webpackCommon = require('./webpack.common.js');
+
+module.exports = merge(webpackCommon(), {
+  mode: 'production',
+  devtool: 'source-map',
+});

--- a/distributions/rhaii/package.json
+++ b/distributions/rhaii/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@odh-dashboard/rhaii-distribution",
+  "version": "0.0.0",
+  "description": "RHAII distribution — composes the base app shell with RHAII-specific plugins",
+  "license": "Apache-2.0",
+  "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "dev": "npm run start:dev",
+    "start:dev": "concurrently -k -n bff,shell \"make -C ../core-bff dev-bff\" \"webpack serve --hot --color --config ./config/webpack.dev.js\"",
+    "build": "webpack --config ./config/webpack.prod.js",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@odh-dashboard/plugin-core": "*",
+    "@openshift/dynamic-plugin-sdk": "^5.0.1",
+    "@patternfly/patternfly": "^6.4.0",
+    "@patternfly/react-core": "^6.4.1",
+    "@patternfly/react-icons": "^6.4.0",
+    "@patternfly/react-styles": "^6.4.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2"
+  },
+  "devDependencies": {
+    "@odh-dashboard/eslint-config": "*",
+    "@odh-dashboard/tsconfig": "*",
+    "@swc/core": "^1.13.3",
+    "concurrently": "^9.2.1",
+    "css-loader": "^5.2.7",
+    "file-loader": "^6.1.1",
+    "fork-ts-checker-webpack-plugin": "^9.0.2",
+    "html-webpack-plugin": "^5.5.0",
+    "raw-loader": "^4.0.2",
+    "sass": "^1.56.2",
+    "sass-loader": "^13.2.0",
+    "style-loader": "^2.0.0",
+    "svg-url-loader": "^6.0.0",
+    "swc-loader": "^0.2.6",
+    "typescript": "^5.8.3",
+    "url-loader": "^4.1.1",
+    "webpack": "5.104.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.1.0",
+    "webpack-merge": "^6.0.1"
+  }
+}

--- a/distributions/rhaii/src/RedirectToScaffold.tsx
+++ b/distributions/rhaii/src/RedirectToScaffold.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+const RedirectToScaffold: React.FC = () => <Navigate to="/scaffold" replace />;
+
+export default RedirectToScaffold;

--- a/distributions/rhaii/src/ScaffoldPage.tsx
+++ b/distributions/rhaii/src/ScaffoldPage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  PageSection,
+  Content,
+  ContentVariants,
+  Card,
+  CardBody,
+  List,
+  ListItem,
+} from '@patternfly/react-core';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+
+const ScaffoldPage: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <Content component={ContentVariants.h1}>Scaffold Plugin</Content>
+    <Content component={ContentVariants.p}>
+      This page validates that the RHAII distribution pattern is working correctly. The extension
+      loading pipeline, provider wiring, and webpack config sharing are all functioning if you can
+      see this page.
+    </Content>
+    <Card>
+      <CardBody>
+        <List isPlain>
+          <ListItem icon={<CheckCircleIcon />}>
+            Extension point pipeline (navigation + routing) is wired
+          </ListItem>
+          <ListItem icon={<CheckCircleIcon />}>
+            Base shell components are importable from rhaii
+          </ListItem>
+          <ListItem icon={<CheckCircleIcon />}>
+            Webpack config sharing via webpack-merge works
+          </ListItem>
+          <ListItem icon={<CheckCircleIcon />}>
+            PluginStore + ExtensibilityContext loads extensions
+          </ListItem>
+        </List>
+      </CardBody>
+    </Card>
+  </PageSection>
+);
+
+export default ScaffoldPage;

--- a/distributions/rhaii/src/bootstrap.tsx
+++ b/distributions/rhaii/src/bootstrap.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { ExtensibilityContextProvider } from './plugins/ExtensibilityContext';
+import { ThemeProvider } from '../../base/src/ThemeContext';
+import { ErrorBoundary } from '../../base/src/ErrorBoundary';
+import Shell from '../../base/src/Shell';
+import ShellHeader from '../../base/src/ShellHeader';
+import ShellNav from '../../base/src/ShellNav';
+import ShellRoutes from '../../base/src/ShellRoutes';
+
+const router = createBrowserRouter([
+  {
+    path: '*',
+    element: (
+      <ThemeProvider>
+        <ExtensibilityContextProvider>
+          <Shell masthead={<ShellHeader />} sidebar={<ShellNav />}>
+            <ShellRoutes />
+          </Shell>
+        </ExtensibilityContextProvider>
+      </ThemeProvider>
+    ),
+  },
+]);
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const root = createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <RouterProvider router={router} />
+    </ErrorBoundary>
+  </React.StrictMode>,
+);

--- a/distributions/rhaii/src/bootstrap.tsx
+++ b/distributions/rhaii/src/bootstrap.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { ExtensibilityContextProvider } from './plugins/ExtensibilityContext';
-import { ThemeProvider } from '../../base/src/ThemeContext';
-import { ErrorBoundary } from '../../base/src/ErrorBoundary';
-import Shell from '../../base/src/Shell';
-import ShellHeader from '../../base/src/ShellHeader';
-import ShellNav from '../../base/src/ShellNav';
-import ShellRoutes from '../../base/src/ShellRoutes';
+import {
+  Shell,
+  ShellHeader,
+  ShellNav,
+  ShellRoutes,
+  ThemeProvider,
+  ErrorBoundary,
+} from '../../base/src/lib';
 
 const router = createBrowserRouter([
   {

--- a/distributions/rhaii/src/components/AuthPlaceholder.tsx
+++ b/distributions/rhaii/src/components/AuthPlaceholder.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { MenuToggle } from '@patternfly/react-core';
+
+const AuthPlaceholder: React.FC = () => (
+  <MenuToggle aria-label="User menu" isDisabled>
+    Auth unimplemented
+  </MenuToggle>
+);
+
+export default AuthPlaceholder;

--- a/distributions/rhaii/src/components/HelpPlaceholder.tsx
+++ b/distributions/rhaii/src/components/HelpPlaceholder.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
+
+const HelpPlaceholder: React.FC = () => (
+  <Button aria-label="Help" variant="plain" icon={<QuestionCircleIcon />} isDisabled />
+);
+
+export default HelpPlaceholder;

--- a/distributions/rhaii/src/components/HelpPlaceholder.tsx
+++ b/distributions/rhaii/src/components/HelpPlaceholder.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Button } from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
-
-const HelpPlaceholder: React.FC = () => (
-  <Button aria-label="Help" variant="plain" icon={<QuestionCircleIcon />} isDisabled />
-);
-
-export default HelpPlaceholder;

--- a/distributions/rhaii/src/index.html
+++ b/distributions/rhaii/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#ffffff" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/distributions/rhaii/src/index.tsx
+++ b/distributions/rhaii/src/index.tsx
@@ -1,0 +1,9 @@
+import('./bootstrap').catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to load application:', error);
+  const root = document.getElementById('root');
+  if (root) {
+    root.textContent = 'Failed to load application. Please refresh the page.';
+    root.style.padding = '2rem';
+  }
+});

--- a/distributions/rhaii/src/plugins/ExtensibilityContext.tsx
+++ b/distributions/rhaii/src/plugins/ExtensibilityContext.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
+import { PluginStore } from '@odh-dashboard/plugin-core';
+import { useAppExtensions } from './useAppExtensions';
+
+export const ExtensibilityContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [appExtensions] = useAppExtensions();
+  const store = React.useMemo(() => new PluginStore(appExtensions), [appExtensions]);
+  return <PluginStoreProvider store={store}>{children}</PluginStoreProvider>;
+};

--- a/distributions/rhaii/src/plugins/ExtensibilityContext.tsx
+++ b/distributions/rhaii/src/plugins/ExtensibilityContext.tsx
@@ -1,10 +1,23 @@
 import * as React from 'react';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { PluginStoreProvider } from '@openshift/dynamic-plugin-sdk';
 import { PluginStore } from '@odh-dashboard/plugin-core';
 import { useAppExtensions } from './useAppExtensions';
 
 export const ExtensibilityContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const [appExtensions] = useAppExtensions();
-  const store = React.useMemo(() => new PluginStore(appExtensions), [appExtensions]);
+  const [appExtensions, loaded] = useAppExtensions();
+  const store = React.useMemo(
+    () => (loaded ? new PluginStore(appExtensions) : null),
+    [appExtensions, loaded],
+  );
+
+  if (!store) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
   return <PluginStoreProvider store={store}>{children}</PluginStoreProvider>;
 };

--- a/distributions/rhaii/src/plugins/useAppExtensions.ts
+++ b/distributions/rhaii/src/plugins/useAppExtensions.ts
@@ -1,0 +1,36 @@
+import type { Extension } from '@openshift/dynamic-plugin-sdk';
+
+const scaffoldExtensions: Extension[] = [
+  {
+    type: 'app.navigation/section',
+    properties: {
+      id: 'scaffold',
+      title: 'Scaffold Section',
+    },
+  },
+  {
+    type: 'app.navigation/href',
+    properties: {
+      id: 'scaffold-page',
+      title: 'Scaffold Page',
+      href: '/scaffold',
+      section: 'scaffold',
+    },
+  },
+  {
+    type: 'app.route',
+    properties: {
+      path: '/scaffold',
+      component: () => import('../ScaffoldPage'),
+    },
+  },
+];
+
+const pluginExtensions: Record<string, Extension[]> = {
+  scaffold: scaffoldExtensions,
+};
+
+export const useAppExtensions = (): [Record<string, Extension[]>, boolean] => [
+  pluginExtensions,
+  true,
+];

--- a/distributions/rhaii/src/plugins/useAppExtensions.ts
+++ b/distributions/rhaii/src/plugins/useAppExtensions.ts
@@ -56,6 +56,8 @@ const pluginExtensions: Record<string, Extension[]> = {
   scaffold: scaffoldExtensions,
 };
 
+// Sync stub — returns loaded: true immediately. Replace with async fetching
+// (useState/useEffect) when real plugin discovery lands.
 export const useAppExtensions = (): [Record<string, Extension[]>, boolean] => [
   pluginExtensions,
   true,

--- a/distributions/rhaii/src/plugins/useAppExtensions.ts
+++ b/distributions/rhaii/src/plugins/useAppExtensions.ts
@@ -45,13 +45,6 @@ const scaffoldExtensions: Extension[] = [
   {
     type: 'app.masthead/toolbar-item',
     properties: {
-      id: 'help-placeholder',
-      component: () => import('../components/HelpPlaceholder'),
-    },
-  } satisfies MastheadToolbarItemExtension,
-  {
-    type: 'app.masthead/toolbar-item',
-    properties: {
       id: 'auth-placeholder',
       component: () => import('../components/AuthPlaceholder'),
       position: 'trailing',

--- a/distributions/rhaii/src/plugins/useAppExtensions.ts
+++ b/distributions/rhaii/src/plugins/useAppExtensions.ts
@@ -1,5 +1,16 @@
 import type { Extension } from '@openshift/dynamic-plugin-sdk';
+import type {
+  NavSectionExtension,
+  HrefNavItemExtension,
+  RouteExtension,
+  MastheadToolbarItemExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
 
+/**
+ * Temporary scaffold extensions for demo purposes.
+ * These will be replaced with real odh-dashboard extensions (e.g. model-serving)
+ * once they are decoupled and ready to integrate into RHAII.
+ */
 const scaffoldExtensions: Extension[] = [
   {
     type: 'app.navigation/section',
@@ -7,7 +18,7 @@ const scaffoldExtensions: Extension[] = [
       id: 'scaffold',
       title: 'Scaffold Section',
     },
-  },
+  } satisfies NavSectionExtension,
   {
     type: 'app.navigation/href',
     properties: {
@@ -16,14 +27,29 @@ const scaffoldExtensions: Extension[] = [
       href: '/scaffold',
       section: 'scaffold',
     },
-  },
+  } satisfies HrefNavItemExtension,
   {
     type: 'app.route',
     properties: {
       path: '/scaffold',
       component: () => import('../ScaffoldPage'),
     },
-  },
+  } satisfies RouteExtension,
+  {
+    type: 'app.route',
+    properties: {
+      path: '/',
+      component: () => import('../RedirectToScaffold'),
+    },
+  } satisfies RouteExtension,
+  {
+    type: 'app.masthead/toolbar-item',
+    properties: {
+      id: 'auth-placeholder',
+      component: () => import('../components/AuthPlaceholder'),
+      group: '9_user',
+    },
+  } satisfies MastheadToolbarItemExtension,
 ];
 
 const pluginExtensions: Record<string, Extension[]> = {

--- a/distributions/rhaii/src/plugins/useAppExtensions.ts
+++ b/distributions/rhaii/src/plugins/useAppExtensions.ts
@@ -45,9 +45,16 @@ const scaffoldExtensions: Extension[] = [
   {
     type: 'app.masthead/toolbar-item',
     properties: {
+      id: 'help-placeholder',
+      component: () => import('../components/HelpPlaceholder'),
+    },
+  } satisfies MastheadToolbarItemExtension,
+  {
+    type: 'app.masthead/toolbar-item',
+    properties: {
       id: 'auth-placeholder',
       component: () => import('../components/AuthPlaceholder'),
-      group: '9_user',
+      position: 'trailing',
     },
   } satisfies MastheadToolbarItemExtension,
 ];

--- a/distributions/rhaii/src/typings.d.ts
+++ b/distributions/rhaii/src/typings.d.ts
@@ -1,0 +1,19 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.gif' {
+  const value: string;
+  export default value;
+}

--- a/distributions/rhaii/tsconfig.json
+++ b/distributions/rhaii/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@odh-dashboard/tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "baseUrl": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "../base/src/**/*.ts", "../base/src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "public"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,109 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "distributions/base": {
+      "name": "@odh-dashboard/base-distribution",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@odh-dashboard/plugin-core": "*",
+        "@openshift/dynamic-plugin-sdk": "^5.0.1",
+        "@patternfly/patternfly": "^6.4.0",
+        "@patternfly/react-core": "^6.4.1",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2"
+      },
+      "devDependencies": {
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "@swc/core": "^1.13.3",
+        "concurrently": "^9.2.1",
+        "css-loader": "^5.2.7",
+        "file-loader": "^6.1.1",
+        "fork-ts-checker-webpack-plugin": "^9.0.2",
+        "html-webpack-plugin": "^5.5.0",
+        "raw-loader": "^4.0.2",
+        "sass": "^1.56.2",
+        "sass-loader": "^13.2.0",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^6.0.0",
+        "swc-loader": "^0.2.6",
+        "typescript": "^5.8.3",
+        "url-loader": "^4.1.1",
+        "webpack": "5.104.1",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0",
+        "webpack-merge": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "distributions/core-bff": {
+      "name": "@odh-dashboard/core-bff",
+      "version": "0.0.1",
+      "extraneous": true,
+      "dependencies": {
+        "@odh-dashboard/internal": "*",
+        "@odh-dashboard/plugin-core": "*"
+      },
+      "devDependencies": {
+        "@odh-dashboard/contract-tests": "*",
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "cross-env": "^10.1.0",
+        "eslint-plugin-n": "^17.23.1"
+      }
+    },
+    "distributions/rhaii": {
+      "name": "@odh-dashboard/rhaii-distribution",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@odh-dashboard/plugin-core": "*",
+        "@openshift/dynamic-plugin-sdk": "^5.0.1",
+        "@patternfly/patternfly": "^6.4.0",
+        "@patternfly/react-core": "^6.4.1",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2"
+      },
+      "devDependencies": {
+        "@module-federation/enhanced": "^0.18.0",
+        "@odh-dashboard/eslint-config": "*",
+        "@odh-dashboard/tsconfig": "*",
+        "@swc/core": "^1.13.3",
+        "concurrently": "^9.2.1",
+        "css-loader": "^5.2.7",
+        "file-loader": "^6.1.1",
+        "fork-ts-checker-webpack-plugin": "^9.0.2",
+        "html-webpack-plugin": "^5.5.0",
+        "raw-loader": "^4.0.2",
+        "sass": "^1.56.2",
+        "sass-loader": "^13.2.0",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^6.0.0",
+        "swc-loader": "^0.2.6",
+        "typescript": "^5.8.3",
+        "url-loader": "^4.1.1",
+        "webpack": "5.104.1",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0",
+        "webpack-merge": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "frontend": {
       "name": "odh-dashboard-frontend",
       "version": "2.0.0",
@@ -394,31 +497,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "frontend/node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
     "frontend/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -450,22 +528,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
-      }
-    },
-    "frontend/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "frontend/node_modules/tslib": {
@@ -12518,6 +12580,47 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,109 +105,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "distributions/base": {
-      "name": "@odh-dashboard/base-distribution",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@odh-dashboard/plugin-core": "*",
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@patternfly/patternfly": "^6.4.0",
-        "@patternfly/react-core": "^6.4.1",
-        "@patternfly/react-icons": "^6.4.0",
-        "@patternfly/react-styles": "^6.4.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2"
-      },
-      "devDependencies": {
-        "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*",
-        "@swc/core": "^1.13.3",
-        "concurrently": "^9.2.1",
-        "css-loader": "^5.2.7",
-        "file-loader": "^6.1.1",
-        "fork-ts-checker-webpack-plugin": "^9.0.2",
-        "html-webpack-plugin": "^5.5.0",
-        "raw-loader": "^4.0.2",
-        "sass": "^1.56.2",
-        "sass-loader": "^13.2.0",
-        "style-loader": "^2.0.0",
-        "svg-url-loader": "^6.0.0",
-        "swc-loader": "^0.2.6",
-        "typescript": "^5.8.3",
-        "url-loader": "^4.1.1",
-        "webpack": "5.104.1",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.1.0",
-        "webpack-merge": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "distributions/core-bff": {
-      "name": "@odh-dashboard/core-bff",
-      "version": "0.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "@odh-dashboard/internal": "*",
-        "@odh-dashboard/plugin-core": "*"
-      },
-      "devDependencies": {
-        "@odh-dashboard/contract-tests": "*",
-        "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*",
-        "cross-env": "^10.1.0",
-        "eslint-plugin-n": "^17.23.1"
-      }
-    },
-    "distributions/rhaii": {
-      "name": "@odh-dashboard/rhaii-distribution",
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@odh-dashboard/plugin-core": "*",
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@patternfly/patternfly": "^6.4.0",
-        "@patternfly/react-core": "^6.4.1",
-        "@patternfly/react-icons": "^6.4.0",
-        "@patternfly/react-styles": "^6.4.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2"
-      },
-      "devDependencies": {
-        "@module-federation/enhanced": "^0.18.0",
-        "@odh-dashboard/eslint-config": "*",
-        "@odh-dashboard/tsconfig": "*",
-        "@swc/core": "^1.13.3",
-        "concurrently": "^9.2.1",
-        "css-loader": "^5.2.7",
-        "file-loader": "^6.1.1",
-        "fork-ts-checker-webpack-plugin": "^9.0.2",
-        "html-webpack-plugin": "^5.5.0",
-        "raw-loader": "^4.0.2",
-        "sass": "^1.56.2",
-        "sass-loader": "^13.2.0",
-        "style-loader": "^2.0.0",
-        "svg-url-loader": "^6.0.0",
-        "swc-loader": "^0.2.6",
-        "typescript": "^5.8.3",
-        "url-loader": "^4.1.1",
-        "webpack": "5.104.1",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.1.0",
-        "webpack-merge": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
     "frontend": {
       "name": "odh-dashboard-frontend",
       "version": "2.0.0",
@@ -497,6 +394,31 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "frontend/node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
     "frontend/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -528,6 +450,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "frontend/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "frontend/node_modules/tslib": {
@@ -12580,47 +12518,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
-    },
-    "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",

--- a/packages/plugin-core/src/extension-points/masthead.ts
+++ b/packages/plugin-core/src/extension-points/masthead.ts
@@ -38,6 +38,8 @@ export type MastheadToolbarItemExtension = Extension<
     component: ComponentCodeRef;
     /** Group used for lexicographic sorting of toolbar items. */
     group?: string;
+    /** Where to render relative to the theme toggle. Defaults to 'leading'. */
+    position?: 'leading' | 'trailing';
   }
 >;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66191
https://issues.redhat.com/browse/RHOAIENG-66192

## Description

Scaffolds `distributions/rhaii/` — the RHAII distribution that composes the base shell with a scaffold plugin to validate the extension pipeline end-to-end. Builds on #7811 (base webpack factory + barrel exports).

**Changes:**

- **Webpack config** — `webpack.common.js` calls the base factory with `{ srcDir, title: 'RHAII' }`; dev server on port 4020 with BFF proxy; prod build
- **Shell composition** — `bootstrap.tsx` imports Shell/ShellHeader/ShellNav/ShellRoutes from base via relative source paths, wraps in ThemeProvider + ExtensibilityContextProvider + ErrorBoundary + RouterProvider
- **Scaffold plugin** — inline extensions (`app.navigation/section`, `app.navigation/href`, `app.route`) that register a "Scaffold Section > Scaffold Page" nav item and route at `/scaffold`
- **ExtensibilityContext** — creates a PluginStore from local `useAppExtensions` and provides it to the shell via PluginStoreProvider

**Note:** `distributions/rhaii` is intentionally **not** registered in root `package.json` workspaces. Workspace registration and barrel import migration are tracked in [RHOAIENG-66776](https://redhat.atlassian.net/browse/RHOAIENG-66776). For local development, see the workaround in `distributions/base/README.md`.

The scaffold plugin proves the distribution pattern works. Once model-serving is decoupled ([RHOAIENG-62515](https://redhat.atlassian.net/browse/RHOAIENG-62515)), swapping it in is a 3-line diff replacing the scaffold extensions with the real ones.

## How Has This Been Tested?

- `npx tsc --noEmit` passes with no type errors in `distributions/rhaii/`
- `npx webpack --config ./config/webpack.prod.js` compiles successfully
- Dev server boots (`npx webpack serve --config ./config/webpack.dev.js`)
- Scaffold nav item appears in sidebar; navigating to `/scaffold` renders ScaffoldPage

## Test Impact

No new tests — this is a scaffold distribution with inline extensions. The scaffold validates the extension pipeline visually (nav + routing renders correctly). Automated tests will be added post-M2 when the scaffold is replaced with real model-serving extensions.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New RHAII distribution: scaffold page, bootstrapped entry, extensibility plumbing, route scaffolding, auth placeholder, redirect to scaffold, and image import support.
  * Dev server with HMR and production build; npm scripts for dev, build, type-check, and lint.

* **Bug Fixes / Improvements**
  * Build output path now resolved to an absolute directory.
  * Masthead toolbar items can be positioned as leading or trailing.

* **Chores**
  * Added package metadata, ESLint preset usage, gitignore, and TypeScript config.

* **UI Changes**
  * Masthead “About” removed; default Home navigation entry hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->