### PR TITLE
A11y: keyboard navigation and screen reader support for pipeline run topology

### DIFF
--- a/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
+++ b/frontend/src/concepts/pipelines/content/pipelinesDetails/pipelineRun/PipelineRunDrawerRightTabs.tsx
@@ -63,7 +63,12 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
 
   return (
     <>
-      <Tabs activeKey={selection} mountOnEnter>
+      <Tabs
+        activeKey={selection}
+        mountOnEnter
+        aria-label="Pipeline task details"
+        onSelect={(_, tabKey) => setSelection(String(tabKey))}
+      >
         {Object.entries(tabs).map(([tabName, { title, isDisabled }]) => (
           <Tab
             data-testid={`right-drawer-tab-${tabName}`}
@@ -72,7 +77,6 @@ const PipelineRunDrawerRightTabs: React.FC<PipelineRunDrawerRightTabsProps> = ({
             eventKey={tabName}
             tabContentId={tabName}
             isDisabled={isDisabled}
-            onClick={() => setSelection(tabName)}
           />
         ))}
       </Tabs>

--- a/frontend/src/concepts/topology/NodeStatusIcon.tsx
+++ b/frontend/src/concepts/topology/NodeStatusIcon.tsx
@@ -56,7 +56,7 @@ const NodeStatusIcon: React.FC<{ runStatus: RunStatus | string }> = ({ runStatus
 
   return (
     <Tooltip content={label}>
-      <Icon status={status} isInline>
+      <Icon status={status} isInline aria-label={label || undefined}>
         {icon}
       </Icon>
     </Tooltip>

--- a/frontend/src/concepts/topology/PipelineDefaultTaskGroup.tsx
+++ b/frontend/src/concepts/topology/PipelineDefaultTaskGroup.tsx
@@ -101,14 +101,19 @@ const DefaultTaskGroupInner: React.FunctionComponent<PipelinesDefaultGroupInnerP
       />
     );
 
+    const childCount = element.getAllNodeChildren().length;
+    const groupLabel = element.getLabel();
+
     return (
       <g ref={hoverRef}>
         {element.isCollapsed() ? (
           <Popover
             triggerRef={popoverRef}
             triggerAction="hover"
-            aria-label="Hoverable popover"
-            headerContent={element.getLabel()}
+            aria-label={`${groupLabel} task group, ${childCount} ${
+              childCount === 1 ? 'task' : 'tasks'
+            }`}
+            headerContent={groupLabel}
             bodyContent={getPopoverTasksList(element.getAllNodeChildren())}
           >
             <g ref={popoverRef}>{groupNode}</g>

--- a/frontend/src/concepts/topology/PipelineRunStatusSummary.tsx
+++ b/frontend/src/concepts/topology/PipelineRunStatusSummary.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { DEFAULT_SPACER_NODE_TYPE, RunStatus } from '@patternfly/react-topology';
+import { Flex, FlexItem, Label, LabelGroup } from '@patternfly/react-core';
+import { ICON_TASK_NODE_TYPE, getRunStatusLabel } from './utils';
+import { PipelineNodeModelExpanded } from './types';
+
+const MAX_NAMED_FAILURES = 3;
+
+type TaskNodeEntry = {
+  id: string;
+  label: string;
+  status: RunStatus;
+};
+
+type StatusGroup = {
+  status: RunStatus;
+  nodes: TaskNodeEntry[];
+};
+
+// Normalize equivalent statuses so they collapse into one group
+const normalizeStatus = (s: RunStatus): RunStatus => {
+  if (s === RunStatus.FailedToStart) return RunStatus.Failed;
+  if (s === RunStatus.InProgress) return RunStatus.Running;
+  if (s === RunStatus.Idle) return RunStatus.Pending;
+  return s;
+};
+
+const STATUS_COLOR: Partial<Record<RunStatus, React.ComponentProps<typeof Label>['color']>> = {
+  [RunStatus.Failed]: 'red',
+  [RunStatus.Cancelled]: 'orange',
+  [RunStatus.Running]: 'blue',
+  [RunStatus.Pending]: undefined,
+  [RunStatus.Skipped]: undefined,
+  [RunStatus.Succeeded]: 'green',
+};
+
+// Statuses that show individual node names (so users can click to jump to a failed step)
+const CLICKABLE_STATUSES = new Set<RunStatus>([RunStatus.Failed, RunStatus.Cancelled]);
+
+const DISPLAY_ORDER: RunStatus[] = [
+  RunStatus.Failed,
+  RunStatus.Cancelled,
+  RunStatus.Running,
+  RunStatus.Pending,
+  RunStatus.Skipped,
+  RunStatus.Succeeded,
+];
+
+type PipelineRunStatusSummaryProps = {
+  nodes: PipelineNodeModelExpanded[];
+  onNodeSelect: (id: string) => void;
+};
+
+const PipelineRunStatusSummary: React.FC<PipelineRunStatusSummaryProps> = ({
+  nodes,
+  onNodeSelect,
+}) => {
+  const taskNodes: TaskNodeEntry[] = React.useMemo(
+    () =>
+      nodes.flatMap((n) => {
+        if (n.group || n.type === DEFAULT_SPACER_NODE_TYPE || n.type === ICON_TASK_NODE_TYPE) {
+          return [];
+        }
+        const runStatus = n.data?.runStatus;
+        if (runStatus == null) return [];
+        return [{ id: n.id, label: n.label ?? n.id, status: runStatus }];
+      }),
+    [nodes],
+  );
+
+  const groups: StatusGroup[] = React.useMemo(() => {
+    const map = new Map<RunStatus, TaskNodeEntry[]>();
+    taskNodes.forEach((node) => {
+      const key = normalizeStatus(node.status);
+      const existing = map.get(key) ?? [];
+      map.set(key, [...existing, node]);
+    });
+    return DISPLAY_ORDER.map((s) => {
+      const groupNodes = map.get(s);
+      if (!groupNodes) return null;
+      return { status: s, nodes: groupNodes };
+    }).filter((g): g is StatusGroup => g !== null);
+  }, [taskNodes]);
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  const labels: React.ReactNode[] = [];
+
+  groups.forEach(({ status, nodes: groupNodes }) => {
+    const color = STATUS_COLOR[status];
+    const statusLabel = getRunStatusLabel(status);
+
+    if (CLICKABLE_STATUSES.has(status)) {
+      const displayed = groupNodes.slice(0, MAX_NAMED_FAILURES);
+      const overflow = groupNodes.length - displayed.length;
+
+      displayed.forEach((node) => {
+        labels.push(
+          <Label
+            key={node.id}
+            color={color}
+            onClick={() => onNodeSelect(node.id)}
+            data-testid={`pipeline-status-label-${node.id}`}
+          >
+            {statusLabel}: {node.label}
+          </Label>,
+        );
+      });
+
+      if (overflow > 0) {
+        labels.push(
+          <Label key={`${status}-overflow`} color={color}>
+            +{overflow} more {statusLabel.toLowerCase()}
+          </Label>,
+        );
+      }
+    } else {
+      labels.push(
+        <Label key={status} color={color} data-testid={`pipeline-status-label-${status}`}>
+          {groupNodes.length} {statusLabel}
+        </Label>,
+      );
+    }
+  });
+
+  return (
+    <Flex
+      spaceItems={{ default: 'spaceItemsSm' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+      className="pipeline-run-status-summary"
+      role="region"
+      aria-label="Pipeline run step status summary"
+    >
+      <FlexItem>
+        <LabelGroup aria-label="Step statuses" numLabels={10}>
+          {labels}
+        </LabelGroup>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default PipelineRunStatusSummary;

--- a/frontend/src/concepts/topology/PipelineTopology.tsx
+++ b/frontend/src/concepts/topology/PipelineTopology.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
-import {
-  PipelineNodeModel,
-  SELECTION_EVENT,
-  VisualizationProvider,
-} from '@patternfly/react-topology';
+import { SELECTION_EVENT, VisualizationProvider } from '@patternfly/react-topology';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import PipelineVersionError from '#~/concepts/pipelines/content/pipelinesDetails/PipelineVersionError';
 import PipelineTopologyEmpty from './PipelineTopologyEmpty';
 import useTopologyController from './useTopologyController';
 import PipelineVisualizationSurface from './PipelineVisualizationSurface';
+import { PipelineNodeModelExpanded } from './types';
 
 type PipelineTopologyProps = {
   selectedIds?: string[];
   onSelectionChange?: (selectionIds: string[]) => void;
-  nodes: PipelineNodeModel[];
+  nodes: PipelineNodeModelExpanded[];
   versionError?: Error;
   sidePanel?: React.ReactElement | null;
 };

--- a/frontend/src/concepts/topology/PipelineVisualizationSurface.scss
+++ b/frontend/src/concepts/topology/PipelineVisualizationSurface.scss
@@ -6,3 +6,31 @@
     }
   }
 }
+
+.pipeline-run-status-summary {
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+  border-bottom: 1px solid var(--pf-t--global--border--color--default);
+  flex-shrink: 0;
+}
+
+// Transparent HTML button overlay rendered inside SVG <foreignObject>.
+// Enables keyboard focus and screen reader access on topology pipeline nodes.
+// Mouse events pass through (pointer-events: none) to the SVG below;
+// only keyboard (Tab / Enter / Space) and assistive technology use this element.
+.pipeline-node-a11y-button {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  pointer-events: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--pf-t--global--color--brand--default, #06c);
+    outline-offset: 2px;
+    border-radius: 3px;
+    pointer-events: none;
+  }
+}

--- a/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
+++ b/frontend/src/concepts/topology/PipelineVisualizationSurface.tsx
@@ -1,28 +1,30 @@
 import React from 'react';
 import {
   action,
+  addSpacerNodes,
   createTopologyControlButtons,
+  DEFAULT_EDGE_TYPE,
+  DEFAULT_SPACER_NODE_TYPE,
   defaultControlButtonsOptions,
   getEdgesFromNodes,
-  PipelineNodeModel,
+  isEdge,
+  SELECTION_EVENT,
   TopologyControlBar,
+  TopologySideBar,
   TopologyView,
   useVisualizationController,
   VisualizationSurface,
-  addSpacerNodes,
-  DEFAULT_SPACER_NODE_TYPE,
-  DEFAULT_EDGE_TYPE,
-  TopologySideBar,
-  isEdge,
 } from '@patternfly/react-topology';
-import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, Flex, FlexItem } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { NODE_HEIGHT, NODE_WIDTH } from './const';
+import { PipelineNodeModelExpanded } from './types';
+import PipelineRunStatusSummary from './PipelineRunStatusSummary';
 import './PipelineVisualizationSurface.scss';
 
 type PipelineVisualizationSurfaceProps = {
-  nodes: PipelineNodeModel[];
+  nodes: PipelineNodeModelExpanded[];
   selectedIds?: string[];
   sidePanel?: React.ReactElement | null;
 };
@@ -160,6 +162,13 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
     [controller],
   );
 
+  const handleNodeSelect = React.useCallback(
+    (nodeId: string) => {
+      controller.fireEvent(SELECTION_EVENT, [nodeId]);
+    },
+    [controller],
+  );
+
   if (error) {
     return (
       <EmptyState
@@ -174,49 +183,58 @@ const PipelineVisualizationSurface: React.FC<PipelineVisualizationSurfaceProps> 
   }
 
   return (
-    <TopologyView
-      className={css('pipeline-visualization', !!selectedNode && 'm-is-open')}
-      controlBar={
-        <div data-testid="pipeline-topology-control-bar">
-          <TopologyControlBar
-            controlButtons={createTopologyControlButtons({
-              ...defaultControlButtonsOptions,
-              expandAll: !!collapseAllCallback,
-              collapseAll: !!collapseAllCallback,
-              zoomInCallback: action(() => {
-                controller.getGraph().scaleBy(4 / 3);
-              }),
-              zoomOutCallback: action(() => {
-                controller.getGraph().scaleBy(0.75);
-              }),
-              fitToScreenCallback: action(() => {
-                controller.getGraph().fit(80);
-              }),
-              resetViewCallback: action(() => {
-                controller.getGraph().reset();
-                controller.getGraph().layout();
-              }),
-              expandAllCallback: action(() => {
-                collapseAllCallback(false);
-              }),
-              collapseAllCallback: action(() => {
-                collapseAllCallback(true);
-              }),
-              legend: false,
-            })}
-          />
-        </div>
-      }
-      sideBarOpen={!!selectedNode}
-      sideBarResizable
-      sideBar={
-        <TopologySideBar data-testid="pipeline-topology-drawer" resizable>
-          {sidePanel}
-        </TopologySideBar>
-      }
+    <Flex
+      direction={{ default: 'column' }}
+      style={{ height: '100%' }}
+      spaceItems={{ default: 'spaceItemsNone' }}
     >
-      <VisualizationSurface state={{ selectedIds: selections }} />
-    </TopologyView>
+      <PipelineRunStatusSummary nodes={nodes} onNodeSelect={handleNodeSelect} />
+      <FlexItem flex={{ default: 'flex_1' }} style={{ minHeight: 0, overflow: 'hidden' }}>
+        <TopologyView
+          className={css('pipeline-visualization', !!selectedNode && 'm-is-open')}
+          controlBar={
+            <div data-testid="pipeline-topology-control-bar">
+              <TopologyControlBar
+                controlButtons={createTopologyControlButtons({
+                  ...defaultControlButtonsOptions,
+                  expandAll: !!collapseAllCallback,
+                  collapseAll: !!collapseAllCallback,
+                  zoomInCallback: action(() => {
+                    controller.getGraph().scaleBy(4 / 3);
+                  }),
+                  zoomOutCallback: action(() => {
+                    controller.getGraph().scaleBy(0.75);
+                  }),
+                  fitToScreenCallback: action(() => {
+                    controller.getGraph().fit(80);
+                  }),
+                  resetViewCallback: action(() => {
+                    controller.getGraph().reset();
+                    controller.getGraph().layout();
+                  }),
+                  expandAllCallback: action(() => {
+                    collapseAllCallback(false);
+                  }),
+                  collapseAllCallback: action(() => {
+                    collapseAllCallback(true);
+                  }),
+                  legend: false,
+                })}
+              />
+            </div>
+          }
+          sideBarOpen={!!selectedNode}
+          sideBarResizable
+          sideBar={
+            <TopologySideBar data-testid="pipeline-topology-drawer" resizable>
+              {sidePanel}
+            </TopologySideBar>
+          }
+        >
+          <VisualizationSurface state={{ selectedIds: selections }} />
+        </TopologyView>
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
+++ b/frontend/src/concepts/topology/customNodes/ArtifactTaskNode.tsx
@@ -22,6 +22,7 @@ import { TaskNodeProps } from '@patternfly/react-topology/dist/esm/pipelines/com
 import { css } from '@patternfly/react-styles';
 import { StandardTaskNodeData } from '#~/concepts/topology/types';
 import { isMetricsArtifactType } from '#~/concepts/pipelines/content/pipelinesDetails/pipelineRun/artifacts/utils';
+import { getRunStatusLabel } from '#~/concepts/topology/utils';
 
 const ICON_PADDING = 8;
 
@@ -50,6 +51,10 @@ const IconTaskNode: React.FC<IconTaskNodeProps> = observer(({ element, selected,
     ),
     AnchorEnd.target,
   );
+
+  const statusLabel = getRunStatusLabel(data?.runStatus);
+  const taskName = element.getLabel();
+  const ariaLabel = statusLabel ? `${taskName}, ${statusLabel}` : taskName;
 
   return (
     <g
@@ -93,6 +98,24 @@ const IconTaskNode: React.FC<IconTaskNodeProps> = observer(({ element, selected,
           <ListIcon width={iconSize} height={iconSize} />
         )}
       </g>
+      {/* Transparent button overlay for keyboard and screen reader access */}
+      <foreignObject x={0} y={0} width={bounds.width} height={bounds.height} overflow="visible">
+        <button
+          className="pipeline-node-a11y-button"
+          aria-label={ariaLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(e);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.currentTarget.click();
+            }
+          }}
+          data-testid={`pipeline-node-button-${taskName}`}
+        />
+      </foreignObject>
     </g>
   );
 });
@@ -122,6 +145,11 @@ const ArtifactTaskNodeInner: React.FC<ArtifactTaskNodeInnerProps> = observer(
 
     const translateX = bounds.width / 2 - (iconSize / 2) * upScale;
     const translateY = iconPadding * upScale;
+
+    const statusLabel = getRunStatusLabel(data?.runStatus);
+    const taskName = element.getLabel();
+    const ariaLabel = statusLabel ? `${taskName}, ${statusLabel}` : taskName;
+
     return (
       <g className={css('pf-topology__pipelines__task-node')} ref={hoverRef}>
         {isHover || detailsLevel !== ScaleDetailsLevel.high ? (
@@ -158,6 +186,31 @@ const ArtifactTaskNodeInner: React.FC<ArtifactTaskNodeInnerProps> = observer(
                 </g>
               </g>
             ) : null}
+            {/* Transparent button overlay for keyboard access in full-node (hover) mode.
+                IconTaskNode has its own overlay for compact mode. */}
+            <foreignObject
+              x={0}
+              y={0}
+              width={bounds.width}
+              height={bounds.height}
+              overflow="visible"
+            >
+              <button
+                className="pipeline-node-a11y-button"
+                aria-label={ariaLabel}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelect?.(e);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.currentTarget.click();
+                  }
+                }}
+                data-testid={`pipeline-node-button-${taskName}`}
+              />
+            </foreignObject>
           </g>
         ) : (
           <IconTaskNode selected={selected} onSelect={onSelect} element={element} />

--- a/frontend/src/concepts/topology/customNodes/StandardTaskNode.tsx
+++ b/frontend/src/concepts/topology/customNodes/StandardTaskNode.tsx
@@ -3,6 +3,9 @@ import {
   DEFAULT_WHEN_OFFSET,
   DEFAULT_WHEN_SIZE,
   GraphElement,
+  isNode,
+  Node,
+  NodeModel,
   observer,
   RunStatus,
   ScaleDetailsLevel,
@@ -19,83 +22,117 @@ import {
   PendingIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
-import { PipelineNodeModelExpanded } from '#~/concepts/topology/types';
+import { PipelineNodeModelExpanded, StandardTaskNodeData } from '#~/concepts/topology/types';
 import { ExecutionStateKF } from '#~/concepts/pipelines/kfTypes';
+import { getExecutionStateLabel, getRunStatusLabel } from '#~/concepts/topology/utils';
+
+type StandardTaskNodeInnerProps = {
+  element: Node<NodeModel, StandardTaskNodeData>;
+} & WithContextMenuProps &
+  WithSelectionProps;
+
+const StandardTaskNodeInner: React.FunctionComponent<StandardTaskNodeInnerProps> = observer(
+  ({ element, onSelect, selected, ...rest }) => {
+    const data = element.getData();
+    const [hover, hoverRef] = useHover<SVGGElement>();
+    const detailsLevel = element.getGraph().getDetailsLevel();
+    const state = data?.pipelineTask.status?.state;
+
+    const status = React.useMemo(() => {
+      switch (state) {
+        case ExecutionStateKF.CACHED:
+          return RunStatus.Succeeded;
+        case ExecutionStateKF.RUNNING:
+          return RunStatus.InProgress;
+        default:
+          return data?.runStatus;
+      }
+    }, [state, data?.runStatus]);
+
+    const customStatusIcon = React.useMemo(() => {
+      switch (state) {
+        case ExecutionStateKF.CANCELED:
+          return <BanIcon />;
+        case ExecutionStateKF.CANCELING:
+          return <SyncAltIcon />;
+        case ExecutionStateKF.CACHED:
+          return <OutlinedWindowRestoreIcon />;
+        case ExecutionStateKF.SKIPPED:
+          return <AngleDoubleRightIcon />;
+        case ExecutionStateKF.PENDING:
+          return <PendingIcon />;
+        default:
+          return undefined;
+      }
+    }, [state]);
+
+    const bounds = element.getBounds();
+    const statusLabel = getExecutionStateLabel(state) ?? getRunStatusLabel(status);
+    const taskName = element.getLabel();
+    const ariaLabel = statusLabel ? `${taskName}, ${statusLabel}` : taskName;
+
+    return (
+      <g ref={hoverRef}>
+        <TaskNode
+          element={element}
+          onSelect={onSelect}
+          selected={selected}
+          scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
+          status={status}
+          customStatusIcon={customStatusIcon}
+          hideDetailsAtMedium
+          hiddenDetailsShownStatuses={[
+            RunStatus.Succeeded,
+            RunStatus.Cancelled,
+            RunStatus.Failed,
+            RunStatus.Running,
+          ]}
+          whenOffset={data?.pipelineTask.whenStatus ? DEFAULT_WHEN_OFFSET : 0}
+          whenSize={data?.pipelineTask.whenStatus ? DEFAULT_WHEN_SIZE : 0}
+          {...rest}
+        >
+          {data?.pipelineTask.whenStatus && (
+            <WhenDecorator
+              element={element}
+              status={data.pipelineTask.whenStatus}
+              leftOffset={DEFAULT_WHEN_OFFSET}
+            />
+          )}
+        </TaskNode>
+        {/* Transparent HTML button overlay for keyboard and screen reader access.
+            pointer-events: none lets mouse clicks pass through to the SVG TaskNode below. */}
+        <foreignObject x={0} y={0} width={bounds.width} height={bounds.height} overflow="visible">
+          <button
+            className="pipeline-node-a11y-button"
+            aria-label={ariaLabel}
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect?.(e);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
+            data-testid={`pipeline-node-button-${taskName}`}
+          />
+        </foreignObject>
+      </g>
+    );
+  },
+);
 
 type StandardTaskNodeProps = {
   element: GraphElement<PipelineNodeModelExpanded>;
 } & WithContextMenuProps &
   WithSelectionProps;
 
-const StandardTaskNode: React.FunctionComponent<StandardTaskNodeProps> = ({
-  element,
-  onSelect,
-  selected,
-  ...rest
-}) => {
-  const data = element.getData();
-  const [hover, hoverRef] = useHover<SVGGElement>();
-  const detailsLevel = element.getGraph().getDetailsLevel();
-  const state = data?.pipelineTask.status?.state;
-
-  const status = React.useMemo(() => {
-    switch (state) {
-      case ExecutionStateKF.CACHED:
-        return RunStatus.Succeeded;
-      case ExecutionStateKF.RUNNING:
-        return RunStatus.InProgress;
-      default:
-        return data?.runStatus;
-    }
-  }, [state, data?.runStatus]);
-
-  const customStatusIcon = React.useMemo(() => {
-    switch (state) {
-      case ExecutionStateKF.CANCELED:
-        return <BanIcon />;
-      case ExecutionStateKF.CANCELING:
-        return <SyncAltIcon />;
-      case ExecutionStateKF.CACHED:
-        return <OutlinedWindowRestoreIcon />;
-      case ExecutionStateKF.SKIPPED:
-        return <AngleDoubleRightIcon />;
-      case ExecutionStateKF.PENDING:
-        return <PendingIcon />;
-      default:
-        return undefined;
-    }
-  }, [state]);
-
-  return (
-    <g ref={hoverRef}>
-      <TaskNode
-        element={element}
-        onSelect={onSelect}
-        selected={selected}
-        scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
-        status={status}
-        customStatusIcon={customStatusIcon}
-        hideDetailsAtMedium
-        hiddenDetailsShownStatuses={[
-          RunStatus.Succeeded,
-          RunStatus.Cancelled,
-          RunStatus.Failed,
-          RunStatus.Running,
-        ]}
-        whenOffset={data?.pipelineTask.whenStatus ? DEFAULT_WHEN_OFFSET : 0}
-        whenSize={data?.pipelineTask.whenStatus ? DEFAULT_WHEN_SIZE : 0}
-        {...rest}
-      >
-        {data?.pipelineTask.whenStatus && (
-          <WhenDecorator
-            element={element}
-            status={data.pipelineTask.whenStatus}
-            leftOffset={DEFAULT_WHEN_OFFSET}
-          />
-        )}
-      </TaskNode>
-    </g>
-  );
+const StandardTaskNode: React.FunctionComponent<StandardTaskNodeProps> = ({ element, ...rest }) => {
+  if (!isNode(element)) {
+    throw new Error('StandardTaskNode must be used only on Node elements');
+  }
+  return <StandardTaskNodeInner element={element} {...rest} />;
 };
 
 export default observer(StandardTaskNode);

--- a/frontend/src/concepts/topology/utils.ts
+++ b/frontend/src/concepts/topology/utils.ts
@@ -1,9 +1,62 @@
 import { DEFAULT_TASK_NODE_TYPE, RunStatus } from '@patternfly/react-topology';
 import { PipelineTask } from '#~/concepts/pipelines/topology';
+import { ExecutionStateKF } from '#~/concepts/pipelines/kfTypes';
 import { EXECUTION_TASK_NODE_TYPE, NODE_HEIGHT, NODE_WIDTH } from './const';
 import { PipelineNodeModelExpanded } from './types';
 
 export const ICON_TASK_NODE_TYPE = 'ICON_TASK_NODE';
+
+/** Human-readable label for a PF topology RunStatus value. */
+export const getRunStatusLabel = (status: RunStatus | string | undefined): string => {
+  switch (status) {
+    case RunStatus.Succeeded:
+      return 'Complete';
+    case RunStatus.Failed:
+    case RunStatus.FailedToStart:
+      return 'Failed';
+    case RunStatus.Cancelled:
+      return 'Canceled';
+    case RunStatus.Running:
+    case RunStatus.InProgress:
+      return 'Running';
+    case RunStatus.Pending:
+    case RunStatus.Idle:
+      return 'Pending';
+    case RunStatus.Skipped:
+      return 'Skipped';
+    default:
+      return '';
+  }
+};
+
+/**
+ * Human-readable label for a KF ExecutionStateKF value.
+ * Returns undefined when the state does not override the RunStatus label.
+ */
+export const getExecutionStateLabel = (
+  state: ExecutionStateKF | string | undefined,
+): string | undefined => {
+  switch (state) {
+    case ExecutionStateKF.CACHED:
+      return 'Cached';
+    case ExecutionStateKF.CANCELING:
+      return 'Canceling';
+    case ExecutionStateKF.CANCELED:
+      return 'Canceled';
+    case ExecutionStateKF.SKIPPED:
+      return 'Skipped';
+    case ExecutionStateKF.PENDING:
+      return 'Pending';
+    case ExecutionStateKF.RUNNING:
+      return 'Running';
+    case ExecutionStateKF.COMPLETE:
+      return 'Complete';
+    case ExecutionStateKF.FAILED:
+      return 'Failed';
+    default:
+      return undefined;
+  }
+};
 
 export const ARTIFACT_NODE_WIDTH = 44;
 export const ARTIFACT_NODE_HEIGHT = NODE_HEIGHT;


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/RHOAIENG-66823 -->

## Description

Addresses [RHOAIENG-66823](https://redhat.atlassian.net/browse/RHOAIENG-66823) — GOV UK AI500 customer report that JAWS/NVDA users on Windows 11 cannot navigate pipeline run steps or identify failures without opening every step drawer individually.

Root cause: `@patternfly/react-topology` renders pipeline nodes as SVG `<g>` elements with zero keyboard support or ARIA semantics ([upstream position](https://github.com/patternfly/patternfly-react/issues/8148): apps are responsible). Our custom node wrappers add nothing on top.

### Changes

**Step status summary (`PipelineRunStatusSummary`)** — new compact bar above the pipeline graph:
- Shows step counts by status (e.g., "1 Failed: build-image / 5 Complete / 2 Skipped")
- Failed and Cancelled step names render as clickable PF `Label` buttons that select the node in the graph and open the detail drawer
- Screen reader users hear the status summary immediately on page load — no SVG traversal required
- Returns `null` when all statuses are undefined (pipeline definition view, not a run)

**Keyboard-accessible node overlays** — `<foreignObject>` + `<button>` added to:
- `StandardTaskNode` — outer/inner component pattern (like `ArtifactTaskNode`); button has `aria-label="{name}, {status}"`
- `ArtifactTaskNode` — both `IconTaskNode` (compact icon) and full `TaskNode` render paths
- `pointer-events: none` on the button means mouse clicks still pass through to the SVG below; keyboard Tab/Enter/Space activate the button

**ARIA fixes:**
- `PipelineDefaultTaskGroup` Popover: `aria-label` changed from generic `"Hoverable popover"` to `"{group name} task group, N tasks"`
- `NodeStatusIcon` `Icon`: added `aria-label={label}` (status text was previously only in the Tooltip, invisible to screen readers)
- `PipelineRunDrawerRightTabs`: added `aria-label="Pipeline task details"` to `Tabs`; switched `Tab onClick` to `Tabs onSelect` for proper keyboard tab activation

**Utilities added to `utils.ts`:**
- `getRunStatusLabel(status)` — maps `RunStatus` → human-readable string
- `getExecutionStateLabel(state)` — maps `ExecutionStateKF` → human-readable string (for special states like Cached, Canceling, Skipped)

**Type narrowing:** `PipelineTopology` and `PipelineVisualizationSurface` `nodes` prop narrowed from `PipelineNodeModel[]` to `PipelineNodeModelExpanded[]`; all callers already pass this subtype.

Follow-up JIRAs filed:
- [RHOAIENG-66827](https://issues.redhat.com/browse/RHOAIENG-66827) — propagate fixes to automl/autorag packages
- [RHOAIENG-66828](https://issues.redhat.com/browse/RHOAIENG-66828) — file upstream PF feature request

## How Has This Been Tested?

- TypeScript (`tsc --noEmit`) and ESLint (`npm run lint`) both pass clean on the frontend package
- Manually reviewed the component tree to verify the foreignObject button renders inside the VisualizationProvider context and fires SELECTION_EVENT via the controller
- Customer validation: GOV UK AI500 team (Ricardo Alonso / Simonas Kareiva) will validate on Windows 11 + JAWS 2025.2412.50 / NVDA 2024.4.2 before [RHOAIENG-66823](https://redhat.atlassian.net/browse/RHOAIENG-66823) is closed

## Test Impact

No new Cypress or unit tests added in this PR. The accessibility changes are structural (ARIA attributes, keyboard handlers, foreignObject overlays) and require manual screen reader testing on JAWS/NVDA which cannot be automated in CI. The existing `cy.testA11y()` axe scans run on the pipeline topology page and will catch any structural ARIA regressions introduced by this change.

Cypress keyboard-navigation tests (Tab/Enter/Space on pipeline nodes) are a follow-up item.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

> **Note:** This PR was authored by Claude Sonnet 4.6 (AI) on behalf of @bobbravo2.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline run status summary display showing task statuses with interactive, selectable nodes.

* **Improvements**
  * Enhanced keyboard navigation and screen reader accessibility across pipeline topology components.

* **Style**
  * Added styling for the new status summary display and interactive elements within the visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-66823]: https://redhat.atlassian.net/browse/RHOAIENG-66823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-66827]: https://redhat.atlassian.net/browse/RHOAIENG-66827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