### PR TITLE
Add weekly preflight skill refinement loop

### DIFF
--- a/.claude/skills/preflight/tests/configs/preflight_check.yaml
+++ b/.claude/skills/preflight/tests/configs/preflight_check.yaml
@@ -1,0 +1,6 @@
+name: "preflight-check"
+experiment_id: "1"
+workspace: "odh-dashboard-tracing"
+judges:
+  - judges/posted_review.py
+  - judges/reviewers_ran.py

--- a/.claude/skills/preflight/tests/judges/posted_review.py
+++ b/.claude/skills/preflight/tests/judges/posted_review.py
@@ -1,0 +1,28 @@
+"""Judge: Did the agent post a PR review?
+
+Searches TOOL spans for a Bash call containing 'gh api' and 'reviews'.
+This is the command that posts a PR review via the GitHub API.
+"""
+
+from mlflow.entities import Feedback, SpanType
+from mlflow.genai.scorers import scorer
+
+
+def get_judges():
+    @scorer(name="posted-review")
+    def posted_review(trace) -> Feedback:
+        tool_spans = trace.search_spans(span_type=SpanType.TOOL)
+        for span in tool_spans:
+            inputs = span.inputs or {}
+            cmd = inputs.get("command", "")
+            if "reviews" in cmd and "gh api" in cmd:
+                return Feedback(
+                    value="yes",
+                    rationale=f"Found review post command: {cmd[:200]}",
+                )
+        return Feedback(
+            value="no",
+            rationale="No 'gh api repos/.../reviews' call found in any tool span",
+        )
+
+    return [posted_review]

--- a/.claude/skills/preflight/tests/judges/reviewers_ran.py
+++ b/.claude/skills/preflight/tests/judges/reviewers_ran.py
@@ -1,0 +1,37 @@
+"""Judge: Did the agent run code reviewers?
+
+The preflight skill spawns subagents for code review. This judge checks
+that at least one review Agent span exists in the trace (e.g., "Claude
+code review", "Style review", "RBAC review").
+"""
+
+from mlflow.entities import Feedback, SpanType
+from mlflow.genai.scorers import scorer
+
+REVIEW_KEYWORDS = ["review", "audit", "angle"]
+
+
+def get_judges():
+    @scorer(name="reviewers-ran")
+    def reviewers_ran(trace) -> Feedback:
+        tool_spans = trace.search_spans(span_type=SpanType.TOOL)
+        found = []
+
+        for span in tool_spans:
+            inputs = span.inputs or {}
+            desc = inputs.get("description", "")
+            if any(kw in desc.lower() for kw in REVIEW_KEYWORDS):
+                found.append(desc[:80])
+
+        if found:
+            return Feedback(
+                value="yes",
+                rationale=f"Found {len(found)} reviewer(s): {'; '.join(found)}",
+            )
+
+        return Feedback(
+            value="no",
+            rationale="No review Agent spans found in trace",
+        )
+
+    return [reviewers_ran]

