### PR TITLE
RHOAIENG-36320: use KServe status.addresses for LLMInferenceService endpoint

### DIFF
--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -1051,12 +1051,6 @@ func ExtractStatusFromInferenceService(isvc *kservev1beta1.InferenceService) str
 	return "Stop"
 }
 
-// ConstructLLMInferenceServiceURL constructs the internal URL for an LLMInferenceService
-// This function is exported for testing purposes
-func ConstructLLMInferenceServiceURL(scheme, serviceName, namespace string, port int32) string {
-	return fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d/v1", scheme, serviceName, namespace, port)
-}
-
 // EnsureV1Suffix ensures that the URL ends with /v1 suffix
 // This function is exported for testing purposes
 func EnsureV1Suffix(url string) string {
@@ -2314,41 +2308,42 @@ func (kc *TokenKubernetesClient) findLLMInferenceServiceByModelName(ctx context.
 	return nil, fmt.Errorf("LLMInferenceService with model name '%s' not found in namespace %s", modelName, namespace)
 }
 
-// extractEndpointFromLLMInferenceService extracts the endpoint URL from LLMInferenceService by constructing internal URL from its Service
-func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(ctx context.Context, llmSvc *kservev1alpha1.LLMInferenceService) (string, error) {
-	// Find services owned by this LLMInferenceService
-	services, err := kc.findServicesForKServeResource(ctx, llmSvc.Namespace, llmSvc)
-	if err != nil {
-		kc.Logger.Error("failed to find services for LLMInferenceService", "name", llmSvc.Name, "error", err)
-		return "", fmt.Errorf("failed to find services for LLMInferenceService '%s': %w", llmSvc.Name, err)
+// extractEndpointFromLLMInferenceService extracts the internal endpoint URL from LLMInferenceService
+// using the standard KServe status.addresses field. This replaces the previous workaround that
+// manually discovered K8s services and constructed URLs, which bypassed llm-d gateway routing.
+func (kc *TokenKubernetesClient) extractEndpointFromLLMInferenceService(_ context.Context, llmSvc *kservev1alpha1.LLMInferenceService) (string, error) {
+	for _, addr := range llmSvc.Status.Addresses {
+		if addr.URL != nil && isInternalClusterHost(addr.URL.Host) {
+			u := addr.URL.String()
+			kc.Logger.Debug("extracted internal URL from LLMInferenceService status.addresses",
+				"llmServiceName", llmSvc.Name,
+				"endpoint", EnsureV1Suffix(u))
+			return EnsureV1Suffix(u), nil
+		}
 	}
-	if len(services) == 0 {
-		kc.Logger.Error("no services found for LLMInferenceService", "name", llmSvc.Name, "namespace", llmSvc.Namespace)
-		return "", fmt.Errorf("no services found for LLMInferenceService '%s' - service may not be ready", llmSvc.Name)
+
+	if llmSvc.Status.Address != nil && llmSvc.Status.Address.URL != nil && isInternalClusterHost(llmSvc.Status.Address.URL.Host) {
+		u := llmSvc.Status.Address.URL.String()
+		kc.Logger.Debug("extracted internal URL from LLMInferenceService status.address (singular fallback)",
+			"llmServiceName", llmSvc.Name,
+			"endpoint", EnsureV1Suffix(u))
+		return EnsureV1Suffix(u), nil
 	}
 
-	// Use the first service to construct internal URL
-	svc := services[0]
-	port := kc.getServingPort(ctx, llmSvc.Namespace, svc.Name)
+	kc.Logger.Error("LLMInferenceService has no internal URL in status",
+		"name", llmSvc.Name, "namespace", llmSvc.Namespace)
+	return "", fmt.Errorf("LLMInferenceService '%s' has no internal URL in status.addresses - service may not be ready", llmSvc.Name)
+}
 
-	// Determine scheme based on authentication annotation
-	var authAnnotation string
-	if llmSvc.Annotations != nil {
-		authAnnotation = llmSvc.Annotations[authAnnotationKey]
+// isInternalClusterHost checks if a host (with optional port) is a cluster-internal address.
+// Validates the hostname suffix rather than substring to prevent spoofing via URL paths.
+func isInternalClusterHost(host string) bool {
+	hostname := host
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		hostname = host[:i]
 	}
-	scheme := DetermineSchemeFromAuth(authAnnotation)
-
-	// Construct internal URL from service name with port
-	// LLMInferenceService workload services (KServe headless mode) always require port
-	internalURL := ConstructLLMInferenceServiceURL(scheme, svc.Name, llmSvc.Namespace, port)
-
-	kc.Logger.Debug("constructed internal URL for LLMInferenceService",
-		"llmServiceName", llmSvc.Name,
-		"k8sServiceName", svc.Name,
-		"port", port,
-		"endpoint", internalURL)
-
-	return internalURL, nil
+	hostname = strings.TrimPrefix(strings.TrimSuffix(hostname, "]"), "[")
+	return strings.HasSuffix(hostname, ".svc.cluster.local")
 }
 
 func (kc *TokenKubernetesClient) DeleteOGXServer(ctx context.Context, identity *integrations.RequestIdentity, namespace string, name string) (*ogxapi.OGXServer, error) {

--- a/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
+++ b/packages/gen-ai/bff/internal/integrations/kubernetes/token_k8s_client_test.go
@@ -336,44 +336,158 @@ func TestGenerateLlamaStackConfig_RBACFlag(t *testing.T) {
 	})
 }
 
-// TestLLMInferenceServiceURLConstruction tests that the URL format for LLMInferenceService
-// remains consistent and doesn't accidentally change
-func TestLLMInferenceServiceURLConstruction(t *testing.T) {
-	tests := []struct {
-		name        string
-		scheme      string
-		serviceName string
-		namespace   string
-		port        int32
-		expected    string
-	}{
-		{
-			name:        "http URL without auth",
-			scheme:      "http",
-			serviceName: "test-service",
-			namespace:   "test-namespace",
-			port:        8080,
-			expected:    "http://test-service.test-namespace.svc.cluster.local:8080/v1",
-		},
-		{
-			name:        "https URL with auth",
-			scheme:      "https",
-			serviceName: "secure-service",
-			namespace:   "prod-namespace",
-			port:        8443,
-			expected:    "https://secure-service.prod-namespace.svc.cluster.local:8443/v1",
-		},
+// TestExtractEndpointFromLLMInferenceService tests that extractEndpointFromLLMInferenceService
+// reads the internal URL from status.addresses instead of constructing it manually.
+func TestExtractEndpointFromLLMInferenceService(t *testing.T) {
+	client := &TokenKubernetesClient{
+		Logger: slog.Default(),
 	}
+	ctx := context.Background()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Call the actual function used in extractEndpointFromLLMInferenceService
-			actual := ConstructLLMInferenceServiceURL(tt.scheme, tt.serviceName, tt.namespace, tt.port)
+	t.Run("status.addresses with internal URL appends /v1", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local/v1", endpoint)
+	})
 
-			assert.Equal(t, tt.expected, actual,
-				"LLMInferenceService URL format must remain: {scheme}://{service}.{namespace}.svc.cluster.local:{port}/v1")
-		})
-	}
+	t.Run("status.addresses with internal URL already having /v1 returns as-is", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://my-model.namespace.svc.cluster.local/v1")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://my-model.namespace.svc.cluster.local/v1", endpoint)
+	})
+
+	t.Run("status.addresses empty falls back to status.address singular", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Address: &duckv1.Addressable{URL: mustParseURL("https://fallback-svc.ns.svc.cluster.local")},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://fallback-svc.ns.svc.cluster.local/v1", endpoint)
+	})
+
+	t.Run("both addresses and address empty returns error", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{}
+		llmSvc.Name = "empty-model"
+		_, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no internal URL")
+	})
+
+	t.Run("multiple addresses picks internal over external", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://my-model.apps.example.com/v1")},
+						{URL: mustParseURL("https://my-model.namespace.svc.cluster.local")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://my-model.namespace.svc.cluster.local/v1", endpoint,
+			"should pick the internal (svc.cluster.local) address, not the external one")
+	})
+
+	t.Run("addresses with nil URL entries are skipped", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: nil},
+						{URL: mustParseURL("https://valid-svc.ns.svc.cluster.local")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://valid-svc.ns.svc.cluster.local/v1", endpoint)
+	})
+
+	t.Run("internal URL with explicit port preserves port and appends /v1", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://my-model.namespace.svc.cluster.local:8443")},
+					},
+				},
+			},
+		}
+		endpoint, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://my-model.namespace.svc.cluster.local:8443/v1", endpoint)
+	})
+
+	t.Run("singular fallback with external URL returns error", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Address: &duckv1.Addressable{URL: mustParseURL("https://my-model.apps.example.com/v1")},
+				},
+			},
+		}
+		llmSvc.Name = "external-only"
+		_, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no internal URL")
+	})
+
+	t.Run("URL with svc.cluster.local in path but not hostname is rejected", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://evil.com/.svc.cluster.local/proxy")},
+					},
+				},
+			},
+		}
+		llmSvc.Name = "spoofed-url"
+		_, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no internal URL")
+	})
+
+	t.Run("IPv6 loopback address is rejected as non-cluster-local", func(t *testing.T) {
+		llmSvc := &kservev1alpha1.LLMInferenceService{
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://[::1]:8080/v1")},
+					},
+				},
+			},
+		}
+		llmSvc.Name = "ipv6-loopback"
+		_, err := client.extractEndpointFromLLMInferenceService(ctx, llmSvc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has no internal URL")
+	})
 }
 
 // TestInferenceServiceURLSuffixConstruction tests that InferenceService URLs
