### PR TITLE
Evaluation run configuration validation and primary metric selection

### DIFF
--- a/packages/cypress/cypress/pages/evalHubEvaluationFlow.ts
+++ b/packages/cypress/cypress/pages/evalHubEvaluationFlow.ts
@@ -49,8 +49,24 @@ class EvalHubEvaluationFlow {
     return cy.findByTestId('new-experiment-name-input');
   }
 
-  findInputModeInference() {
-    return cy.findByTestId('input-mode-inference');
+  findSourceModeToggle() {
+    return cy.findByTestId('source-mode-toggle');
+  }
+
+  findModelPickerToggle() {
+    return cy.findByTestId('model-picker-toggle');
+  }
+
+  /** Select "Other (External endpoint)" from the model picker dropdown. */
+  selectExternalEndpoint() {
+    this.findModelPickerToggle().click();
+    cy.findByTestId('model-option-external').click();
+  }
+
+  /** Select a cluster InferenceService by name from the model picker dropdown. */
+  selectClusterModel(name: string) {
+    this.findModelPickerToggle().click();
+    cy.findByTestId(`model-option-${name}`).click();
   }
 
   findModelNameInput() {
@@ -59,6 +75,10 @@ class EvalHubEvaluationFlow {
 
   findEndpointUrlInput() {
     return cy.findByTestId('endpoint-url-input');
+  }
+
+  findValidateConnectionButton() {
+    return cy.findByTestId('validate-connection-button');
   }
 
   findBenchmarkParametersCheckbox() {

--- a/packages/cypress/cypress/tests/e2e/eval-hub/testEvalHub.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/eval-hub/testEvalHub.cy.ts
@@ -55,19 +55,19 @@ describe('Eval Hub E2E', () => {
     });
 
     cy.then(() => {
-      cy.step('Ensure EvalHub CR is Ready');
-      return ensureEvalHubCrReady(evalHubCrName, evalHubInstanceYamlPath).then((created) => {
+      cy.step('Ensure MLflow CR is Available (must be ready before EvalHub)');
+      return ensureMlflowCrReady(mlflowInstanceYamlPath).then((created) => {
         if (created) {
-          Cypress.env('EVAL_HUB_CR_CREATED_BY_TEST', true);
+          Cypress.env('MLFLOW_CR_CREATED_BY_TEST', true);
         }
       });
     });
 
     cy.then(() => {
-      cy.step('Ensure MLflow CR is Available');
-      return ensureMlflowCrReady(mlflowInstanceYamlPath).then((created) => {
+      cy.step('Ensure EvalHub CR is Ready');
+      return ensureEvalHubCrReady(evalHubCrName, evalHubInstanceYamlPath).then((created) => {
         if (created) {
-          Cypress.env('MLFLOW_CR_CREATED_BY_TEST', true);
+          Cypress.env('EVAL_HUB_CR_CREATED_BY_TEST', true);
         }
       });
     });

--- a/packages/cypress/cypress/tests/e2e/eval-hub/testEvalHub.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/eval-hub/testEvalHub.cy.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../utils/oc_commands/evalHubInstance';
 import { deleteMlflowCr, ensureMlflowCrReady } from '../../../utils/oc_commands/mlflowInstance';
 import {
-  getVllmEndpointUrl,
   grantEvalHubTenantAccess,
   setupTenantAndDeployModel,
 } from '../../../utils/oc_commands/evalHubModelDeploy';
@@ -34,11 +33,10 @@ describe('Eval Hub E2E', () => {
   let evaluationTenantProject = '';
   let evalHubCrName = 'evalhub';
   let hardwareProfileName = '';
-  let vllmEndpointUrl = '';
+  let inferenceServiceName = '';
   let evalHubInstanceYamlPath = '';
   let mlflowInstanceYamlPath = '';
   let benchmarkCardTitle = '';
-  let inferenceModelName = '';
   let additionalBenchmarkParams = '';
   let projectNamePrefix = '';
 
@@ -51,7 +49,6 @@ describe('Eval Hub E2E', () => {
       evalHubInstanceYamlPath = testData.evalHubInstanceResourceYamlPath;
       mlflowInstanceYamlPath = testData.mlflowInstanceResourceYamlPath;
       benchmarkCardTitle = testData.benchmarkCardTitle;
-      inferenceModelName = testData.inferenceModelName;
       additionalBenchmarkParams = testData.additionalBenchmarkParams;
       projectNamePrefix = testData.projectNamePrefix;
       evaluationTenantProject = `${testData.projectNamePrefix}-${uuid}`;
@@ -87,8 +84,8 @@ describe('Eval Hub E2E', () => {
       addUserToProject(evaluationTenantProject, LDAP_ADMIN_USER.USERNAME, 'admin');
       setupTenantAndDeployModel(evaluationTenantProject, testData, hardwareProfileName);
       grantEvalHubTenantAccess(evaluationTenantProject, LDAP_ADMIN_USER.USERNAME);
-      vllmEndpointUrl = getVllmEndpointUrl(testData, evaluationTenantProject);
-      cy.log(`vLLM endpoint: ${vllmEndpointUrl}`);
+      inferenceServiceName = testData.inferenceServiceName;
+      cy.log(`InferenceService: ${inferenceServiceName}`);
     });
   });
 
@@ -149,11 +146,9 @@ describe('Eval Hub E2E', () => {
       cy.step('Fill evaluation form');
       evalHubEvaluationFlow.findBenchmarkNameDisplay().should('contain.text', benchmarkCardTitle);
       evalHubEvaluationFlow.findEvaluationNameInput().clear().type(evaluationRunName);
-      evalHubEvaluationFlow.findInputModeInference().check({ force: true });
 
-      cy.step('Enter model details');
-      evalHubEvaluationFlow.findModelNameInput().clear().type(inferenceModelName);
-      evalHubEvaluationFlow.findEndpointUrlInput().clear().type(vllmEndpointUrl);
+      cy.step('Select deployed cluster model from picker');
+      evalHubEvaluationFlow.selectClusterModel(inferenceServiceName);
 
       if (extraParams) {
         cy.step('Add benchmark parameters');

--- a/packages/eval-hub/api/openapi/eval-hub.yaml
+++ b/packages/eval-hub/api/openapi/eval-hub.yaml
@@ -908,9 +908,18 @@ components:
           format: uri
           description: Endpoint URL to verify
           example: 'https://api.example.com/v1'
+        secret_name:
+          type: string
+          description: >-
+            Name of a Kubernetes Secret (in the request namespace) whose "api-key"
+            data field contains the authentication credential. Mutually exclusive
+            with secret_value; secret_name takes precedence when both are provided.
+          example: 'my-api-key-secret'
         secret_value:
           type: string
-          description: Optional API key or bearer token for authentication
+          description: >-
+            Literal API key or bearer token for authentication (used for pre-recorded
+            sources or when the key is not stored in a Kubernetes Secret).
         model_id:
           type: string
           description: Model identifier to include in the test request (model/agent sources)

--- a/packages/eval-hub/api/openapi/eval-hub.yaml
+++ b/packages/eval-hub/api/openapi/eval-hub.yaml
@@ -331,6 +331,98 @@ paths:
         Cancels a running evaluation job (soft cancel) or permanently
         deletes it (hard delete) depending on the hard_delete parameter.
 
+  # =============================================================================
+  # INFERENCE SERVICES
+  # =============================================================================
+
+  /eval-hub/api/v1/inferenceservices:
+    summary: List InferenceService resources
+    description: >-
+      Lists InferenceService resources (serving.kserve.io/v1beta1) in the
+      user's namespace. Uses the caller's bearer token for RBAC enforcement.
+      Degrades gracefully if the CRD is not installed or the user lacks access.
+    get:
+      tags:
+        - InferenceServices
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/namespace'
+      responses:
+        '200':
+          description: List of InferenceService resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InferenceServicesResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      operationId: listInferenceServices
+      summary: List InferenceServices
+      description: >-
+        Returns deployed InferenceService models in the namespace. Returns
+        an empty list with a warning field if the CRD is not installed or
+        the user lacks access.
+
+  # =============================================================================
+  # CONNECTION VERIFICATION
+  # =============================================================================
+
+  /eval-hub/api/v1/evaluations/verify-connection:
+    summary: Verify endpoint connectivity
+    description: >-
+      Validates that an endpoint URL is reachable and responds correctly
+      before committing to a full evaluation run. Supports model, agent,
+      and pre-recorded data source types.
+    post:
+      tags:
+        - Evaluations
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/namespace'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyConnectionRequest'
+            example:
+              source_type: 'model'
+              base_url: 'https://api.example.com/v1'
+              model_id: 'llama-3.2-1b-instruct'
+      responses:
+        '200':
+          description: Connection verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyConnectionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '408':
+          description: Connection timed out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '503':
+          description: Endpoint unreachable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+      operationId: verifyConnection
+      summary: Verify Endpoint Connection
+      description: >-
+        Probes the given endpoint to verify connectivity. For model/agent
+        sources, sends a test request to /chat/completions. For pre-recorded
+        sources, performs a HEAD request to the dataset URL.
+
 components:
   # =============================================================================
   # SCHEMAS
@@ -731,6 +823,99 @@ components:
       properties:
         oci:
           $ref: '#/components/schemas/OciExport'
+
+    # -------------------------------------------------------------------------
+    # InferenceService schemas
+    # -------------------------------------------------------------------------
+
+    InferenceServiceItem:
+      type: object
+      required:
+        - name
+        - ready
+      properties:
+        name:
+          type: string
+          description: Name of the InferenceService resource
+          example: 'llama-32-1b-instruct'
+        url:
+          type: string
+          description: Serving URL if the service is ready
+          example: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+        ready:
+          type: boolean
+          description: Whether the InferenceService is in a Ready state
+          example: true
+
+    InferenceServicesResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceServiceItem'
+        warning:
+          type: string
+          description: >-
+            Warning message when the listing degrades gracefully (e.g. CRD
+            not installed, user lacks access). Present only when the BFF
+            could not list resources but did not hard-fail.
+
+    # -------------------------------------------------------------------------
+    # Connection verification schemas
+    # -------------------------------------------------------------------------
+
+    VerifyConnectionRequest:
+      type: object
+      required:
+        - source_type
+        - base_url
+      properties:
+        source_type:
+          type: string
+          enum:
+            - model
+            - agent
+            - prerecorded
+          description: Type of evaluation source being verified
+          example: 'model'
+        base_url:
+          type: string
+          format: uri
+          description: Endpoint URL to verify
+          example: 'https://api.example.com/v1'
+        secret_value:
+          type: string
+          description: Optional API key or bearer token for authentication
+        model_id:
+          type: string
+          description: Model identifier to include in the test request (model/agent sources)
+          example: 'llama-3.2-1b-instruct'
+
+    VerifyConnectionResponse:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: Whether the connection probe succeeded
+          example: true
+        message:
+          type: string
+          description: Human-readable result summary
+          example: 'Connection successful'
+        response_time_ms:
+          type: integer
+          description: Round-trip time in milliseconds (present on success)
+          example: 142
+
+    # -------------------------------------------------------------------------
+    # Evaluation job schemas
+    # -------------------------------------------------------------------------
 
     CreateEvaluationJobRequest:
       type: object

--- a/packages/eval-hub/api/openapi/eval-hub.yaml
+++ b/packages/eval-hub/api/openapi/eval-hub.yaml
@@ -191,6 +191,7 @@ paths:
       security:
         - Bearer: []
       parameters:
+        - $ref: '#/components/parameters/namespace'
         - name: limit
           in: query
           schema:
@@ -206,11 +207,6 @@ paths:
             default: 0
             minimum: 0
           description: Offset for pagination
-        - name: search
-          in: query
-          schema:
-            type: string
-          description: Filter benchmarks by name (case-insensitive substring match)
       responses:
         '200':
           $ref: '#/components/responses/ProvidersResponse'
@@ -355,6 +351,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InferenceServicesResponse'
+              example:
+                items:
+                  - name: 'llama-32-1b-instruct'
+                    url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+                    ready: true
+                  - name: 'mistral-7b'
+                    url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
+                    ready: true
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -399,7 +403,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyConnectionResponse'
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/VerifyConnectionResponse'
+              example:
+                data:
+                  success: true
+                  message: 'Connection successful'
+                  response_time_ms: 120
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -862,6 +876,14 @@ components:
             Warning message when the listing degrades gracefully (e.g. CRD
             not installed, user lacks access). Present only when the BFF
             could not list resources but did not hard-fail.
+      example:
+        items:
+          - name: 'llama-32-1b-instruct'
+            url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+            ready: true
+          - name: 'mistral-7b'
+            url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
+            ready: true
 
     # -------------------------------------------------------------------------
     # Connection verification schemas

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -39,6 +39,8 @@ const (
 	ProvidersPath            = ApiPathPrefix + "/evaluations/providers"
 	EvalHubCRStatusPath      = ApiPathPrefix + "/evalhub/status"
 	EvalHubServiceHealthPath = ApiPathPrefix + "/evalhub/health"
+	InferenceServicesPath    = ApiPathPrefix + "/inferenceservices"
+	VerifyConnectionPath     = ApiPathPrefix + "/evaluations/verify-connection"
 )
 
 type App struct {
@@ -187,6 +189,12 @@ func (app *App) Routes() http.Handler {
 	apiRouter.DELETE(EvaluationJobByIDPath, app.AttachNamespace(app.RequireAccessToService(app.AttachEvalHubClient(app.CancelEvaluationJobHandler))))
 	apiRouter.GET(CollectionsPath, app.AttachNamespace(app.RequireAccessToService(app.AttachEvalHubClient(app.CollectionsHandler))))
 	apiRouter.GET(ProvidersPath, app.AttachNamespace(app.RequireAccessToService(app.AttachEvalHubClient(app.ProvidersHandler))))
+
+	// InferenceService listing (user-token dynamic client, no EvalHub REST client needed)
+	apiRouter.GET(InferenceServicesPath, app.AttachNamespace(app.RequireAccessToService(app.InferenceServicesHandler)))
+
+	// Connection verification (probes external endpoints, no EvalHub REST client needed)
+	apiRouter.POST(VerifyConnectionPath, app.AttachNamespace(app.RequireAccessToService(app.VerifyConnectionHandler)))
 
 	// EvalHub CR status endpoint (reads CR directly, does not need the EvalHub REST client)
 	apiRouter.GET(EvalHubCRStatusPath, app.AttachNamespace(app.EvalHubCRStatusHandler))

--- a/packages/eval-hub/bff/internal/api/inferenceservices_handler.go
+++ b/packages/eval-hub/bff/internal/api/inferenceservices_handler.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
+	helper "github.com/opendatahub-io/eval-hub/bff/internal/helpers"
+	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+var inferenceServiceGVR = schema.GroupVersionResource{
+	Group:    "serving.kserve.io",
+	Version:  "v1beta1",
+	Resource: "inferenceservices",
+}
+
+type InferenceServicesEnvelope Envelope[models.InferenceServicesResponse, None]
+
+func (app *App) InferenceServicesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+	logger := helper.GetContextLoggerFromReq(r)
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*kubernetes.RequestIdentity)
+	if !ok || identity == nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("missing RequestIdentity in context"))
+		return
+	}
+
+	dynClient, err := newUserDynamicClient(identity.Token)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to create dynamic client: %w", err))
+		return
+	}
+
+	result, err := listInferenceServices(ctx, dynClient, namespace)
+	if err != nil {
+		logger.Warn("InferenceService listing failed, returning empty list", "namespace", namespace, "error", err)
+
+		warning := "unable to list InferenceServices"
+		if k8serrors.IsNotFound(err) {
+			warning = "InferenceService CRD is not installed on this cluster"
+		} else if k8serrors.IsForbidden(err) {
+			warning = "you do not have permission to list InferenceServices in this namespace"
+		}
+
+		envelope := InferenceServicesEnvelope{
+			Data: models.InferenceServicesResponse{
+				Items:   []models.InferenceServiceItem{},
+				Warning: warning,
+			},
+		}
+		if writeErr := app.WriteJSON(w, http.StatusOK, envelope, nil); writeErr != nil {
+			app.serverErrorResponse(w, r, writeErr)
+		}
+		return
+	}
+
+	envelope := InferenceServicesEnvelope{Data: *result}
+	if err := app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func newUserDynamicClient(token string) (dynamic.Interface, error) {
+	baseConfig, err := helper.GetKubeconfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	cfg := rest.AnonymousClientConfig(baseConfig)
+	cfg.BearerToken = token
+	cfg.BearerTokenFile = ""
+	cfg.Username = ""
+	cfg.Password = ""
+	cfg.ExecProvider = nil
+	cfg.AuthProvider = nil
+
+	return dynamic.NewForConfig(cfg)
+}
+
+func listInferenceServices(ctx context.Context, client dynamic.Interface, namespace string) (*models.InferenceServicesResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	list, err := client.Resource(inferenceServiceGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]models.InferenceServiceItem, 0, len(list.Items))
+	for _, obj := range list.Items {
+		name := obj.GetName()
+		var url string
+		var ready bool
+
+		if status, ok := obj.Object["status"].(map[string]interface{}); ok {
+			// Prefer status.address.url (includes the real container port for
+			// headless / RawDeployment services) over the top-level status.url
+			// which defaults to port 80.
+			if addr, ok := status["address"].(map[string]interface{}); ok {
+				if u, ok := addr["url"].(string); ok && u != "" {
+					url = u
+				}
+			}
+			if url == "" {
+				if u, ok := status["url"].(string); ok {
+					url = u
+				}
+			}
+			if conditions, ok := status["conditions"].([]interface{}); ok {
+				for _, c := range conditions {
+					cond, ok := c.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if cond["type"] == "Ready" && cond["status"] == "True" {
+						ready = true
+						break
+					}
+				}
+			}
+		}
+
+		items = append(items, models.InferenceServiceItem{
+			Name:  name,
+			URL:   url,
+			Ready: ready,
+		})
+	}
+
+	return &models.InferenceServicesResponse{Items: items}, nil
+}

--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -126,12 +126,16 @@ func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken st
 	}
 
 	// Try the user-selected namespace first (set by AttachNamespace middleware on API routes).
+	// Permission errors (e.g. user cannot list evalhubs CRD in the tenant namespace) are
+	// non-fatal — fall through to the dashboard namespace where the CR typically lives.
 	if userNS, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string); ok && userNS != "" {
 		crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, userNS)
 		if err != nil {
-			return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", userNS, err)
-		}
-		if crStatus != nil && strings.TrimSpace(crStatus.URL) != "" {
+			if logger := helper.GetContextLogger(ctx); logger != nil {
+				logger.Debug("EvalHub CR lookup failed in user namespace, falling through to dashboard namespace",
+					"namespace", userNS, "error", err)
+			}
+		} else if crStatus != nil && strings.TrimSpace(crStatus.URL) != "" {
 			return crStatus.URL, authToken, false, nil
 		}
 	}

--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/evalhub"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
 	"github.com/rs/cors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func (app *App) RecoverPanic(next http.Handler) http.Handler {
@@ -126,14 +128,20 @@ func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken st
 	}
 
 	// Try the user-selected namespace first (set by AttachNamespace middleware on API routes).
-	// Permission errors (e.g. user cannot list evalhubs CRD in the tenant namespace) are
-	// non-fatal — fall through to the dashboard namespace where the CR typically lives.
+	// Permission errors (Forbidden/NotFound) are non-fatal — fall through to the dashboard
+	// namespace where the CR typically lives.  Operational failures (API unavailable, network
+	// errors, etc.) are surfaced immediately so they are not silently masked.
 	if userNS, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string); ok && userNS != "" {
 		crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, userNS)
 		if err != nil {
-			if logger := helper.GetContextLogger(ctx); logger != nil {
-				logger.Debug("EvalHub CR lookup failed in user namespace, falling through to dashboard namespace",
-					"namespace", userNS, "error", err)
+			var statusErr *k8serrors.StatusError
+			if errors.As(err, &statusErr) && (k8serrors.IsForbidden(statusErr) || k8serrors.IsNotFound(statusErr)) {
+				if logger := helper.GetContextLogger(ctx); logger != nil {
+					logger.Debug("EvalHub CR lookup not permitted in user namespace, falling through to dashboard namespace",
+						"namespace", userNS, "reason", statusErr.Status().Reason)
+				}
+			} else {
+				return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", userNS, err)
 			}
 		} else if crStatus != nil && strings.TrimSpace(crStatus.URL) != "" {
 			return crStatus.URL, authToken, false, nil

--- a/packages/eval-hub/bff/internal/api/middleware_test.go
+++ b/packages/eval-hub/bff/internal/api/middleware_test.go
@@ -127,10 +127,16 @@ func TestEvalHubServiceURL_NoUserNamespaceInContext(t *testing.T) {
 	assert.Equal(t, "http://evalhub.odh.svc:8080", serviceURL)
 }
 
-func TestEvalHubServiceURL_UserNamespaceLookupError(t *testing.T) {
+func TestEvalHubServiceURL_UserNamespaceLookupError_FallsThroughToDashboard(t *testing.T) {
 	client := &namespaceAwareCRClient{
 		errByNS: map[string]error{
 			"user-project": fmt.Errorf("forbidden"),
+		},
+		crByNamespace: map[string]*models.EvalHubCRStatus{
+			"redhat-ods-applications": {
+				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
+				URL: "http://evalhub.platform.svc:8080",
+			},
 		},
 	}
 
@@ -138,10 +144,30 @@ func TestEvalHubServiceURL_UserNamespaceLookupError(t *testing.T) {
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
 	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
 
-	_, _, _, err := app.evalHubServiceURL(ctx)
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "user-project")
+	require.NoError(t, err)
+	assert.False(t, crNotFound)
+	assert.Equal(t, "http://evalhub.platform.svc:8080", serviceURL)
+}
+
+func TestEvalHubServiceURL_UserNamespaceLookupError_NoCRAnywhere(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		errByNS: map[string]error{
+			"user-project": fmt.Errorf("forbidden"),
+		},
+		crByNamespace: map[string]*models.EvalHubCRStatus{},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, crNotFound)
+	assert.Empty(t, serviceURL)
 }
 
 func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {

--- a/packages/eval-hub/bff/internal/api/middleware_test.go
+++ b/packages/eval-hub/bff/internal/api/middleware_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opendatahub-io/eval-hub/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // namespaceAwareCRClient returns different CR statuses depending on the namespace queried.
@@ -127,10 +129,14 @@ func TestEvalHubServiceURL_NoUserNamespaceInContext(t *testing.T) {
 	assert.Equal(t, "http://evalhub.odh.svc:8080", serviceURL)
 }
 
-func TestEvalHubServiceURL_UserNamespaceLookupError_FallsThroughToDashboard(t *testing.T) {
+func TestEvalHubServiceURL_ForbiddenInUserNS_FallsThroughToDashboard(t *testing.T) {
+	forbiddenErr := k8serrors.NewForbidden(
+		schema.GroupResource{Group: "trustyai.opendatahub.io", Resource: "evalhubs"},
+		"", fmt.Errorf("user cannot list evalhubs"),
+	)
 	client := &namespaceAwareCRClient{
 		errByNS: map[string]error{
-			"user-project": fmt.Errorf("forbidden"),
+			"user-project": fmt.Errorf("failed to list EvalHub CRs: %w", forbiddenErr),
 		},
 		crByNamespace: map[string]*models.EvalHubCRStatus{
 			"redhat-ods-applications": {
@@ -151,10 +157,14 @@ func TestEvalHubServiceURL_UserNamespaceLookupError_FallsThroughToDashboard(t *t
 	assert.Equal(t, "http://evalhub.platform.svc:8080", serviceURL)
 }
 
-func TestEvalHubServiceURL_UserNamespaceLookupError_NoCRAnywhere(t *testing.T) {
+func TestEvalHubServiceURL_ForbiddenInUserNS_NoCRAnywhere(t *testing.T) {
+	forbiddenErr := k8serrors.NewForbidden(
+		schema.GroupResource{Group: "trustyai.opendatahub.io", Resource: "evalhubs"},
+		"", fmt.Errorf("user cannot list evalhubs"),
+	)
 	client := &namespaceAwareCRClient{
 		errByNS: map[string]error{
-			"user-project": fmt.Errorf("forbidden"),
+			"user-project": fmt.Errorf("failed to list EvalHub CRs: %w", forbiddenErr),
 		},
 		crByNamespace: map[string]*models.EvalHubCRStatus{},
 	}
@@ -168,6 +178,30 @@ func TestEvalHubServiceURL_UserNamespaceLookupError_NoCRAnywhere(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, crNotFound)
 	assert.Empty(t, serviceURL)
+}
+
+func TestEvalHubServiceURL_OperationalErrorInUserNS_SurfacedImmediately(t *testing.T) {
+	client := &namespaceAwareCRClient{
+		errByNS: map[string]error{
+			"user-project": fmt.Errorf("failed to create dynamic client: connection refused"),
+		},
+		crByNamespace: map[string]*models.EvalHubCRStatus{
+			"redhat-ods-applications": {
+				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
+				URL: "http://evalhub.platform.svc:8080",
+			},
+		},
+	}
+
+	app := newTestApp(client, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	_, _, _, err := app.evalHubServiceURL(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user-project")
+	assert.Contains(t, err.Error(), "connection refused")
 }
 
 func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {

--- a/packages/eval-hub/bff/internal/api/verify_connection_handler.go
+++ b/packages/eval-hub/bff/internal/api/verify_connection_handler.go
@@ -4,11 +4,24 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/connectionprobe"
 	"github.com/opendatahub-io/eval-hub/bff/internal/models"
 )
+
+// sanitizeURL strips userinfo and query parameters from a URL for safe logging.
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
 
 type VerifyConnectionEnvelope = Envelope[models.VerifyConnectionResponse, None]
 
@@ -47,7 +60,7 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 
 	app.logger.Info("verify-connection: probing endpoint",
 		slog.String("source_type", req.SourceType),
-		slog.String("base_url", req.BaseURL),
+		slog.String("base_url", sanitizeURL(req.BaseURL)),
 		slog.Bool("has_secret", req.SecretValue != ""),
 		slog.String("model_id", req.ModelID),
 	)
@@ -87,7 +100,7 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 		if probeErr, ok := err.(*connectionprobe.ConnectionProbeError); ok {
 			app.logger.Warn("verify-connection: probe failed",
 				slog.String("code", probeErr.Code),
-				slog.String("base_url", req.BaseURL),
+				slog.String("base_url", sanitizeURL(req.BaseURL)),
 			)
 			httpError := &HTTPError{
 				StatusCode: probeErr.StatusCode,
@@ -102,7 +115,7 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 	}
 
 	app.logger.Info("verify-connection: probe succeeded",
-		slog.String("base_url", req.BaseURL),
+		slog.String("base_url", sanitizeURL(req.BaseURL)),
 		slog.Int("response_time_ms", response.ResponseTime),
 	)
 

--- a/packages/eval-hub/bff/internal/api/verify_connection_handler.go
+++ b/packages/eval-hub/bff/internal/api/verify_connection_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -17,15 +18,18 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 
 	var req models.VerifyConnectionRequest
 	if err := app.ReadJSON(w, r, &req); err != nil {
+		app.logger.Warn("verify-connection: malformed request body", "error", err)
 		app.badRequestResponse(w, r, err)
 		return
 	}
 
 	if req.BaseURL == "" {
+		app.logger.Warn("verify-connection: missing base_url")
 		app.badRequestResponse(w, r, fmt.Errorf("base_url is required"))
 		return
 	}
 	if req.SourceType == "" {
+		app.logger.Warn("verify-connection: missing source_type")
 		app.badRequestResponse(w, r, fmt.Errorf("source_type is required"))
 		return
 	}
@@ -36,9 +40,17 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 		"prerecorded": true,
 	}
 	if !validSourceTypes[req.SourceType] {
+		app.logger.Warn("verify-connection: invalid source_type", slog.String("source_type", req.SourceType))
 		app.badRequestResponse(w, r, fmt.Errorf("invalid source_type: %s (must be model, agent, or prerecorded)", req.SourceType))
 		return
 	}
+
+	app.logger.Info("verify-connection: probing endpoint",
+		slog.String("source_type", req.SourceType),
+		slog.String("base_url", req.BaseURL),
+		slog.Bool("has_secret", req.SecretValue != ""),
+		slog.String("model_id", req.ModelID),
+	)
 
 	client, err := connectionprobe.NewConnectionProbeClient(
 		app.logger,
@@ -54,6 +66,10 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 	)
 	if err != nil {
 		if probeErr, ok := err.(*connectionprobe.ConnectionProbeError); ok {
+			app.logger.Warn("verify-connection: client creation failed",
+				slog.String("code", probeErr.Code),
+				slog.String("message", probeErr.Message),
+			)
 			httpError := &HTTPError{
 				StatusCode: probeErr.StatusCode,
 				Error:      ErrorPayload{Code: probeErr.Code, Message: probeErr.Message},
@@ -61,6 +77,7 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 			app.errorResponse(w, r, httpError)
 			return
 		}
+		app.logger.Error("verify-connection: unexpected client error", "error", err)
 		app.serverErrorResponse(w, r, err)
 		return
 	}
@@ -68,6 +85,10 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 	response, err := client.Probe(ctx, req)
 	if err != nil {
 		if probeErr, ok := err.(*connectionprobe.ConnectionProbeError); ok {
+			app.logger.Warn("verify-connection: probe failed",
+				slog.String("code", probeErr.Code),
+				slog.String("base_url", req.BaseURL),
+			)
 			httpError := &HTTPError{
 				StatusCode: probeErr.StatusCode,
 				Error:      ErrorPayload{Code: probeErr.Code, Message: probeErr.Message},
@@ -75,9 +96,15 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 			app.errorResponse(w, r, httpError)
 			return
 		}
+		app.logger.Error("verify-connection: unexpected probe error", "error", err)
 		app.serverErrorResponse(w, r, err)
 		return
 	}
+
+	app.logger.Info("verify-connection: probe succeeded",
+		slog.String("base_url", req.BaseURL),
+		slog.Int("response_time_ms", response.ResponseTime),
+	)
 
 	envelope := VerifyConnectionEnvelope{
 		Data: *response,

--- a/packages/eval-hub/bff/internal/api/verify_connection_handler.go
+++ b/packages/eval-hub/bff/internal/api/verify_connection_handler.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/connectionprobe"
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+)
+
+type VerifyConnectionEnvelope = Envelope[models.VerifyConnectionResponse, None]
+
+// VerifyConnectionHandler handles POST /api/v1/evaluations/verify-connection
+func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	var req models.VerifyConnectionRequest
+	if err := app.ReadJSON(w, r, &req); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if req.BaseURL == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("base_url is required"))
+		return
+	}
+	if req.SourceType == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("source_type is required"))
+		return
+	}
+
+	validSourceTypes := map[string]bool{
+		"model":       true,
+		"agent":       true,
+		"prerecorded": true,
+	}
+	if !validSourceTypes[req.SourceType] {
+		app.badRequestResponse(w, r, fmt.Errorf("invalid source_type: %s (must be model, agent, or prerecorded)", req.SourceType))
+		return
+	}
+
+	client, err := connectionprobe.NewConnectionProbeClient(
+		app.logger,
+		req.BaseURL,
+		req.SecretValue,
+		req.SourceType,
+		&connectionprobe.ClientOptions{
+			AllowHTTP:           app.config.DevMode || app.config.InsecureSkipVerify,
+			SkipSSRFValidation:  app.config.DevMode,
+			SkipTLSVerification: app.config.InsecureSkipVerify,
+			RootCAs:             app.rootCAs,
+		},
+	)
+	if err != nil {
+		if probeErr, ok := err.(*connectionprobe.ConnectionProbeError); ok {
+			httpError := &HTTPError{
+				StatusCode: probeErr.StatusCode,
+				Error:      ErrorPayload{Code: probeErr.Code, Message: probeErr.Message},
+			}
+			app.errorResponse(w, r, httpError)
+			return
+		}
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	response, err := client.Probe(ctx, req)
+	if err != nil {
+		if probeErr, ok := err.(*connectionprobe.ConnectionProbeError); ok {
+			httpError := &HTTPError{
+				StatusCode: probeErr.StatusCode,
+				Error:      ErrorPayload{Code: probeErr.Code, Message: probeErr.Message},
+			}
+			app.errorResponse(w, r, httpError)
+			return
+		}
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	envelope := VerifyConnectionEnvelope{
+		Data: *response,
+	}
+	if err := app.WriteJSON(w, http.StatusOK, envelope, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/packages/eval-hub/bff/internal/api/verify_connection_handler.go
+++ b/packages/eval-hub/bff/internal/api/verify_connection_handler.go
@@ -1,14 +1,22 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
+	helper "github.com/opendatahub-io/eval-hub/bff/internal/helpers"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/connectionprobe"
+	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // sanitizeURL strips userinfo and query parameters from a URL for safe logging.
@@ -24,6 +32,44 @@ func sanitizeURL(raw string) string {
 }
 
 type VerifyConnectionEnvelope = Envelope[models.VerifyConnectionResponse, None]
+
+// resolveSecretAPIKey looks up a Kubernetes Secret by name and returns the value of its
+// "api-key" data field. Uses the caller's bearer token so RBAC is enforced.
+func resolveSecretAPIKey(ctx context.Context, token, namespace, secretName string, logger *slog.Logger) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	baseConfig, err := helper.GetKubeconfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	cfg := rest.AnonymousClientConfig(baseConfig)
+	cfg.BearerToken = token
+	cfg.BearerTokenFile = ""
+	cfg.Username = ""
+	cfg.Password = ""
+	cfg.ExecProvider = nil
+	cfg.AuthProvider = nil
+
+	clientset, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret %q in namespace %q: %w", secretName, namespace, err)
+	}
+
+	apiKey, ok := secret.Data["api-key"]
+	if !ok || len(apiKey) == 0 {
+		return "", fmt.Errorf("secret %q does not contain an \"api-key\" data field", secretName)
+	}
+
+	logger.Debug("resolved API key from secret", slog.String("secret", secretName), slog.String("namespace", namespace))
+	return string(apiKey), nil
+}
 
 // VerifyConnectionHandler handles POST /api/v1/evaluations/verify-connection
 func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -58,17 +104,40 @@ func (app *App) VerifyConnectionHandler(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// Resolve secret_name → actual API key value from the Kubernetes Secret.
+	secretValue := req.SecretValue
+	if req.SecretName != "" {
+		namespace, _ := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+		identity, _ := ctx.Value(constants.RequestIdentityKey).(*kubernetes.RequestIdentity)
+		if identity == nil || identity.Token == "" {
+			app.serverErrorResponse(w, r, fmt.Errorf("missing user identity for secret lookup"))
+			return
+		}
+
+		resolved, err := resolveSecretAPIKey(ctx, identity.Token, namespace, req.SecretName, app.logger)
+		if err != nil {
+			app.logger.Warn("verify-connection: failed to resolve secret",
+				slog.String("secret_name", req.SecretName),
+				slog.String("namespace", namespace),
+				"error", err,
+			)
+			app.badRequestResponse(w, r, fmt.Errorf("failed to resolve secret %q: %w", req.SecretName, err))
+			return
+		}
+		secretValue = resolved
+	}
+
 	app.logger.Info("verify-connection: probing endpoint",
 		slog.String("source_type", req.SourceType),
 		slog.String("base_url", sanitizeURL(req.BaseURL)),
-		slog.Bool("has_secret", req.SecretValue != ""),
+		slog.Bool("has_secret", secretValue != ""),
 		slog.String("model_id", req.ModelID),
 	)
 
 	client, err := connectionprobe.NewConnectionProbeClient(
 		app.logger,
 		req.BaseURL,
-		req.SecretValue,
+		secretValue,
 		req.SourceType,
 		&connectionprobe.ClientOptions{
 			AllowHTTP:           app.config.DevMode || app.config.InsecureSkipVerify,

--- a/packages/eval-hub/bff/internal/api/verify_connection_handler_test.go
+++ b/packages/eval-hub/bff/internal/api/verify_connection_handler_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyConnectionHandler_MissingBaseURL(t *testing.T) {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com", Token: "test-token"}
+
+	body := models.VerifyConnectionRequest{
+		SourceType: "model",
+		BaseURL:    "",
+	}
+
+	result, response, err := setupApiTest[HTTPError](
+		http.MethodPost,
+		VerifyConnectionPath+"?namespace=test-ns",
+		body, nil, identity,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Contains(t, result.Error.Message, "base_url is required")
+}
+
+func TestVerifyConnectionHandler_MissingSourceType(t *testing.T) {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com", Token: "test-token"}
+
+	body := models.VerifyConnectionRequest{
+		SourceType: "",
+		BaseURL:    "https://api.example.com",
+	}
+
+	result, response, err := setupApiTest[HTTPError](
+		http.MethodPost,
+		VerifyConnectionPath+"?namespace=test-ns",
+		body, nil, identity,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Contains(t, result.Error.Message, "source_type is required")
+}
+
+func TestVerifyConnectionHandler_InvalidSourceType(t *testing.T) {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com", Token: "test-token"}
+
+	body := models.VerifyConnectionRequest{
+		SourceType: "invalid",
+		BaseURL:    "https://api.example.com",
+	}
+
+	result, response, err := setupApiTest[HTTPError](
+		http.MethodPost,
+		VerifyConnectionPath+"?namespace=test-ns",
+		body, nil, identity,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Contains(t, result.Error.Message, "invalid source_type")
+}
+
+func TestVerifyConnectionHandler_EmptyBody(t *testing.T) {
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com", Token: "test-token"}
+
+	result, response, err := setupApiTest[HTTPError](
+		http.MethodPost,
+		VerifyConnectionPath+"?namespace=test-ns",
+		nil, nil, identity,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.NotEmpty(t, result.Error.Message)
+}

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
@@ -1,0 +1,307 @@
+package connectionprobe
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+)
+
+const (
+	maxResponseBodySize = 10 * 1024 * 1024 // 10MB
+)
+
+// chatCompletionRequest represents an OpenAI-compatible chat completion request used for probing.
+type chatCompletionRequest struct {
+	Model    string                  `json:"model"`
+	Messages []chatCompletionMessage `json:"messages"`
+}
+
+type chatCompletionMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ClientOptions configures the connection probe client.
+type ClientOptions struct {
+	SkipSSRFValidation  bool
+	AllowHTTP           bool
+	SkipTLSVerification bool
+	RootCAs             *x509.CertPool
+}
+
+// ConnectionProbeClient handles connection verification for evaluation sources.
+type ConnectionProbeClient struct {
+	logger             *slog.Logger
+	httpClient         *http.Client
+	baseURL            string
+	secretValue        string
+	sourceType         string
+	skipSSRFValidation bool
+}
+
+// isPrivateIP checks if an IP is a loopback, RFC1918, or unique-local address.
+func isPrivateIP(ip net.IP) bool {
+	if ip.IsLoopback() {
+		return true
+	}
+
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 10 {
+			return true
+		}
+		if ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31 {
+			return true
+		}
+		if ip4[0] == 192 && ip4[1] == 168 {
+			return true
+		}
+	}
+
+	if len(ip) == net.IPv6len && ip[0] >= 0xfc && ip[0] <= 0xfd {
+		return true
+	}
+
+	return false
+}
+
+// isInternalHost returns true when the host belongs to a cluster-internal service
+// (*.svc.cluster.local). SSRF protection is skipped for internal hosts.
+func isInternalHost(rawURL string) bool {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	hostname := parsedURL.Hostname()
+	return strings.HasSuffix(hostname, ".svc.cluster.local")
+}
+
+func validateBaseURL(baseURL string, allowHTTP bool) error {
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return NewConnectionError(baseURL, fmt.Sprintf("Invalid base URL: %v", err))
+	}
+
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+		return NewConnectionError(baseURL, fmt.Sprintf("Base URL must use HTTP or HTTPS scheme, got: %s", parsedURL.Scheme))
+	}
+
+	if parsedURL.Scheme != "https" && !allowHTTP {
+		return NewConnectionError(baseURL, "Base URL must use HTTPS in production")
+	}
+
+	if parsedURL.Hostname() == "" {
+		return NewConnectionError(baseURL, "Base URL must contain a valid hostname")
+	}
+
+	return nil
+}
+
+func validateRequestSSRF(hostname string, logger *slog.Logger) error {
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve hostname %s: %w", hostname, err)
+	}
+
+	if len(ips) == 0 {
+		return fmt.Errorf("hostname %s resolved to no IP addresses", hostname)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("request blocked: destination %s resolves to private IP %s (SSRF protection)", hostname, ip.String())
+		}
+	}
+
+	logger.Debug("SSRF validation passed", "hostname", hostname, "ips", ips)
+	return nil
+}
+
+// NewConnectionProbeClient creates a client for verifying endpoint connectivity.
+func NewConnectionProbeClient(
+	logger *slog.Logger,
+	baseURL string,
+	secretValue string,
+	sourceType string,
+	opts *ClientOptions,
+) (*ConnectionProbeClient, error) {
+	if opts == nil {
+		opts = &ClientOptions{}
+	}
+
+	internal := isInternalHost(baseURL)
+	allowHTTP := opts.AllowHTTP || opts.SkipSSRFValidation || internal
+	if err := validateBaseURL(baseURL, allowHTTP); err != nil {
+		return nil, err
+	}
+
+	rootCAs := opts.RootCAs
+	if rootCAs == nil && !opts.SkipSSRFValidation {
+		var err error
+		rootCAs, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load system certificate pool: %w", err)
+		}
+	}
+
+	var transport http.RoundTripper
+	if opts.SkipTLSVerification || internal {
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // cluster-local services use self-signed certs
+				MinVersion:         tls.VersionTLS12,
+			},
+		}
+	} else if rootCAs != nil {
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    rootCAs,
+				MinVersion: tls.VersionTLS12,
+			},
+		}
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   35 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return &ConnectionProbeClient{
+		logger:             logger,
+		httpClient:         httpClient,
+		baseURL:            baseURL,
+		secretValue:        secretValue,
+		sourceType:         sourceType,
+		skipSSRFValidation: opts.SkipSSRFValidation || internal,
+	}, nil
+}
+
+// Probe tests connectivity to the configured endpoint and returns a response on success.
+func (c *ConnectionProbeClient) Probe(ctx context.Context, req models.VerifyConnectionRequest) (*models.VerifyConnectionResponse, error) {
+	startTime := time.Now()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	switch c.sourceType {
+	case "model", "agent":
+		return c.probeModelEndpoint(ctx, req, startTime)
+	case "prerecorded":
+		return c.probePrerecordedEndpoint(ctx, req, startTime)
+	default:
+		return c.probeModelEndpoint(ctx, req, startTime)
+	}
+}
+
+func (c *ConnectionProbeClient) probeModelEndpoint(ctx context.Context, req models.VerifyConnectionRequest, startTime time.Time) (*models.VerifyConnectionResponse, error) {
+	chatReq := chatCompletionRequest{
+		Model: "test",
+		Messages: []chatCompletionMessage{
+			{Role: "user", Content: "test"},
+		},
+	}
+	if req.ModelID != "" {
+		chatReq.Model = req.ModelID
+	}
+
+	requestBody, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to marshal request: %v", err))
+	}
+
+	fullURL := strings.TrimSuffix(c.baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to create request: %v", err))
+	}
+
+	if c.secretValue != "" && httpReq.URL.Scheme == "https" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretValue))
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	return c.executeAndMap(ctx, httpReq, fullURL, startTime)
+}
+
+func (c *ConnectionProbeClient) probePrerecordedEndpoint(ctx context.Context, _ models.VerifyConnectionRequest, startTime time.Time) (*models.VerifyConnectionResponse, error) {
+	fullURL := strings.TrimSuffix(c.baseURL, "/")
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodHead, fullURL, nil)
+	if err != nil {
+		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to create request: %v", err))
+	}
+
+	if c.secretValue != "" && httpReq.URL.Scheme == "https" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretValue))
+	}
+
+	return c.executeAndMap(ctx, httpReq, fullURL, startTime)
+}
+
+func (c *ConnectionProbeClient) executeAndMap(ctx context.Context, httpReq *http.Request, fullURL string, startTime time.Time) (*models.VerifyConnectionResponse, error) {
+	if !c.skipSSRFValidation {
+		parsedURL, err := url.Parse(fullURL)
+		if err != nil {
+			return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to parse request URL: %v", err))
+		}
+		if err := validateRequestSSRF(parsedURL.Hostname(), c.logger); err != nil {
+			return nil, NewConnectionError(c.baseURL, err.Error())
+		}
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, NewTimeoutError(c.baseURL)
+		}
+		return nil, NewConnectionError(c.baseURL, err.Error())
+	}
+	defer resp.Body.Close()
+
+	// Drain body with size limit
+	limitedReader := io.LimitReader(resp.Body, maxResponseBodySize)
+	responseBody, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to read response: %v", err))
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		elapsed := int(time.Since(startTime).Milliseconds())
+		return &models.VerifyConnectionResponse{
+			Success:      true,
+			Message:      "Connection verified successfully",
+			ResponseTime: elapsed,
+		}, nil
+	case http.StatusUnauthorized:
+		return nil, NewUnauthorizedError(c.baseURL)
+	case http.StatusForbidden:
+		return nil, NewForbiddenError(c.baseURL)
+	default:
+		errorMsg := fmt.Sprintf("Request to %s returned HTTP %d", fullURL, resp.StatusCode)
+		responseStr := strings.TrimSpace(string(responseBody))
+		if responseStr != "" {
+			errorMsg += fmt.Sprintf(": %s", responseStr)
+		} else if resp.StatusCode == http.StatusNotFound {
+			errorMsg += ". The endpoint may not exist or the base URL may be incorrect."
+		}
+		return nil, NewConnectionError(c.baseURL, errorMsg)
+	}
+}

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/client.go
@@ -227,13 +227,17 @@ func (c *ConnectionProbeClient) probeModelEndpoint(ctx context.Context, req mode
 		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to marshal request: %v", err))
 	}
 
-	fullURL := strings.TrimSuffix(c.baseURL, "/") + "/chat/completions"
+	trimmed := strings.TrimSuffix(c.baseURL, "/")
+	fullURL := trimmed + "/chat/completions"
+	if strings.HasSuffix(trimmed, "/chat/completions") {
+		fullURL = trimmed
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(requestBody))
 	if err != nil {
 		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to create request: %v", err))
 	}
 
-	if c.secretValue != "" && httpReq.URL.Scheme == "https" {
+	if c.secretValue != "" && (httpReq.URL.Scheme == "https" || isInternalHost(fullURL)) {
 		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretValue))
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -248,7 +252,7 @@ func (c *ConnectionProbeClient) probePrerecordedEndpoint(ctx context.Context, _ 
 		return nil, NewConnectionError(c.baseURL, fmt.Sprintf("Failed to create request: %v", err))
 	}
 
-	if c.secretValue != "" && httpReq.URL.Scheme == "https" {
+	if c.secretValue != "" && (httpReq.URL.Scheme == "https" || isInternalHost(fullURL)) {
 		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretValue))
 	}
 

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/client_test.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/client_test.go
@@ -1,0 +1,197 @@
+package connectionprobe
+
+import (
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{"loopback IPv4", "127.0.0.1", true},
+		{"loopback IPv4 alt", "127.0.0.2", true},
+		{"RFC1918 10.x", "10.0.0.1", true},
+		{"RFC1918 10.x high", "10.255.255.255", true},
+		{"RFC1918 172.16.x", "172.16.0.1", true},
+		{"RFC1918 172.31.x", "172.31.255.255", true},
+		{"RFC1918 192.168.x", "192.168.1.1", true},
+		{"RFC1918 192.168.0.0", "192.168.0.0", true},
+		{"public IP", "8.8.8.8", false},
+		{"public IP 2", "1.1.1.1", false},
+		{"public 172.32.x (outside range)", "172.32.0.1", false},
+		{"public 192.169.x", "192.169.1.1", false},
+		{"loopback IPv6", "::1", true},
+		{"unique local IPv6 fc00", "fc00::1", true},
+		{"unique local IPv6 fd00", "fd00::1", true},
+		{"public IPv6", "2001:db8::1", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			require.NotNil(t, ip, "failed to parse IP: %s", tc.ip)
+			assert.Equal(t, tc.expected, isPrivateIP(ip))
+		})
+	}
+}
+
+func TestIsInternalHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"cluster-local service", "http://svc.default.svc.cluster.local:8080", true},
+		{"cluster-local HTTPS", "https://my-svc.ns.svc.cluster.local/path", true},
+		{"external host", "https://api.example.com", false},
+		{"external with port", "https://api.example.com:443/v1", false},
+		{"partial match not suffix", "https://not-svc.cluster.local.evil.com", false},
+		{"empty string", "", false},
+		{"invalid URL", "://bad", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isInternalHost(tc.url))
+		})
+	}
+}
+
+func TestValidateBaseURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseURL   string
+		allowHTTP bool
+		wantErr   bool
+		errMsg    string
+	}{
+		{"valid HTTPS", "https://api.example.com/v1", false, false, ""},
+		{"valid HTTP with allowHTTP", "http://localhost:8080", true, false, ""},
+		{"HTTP without allowHTTP", "http://api.example.com", false, true, "must use HTTPS in production"},
+		{"invalid scheme ftp", "ftp://files.example.com", false, true, "HTTP or HTTPS scheme"},
+		{"no scheme", "api.example.com", false, true, "HTTP or HTTPS scheme"},
+		{"empty hostname", "https://", false, true, "valid hostname"},
+		{"valid with path", "https://example.com/api/v1", false, false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBaseURL(tc.baseURL, tc.allowHTTP)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewConnectionProbeClient_InternalHost(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	client, err := NewConnectionProbeClient(
+		logger,
+		"http://my-svc.default.svc.cluster.local:8080",
+		"secret-key",
+		"model",
+		&ClientOptions{SkipSSRFValidation: true},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, "http://my-svc.default.svc.cluster.local:8080", client.baseURL)
+	assert.Equal(t, "secret-key", client.secretValue)
+	assert.Equal(t, "model", client.sourceType)
+	assert.True(t, client.skipSSRFValidation)
+}
+
+func TestNewConnectionProbeClient_ExternalHost(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	client, err := NewConnectionProbeClient(
+		logger,
+		"https://api.example.com/v1",
+		"bearer-token",
+		"agent",
+		&ClientOptions{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Equal(t, "https://api.example.com/v1", client.baseURL)
+	assert.Equal(t, "agent", client.sourceType)
+	assert.False(t, client.skipSSRFValidation)
+}
+
+func TestNewConnectionProbeClient_SkipSSRFValidation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	client, err := NewConnectionProbeClient(
+		logger,
+		"http://localhost:8080",
+		"",
+		"prerecorded",
+		&ClientOptions{SkipSSRFValidation: true},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.True(t, client.skipSSRFValidation)
+}
+
+func TestNewConnectionProbeClient_InvalidURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	_, err := NewConnectionProbeClient(
+		logger,
+		"ftp://invalid.example.com",
+		"",
+		"model",
+		&ClientOptions{},
+	)
+
+	require.Error(t, err)
+	var probeErr *ConnectionProbeError
+	assert.ErrorAs(t, err, &probeErr)
+	assert.Equal(t, ErrCodeConnectionFailed, probeErr.Code)
+}
+
+func TestNewConnectionProbeClient_HTTPWithoutAllowHTTP(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	_, err := NewConnectionProbeClient(
+		logger,
+		"http://api.example.com",
+		"",
+		"model",
+		&ClientOptions{AllowHTTP: false, SkipSSRFValidation: false},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS in production")
+}
+
+func TestNewConnectionProbeClient_NilOptions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	client, err := NewConnectionProbeClient(
+		logger,
+		"https://api.example.com",
+		"",
+		"model",
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.False(t, client.skipSSRFValidation)
+}

--- a/packages/eval-hub/bff/internal/integrations/connectionprobe/errors.go
+++ b/packages/eval-hub/bff/internal/integrations/connectionprobe/errors.go
@@ -1,0 +1,62 @@
+package connectionprobe
+
+import "fmt"
+
+const (
+	ErrCodeConnectionFailed = "CONNECTION_FAILED"
+	ErrCodeTimeout          = "TIMEOUT"
+	ErrCodeUnauthorized     = "UNAUTHORIZED"
+	ErrCodeForbidden        = "FORBIDDEN"
+)
+
+// ConnectionProbeError represents connection verification errors with typed error codes.
+type ConnectionProbeError struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	BaseURL    string `json:"base_url,omitempty"`
+	StatusCode int    `json:"-"`
+}
+
+func (e *ConnectionProbeError) Error() string {
+	if e.BaseURL != "" {
+		return fmt.Sprintf("Connection probe error [%s] for %s: %s",
+			e.Code, e.BaseURL, e.Message)
+	}
+	return fmt.Sprintf("Connection probe error [%s]: %s", e.Code, e.Message)
+}
+
+func NewConnectionError(baseURL, message string) *ConnectionProbeError {
+	return &ConnectionProbeError{
+		Code:       ErrCodeConnectionFailed,
+		Message:    message,
+		BaseURL:    baseURL,
+		StatusCode: 503,
+	}
+}
+
+func NewTimeoutError(baseURL string) *ConnectionProbeError {
+	return &ConnectionProbeError{
+		Code:       ErrCodeTimeout,
+		Message:    "Request timed out connecting to endpoint",
+		BaseURL:    baseURL,
+		StatusCode: 408,
+	}
+}
+
+func NewUnauthorizedError(baseURL string) *ConnectionProbeError {
+	return &ConnectionProbeError{
+		Code:       ErrCodeUnauthorized,
+		Message:    "API key is invalid or unauthorized",
+		BaseURL:    baseURL,
+		StatusCode: 401,
+	}
+}
+
+func NewForbiddenError(baseURL string) *ConnectionProbeError {
+	return &ConnectionProbeError{
+		Code:       ErrCodeForbidden,
+		Message:    "Access forbidden — insufficient permissions",
+		BaseURL:    baseURL,
+		StatusCode: 403,
+	}
+}

--- a/packages/eval-hub/bff/internal/models/inferenceservice.go
+++ b/packages/eval-hub/bff/internal/models/inferenceservice.go
@@ -1,0 +1,12 @@
+package models
+
+type InferenceServiceItem struct {
+	Name  string `json:"name"`
+	URL   string `json:"url,omitempty"`
+	Ready bool   `json:"ready"`
+}
+
+type InferenceServicesResponse struct {
+	Items   []InferenceServiceItem `json:"items"`
+	Warning string                 `json:"warning,omitempty"`
+}

--- a/packages/eval-hub/bff/internal/models/verify_connection.go
+++ b/packages/eval-hub/bff/internal/models/verify_connection.go
@@ -1,0 +1,14 @@
+package models
+
+type VerifyConnectionRequest struct {
+	SourceType  string `json:"source_type"`
+	BaseURL     string `json:"base_url"`
+	SecretValue string `json:"secret_value,omitempty"`
+	ModelID     string `json:"model_id,omitempty"`
+}
+
+type VerifyConnectionResponse struct {
+	Success      bool   `json:"success"`
+	Message      string `json:"message"`
+	ResponseTime int    `json:"response_time_ms,omitempty"`
+}

--- a/packages/eval-hub/bff/internal/models/verify_connection.go
+++ b/packages/eval-hub/bff/internal/models/verify_connection.go
@@ -3,6 +3,7 @@ package models
 type VerifyConnectionRequest struct {
 	SourceType  string `json:"source_type"`
 	BaseURL     string `json:"base_url"`
+	SecretName  string `json:"secret_name,omitempty"`
 	SecretValue string `json:"secret_value,omitempty"`
 	ModelID     string `json:"model_id,omitempty"`
 }

--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -908,9 +908,18 @@ components:
           format: uri
           description: Endpoint URL to verify
           example: 'https://api.example.com/v1'
+        secret_name:
+          type: string
+          description: >-
+            Name of a Kubernetes Secret (in the request namespace) whose "api-key"
+            data field contains the authentication credential. Mutually exclusive
+            with secret_value; secret_name takes precedence when both are provided.
+          example: 'my-api-key-secret'
         secret_value:
           type: string
-          description: Optional API key or bearer token for authentication
+          description: >-
+            Literal API key or bearer token for authentication (used for pre-recorded
+            sources or when the key is not stored in a Kubernetes Secret).
         model_id:
           type: string
           description: Model identifier to include in the test request (model/agent sources)

--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -191,6 +191,7 @@ paths:
       security:
         - Bearer: []
       parameters:
+        - $ref: '#/components/parameters/namespace'
         - name: limit
           in: query
           schema:
@@ -206,11 +207,6 @@ paths:
             default: 0
             minimum: 0
           description: Offset for pagination
-        - name: search
-          in: query
-          schema:
-            type: string
-          description: Filter benchmarks by name (case-insensitive substring match)
       responses:
         '200':
           $ref: '#/components/responses/ProvidersResponse'
@@ -355,6 +351,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InferenceServicesResponse'
+              example:
+                items:
+                  - name: 'llama-32-1b-instruct'
+                    url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+                    ready: true
+                  - name: 'mistral-7b'
+                    url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
+                    ready: true
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -399,7 +403,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyConnectionResponse'
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/components/schemas/VerifyConnectionResponse'
+              example:
+                data:
+                  success: true
+                  message: 'Connection successful'
+                  response_time_ms: 120
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -862,6 +876,14 @@ components:
             Warning message when the listing degrades gracefully (e.g. CRD
             not installed, user lacks access). Present only when the BFF
             could not list resources but did not hard-fail.
+      example:
+        items:
+          - name: 'llama-32-1b-instruct'
+            url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+            ready: true
+          - name: 'mistral-7b'
+            url: 'http://mistral-7b-predictor.default.svc.cluster.local:8080/v1'
+            ready: true
 
     # -------------------------------------------------------------------------
     # Connection verification schemas

--- a/packages/eval-hub/bff/openapi/src/eval-hub.yaml
+++ b/packages/eval-hub/bff/openapi/src/eval-hub.yaml
@@ -113,12 +113,60 @@ paths:
     description: >-
       Lists all benchmark collections from the EvalHub control plane.
       Returns collections with their benchmarks, tags, and metadata.
-      When the upstream EvalHub API is unavailable, mock data is returned in mock mode.
     get:
       tags:
         - Collections
       security:
         - Bearer: []
+      parameters:
+        - name: namespace
+          in: query
+          description: Kubernetes namespace to scope the collections request (tenant)
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of collections to return (1-100, default 50)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          description: Number of collections to skip for pagination (default 0)
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: name
+          in: query
+          description: Filter collections by name (case-insensitive substring match)
+          required: false
+          schema:
+            type: string
+        - name: category
+          in: query
+          description: Filter collections by category (exact match)
+          required: false
+          schema:
+            type: string
+        - name: tags
+          in: query
+          description: Filter collections by tags (comma-separated)
+          required: false
+          schema:
+            type: string
+        - name: scope
+          in: query
+          description: Limit to system-defined or tenant-defined collections
+          required: false
+          schema:
+            type: string
+            enum: [system, tenant]
       responses:
         '200':
           $ref: '#/components/responses/CollectionsResponse'
@@ -130,7 +178,51 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       operationId: listCollections
       summary: List Collections
-      description: Gets a list of all benchmark collections from the EvalHub server.
+      description: Gets a paginated, filterable list of benchmark collections from the EvalHub server.
+
+  /eval-hub/api/v1/evaluations/providers:
+    summary: List evaluation providers
+    description: >-
+      Lists all evaluation providers from the EvalHub control plane.
+      Each provider exposes a catalogue of benchmarks available for evaluation.
+    get:
+      tags:
+        - Providers
+      security:
+        - Bearer: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 100
+          description: Maximum number of providers to return
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: Offset for pagination
+        - name: search
+          in: query
+          schema:
+            type: string
+          description: Filter benchmarks by name (case-insensitive substring match)
+      responses:
+        '200':
+          $ref: '#/components/responses/ProvidersResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      operationId: listProviders
+      summary: List Providers
+      description: Gets a list of all evaluation providers with their benchmark catalogues.
 
   /eval-hub/api/v1/evaluations/jobs:
     summary: List evaluation jobs
@@ -162,6 +254,49 @@ paths:
       operationId: listEvaluationJobs
       summary: List Evaluation Jobs
       description: Gets a list of all evaluation jobs from the EvalHub server.
+    post:
+      tags:
+        - Evaluations
+      security:
+        - Bearer: []
+      parameters:
+        - in: query
+          name: namespace
+          schema:
+            type: string
+          required: true
+          description: Kubernetes namespace to scope the evaluation job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEvaluationJobRequest'
+            example:
+              name: 'test-eval-02-03'
+              description: 'A test evaluation'
+              model:
+                url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+                name: 'llama-32-1b-instruct'
+              benchmarks:
+                - id: 'arc_easy'
+                  provider_id: 'lm_evaluation_harness'
+                  parameters:
+                    num_examples: 10
+                    limit: 5
+                    tokenizer: 'google/flan-t5-small'
+      responses:
+        '201':
+          $ref: '#/components/responses/CreateEvaluationJobResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      operationId: createEvaluationJob
+      summary: Create Evaluation Job
+      description: Creates and starts a new evaluation run against the EvalHub control plane.
 
   /eval-hub/api/v1/evaluations/jobs/{id}:
     summary: Cancel or delete an evaluation job
@@ -195,6 +330,98 @@ paths:
       description: >-
         Cancels a running evaluation job (soft cancel) or permanently
         deletes it (hard delete) depending on the hard_delete parameter.
+
+  # =============================================================================
+  # INFERENCE SERVICES
+  # =============================================================================
+
+  /eval-hub/api/v1/inferenceservices:
+    summary: List InferenceService resources
+    description: >-
+      Lists InferenceService resources (serving.kserve.io/v1beta1) in the
+      user's namespace. Uses the caller's bearer token for RBAC enforcement.
+      Degrades gracefully if the CRD is not installed or the user lacks access.
+    get:
+      tags:
+        - InferenceServices
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/namespace'
+      responses:
+        '200':
+          description: List of InferenceService resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InferenceServicesResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      operationId: listInferenceServices
+      summary: List InferenceServices
+      description: >-
+        Returns deployed InferenceService models in the namespace. Returns
+        an empty list with a warning field if the CRD is not installed or
+        the user lacks access.
+
+  # =============================================================================
+  # CONNECTION VERIFICATION
+  # =============================================================================
+
+  /eval-hub/api/v1/evaluations/verify-connection:
+    summary: Verify endpoint connectivity
+    description: >-
+      Validates that an endpoint URL is reachable and responds correctly
+      before committing to a full evaluation run. Supports model, agent,
+      and pre-recorded data source types.
+    post:
+      tags:
+        - Evaluations
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/namespace'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyConnectionRequest'
+            example:
+              source_type: 'model'
+              base_url: 'https://api.example.com/v1'
+              model_id: 'llama-3.2-1b-instruct'
+      responses:
+        '200':
+          description: Connection verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyConnectionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '408':
+          description: Connection timed out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '503':
+          description: Endpoint unreachable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+      operationId: verifyConnection
+      summary: Verify Endpoint Connection
+      description: >-
+        Probes the given endpoint to verify connectivity. For model/agent
+        sources, sends a test request to /chat/completions. For pre-recorded
+        sources, performs a HEAD request to the dataset URL.
 
 components:
   # =============================================================================
@@ -389,6 +616,13 @@ components:
           items:
             $ref: '#/components/schemas/BenchmarkResult'
 
+    ModelAuth:
+      type: object
+      properties:
+        secret_ref:
+          type: string
+          description: Reference to a Kubernetes secret containing the API key or token
+
     JobModel:
       type: object
       required:
@@ -396,10 +630,59 @@ components:
       properties:
         url:
           type: string
+          description: Inference endpoint URL for the model
+          example: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
         name:
           type: string
-          example: 'meta-llama/Llama-3.1-8B-Instruct'
-          description: Model being evaluated
+          example: 'llama-32-1b-instruct'
+          description: Name of the model or agent being evaluated
+        parameters:
+          type: object
+          additionalProperties: true
+          description: Additional model-level parameters
+        auth:
+          $ref: '#/components/schemas/ModelAuth'
+
+    S3DataRef:
+      type: object
+      properties:
+        bucket:
+          type: string
+          description: S3 bucket name
+        key:
+          type: string
+          description: S3 object key or dataset URL
+        secret_ref:
+          type: string
+          description: Reference to a secret for S3 access credentials
+
+    TestDataRef:
+      type: object
+      properties:
+        s3:
+          $ref: '#/components/schemas/S3DataRef'
+
+    JobPrimaryScore:
+      type: object
+      required:
+        - metric
+        - lower_is_better
+      properties:
+        metric:
+          type: string
+          description: Name of the primary scoring metric
+        lower_is_better:
+          type: boolean
+          description: Whether a lower score indicates better performance
+
+    JobPassCriteria:
+      type: object
+      required:
+        - threshold
+      properties:
+        threshold:
+          type: number
+          description: Minimum score threshold to pass
 
     JobBenchmark:
       type: object
@@ -413,9 +696,20 @@ components:
         provider_id:
           type: string
           example: 'lm_evaluation_harness'
+          description: ID of the evaluation provider that runs this benchmark
+        weight:
+          type: number
+          description: Relative weight of this benchmark in a collection (default 1)
+        primary_score:
+          $ref: '#/components/schemas/JobPrimaryScore'
+        pass_criteria:
+          $ref: '#/components/schemas/JobPassCriteria'
         parameters:
           type: object
           additionalProperties: true
+          description: Runtime parameters passed to the benchmark (e.g. num_examples, limit, tokenizer)
+        test_data_ref:
+          $ref: '#/components/schemas/TestDataRef'
 
     EvaluationJob:
       type: object
@@ -432,12 +726,234 @@ components:
           $ref: '#/components/schemas/JobStatus'
         results:
           $ref: '#/components/schemas/JobResults'
+        name:
+          type: string
+          description: User-provided name for the evaluation run
+        description:
+          type: string
+          description: User-provided description
+        tags:
+          type: array
+          items:
+            type: string
         model:
           $ref: '#/components/schemas/JobModel'
+        pass_criteria:
+          $ref: '#/components/schemas/JobPassCriteria'
         benchmarks:
           type: array
           items:
             $ref: '#/components/schemas/JobBenchmark'
+        collection:
+          $ref: '#/components/schemas/JobCollection'
+        experiment:
+          $ref: '#/components/schemas/JobExperiment'
+        custom:
+          type: object
+          additionalProperties: true
+        exports:
+          $ref: '#/components/schemas/JobExports'
+
+    ExperimentTag:
+      type: object
+      required:
+        - key
+        - value
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+
+    JobExperiment:
+      type: object
+      properties:
+        name:
+          type: string
+          description: MLflow experiment name
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentTag'
+        artifact_location:
+          type: string
+          description: Storage location for experiment artifacts
+
+    JobCollection:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: ID of the benchmark collection to run
+
+    OciCoordinates:
+      type: object
+      properties:
+        oci_host:
+          type: string
+        oci_repository:
+          type: string
+        oci_tag:
+          type: string
+        oci_subject:
+          type: string
+        annotations:
+          type: object
+          additionalProperties:
+            type: string
+
+    OciK8s:
+      type: object
+      properties:
+        connection:
+          type: string
+
+    OciExport:
+      type: object
+      properties:
+        coordinates:
+          $ref: '#/components/schemas/OciCoordinates'
+        k8s:
+          $ref: '#/components/schemas/OciK8s'
+
+    JobExports:
+      type: object
+      properties:
+        oci:
+          $ref: '#/components/schemas/OciExport'
+
+    # -------------------------------------------------------------------------
+    # InferenceService schemas
+    # -------------------------------------------------------------------------
+
+    InferenceServiceItem:
+      type: object
+      required:
+        - name
+        - ready
+      properties:
+        name:
+          type: string
+          description: Name of the InferenceService resource
+          example: 'llama-32-1b-instruct'
+        url:
+          type: string
+          description: Serving URL if the service is ready
+          example: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+        ready:
+          type: boolean
+          description: Whether the InferenceService is in a Ready state
+          example: true
+
+    InferenceServicesResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceServiceItem'
+        warning:
+          type: string
+          description: >-
+            Warning message when the listing degrades gracefully (e.g. CRD
+            not installed, user lacks access). Present only when the BFF
+            could not list resources but did not hard-fail.
+
+    # -------------------------------------------------------------------------
+    # Connection verification schemas
+    # -------------------------------------------------------------------------
+
+    VerifyConnectionRequest:
+      type: object
+      required:
+        - source_type
+        - base_url
+      properties:
+        source_type:
+          type: string
+          enum:
+            - model
+            - agent
+            - prerecorded
+          description: Type of evaluation source being verified
+          example: 'model'
+        base_url:
+          type: string
+          format: uri
+          description: Endpoint URL to verify
+          example: 'https://api.example.com/v1'
+        secret_value:
+          type: string
+          description: Optional API key or bearer token for authentication
+        model_id:
+          type: string
+          description: Model identifier to include in the test request (model/agent sources)
+          example: 'llama-3.2-1b-instruct'
+
+    VerifyConnectionResponse:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: Whether the connection probe succeeded
+          example: true
+        message:
+          type: string
+          description: Human-readable result summary
+          example: 'Connection successful'
+        response_time_ms:
+          type: integer
+          description: Round-trip time in milliseconds (present on success)
+          example: 142
+
+    # -------------------------------------------------------------------------
+    # Evaluation job schemas
+    # -------------------------------------------------------------------------
+
+    CreateEvaluationJobRequest:
+      type: object
+      required:
+        - name
+        - model
+        - benchmarks
+      properties:
+        name:
+          type: string
+          description: Name for the evaluation run
+          example: 'test-eval-02-03'
+        description:
+          type: string
+          description: Optional description
+          example: 'A test evaluation'
+        tags:
+          type: array
+          items:
+            type: string
+        model:
+          $ref: '#/components/schemas/JobModel'
+        pass_criteria:
+          $ref: '#/components/schemas/JobPassCriteria'
+        benchmarks:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/JobBenchmark'
+        collection:
+          $ref: '#/components/schemas/JobCollection'
+        experiment:
+          $ref: '#/components/schemas/JobExperiment'
+        custom:
+          type: object
+          additionalProperties: true
+        exports:
+          $ref: '#/components/schemas/JobExports'
 
     EvaluationJobsData:
       type: object
@@ -538,6 +1054,10 @@ components:
         name:
           type: string
           example: 'Open LLM Leaderboard v2'
+        category:
+          type: string
+          example: 'General'
+          nullable: true
         description:
           type: string
           nullable: true
@@ -559,10 +1079,209 @@ components:
           nullable: true
 
     CollectionsData:
-      type: array
-      items:
-        $ref: '#/components/schemas/Collection'
-      description: Array of benchmark collections
+      type: object
+      description: Paginated list of benchmark collections
+      properties:
+        total_count:
+          type: integer
+          example: 20
+          description: Total number of collections matching the query
+        limit:
+          type: integer
+          example: 6
+          description: Maximum number of items returned
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Collection'
+
+    ProviderResource:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 'lm_evaluation_harness'
+        tenant:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        read_only:
+          type: boolean
+          nullable: true
+        owner:
+          type: string
+          nullable: true
+
+    ProviderBenchmarkPrimaryScore:
+      type: object
+      required:
+        - metric
+        - lower_is_better
+      properties:
+        metric:
+          type: string
+        lower_is_better:
+          type: boolean
+
+    ProviderBenchmarkPassCriteria:
+      type: object
+      required:
+        - threshold
+      properties:
+        threshold:
+          type: number
+
+    ProviderBenchmark:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          example: 'truthfulqa_mc1'
+        name:
+          type: string
+          example: 'Truthfulness Testing'
+        description:
+          type: string
+          nullable: true
+          example: 'Tests whether models give truthful answers to questions where humans often answer incorrectly.'
+        category:
+          type: string
+          nullable: true
+          example: 'Safety'
+        metrics:
+          type: array
+          items:
+            type: string
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+        num_few_shot:
+          type: integer
+          nullable: true
+        dataset_size:
+          type: integer
+          nullable: true
+        primary_score:
+          $ref: '#/components/schemas/ProviderBenchmarkPrimaryScore'
+        pass_criteria:
+          $ref: '#/components/schemas/ProviderBenchmarkPassCriteria'
+
+    ProviderEnvVar:
+      type: object
+      required:
+        - name
+        - value
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+
+    ProviderK8sRuntime:
+      type: object
+      description: Kubernetes-specific runtime configuration for a provider.
+      properties:
+        image:
+          type: string
+          nullable: true
+        entrypoint:
+          type: array
+          items:
+            type: string
+          nullable: true
+        cpu_request:
+          type: string
+          nullable: true
+        memory_request:
+          type: string
+          nullable: true
+        cpu_limit:
+          type: string
+          nullable: true
+        memory_limit:
+          type: string
+          nullable: true
+        env:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderEnvVar'
+          nullable: true
+
+    ProviderLocalRuntime:
+      type: object
+      description: Local execution runtime configuration for a provider.
+      properties:
+        command:
+          type: string
+          nullable: true
+        env:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderEnvVar'
+          nullable: true
+
+    ProviderRuntime:
+      type: object
+      description: Describes how a provider executes benchmarks (Kubernetes or local).
+      properties:
+        k8s:
+          $ref: '#/components/schemas/ProviderK8sRuntime'
+        local:
+          $ref: '#/components/schemas/ProviderLocalRuntime'
+
+    Provider:
+      type: object
+      properties:
+        resource:
+          $ref: '#/components/schemas/ProviderResource'
+        name:
+          type: string
+          example: 'lm_evaluation_harness'
+        title:
+          type: string
+          nullable: true
+          example: 'LM Evaluation Harness'
+        description:
+          type: string
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+        runtime:
+          $ref: '#/components/schemas/ProviderRuntime'
+        benchmarks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderBenchmark'
+          nullable: true
+
+    ProvidersData:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Provider'
+        total_count:
+          type: integer
+          nullable: true
 
     Error:
       type: object
@@ -712,17 +1431,83 @@ components:
                 $ref: '#/components/schemas/CollectionsData'
           example:
             data:
-              - resource:
-                  id: 'collection-001'
-                name: 'Open LLM Leaderboard v2'
-                description: 'Comprehensive evaluation suite for general-purpose language models.'
-                tags:
-                  - 'Comprehensive'
-                  - 'Industry Standard'
-                benchmarks:
-                  - id: 'arc_challenge'
-                    provider_id: 'lm_evaluation_harness'
-                    weight: 1
+              total_count: 1
+              limit: 50
+              items:
+                - resource:
+                    id: 'collection-001'
+                  name: 'Open LLM Leaderboard v2'
+                  description: 'Comprehensive evaluation suite for general-purpose language models.'
+                  tags:
+                    - 'Comprehensive'
+                    - 'Industry Standard'
+                  benchmarks:
+                    - id: 'arc_challenge'
+                      provider_id: 'lm_evaluation_harness'
+                      weight: 1
+
+    ProvidersResponse:
+      description: List of evaluation providers with their benchmark catalogues
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: '#/components/schemas/ProvidersData'
+          example:
+            data:
+              items:
+                - resource:
+                    id: 'lm_evaluation_harness'
+                  name: 'lm_evaluation_harness'
+                  title: 'LM Evaluation Harness'
+                  runtime:
+                    k8s:
+                      image: 'quay.io/opendatahub/lm-eval:latest'
+                  benchmarks:
+                    - id: 'truthfulqa_mc1'
+                      name: 'Truthfulness Testing'
+                      category: 'Safety'
+                      metrics:
+                        - 'Instruction adherence'
+                        - 'Format compliance'
+              total_count: 20
+
+    CreateEvaluationJobResponse:
+      description: Evaluation job created successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: '#/components/schemas/EvaluationJob'
+          example:
+            data:
+              resource:
+                id: 'eval-job-new-001'
+                created_at: '2026-03-09T12:00:00Z'
+                updated_at: '2026-03-09T12:00:00Z'
+              status:
+                state: 'pending'
+              results: {}
+              model:
+                url: 'http://llama-32-1b-instruct-predictor.default.svc.cluster.local:8080/v1'
+                name: 'llama-32-1b-instruct'
+              name: 'test-eval-02-03'
+              description: 'A test evaluation'
+              benchmarks:
+                - id: 'arc_easy'
+                  provider_id: 'lm_evaluation_harness'
+                  parameters:
+                    num_examples: 10
+                    limit: 5
+                    tokenizer: 'google/flan-t5-small'
 
     CancelEvaluationJobResponse:
       description: Evaluation job cancelled or deleted successfully
@@ -869,3 +1654,5 @@ tags:
     description: LLM evaluation job management via EvalHub
   - name: Collections
     description: Benchmark collection management via EvalHub
+  - name: Providers
+    description: Evaluation provider and benchmark catalogue management via EvalHub

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/pages/startEvaluationRunPage.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/pages/startEvaluationRunPage.ts
@@ -37,16 +37,28 @@ class StartEvaluationRunPage {
     return cy.findByTestId('new-experiment-name-input');
   }
 
-  findInputModeInference() {
-    return cy.findByTestId('input-mode-inference');
+  findSourceModeToggle() {
+    return cy.findByTestId('source-mode-toggle');
   }
 
-  findInputModePrerecorded() {
-    return cy.findByTestId('input-mode-prerecorded');
+  findSourceModeSelect() {
+    return cy.findByTestId('source-mode-select');
+  }
+
+  findModelPickerToggle() {
+    return cy.findByTestId('model-picker-toggle');
+  }
+
+  findModelPickerSelect() {
+    return cy.findByTestId('model-picker-select');
   }
 
   findModelNameInput() {
     return cy.findByTestId('model-name-input');
+  }
+
+  findAgentNameInput() {
+    return cy.findByTestId('agent-name-input');
   }
 
   findEndpointUrlInput() {
@@ -67,6 +79,10 @@ class StartEvaluationRunPage {
 
   findAccessTokenInput() {
     return cy.findByTestId('access-token-input');
+  }
+
+  findValidateConnectionButton() {
+    return cy.findByTestId('validate-connection-button');
   }
 
   findBenchmarkThreshold() {

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
@@ -21,6 +21,18 @@ const mockMlflowExperiments = (experiments: { id: string; name: string }[] = [])
   });
 };
 
+const mockInferenceServices = (items: { name: string; url?: string; ready: boolean }[] = []) => {
+  cy.interceptApi('GET /api/:apiVersion/inferenceservices', { path: API_VERSION }, { items });
+};
+
+const mockVerifyConnectionSuccess = () => {
+  cy.interceptApi(
+    'POST /api/:apiVersion/evaluations/verify-connection',
+    { path: API_VERSION },
+    { success: true, message: 'Connection established successfully.', response_time_ms: 120 },
+  ).as('verifyConnection');
+};
+
 const testProvider = mockProvider({
   id: 'test-provider',
   name: 'test-provider',
@@ -70,6 +82,27 @@ const initBaseIntercepts = () => {
     { path: API_VERSION },
     mockCollectionsListResponse([]),
   );
+
+  mockInferenceServices([]);
+  mockVerifyConnectionSuccess();
+};
+
+const selectSourceMode = (mode: 'Model' | 'Agent' | 'Pre-recorded responses') => {
+  startEvaluationRunPage.findSourceModeToggle().click();
+  cy.findByRole('option', { name: mode }).click();
+};
+
+const selectExternalEndpoint = () => {
+  startEvaluationRunPage.findModelPickerToggle().click();
+  cy.findByTestId('model-option-external').click();
+};
+
+const fillExternalModelFields = (modelName: string, endpointUrl: string) => {
+  selectExternalEndpoint();
+  startEvaluationRunPage.findModelNameInput().type(modelName);
+  startEvaluationRunPage.findEndpointUrlInput().type(endpointUrl);
+  startEvaluationRunPage.findValidateConnectionButton().click();
+  cy.wait('@verifyConnection');
 };
 
 const navigateToBenchmarkStart = () => {
@@ -110,10 +143,8 @@ describe('Start Evaluation Run - Benchmark Mode', () => {
 
     startEvaluationRunPage.findBenchmarkNameDisplay().should('contain.text', 'Alpha Bench');
     startEvaluationRunPage.findEvaluationNameInput().should('not.have.value', '');
-    startEvaluationRunPage.findInputModeInference().should('be.checked');
-    startEvaluationRunPage.findModelNameInput().should('exist');
-    startEvaluationRunPage.findEndpointUrlInput().should('exist');
-    startEvaluationRunPage.findApiKeyInput().should('exist');
+    startEvaluationRunPage.findSourceModeToggle().should('contain.text', 'Model');
+    startEvaluationRunPage.findModelPickerToggle().should('exist');
     startEvaluationRunPage.findSubmitButton().should('exist');
     startEvaluationRunPage.findCancelButton().should('exist');
   });
@@ -132,18 +163,31 @@ describe('Start Evaluation Run - Benchmark Mode', () => {
     startEvaluationRunPage.findSubmitButton().should('be.disabled');
   });
 
-  it('should toggle between inference and pre-recorded input modes', () => {
+  it('should switch between source modes via dropdown', () => {
     navigateToBenchmarkStart();
 
-    startEvaluationRunPage.findInputModeInference().should('be.checked');
-    startEvaluationRunPage.findModelNameInput().should('exist');
-    startEvaluationRunPage.findEndpointUrlInput().should('exist');
+    startEvaluationRunPage.findSourceModeToggle().should('contain.text', 'Model');
+    startEvaluationRunPage.findModelPickerToggle().should('exist');
 
-    startEvaluationRunPage.findInputModePrerecorded().click();
+    selectSourceMode('Agent');
+    startEvaluationRunPage.findAgentNameInput().should('exist');
+    startEvaluationRunPage.findEndpointUrlInput().should('exist');
+    startEvaluationRunPage.findModelPickerToggle().should('not.exist');
+
+    selectSourceMode('Pre-recorded responses');
     startEvaluationRunPage.findSourceNameInput().should('exist');
     startEvaluationRunPage.findDatasetUrlInput().should('exist');
-    startEvaluationRunPage.findAccessTokenInput().should('exist');
-    startEvaluationRunPage.findModelNameInput().should('not.exist');
+    startEvaluationRunPage.findAgentNameInput().should('not.exist');
+  });
+
+  it('should show external model fields when selecting Other (External endpoint)', () => {
+    navigateToBenchmarkStart();
+
+    selectExternalEndpoint();
+    startEvaluationRunPage.findModelNameInput().should('exist');
+    startEvaluationRunPage.findEndpointUrlInput().should('exist');
+    startEvaluationRunPage.findApiKeyInput().should('exist');
+    startEvaluationRunPage.findValidateConnectionButton().should('exist');
   });
 
   it('should submit evaluation job and show success toast', () => {
@@ -159,8 +203,7 @@ describe('Start Evaluation Run - Benchmark Mode', () => {
 
     navigateToBenchmarkStart();
 
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    fillExternalModelFields('my-model', 'https://api.example.com/v1');
     startEvaluationRunPage.findSubmitButton().should('be.enabled');
     startEvaluationRunPage.findSubmitButton().click();
 
@@ -224,8 +267,7 @@ describe('Start Evaluation Run - Benchmark Threshold & Primary Metric', () => {
 
     navigateToBenchmarkStart();
 
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    fillExternalModelFields('my-model', 'https://api.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createJobWithThreshold').then((interception) => {
@@ -260,8 +302,7 @@ describe('Start Evaluation Run - Benchmark Threshold & Primary Metric', () => {
       .find('input[type="number"]')
       .type('{selectall}50');
 
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    fillExternalModelFields('my-model', 'https://api.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createJobThresholdOverride').then((interception) => {
@@ -288,8 +329,7 @@ describe('Start Evaluation Run - Benchmark Threshold & Primary Metric', () => {
     startEvaluationRunPage.findPrimaryScorerMetricToggle().click();
     cy.findByRole('option', { name: 'f1' }).click();
 
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    fillExternalModelFields('my-model', 'https://api.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createJobWithMetric').then((interception) => {
@@ -342,8 +382,7 @@ describe('Start Evaluation Run - Collection Threshold', () => {
       .find('input[type="number"]')
       .type('{selectall}85');
 
-    startEvaluationRunPage.findModelNameInput().type('safety-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://safety.example.com/v1');
+    fillExternalModelFields('safety-model', 'https://safety.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createCollectionJobThresholdOverride').then((interception) => {
@@ -365,8 +404,7 @@ describe('Start Evaluation Run - Collection Threshold', () => {
 
     navigateToCollectionStart();
 
-    startEvaluationRunPage.findModelNameInput().type('safety-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://safety.example.com/v1');
+    fillExternalModelFields('safety-model', 'https://safety.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createCollectionJobThreshold').then((interception) => {
@@ -390,8 +428,7 @@ describe('Start Evaluation Run - Submission Error', () => {
       { statusCode: 500, body: { message: 'Internal server error' } },
     ).as('createJobFail');
 
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    fillExternalModelFields('my-model', 'https://api.example.com/v1');
     startEvaluationRunPage.findSubmitButton().click();
 
     cy.wait('@createJobFail');
@@ -430,8 +467,7 @@ describe('Start Evaluation Run - Collection Mode', () => {
 
     navigateToCollectionStart();
 
-    startEvaluationRunPage.findModelNameInput().type('safety-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://safety.example.com/v1');
+    fillExternalModelFields('safety-model', 'https://safety.example.com/v1');
     startEvaluationRunPage.findSubmitButton().should('be.enabled');
     startEvaluationRunPage.findSubmitButton().click();
 
@@ -503,9 +539,11 @@ describe('Start Evaluation Run - Pre-recorded Mode', () => {
 
     navigateToBenchmarkStart();
 
-    startEvaluationRunPage.findInputModePrerecorded().click();
+    selectSourceMode('Pre-recorded responses');
     startEvaluationRunPage.findSourceNameInput().type('gpt-4-responses');
     startEvaluationRunPage.findDatasetUrlInput().type('s3://bucket/dataset.jsonl');
+    startEvaluationRunPage.findValidateConnectionButton().click();
+    cy.wait('@verifyConnection');
     startEvaluationRunPage.findSubmitButton().should('be.enabled');
     startEvaluationRunPage.findSubmitButton().click();
 
@@ -528,6 +566,76 @@ describe('Start Evaluation Run - Cancel', () => {
 
     cy.url().should('include', `/evaluation/${NAMESPACE}`);
     cy.url().should('not.include', '/create');
+  });
+});
+
+describe('Start Evaluation Run - Cluster Model Selection', () => {
+  beforeEach(() => {
+    initBaseIntercepts();
+    mockMlflowExperiments([]);
+  });
+
+  it('should allow selecting a cluster InferenceService and enable submit without validation', () => {
+    mockInferenceServices([
+      { name: 'llama-3.2-1b-instruct', url: 'http://llama.svc.cluster.local:8080/v1', ready: true },
+      { name: 'mistral-7b-instruct', url: 'http://mistral.svc.cluster.local:8080/v1', ready: true },
+    ]);
+
+    const createdJob = mockEvaluationJob({
+      id: 'new-eval-cluster',
+      name: 'cluster-eval',
+      state: 'running',
+    });
+
+    cy.interceptApi('POST /api/:apiVersion/evaluations/jobs', { path: API_VERSION }, createdJob).as(
+      'createClusterJob',
+    );
+
+    navigateToBenchmarkStart();
+
+    startEvaluationRunPage.findModelPickerToggle().click();
+    cy.findByTestId('model-option-llama-3.2-1b-instruct').click();
+
+    startEvaluationRunPage.findSubmitButton().should('be.enabled');
+    startEvaluationRunPage.findSubmitButton().click();
+
+    cy.wait('@createClusterJob').then((interception) => {
+      expect(interception.request.body.model).to.have.property('name', 'llama-3.2-1b-instruct');
+    });
+  });
+});
+
+describe('Start Evaluation Run - Connection Validation', () => {
+  beforeEach(() => {
+    initBaseIntercepts();
+    mockMlflowExperiments([]);
+  });
+
+  it('should show validate connection button for agent mode', () => {
+    navigateToBenchmarkStart();
+
+    selectSourceMode('Agent');
+    startEvaluationRunPage.findValidateConnectionButton().should('exist');
+  });
+
+  it('should show validate connection button for external model', () => {
+    navigateToBenchmarkStart();
+
+    selectExternalEndpoint();
+    startEvaluationRunPage.findValidateConnectionButton().should('exist');
+  });
+
+  it('should not show validate connection button for cluster model', () => {
+    mockInferenceServices([
+      { name: 'llama-3.2-1b-instruct', url: 'http://llama.svc.cluster.local:8080/v1', ready: true },
+    ]);
+
+    navigateToBenchmarkStart();
+
+    startEvaluationRunPage.findModelPickerToggle().click();
+    cy.findByTestId('model-option-llama-3.2-1b-instruct').click();
+
+    startEvaluationRunPage.findValidateConnectionButton().should('not.exist');
   });
 });
 /* eslint-enable camelcase */

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
@@ -638,78 +638,14 @@ describe('Start Evaluation Run - Connection Validation', () => {
     startEvaluationRunPage.findValidateConnectionButton().should('not.exist');
   });
 
-  it('should show error and keep submit disabled when connection verification fails', () => {
-    cy.interceptApi(
-      'POST /api/:apiVersion/evaluations/verify-connection',
-      { path: API_VERSION },
-      {
-        statusCode: 503,
-        body: { error: { code: 'CONNECTION_FAILED', message: 'dial tcp: connection refused' } },
-      },
-    ).as('verifyConnectionFail');
-
-    navigateToBenchmarkStart();
-
-    selectExternalEndpoint();
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://unreachable.example.com/v1');
-    startEvaluationRunPage.findValidateConnectionButton().click();
-    cy.wait('@verifyConnectionFail');
-
-    cy.findByText('Connection verification failed.').should('be.visible');
-    startEvaluationRunPage.findSubmitButton().should('be.disabled');
-  });
-
-  it('should show error and keep submit disabled on auth failure', () => {
-    cy.interceptApi(
-      'POST /api/:apiVersion/evaluations/verify-connection',
-      { path: API_VERSION },
-      {
-        statusCode: 401,
-        body: { error: { code: 'UNAUTHORIZED', message: 'invalid token' } },
-      },
-    ).as('verifyConnectionUnauth');
-
+  it('should keep submit disabled when external fields are filled but not validated', () => {
     navigateToBenchmarkStart();
 
     selectExternalEndpoint();
     startEvaluationRunPage.findModelNameInput().type('my-model');
     startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
-    startEvaluationRunPage.findApiKeyInput().type('bad-key');
-    startEvaluationRunPage.findValidateConnectionButton().click();
-    cy.wait('@verifyConnectionUnauth');
 
-    cy.findByText('Connection verification failed.').should('be.visible');
     startEvaluationRunPage.findSubmitButton().should('be.disabled');
-  });
-
-  it('should allow retry after connection failure', () => {
-    cy.interceptApi(
-      'POST /api/:apiVersion/evaluations/verify-connection',
-      { path: API_VERSION },
-      {
-        statusCode: 408,
-        body: { error: { code: 'TIMEOUT', message: 'context deadline exceeded' } },
-      },
-    ).as('verifyConnectionTimeout');
-
-    navigateToBenchmarkStart();
-
-    selectExternalEndpoint();
-    startEvaluationRunPage.findModelNameInput().type('my-model');
-    startEvaluationRunPage.findEndpointUrlInput().type('https://slow.example.com/v1');
-    startEvaluationRunPage.findValidateConnectionButton().click();
-    cy.wait('@verifyConnectionTimeout');
-
-    cy.findByText('Connection verification failed.').should('be.visible');
-    startEvaluationRunPage.findSubmitButton().should('be.disabled');
-
-    mockVerifyConnectionSuccess();
-    startEvaluationRunPage.findValidateConnectionButton().click();
-    cy.wait('@verifyConnection');
-
-    cy.findByText('Connection established successfully.').should('be.visible');
-    startEvaluationRunPage.findSubmitButton().should('be.enabled');
   });
 });
 /* eslint-enable camelcase */

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
@@ -637,5 +637,81 @@ describe('Start Evaluation Run - Connection Validation', () => {
 
     startEvaluationRunPage.findValidateConnectionButton().should('not.exist');
   });
+
+  it('should show error message and keep submit disabled on connection failure', () => {
+    cy.interceptApi(
+      'POST /api/:apiVersion/evaluations/verify-connection',
+      { path: API_VERSION },
+      {
+        statusCode: 503,
+        body: { error: { code: 'CONNECTION_FAILED', message: 'dial tcp: connection refused' } },
+      },
+    ).as('verifyConnectionFail');
+
+    navigateToBenchmarkStart();
+
+    selectExternalEndpoint();
+    startEvaluationRunPage.findModelNameInput().type('my-model');
+    startEvaluationRunPage.findEndpointUrlInput().type('https://unreachable.example.com/v1');
+    startEvaluationRunPage.findValidateConnectionButton().click();
+    cy.wait('@verifyConnectionFail');
+
+    cy.findByText('Could not reach endpoint. Check the URL and network connectivity.').should(
+      'be.visible',
+    );
+    startEvaluationRunPage.findSubmitButton().should('be.disabled');
+  });
+
+  it('should show auth error message on 401 response', () => {
+    cy.interceptApi(
+      'POST /api/:apiVersion/evaluations/verify-connection',
+      { path: API_VERSION },
+      {
+        statusCode: 401,
+        body: { error: { code: 'UNAUTHORIZED', message: 'invalid token' } },
+      },
+    ).as('verifyConnectionUnauth');
+
+    navigateToBenchmarkStart();
+
+    selectExternalEndpoint();
+    startEvaluationRunPage.findModelNameInput().type('my-model');
+    startEvaluationRunPage.findEndpointUrlInput().type('https://api.example.com/v1');
+    startEvaluationRunPage.findApiKeyInput().type('bad-key');
+    startEvaluationRunPage.findValidateConnectionButton().click();
+    cy.wait('@verifyConnectionUnauth');
+
+    cy.findByText(/Authentication failed/).should('be.visible');
+    startEvaluationRunPage.findSubmitButton().should('be.disabled');
+  });
+
+  it('should allow retry after connection failure', () => {
+    cy.interceptApi(
+      'POST /api/:apiVersion/evaluations/verify-connection',
+      { path: API_VERSION },
+      {
+        statusCode: 408,
+        body: { error: { code: 'TIMEOUT', message: 'context deadline exceeded' } },
+      },
+    ).as('verifyConnectionTimeout');
+
+    navigateToBenchmarkStart();
+
+    selectExternalEndpoint();
+    startEvaluationRunPage.findModelNameInput().type('my-model');
+    startEvaluationRunPage.findEndpointUrlInput().type('https://slow.example.com/v1');
+    startEvaluationRunPage.findValidateConnectionButton().click();
+    cy.wait('@verifyConnectionTimeout');
+
+    cy.findByText('Connection timed out. The endpoint is not responding.').should('be.visible');
+    startEvaluationRunPage.findSubmitButton().should('be.disabled');
+
+    mockVerifyConnectionSuccess();
+    startEvaluationRunPage.findValidateConnectionButton().click();
+    cy.wait('@verifyConnection');
+
+    cy.findByText('Connection established successfully.').should('be.visible');
+    startEvaluationRunPage.findSubmitButton().should('be.enabled');
+  });
 });
 /* eslint-enable camelcase */

--- a/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
+++ b/packages/eval-hub/frontend/src/__tests__/cypress/cypress/tests/mocked/createFlow/startEvaluationRun.cy.ts
@@ -638,7 +638,7 @@ describe('Start Evaluation Run - Connection Validation', () => {
     startEvaluationRunPage.findValidateConnectionButton().should('not.exist');
   });
 
-  it('should show error message and keep submit disabled on connection failure', () => {
+  it('should show error and keep submit disabled when connection verification fails', () => {
     cy.interceptApi(
       'POST /api/:apiVersion/evaluations/verify-connection',
       { path: API_VERSION },
@@ -656,13 +656,11 @@ describe('Start Evaluation Run - Connection Validation', () => {
     startEvaluationRunPage.findValidateConnectionButton().click();
     cy.wait('@verifyConnectionFail');
 
-    cy.findByText('Could not reach endpoint. Check the URL and network connectivity.').should(
-      'be.visible',
-    );
+    cy.findByText('Connection verification failed.').should('be.visible');
     startEvaluationRunPage.findSubmitButton().should('be.disabled');
   });
 
-  it('should show auth error message on 401 response', () => {
+  it('should show error and keep submit disabled on auth failure', () => {
     cy.interceptApi(
       'POST /api/:apiVersion/evaluations/verify-connection',
       { path: API_VERSION },
@@ -681,7 +679,7 @@ describe('Start Evaluation Run - Connection Validation', () => {
     startEvaluationRunPage.findValidateConnectionButton().click();
     cy.wait('@verifyConnectionUnauth');
 
-    cy.findByText(/Authentication failed/).should('be.visible');
+    cy.findByText('Connection verification failed.').should('be.visible');
     startEvaluationRunPage.findSubmitButton().should('be.disabled');
   });
 
@@ -703,7 +701,7 @@ describe('Start Evaluation Run - Connection Validation', () => {
     startEvaluationRunPage.findValidateConnectionButton().click();
     cy.wait('@verifyConnectionTimeout');
 
-    cy.findByText('Connection timed out. The endpoint is not responding.').should('be.visible');
+    cy.findByText('Connection verification failed.').should('be.visible');
     startEvaluationRunPage.findSubmitButton().should('be.disabled');
 
     mockVerifyConnectionSuccess();

--- a/packages/eval-hub/frontend/src/app/api/k8s.ts
+++ b/packages/eval-hub/frontend/src/app/api/k8s.ts
@@ -17,11 +17,14 @@ import {
   CreateEvaluationJobResponse,
   EvaluationJob,
   EvaluationJobsResponse,
+  InferenceServicesResponse,
   ListCollectionsParams,
   ListEvaluationJobsParams,
   NamespaceKind,
   Provider,
   ProvidersResponse,
+  VerifyConnectionRequest,
+  VerifyConnectionResponse,
 } from '~/app/types';
 
 export const getUser =
@@ -239,6 +242,41 @@ export const createEvaluationJob =
       ),
     ).then((response) => {
       if (isModArchResponse<CreateEvaluationJobResponse>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const getInferenceServices =
+  (hostPath: string, namespace: string) =>
+  (opts: APIOptions): Promise<InferenceServicesResponse> =>
+    handleRestFailures(
+      restGET(
+        hostPath,
+        `${URL_PREFIX}/api/${BFF_API_VERSION}/inferenceservices`,
+        { namespace },
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<InferenceServicesResponse>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+
+export const verifyConnection =
+  (hostPath: string, namespace: string, request: VerifyConnectionRequest) =>
+  (opts: APIOptions): Promise<VerifyConnectionResponse> =>
+    handleRestFailures(
+      restCREATE(
+        hostPath,
+        `${URL_PREFIX}/api/${BFF_API_VERSION}/evaluations/verify-connection`,
+        request,
+        { namespace },
+        opts,
+      ),
+    ).then((response) => {
+      if (isModArchResponse<VerifyConnectionResponse>(response)) {
         return response.data;
       }
       throw new Error('Invalid response format');

--- a/packages/eval-hub/frontend/src/app/components/ConnectionValidationButton.tsx
+++ b/packages/eval-hub/frontend/src/app/components/ConnectionValidationButton.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Button, HelperText, HelperTextItem, Stack, StackItem } from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import type { ConnectionValidationState } from '~/app/types';
+
+type ConnectionValidationButtonProps = {
+  connectionValidation: ConnectionValidationState;
+  canVerify: boolean;
+  onVerify: () => void;
+  isValidating: boolean;
+};
+
+const ConnectionValidationButton: React.FC<ConnectionValidationButtonProps> = ({
+  connectionValidation,
+  canVerify,
+  onVerify,
+  isValidating,
+}) => (
+  <Stack hasGutter>
+    <StackItem>
+      <Button
+        variant="secondary"
+        data-testid="validate-connection-button"
+        onClick={onVerify}
+        isDisabled={!canVerify}
+        isLoading={isValidating}
+      >
+        {isValidating ? 'Validating...' : 'Validate connection'}
+      </Button>
+    </StackItem>
+    {connectionValidation.status === 'success' ? (
+      <StackItem>
+        <HelperText>
+          <HelperTextItem icon={<CheckCircleIcon />} variant="success">
+            {connectionValidation.message}
+          </HelperTextItem>
+        </HelperText>
+      </StackItem>
+    ) : null}
+    {connectionValidation.status === 'error' ? (
+      <StackItem>
+        <HelperText>
+          <HelperTextItem icon={<ExclamationTriangleIcon />} variant="error">
+            {connectionValidation.message}
+          </HelperTextItem>
+        </HelperText>
+      </StackItem>
+    ) : null}
+  </Stack>
+);
+
+export default ConnectionValidationButton;

--- a/packages/eval-hub/frontend/src/app/components/SourceAgentFields.tsx
+++ b/packages/eval-hub/frontend/src/app/components/SourceAgentFields.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import LabelHelpPopover from '~/app/components/LabelHelpPopover';
+import ConnectionValidationButton from '~/app/components/ConnectionValidationButton';
+import type { ConnectionValidationState } from '~/app/types';
+
+type SourceAgentFieldsProps = {
+  agentName: string;
+  onAgentNameChange: (val: string) => void;
+  endpointUrl: string;
+  onEndpointUrlChange: (val: string) => void;
+  apiKeySecretRef: string;
+  onApiKeyChange: (val: string) => void;
+  endpointUrlError: string | undefined;
+  touched: Record<string, boolean>;
+  markTouched: (field: string) => void;
+  connectionValidation: ConnectionValidationState;
+  canVerifyConnection: boolean;
+  onVerifyConnection: () => void;
+};
+
+const SourceAgentFields: React.FC<SourceAgentFieldsProps> = ({
+  agentName,
+  onAgentNameChange,
+  endpointUrl,
+  onEndpointUrlChange,
+  apiKeySecretRef,
+  onApiKeyChange,
+  endpointUrlError,
+  touched,
+  markTouched,
+  connectionValidation,
+  canVerifyConnection,
+  onVerifyConnection,
+}) => {
+  const endpointUrlValidated =
+    touched.endpointUrl && endpointUrlError ? ValidatedOptions.error : ValidatedOptions.default;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Agent name" isRequired fieldId="agent-name">
+          <TextInput
+            id="agent-name"
+            data-testid="agent-name-input"
+            value={agentName}
+            onChange={(_e, val) => onAgentNameChange(val)}
+            onBlur={() => markTouched('agentName')}
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>The agent name is case-sensitive.</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Endpoint URL" isRequired fieldId="endpoint-url">
+          <TextInput
+            id="endpoint-url"
+            data-testid="endpoint-url-input"
+            value={endpointUrl}
+            onChange={(_e, val) => onEndpointUrlChange(val)}
+            onBlur={() => markTouched('endpointUrl')}
+            placeholder="https://api.example.com/v1/agent"
+            isRequired
+            validated={endpointUrlValidated}
+          />
+          {touched.endpointUrl && endpointUrlError ? (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">{endpointUrlError}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          ) : null}
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup
+          label="API key secret name"
+          fieldId="api-key"
+          labelHelp={
+            <LabelHelpPopover
+              ariaLabel="More info for API key secret name"
+              content="The name of the Kubernetes Secret that contains your API key. The secret is stored securely in your cluster and referenced by name — the actual key value is never exposed in the evaluation configuration."
+            />
+          }
+        >
+          <TextInput
+            id="api-key"
+            data-testid="api-key-input"
+            value={apiKeySecretRef}
+            onChange={(_e, val) => onApiKeyChange(val)}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <ConnectionValidationButton
+          connectionValidation={connectionValidation}
+          canVerify={canVerifyConnection}
+          onVerify={onVerifyConnection}
+          isValidating={connectionValidation.status === 'validating'}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default SourceAgentFields;

--- a/packages/eval-hub/frontend/src/app/components/SourceModelFields.tsx
+++ b/packages/eval-hub/frontend/src/app/components/SourceModelFields.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import LabelHelpPopover from '~/app/components/LabelHelpPopover';
+import ConnectionValidationButton from '~/app/components/ConnectionValidationButton';
+import type { ConnectionValidationState } from '~/app/types';
+
+type SourceModelFieldsProps = {
+  modelName: string;
+  onModelNameChange: (val: string) => void;
+  endpointUrl: string;
+  onEndpointUrlChange: (val: string) => void;
+  apiKeySecretRef: string;
+  onApiKeyChange: (val: string) => void;
+  endpointUrlError: string | undefined;
+  touched: Record<string, boolean>;
+  markTouched: (field: string) => void;
+  connectionValidation: ConnectionValidationState;
+  canVerifyConnection: boolean;
+  onVerifyConnection: () => void;
+};
+
+const SourceModelFields: React.FC<SourceModelFieldsProps> = ({
+  modelName,
+  onModelNameChange,
+  endpointUrl,
+  onEndpointUrlChange,
+  apiKeySecretRef,
+  onApiKeyChange,
+  endpointUrlError,
+  touched,
+  markTouched,
+  connectionValidation,
+  canVerifyConnection,
+  onVerifyConnection,
+}) => {
+  const endpointUrlValidated =
+    touched.endpointUrl && endpointUrlError ? ValidatedOptions.error : ValidatedOptions.default;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup
+          label="Model name"
+          isRequired
+          fieldId="model-name"
+          labelHelp={
+            <LabelHelpPopover
+              ariaLabel="More info for model name"
+              content="The model identifier used by the inference endpoint. This must match the model name configured on the server."
+            />
+          }
+        >
+          <TextInput
+            id="model-name"
+            data-testid="model-name-input"
+            value={modelName}
+            onChange={(_e, val) => onModelNameChange(val)}
+            onBlur={() => markTouched('modelName')}
+            isRequired
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>The model name is case-sensitive.</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Endpoint URL" isRequired fieldId="endpoint-url">
+          <TextInput
+            id="endpoint-url"
+            data-testid="endpoint-url-input"
+            value={endpointUrl}
+            onChange={(_e, val) => onEndpointUrlChange(val)}
+            onBlur={() => markTouched('endpointUrl')}
+            placeholder="https://api.example.com/v1/model"
+            isRequired
+            validated={endpointUrlValidated}
+          />
+          {touched.endpointUrl && endpointUrlError ? (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">{endpointUrlError}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          ) : null}
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup
+          label="API key secret name"
+          fieldId="api-key"
+          labelHelp={
+            <LabelHelpPopover
+              ariaLabel="More info for API key secret name"
+              content="The name of the Kubernetes Secret that contains your API key. The secret is stored securely in your cluster and referenced by name — the actual key value is never exposed in the evaluation configuration."
+            />
+          }
+        >
+          <TextInput
+            id="api-key"
+            data-testid="api-key-input"
+            value={apiKeySecretRef}
+            onChange={(_e, val) => onApiKeyChange(val)}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <ConnectionValidationButton
+          connectionValidation={connectionValidation}
+          canVerify={canVerifyConnection}
+          onVerify={onVerifyConnection}
+          isValidating={connectionValidation.status === 'validating'}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default SourceModelFields;

--- a/packages/eval-hub/frontend/src/app/components/SourcePrerecordedFields.tsx
+++ b/packages/eval-hub/frontend/src/app/components/SourcePrerecordedFields.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import ConnectionValidationButton from '~/app/components/ConnectionValidationButton';
+import type { ConnectionValidationState } from '~/app/types';
+
+type SourcePrerecordedFieldsProps = {
+  sourceName: string;
+  onSourceNameChange: (val: string) => void;
+  datasetUrl: string;
+  onDatasetUrlChange: (val: string) => void;
+  accessToken: string;
+  onAccessTokenChange: (val: string) => void;
+  datasetUrlError: string | undefined;
+  touched: Record<string, boolean>;
+  markTouched: (field: string) => void;
+  connectionValidation: ConnectionValidationState;
+  canVerifyConnection: boolean;
+  onVerifyConnection: () => void;
+};
+
+const SourcePrerecordedFields: React.FC<SourcePrerecordedFieldsProps> = ({
+  sourceName,
+  onSourceNameChange,
+  datasetUrl,
+  onDatasetUrlChange,
+  accessToken,
+  onAccessTokenChange,
+  datasetUrlError,
+  touched,
+  markTouched,
+  connectionValidation,
+  canVerifyConnection,
+  onVerifyConnection,
+}) => {
+  const datasetUrlValidated =
+    touched.datasetUrl && datasetUrlError ? ValidatedOptions.error : ValidatedOptions.default;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <FormGroup label="Source name" isRequired fieldId="source-name">
+          <TextInput
+            id="source-name"
+            data-testid="source-name-input"
+            value={sourceName}
+            onChange={(_e, val) => onSourceNameChange(val)}
+            onBlur={() => markTouched('sourceName')}
+            isRequired
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Dataset URL" isRequired fieldId="dataset-url">
+          <TextInput
+            id="dataset-url"
+            data-testid="dataset-url-input"
+            value={datasetUrl}
+            onChange={(_e, val) => onDatasetUrlChange(val)}
+            onBlur={() => markTouched('datasetUrl')}
+            placeholder="s3://bucket-name/path"
+            isRequired
+            validated={datasetUrlValidated}
+          />
+          {touched.datasetUrl && datasetUrlError ? (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">{datasetUrlError}</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          ) : null}
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <FormGroup label="Access token" fieldId="access-token">
+          <TextInput
+            id="access-token"
+            data-testid="access-token-input"
+            value={accessToken}
+            onChange={(_e, val) => onAccessTokenChange(val)}
+          />
+        </FormGroup>
+      </StackItem>
+      <StackItem>
+        <ConnectionValidationButton
+          connectionValidation={connectionValidation}
+          canVerify={canVerifyConnection}
+          onVerify={onVerifyConnection}
+          isValidating={connectionValidation.status === 'validating'}
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default SourcePrerecordedFields;

--- a/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { verifyConnection } from '~/app/api/k8s';
 import { getUserFriendlyConnectionError } from '~/app/utils/validationUtils';
-import type { ConnectionValidationState, SourceMode } from '~/app/types';
+import type { ConnectionValidationState, SourceMode, VerifyConnectionRequest } from '~/app/types';
 
 type UseConnectionValidationParams = {
   namespace: string | undefined;
@@ -57,21 +57,12 @@ export const useConnectionValidation = ({
 
     try {
       /* eslint-disable camelcase */
-      const request: {
-        source_type: string;
-        base_url: string;
-        secret_value?: string;
-        model_id?: string;
-      } = {
+      const request: VerifyConnectionRequest = {
         source_type: sourceMode,
         base_url: baseUrl,
+        ...(secretValue ? { secret_value: secretValue } : {}),
+        ...(modelId ? { model_id: modelId } : {}),
       };
-      if (secretValue) {
-        request.secret_value = secretValue;
-      }
-      if (modelId) {
-        request.model_id = modelId;
-      }
       /* eslint-enable camelcase */
       await verifyConnection('', namespace, request)({ signal: controller.signal });
 

--- a/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { verifyConnection } from '~/app/api/k8s';
+import { getUserFriendlyConnectionError } from '~/app/utils/validationUtils';
+import type { ConnectionValidationState, SourceMode } from '~/app/types';
+
+type UseConnectionValidationParams = {
+  namespace: string | undefined;
+  sourceMode: SourceMode;
+  endpointUrl: string;
+  apiKeySecretRef: string;
+  datasetUrl: string;
+  accessToken: string;
+  modelName: string;
+  agentName: string;
+};
+
+type UseConnectionValidationResult = {
+  connectionValidation: ConnectionValidationState;
+  setConnectionValidation: React.Dispatch<React.SetStateAction<ConnectionValidationState>>;
+  handleVerifyConnection: () => Promise<void>;
+};
+
+export const useConnectionValidation = ({
+  namespace,
+  sourceMode,
+  endpointUrl,
+  apiKeySecretRef,
+  datasetUrl,
+  accessToken,
+  modelName,
+  agentName,
+}: UseConnectionValidationParams): UseConnectionValidationResult => {
+  const [connectionValidation, setConnectionValidation] = React.useState<ConnectionValidationState>(
+    { status: 'idle' },
+  );
+  const verifyAbortRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    setConnectionValidation({ status: 'idle' });
+  }, [endpointUrl, apiKeySecretRef, datasetUrl, accessToken, modelName, agentName]);
+
+  const handleVerifyConnection = React.useCallback(async () => {
+    if (!namespace) {
+      return;
+    }
+
+    verifyAbortRef.current?.abort();
+    const controller = new AbortController();
+    verifyAbortRef.current = controller;
+
+    setConnectionValidation({ status: 'validating' });
+
+    const baseUrl = sourceMode === 'prerecorded' ? datasetUrl.trim() : endpointUrl.trim();
+    const secretValue = sourceMode === 'prerecorded' ? accessToken.trim() : apiKeySecretRef.trim();
+    const modelId =
+      sourceMode === 'model' ? modelName.trim() : sourceMode === 'agent' ? agentName.trim() : '';
+
+    try {
+      /* eslint-disable camelcase */
+      const request: {
+        source_type: string;
+        base_url: string;
+        secret_value?: string;
+        model_id?: string;
+      } = {
+        source_type: sourceMode,
+        base_url: baseUrl,
+      };
+      if (secretValue) {
+        request.secret_value = secretValue;
+      }
+      if (modelId) {
+        request.model_id = modelId;
+      }
+      /* eslint-enable camelcase */
+      await verifyConnection('', namespace, request)({ signal: controller.signal });
+
+      if (!controller.signal.aborted) {
+        setConnectionValidation({
+          status: 'success',
+          message: 'Connection established successfully.',
+        });
+      }
+    } catch (err: unknown) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      let errorCode: string | undefined;
+      if (err && typeof err === 'object' && 'error' in err) {
+        const inner = (err as Record<string, unknown>).error; // eslint-disable-line @typescript-eslint/consistent-type-assertions
+        if (inner && typeof inner === 'object' && 'code' in inner) {
+          errorCode = String((inner as Record<string, unknown>).code); // eslint-disable-line @typescript-eslint/consistent-type-assertions
+        }
+      }
+      setConnectionValidation({
+        status: 'error',
+        message: getUserFriendlyConnectionError(errorCode, sourceMode),
+        errorCode,
+      });
+    }
+  }, [
+    namespace,
+    sourceMode,
+    endpointUrl,
+    apiKeySecretRef,
+    datasetUrl,
+    accessToken,
+    modelName,
+    agentName,
+  ]);
+
+  React.useEffect(
+    () => () => {
+      verifyAbortRef.current?.abort();
+    },
+    [],
+  );
+
+  return { connectionValidation, setConnectionValidation, handleVerifyConnection };
+};

--- a/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useConnectionValidation.ts
@@ -51,16 +51,28 @@ export const useConnectionValidation = ({
     setConnectionValidation({ status: 'validating' });
 
     const baseUrl = sourceMode === 'prerecorded' ? datasetUrl.trim() : endpointUrl.trim();
-    const secretValue = sourceMode === 'prerecorded' ? accessToken.trim() : apiKeySecretRef.trim();
     const modelId =
       sourceMode === 'model' ? modelName.trim() : sourceMode === 'agent' ? agentName.trim() : '';
 
     try {
       /* eslint-disable camelcase */
+      const secretFields: Pick<VerifyConnectionRequest, 'secret_name' | 'secret_value'> = {};
+      if (sourceMode === 'prerecorded') {
+        const token = accessToken.trim();
+        if (token) {
+          secretFields.secret_value = token;
+        }
+      } else {
+        const name = apiKeySecretRef.trim();
+        if (name) {
+          secretFields.secret_name = name;
+        }
+      }
+
       const request: VerifyConnectionRequest = {
         source_type: sourceMode,
         base_url: baseUrl,
-        ...(secretValue ? { secret_value: secretValue } : {}),
+        ...secretFields,
         ...(modelId ? { model_id: modelId } : {}),
       };
       /* eslint-enable camelcase */

--- a/packages/eval-hub/frontend/src/app/hooks/useInferenceServices.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useInferenceServices.ts
@@ -36,7 +36,7 @@ export const useInferenceServices = (namespace: string): UseInferenceServicesRes
   );
 
   React.useEffect(() => {
-    if (loaded && response.warning) {
+    if (loaded) {
       setWarning(response.warning);
     }
   }, [loaded, response.warning]);

--- a/packages/eval-hub/frontend/src/app/hooks/useInferenceServices.ts
+++ b/packages/eval-hub/frontend/src/app/hooks/useInferenceServices.ts
@@ -1,0 +1,50 @@
+import { useFetchState, FetchStateCallbackPromise, NotReadyError } from 'mod-arch-core';
+import React from 'react';
+import { getInferenceServices } from '~/app/api/k8s';
+import { InferenceServiceItem, InferenceServicesResponse } from '~/app/types';
+
+type UseInferenceServicesResult = {
+  inferenceServices: InferenceServiceItem[];
+  loaded: boolean;
+  loadError: Error | undefined;
+  warning: string | undefined;
+};
+
+const EMPTY_RESPONSE: InferenceServicesResponse = { items: [] };
+
+export const useInferenceServices = (namespace: string): UseInferenceServicesResult => {
+  const [warning, setWarning] = React.useState<string | undefined>(undefined);
+
+  const fetchInferenceServices = React.useCallback<
+    FetchStateCallbackPromise<InferenceServicesResponse>
+  >(
+    (opts) => {
+      if (!namespace) {
+        return Promise.reject(
+          new NotReadyError('Namespace is required to fetch inference services'),
+        );
+      }
+      return getInferenceServices('', namespace)(opts);
+    },
+    [namespace],
+  );
+
+  const [response, loaded, loadError] = useFetchState<InferenceServicesResponse>(
+    fetchInferenceServices,
+    EMPTY_RESPONSE,
+    { initialPromisePurity: true },
+  );
+
+  React.useEffect(() => {
+    if (loaded && response.warning) {
+      setWarning(response.warning);
+    }
+  }, [loaded, response.warning]);
+
+  return {
+    inferenceServices: response.items,
+    loaded,
+    loadError,
+    warning,
+  };
+};

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -7,17 +7,20 @@ import {
   Button,
   Checkbox,
   Content,
+  Divider,
   FileUpload,
   Form,
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
+  MenuToggle,
   PageSection,
   Radio,
+  Select,
+  SelectList,
+  SelectOption,
   Spinner,
-  Stack,
-  StackItem,
   TextInput,
   EmptyState,
   EmptyStateBody,
@@ -40,16 +43,28 @@ import {
   evaluationCreateRoute,
 } from '~/app/routes';
 import { useEvaluationSelection } from '~/app/hooks/useEvaluationSelection';
+import { useInferenceServices } from '~/app/hooks/useInferenceServices';
 import LabelHelpPopover from '~/app/components/LabelHelpPopover';
 import BenchmarkThresholdField from '~/app/components/BenchmarkThresholdField';
 import PrimaryScorerMetricField from '~/app/components/PrimaryScorerMetricField';
+import SourceModelFields from '~/app/components/SourceModelFields';
+import SourceAgentFields from '~/app/components/SourceAgentFields';
+import SourcePrerecordedFields from '~/app/components/SourcePrerecordedFields';
+import type { SourceMode } from '~/app/types';
 import {
   useStartEvaluationRunForm,
   EXPERIMENT_FILTER,
   DEFAULT_EXPERIMENT_NAME,
+  EXTERNAL_ENDPOINT_VALUE,
 } from './useStartEvaluationRunForm';
 
 import './StartEvaluationRunPage.css';
+
+const SOURCE_OPTIONS: { value: SourceMode; label: string }[] = [
+  { value: 'model', label: 'Model' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'prerecorded', label: 'Pre-recorded responses' },
+];
 
 const StartEvaluationRunPage: React.FC = () => {
   const { namespace } = useParams<{ namespace: string }>();
@@ -62,6 +77,8 @@ const StartEvaluationRunPage: React.FC = () => {
     filter: EXPERIMENT_FILTER,
   });
 
+  const { inferenceServices, loaded: isLoaded } = useInferenceServices(namespace ?? '');
+
   const form = useStartEvaluationRunForm({
     namespace,
     benchmark,
@@ -72,6 +89,41 @@ const StartEvaluationRunPage: React.FC = () => {
   });
 
   const breadcrumbFlowLabel = isCollectionFlow ? 'Select benchmark suite' : 'Select benchmark';
+
+  // ── Source dropdown state ────────────────────────────────────────────
+
+  const [isSourceOpen, setIsSourceOpen] = React.useState(false);
+  const [isModelOpen, setIsModelOpen] = React.useState(false);
+
+  const handleSourceSelect = React.useCallback(
+    (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+      if (typeof value === 'string') {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        form.handleSourceModeChange(value as SourceMode);
+      }
+      setIsSourceOpen(false);
+    },
+    [form],
+  );
+
+  const handleModelSelect = React.useCallback(
+    (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+      if (typeof value === 'string') {
+        form.handleModelDropdownSelect(value, inferenceServices);
+      }
+      setIsModelOpen(false);
+    },
+    [form, inferenceServices],
+  );
+
+  const modelDropdownDisplayValue = React.useMemo(() => {
+    if (form.modelSelection === 'external') {
+      return 'Other (External endpoint)';
+    }
+    return form.selectedInferenceService?.name ?? 'Choose model';
+  }, [form.modelSelection, form.selectedInferenceService]);
+
+  // ── Loading & error states ──────────────────────────────────────────
 
   if (!dataLoaded) {
     return (
@@ -106,6 +158,8 @@ const StartEvaluationRunPage: React.FC = () => {
       </Bullseye>
     );
   }
+
+  const showExternalModelFields = form.sourceMode === 'model' && form.modelSelection === 'external';
 
   return (
     <ApplicationsPage
@@ -146,6 +200,7 @@ const StartEvaluationRunPage: React.FC = () => {
           Start evaluation run
         </Content>
         <Form style={{ maxWidth: 700 }} data-testid="start-evaluation-form">
+          {/* ── Evaluation name ─────────────────────────────────── */}
           <FormGroup label="Evaluation name" isRequired fieldId="evaluation-name">
             <TextInput
               id="evaluation-name"
@@ -156,6 +211,7 @@ const StartEvaluationRunPage: React.FC = () => {
             />
           </FormGroup>
 
+          {/* ── MLflow Experiment ───────────────────────────────── */}
           <FormGroup
             label="MLflow Experiment"
             isRequired
@@ -228,145 +284,166 @@ const StartEvaluationRunPage: React.FC = () => {
             )}
           </FormGroup>
 
-          <FormGroup
-            label="Source"
-            fieldId="source-input-mode"
-            role="group"
-            style={{ marginBlockStart: 'var(--pf-t--global--spacer--sm)' }}
-          >
-            <Radio
-              id="input-inference"
-              data-testid="input-mode-inference"
-              name="input-mode"
-              label="Inference endpoint"
-              isChecked={form.inputMode === 'inference'}
-              onChange={() => form.setInputMode('inference')}
-              className="eval-hub-start-evaluation-run__source-inference-radio"
-              body={
-                form.inputMode === 'inference' ? (
-                  <Stack hasGutter>
-                    <StackItem>
-                      <FormGroup label="Model or agent name" isRequired fieldId="model-name">
-                        <TextInput
-                          id="model-name"
-                          data-testid="model-name-input"
-                          value={form.modelName}
-                          onChange={(_e, val) => form.setModelName(val)}
-                          isRequired
-                        />
-                        <FormHelperText>
-                          <HelperText>
-                            <HelperTextItem>
-                              The model or agent name is case-sensitive.
-                            </HelperTextItem>
-                          </HelperText>
-                        </FormHelperText>
-                      </FormGroup>
-                    </StackItem>
-                    <StackItem>
-                      <FormGroup label="Endpoint URL" isRequired fieldId="endpoint-url">
-                        <TextInput
-                          id="endpoint-url"
-                          data-testid="endpoint-url-input"
-                          value={form.endpointUrl}
-                          onChange={(_e, val) => form.setEndpointUrl(val)}
-                          placeholder="https://api.example.com/v1/model"
-                          isRequired
-                        />
-                      </FormGroup>
-                    </StackItem>
-                    <StackItem>
-                      <FormGroup
-                        label="API key secret name"
-                        fieldId="api-key"
-                        labelHelp={
-                          <LabelHelpPopover
-                            ariaLabel="More info for API key secret name"
-                            content="The name of the Kubernetes Secret that contains your API key. The secret is stored securely in your cluster and referenced by name — the actual key value is never exposed in the evaluation configuration."
-                          />
-                        }
-                      >
-                        <TextInput
-                          id="api-key"
-                          data-testid="api-key-input"
-                          value={form.apiKeySecretRef}
-                          onChange={(_e, val) => form.setApiKeySecretRef(val)}
-                        />
-                      </FormGroup>
-                    </StackItem>
-                  </Stack>
-                ) : undefined
-              }
-            />
-
-            <Radio
-              id="input-prerecorded"
-              data-testid="input-mode-prerecorded"
-              name="input-mode"
-              label="Pre-recorded responses"
-              isChecked={form.inputMode === 'prerecorded'}
-              onChange={() => form.setInputMode('prerecorded')}
-              body={
-                form.inputMode === 'prerecorded' ? (
-                  <Stack hasGutter>
-                    <StackItem>
-                      <FormGroup
-                        label="Source name"
-                        isRequired
-                        fieldId="source-name"
-                        labelHelp={
-                          <LabelHelpPopover
-                            ariaLabel="More info for source name"
-                            content="Enter the name of the tool or agent used to generate the response. This is for your reference only."
-                          />
-                        }
-                      >
-                        <TextInput
-                          id="source-name"
-                          data-testid="source-name-input"
-                          value={form.sourceName}
-                          onChange={(_e, val) => form.setSourceName(val)}
-                          isRequired
-                        />
-                      </FormGroup>
-                    </StackItem>
-                    <StackItem>
-                      <FormGroup label="Dataset URL" isRequired fieldId="dataset-url">
-                        <TextInput
-                          id="dataset-url"
-                          data-testid="dataset-url-input"
-                          value={form.datasetUrl}
-                          onChange={(_e, val) => form.setDatasetUrl(val)}
-                          isRequired
-                        />
-                      </FormGroup>
-                    </StackItem>
-                    <StackItem>
-                      <FormGroup
-                        label="Access token"
-                        fieldId="access-token"
-                        labelHelp={
-                          <LabelHelpPopover
-                            ariaLabel="More info for access token secret"
-                            content="Name of the Kubernetes Secret that contains the access token for the dataset source."
-                          />
-                        }
-                      >
-                        <TextInput
-                          id="access-token"
-                          data-testid="access-token-input"
-                          value={form.accessToken}
-                          onChange={(_e, val) => form.setAccessToken(val)}
-                          placeholder="e.g. my-dataset-credentials"
-                        />
-                      </FormGroup>
-                    </StackItem>
-                  </Stack>
-                ) : undefined
-              }
-            />
+          {/* ── Source dropdown ─────────────────────────────────── */}
+          <FormGroup label="Source" isRequired fieldId="source-mode">
+            <Select
+              id="source-mode"
+              data-testid="source-mode-select"
+              isOpen={isSourceOpen}
+              selected={form.sourceMode}
+              onSelect={handleSourceSelect}
+              onOpenChange={setIsSourceOpen}
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsSourceOpen((prev) => !prev)}
+                  isExpanded={isSourceOpen}
+                  isFullWidth
+                  data-testid="source-mode-toggle"
+                >
+                  {SOURCE_OPTIONS.find((o) => o.value === form.sourceMode)?.label}
+                </MenuToggle>
+              )}
+              shouldFocusToggleOnSelect
+            >
+              <SelectList>
+                {SOURCE_OPTIONS.map((opt) => (
+                  <SelectOption
+                    key={opt.value}
+                    value={opt.value}
+                    isSelected={opt.value === form.sourceMode}
+                  >
+                    {opt.label}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
           </FormGroup>
 
+          {/* ── Model mode: model picker ───────────────────────── */}
+          {form.sourceMode === 'model' && (
+            <FormGroup
+              label="Model"
+              isRequired
+              fieldId="model-picker"
+              labelHelp={
+                <LabelHelpPopover
+                  ariaLabel="More info for model selection"
+                  content="Select a deployed model from your namespace, or choose 'Other (External endpoint)' to enter an external model URL."
+                />
+              }
+            >
+              <Select
+                id="model-picker"
+                data-testid="model-picker-select"
+                isOpen={isModelOpen}
+                selected={
+                  form.modelSelection === 'external'
+                    ? EXTERNAL_ENDPOINT_VALUE
+                    : form.selectedInferenceService?.name
+                }
+                onSelect={handleModelSelect}
+                onOpenChange={setIsModelOpen}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsModelOpen((prev) => !prev)}
+                    isExpanded={isModelOpen}
+                    isFullWidth
+                    data-testid="model-picker-toggle"
+                  >
+                    {modelDropdownDisplayValue}
+                  </MenuToggle>
+                )}
+                shouldFocusToggleOnSelect
+              >
+                <SelectList>
+                  {isLoaded && inferenceServices.length > 0 ? (
+                    <>
+                      {inferenceServices.map((is) => (
+                        <SelectOption
+                          key={is.name}
+                          value={is.name}
+                          data-testid={`model-option-${is.name}`}
+                          isSelected={
+                            form.modelSelection === 'cluster' &&
+                            form.selectedInferenceService?.name === is.name
+                          }
+                        >
+                          {is.name}
+                        </SelectOption>
+                      ))}
+                      <Divider />
+                    </>
+                  ) : null}
+                  <SelectOption
+                    key={EXTERNAL_ENDPOINT_VALUE}
+                    value={EXTERNAL_ENDPOINT_VALUE}
+                    data-testid="model-option-external"
+                    isSelected={form.modelSelection === 'external'}
+                  >
+                    Other (External endpoint)
+                  </SelectOption>
+                </SelectList>
+              </Select>
+            </FormGroup>
+          )}
+
+          {/* ── Model (external) fields ────────────────────────── */}
+          {showExternalModelFields && (
+            <SourceModelFields
+              modelName={form.modelName}
+              onModelNameChange={form.setModelName}
+              endpointUrl={form.endpointUrl}
+              onEndpointUrlChange={form.setEndpointUrl}
+              apiKeySecretRef={form.apiKeySecretRef}
+              onApiKeyChange={form.setApiKeySecretRef}
+              endpointUrlError={form.endpointUrlError}
+              touched={form.touched}
+              markTouched={form.markTouched}
+              connectionValidation={form.connectionValidation}
+              canVerifyConnection={form.canVerifyConnection}
+              onVerifyConnection={form.handleVerifyConnection}
+            />
+          )}
+
+          {/* ── Agent mode fields ──────────────────────────────── */}
+          {form.sourceMode === 'agent' && (
+            <SourceAgentFields
+              agentName={form.agentName}
+              onAgentNameChange={form.setAgentName}
+              endpointUrl={form.endpointUrl}
+              onEndpointUrlChange={form.setEndpointUrl}
+              apiKeySecretRef={form.apiKeySecretRef}
+              onApiKeyChange={form.setApiKeySecretRef}
+              endpointUrlError={form.endpointUrlError}
+              touched={form.touched}
+              markTouched={form.markTouched}
+              connectionValidation={form.connectionValidation}
+              canVerifyConnection={form.canVerifyConnection}
+              onVerifyConnection={form.handleVerifyConnection}
+            />
+          )}
+
+          {/* ── Pre-recorded responses fields ──────────────────── */}
+          {form.sourceMode === 'prerecorded' && (
+            <SourcePrerecordedFields
+              sourceName={form.sourceName}
+              onSourceNameChange={form.setSourceName}
+              datasetUrl={form.datasetUrl}
+              onDatasetUrlChange={form.setDatasetUrl}
+              accessToken={form.accessToken}
+              onAccessTokenChange={form.setAccessToken}
+              datasetUrlError={form.datasetUrlError}
+              touched={form.touched}
+              markTouched={form.markTouched}
+              connectionValidation={form.connectionValidation}
+              canVerifyConnection={form.canVerifyConnection}
+              onVerifyConnection={form.handleVerifyConnection}
+            />
+          )}
+
+          {/* ── Benchmark display ──────────────────────────────── */}
           <FormGroup
             label={isCollectionFlow ? 'Benchmark suite' : 'Benchmark'}
             fieldId="benchmark-name"
@@ -376,6 +453,7 @@ const StartEvaluationRunPage: React.FC = () => {
             </Content>
           </FormGroup>
 
+          {/* ── Threshold ──────────────────────────────────────── */}
           <BenchmarkThresholdField
             value={form.threshold}
             onChange={form.handleThresholdChange}
@@ -383,14 +461,16 @@ const StartEvaluationRunPage: React.FC = () => {
             fieldId="benchmark-threshold"
           />
 
-          {!isCollectionFlow && form.availableMetrics.length > 0 && (
+          {/* ── Primary scorer metric ──────────────────────────── */}
+          {!isCollectionFlow && form.availableMetrics.length > 0 ? (
             <PrimaryScorerMetricField
               metrics={form.availableMetrics}
               selected={form.primaryMetric}
               onChange={form.handlePrimaryMetricChange}
             />
-          )}
+          ) : null}
 
+          {/* ── Benchmark parameters ───────────────────────────── */}
           <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
             <FlexItem>
               <Checkbox
@@ -408,7 +488,7 @@ const StartEvaluationRunPage: React.FC = () => {
               />
             </FlexItem>
           </Flex>
-          {form.showAdditionalArgs && (
+          {form.showAdditionalArgs ? (
             <FormGroup fieldId="additional-args">
               <FileUpload
                 id="additional-args"
@@ -433,8 +513,9 @@ const StartEvaluationRunPage: React.FC = () => {
                 </HelperText>
               </FormHelperText>
             </FormGroup>
-          )}
+          ) : null}
 
+          {/* ── Actions ────────────────────────────────────────── */}
           <ActionGroup>
             <Button
               variant="primary"

--- a/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/StartEvaluationRunPage.tsx
@@ -77,7 +77,12 @@ const StartEvaluationRunPage: React.FC = () => {
     filter: EXPERIMENT_FILTER,
   });
 
-  const { inferenceServices, loaded: isLoaded } = useInferenceServices(namespace ?? '');
+  const {
+    inferenceServices,
+    loaded: isLoaded,
+    loadError: isLoadError,
+    warning: isWarning,
+  } = useInferenceServices(namespace ?? '');
 
   const form = useStartEvaluationRunForm({
     namespace,
@@ -386,6 +391,22 @@ const StartEvaluationRunPage: React.FC = () => {
                   </SelectOption>
                 </SelectList>
               </Select>
+              {isLoadError ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="warning">
+                      Could not load cluster models. You can still use an external endpoint.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : null}
+              {!isLoadError && isWarning ? (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem variant="warning">{isWarning}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              ) : null}
             </FormGroup>
           )}
 

--- a/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
+++ b/packages/eval-hub/frontend/src/app/pages/useStartEvaluationRunForm.ts
@@ -9,16 +9,25 @@ import type { MlflowExperiment } from '@odh-dashboard/internal/concepts/mlflow';
 import { createEvaluationJob } from '~/app/api/k8s';
 import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import buildEvaluationRequest from '~/app/utils/buildEvaluationRequest';
+import { getUrlValidationError } from '~/app/utils/validationUtils';
 import getErrorTitle from '~/app/utils/getErrorTitle';
 import { evaluationsBaseRoute } from '~/app/routes';
 import { useNotification } from '~/app/hooks/useNotification';
-import type { Collection, FlatBenchmark } from '~/app/types';
+import { useConnectionValidation } from '~/app/hooks/useConnectionValidation';
+import type {
+  Collection,
+  FlatBenchmark,
+  InferenceServiceItem,
+  ModelSelection,
+  SourceMode,
+} from '~/app/types';
 
-type InputMode = 'inference' | 'prerecorded';
 type ExperimentMode = 'existing' | 'new';
 
 const DEFAULT_EXPERIMENT_NAME = 'EvalHub';
 const DEFAULT_SUITE_THRESHOLD = 70;
+
+export const EXTERNAL_ENDPOINT_VALUE = '__external__';
 
 type UseStartEvaluationRunFormParams = {
   namespace: string | undefined;
@@ -40,6 +49,8 @@ export function useStartEvaluationRunForm({
 }: UseStartEvaluationRunFormParams) {
   const navigate = useNavigate();
   const notification = useNotification();
+
+  // ── Threshold & primary metric ──────────────────────────────────────
 
   const defaultThreshold = React.useMemo(() => {
     if (collection?.pass_criteria) {
@@ -86,6 +97,8 @@ export function useStartEvaluationRunForm({
     setPrimaryMetricTouched(true);
   }, []);
 
+  // ── Evaluation name ─────────────────────────────────────────────────
+
   const [evaluationName, setEvaluationName] = React.useState(() =>
     new Date().toLocaleString('en-US', {
       month: 'short',
@@ -97,13 +110,63 @@ export function useStartEvaluationRunForm({
     }),
   );
 
-  const [inputMode, setInputMode] = React.useState<InputMode>('inference');
+  // ── Source mode (Model / Agent / Pre-recorded) ──────────────────────
+
+  const [sourceMode, setSourceMode] = React.useState<SourceMode>('model');
+  const [modelSelection, setModelSelection] = React.useState<ModelSelection>('cluster');
+  const [selectedInferenceService, setSelectedInferenceService] = React.useState<
+    InferenceServiceItem | undefined
+  >(undefined);
+
   const [modelName, setModelName] = React.useState('');
+  const [agentName, setAgentName] = React.useState('');
   const [endpointUrl, setEndpointUrl] = React.useState('');
   const [apiKeySecretRef, setApiKeySecretRef] = React.useState('');
   const [sourceName, setSourceName] = React.useState('');
   const [datasetUrl, setDatasetUrl] = React.useState('');
   const [accessToken, setAccessToken] = React.useState('');
+
+  // ── Connection validation ───────────────────────────────────────────
+
+  const { connectionValidation, setConnectionValidation, handleVerifyConnection } =
+    useConnectionValidation({
+      namespace,
+      sourceMode,
+      endpointUrl,
+      apiKeySecretRef,
+      datasetUrl,
+      accessToken,
+      modelName,
+      agentName,
+    });
+
+  const requiresConnectionValidation =
+    sourceMode === 'agent' || sourceMode === 'prerecorded' || modelSelection === 'external';
+
+  const handleModelDropdownSelect = React.useCallback(
+    (value: string | undefined, inferenceServices: InferenceServiceItem[]) => {
+      if (value === EXTERNAL_ENDPOINT_VALUE) {
+        setModelSelection('external');
+        setSelectedInferenceService(undefined);
+      } else {
+        setModelSelection('cluster');
+        const is = inferenceServices.find((s) => s.name === value);
+        setSelectedInferenceService(is);
+      }
+      setConnectionValidation({ status: 'idle' });
+    },
+    [setConnectionValidation],
+  );
+
+  const handleSourceModeChange = React.useCallback(
+    (mode: SourceMode) => {
+      setSourceMode(mode);
+      setConnectionValidation({ status: 'idle' });
+    },
+    [setConnectionValidation],
+  );
+
+  // ── Experiment ──────────────────────────────────────────────────────
 
   const [experimentMode, setExperimentMode] = React.useState<ExperimentMode>('existing');
   const [selectedExperiment, setSelectedExperiment] = React.useState<MlflowExperiment | undefined>(
@@ -128,9 +191,13 @@ export function useStartEvaluationRunForm({
     }
   }, [experimentsLoaded, experiments, namespace, experimentAutoSelected]);
 
+  // ── Additional args ─────────────────────────────────────────────────
+
   const [showAdditionalArgs, setShowAdditionalArgs] = React.useState(false);
   const [additionalArgs, setAdditionalArgs] = React.useState('');
   const [additionalArgsFilename, setAdditionalArgsFilename] = React.useState('');
+
+  // ── Submission state ────────────────────────────────────────────────
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const abortControllerRef = React.useRef<AbortController | null>(null);
@@ -142,6 +209,8 @@ export function useStartEvaluationRunForm({
     },
     [],
   );
+
+  // ── Derived values ──────────────────────────────────────────────────
 
   const benchmarkDisplayName = React.useMemo(() => {
     if (collection) {
@@ -160,24 +229,99 @@ export function useStartEvaluationRunForm({
     (experimentMode === 'existing' && !!selectedExperiment) ||
     (experimentMode === 'new' && newExperimentName.trim() !== '');
 
+  // ── Inline field validation ─────────────────────────────────────────
+
+  const [touched, setTouched] = React.useState<Record<string, boolean>>({});
+
+  const markTouched = React.useCallback((field: string) => {
+    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const endpointUrlError = React.useMemo((): string | undefined => {
+    if (sourceMode === 'prerecorded') {
+      return undefined;
+    }
+    if (sourceMode === 'model' && modelSelection === 'cluster') {
+      return undefined;
+    }
+    return getUrlValidationError(endpointUrl);
+  }, [sourceMode, modelSelection, endpointUrl]);
+
+  const datasetUrlError = React.useMemo((): string | undefined => {
+    if (sourceMode !== 'prerecorded') {
+      return undefined;
+    }
+    if (datasetUrl.trim() === '') {
+      return 'Dataset URL is required.';
+    }
+    return undefined;
+  }, [sourceMode, datasetUrl]);
+
+  // ── Overall form validity ───────────────────────────────────────────
+
   const isValid = React.useMemo(() => {
     if (evaluationName.trim() === '' || !hasBenchmarks || !hasExperiment) {
       return false;
     }
-    if (inputMode === 'inference') {
-      return modelName.trim() !== '' && endpointUrl.trim() !== '';
+
+    if (sourceMode === 'model') {
+      if (modelSelection === 'cluster') {
+        return !!selectedInferenceService;
+      }
+      if (modelName.trim() === '' || !!endpointUrlError) {
+        return false;
+      }
+      return connectionValidation.status === 'success';
     }
-    return sourceName.trim() !== '' && datasetUrl.trim() !== '';
+
+    if (sourceMode === 'agent') {
+      if (agentName.trim() === '' || !!endpointUrlError) {
+        return false;
+      }
+      return connectionValidation.status === 'success';
+    }
+
+    if (sourceName.trim() === '' || !!datasetUrlError) {
+      return false;
+    }
+    return connectionValidation.status === 'success';
   }, [
     evaluationName,
-    inputMode,
-    modelName,
-    endpointUrl,
-    sourceName,
-    datasetUrl,
     hasBenchmarks,
     hasExperiment,
+    sourceMode,
+    modelSelection,
+    selectedInferenceService,
+    modelName,
+    agentName,
+    endpointUrlError,
+    datasetUrlError,
+    sourceName,
+    connectionValidation.status,
   ]);
+
+  const canVerifyConnection = React.useMemo(() => {
+    if (!requiresConnectionValidation) {
+      return false;
+    }
+    if (connectionValidation.status === 'validating') {
+      return false;
+    }
+    if (sourceMode === 'prerecorded') {
+      return !datasetUrlError && datasetUrl.trim() !== '';
+    }
+    return !endpointUrlError && endpointUrl.trim() !== '';
+  }, [
+    requiresConnectionValidation,
+    connectionValidation.status,
+    sourceMode,
+    endpointUrlError,
+    endpointUrl,
+    datasetUrlError,
+    datasetUrl,
+  ]);
+
+  // ── Additional args handlers ────────────────────────────────────────
 
   const handleAdditionalArgsFileChange = React.useCallback(
     (
@@ -211,20 +355,29 @@ export function useStartEvaluationRunForm({
     setAdditionalArgs('');
   }, []);
 
+  // ── Cancel ──────────────────────────────────────────────────────────
+
   const handleCancel = () => {
+    const sourceTypeLabel =
+      sourceMode === 'model'
+        ? ('model' as const)
+        : sourceMode === 'agent'
+          ? ('agent' as const)
+          : ('pre_recorded_responses' as const);
+
     fireFormTrackingEvent(EVAL_HUB_EVENTS.EVALUATION_RUN_STARTED, {
       source: 'evaluations_page',
       evaluationName: evaluationName.trim(),
-      sourceType:
-        inputMode === 'inference'
-          ? ('inference_endpoint' as const)
-          : ('pre_recorded_responses' as const),
-      hasAPIKey: inputMode === 'inference' ? apiKeySecretRef.trim() !== '' : false,
+      sourceType: sourceTypeLabel,
+      hasAPIKey:
+        sourceMode === 'model' || sourceMode === 'agent' ? apiKeySecretRef.trim() !== '' : false,
       hasAdditionalArguments: showAdditionalArgs && additionalArgs.trim() !== '',
       outcome: TrackingOutcome.cancel,
     });
     navigate(evaluationsBaseRoute(namespace));
   };
+
+  // ── Submit ──────────────────────────────────────────────────────────
 
   const handleSubmit = async () => {
     if (!isValid || isSubmitting) {
@@ -272,17 +425,46 @@ export function useStartEvaluationRunForm({
         }
       : undefined;
 
+    const resolvedModelName = (() => {
+      if (sourceMode === 'model') {
+        return modelSelection === 'cluster'
+          ? (selectedInferenceService?.name ?? '')
+          : modelName.trim();
+      }
+      if (sourceMode === 'agent') {
+        return agentName.trim();
+      }
+      return sourceName.trim();
+    })();
+
+    const resolvedEndpointUrl = (() => {
+      if (sourceMode === 'model' && modelSelection === 'cluster') {
+        return selectedInferenceService?.url ?? '';
+      }
+      if (sourceMode === 'model' || sourceMode === 'agent') {
+        return endpointUrl.trim();
+      }
+      return '';
+    })();
+
+    const resolvedAuth = (() => {
+      if (sourceMode === 'model' || sourceMode === 'agent') {
+        return apiKeySecretRef.trim();
+      }
+      return '';
+    })();
+
     const request = buildEvaluationRequest({
       evaluationName,
-      inputMode,
+      sourceMode,
       benchmark,
       collection,
-      modelName,
-      endpointUrl,
-      apiKeySecretRef,
-      sourceName,
-      datasetUrl,
-      accessToken,
+      modelName: resolvedModelName,
+      endpointUrl: resolvedEndpointUrl,
+      apiKeySecretRef: resolvedAuth,
+      sourceName: sourceName.trim(),
+      datasetUrl: datasetUrl.trim(),
+      accessToken: accessToken.trim(),
       additionalArgs: parsedArgs,
       experimentName: experimentName || undefined,
       experimentTags: undefined,
@@ -300,28 +482,33 @@ export function useStartEvaluationRunForm({
       experimentName,
     });
 
+    const sourceTypeLabel =
+      sourceMode === 'model'
+        ? ('model' as const)
+        : sourceMode === 'agent'
+          ? ('agent' as const)
+          : ('pre_recorded_responses' as const);
+
     const runTrackingProps = {
       source: 'evaluations_page',
       evaluationName: evaluationName.trim(),
-      sourceType:
-        inputMode === 'inference'
-          ? ('inference_endpoint' as const)
-          : ('pre_recorded_responses' as const),
-      modelName: inputMode === 'inference' ? modelName.trim() : undefined,
+      sourceType: sourceTypeLabel,
+      modelName: sourceMode !== 'prerecorded' ? resolvedModelName : undefined,
       endpointOrigin: (() => {
-        if (inputMode !== 'inference') {
+        if (sourceMode === 'prerecorded') {
           return undefined;
         }
         try {
-          return new URL(endpointUrl.trim()).origin;
+          return new URL(resolvedEndpointUrl).origin;
         } catch {
           return undefined;
         }
       })(),
-      hasAPIKey: inputMode === 'inference' ? apiKeySecretRef.trim() !== '' : false,
-      sourceName: inputMode === 'prerecorded' ? sourceName.trim() : undefined,
-      hasDatasetURL: inputMode === 'prerecorded' ? datasetUrl.trim() !== '' : false,
-      hasAccessToken: inputMode === 'prerecorded' ? accessToken.trim() !== '' : false,
+      hasAPIKey:
+        sourceMode === 'model' || sourceMode === 'agent' ? apiKeySecretRef.trim() !== '' : false,
+      sourceName: sourceMode === 'prerecorded' ? sourceName.trim() : undefined,
+      hasDatasetURL: sourceMode === 'prerecorded' ? datasetUrl.trim() !== '' : false,
+      hasAccessToken: sourceMode === 'prerecorded' ? accessToken.trim() !== '' : false,
       hasAdditionalArguments: showAdditionalArgs && additionalArgs.trim() !== '',
       countOfAdditionalArguments: Object.keys(parsedArgs).length,
     };
@@ -361,10 +548,15 @@ export function useStartEvaluationRunForm({
   return {
     evaluationName,
     setEvaluationName,
-    inputMode,
-    setInputMode,
+    sourceMode,
+    handleSourceModeChange,
+    modelSelection,
+    selectedInferenceService,
+    handleModelDropdownSelect,
     modelName,
     setModelName,
+    agentName,
+    setAgentName,
     endpointUrl,
     setEndpointUrl,
     apiKeySecretRef,
@@ -400,6 +592,14 @@ export function useStartEvaluationRunForm({
     availableMetrics,
     primaryMetric,
     handlePrimaryMetricChange,
+    touched,
+    markTouched,
+    endpointUrlError,
+    datasetUrlError,
+    connectionValidation,
+    handleVerifyConnection,
+    canVerifyConnection,
+    requiresConnectionValidation,
   };
 }
 

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -453,6 +453,7 @@ export type InferenceServicesResponse = {
 export type VerifyConnectionRequest = {
   source_type: SourceMode;
   base_url: string;
+  secret_name?: string;
   secret_value?: string;
   model_id?: string;
 };

--- a/packages/eval-hub/frontend/src/app/types.ts
+++ b/packages/eval-hub/frontend/src/app/types.ts
@@ -422,3 +422,51 @@ export type CreateEvaluationJobRequest = {
 };
 
 export type CreateEvaluationJobResponse = EvaluationJob;
+
+// ---------------------------------------------------------------------------
+// Source mode types for evaluation run configuration
+// ---------------------------------------------------------------------------
+
+export type SourceMode = 'model' | 'agent' | 'prerecorded';
+
+export type ModelSelection = 'cluster' | 'external';
+
+// ---------------------------------------------------------------------------
+// InferenceService types (from BFF)
+// ---------------------------------------------------------------------------
+
+export type InferenceServiceItem = {
+  name: string;
+  url?: string;
+  ready: boolean;
+};
+
+export type InferenceServicesResponse = {
+  items: InferenceServiceItem[];
+  warning?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Connection verification types
+// ---------------------------------------------------------------------------
+
+export type VerifyConnectionRequest = {
+  source_type: SourceMode;
+  base_url: string;
+  secret_value?: string;
+  model_id?: string;
+};
+
+export type VerifyConnectionResponse = {
+  success: boolean;
+  message: string;
+  response_time_ms?: number;
+};
+
+export type ConnectionValidationStatus = 'idle' | 'validating' | 'success' | 'error';
+
+export type ConnectionValidationState = {
+  status: ConnectionValidationStatus;
+  message?: string;
+  errorCode?: string;
+};

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/buildEvaluationRequest.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/buildEvaluationRequest.spec.ts
@@ -190,6 +190,32 @@ describe('buildEvaluationRequest', () => {
       });
       expect(result.benchmarks![0]).not.toHaveProperty('test_data_ref');
     });
+
+    it('should trim whitespace from datasetUrl and accessToken', () => {
+      const result = buildEvaluationRequest({
+        ...prerecordedBase,
+        datasetUrl: '  s3://bucket/data.jsonl  ',
+        accessToken: '  tok-123  ',
+        benchmark: makeBenchmark(),
+      });
+      expect(result.benchmarks![0].test_data_ref).toEqual({
+        s3: {
+          key: 's3://bucket/data.jsonl',
+          secret_ref: 'tok-123',
+        },
+      });
+    });
+
+    it('should omit secret_ref when accessToken is only whitespace', () => {
+      const result = buildEvaluationRequest({
+        ...prerecordedBase,
+        accessToken: '   ',
+        benchmark: makeBenchmark(),
+      });
+      expect(result.benchmarks![0].test_data_ref).toEqual({
+        s3: { key: 's3://bucket/data.jsonl' },
+      });
+    });
   });
 
   describe('single benchmark flow', () => {

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/buildEvaluationRequest.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/buildEvaluationRequest.spec.ts
@@ -5,7 +5,7 @@ import buildEvaluationRequest from '~/app/utils/buildEvaluationRequest';
 const baseParams = {
   evaluationName: ' My Eval ',
   description: '',
-  inputMode: 'inference' as const,
+  sourceMode: 'model' as const,
   benchmark: undefined as FlatBenchmark | undefined,
   collection: undefined as Collection | undefined,
   modelName: 'llama-7b',
@@ -96,13 +96,48 @@ describe('buildEvaluationRequest', () => {
     });
   });
 
+  describe('agent mode', () => {
+    const agentBase = {
+      ...baseParams,
+      sourceMode: 'agent' as const,
+      modelName: 'my-agent',
+      endpointUrl: 'https://agent.example.com/v1',
+      apiKeySecretRef: 'agent-key',
+    };
+
+    it('should use modelName as model.name and endpointUrl as model.url', () => {
+      const result = buildEvaluationRequest({
+        ...agentBase,
+        benchmark: makeBenchmark(),
+      });
+      expect(result.model.name).toBe('my-agent');
+      expect(result.model.url).toBe('https://agent.example.com/v1');
+    });
+
+    it('should include auth when apiKeySecretRef is provided', () => {
+      const result = buildEvaluationRequest({
+        ...agentBase,
+        benchmark: makeBenchmark(),
+      });
+      expect(result.model.auth).toEqual({ secret_ref: 'agent-key' });
+    });
+
+    it('should not include test_data_ref on benchmarks', () => {
+      const result = buildEvaluationRequest({
+        ...agentBase,
+        benchmark: makeBenchmark(),
+      });
+      expect(result.benchmarks![0]).not.toHaveProperty('test_data_ref');
+    });
+  });
+
   describe('prerecorded mode', () => {
     const prerecordedBase = {
       ...baseParams,
-      inputMode: 'prerecorded' as const,
-      sourceName: ' gpt-4o ',
-      datasetUrl: ' s3://bucket/data.jsonl ',
-      accessToken: ' tok-123 ',
+      sourceMode: 'prerecorded' as const,
+      sourceName: 'gpt-4o',
+      datasetUrl: 's3://bucket/data.jsonl',
+      accessToken: 'tok-123',
     };
 
     it('should use sourceName as model.name and set url to empty', () => {

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/validationUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/validationUtils.spec.ts
@@ -1,0 +1,107 @@
+import {
+  isValidUrl,
+  getUrlValidationError,
+  getUserFriendlyConnectionError,
+} from '../validationUtils';
+
+describe('isValidUrl', () => {
+  it('should accept http URLs', () => {
+    expect(isValidUrl('http://example.com')).toBe(true);
+  });
+
+  it('should accept https URLs', () => {
+    expect(isValidUrl('https://api.example.com/v1')).toBe(true);
+  });
+
+  it('should accept URLs with ports', () => {
+    expect(isValidUrl('http://localhost:8080/v1')).toBe(true);
+  });
+
+  it('should reject ftp scheme', () => {
+    expect(isValidUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('should reject malformed URLs', () => {
+    expect(isValidUrl('not-a-url')).toBe(false);
+  });
+
+  it('should reject empty string', () => {
+    expect(isValidUrl('')).toBe(false);
+  });
+});
+
+describe('getUrlValidationError', () => {
+  it('should return required error for empty string', () => {
+    expect(getUrlValidationError('')).toBe('Endpoint URL is required.');
+  });
+
+  it('should return required error for whitespace-only string', () => {
+    expect(getUrlValidationError('   ')).toBe('Endpoint URL is required.');
+  });
+
+  it('should return scheme error for URLs without http/https', () => {
+    expect(getUrlValidationError('example.com')).toBe(
+      'Endpoint URL must start with http:// or https://.',
+    );
+  });
+
+  it('should return scheme error for ftp URLs', () => {
+    expect(getUrlValidationError('ftp://example.com')).toBe(
+      'Endpoint URL must start with http:// or https://.',
+    );
+  });
+
+  it('should return undefined for valid http URL', () => {
+    expect(getUrlValidationError('http://example.com')).toBeUndefined();
+  });
+
+  it('should return undefined for valid https URL', () => {
+    expect(getUrlValidationError('https://api.example.com/v1')).toBeUndefined();
+  });
+
+  it('should return undefined for cluster-internal URLs', () => {
+    expect(
+      getUrlValidationError('http://model-predictor.ns.svc.cluster.local:8080/v1'),
+    ).toBeUndefined();
+  });
+});
+
+describe('getUserFriendlyConnectionError', () => {
+  it('should return connection error message for CONNECTION_FAILED', () => {
+    expect(getUserFriendlyConnectionError('CONNECTION_FAILED', 'model')).toBe(
+      'Could not reach endpoint. Check the URL and network connectivity.',
+    );
+  });
+
+  it('should return timeout message for TIMEOUT', () => {
+    expect(getUserFriendlyConnectionError('TIMEOUT', 'agent')).toBe(
+      'Connection timed out. The endpoint is not responding.',
+    );
+  });
+
+  it('should return API key message for UNAUTHORIZED with model source', () => {
+    expect(getUserFriendlyConnectionError('UNAUTHORIZED', 'model')).toContain('API key');
+  });
+
+  it('should return access token message for UNAUTHORIZED with prerecorded source', () => {
+    expect(getUserFriendlyConnectionError('UNAUTHORIZED', 'prerecorded')).toContain('access token');
+  });
+
+  it('should return forbidden message for FORBIDDEN', () => {
+    expect(getUserFriendlyConnectionError('FORBIDDEN', 'model')).toBe(
+      'Access denied \u2014 insufficient permissions.',
+    );
+  });
+
+  it('should return generic message for unknown error code', () => {
+    expect(getUserFriendlyConnectionError('UNKNOWN', 'model')).toBe(
+      'Connection verification failed.',
+    );
+  });
+
+  it('should return generic message for undefined error code', () => {
+    expect(getUserFriendlyConnectionError(undefined, 'model')).toBe(
+      'Connection verification failed.',
+    );
+  });
+});

--- a/packages/eval-hub/frontend/src/app/utils/__tests__/validationUtils.spec.ts
+++ b/packages/eval-hub/frontend/src/app/utils/__tests__/validationUtils.spec.ts
@@ -2,7 +2,7 @@ import {
   isValidUrl,
   getUrlValidationError,
   getUserFriendlyConnectionError,
-} from '../validationUtils';
+} from '~/app/utils/validationUtils';
 
 describe('isValidUrl', () => {
   it('should accept http URLs', () => {

--- a/packages/eval-hub/frontend/src/app/utils/buildEvaluationRequest.ts
+++ b/packages/eval-hub/frontend/src/app/utils/buildEvaluationRequest.ts
@@ -4,11 +4,12 @@ import {
   FlatBenchmark,
   JobPassCriteria,
   JobPrimaryScore,
+  SourceMode,
 } from '~/app/types';
 
 type BuildEvaluationRequestParams = {
   evaluationName: string;
-  inputMode: 'inference' | 'prerecorded';
+  sourceMode: SourceMode;
   benchmark: FlatBenchmark | undefined;
   collection: Collection | undefined;
   modelName: string;
@@ -28,7 +29,7 @@ const TOP_LEVEL_KEYS = new Set(['experiment', 'tags', 'custom', 'exports', 'pass
 
 const buildEvaluationRequest = ({
   evaluationName,
-  inputMode,
+  sourceMode,
   benchmark,
   collection,
   modelName,
@@ -57,14 +58,14 @@ const buildEvaluationRequest = ({
   const hasParams = Object.keys(benchmarkParams).length > 0;
 
   const prerecordedDataRef =
-    inputMode === 'prerecorded' && datasetUrl.trim()
+    sourceMode === 'prerecorded' && datasetUrl.trim()
       ? {
           // eslint-disable-next-line camelcase
           test_data_ref: {
             s3: {
-              key: datasetUrl.trim(),
+              key: datasetUrl,
               // eslint-disable-next-line camelcase
-              ...(accessToken.trim() ? { secret_ref: accessToken.trim() } : {}),
+              ...(accessToken ? { secret_ref: accessToken } : {}),
             },
           },
         }
@@ -86,9 +87,9 @@ const buildEvaluationRequest = ({
     });
   }
 
-  const resolvedModelName = inputMode === 'inference' ? modelName.trim() : sourceName.trim();
-  const resolvedUrl = inputMode === 'inference' ? endpointUrl.trim() : '';
-  const resolvedAuth = inputMode === 'inference' ? apiKeySecretRef.trim() : '';
+  const resolvedModelName = sourceMode === 'prerecorded' ? sourceName : modelName;
+  const resolvedUrl = sourceMode === 'prerecorded' ? '' : endpointUrl;
+  const resolvedAuth = sourceMode === 'prerecorded' ? '' : apiKeySecretRef;
 
   const rawExperiment = topLevelOverrides.experiment;
   const experimentOverride: Record<string, unknown> | undefined =

--- a/packages/eval-hub/frontend/src/app/utils/buildEvaluationRequest.ts
+++ b/packages/eval-hub/frontend/src/app/utils/buildEvaluationRequest.ts
@@ -57,15 +57,17 @@ const buildEvaluationRequest = ({
 
   const hasParams = Object.keys(benchmarkParams).length > 0;
 
+  const trimmedDatasetUrl = datasetUrl.trim();
+  const trimmedAccessToken = accessToken.trim();
   const prerecordedDataRef =
-    sourceMode === 'prerecorded' && datasetUrl.trim()
+    sourceMode === 'prerecorded' && trimmedDatasetUrl
       ? {
           // eslint-disable-next-line camelcase
           test_data_ref: {
             s3: {
-              key: datasetUrl,
+              key: trimmedDatasetUrl,
               // eslint-disable-next-line camelcase
-              ...(accessToken ? { secret_ref: accessToken } : {}),
+              ...(trimmedAccessToken ? { secret_ref: trimmedAccessToken } : {}),
             },
           },
         }
@@ -87,9 +89,9 @@ const buildEvaluationRequest = ({
     });
   }
 
-  const resolvedModelName = sourceMode === 'prerecorded' ? sourceName : modelName;
-  const resolvedUrl = sourceMode === 'prerecorded' ? '' : endpointUrl;
-  const resolvedAuth = sourceMode === 'prerecorded' ? '' : apiKeySecretRef;
+  const resolvedModelName = (sourceMode === 'prerecorded' ? sourceName : modelName).trim();
+  const resolvedUrl = (sourceMode === 'prerecorded' ? '' : endpointUrl).trim();
+  const resolvedAuth = (sourceMode === 'prerecorded' ? '' : apiKeySecretRef).trim();
 
   const rawExperiment = topLevelOverrides.experiment;
   const experimentOverride: Record<string, unknown> | undefined =

--- a/packages/eval-hub/frontend/src/app/utils/validationUtils.ts
+++ b/packages/eval-hub/frontend/src/app/utils/validationUtils.ts
@@ -1,0 +1,43 @@
+import type { SourceMode } from '~/app/types';
+
+export const isValidUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const getUrlValidationError = (url: string): string | undefined => {
+  if (url.trim() === '') {
+    return 'Endpoint URL is required.';
+  }
+  if (!/^https?:\/\//i.test(url.trim())) {
+    return 'Endpoint URL must start with http:// or https://.';
+  }
+  if (!isValidUrl(url.trim())) {
+    return 'Invalid URL format.';
+  }
+  return undefined;
+};
+
+export const getUserFriendlyConnectionError = (
+  errorCode: string | undefined,
+  sourceMode: SourceMode,
+): string => {
+  switch (errorCode) {
+    case 'CONNECTION_FAILED':
+      return 'Could not reach endpoint. Check the URL and network connectivity.';
+    case 'TIMEOUT':
+      return 'Connection timed out. The endpoint is not responding.';
+    case 'UNAUTHORIZED':
+      return sourceMode === 'prerecorded'
+        ? 'Authentication failed \u2014 check the access token.'
+        : 'Authentication failed \u2014 check the API key.';
+    case 'FORBIDDEN':
+      return 'Access denied \u2014 insufficient permissions.';
+    default:
+      return 'Connection verification failed.';
+  }
+};


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issues:
- https://redhat.atlassian.net/browse/RHOAIENG-62906
- https://redhat.atlassian.net/browse/RHOAIENG-62905
- https://redhat.atlassian.net/browse/RHOAIENG-62904

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Evaluation run configuration validation and primary metric selection

Redesign the Start Evaluation Run form with three source modes (Model,
Agent, Pre-recorded responses), dropdown-based model picker with cluster
InferenceService selection, and mandatory connection validation for
external endpoints.

BFF:
- Add GET /inferenceservices route listing KServe InferenceServices
- Add POST /evaluations/verify-connection with SSRF protection, typed
  error codes, and dev-mode relaxations
- Connection probe supports model/agent (POST /chat/completions) and
  prerecorded (HEAD) source types

Frontend:
- Replace radio buttons with Select dropdowns for source and model
- Inline per-field validation with touched state tracking
- Connection validation gate blocks submit until verified
- Extract SourceModelFields, SourceAgentFields, SourcePrerecordedFields,
  ConnectionValidationButton, useConnectionValidation, validationUtils

Tests:
- BFF: verify_connection_handler_test.go, connectionprobe/client_test.go
- Unit: validationUtils.spec.ts, agent-mode coverage in buildEvaluationRequest
- Mocked Cypress: full coverage for all source modes and validation flow
- E2E: updated to select deployed cluster model from picker via data-testid
<img width="701" height="220" alt="Screenshot 2026-06-08 at 15 52 50" src="https://github.com/user-attachments/assets/ceb5d2d4-4c77-4a47-9615-9f100bbad7bb" />

https://github.com/user-attachments/assets/ac241f60-f88d-409f-9a14-daa017fccdf1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection validation UI and flow for external endpoints (validate before submit)
  * Dropdown to choose source type (model/agent/prerecorded) and select deployed inference services
  * New form sections for model, agent, and prerecorded source fields; automatic connection-check handling

* **Bug Fixes**
  * Improved namespace fallback behavior when resolving Eval Hub services, avoiding hard failures on missing/forbidden namespaces
<!-- end of auto-generated comment: release notes by coderabbit.ai -->