### PR TITLE
fix(agent-ops): resolve Dockerfile.workspace build failure from #7789

### DIFF
--- a/packages/agent-ops/frontend/config/webpack.common.js
+++ b/packages/agent-ops/frontend/config/webpack.common.js
@@ -13,7 +13,6 @@ const PUBLIC_PATH = process.env._PUBLIC_PATH;
 const SRC_DIR = process.env._SRC_DIR;
 const COMMON_DIR = process.env._COMMON_DIR;
 const DIST_DIR = process.env._DIST_DIR;
-const INTERNAL_DIR = path.resolve(RELATIVE_DIRNAME, '../../../frontend/src');
 const ROOT_NODE_MODULES = path.resolve(RELATIVE_DIRNAME, '../../../node_modules');
 const { _OUTPUT_ONLY: OUTPUT_ONLY, FAVICON, PRODUCT_NAME, COVERAGE } = process.env;
 const BASE_PATH = PUBLIC_PATH;
@@ -245,7 +244,6 @@ module.exports = (env) => ({
     extensions: ['.js', '.ts', '.tsx', '.jsx'],
     alias: {
       '~': path.resolve(SRC_DIR),
-      '@odh-dashboard/internal': path.resolve(RELATIVE_DIRNAME, '../../../frontend/src'),
     },
     symlinks: false,
     cacheWithContext: false,

--- a/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
+++ b/packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts
@@ -1,6 +1,7 @@
-import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import { agentDeploymentsPath, globAgentOpsAll } from '~/app/utilities/routes';
 import extensions from '~/odh/extensions';
+
+const AGENT_OPS = 'agent-ops';
 
 describe('agent-ops extensions', () => {
   it('should register area, navigation, and route extensions', () => {
@@ -17,7 +18,7 @@ describe('agent-ops extensions', () => {
     expect(area).toMatchObject({
       type: 'app.area',
       properties: {
-        id: SupportedArea.AGENT_OPS,
+        id: AGENT_OPS,
         featureFlags: ['agentOps'],
       },
     });
@@ -28,7 +29,7 @@ describe('agent-ops extensions', () => {
     expect(nav).toMatchObject({
       type: 'app.navigation/href',
       flags: {
-        required: [SupportedArea.AGENT_OPS],
+        required: [AGENT_OPS],
       },
       properties: {
         id: 'agent-ops-deployments',
@@ -46,7 +47,7 @@ describe('agent-ops extensions', () => {
     expect(route).toMatchObject({
       type: 'app.route',
       flags: {
-        required: [SupportedArea.AGENT_OPS],
+        required: [AGENT_OPS],
       },
       properties: {
         path: globAgentOpsAll,

--- a/packages/agent-ops/frontend/src/odh/extensions.ts
+++ b/packages/agent-ops/frontend/src/odh/extensions.ts
@@ -1,4 +1,3 @@
-import { SupportedArea } from '@odh-dashboard/internal/concepts/areas/types';
 import type {
   NavExtension,
   RouteExtension,
@@ -6,18 +5,20 @@ import type {
 } from '@odh-dashboard/plugin-core/extension-points';
 import { agentDeploymentsPath, globAgentOpsAll } from '~/app/utilities/routes';
 
+const AGENT_OPS = 'agent-ops';
+
 const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
   {
     type: 'app.area',
     properties: {
-      id: SupportedArea.AGENT_OPS,
+      id: AGENT_OPS,
       featureFlags: ['agentOps'],
     },
   },
   {
     type: 'app.navigation/href',
     flags: {
-      required: [SupportedArea.AGENT_OPS],
+      required: [AGENT_OPS],
     },
     properties: {
       id: 'agent-ops-deployments',
@@ -31,7 +32,7 @@ const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
   {
     type: 'app.route',
     flags: {
-      required: [SupportedArea.AGENT_OPS],
+      required: [AGENT_OPS],
     },
     properties: {
       path: globAgentOpsAll,

--- a/packages/agent-ops/frontend/tsconfig.json
+++ b/packages/agent-ops/frontend/tsconfig.json
@@ -25,9 +25,6 @@
     "paths": {
       "~/*": [
         "./*"
-      ],
-      "@odh-dashboard/internal/*": [
-        "../../../frontend/src/*"
       ]
     },
     "importHelpers": true,


### PR DESCRIPTION


## Description

For https://issues.redhat.com/browse/RHOAIENG-66735

This PR reverts PR #7789’s cross-package SupportedArea import in agent-ops federated extensions (replaced with local 'agent-ops' constant), and removes @odh-dashboard/internal tsconfig path + webpack alias so Dockerfile.workspace builds without TS6059 rootDir errors.

**Root cause**

PR #7789 changed `packages/agent-ops/frontend/src/odh/extensions.ts` to import `SupportedArea` from `@odh-dashboard/internal/concepts/areas/types`. During the isolated `Dockerfile.workspace` build, `ts-loader` resolves that import to `frontend/src/…`, which is outside the package `rootDir` (`packages/agent-ops/frontend`). That triggers:
`TS6059: File '.../frontend/src/concepts/areas/types.ts' is not under 'rootDir' '.../packages/agent-ops/frontend'
`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it locally using `docker build --file ./packages/agent-ops/Dockerfile.workspace .` 
And  manually confirmed `extensions.ts` still registers the same area id (agent-ops), nav item, and routes as before — only the import source changed

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
Updated

- packages/agent-ops/frontend/src/odh/__tests__/extensions.spec.ts — assertions now use local AGENT_OPS constant instead of SupportedArea.AGENT_OPS enum import

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module resolution and simplified dependency management in the Agent Operations frontend package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->