--- a/.claude/skills/preflight/tests/run_judges.py
+++ b/.claude/skills/preflight/tests/run_judges.py
@@ -1,0 +1,129 @@
+"""Judge runner — loads judge modules dynamically and evaluates traces.
+
+Follows the mlflow/skills pattern: each judge module exposes get_judges()
+which returns a list of @scorer functions. Results are logged to MLflow
+as an evaluation run via mlflow.genai.evaluate().
+
+Usage:
+    # Evaluate the trace for a specific commit (CI mode):
+    python run_judges.py --judges judges/posted_review.py --commit abc123
+
+    # Evaluate all traces (backfill):
+    python run_judges.py --judges judges/posted_review.py
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import warnings
+
+import mlflow
+
+warnings.filterwarnings("ignore")
+
+
+def load_judges(judge_paths, base_dir):
+    """Dynamically load judge modules and collect all scorers."""
+    all_judges = []
+    for i, path in enumerate(judge_paths):
+        full_path = os.path.join(base_dir, path) if not os.path.isabs(path) else path
+        if not os.path.exists(full_path):
+            print(f"[ERROR] Judge file not found: {full_path}", file=sys.stderr)
+            sys.exit(1)
+
+        spec = importlib.util.spec_from_file_location(f"judge_{i}", full_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        if not hasattr(module, "get_judges"):
+            print(f"[ERROR] {path} missing get_judges() function", file=sys.stderr)
+            sys.exit(1)
+
+        judges = module.get_judges()
+        all_judges.extend(judges)
+        print(f"[LOAD] {path} -> {len(judges)} judge(s)")
+
+    return all_judges
+
+
+def run(judge_paths, experiment_id, base_dir, commit=None):
+    """Fetch traces, run judges via mlflow.genai.evaluate(), return results.
+
+    Args:
+        commit: Filter to the trace matching this git commit SHA.
+                Each preflight run produces a trace tagged with the
+                PR head commit, so this uniquely identifies the trace.
+    """
+    judges = load_judges(judge_paths, base_dir)
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id],
+        return_type="list",
+    )
+
+    if commit:
+        traces = [
+            t for t in traces
+            if t.info.request_metadata.get("mlflow.source.git.commit", "").startswith(commit)
+        ]
+        print(f"[FILTER] Traces for commit {commit[:12]}: {len(traces)} found")
+
+    if not traces:
+        print("[WARN] No traces found to evaluate")
+        return []
+
+    print(f"[EVAL] Running {len(judges)} judges on {len(traces)} traces")
+
+    results = mlflow.genai.evaluate(data=traces, scorers=judges)
+    df = results.tables["eval_results"]
+
+    judge_names = []
+    for judge in judges:
+        judge_names.append(judge._name if hasattr(judge, "_name") else judge.name)
+
+    output = []
+    for _, row in df.iterrows():
+        trace_id = row["trace_id"]
+        for name in judge_names:
+            value_col = f"{name}/value"
+            value = str(row.get(value_col, "unknown"))
+            passed = value.lower() in ("yes", "true", "pass", "1")
+            output.append({
+                "judge_name": name,
+                "trace_id": trace_id,
+                "value": value,
+                "pass": passed,
+            })
+
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run preflight judges")
+    parser.add_argument("--judges", nargs="+", required=True)
+    parser.add_argument("--experiment-id", default="1")
+    parser.add_argument("--base-dir", default=os.path.dirname(__file__))
+    parser.add_argument("--commit", default=None,
+                        help="Evaluate only the trace for this git commit SHA")
+    args = parser.parse_args()
+
+    results = run(args.judges, args.experiment_id, args.base_dir,
+                  commit=args.commit)
+
+    print(json.dumps(results, indent=2))
+
+    all_passed = all(r["pass"] for r in results)
+    if not all_passed:
+        failures = [r for r in results if not r["pass"]]
+        print(f"\n[FAIL] {len(failures)} judge(s) failed:", file=sys.stderr)
+        for f in failures:
+            print(f"  {f['judge_name']} on {f['trace_id'][:16]}", file=sys.stderr)
+        sys.exit(3)
+    else:
+        print(f"\n[PASS] All {len(results)} judgments passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/preflight/tests/test_skill.py
+++ b/.claude/skills/preflight/tests/test_skill.py
@@ -1,0 +1,118 @@
+"""Preflight skill test harness.
+
+Follows the mlflow/skills Trace → Judge → Refine pattern.
+Loads a YAML config, connects to MLflow, fetches traces,
+and runs judges against them.
+
+Usage:
+    # CI mode — evaluate the trace for the current commit:
+    python test_skill.py configs/preflight_check.yaml --commit $(git rev-parse HEAD)
+
+    # Backfill — evaluate all traces:
+    python test_skill.py configs/preflight_check.yaml
+
+Exit codes:
+    0 - All judges passed on all traces
+    1 - Setup/config error
+    3 - One or more judges failed
+"""
+
+import argparse
+import os
+import sys
+import warnings
+
+import yaml
+
+warnings.filterwarnings("ignore")
+
+EXIT_SUCCESS = 0
+EXIT_SETUP_FAILED = 1
+EXIT_VERIFICATION_FAILED = 3
+
+
+def load_config(config_path):
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def setup_mlflow(config):
+    """Configure MLflow connection from config and environment."""
+    import mlflow
+
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", config.get("tracking_uri"))
+    if not tracking_uri:
+        print("[ERROR] No MLFLOW_TRACKING_URI set and no tracking_uri in config", file=sys.stderr)
+        sys.exit(EXIT_SETUP_FAILED)
+
+    workspace = os.environ.get("MLFLOW_WORKSPACE", config.get("workspace"))
+    if workspace:
+        os.environ["MLFLOW_WORKSPACE"] = workspace
+
+    experiment_id = config.get("experiment_id", "1")
+
+    try:
+        client = mlflow.MlflowClient()
+        exp = client.get_experiment(experiment_id)
+        print(f"[SETUP] Connected to experiment: {exp.name} (id={experiment_id})")
+    except Exception as e:
+        print(f"[ERROR] Cannot connect to MLflow: {e}", file=sys.stderr)
+        sys.exit(EXIT_SETUP_FAILED)
+
+    return experiment_id
+
+
+def run_judges(config, experiment_id, base_dir, commit=None):
+    """Load and execute all judges from config."""
+    from run_judges import run
+
+    judge_paths = config.get("judges", [])
+    if not judge_paths:
+        print("[ERROR] No judges specified in config", file=sys.stderr)
+        sys.exit(EXIT_SETUP_FAILED)
+
+    results = run(judge_paths, experiment_id, base_dir, commit=commit)
+    return results
+
+
+def print_results(results):
+    """Print results summary."""
+    print("\n" + "=" * 60)
+    print("JUDGE RESULTS")
+    print("=" * 60)
+
+    for r in results:
+        status = "[PASS]" if r["pass"] else "[FAIL]"
+        print(f"  {status} {r['judge_name']} on {r['trace_id'][:16]}")
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+    print(f"\n  {passed}/{total} passed")
+    print("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Preflight skill test harness")
+    parser.add_argument("config", help="Path to YAML test config")
+    parser.add_argument("--commit", default=None,
+                        help="Evaluate only the trace for this git commit SHA")
+    args = parser.parse_args()
+
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = args.config
+    if not os.path.isabs(config_path):
+        config_path = os.path.join(tests_dir, config_path)
+
+    config = load_config(config_path)
+    print(f"[CONFIG] Loaded: {config['name']}")
+
+    experiment_id = setup_mlflow(config)
+    results = run_judges(config, experiment_id, tests_dir, commit=args.commit)
+    print_results(results)
+
+    all_passed = all(r["pass"] for r in results)
+    sys.exit(EXIT_SUCCESS if all_passed else EXIT_VERIFICATION_FAILED)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-preflight-refine.yml
+++ b/.github/workflows/claude-preflight-refine.yml
@@ -1,0 +1,165 @@
+name: "Preflight Skill Refinement"
+
+on:
+  schedule:
+    - cron: "23 14 * * 1" # Weekly on Monday ~2:23pm UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refine:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install "mlflow>=3.12" pyyaml
+
+      # ── Query failing traces from the past week ──
+      - name: Query failing assessments
+        id: query-failures
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+          MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
+          MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
+          MLFLOW_WORKSPACE: "odh-dashboard-tracing"
+        run: |
+          python3 - <<'PYEOF'
+          import mlflow
+          import json
+          import time
+          import os
+          import warnings
+          warnings.filterwarnings("ignore")
+
+          one_week_ago_ms = int((time.time() - 7 * 86400) * 1000)
+
+          traces = mlflow.search_traces(
+              experiment_ids=["1"],
+              return_type="list",
+          )
+
+          recent = [t for t in traces if t.info.timestamp_ms >= one_week_ago_ms]
+          print(f"Found {len(recent)} traces from the past week")
+
+          # Check for failing assessments from eval runs
+          failing = []
+          for trace in recent:
+              assessments = getattr(trace.info, 'assessments', []) or []
+              for a in assessments:
+                  if hasattr(a, 'value') and str(a.value).lower() in ('no', 'false', 'fail', '0'):
+                      failing.append({
+                          "trace_id": trace.info.request_id,
+                          "judge": getattr(a, 'name', 'unknown'),
+                          "value": str(a.value),
+                      })
+
+          if not failing:
+              # Fallback: re-run judges to check
+              from mlflow.entities import SpanType, Feedback
+              from mlflow.genai.scorers import scorer
+
+              @scorer(name="posted-review")
+              def posted_review(trace) -> Feedback:
+                  tool_spans = trace.search_spans(span_type=SpanType.TOOL)
+                  for span in tool_spans:
+                      inputs = span.inputs or {}
+                      cmd = inputs.get("command", "")
+                      if "reviews" in cmd and "gh api" in cmd:
+                          return Feedback(value="yes", rationale=f"Found: {cmd[:200]}")
+                  return Feedback(value="no", rationale="No gh api .../reviews call found")
+
+              for trace in recent:
+                  result = posted_review(trace=trace)
+                  if result.value == "no":
+                      commit = trace.info.request_metadata.get("mlflow.source.git.commit", "unknown")[:12]
+                      failing.append({
+                          "trace_id": trace.info.request_id,
+                          "judge": "posted-review",
+                          "value": "no",
+                          "commit": commit,
+                          "rationale": result.rationale,
+                      })
+
+          print(f"Failing traces: {len(failing)}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"failure_count={len(failing)}\n")
+              f.write(f"failures={json.dumps(failing)}\n")
+
+          if failing:
+              print("Failures found:")
+              for f_item in failing:
+                  print(f"  {f_item['judge']} on {f_item['trace_id'][:16]}")
+          PYEOF
+
+      # ── Skip if no failures ──
+      - name: Check if refinement needed
+        if: steps.query-failures.outputs.failure_count == '0'
+        run: |
+          echo "No failing traces this week — skipping refinement"
+          exit 0
+
+      # ── Install MLflow skills for trace analysis ──
+      - name: Install MLflow skills
+        if: steps.query-failures.outputs.failure_count != '0'
+        run: npx skills add mlflow/skills
+
+      # ── Run Claude to analyze and fix ──
+      - name: Generate app token
+        if: steps.query-failures.outputs.failure_count != '0'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Refine preflight skill
+        if: steps.query-failures.outputs.failure_count != '0'
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_vertex: "true"
+          settings: |
+            {
+              "env": {
+                "MLFLOW_TRACKING_URI": "${{ secrets.MLFLOW_TRACKING_URI }}",
+                "MLFLOW_TRACKING_TOKEN": "${{ secrets.MLFLOW_TRACKING_TOKEN }}",
+                "MLFLOW_EXPERIMENT_NAME": "${{ secrets.MLFLOW_EXPERIMENT_NAME }}",
+                "MLFLOW_WORKSPACE": "odh-dashboard-tracing"
+              }
+            }
+          claude_args: >-
+            --max-turns 50
+            --model "claude-sonnet-4-6[1m]"
+            --permission-mode acceptEdits
+            --allowedTools "Bash(gh *)"
+            --allowedTools "Bash(git *)"
+            --allowedTools "Bash(pip *)"
+            --allowedTools "Bash(python3 *)"
+          prompt: |
+            The following preflight judges failed this week:
+
+            ${{ steps.query-failures.outputs.failures }}
+
+            Your task:
+            1. Use the analyze-mlflow-trace skill to inspect the failing traces
+            2. Identify the root cause pattern — why did the agent fail to complete these steps?
+            3. Edit .claude/skills/preflight/SKILL.md with a targeted fix to prevent this failure mode
+            4. Create a new branch, commit the change, and open a PR to opendatahub-io/odh-dashboard
+
+            Focus on the SKILL.md instructions that would have prevented the failure.
+            Do not make broad changes — only fix what the traces show is broken.

--- a/.github/workflows/claude-preflight.yml
+++ b/.github/workflows/claude-preflight.yml
@@ -292,6 +292,20 @@ jobs:
             --allowedTools "Bash(bash *)"
           prompt: "/preflight ${{ env.PR_NUMBER }} --fix --skip-review coderabbit --ci"
 
+      # ── Evaluate trace ──
+      - name: Evaluate preflight trace
+        if: always()
+        continue-on-error: true
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+          MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
+          MLFLOW_EXPERIMENT_NAME: ${{ secrets.MLFLOW_EXPERIMENT_NAME }}
+          MLFLOW_WORKSPACE: "odh-dashboard-tracing"
+        run: |
+          python3 .claude/skills/preflight/tests/test_skill.py \
+            .claude/skills/preflight/tests/configs/preflight_check.yaml \
+            --commit $(git rev-parse HEAD)
+
       # ── Report ──
       - name: Update check run (success)
         if: success() && steps.check-run.outputs.id


### PR DESCRIPTION
## Summary
- Weekly cron GHA that queries MLflow for failing preflight trace assessments from the past week
- Installs [mlflow/skills](https://github.com/mlflow/skills) at runtime for trace analysis (not committed to repo)
- Runs Claude with `analyze-mlflow-trace` skill to inspect failures, identify root cause patterns, and fix SKILL.md
- Opens a PR upstream with the targeted fix

Follows the [mlflow/skills Trace → Judge → Refine pattern](https://mlflow.org/blog/evaluating-skills-mlflow/) for automated skill improvement.

## Dependencies
- Depends on #7861 (judges + CI step)

## Test plan
- [ ] Verify query step correctly finds failing assessments from MLflow
- [ ] Verify skip when no failures exist
- [ ] Verify Claude can analyze traces with mlflow/skills and propose SKILL.md fix
- [ ] Verify PR is opened with targeted change

🤖 Generated with [Claude Code](https://claude.com/claude-code)