### PR TITLE
Convert module onboarding rule into a skill

### DIFF
--- a/.claude/skills/module-onboarding/SKILL.md
+++ b/.claude/skills/module-onboarding/SKILL.md
@@ -69,7 +69,7 @@ See [reference.md](reference.md) for naming conventions, port ranges, templates,
 ### Step 1: Run the installer
 
 ```bash
-cd packages && npx --yes mod-arch-installer@latest -n <name>
+cd packages && npx mod-arch-installer -n <name>
 ```
 
 If the installer fails (network error, not found, etc.), fall back to **manual scaffolding**: copy the structure from an existing federated module like `packages/eval-hub/` and replace all name references. See reference.md § Module Federation Config for the package.json template.

--- a/.claude/skills/module-onboarding/SKILL.md
+++ b/.claude/skills/module-onboarding/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: module-onboarding
+description: Scaffold a new federated module under packages/. Runs mod-arch-installer, allocates ports, registers the feature flag and SupportedArea in the host, verifies the build (type-check, port validation, container image). Pass the module name in kebab-case as the argument.
+---
+
+# Module Onboarding
+
+Scaffold a new federated module (Module Federation remote with optional Go BFF) in the ODH Dashboard monorepo. The module is ready to build and run after this skill completes.
+
+See [reference.md](reference.md) for naming conventions, port ranges, templates, and troubleshooting. See `.claude/rules/module-onboarding.md` for the full manual guide.
+
+## Arguments
+
+`$ARGUMENTS` — Module name in kebab-case (e.g., `my-module`). If empty, ask the user.
+
+## Phase 0: Parse & Validate
+
+1. **Extract the module name** from `$ARGUMENTS`. If empty, ask the user for a name.
+
+2. **Validate the name**:
+   - Must be non-empty, lowercase, kebab-case (only `[a-z0-9-]`, no leading/trailing hyphens).
+   - Must not already exist: check that `packages/<name>/` does not exist.
+
+3. **Compute all name variants** (see reference.md § Name Transformation Rules):
+
+   ```
+   kebab-case:       my-module
+   camelCase:        myModule
+   UPPER_SNAKE_CASE: MY_MODULE
+   Title Case:       My Module
+   ```
+
+   And derived identifiers:
+
+   ```
+   Package:       @odh-dashboard/my-module
+   SupportedArea: PLUGIN_MY_MODULE = 'plugin-my-module'
+   Feature flag:  myModule
+   MF name:       myModule
+   Proxy path:    /my-module/api
+   ```
+
+4. **Ask the user**: Include a Go BFF (backend-for-frontend)? Default: **yes**.
+
+## Phase 1: Port Allocation
+
+1. **Scan existing frontend ports**:
+
+   ```bash
+   grep -r '"port"' packages/*/package.json | grep -E '"local"' -A2 | grep -oP '\d{4,5}' | sort -n
+   ```
+
+   Or more precisely, read every `packages/*/package.json` that has a `module-federation` key and collect `module-federation.local.port` values. Find the next unused integer in the **9100–9399** range.
+
+2. **Scan existing BFF ports** (if BFF included):
+
+   ```bash
+   grep -r 'PROXY_PORT=' packages/*/Makefile | grep -oP '\d{4,5}' | sort -n
+   ```
+
+   Find the next unused integer in the **4000–4099** range.
+
+3. **Report** the chosen ports to the user:
+   - Frontend dev port: `<port>`
+   - BFF proxy port: `<port>` (if applicable)
+
+## Phase 2: Scaffold with mod-arch-installer
+
+### Step 1: Run the installer
+
+```bash
+cd packages && npx mod-arch-installer -n <name>
+```
+
+If the installer fails (network error, not found, etc.), fall back to **manual scaffolding**: copy the structure from an existing federated module like `packages/eval-hub/` and replace all name references. See reference.md § Module Federation Config for the package.json template.
+
+### Step 2: Verify and patch the generated output
+
+After the installer completes, verify the following files exist and are correct. Patch any that need fixing:
+
+**`packages/<name>/package.json`**:
+- `name` is `@odh-dashboard/<name>`
+- `module-federation.name` is the correct `<camelCase>`
+- `module-federation.local.port` matches the allocated frontend port from Phase 1
+- `module-federation.proxy[0].path` is `/<name>/api`
+- `module-federation.service.port` is `8043`
+- If BFF included, add `bffConfig` section:
+  ```json
+  "bffConfig": {
+    "enabled": true,
+    "port": 8080,
+    "healthEndpoint": "/healthcheck",
+    "startCommand": "make dev-bff-e2e-mock"
+  }
+  ```
+- Dependencies include `@odh-dashboard/plugin-core` and `@odh-dashboard/internal`
+- `exports` includes `"./extensions": "./frontend/src/odh/extensions.ts"`
+
+**`packages/<name>/frontend/config/moduleFederation.js`**:
+- `name` matches `<camelCase>`
+- `shared` includes all required singletons (see reference.md § Shared Singletons)
+- `exposes` includes `'./extensions': './src/odh/extensions'`
+
+**`packages/<name>/frontend/src/odh/extensions.ts`**:
+- Contains `app.area` extension with `id` referencing the module's area constant and `featureFlags` referencing the feature flag name
+- Contains `app.navigation/section` or `app.navigation/href` stub
+- Contains `app.route` stub with a lazy-loaded placeholder component
+
+**`packages/<name>/Makefile`**:
+- `PORT` variable matches the allocated frontend port
+- `PROXY_PORT` variable matches the allocated BFF port (if applicable)
+- Has standard targets: `dev-install-dependencies`, `dev-frontend-federated`, `dev-start-federated`
+- If BFF included: has `dev-bff-federated`, `dev-bff-e2e-mock`, `dev-bff-e2e-cluster` targets
+
+**`packages/<name>/tsconfig.json`**, **`jest.config.ts`**, **`.eslintrc.js`**:
+- Present and correctly extending shared configs
+
+### Step 3: Create placeholder component (if not generated)
+
+If the installer didn't create a page component, create a minimal placeholder:
+
+```tsx
+// packages/<name>/frontend/src/app/pages/OverviewPage.tsx
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+
+const OverviewPage: React.FC = () => (
+  <PageSection hasBodyWrapper={false}>
+    <EmptyState
+      headingLevel="h1"
+      icon={CubesIcon}
+      titleText="<Title Case>"
+      variant={EmptyStateVariant.full}
+    >
+      <EmptyStateBody>This module is under development.</EmptyStateBody>
+    </EmptyState>
+  </PageSection>
+);
+
+export default OverviewPage;
+```
+
+Ensure the extensions file's route component import points to this file.
+
+## Phase 3: Register in Host
+
+This phase modifies **three files** in the host application. Read each file first to find the correct insertion point.
+
+### 1. Add feature flag type — `frontend/src/k8sTypes.ts`
+
+Read the file and find the `DashboardCommonConfig` type. Add the new flag as an **optional boolean** in the tech-preview section (near the end of the type, where the other optional `?: boolean` flags are):
+
+```typescript
+<camelCase>?: boolean;
+```
+
+### 2. Add SupportedArea enum — `frontend/src/concepts/areas/types.ts`
+
+Read the file and find the `SupportedArea` enum. Add the new entry under the `/* Plugins */` comment section:
+
+```typescript
+PLUGIN_<UPPER_SNAKE> = 'plugin-<kebab>',
+```
+
+### 3. Add flag default + state map — `frontend/src/concepts/areas/const.ts`
+
+**a)** Add the flag default to `devTemporaryFeatureFlags`:
+
+```typescript
+<camelCase>: false,
+```
+
+**b)** Add an entry to `SupportedAreasStateMap` (at the end, before the closing `};`):
+
+```typescript
+[SupportedArea.PLUGIN_<UPPER_SNAKE>]: {
+  featureFlags: ['<camelCase>'],
+},
+```
+
+## Phase 4: Dockerfile Verification
+
+1. Check that `packages/<name>/Dockerfile.workspace` exists.
+2. Read it and verify:
+   - `ARG MODULE_NAME` default matches `<name>`
+   - Multi-stage build has Node builder stage (frontend) and, if BFF included, Go builder stage
+   - Final stage copies built artifacts correctly
+3. If the Dockerfile is missing, copy from `packages/plugin-template/Dockerfile.workspace` and patch the `MODULE_NAME` default.
+
+## Phase 5: Install & Build Verification
+
+Run these sequentially. Stop and fix on first failure before proceeding.
+
+### Step 1: Install workspace
+
+```bash
+npm install
+```
+
+This wires up the new package in the npm workspace. Must succeed before other steps.
+
+### Step 2: Validate ports
+
+```bash
+npm run validate:ports
+```
+
+If this fails, a port conflict exists. Fix the conflicting port in `package.json` and re-run.
+
+### Step 3: Type-check
+
+```bash
+npm run type-check
+```
+
+This verifies:
+- The feature flag is correctly typed in `DashboardCommonConfig`
+- The `SupportedArea` enum entry is valid
+- The `SupportedAreasStateMap` references are correct
+- The extensions file compiles
+
+If it fails with a flag name error, the flag was likely not added to `k8sTypes.ts`. Fix and re-run.
+
+### Step 4: BFF compilation (if BFF included)
+
+```bash
+cd packages/<name>/bff && go build ./cmd
+```
+
+If it fails, run `go mod tidy` first and retry.
+
+### Step 5: Container build
+
+```bash
+podman build --file ./packages/<name>/Dockerfile.workspace .
+```
+
+If `podman` is not available, try `docker build` instead. This confirms the full build pipeline works end-to-end.
+
+If this step is slow or the user wants to skip it, it can be deferred — the earlier steps already confirm correctness. Ask before running.
+
+## Phase 6: Report
+
+Summarize the completed onboarding:
+
+1. **Files created** — list all new files under `packages/<name>/`
+2. **Host files modified** — `k8sTypes.ts`, `types.ts`, `const.ts`
+3. **Port assignments** — frontend port, BFF port (if applicable)
+4. **Build results** — pass/fail for each verification step
+5. **Next steps** for the team:
+   - Write feature code in `packages/<name>/frontend/src/app/`
+   - Add unit tests in `packages/<name>/__tests__/`
+   - Add E2E tests in `packages/cypress/cypress/tests/e2e/<name>/`
+   - Add contract tests in `packages/<name>/contract-tests/` (if BFF)
+   - Start the dev server: `cd packages/<name> && make dev-start-federated`
+   - Enable the feature locally: set `<camelCase>: true` in the dashboard config

