### PR TITLE
Evalhub updates

### DIFF
--- a/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
+++ b/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
@@ -30,10 +30,11 @@ type EvalHubServiceHealth struct {
 
 type EvalHubServiceHealthEnvelope Envelope[EvalHubServiceHealth, None]
 
-// EvalHubServiceHealthHandler performs per-request CR discovery in the dashboard namespace
-// using the caller's bearer token and then pings the discovered EvalHub service. It always
-// returns HTTP 200 with one of the three EvalHubHealthStatus values so the frontend always
-// reaches a loaded state.
+// EvalHubServiceHealthHandler performs per-request CR discovery using the caller's bearer
+// token and then pings the discovered EvalHub service. Because this endpoint does not have
+// the AttachNamespace middleware, it only checks app.dashboardNamespace. It always returns
+// HTTP 200 with one of the three EvalHubHealthStatus values so the frontend always reaches
+// a loaded state.
 //
 // Priority:
 //  1. MockEvalHubClient=true — return healthy immediately (dev/test mode, no K8s call).

--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -92,14 +92,15 @@ func (app *App) EnableTelemetry(next http.Handler) http.Handler {
 //   - serviceURL  — the URL to use for the EvalHub REST client.
 //   - authToken   — the caller's bearer token (empty when using an env-override URL and no
 //     identity is present, e.g. in dev mode).
-//   - crNotFound  — true when no EvalHub CR exists in the dashboard namespace (not an error;
+//   - crNotFound  — true when no EvalHub CR exists in either namespace (not an error;
 //     callers should surface this as a distinct state rather than 500).
 //   - err         — a real unexpected error (K8s API failure, missing identity, etc.).
 //
 // Priority (evaluated per-request):
 //  1. EVAL_HUB_URL env override — used directly; no K8s call needed.
-//  2. CR discovery              — lists evalhubs.trustyai.opendatahub.io in
-//     app.dashboardNamespace via the caller's bearer token.
+//  2. CR discovery in the user-selected namespace (from context, if present).
+//  3. Fallback CR discovery in app.dashboardNamespace (covers the health endpoint and cases
+//     where the CR lives in the platform namespace).
 //
 // Mock mode is NOT handled here; callers must short-circuit before calling this function.
 func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken string, crNotFound bool, err error) {
@@ -123,9 +124,22 @@ func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken st
 		return "", "", false, fmt.Errorf("failed to get Kubernetes client: %w", err)
 	}
 
+	// Try the user-selected namespace first (set by AttachNamespace middleware on API routes).
+	if userNS, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string); ok && userNS != "" {
+		crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, userNS)
+		if err != nil {
+			return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", userNS, err)
+		}
+		if crStatus != nil && strings.TrimSpace(crStatus.URL) != "" {
+			return crStatus.URL, authToken, false, nil
+		}
+	}
+
+	// Fallback to the dashboard (platform) namespace for the health endpoint and clusters
+	// where the CR still lives in the operator-managed namespace.
 	crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, app.dashboardNamespace)
 	if err != nil {
-		return "", "", false, fmt.Errorf("EvalHub CR lookup failed: %w", err)
+		return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", app.dashboardNamespace, err)
 	}
 	if crStatus == nil || strings.TrimSpace(crStatus.URL) == "" {
 		return "", authToken, true, nil
@@ -136,14 +150,14 @@ func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken st
 // AttachEvalHubClient middleware creates an EvalHub client and attaches it to context.
 //
 // The EvalHub service URL is resolved on every request (per-request discovery) using the
-// caller's bearer token to list EvalHub CRs in the dashboard namespace. This ensures the
-// BFF always reflects the current cluster state without requiring a pod restart.
+// caller's bearer token. This ensures the BFF always reflects the current cluster state
+// without requiring a pod restart.
 //
 // Priority for resolving the URL (evaluated per-request):
 //  1. MOCK_EVAL_HUB_CLIENT=true  → mock client (test/dev mode, no URL needed)
 //  2. EVAL_HUB_URL env var set   → developer override, used directly (no K8s call)
-//  3. CR discovery               → lists evalhubs.trustyai.opendatahub.io in dashboard
-//     namespace via the caller's bearer token
+//  3. CR discovery in user-selected namespace (from ?namespace= query param)
+//  4. Fallback CR discovery in app.dashboardNamespace
 func (app *App) AttachEvalHubClient(next func(http.ResponseWriter, *http.Request, httprouter.Params)) func(http.ResponseWriter, *http.Request, httprouter.Params) {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		ctx := r.Context()
@@ -161,7 +175,7 @@ func (app *App) AttachEvalHubClient(next func(http.ResponseWriter, *http.Request
 				return
 			}
 			if crNotFound {
-				app.serviceUnavailableResponse(w, r, fmt.Errorf("EvalHub CR not found in namespace %q — operator not configured", app.dashboardNamespace))
+				app.serviceUnavailableResponse(w, r, fmt.Errorf("EvalHub CR not found in user namespace or dashboard namespace %q — operator not configured", app.dashboardNamespace))
 				return
 			}
 			logger.Debug("Resolved EvalHub service URL", "serviceURL", serviceURL)

--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"runtime/debug"
 	"strings"
 
@@ -231,11 +232,18 @@ func (app *App) RequireAccessToService(next func(http.ResponseWriter, *http.Requ
 	}
 }
 
+// validNamespaceRE matches a valid Kubernetes namespace name (RFC 1123 DNS label).
+var validNamespaceRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
 func (app *App) AttachNamespace(next func(http.ResponseWriter, *http.Request, httprouter.Params)) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		namespace := r.URL.Query().Get(string(constants.NamespaceHeaderParameterKey))
 		if namespace == "" {
 			app.badRequestResponse(w, r, fmt.Errorf("missing required query parameter: %s", constants.NamespaceHeaderParameterKey))
+			return
+		}
+		if !validNamespaceRE.MatchString(namespace) {
+			app.badRequestResponse(w, r, fmt.Errorf("invalid namespace %q: must be a valid RFC 1123 DNS label", namespace))
 			return
 		}
 

--- a/packages/eval-hub/bff/internal/api/middleware_test.go
+++ b/packages/eval-hub/bff/internal/api/middleware_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/opendatahub-io/eval-hub/bff/internal/config"
+	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
+	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// namespaceAwareCRClient returns different CR statuses depending on the namespace queried.
+type namespaceAwareCRClient struct {
+	testK8sClient
+	crByNamespace map[string]*models.EvalHubCRStatus
+	errByNS       map[string]error
+}
+
+func (c *namespaceAwareCRClient) GetEvalHubCRStatus(_ context.Context, _ *kubernetes.RequestIdentity, namespace string) (*models.EvalHubCRStatus, error) {
+	if c.errByNS != nil {
+		if err, ok := c.errByNS[namespace]; ok {
+			return nil, err
+		}
+	}
+	if c.crByNamespace != nil {
+		return c.crByNamespace[namespace], nil
+	}
+	return nil, nil
+}
+
+func newTestApp(k8sClient kubernetes.KubernetesClientInterface, dashboardNS string) *App {
+	return &App{
+		config:                  config.EnvConfig{AuthMethod: config.AuthMethodInternal},
+		logger:                  testLogger,
+		kubernetesClientFactory: &crStatusK8sFactory{client: k8sClient},
+		dashboardNamespace:      dashboardNS,
+	}
+}
+
+func TestEvalHubServiceURL_UserNamespaceHasCR(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		crByNamespace: map[string]*models.EvalHubCRStatus{
+			"user-project": {
+				Name: "evalhub", Namespace: "user-project", Phase: "Ready",
+				URL: "http://evalhub.user-project.svc:8080",
+			},
+			"redhat-ods-applications": {
+				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
+				URL: "http://evalhub.platform.svc:8080",
+			},
+		},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	serviceURL, authToken, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, crNotFound)
+	assert.Equal(t, "http://evalhub.user-project.svc:8080", serviceURL)
+	assert.Equal(t, "tok", authToken)
+}
+
+func TestEvalHubServiceURL_FallbackToDashboardNamespace(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		crByNamespace: map[string]*models.EvalHubCRStatus{
+			"redhat-ods-applications": {
+				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
+				URL: "http://evalhub.platform.svc:8080",
+			},
+		},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, crNotFound)
+	assert.Equal(t, "http://evalhub.platform.svc:8080", serviceURL)
+}
+
+func TestEvalHubServiceURL_CRNotFoundAnywhere(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		crByNamespace: map[string]*models.EvalHubCRStatus{},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, crNotFound)
+	assert.Empty(t, serviceURL)
+}
+
+func TestEvalHubServiceURL_NoUserNamespaceInContext(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		crByNamespace: map[string]*models.EvalHubCRStatus{
+			"opendatahub": {
+				Name: "evalhub", Namespace: "opendatahub", Phase: "Ready",
+				URL: "http://evalhub.odh.svc:8080",
+			},
+		},
+	}
+
+	app := newTestApp(client, "opendatahub")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, crNotFound)
+	assert.Equal(t, "http://evalhub.odh.svc:8080", serviceURL)
+}
+
+func TestEvalHubServiceURL_UserNamespaceLookupError(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		errByNS: map[string]error{
+			"user-project": fmt.Errorf("forbidden"),
+		},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	_, _, _, err := app.evalHubServiceURL(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user-project")
+}
+
+func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {
+	client := &namespaceAwareCRClient{}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	app.config.EvalHubURL = "http://override:9090"
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.False(t, crNotFound)
+	assert.Equal(t, "http://override:9090", serviceURL)
+}

--- a/packages/eval-hub/bff/internal/api/middleware_test.go
+++ b/packages/eval-hub/bff/internal/api/middleware_test.go
@@ -3,8 +3,11 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/eval-hub/bff/internal/config"
 	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
@@ -154,4 +157,56 @@ func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, crNotFound)
 	assert.Equal(t, "http://override:9090", serviceURL)