@@ -1535,7 +1649,8 @@ func TestGetModelDetailsFromServingRuntimeNilName(t *testing.T) {
 	)
 	llmUID := types.UID("llm-uid-123")
 
-	// newLLMService creates an LLMInferenceService with an optional Spec.Model.Name.
+	// newLLMService creates an LLMInferenceService with an optional Spec.Model.Name
+	// and status.addresses populated (required by extractEndpointFromLLMInferenceService).
 	newLLMService := func(modelNamePtr *string) *kservev1alpha1.LLMInferenceService {
 		svc := &kservev1alpha1.LLMInferenceService{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1543,34 +1658,18 @@ func TestGetModelDetailsFromServingRuntimeNilName(t *testing.T) {
 				Namespace: namespace,
 				UID:       llmUID,
 			},
+			Status: kservev1alpha1.LLMInferenceServiceStatus{
+				AddressStatus: duckv1.AddressStatus{
+					Addresses: []duckv1.Addressable{
+						{URL: mustParseURL("https://" + serviceName + "-workload." + namespace + ".svc.cluster.local")},
+					},
+				},
+			},
 		}
 		if modelNamePtr != nil {
 			svc.Spec.Model.Name = modelNamePtr
 		}
 		return svc
-	}
-
-	// workloadService returns a corev1.Service that extractEndpointFromLLMInferenceService
-	// will discover via label selector + owner-reference match.
-	workloadService := func() *corev1.Service {
-		return &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName + "-workload",
-				Namespace: namespace,
-				Labels: map[string]string{
-					LLMInferenceServiceName:      serviceName,
-					LLMInferenceServiceComponent: LLMInferenceServiceWorkloadComponent,
-				},
-				OwnerReferences: []metav1.OwnerReference{
-					{UID: llmUID},
-				},
-			},
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{Port: 8080},
-				},
-			},
-		}
 	}
 
 	modelName := "explicit-model-name"