--- a/.claude/skills/module-onboarding/SKILL.md
+++ b/.claude/skills/module-onboarding/SKILL.md
@@ -23,7 +23,7 @@ See [reference.md](reference.md) for naming conventions, port ranges, templates,
 
 3. **Compute all name variants** (see reference.md § Name Transformation Rules):
 
-   ```
+   ```text
    kebab-case:       my-module
    camelCase:        myModule
    UPPER_SNAKE_CASE: MY_MODULE
@@ -32,7 +32,7 @@ See [reference.md](reference.md) for naming conventions, port ranges, templates,
 
    And derived identifiers:
 
-   ```
+   ```text
    Package:       @odh-dashboard/my-module
    SupportedArea: PLUGIN_MY_MODULE = 'plugin-my-module'
    Feature flag:  myModule
@@ -47,10 +47,10 @@ See [reference.md](reference.md) for naming conventions, port ranges, templates,
 1. **Scan existing frontend ports**:
 
    ```bash
-   grep -r '"port"' packages/*/package.json | grep -E '"local"' -A2 | grep -oP '\d{4,5}' | sort -n
+   jq -r '."module-federation".local.port // empty' packages/*/package.json 2>/dev/null | awk '$1>=9100 && $1<=9399' | sort -n
    ```
 
-   Or more precisely, read every `packages/*/package.json` that has a `module-federation` key and collect `module-federation.local.port` values. Find the next unused integer in the **9100–9399** range.
+   This reads every `packages/*/package.json` that has a `module-federation` key and collects `module-federation.local.port` values. Find the next unused integer in the **9100–9399** range.
 
 2. **Scan existing BFF ports** (if BFF included):
 
