### PR TITLE
Fix(RHOAIENG-66732):resolved the feature store token issue

### DIFF
--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events';
 import * as https from 'https';
 import * as k8s from '@kubernetes/client-node';
+import * as constants from '../utils/constants';
+import * as devFlags from '../devFlags';
 
 jest.mock('https', () => {
   const actual = jest.requireActual<typeof import('https')>('https');
@@ -111,13 +113,15 @@ const createMockKubeFastify = (mockApi = createMockApi()) =>
  * Call this in beforeEach after mockApi is assigned so the spy captures the right instance.
  */
 const spyKubeConfigForMockApi = (getMockApi: () => ReturnType<typeof createMockApi>) => {
+  const loadFromClusterAndUser = jest.fn();
   jest.spyOn(k8s, 'KubeConfig').mockImplementation(
     () =>
       ({
-        loadFromClusterAndUser: jest.fn(),
+        loadFromClusterAndUser,
         makeApiClient: jest.fn().mockReturnValue(getMockApi()),
       } as any),
   );
+  return { loadFromClusterAndUser };
 };
 
 const KUBE_HEADERS = { Authorization: 'Bearer test-token' } as Record<string, string>;
@@ -433,10 +437,12 @@ describe('featureStoreUtils', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
 
+    let loadFromClusterAndUser: jest.Mock;
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
-      spyKubeConfigForMockApi(() => mockApi);
+      ({ loadFromClusterAndUser } = spyKubeConfigForMockApi(() => mockApi));
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -463,6 +469,10 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         { headers: {} },
+      );
+      expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+        { name: 'test-cluster', server: 'https://test' },
+        { name: 'current-user', token: 'test-token' },
       );
     });
 
@@ -521,6 +531,7 @@ describe('featureStoreUtils', () => {
       expect(mockFastify.log.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to list Feast namespaces for user'),
       );
+      expect(loadFromClusterAndUser).not.toHaveBeenCalled();
     });
 
     it('should return empty array and log when no access token is provided', async () => {
@@ -530,6 +541,40 @@ describe('featureStoreUtils', () => {
       expect(mockFastify.log.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to list Feast namespaces for user'),
       );
+      expect(loadFromClusterAndUser).not.toHaveBeenCalled();
+    });
+
+    describe('DEV_MODE token selection', () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it('should use impersonation token in DEV_MODE when impersonating', async () => {
+        jest.replaceProperty(constants, 'DEV_MODE', true);
+        jest.spyOn(devFlags, 'isImpersonating').mockReturnValue(true);
+        jest.spyOn(devFlags, 'getImpersonateAccessToken').mockReturnValue('impersonate-token');
+        mockApi.listClusterCustomObject.mockResolvedValue({ body: { items: [] } });
+
+        await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+        expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+          { name: 'test-cluster', server: 'https://test' },
+          { name: 'current-user', token: 'impersonate-token' },
+        );
+      });
+
+      it('should use kube config user token in DEV_MODE when not impersonating', async () => {
+        jest.replaceProperty(constants, 'DEV_MODE', true);
+        jest.spyOn(devFlags, 'isImpersonating').mockReturnValue(false);
+        mockApi.listClusterCustomObject.mockResolvedValue({ body: { items: [] } });
+
+        await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+        expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+          { name: 'test-cluster', server: 'https://test' },
+          { name: 'current-user', token: 'kube-token' },
+        );
+      });
     });
   });
 
@@ -537,10 +582,12 @@ describe('featureStoreUtils', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
 
+    let loadFromClusterAndUser: jest.Mock;
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
-      spyKubeConfigForMockApi(() => mockApi);
+      ({ loadFromClusterAndUser } = spyKubeConfigForMockApi(() => mockApi));
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -567,6 +614,10 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         { headers: {} },
+      );
+      expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+        { name: 'test-cluster', server: 'https://test' },
+        { name: 'current-user', token: 'test-token' },
       );
     });
 
@@ -595,10 +646,12 @@ describe('featureStoreUtils', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
 
+    let loadFromClusterAndUser: jest.Mock;
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
-      spyKubeConfigForMockApi(() => mockApi);
+      ({ loadFromClusterAndUser } = spyKubeConfigForMockApi(() => mockApi));
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -637,6 +690,10 @@ describe('featureStoreUtils', () => {
         undefined,
         { headers: {} },
       );
+      expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+        { name: 'test-cluster', server: 'https://test' },
+        { name: 'current-user', token: 'test-token' },
+      );
     });
 
     it('should return empty array on 403 without throwing', async () => {
@@ -672,10 +729,12 @@ describe('featureStoreUtils', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
 
+    let loadFromClusterAndUser: jest.Mock;
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
-      spyKubeConfigForMockApi(() => mockApi);
+      ({ loadFromClusterAndUser } = spyKubeConfigForMockApi(() => mockApi));
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -708,6 +767,10 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         { headers: {} },
+      );
+      expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+        { name: 'test-cluster', server: 'https://test' },
+        { name: 'current-user', token: 'test-token' },
       );
     });
 