+}
+
+func TestAttachNamespace_ValidNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		wantCode  int
+	}{
+		{"simple name", "my-project", http.StatusOK},
+		{"single char", "a", http.StatusOK},
+		{"max length", "a234567890123456789012345678901234567890123456789012345678901ab", http.StatusOK},
+		{"with numbers", "ns-123-test", http.StatusOK},
+		{"empty", "", http.StatusBadRequest},
+		{"uppercase", "My-Project", http.StatusBadRequest},
+		{"starts with dash", "-invalid", http.StatusBadRequest},
+		{"ends with dash", "invalid-", http.StatusBadRequest},
+		{"has spaces", "my project", http.StatusBadRequest},
+		{"has dots", "my.project", http.StatusBadRequest},
+		{"has underscore", "my_project", http.StatusBadRequest},
+		{"too long", "a2345678901234567890123456789012345678901234567890123456789012345", http.StatusBadRequest},
+		{"path traversal attempt", "../etc/passwd", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{
+				config: config.EnvConfig{AllowedOrigins: []string{"*"}, AuthMethod: config.AuthMethodInternal},
+				logger: testLogger,
+			}
+
+			called := false
+			handler := app.AttachNamespace(func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			url := "/test"
+			if tt.namespace != "" {
+				url += "?namespace=" + tt.namespace
+			}
+			req, _ := http.NewRequest(http.MethodGet, url, http.NoBody)
+			rr := httptest.NewRecorder()
+			handler(rr, req, nil)
+
+			assert.Equal(t, tt.wantCode, rr.Code)
+			if tt.wantCode == http.StatusOK {
+				assert.True(t, called, "handler should have been called")
+			} else {
+				assert.False(t, called, "handler should not have been called")
+			}
+		})
+	}
 }

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -277,12 +277,12 @@ const StartEvaluationRunPage: React.FC = () => {
                     </StackItem>
                     <StackItem>
                       <FormGroup
-                        label="API key"
+                        label="API key secret name"
                         fieldId="api-key"
                         labelHelp={
                           <LabelHelpPopover
-                            ariaLabel="More info for API key"
-                            content="If access to the model or agent is restricted or requires authentication, provide the API key for its inference endpoint."
+                            ariaLabel="More info for API key secret name"
+                            content="The name of the Kubernetes Secret that contains your API key. The secret is stored securely in your cluster and referenced by name — the actual key value is never exposed in the evaluation configuration."
                           />
                         }
                       >


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
- Updated API Key secret info
<img width="723" height="241" alt="Screenshot 2026-06-04 at 22 58 20" src="https://github.com/user-attachments/assets/963a69ae-5432-4606-a251-dc4ed4c95da8" />

- Resolve EvalHub CR from user-selected project namespace.
It unblocks users whose EvalHub CR lives outside the platform namespace
(e.g. multi-tenant setups). The BFF now checks the ?namespace= query param first, falling back to dashboardNamespace for backward compat.
Temporary workaround until `RHOAIENG-2289` delivers proper multi-tenancy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added test for new bff behavior

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EvalHub discovery now prioritizes a user-selected namespace with automatic fallback to the dashboard namespace.

* **Changes**
  * Namespace query validation added; invalid namespace values now return a clear bad-request response.
  * Lookup errors now include the namespace in error messages for clarity.

* **Documentation**
  * Clarified that the API key field expects a Kubernetes Secret name (not the raw key).

* **Tests**
  * Added unit tests for namespace-aware discovery, fallback, validation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->