@@ -69,7 +69,7 @@ See [reference.md](reference.md) for naming conventions, port ranges, templates,
 ### Step 1: Run the installer
 
 ```bash
-cd packages && npx mod-arch-installer -n <name>
+cd packages && npx --yes mod-arch-installer@latest -n <name>
 ```
 
 If the installer fails (network error, not found, etc.), fall back to **manual scaffolding**: copy the structure from an existing federated module like `packages/eval-hub/` and replace all name references. See reference.md § Module Federation Config for the package.json template.
@@ -85,6 +85,7 @@ After the installer completes, verify the following files exist and are correct.
 - `module-federation.proxy[0].path` is `/<name>/api`
 - `module-federation.service.port` is `8043`
 - If BFF included, add `bffConfig` section:
+
   ```json
   "bffConfig": {
     "enabled": true,
@@ -93,6 +94,7 @@ After the installer completes, verify the following files exist and are correct.
     "startCommand": "make dev-bff-e2e-mock"
   }
   ```
+
 - Dependencies include `@odh-dashboard/plugin-core` and `@odh-dashboard/internal`
 - `exports` includes `"./extensions": "./frontend/src/odh/extensions.ts"`
 

--- a/.claude/skills/module-onboarding/reference.md
+++ b/.claude/skills/module-onboarding/reference.md
@@ -282,7 +282,7 @@ This checklist maps to skill phases. Items marked with a phase are handled autom
 
 **Symptom**: `npx mod-arch-installer` fails with ENOENT or network error.
 