@@ -746,10 +809,12 @@ describe('featureStoreUtils', () => {
     let mockFastify: ReturnType<typeof createMockKubeFastify>;
     let mockApi: ReturnType<typeof createMockApi>;
 
+    let loadFromClusterAndUser: jest.Mock;
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
-      spyKubeConfigForMockApi(() => mockApi);
+      ({ loadFromClusterAndUser } = spyKubeConfigForMockApi(() => mockApi));
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -772,6 +837,10 @@ describe('featureStoreUtils', () => {
         'featurestores',
         PROJECT.BANKING,
         { headers: {} },
+      );
+      expect(loadFromClusterAndUser).toHaveBeenCalledWith(
+        { name: 'test-cluster', server: 'https://test' },
+        { name: 'current-user', token: 'test-token' },
       );
     });
 

--- a/backend/src/__tests__/featureStoreUtils.spec.ts
+++ b/backend/src/__tests__/featureStoreUtils.spec.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import * as https from 'https';
+import * as k8s from '@kubernetes/client-node';
 
 jest.mock('https', () => {
   const actual = jest.requireActual<typeof import('https')>('https');
@@ -96,8 +97,28 @@ const createMockKubeFastify = (mockApi = createMockApi()) =>
     },
     kube: {
       customObjectsApi: mockApi,
+      config: {
+        getCurrentCluster: jest
+          .fn()
+          .mockReturnValue({ name: 'test-cluster', server: 'https://test' }),
+        getCurrentUser: jest.fn().mockReturnValue({ name: 'test-user', token: 'kube-token' }),
+      },
     },
   } as any);
+
+/**
+ * Wire `new k8s.KubeConfig()` → mockApi for describe blocks that test K8s API calls.
+ * Call this in beforeEach after mockApi is assigned so the spy captures the right instance.
+ */
+const spyKubeConfigForMockApi = (getMockApi: () => ReturnType<typeof createMockApi>) => {
+  jest.spyOn(k8s, 'KubeConfig').mockImplementation(
+    () =>
+      ({
+        loadFromClusterAndUser: jest.fn(),
+        makeApiClient: jest.fn().mockReturnValue(getMockApi()),
+      } as any),
+  );
+};
 
 const KUBE_HEADERS = { Authorization: 'Bearer test-token' } as Record<string, string>;
 
@@ -415,6 +436,7 @@ describe('featureStoreUtils', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
+      spyKubeConfigForMockApi(() => mockApi);
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -440,7 +462,7 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         undefined,
-        { headers: KUBE_HEADERS },
+        { headers: {} },
       );
     });
 
@@ -489,6 +511,26 @@ describe('featureStoreUtils', () => {
         expect.stringContaining('Failed to list Feast namespaces for user'),
       );
     });
+
+    it('should return empty array and log when cluster is not configured', async () => {
+      mockFastify.kube.config.getCurrentCluster.mockReturnValue(null);
+
+      const result = await listFeastNamespaces(mockFastify, KUBE_HEADERS);
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to list Feast namespaces for user'),
+      );
+    });
+
+    it('should return empty array and log when no access token is provided', async () => {
+      const result = await listFeastNamespaces(mockFastify, {});
+
+      expect(result).toEqual([]);
+      expect(mockFastify.log.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to list Feast namespaces for user'),
+      );
+    });
   });
 
   describe('listUserOpenShiftProjects', () => {
@@ -498,6 +540,7 @@ describe('featureStoreUtils', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
+      spyKubeConfigForMockApi(() => mockApi);
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -523,7 +566,7 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         undefined,
-        { headers: KUBE_HEADERS },
+        { headers: {} },
       );
     });
 
@@ -555,6 +598,7 @@ describe('featureStoreUtils', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
+      spyKubeConfigForMockApi(() => mockApi);
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -591,7 +635,7 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         undefined,
-        { headers: KUBE_HEADERS },
+        { headers: {} },
       );
     });
 
@@ -631,6 +675,7 @@ describe('featureStoreUtils', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
+      spyKubeConfigForMockApi(() => mockApi);
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -662,7 +707,7 @@ describe('featureStoreUtils', () => {
         undefined,
         undefined,
         undefined,
-        { headers: KUBE_HEADERS },
+        { headers: {} },
       );
     });
 
