### PR TITLE
CRD + backend API for global MLflow namespace management

### DIFF
--- a/backend/src/__tests__/mlflow-global-namespace/mlflowGlobalNamespaceUtils.spec.ts
+++ b/backend/src/__tests__/mlflow-global-namespace/mlflowGlobalNamespaceUtils.spec.ts
@@ -1,0 +1,407 @@
+import {
+  updateGlobalMLflowNamespaces,
+  GLOBAL_MLFLOW_LABEL_KEY,
+  GLOBAL_MLFLOW_CR_NAME,
+} from '../../routes/api/mlflow-global-namespace/mlflowGlobalNamespaceUtils';
+
+jest.mock('../../utils/resourceUtils', () => ({
+  getDashboardConfig: jest.fn(),
+}));
+jest.mock('../../routes/api/config/configUtils', () => ({
+  setDashboardConfig: jest.fn(),
+}));
+jest.mock('../../routes/api/namespaces/namespaceUtils', () => ({
+  ...jest.requireActual('../../routes/api/namespaces/namespaceUtils'),
+  ensureNamespaceAccessPermission: jest.fn(),
+}));
+
+import { getDashboardConfig } from '../../utils/resourceUtils';
+import { setDashboardConfig } from '../../routes/api/config/configUtils';
+import { ensureNamespaceAccessPermission } from '../../routes/api/namespaces/namespaceUtils';
+
+const mockGetDashboardConfig = getDashboardConfig as jest.Mock;
+const mockSetDashboardConfig = setDashboardConfig as jest.Mock;
+const mockEnsurePermission = ensureNamespaceAccessPermission as jest.Mock;
+
+const mockPatchNamespace = jest.fn();
+const mockReadNamespace = jest.fn();
+
+const mockFastify = {
+  kube: {
+    coreV1Api: {
+      patchNamespace: mockPatchNamespace,
+      readNamespace: mockReadNamespace,
+    },
+  },
+  log: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
+} as any;
+
+const mockRequest = {} as any;
+
+const makeDashboardConfig = (globalMLflowNamespaces: string[] = []) => ({
+  spec: {
+    dashboardConfig: {},
+    globalMLflowNamespaces,
+  },
+});
+
+const expectLabelApply = (ns: string, callIndex?: number) => {
+  const args = [
+    ns,
+    { metadata: { labels: { [GLOBAL_MLFLOW_LABEL_KEY]: GLOBAL_MLFLOW_CR_NAME } } },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    expect.objectContaining({ headers: expect.any(Object) }),
+  ];
+  if (callIndex !== undefined) {
+    expect(mockPatchNamespace).toHaveBeenNthCalledWith(callIndex, ...args);
+  } else {
+    expect(mockPatchNamespace).toHaveBeenCalledWith(...args);
+  }
+};
+
+const expectLabelRemove = (ns: string, callIndex?: number) => {
+  const args = [
+    ns,
+    { metadata: { labels: { [GLOBAL_MLFLOW_LABEL_KEY]: null } } },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    expect.objectContaining({ headers: expect.any(Object) }),
+  ];
+  if (callIndex !== undefined) {
+    expect(mockPatchNamespace).toHaveBeenNthCalledWith(callIndex, ...args);
+  } else {
+    expect(mockPatchNamespace).toHaveBeenCalledWith(...args);
+  }
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSetDashboardConfig.mockResolvedValue({});
+  mockReadNamespace.mockResolvedValue({ body: {} });
+  mockPatchNamespace.mockResolvedValue({ body: {} });
+  mockEnsurePermission.mockResolvedValue(undefined);
+});
+
+describe('updateGlobalMLflowNamespaces', () => {
+  it('sets a single namespace fresh ([] -> ["ns-a"])', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: ['ns-a'] });
+    expect(mockReadNamespace).toHaveBeenCalledWith('ns-a');
+    expect(mockEnsurePermission).toHaveBeenCalledTimes(1);
+    expect(mockSetDashboardConfig).toHaveBeenCalledWith(mockFastify, {
+      spec: { globalMLflowNamespaces: ['ns-a'] },
+    });
+    expectLabelApply('ns-a');
+  });
+
+  it('changes a single namespace (["ns-a"] -> ["ns-b"])', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-a']));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-b']);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: ['ns-b'] });
+    expectLabelRemove('ns-a', 1);
+    expectLabelApply('ns-b', 2);
+    expect(mockSetDashboardConfig).toHaveBeenCalledWith(mockFastify, {
+      spec: { globalMLflowNamespaces: ['ns-b'] },
+    });
+  });
+
+  it('clears all (["ns-a"] -> [])', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-a']));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, []);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: [] });
+    expectLabelRemove('ns-a');
+    expect(mockSetDashboardConfig).toHaveBeenCalledWith(mockFastify, {
+      spec: { globalMLflowNamespaces: [] },
+    });
+  });
+
+  it('is a no-op when clearing with nothing set ([] -> [])', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, []);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: [] });
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockReadNamespace).not.toHaveBeenCalled();
+    expect(mockEnsurePermission).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).toHaveBeenCalledWith(mockFastify, {
+      spec: { globalMLflowNamespaces: [] },
+    });
+  });
+
+  it('re-applies label when same namespace re-set (["ns-a"] -> ["ns-a"])', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-a']));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: ['ns-a'] });
+    expect(mockReadNamespace).not.toHaveBeenCalled();
+    expect(mockEnsurePermission).not.toHaveBeenCalled();
+    expectLabelApply('ns-a');
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('rejects with 404 when namespace does not exist', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockReadNamespace.mockRejectedValue({ response: { statusCode: 404 } });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['nonexistent']),
+    ).rejects.toMatchObject({ code: 404 });
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 for system namespace (openshift prefix)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['openshift-monitoring']),
+    ).rejects.toMatchObject({ code: 400 });
+
+    expect(mockReadNamespace).not.toHaveBeenCalled();
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 for system namespace (kube prefix)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['kube-system']),
+    ).rejects.toMatchObject({ code: 400 });
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 when SSAR is denied', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    const forbiddenError = Object.assign(new Error('Forbidden'), { code: 403 });
+    mockEnsurePermission.mockRejectedValue(forbiddenError);
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({ code: 403 });
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('handles stale namespace (previous namespace deleted) -- label removal skips gracefully', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['deleted-ns']));
+    mockPatchNamespace
+      .mockRejectedValueOnce({ response: { statusCode: 404 } })
+      .mockResolvedValueOnce({ body: {} });
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-new']);
+
+    expect(result.success).toBe(true);
+    expect(result.globalMLflowNamespaces).toEqual(['ns-new']);
+    expect(result.warnings).toBeUndefined();
+    expect(mockFastify.log.warn).toHaveBeenCalledWith(expect.stringContaining('deleted-ns'));
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('checks SSAR permission for namespace removal', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-old']));
+
+    await updateGlobalMLflowNamespaces(mockFastify, mockRequest, []);
+
+    expect(mockEnsurePermission).toHaveBeenCalledTimes(1);
+    expect(mockEnsurePermission).toHaveBeenCalledWith(
+      mockFastify,
+      mockRequest,
+      'ns-old',
+      expect.any(Function),
+      expect.stringContaining('ns-old'),
+    );
+  });
+
+  it('rejects with 403 when SSAR denied on removal', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-old']));
+    const forbiddenError = Object.assign(new Error('Forbidden'), { code: 403 });
+    mockEnsurePermission.mockRejectedValue(forbiddenError);
+
+    await expect(updateGlobalMLflowNamespaces(mockFastify, mockRequest, [])).rejects.toMatchObject({
+      code: 403,
+    });
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('throws when label application fails for new namespace', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockPatchNamespace.mockRejectedValue({
+      response: { statusCode: 500 },
+      message: 'patch failed',
+    });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({
+      message: 'Unable to apply global MLflow label to namespace "ns-a": unexpected error',
+      statusCode: 500,
+    });
+
+    expect(mockFastify.log.error).toHaveBeenCalled();
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('does not apply labels when config CR patch fails', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockSetDashboardConfig.mockRejectedValue(new Error('CR patch failed'));
+
+    await expect(updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a'])).rejects.toThrow(
+      'CR patch failed',
+    );
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+  });
+
+  it('returns warnings when label removal fails (non-404)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-old']));
+    mockPatchNamespace
+      .mockRejectedValueOnce({ response: { statusCode: 500 }, message: 'internal error' })
+      .mockResolvedValueOnce({ body: {} });
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-new']);
+
+    expect(result.success).toBe(true);
+    expect(result.globalMLflowNamespaces).toEqual(['ns-new']);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('ns-old');
+    expect(mockFastify.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'ns-old', error: expect.any(String) }),
+      expect.stringContaining('ns-old'),
+    );
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('rejects multiple namespaces (maxItems enforcement)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a', 'ns-b']),
+    ).rejects.toMatchObject({ code: 400 });
+
+    expect(mockReadNamespace).not.toHaveBeenCalled();
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates input array', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a', 'ns-a']);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: ['ns-a'] });
+    expect(mockReadNamespace).toHaveBeenCalledTimes(1);
+    expect(mockEnsurePermission).toHaveBeenCalledTimes(1);
+    expect(mockPatchNamespace).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates non-404 error from namespace validation (e.g. 500)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockReadNamespace.mockRejectedValue({
+      response: { statusCode: 500 },
+      message: 'Internal server error',
+    });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({
+      statusCode: 500,
+      message: expect.stringContaining('ns-a'),
+    });
+
+    expect(mockPatchNamespace).not.toHaveBeenCalled();
+    expect(mockSetDashboardConfig).not.toHaveBeenCalled();
+  });
+
+  it('returns "insufficient permissions" reason when label application gets 403', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockPatchNamespace.mockRejectedValue({
+      response: { statusCode: 403, body: { message: 'Forbidden' } },
+    });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('insufficient permissions'),
+      statusCode: 403,
+    });
+
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('returns "conflict" reason when label application gets 409', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockPatchNamespace.mockRejectedValue({
+      response: { statusCode: 409, body: { message: 'Conflict' } },
+    });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('conflict'),
+      statusCode: 409,
+    });
+
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('returns 404 when namespace is deleted between validation and label application (TOCTOU)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig([]));
+    mockPatchNamespace.mockRejectedValue({ response: { statusCode: 404 } });
+
+    await expect(
+      updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']),
+    ).rejects.toMatchObject({
+      code: 404,
+      message: expect.stringContaining('deleted before the label could be applied'),
+    });
+
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('silently skips label removal when namespace returns 404 (already deleted)', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-old']));
+    mockPatchNamespace.mockRejectedValue({ response: { statusCode: 404 } });
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, []);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: [] });
+    expect(mockFastify.log.warn).toHaveBeenCalledWith(expect.stringContaining('no longer exists'));
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+
+  it('applies label on retry when CR already has the desired value', async () => {
+    mockGetDashboardConfig.mockReturnValue(makeDashboardConfig(['ns-a']));
+
+    const result = await updateGlobalMLflowNamespaces(mockFastify, mockRequest, ['ns-a']);
+
+    expect(result).toEqual({ success: true, globalMLflowNamespaces: ['ns-a'] });
+    expectLabelApply('ns-a');
+    expect(mockSetDashboardConfig).toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/api/mlflow-global-namespace/index.ts
+++ b/backend/src/routes/api/mlflow-global-namespace/index.ts
@@ -1,0 +1,34 @@
+import { FastifyReply } from 'fastify';
+import { KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
+import { createCustomError } from '../../../utils/requestUtils';
+import { secureAdminRoute } from '../../../utils/route-security';
+import { updateGlobalMLflowNamespaces } from './mlflowGlobalNamespaceUtils';
+
+export default async (fastify: KubeFastifyInstance): Promise<void> => {
+  fastify.put(
+    '/',
+    secureAdminRoute(fastify)(
+      async (
+        request: OauthFastifyRequest<{
+          Body: { globalMLflowNamespaces: string[] };
+        }>,
+        reply: FastifyReply,
+      ) => {
+        const { globalMLflowNamespaces } = request.body;
+        if (
+          !Array.isArray(globalMLflowNamespaces) ||
+          !globalMLflowNamespaces.every((ns) => typeof ns === 'string' && ns.trim().length > 0)
+        ) {
+          throw createCustomError(
+            'Validation error',
+            'globalMLflowNamespaces must be an array of non-empty strings',
+            400,
+          );
+        }
+        const trimmed = globalMLflowNamespaces.map((ns) => ns.trim());
+        const result = await updateGlobalMLflowNamespaces(fastify, request, trimmed);
+        reply.send(result);
+      },
+    ),
+  );
+};

--- a/backend/src/routes/api/mlflow-global-namespace/mlflowGlobalNamespaceUtils.ts
+++ b/backend/src/routes/api/mlflow-global-namespace/mlflowGlobalNamespaceUtils.ts
@@ -1,0 +1,186 @@
+import { KnownLabels, KubeFastifyInstance, OauthFastifyRequest } from '../../../types';
+import { createCustomError } from '../../../utils/requestUtils';
+import { getDashboardConfig } from '../../../utils/resourceUtils';
+import { setDashboardConfig } from '../config/configUtils';
+import {
+  checkAdminNamespacePermission,
+  ensureNamespaceAccessPermission,
+  MERGE_PATCH_OPTIONS,
+  validateNotSystemNamespace,
+} from '../namespaces/namespaceUtils';
+
+export const GLOBAL_MLFLOW_LABEL_KEY = KnownLabels.GLOBAL_MLFLOW_WORKSPACE;
+// Once we support multiple MLflow instances per namespace, this should
+// be replaced with dynamic CR name selection from the API request.
+export const GLOBAL_MLFLOW_CR_NAME = 'mlflow';
+// Must match maxItems in the CRD schema for globalMLflowNamespaces
+const MAX_GLOBAL_MLFLOW_NAMESPACES = 1;
+
+const isNamespaceNotFound = (e: {
+  code?: number;
+  statusCode?: number;
+  response?: { statusCode?: number; body?: { code?: number } };
+}): boolean =>
+  e.response?.statusCode === 404 ||
+  e.response?.body?.code === 404 ||
+  e.code === 404 ||
+  e.statusCode === 404;
+
+const validateNamespace = async (fastify: KubeFastifyInstance, name: string): Promise<void> => {
+  validateNotSystemNamespace(name);
+
+  try {
+    await fastify.kube.coreV1Api.readNamespace(name);
+  } catch (e) {
+    if (isNamespaceNotFound(e)) {
+      throw createCustomError('Namespace not found', `Namespace "${name}" does not exist`, 404);
+    }
+    fastify.log.error(
+      { namespace: name, error: e.message },
+      `Failed to validate namespace "${name}"`,
+    );
+    throw createCustomError(
+      'Namespace validation failed',
+      `Unable to validate namespace "${name}"`,
+      e.response?.statusCode || e.statusCode || 500,
+    );
+  }
+};
+
+const applyGlobalMLflowLabel = async (
+  fastify: KubeFastifyInstance,
+  name: string,
+): Promise<void> => {
+  try {
+    await fastify.kube.coreV1Api.patchNamespace(
+      name,
+      { metadata: { labels: { [GLOBAL_MLFLOW_LABEL_KEY]: GLOBAL_MLFLOW_CR_NAME } } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      MERGE_PATCH_OPTIONS,
+    );
+  } catch (e) {
+    if (isNamespaceNotFound(e)) {
+      throw createCustomError(
+        'Namespace not found',
+        `Namespace "${name}" was deleted before the label could be applied`,
+        404,
+      );
+    }
+    const statusCode = e.response?.statusCode || e.statusCode;
+    const reason =
+      statusCode === 403
+        ? 'insufficient permissions'
+        : statusCode === 409
+        ? 'conflict'
+        : 'unexpected error';
+    fastify.log.error(
+      { namespace: name, error: e.response?.body?.message || e.message },
+      `Failed to apply MLflow label to namespace "${name}"`,
+    );
+    throw createCustomError(
+      'Label application failed',
+      `Unable to apply global MLflow label to namespace "${name}": ${reason}`,
+      statusCode,
+    );
+  }
+};
+
+const removeGlobalMLflowLabel = async (
+  fastify: KubeFastifyInstance,
+  name: string,
+): Promise<string | null> => {
+  try {
+    await fastify.kube.coreV1Api.patchNamespace(
+      name,
+      { metadata: { labels: { [GLOBAL_MLFLOW_LABEL_KEY]: null } } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      MERGE_PATCH_OPTIONS,
+    );
+    return null;
+  } catch (e) {
+    if (isNamespaceNotFound(e)) {
+      fastify.log.warn(`Namespace "${name}" no longer exists; skipping label removal`);
+      return null;
+    }
+    const clientMessage = `Failed to remove global MLflow label from namespace "${name}"`;
+    fastify.log.warn(
+      { namespace: name, error: e.response?.body?.message || e.message },
+      clientMessage,
+    );
+    return clientMessage;
+  }
+};
+
+export const updateGlobalMLflowNamespaces = async (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  newNamespaces: string[],
+): Promise<{ success: boolean; globalMLflowNamespaces: string[]; warnings?: string[] }> => {
+  const uniqueNamespaces = [...new Set(newNamespaces)];
+
+  if (uniqueNamespaces.length > MAX_GLOBAL_MLFLOW_NAMESPACES) {
+    throw createCustomError(
+      'Validation error',
+      `Currently only ${MAX_GLOBAL_MLFLOW_NAMESPACES} global MLflow namespace is supported`,
+      400,
+    );
+  }
+
+  const config = getDashboardConfig(request);
+  const oldNamespaces = config.spec.globalMLflowNamespaces ?? [];
+
+  const toAdd = uniqueNamespaces.filter((ns) => !oldNamespaces.includes(ns));
+  const toRemove = oldNamespaces.filter((ns) => !uniqueNamespaces.includes(ns));
+
+  for (const ns of toAdd) {
+    await validateNamespace(fastify, ns);
+    await ensureNamespaceAccessPermission(
+      fastify,
+      request,
+      ns,
+      checkAdminNamespacePermission,
+      `You don't have permission to manage namespace "${ns}"`,
+    );
+  }
+
+  for (const ns of toRemove) {
+    await ensureNamespaceAccessPermission(
+      fastify,
+      request,
+      ns,
+      checkAdminNamespacePermission,
+      `You don't have permission to manage namespace "${ns}"`,
+    );
+  }
+
+  const warnings: string[] = [];
+  for (const ns of toRemove) {
+    const warning = await removeGlobalMLflowLabel(fastify, ns);
+    if (warning) {
+      warnings.push(warning);
+    }
+  }
+
+  await setDashboardConfig(fastify, {
+    spec: { globalMLflowNamespaces: uniqueNamespaces },
+  });
+
+  for (const ns of uniqueNamespaces) {
+    await applyGlobalMLflowLabel(fastify, ns);
+  }
+
+  const result: { success: boolean; globalMLflowNamespaces: string[]; warnings?: string[] } = {
+    success: true,
+    globalMLflowNamespaces: uniqueNamespaces,
+  };
+  if (warnings.length > 0) {
+    result.warnings = warnings;
+  }
+  return result;
+};

--- a/backend/src/routes/api/namespaces/namespaceUtils.ts
+++ b/backend/src/routes/api/namespaces/namespaceUtils.ts
@@ -6,7 +6,7 @@ import { isK8sStatus } from '../../../utils/pass-through';
 import { getDashboardConfig } from '../../../utils/resourceUtils';
 import { createSelfSubjectAccessReview } from '../../../utils/authUtils';
 
-const checkAdminNamespacePermission = (
+export const checkAdminNamespacePermission = (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
   name: string,
@@ -34,6 +34,37 @@ const checkEditNamespacePermission = (
     namespace: name,
   });
 
+export const MERGE_PATCH_OPTIONS = {
+  headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
+};
+
+export const validateNotSystemNamespace = (name: string): void => {
+  if (name.startsWith('openshift') || name.startsWith('kube')) {
+    throw createCustomError(
+      'Invalid namespace target',
+      'Cannot mutate namespaces with "openshift" or "kube"',
+      400,
+    );
+  }
+};
+
+export const ensureNamespaceAccessPermission = async (
+  fastify: KubeFastifyInstance,
+  request: OauthFastifyRequest,
+  name: string,
+  checkFn: typeof checkAdminNamespacePermission,
+  forbiddenMessage = "You don't have permission to manage this namespace.",
+): Promise<void> => {
+  const review = await checkFn(fastify, request, name);
+  if (isK8sStatus(review)) {
+    throw createCustomError(review.reason, review.message, review.code);
+  }
+  if (!review.status.allowed) {
+    fastify.log.error(`SSAR denied for namespace "${name}": ${review.status.reason}`);
+    throw createCustomError('Forbidden', forbiddenMessage, 403);
+  }
+};
+
 export const applyNamespaceChange = async (
   fastify: KubeFastifyInstance,
   request: OauthFastifyRequest,
@@ -41,14 +72,7 @@ export const applyNamespaceChange = async (
   context: NamespaceApplicationCase,
   dryRun?: string,
 ): Promise<{ applied: boolean }> => {
-  if (name.startsWith('openshift') || name.startsWith('kube')) {
-    // Kubernetes and OpenShift namespaces are off limits to this flow
-    throw createCustomError(
-      'Invalid namespace target',
-      'Cannot mutate namespaces with "openshift" or "kube"',
-      400,
-    );
-  }
+  validateNotSystemNamespace(name);
 
   let annotations = {};
   let labels = {};
@@ -95,22 +119,13 @@ export const applyNamespaceChange = async (
       500,
     );
   }
-  const selfSubjectAccessReview = await checkPermissionsFn(fastify, request, name);
-  if (isK8sStatus(selfSubjectAccessReview)) {
-    throw createCustomError(
-      selfSubjectAccessReview.reason,
-      selfSubjectAccessReview.message,
-      selfSubjectAccessReview.code,
-    );
-  }
-  if (!selfSubjectAccessReview.status.allowed) {
-    fastify.log.error(`Unable to access the namespace, ${selfSubjectAccessReview.status.reason}`);
-    throw createCustomError(
-      'Forbidden',
-      "You don't have permission to update serving platform labels on the current project.",
-      403,
-    );
-  }
+  await ensureNamespaceAccessPermission(
+    fastify,
+    request,
+    name,
+    checkPermissionsFn,
+    "You don't have permission to update serving platform labels on the current project.",
+  );
 
   return fastify.kube.coreV1Api
     .patchNamespace(
@@ -120,9 +135,7 @@ export const applyNamespaceChange = async (
       dryRun,
       undefined,
       undefined,
-      {
-        headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH },
-      },
+      MERGE_PATCH_OPTIONS,
     )
     .then(() => ({ applied: true }))
     .catch((e) => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -88,6 +88,7 @@ export type DashboardConfig = K8sResourceCommon & {
       deploymentStrategy?: string;
       isLLMdDefault?: boolean;
     };
+    globalMLflowNamespaces?: string[];
     genAiStudioConfig?: {
       aiAssetCustomEndpoints?: {
         externalProviders?: boolean;
@@ -968,6 +969,7 @@ export enum KnownLabels {
   CONNECTION_TYPE = 'opendatahub.io/connection-type',
   LABEL_SELECTOR_MODEL_REGISTRY = 'component=model-registry',
   KUEUE_MANAGED = 'kueue.openshift.io/managed',
+  GLOBAL_MLFLOW_WORKSPACE = 'opendatahub.io/global-mlflow-workspace',
 }
 
 export type ManagementState = 'Managed' | 'Unmanaged' | 'Removed';

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -110,6 +110,7 @@ export const blankDashboardCR: DashboardConfig = {
       enabled: true,
     },
     templateOrder: [],
+    globalMLflowNamespaces: [],
     genAiStudioConfig: {
       aiAssetCustomEndpoints: {
         externalProviders: false,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -63,6 +63,7 @@ export type MockDashboardConfigType = {
   maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  globalMLflowNamespaces?: string[];
   genAiStudioConfig?: {
     aiAssetCustomEndpoints?: {
       externalProviders?: boolean;
@@ -127,6 +128,7 @@ export const mockDashboardConfig = ({
   agentOps = false,
   roleManagement = false,
   hardwareProfileOrder = ['test-hardware-profile'],
+  globalMLflowNamespaces = [],
   genAiStudioConfig = {
     aiAssetCustomEndpoints: {
       externalProviders: false,
@@ -326,6 +328,7 @@ export const mockDashboardConfig = ({
     templateOrder: ['test-model'],
     templateDisablement: ['test-model'],
     hardwareProfileOrder,
+    globalMLflowNamespaces,
     genAiStudioConfig,
   },
 });

--- a/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/manifests/common/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -342,6 +342,15 @@ spec:
                     isLLMdDefault:
                       description: 'When true, sets LLMd as the default serving platform for new model deployments.'
                       type: boolean
+                globalMLflowNamespaces:
+                  description: >-
+                    List of namespaces designated as global MLflow workspaces for shared
+                    resources. Currently limited to a single namespace.
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: string
+                    minLength: 1
                 genAiStudioConfig:
                   description: 'Configuration options for Gen AI Studio features'
                   type: object

--- a/packages/cypress/cypress/support/commands/odh.ts
+++ b/packages/cypress/cypress/support/commands/odh.ts
@@ -1223,6 +1223,14 @@ declare global {
           type: 'GET /maas/api/v1/subscriptions/:id',
           options: { path: { id: string } },
           response: OdhResponse<{ data: UserSubscription }>,
+        ) => Cypress.Chainable<null>) &
+        ((
+          type: 'PUT /api/mlflow-global-namespace',
+          response: OdhResponse<{
+            success: boolean;
+            globalMLflowNamespaces: string[];
+            warnings?: string[];
+          }>,
         ) => Cypress.Chainable<null>);
     }
   }

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -46,6 +46,7 @@ export enum KnownLabels {
   MODEL_VERSION_ID = 'modelregistry.opendatahub.io/model-version-id',
   MODEL_REGISTRY_NAME = 'modelregistry.opendatahub.io/name',
   KUEUE_MANAGED = 'kueue.openshift.io/managed',
+  GLOBAL_MLFLOW_WORKSPACE = 'opendatahub.io/global-mlflow-workspace',
 }
 
 export enum MetadataAnnotation {
@@ -297,6 +298,7 @@ export type DashboardConfigKind = K8sResourceCommon & {
       deploymentStrategy?: string;
       isLLMdDefault?: boolean;
     };
+    globalMLflowNamespaces?: string[];
     genAiStudioConfig?: {
       aiAssetCustomEndpoints?: {
         externalProviders?: boolean;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65178

## Description

Implements Task 1 (Stream A, Config & Settings) of epic [RHOAIENG-65177](https://issues.redhat.com/browse/RHOAIENG-65177) per [ADR ODH-ADR-ML-0002](https://github.com/opendatahub-io/architecture-decision-records/blob/main/architecture-decision-records/mlflow/ODH-ADR-ML-0002-shared-workspace-for-cross-namespace-resource-sharing.md).

Adds the `globalMLflowNamespaces` field to the OdhDashboardConfig CRD and a new `PUT /api/mlflow-global-namespace` backend endpoint that manages global MLflow workspace designation end-to-end.

### What this PR does

CRD: Adds `spec.globalMLflowNamespaces` as an optional array of strings with `maxItems: 1` (CRD-level UX constraint; backend code handles N namespaces for future extensibility).

Backend API: A single PUT endpoint that orchestrates four phases:

**Phase 1 — Validate (no mutations):**
1. Validates input (type check, deduplication, maxItems enforcement)
2. Diffs old vs new namespace arrays
3. For additions: validates namespace exists, rejects system namespaces (`openshift*`/`kube*`), SSAR-checks `update` permission
4. For removals: SSAR-checks `update` permission

**Phase 2 — Remove old labels (before CR update):**
5. Removes the `opendatahub.io/global-mlflow-workspace` label from namespaces being removed. Done before the CR update so that on retry, the removal diff can be re-derived from the CR's old value.

**Phase 3 — Update config CR:**
6. Updates the config CR via `setDashboardConfig` (source of truth per ADR). Done before label application so that labels are never orphaned without the CR recording admin intent — orphaned labels would trigger the Auth CR controller to create unintended RoleBindings.

**Phase 4 — Apply labels (idempotent reconciliation):**
7. Applies the label to **all** desired namespaces (not just additions). Uses `uniqueNamespaces` instead of `toAdd` so that a retry after "CR updated but label failed" still applies the missing label. Merge-patch is idempotent.

### Mutation ordering rationale

Labels and the config CR are separate K8s resources — they cannot be updated atomically. The ordering was chosen to handle every partial-failure scenario safely:

| Failure point | State after failure | On retry |
|---|---|---|
| Phase 2 (label removal) fails | CR unchanged, labels partially removed | Same diff → retry re-attempts removal |
| Phase 3 (CR update) fails | Old labels removed, CR unchanged | Same diff → removal is idempotent, CR retried |
| Phase 4 (label apply) fails | CR updated, label missing | Phase 4 applies to all `uniqueNamespaces` → label applied |

This prevents the Auth CR controller from creating RoleBindings for orphaned labels (ADR security requirement) while ensuring retry always self-heals.

Label removal failures return a `warnings` array in the response rather than blocking the operation.

Types: Adds `GLOBAL_MLFLOW_WORKSPACE` to `KnownLabels` enum in both backend and frontend.

Shared helpers: Extracts `validateNotSystemNamespace`, `ensureNamespaceAccessPermission`, and `MERGE_PATCH_OPTIONS` from `namespaceUtils.ts` for reuse. Existing `applyNamespaceChange` refactored to use these shared helpers with no behavior change.

Read path: No new read endpoint needed. `globalMLflowNamespaces` is automatically included in the existing `GET /api/config` response.

Related: PR #7815 ([RHOAIENG-65184](https://issues.redhat.com/browse/RHOAIENG-65184)) migrates the MLflow BFF to read this field from the config CR.

### Design decisions
- Field is optional in the CRD, no migration needed for existing clusters
- Single PUT request with backend orchestration (vs per-namespace frontend calls) to keep config CR array and namespace labels in sync
- SSAR enforced symmetrically for both additions and removals per ADR Decision
- Label value is the MLflow CR name (`mlflow`), not a boolean, to support multiple MLflow instances in the future
- `isNamespaceNotFound` covers all K8s client error shapes including `e.response?.body?.code` (V1Status)
- TOCTOU: if a namespace is deleted between validation and label application, `applyGlobalMLflowLabel` returns a clear 404 error
- Route uses `export default` and `createCustomError` for consistency with newer backend routes

## How Has This Been Tested?

Unit tests: 23 scenarios covering:
- Set, change, clear, no-op, idempotent re-apply
- Namespace not found (404), system namespace rejection (400), SSAR denied (403)
- SSAR checks on both additions and removals
- Stale namespace handling (deleted namespace label removal handled gracefully)
- Config CR patch failure before labels applied
- Label removal failure returns warnings
- Label application failure (403 insufficient permissions, 409 conflict, 500 unexpected, 404 TOCTOU)
- Namespace validation non-404 error propagation
- maxItems enforcement, input deduplication
- Retry after CR updated but label failed (label re-applied via idempotent reconciliation)

Live cluster testing (operator scaled down to apply CRD):
- `PUT /api/mlflow-global-namespace` with `["a-test-project"]` returned success, label applied, config updated
- `GET /api/config` returned `globalMLflowNamespaces: ["a-test-project"]`
- `PUT` with `[]` returned success, label removed, config cleared
- Verified label `opendatahub.io/global-mlflow-workspace: mlflow` present/absent on namespace

Full backend test suite: 198 tests pass, zero regressions (including pre-existing `namespaceUtils` consumers).

## Test Impact

23 unit tests in `backend/src/__tests__/mlflow-global-namespace/mlflowGlobalNamespaceUtils.spec.ts`.

Cypress mock tests in `packages/cypress/cypress/tests/mocked/mlflow/mlflowGlobalNamespace.cy.ts` are intercept registration stubs for the PUT endpoint and config response shape verification. These are scaffolding for the UI ticket (Stream B) and will be extended with interaction-driven tests when the admin settings UI is built.

No existing tests modified (refactored `namespaceUtils.ts` exports are backward-compatible).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- N/A, backend, CRD, and type changes only. No UI in this PR.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing a global MLflow namespace setting.
  * Users can now set, change, or clear the allowed namespace list through the API.
  * Namespace labels are updated automatically to keep MLflow access in sync.

* **Bug Fixes**
  * Improved validation for invalid, duplicate, missing, or system-reserved namespaces.
  * Added clearer handling for permission issues and namespace changes that happen during update.
  * Non-fatal cleanup issues now return warnings instead of failing the whole update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->