### PR TITLE
fix: remove agent-ops from federation-configmap until container is deployed [RHOAIENG-66735]

### DIFF
--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -27,6 +27,27 @@ data:
         }
       },
       {
+          "name": "genAi",
+          "remoteEntry": "/remoteEntry.js",
+          "authorize": true,
+          "tls": true,
+          "proxy": [
+            {
+              "path": "/gen-ai/api",
+              "pathRewrite": "/api"
+            }
+          ],
+          "local": {
+            "host": "localhost",
+            "port": 8080
+          },
+          "service": {
+            "name": "odh-dashboard",
+            "namespace": "opendatahub",
+            "port": 8143
+        }
+      },
+      {
           "name": "maas",
           "remoteEntry": "/remoteEntry.js",
           "authorize": true,
@@ -129,31 +150,6 @@ data:
             "name": "odh-dashboard",
             "namespace": "opendatahub",
             "port": 8743
-        }
-      },
-      {
-        "name": "agentOps",
-        "remoteEntry": "/remoteEntry.js",
-        "authorize": true,
-        "tls": true,
-        "proxy": [
-          {
-            "path": "/agent-ops/api",
-            "pathRewrite": "/api"
-          },
-          {
-            "path": "/agent-ops/healthcheck",
-            "pathRewrite": "/healthcheck"
-          }
-        ],
-        "local": {
-          "host": "localhost",
-          "port": 8080
-        },
-        "service": {
-          "name": "odh-dashboard",
-          "namespace": "opendatahub",
-          "port": 8843
         }
       },
       {

--- a/manifests/modular-architecture/federation-configmap.yaml
+++ b/manifests/modular-architecture/federation-configmap.yaml
@@ -27,27 +27,6 @@ data:
         }
       },
       {
-          "name": "genAi",
-          "remoteEntry": "/remoteEntry.js",
-          "authorize": true,
-          "tls": true,
-          "proxy": [
-            {
-              "path": "/gen-ai/api",
-              "pathRewrite": "/api"
-            }
-          ],
-          "local": {
-            "host": "localhost",
-            "port": 8080
-          },
-          "service": {
-            "name": "odh-dashboard",
-            "namespace": "opendatahub",
-            "port": 8143
-        }
-      },
-      {
           "name": "maas",
           "remoteEntry": "/remoteEntry.js",
           "authorize": true,

--- a/manifests/rhoai/base/federation-configmap.yaml
+++ b/manifests/rhoai/base/federation-configmap.yaml
@@ -153,31 +153,6 @@ data:
         }
       },
       {
-        "name": "agentOps",
-        "remoteEntry": "/remoteEntry.js",
-        "authorize": true,
-        "tls": true,
-        "proxy": [
-          {
-            "path": "/agent-ops/api",
-            "pathRewrite": "/api"
-          },
-          {
-            "path": "/agent-ops/healthcheck",
-            "pathRewrite": "/healthcheck"
-          }
-        ],
-        "local": {
-          "host": "localhost",
-          "port": 8080
-        },
-        "service": {
-          "name": "rhods-dashboard",
-          "namespace": "redhat-ods-applications",
-          "port": 8843
-        }
-      },
-      {
         "name": "perses",
         "proxyService": [
           {


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
For https://issues.redhat.com/browse/RHOAIENG-66735

This PR reverts the configmap entry from PR #7789. It removes the agentOps entry from both federation configmaps (ODH + RHOAI). The agent-ops container has not yet been built or deployed, so the dashboard attempts to load remoteEntry.js from a non-existent service, resulting in 10+ second page load timeouts and blank white screens.

The configmap entry should be re-added once the agent-ops container is available via Konflux (pending https://github.com/openshift/release/pull/80040).

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete "agentOps" module federation entries from deployment configuration to clean up module list and proxy mappings.
  * Streamlined module-federation configuration so modules proceed directly from "autorag" to "perses", reducing unnecessary routing and maintenance overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->