@@ -704,6 +749,7 @@ describe('featureStoreUtils', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockApi = createMockApi();
+      spyKubeConfigForMockApi(() => mockApi);
       mockFastify = createMockKubeFastify(mockApi);
     });
 
@@ -725,7 +771,7 @@ describe('featureStoreUtils', () => {
         NAMESPACE.VIEWER,
         'featurestores',
         PROJECT.BANKING,
-        { headers: KUBE_HEADERS },
+        { headers: {} },
       );
     });
 

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -112,7 +112,7 @@ function getUserScopedCustomObjectsApi(
 
   return {
     api: userKc.makeApiClient(k8s.CustomObjectsApi),
-    opts: { headers: {} as Record<string, string> },
+    opts: { headers: {} },
   };
 }
 

--- a/backend/src/routes/api/featurestores/featureStoreUtils.ts
+++ b/backend/src/routes/api/featurestores/featureStoreUtils.ts
@@ -1,6 +1,10 @@
 import * as https from 'https';
 import * as http from 'http';
+import * as k8s from '@kubernetes/client-node';
 import { KubeFastifyInstance } from '../../../types';
+import { DEV_MODE } from '../../../utils/constants';
+import { isImpersonating, getImpersonateAccessToken } from '../../../devFlags';
+import { getAccessToken } from '../../../utils/directCallUtils';
 
 const REGISTRY_CONDITION_TYPE = 'Registry';
 
@@ -78,11 +82,38 @@ export function handleError(fastify: KubeFastifyInstance, error: unknown, contex
   return errorMessage;
 }
 
+/**
+ * Build a CustomObjectsApi that authenticates as the requesting user rather than the dashboard service-account. This is required so that K8s RBAC is enforced per-user.
+ */
 function getUserScopedCustomObjectsApi(
   fastify: KubeFastifyInstance,
   kubeHeaders: Record<string, string>,
 ) {
-  return { api: fastify.kube.customObjectsApi, opts: { headers: kubeHeaders } };
+  const baseKc = fastify.kube.config;
+  const cluster = baseKc.getCurrentCluster();
+
+  if (!cluster) {
+    throw new Error('No current cluster configured');
+  }
+
+  let token: string;
+  if (DEV_MODE) {
+    token = isImpersonating() ? getImpersonateAccessToken() : baseKc.getCurrentUser()?.token ?? '';
+  } else {
+    const accessToken = getAccessToken({ headers: kubeHeaders });
+    if (!accessToken) {
+      throw new Error('No access token provided by oauth. Cannot make user-scoped API calls.');
+    }
+    token = accessToken;
+  }
+
+  const userKc = new k8s.KubeConfig();
+  userKc.loadFromClusterAndUser(cluster, { name: 'current-user', token });
+
+  return {
+    api: userKc.makeApiClient(k8s.CustomObjectsApi),
+    opts: { headers: {} as Record<string, string> },
+  };
 }
 
 /** Lists custom objects cluster-wide or namespace-scoped using the user's token. Returns [] on 403. */


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes [RHOAIENG-66732](https://redhat.atlassian.net/browse/RHOAIENG-66732)

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Feature store K8s API calls were not respecting the logged-in user's namespace permissions, they were running as the dashboard service account instead.

The root cause was in `getUserScopedCustomObjectsApi`. The code tried to use the user's token by passing it in `opts.headers`, but the K8s client library ignores that and always uses the service account token from its internal config. So non-admin users were seeing data from namespaces they shouldn't have access to.
Fixed by building a new K8s client using the user's token directly, so RBAC is enforced.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it with three users with dev impersonation
1. Cluster admin
<img width="1457" height="838" alt="Screenshot 2026-06-05 at 8 04 41 PM" src="https://github.com/user-attachments/assets/482979a6-3351-4e6e-854c-1a52b32c2a64" />
2. Entities 

https://github.com/user-attachments/assets/9c219653-a3df-41fb-b6c0-7b0b4e47e85d

3. Sources
Before Fix incorrect feature store still visible to user
<img width="1459" height="891" alt="Screenshot 2026-06-05 at 8 28 08 PM" src="https://github.com/user-attachments/assets/5c1423bd-8919-4d3e-a20b-193ad69c22c7" />

After fix

https://github.com/user-attachments/assets/f79392d8-ad80-4b07-a528-ac9284fac240


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
1. Updated test cases

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [X] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for feature store flows with improved Kubernetes client mocking, added edge-case tests for missing cluster/token, and updated impersonation behavior checks in DEV_MODE.

* **Refactor**
  * Switched to per-user API client construction so requests use the configured cluster and user token, enforcing presence of access tokens and clearer permission isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->