### PR TITLE
chore(gen-ai): RHOAIENG-66815 Add some .env and Makefile updates

### DIFF
--- a/packages/gen-ai/.env.local.example
+++ b/packages/gen-ai/.env.local.example
@@ -20,8 +20,15 @@ RELATED_IMAGE_POSTGRESQL_16_IMAGE=registry.redhat.io/rhel9/postgresql-16
 # For HTTP (direct maas-api via port-forward): use http:// with INSECURE_SKIP_VERIFY=false
 MAAS_URL=https://maas.apps.<your-cluster-domain>/maas-api
 
-# Skip TLS certificate verification — ONLY set to true for local dev clusters
-# with self-signed certificates. Never enable in production.
+# NeMo Guardrails service URL for content moderation (input/output safety checks).
+# On-cluster the BFF auto-discovers this from the NemoGuardrails CR, but if running local bff
+# you can set this value so that `make dev-portforward` auto port-forwards (if it points to localhost) to the service in the cluster,
+# using PLAYGROUND_NAMESPACE for the target namespace
+NEMO_GUARDRAILS_URL=https://localhost:9443
+# Alternatively you can point to an externally accessible URL for the Guardrails service
+# NEMO_GUARDRAILS_URL=https://some-nemo-guardrails-openshift-dev-instance.com
+
+# Skip TLS certificate verification - set to true when using TLS backend via port-forward
 INSECURE_SKIP_VERIFY=false
 
 # MLflow tracking server URL

--- a/packages/gen-ai/.env.local.example
+++ b/packages/gen-ai/.env.local.example
@@ -22,8 +22,8 @@ MAAS_URL=https://maas.apps.<your-cluster-domain>/maas-api
 
 # NeMo Guardrails service URL for content moderation (input/output safety checks).
 # On-cluster the BFF auto-discovers this from the NemoGuardrails CR, but if running local bff
-# you can set this value so that `make dev-portforward` auto port-forwards (if it points to localhost) to the service in the cluster,
-# using PLAYGROUND_NAMESPACE for the target namespace
+# you can set this value so that `make dev-portforward` auto port-forwards (if it points to localhost)
+# to the service in the cluster, using PLAYGROUND_NAMESPACE for the target namespace
 NEMO_GUARDRAILS_URL=https://localhost:9443
 # Alternatively you can point to an externally accessible URL for the Guardrails service
 # NEMO_GUARDRAILS_URL=https://some-nemo-guardrails-openshift-dev-instance.com

--- a/packages/gen-ai/Makefile
+++ b/packages/gen-ai/Makefile
@@ -98,6 +98,11 @@ dev-portforward: ## Start port-forwarding for cluster services (Llama Stack, opt
 		echo "Starting port-forward for ASR model ($${ASR_SERVICE_NAME}) on port $${ASR_LOCAL_PORT:-8790}..."; \
 		oc port-forward -n ${PLAYGROUND_NAMESPACE} svc/$${ASR_SERVICE_NAME} $${ASR_LOCAL_PORT:-8790}:8080 & \
 	fi
+	@if echo "${NEMO_GUARDRAILS_URL}" | grep -q "localhost"; then \
+		sleep 1; \
+		echo "Starting port-forward for nemoguardrails on port 9443..."; \
+		oc port-forward -n ${PLAYGROUND_NAMESPACE} svc/nemoguardrails 9443:443 & \
+	fi
 	@echo "Port-forwarding started in background!"
 
 .PHONY: dev-start

--- a/packages/gen-ai/bff/Makefile
+++ b/packages/gen-ai/bff/Makefile
@@ -88,6 +88,7 @@ vet:  . ## Runs static analysis tools on source files and reports suspicious con
 .PHONY: test
 test: fmt vet envtest uv ## Runs the full test suite.
 	GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \
+	UV_PYTHON=">=3.12,<3.14" \
 	ENVTEST_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	MLFLOW_PORT=$(MLFLOW_PORT) MLFLOW_VERSION=$(MLFLOW_VERSION) \
 	LLAMA_STACK_TEST_ID=$(TEST_LLAMA_STACK_TEST_ID) \


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66815

## Description
Three small changes for gen-ai BFF local development:

1. **Document `NEMO_GUARDRAILS_URL` in `.env.local.example`** — The env var was missing from the example file, making it unclear how to configure NeMo guardrails for local development.

2. **Auto port-forward NeMo guardrails service** — When `NEMO_GUARDRAILS_URL` points to localhost, `make dev-portforward` now also port-forwards the `nemoguardrails` service (port 9443→443), removing a manual step. Remote/public URLs are left alone.

3. **Pin `UV_PYTHON` range for BFF tests** — The `make test` target now sets `UV_PYTHON=">=3.12,<3.14"` so `uv` picks a compatible Python version. Without this, tests can fail on Python <3.12 (ogx requires it) or hit untested 3.14-alpha.

## How Has This Been Tested?                                                                                                                                                                  
- Verified `make dev-portforward` starts the nemoguardrails port-forward when `NEMO_GUARDRAILS_URL=https://localhost:9443`
- Verified port-forward is skipped when `NEMO_GUARDRAILS_URL` points to a non-localhost URL
- Verified `make test` in `bff/` picks up the `UV_PYTHON` constraint

## Test Impact
Makefile-only changes — no application code modified, no tests to add.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added documented configuration for NeMo Guardrails in the development env example.
  * Improved local dev experience with conditional port-forwarding to enable Guardrails when running locally.
  * Tightened the Python runtime constraint used by the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->