-**Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer@latest` and retry.
+**Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer` and retry.
 
 ### Webpack build fails with "shared module not found"
 

--- a/.claude/skills/module-onboarding/reference.md
+++ b/.claude/skills/module-onboarding/reference.md
@@ -40,7 +40,7 @@ Given a kebab-case module name (e.g., `my-module`):
 
 ```bash
 # Frontend ports — scan all packages
-grep -r '"port"' packages/*/package.json | grep 'local' | grep -oP '\d{4,5}' | sort -n
+jq -r '."module-federation".local.port // empty' packages/*/package.json 2>/dev/null | awk '$1>=9100 && $1<=9399' | sort -n
 
 # BFF ports — scan Makefiles
 grep -r 'PROXY_PORT=' packages/*/Makefile | grep -oP '\d{4,5}' | sort -n
@@ -282,7 +282,7 @@ This checklist maps to skill phases. Items marked with a phase are handled autom
 
 **Symptom**: `npx mod-arch-installer` fails with ENOENT or network error.
 
-**Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer` and retry.
+**Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer@latest` and retry.
 
 ### Webpack build fails with "shared module not found"
 

--- a/.claude/skills/module-onboarding/reference.md
+++ b/.claude/skills/module-onboarding/reference.md
@@ -1,0 +1,297 @@
+# Module Onboarding — Reference
+
+Supplementary reference for the module-onboarding skill. Read `.claude/rules/module-onboarding.md` for the full manual guide.
+
+## Name Transformation Rules
+
+Given a kebab-case module name (e.g., `my-module`):
+
+| Variant | Algorithm | Example |
+|---------|-----------|---------|
+| `kebab-case` | As-is | `my-module` |
+| `camelCase` | Remove hyphens, capitalize each word after the first | `myModule` |
+| `UPPER_SNAKE_CASE` | Replace hyphens with `_`, uppercase all | `MY_MODULE` |
+| `Title Case` | Capitalize first letter of each word, join with space | `My Module` |
+
+**Derived identifiers:**
+
+| Identifier | Pattern | Example |
+|------------|---------|---------|
+| Package name | `@odh-dashboard/<kebab>` | `@odh-dashboard/my-module` |
+| Directory | `packages/<kebab>/` | `packages/my-module/` |
+| MF name | `<camelCase>` | `myModule` |
+| SupportedArea enum | `PLUGIN_<UPPER_SNAKE>` | `PLUGIN_MY_MODULE` |
+| SupportedArea value | `'plugin-<kebab>'` | `'plugin-my-module'` |
+| Feature flag key | `<camelCase>` | `myModule` |
+| Proxy path | `/<kebab>/api` | `/my-module/api` |
+| Nav section ID | `<kebab>` | `my-module` |
+| Nav group | `'5_<snake_case>'` | `'5_my_module'` |
+| CSS prefix | `<kebab>-` | `my-module-` |
+
+## Port Ranges
+
+| Purpose | Range | Config location |
+|---------|-------|-----------------|
+| Frontend dev server | 9100–9399 | `package.json` → `module-federation.local.port` |
+| BFF proxy port | 4000–4099 | `Makefile` → `PROXY_PORT` |
+| Production service | 8043 (shared) | `package.json` → `module-federation.service.port` |
+
+**How to find the next available port:**
+
+```bash
+# Frontend ports — scan all packages
+grep -r '"port"' packages/*/package.json | grep 'local' | grep -oP '\d{4,5}' | sort -n
+
+# BFF ports — scan Makefiles
+grep -r 'PROXY_PORT=' packages/*/Makefile | grep -oP '\d{4,5}' | sort -n
+```
+
+Validate after creation: `npm run validate:ports`
+
+## Feature Flag Registration (3-File Pattern)
+
+New modules require changes in **three files** to register their feature flag:
+
+### 1. `frontend/src/k8sTypes.ts` — Type definition
+
+Add to the `DashboardCommonConfig` type as an optional boolean, in the tech-preview section (after the existing optional flags):
+
+```typescript
+export type DashboardCommonConfig = {
+  // ... existing flags ...
+  myModule?: boolean;  // ← add here
+};
+```
+
+### 2. `frontend/src/concepts/areas/types.ts` — SupportedArea enum
+
+Add an entry to the `SupportedArea` enum. Place under the appropriate section comment:
+
+```typescript
+export enum SupportedArea {
+  // ... existing entries ...
+
+  /* Plugins */
+  PLUGIN_MY_MODULE = 'plugin-my-module',
+}
+```
+
+### 3. `frontend/src/concepts/areas/const.ts` — Flag default + state map
+
+**a)** Add the flag default to the appropriate group:
+
+```typescript
+// For new/experimental modules → devTemporaryFeatureFlags
+export const devTemporaryFeatureFlags = {
+  // ... existing flags ...
+  myModule: false,
+} satisfies Partial<DashboardCommonConfig>;
+```
+
+**b)** Add the area to `SupportedAreasStateMap`:
+
+```typescript
+export const SupportedAreasStateMap: SupportedAreasState = {
+  // ... existing entries ...
+  [SupportedArea.PLUGIN_MY_MODULE]: {
+    featureFlags: ['myModule'],
+  },
+};
+```
+
+## Extension Types Reference
+
+Extensions are defined in `frontend/src/odh/extensions.ts` (federated modules).
+
+### `app.area` — Feature area definition
+
+```typescript
+{
+  type: 'app.area',
+  properties: {
+    id: '<PLUGIN_AREA_CONSTANT>',  // e.g., PLUGIN_MY_MODULE
+    featureFlags: ['<flagName>'],  // e.g., ['myModule']
+  },
+}
+```
+
+### `app.navigation/section` — Nav section (collapsible group)
+
+```typescript
+{
+  type: 'app.navigation/section',
+  flags: { required: ['<PLUGIN_AREA_CONSTANT>'] },
+  properties: {
+    id: '<kebab-name>',
+    title: '<Title Case>',
+    group: '5_<snake_case>',
+  },
+}
+```
+
+### `app.navigation/href` — Nav link
+
+```typescript
+{
+  type: 'app.navigation/href',
+  flags: { required: ['<PLUGIN_AREA_CONSTANT>'] },
+  properties: {
+    id: '<kebab-name>-overview',
+    title: 'Overview',
+    href: '/<kebab-name>',
+    section: '<kebab-name>',
+  },
+}
+```
+
+### `app.route` — Page route
+
+```typescript
+{
+  type: 'app.route',
+  flags: { required: ['<PLUGIN_AREA_CONSTANT>'] },
+  properties: {
+    path: '/<kebab-name>',
+    component: () => import('./pages/OverviewPage'),
+  },
+}
+```
+
+## Makefile Target Reference
+
+Standard targets for federated modules (see `packages/eval-hub/Makefile` or `packages/gen-ai/Makefile` for examples):
+
+| Target | Purpose |
+|--------|---------|
+| `dev-install-dependencies` | Install frontend deps |
+| `dev-frontend-federated` | Run frontend dev server on allocated port |
+| `dev-bff-federated` | Run Go BFF with port forwarding |
+| `dev-start-federated` | Run both BFF and frontend |
+| `dev-bff-e2e-mock` | Start BFF in mock mode for E2E tests |
+| `dev-bff-e2e-cluster` | Start BFF against real cluster for E2E |
+| `docker-build-federated` | Build container image |
+
+Key variables in Makefile:
+
+```makefile
+PORT=<frontend-port>        # e.g., 9110
+PROXY_PORT=<bff-port>       # e.g., 4010
+AUTH_METHOD=user_token
+DEPLOYMENT_MODE=federated
+STYLE_THEME=patternfly
+```
+
+## Dockerfile Pattern
+
+Federated modules use `Dockerfile.workspace` — a multi-stage build:
+
+1. **Stage 1 (Node)**: Build the frontend webpack bundle
+   - Copy root workspace manifests, install deps
+   - Copy package source, run `npm run build` with `DEPLOYMENT_MODE=standalone`
+2. **Stage 2 (Go)**: Build the BFF binary (if included)
+   - Copy `bff/` directory, run `go build -o /bff-binary ./cmd`
+3. **Stage 3 (Runtime)**: Minimal image with built artifacts
+   - Copy frontend dist from stage 1
+   - Copy BFF binary from stage 2 (if included)
+   - Set entrypoint
+
+Build from repo root:
+
+```bash
+podman build --file ./packages/<name>/Dockerfile.workspace .
+# or
+docker build --file ./packages/<name>/Dockerfile.workspace .
+```
+
+## Module Federation Config in package.json
+
+```json
+{
+  "module-federation": {
+    "name": "<camelCase>",
+    "remoteEntry": "/remoteEntry.js",
+    "authorize": true,
+    "tls": false,
+    "proxy": [{ "path": "/<kebab>/api", "pathRewrite": "/api" }],
+    "local": { "host": "localhost", "port": <frontend-port> },
+    "service": { "name": "odh-dashboard", "port": 8043 }
+  }
+}
+```
+
+## Shared Singletons (moduleFederation.js)
+
+Every federated module must share these as singletons:
+
+```javascript
+shared: {
+  react: { singleton: true, requiredVersion: deps.react },
+  'react-dom': { singleton: true, requiredVersion: deps['react-dom'] },
+  'react-router': { singleton: true, requiredVersion: deps['react-router'] },
+  'react-router-dom': { singleton: true, requiredVersion: deps['react-router-dom'] },
+  '@patternfly/react-core': { singleton: true, requiredVersion: deps['@patternfly/react-core'] },
+  '@odh-dashboard/internal': { singleton: true, requiredVersion: '*' },
+  '@odh-dashboard/plugin-core': { singleton: true, requiredVersion: '*' },
+}
+```
+
+## Onboarding Checklist
+
+This checklist maps to skill phases. Items marked with a phase are handled automatically.
+
+| # | Item | Skill Phase |
+|---|------|-------------|
+| 1 | Package directory exists under `packages/<name>/` | Phase 2 |
+| 2 | `package.json` has correct name, exports, module-federation config | Phase 2 |
+| 3 | Unique frontend port allocated (9100–9399) | Phase 1 |
+| 4 | Unique BFF port allocated (4000–4099) if BFF included | Phase 1 |
+| 5 | `tsconfig.json`, `jest.config.ts`, `.eslintrc.js` present | Phase 2 |
+| 6 | Webpack configs under `frontend/config/` | Phase 2 |
+| 7 | Extensions file with area, nav, route stubs | Phase 2 |
+| 8 | Feature flag added to `DashboardCommonConfig` in `k8sTypes.ts` | Phase 3 |
+| 9 | `SupportedArea` enum entry added in `types.ts` | Phase 3 |
+| 10 | Flag default + `SupportedAreasStateMap` entry in `const.ts` | Phase 3 |
+| 11 | BFF with `/healthcheck` endpoint (if included) | Phase 2 |
+| 12 | `Dockerfile.workspace` present and builds | Phase 4 |
+| 13 | `Makefile` with standard targets | Phase 2 |
+| 14 | `npm install` succeeds | Phase 5 |
+| 15 | `npm run validate:ports` passes | Phase 5 |
+| 16 | `npm run type-check` passes | Phase 5 |
+| 17 | Container image builds successfully | Phase 5 |
+| — | Unit tests in `__tests__/` | Manual (post-skill) |
+| — | E2E tests in `packages/cypress/cypress/tests/e2e/<name>/` | Manual (post-skill) |
+| — | Contract tests in `contract-tests/` (if BFF) | Manual (post-skill) |
+
+## Troubleshooting
+
+### Port conflict after creation
+
+**Symptom**: `npm run validate:ports` fails with duplicate port error.
+
+**Fix**: Edit `packages/<name>/package.json` → `module-federation.local.port` to a different value. Re-run validation.
+
+### Type-check fails after area registration
+
+**Symptom**: `npm run type-check` reports error in `const.ts` — feature flag name not assignable to `FeatureFlag`.
+
+**Cause**: The flag name was not added to `DashboardCommonConfig` in `k8sTypes.ts`.
+
+**Fix**: Add `<flagName>?: boolean;` to the `DashboardCommonConfig` type in `frontend/src/k8sTypes.ts`.
+
+### mod-arch-installer not found or fails
+
+**Symptom**: `npx mod-arch-installer` fails with ENOENT or network error.
+
+**Fix**: The skill falls back to manual scaffolding. Alternatively, install it explicitly: `npm install -g mod-arch-installer` and retry.
+
+### Webpack build fails with "shared module not found"
+
+**Symptom**: Build error mentioning missing shared module.
+
+**Fix**: Verify `frontend/config/moduleFederation.js` lists all required singletons (see Shared Singletons section above). Ensure `@odh-dashboard/plugin-core` and `@odh-dashboard/internal` are in the package's dependencies.
+
+### BFF Go build fails
+
+**Symptom**: `go build ./cmd` fails with import errors.
+
+**Fix**: Run `cd packages/<name>/bff && go mod tidy` to resolve dependencies. Ensure `go.mod` has the correct module path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,5 +133,6 @@ Skills provide multi-step workflows. They live in `.claude/skills/`. Read the re
 | **Jira Validate Area Label**      | `skills/jira-validate-area-label/`     | Validating or assigning `dashboard-area-*` labels based on multi-signal content analysis |
 | **Jira Assign Scrum Team**        | `skills/jira-assign-scrum-team/`       | Assigning a scrum team label based on area-to-scrum mapping during triage |
 | **Jira Eval Review**               | `skills/jira-eval-review/`             | Evaluating PR code changes against Jira acceptance criteria for per-criterion verdicts |
+| **Module Onboarding**              | `skills/module-onboarding/`            | Scaffolding a new federated module under `packages/` — handles installer, port allocation, host registration, and build verification (pass module name as argument) |
 
 **Important**: Always read the relevant rule or skill file before starting the task to ensure you follow the project's conventions and patterns.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-63723

## Description

Converts the existing module onboarding rule (`.claude/rules/module-onboarding.md`) into an interactive Claude Code skill at `.claude/skills/module-onboarding/`. The existing rule remains as static reference documentation.

The skill automates the full federated module scaffolding workflow:

- **Phase 0**: Parses/validates the module name from `$ARGUMENTS`, computes all name variants (kebab-case, camelCase, UPPER_SNAKE_CASE, Title Case), asks about BFF inclusion
- **Phase 1**: Scans existing `package.json` files to allocate the next available frontend port (9100–9399) and BFF port (4000–4099)
- **Phase 2**: Runs `mod-arch-installer`, verifies and patches the generated output
- **Phase 3**: Registers the module in the host via the 3-file feature flag pattern (`k8sTypes.ts`, `types.ts`, `const.ts`)
- **Phase 4**: Verifies the generated Dockerfile
- **Phase 5**: Runs install, port validation, type-check, BFF build, and container build
- **Phase 6**: Reports summary with next steps

### Files

| File | Change |
|------|--------|
| `.claude/skills/module-onboarding/SKILL.md` | New — main skill definition (7 phases) |
| `.claude/skills/module-onboarding/reference.md` | New — naming conventions, port ranges, templates, checklists, troubleshooting |
| `AGENTS.md` | Added skill entry to the skills table |

The existing `.claude/rules/module-onboarding.md` is **unchanged**.

## How Has This Been Tested?

### Skill Validation Test — `agentic-test` module

The skill was executed end-to-end to scaffold a test module called `agentic-test` (with BFF). The test module was **not committed** — it was used purely for validation.

#### Test execution flow

1. **Phase 0 — Parse & Validate**: Module name `agentic-test` parsed and validated. All name variants computed:
   - kebab: `agentic-test`, camelCase: `agenticTest`, UPPER_SNAKE: `AGENTIC_TEST`, Title: `Agentic Test`

2. **Phase 1 — Port Allocation**: Scanned all 12 existing federated modules. Allocated:
   - Frontend port: **9103** (next available after 9102/observability)
   - BFF port: **4004** (next available after 4003/eval-hub)

3. **Phase 2 — Scaffold with mod-arch-installer**: `npx mod-arch-installer -n agentic-test` ran successfully. Patches applied:
   - `package.json`: Added `bffConfig` section (port 4004), verified MF name and port
   - `Makefile`: Fixed BFF port from default 4000 → 4004 in all 3 targets (`dev-bff`, `dev-bff-kubeflow`, `dev-bff-federated`)
   - `extensions.ts`: Fixed from `devFlags: ['agentic-test-module']` (would never work — undefined key in dashboardConfig) to `featureFlags: ['agenticTest']` (proper FeatureFlag type)

4. **Phase 3 — Host Registration** (3-file pattern):
   - `frontend/src/k8sTypes.ts`: Added `agenticTest?: boolean` to `DashboardCommonConfig`
   - `frontend/src/concepts/areas/types.ts`: Added `PLUGIN_AGENTIC_TEST = 'plugin-agentic-test'` to `SupportedArea` enum
   - `frontend/src/concepts/areas/const.ts`: Added `agenticTest: true` to `devTemporaryFeatureFlags` + `SupportedAreasStateMap` entry

5. **Phase 4 — Dockerfile Verification**: `Dockerfile.workspace` confirmed present with correct multi-stage build structure

6. **Phase 5 — Build Verification**:

| Step | Result |
|------|--------|
| `npm install` | **PASS** — workspace wired up correctly |
| `npm run validate:ports` | **PASS** — port 9103 confirmed unique across all modules |
| `npm run type-check` | **PASS** — all 12/12 relevant packages pass (1 pre-existing eval-hub TextEncoder issue) |
| Go BFF build (`go build -o agentic-test-bff ./cmd/`) | **PASS** — compiles with no errors |

#### Key findings during validation

- **`devFlags` vs `featureFlags`**: The installer generates `devFlags: ['agentic-test-module']` in extensions, which would never enable the area because `'agentic-test-module'` is not a key in `dashboardConfig` (so `isFlagOn` returns `'off'` for undefined). The skill correctly patches this to `featureFlags: ['agenticTest']` with proper host registration.
- **Go build command**: `go build ./cmd` fails with "build output 'cmd' already exists and is a directory". The skill documents using `go build -o <name> ./cmd/` instead.
- **BFF port**: The installer defaults all BFF ports to 4000, requiring manual patching in 3 Makefile targets.

## Test Impact

No tests are applicable — this is a Claude Code skill definition (markdown files under `.claude/`), not application code. It does not affect the build, runtime behavior, or existing tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

If you have UI changes:
- N/A — no UI changes (Claude Code skill definition only)