@@ -1606,7 +1705,7 @@ func TestGetModelDetailsFromServingRuntimeNilName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(newLLMService(tt.modelNamePtr), workloadService()).
+				WithObjects(newLLMService(tt.modelNamePtr)).
 				Build()
 
 			kc := &TokenKubernetesClient{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-36320

## Description

Replaces the manual URL construction workaround in `extractEndpointFromLLMInferenceService` with direct reading from KServe's `status.addresses[0].url`, enabling proper llm-d gateway routing for models deployed via `LLMInferenceService`.

**What changed (2 files, +121/-97):**

- **token_k8s_client.go — `extractEndpointFromLLMInferenceService`** — Rewritten to iterate `status.addresses` (plural), filtering for `.svc.cluster.local` entries, and applying `EnsureV1Suffix`. Falls back to `status.address` (singular) for compatibility. No longer calls `findServicesForKServeResource`, `getServingPort`, or `DetermineSchemeFromAuth` — all K8s service discovery is eliminated from this path. The `ctx` parameter is now unused (marked `_`) since no API calls are made.
- **token_k8s_client.go — `ConstructLLMInferenceServiceURL`** — Removed. This was the only caller, and the function manually constructed `{scheme}://{service}.{namespace}.svc.cluster.local:{port}/v1` which bypassed the llm-d gateway. `EnsureV1Suffix` and `DetermineSchemeFromAuth` are kept — they have other callers.
- **token_k8s_client_test.go — `TestExtractEndpointFromLLMInferenceService`** — New test (replaces `TestLLMInferenceServiceURLConstruction`) with 6 cases covering: internal URL with `/v1` appended (real cluster data from `tinyllama` on a GPU cluster), idempotent `/v1`, singular address fallback, empty status error, internal-over-external selection, and nil URL entries.
- **token_k8s_client_test.go — `TestGetModelDetailsFromServingRuntimeNilName`** — Updated `newLLMService` helper to populate `status.addresses` (required by the refactored function). Removed `workloadService` helper and its reference in the fake client builder — no longer needed since endpoint extraction doesn't discover K8s Services.

**Key design decisions:**

- **`status.addresses` (plural) as primary source** — this is what the KServe controller populates. Verified on a real cluster: only `addresses` (plural) has data; `address` (singular) and `url` are empty.
- **Filter by `.svc.cluster.local`** — `status.addresses` can contain both internal and external URLs. The BFF always makes internal calls, so we select the cluster-local one.
- **`EnsureV1Suffix` post-processing** — KServe URLs omit the `/v1` path that the vLLM OpenAI-compatible API requires. This function already existed in the codebase.
- **No changes to `findServicesForKServeResource` or `getServingPort`** — these are still used by the `InferenceService` (non-LLM) code path in `getModelDetailsFromServingRuntime`.

## How Has This Been Tested?

- 242 unit tests in the `kubernetes` package, all passing (`go test ./internal/integrations/kubernetes/... -count=1`).
- Full `go build ./...` compiles cleanly.
- Verified on a real GPU cluster (`gmenende-gpus`, 5x g4dn.xlarge with Tesla T4) that `LLMInferenceService` `tinyllama` has `status.addresses[0].url = https://tinyllama-kserve-workload-svc.kserve-test.svc.cluster.local` — test case 1 uses this exact value.

## Test Impact

- **`TestExtractEndpointFromLLMInferenceService`** — 6 new tests covering the refactored function: internal URL appends `/v1`, idempotent `/v1`, singular fallback, empty status error, multiple addresses picks internal, nil URL entries skipped.
- **`TestGetModelDetailsFromServingRuntimeNilName`** — 4 existing tests updated to work with status-based extraction (all pass).
- **`TestLLMInferenceServiceURLConstruction`** — Removed (tested the deleted `ConstructLLMInferenceServiceURL` function).

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

> **Note to reviewers:** Manual validation on a live KServe + llm-d cluster is recommended to confirm that requests route through the gateway rather than directly to vLLM.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of LLM inference endpoints by reading service status addresses and preferring cluster-local URLs
  * Improved fallback when multiple/alternative address fields are present
  * Normalized endpoint formatting to ensure a consistent /v1 suffix
  * Better handling of missing or invalid endpoint entries (returns an error when none found)

* **Chores**
  * Removed a legacy URL-construction path used for testing

* **Tests**
  * Updated and expanded tests validating endpoint extraction behavior, address selection, suffix handling, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->