### PR TITLE
fix: remove agent-ops from federation-configmap until container is deployed [RHOAIENG-66735]

### DIFF
--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -153,31 +153,6 @@ data:
         }
       },
       {
-        "name": "agentOps",
-        "remoteEntry": "/remoteEntry.js",
-        "authorize": true,
-        "tls": true,
-        "proxy": [
-          {
-            "path": "/agent-ops/api",
-            "pathRewrite": "/api"
-          },
-          {
-            "path": "/agent-ops/healthcheck",
-            "pathRewrite": "/healthcheck"
-          }
-        ],
-        "local": {
-          "host": "localhost",
-          "port": 8080
-        },
-        "service": {
-          "name": "odh-dashboard",
-          "namespace": "opendatahub",
-          "port": 8843
-        }
-      },
-      {
         "name": "perses",
         "proxyService": [
           {

--- a/manifests/rhoai/base/federation-configmap.yaml
+++ b/manifests/rhoai/base/federation-configmap.yaml
@@ -153,31 +153,6 @@ data:
         }
       },
       {
-        "name": "agentOps",
-        "remoteEntry": "/remoteEntry.js",
-        "authorize": true,
-        "tls": true,
-        "proxy": [
-          {
-            "path": "/agent-ops/api",
-            "pathRewrite": "/api"
-          },
-          {
-            "path": "/agent-ops/healthcheck",
-            "pathRewrite": "/healthcheck"
-          }
-        ],
-        "local": {
-          "host": "localhost",
-          "port": 8080
-        },
-        "service": {
-          "name": "rhods-dashboard",
-          "namespace": "redhat-ods-applications",
-          "port": 8843
-        }
-      },
-      {
         "name": "perses",
         "proxyService": [
           {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-66735

## Summary
Removes the `agentOps` entry from both federation configmaps (ODH + RHOAI). The agent-ops container is not yet built or deployed, so the dashboard attempts to load `remoteEntry.js` from a non-existent service, causing 10+ second page load timeouts and blank white screens.

Introduced in #7789. The configmap entry should be re-added once the agent-ops container is available via Konflux (pending openshift/release#80040).

## Test plan
- [ ] Dashboard loads without 10s delay on clusters without agent-ops deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the agentOps module from the application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->