### PR TITLE
RHOAIENG-66494: integrate jira-eval-review into preflight checks

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -29,7 +29,7 @@ Flags:
   --fix                 Fix failing checks after reporting
   --local               Ignore PR even if one exists, run everything locally
   --review X,Y          Run specific reviewers without asking
-                        Options: coderabbit, claude, style, rbac
+                        Options: coderabbit, claude, style, rbac, jira-eval
   --skip-review X,Y     Run all reviewers EXCEPT these (no interactive prompt)
   --ci                  Non-interactive CI mode: skip all prompts, post results
                         as a PR review when done
@@ -42,6 +42,8 @@ Examples:
   /preflight --review coderabbit,style,rbac    Run specific reviewers
   /preflight --skip-review coderabbit         Run all reviewers except CodeRabbit
   /preflight 1234 --review claude --fix       Check PR, run Claude review, fix issues
+  /preflight --review jira-eval,style         Run Jira eval and style reviewers
+  /preflight --skip-review jira-eval          Run all reviewers except Jira eval
 
 How it works:
   1. Gather    Detect PR, sync status, affected packages, Jira key
@@ -55,7 +57,7 @@ How it works:
 Parse these from `$ARGUMENTS` before processing:
 - `--fix` — after reporting, fix failing checks without asking
 - `--local` — ignore PR even if one exists, run everything locally
-- `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`)
+- `--review X,Y` — run specific reviewers without asking (options: `coderabbit`, `claude`, `style`, `rbac`, `jira-eval`)
 - `--skip-review X,Y` — run all reviewers EXCEPT the listed ones, without asking. Mutually exclusive with `--review`.
 - `--ci` — non-interactive CI mode. Skips all interactive prompts (no `AskUserQuestion`). Posts the results as a PR review using the template in [references/ci-comment-template.md](references/ci-comment-template.md).
 - `--help` — print usage and stop
@@ -150,6 +152,7 @@ If `--review` flag was passed, use those reviewers directly. If `--skip-review` 
 - "Claude review" — invoke `/review` built-in skill
 - "Style review" — invoke `/style-review` for code style and pattern checks
 - "RBAC review" — invoke `/rbac-review` for Kubernetes RBAC permission enforcement checks
+- "Jira Eval review" — invoke `/jira-eval-review` to evaluate code changes against Jira acceptance criteria (requires Jira MCP; reports ➖ if no Jira key found, MCP unavailable, or no acceptance criteria)
 - "Skip review" — no review
 
 Run whichever the user picks. If a reviewer fails (e.g. CR CLI not installed or errors), report the failure clearly — don't silently fall back to something else.

--- a/.claude/skills/preflight/references/checks.md
+++ b/.claude/skills/preflight/references/checks.md
@@ -92,6 +92,26 @@ Report: `Claude (local)` as the source.
 
 Report: `RBAC (local)` as the source. Any critical findings → ❌. Warnings only → ⚠️. None or info only → ✅.
 
+### Jira Eval Review
+
+Evaluates code changes against Jira acceptance criteria using the `/jira-eval-review` skill. This is separate from the basic Jira check (which only verifies a key is present).
+
+| Context | How to check |
+|---|---|
+| Ran in Step 2 | Results from `/jira-eval-review` invocation. Verdicts: PASS, PARTIAL, MISS, SKIP. |
+| Not run | ➖ "not run" |
+| No Jira key found | ➖ "no Jira key" |
+| Jira MCP unavailable | ➖ "Jira MCP unavailable" |
+| Issue has no acceptance criteria | ➖ "no acceptance criteria" |
+
+**Prerequisites:** Requires both a Jira issue key (extracted in Step 1) and a working Jira MCP connection. In CI mode, the `mcp-atlassian` server provides Jira access via GitHub Actions secrets. Locally, the developer's existing Jira MCP authentication is used.
+
+**How to invoke:** Pass the Jira issue key and current PR number (if available) to `/jira-eval-review`. The skill fetches the issue's acceptance criteria, evaluates the code changes against each criterion, and returns per-criterion verdicts.
+
+**Status mapping:** All PASS → ✅. Any PARTIAL → ⚠️. Any MISS → ❌. All SKIP → ➖.
+
+Report: `Jira Eval (local)` as the source. Include the verdict summary (e.g., "5/5 criteria satisfied" or "3/5 satisfied, 1 partial, 1 missed").
+
 ## Jira
 
 Checks that the work is tracked in Jira.

--- a/.claude/skills/preflight/references/ci-comment-template.md
+++ b/.claude/skills/preflight/references/ci-comment-template.md
@@ -126,6 +126,7 @@ If the review produced a concrete suggested fix, include it:
 | `Claude review` | Found by `/review` |
 | `Style review` | Found by `/style-review` |
 | `RBAC review` | Found by `/rbac-review` |
+| `Jira Eval review` | Found by `/jira-eval-review` |
 | `CodeRabbit` | Found by CodeRabbit (PR or CLI) |
 | `Claude review, Style review` | Found by multiple reviewers |
 

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -23,7 +23,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: read
+  issues: write
   checks: read
 
 jobs:
@@ -47,6 +47,7 @@ jobs:
           ACTOR: ${{ github.triggering_actor }}
           IS_PR: ${{ github.event.issue.pull_request.url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
           REPO: ${{ github.repository }}
         run: |
           if [[ "$ACTOR" == *"[bot]"* ]]; then
@@ -69,6 +70,8 @@ jobs:
           if [ -z "$MODE" ]; then
             echo "Skipping: no @odh-dashboard-agent command found"; exit 0
           fi
+
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content="+1" --silent || true
 
           PR_DATA=$(gh pr view "$ISSUE_NUMBER" --repo "$REPO" --json headRefOid,headRefName,headRepository)
           SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -23,7 +23,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: write
+  issues: read
   checks: read
 
 jobs:
@@ -33,6 +33,11 @@ jobs:
   router:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+      checks: read
     outputs:
       matrix: ${{ steps.comment.outputs.matrix || steps.cron.outputs.matrix || '[]' }}
 

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -228,6 +228,9 @@ jobs:
       - name: Install MLflow
         run: pip install "mlflow==3.12.0"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
       # ── Check (read-only) ──
       - name: Preflight check
         if: matrix.mode == 'check-only'
@@ -258,6 +261,8 @@ jobs:
             --allowedTools "Bash(npm *)"
             --allowedTools "Bash(npx *)"
             --allowedTools "Bash(bash *)"
+            --allowedTools "mcp__jira__*"
+            --mcp-config '{"mcpServers":{"jira":{"command":"uvx","args":["mcp-atlassian"],"env":{"JIRA_URL":"${{ secrets.JIRA_URL }}","JIRA_USERNAME":"${{ secrets.JIRA_USERNAME }}","JIRA_API_TOKEN":"${{ secrets.JIRA_API_TOKEN }}","READ_ONLY_MODE":"true"}}}}'
           prompt: "/preflight ${{ env.PR_NUMBER }} --skip-review coderabbit --ci"
 
       # ── Fix (iterative) ──
@@ -290,6 +295,8 @@ jobs:
             --allowedTools "Bash(npm *)"
             --allowedTools "Bash(npx *)"
             --allowedTools "Bash(bash *)"
+            --allowedTools "mcp__jira__*"
+            --mcp-config '{"mcpServers":{"jira":{"command":"uvx","args":["mcp-atlassian"],"env":{"JIRA_URL":"${{ secrets.JIRA_URL }}","JIRA_USERNAME":"${{ secrets.JIRA_USERNAME }}","JIRA_API_TOKEN":"${{ secrets.JIRA_API_TOKEN }}","READ_ONLY_MODE":"true"}}}}'
           prompt: "/preflight ${{ env.PR_NUMBER }} --fix --skip-review coderabbit --ci"
 
       # ── Report ──


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66494

## Description

Integrates the [jira-eval-review skill](https://redhat.atlassian.net/browse/RHOAIENG-60443) into the preflight skill as a **reviewer** that runs alongside existing review skills (Style review, RBAC review, Claude review, CodeRabbit). When a PR references a Jira issue with acceptance criteria, the preflight skill automatically evaluates the code changes against those criteria and includes the results in the checks table.

**Skill changes** (`.claude/skills/preflight/`):
- Added `jira-eval` to `--review` and `--skip-review` flag options (e.g. `--review jira-eval,style`)
- Added Jira Eval review to the interactive reviewer selection prompt in Step 2
- Added help text examples for the new reviewer option
- Added "Jira Eval Review" check definition in `references/checks.md` with context-aware behavior (ran in Step 2, not run, no Jira key, MCP unavailable, no AC) and status mapping (all PASS → ✅, any PARTIAL → ⚠️, any MISS → ❌, all SKIP → ➖)
- Added `Jira Eval review` as a reviewer source in `references/ci-comment-template.md`

**CI changes** (`.github/workflows/claude-preflight.yml`):
- Added `astral-sh/setup-uv@v4` step so `uvx` is available to launch `mcp-atlassian`
- Added `--allowedTools "mcp__jira__*"` to both check-only and managed steps
- Added `--mcp-config` with inline JSON configuring the `jira` MCP server using `JIRA_URL`, `JIRA_USERNAME`, `JIRA_API_TOKEN` secrets with `READ_ONLY_MODE=true`
- Inline JSON format is required due to a [known issue](https://github.com/anthropics/claude-code-action/issues/1004) where file paths are silently dropped

Additional:
- Added thumbs-up reaction to the trigger comment for immediate visual feedback that the workflow picked up the command

## How Has This Been Tested?

- Verified the preflight skill parses `--review jira-eval` correctly from help text and flag definitions
- Ran `/preflight 7770 --review jira-eval` locally against [PR #7770](https://github.com/opendatahub-io/odh-dashboard/pull/7770) to validate the Jira Eval Review flow end-to-end — the skill successfully fetched the Jira issue ([RHOAIENG-41542](https://redhat.atlassian.net/browse/RHOAIENG-41542)), extracted acceptance criteria, evaluated code changes, and produced a structured per-criterion verdict report (3/3 PASS)
- Validated YAML syntax of the workflow file

## Test Impact

No automated tests are applicable for this change. The modifications are to Claude skill Markdown files (agent instructions) and a GitHub Actions workflow (CI configuration). These are not covered by unit or Cypress tests — they are validated by running the skill interactively and by CI workflow execution.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Jira Eval" reviewer option and an interactive "Jira Eval review" choice to run or skip Jira-based evaluations.

* **Documentation**
  * Expanded help text, examples, prerequisites, invocation details, and verdict/output guidance for Jira Eval.
  * Added a Jira Eval section to preflight checks and updated the CI comment template mapping.

* **Chores**
  * CI workflow updated to enable Jira connector tooling, adjust runtime setup, and record comment acknowledgements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->