### PR TITLE
feat: add config endpoints and connection-types handler to Core BFF

### DIFF
--- a/distributions/core-bff/AGENTS.md
+++ b/distributions/core-bff/AGENTS.md
@@ -57,7 +57,10 @@ core-bff/
 │   └── README.md                # BFF documentation
 ├── contract-tests/              # Contract tests
 │   └── __tests__/
-│       └── testCoreBffContract.test.ts
+│       ├── helpers.ts           # Shared test utilities (API clients, schema, matchers)
+│       ├── foundation/          # Platform-agnostic tests (run on both OpenShift and XKS)
+│       ├── openshift/           # OpenShift-specific tests
+│       └── xks/                 # XKS-specific tests
 ├── frontend/                    # React Frontend
 │   ├── src/
 │   │   ├── app/
@@ -363,9 +366,16 @@ make test   # Run tests
 
 ### Contract Testing
 
+Tests are split by platform. Foundation tests are platform-agnostic and run on both. Platform-specific
+tests validate behavior unique to OpenShift or XKS (e.g., feature flag defaults).
+
 ```bash
-# From the core-bff root
+# Run both platforms (umbrella script)
 npm run test:contract
+
+# Run a single platform
+npm run test:contract:openshift   # foundation + openshift tests
+npm run test:contract:xks         # foundation + xks tests
 ```
 
 ---

--- a/distributions/core-bff/README.md
+++ b/distributions/core-bff/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Core BFF replaces the Fastify backend for RHOAI sidecar deployments. It contains a Go backend (BFF) and a React frontend.
+The Core BFF is a Go backend that replaces Fastify across both RHOAI (sidecar) and RHAII (standalone) deployments. It contains a Go backend (BFF) and a React frontend.
 
 ## Contributing
 

--- a/distributions/core-bff/bff/README.md
+++ b/distributions/core-bff/bff/README.md
@@ -8,37 +8,49 @@ Backend-for-frontend providing core endpoints required by the dashboard UI.
 
 ## Scope
 
-This service exposes:
+This service exposes infrastructure endpoints, config/status endpoints, and resource CRUD:
 
-- GET `/healthcheck` - liveness probe (no auth)
-- GET `/api/v1/healthcheck` - health check (with auth middleware)
-- GET `/api/v1/user` - returns the authenticated user
-- GET `/api/v1/namespaces` - list namespaces (available only when DEV_MODE=true or mock k8s enabled)
+**Infrastructure:**
+- `GET /healthcheck` - liveness probe (no auth)
+- `GET /api/v1/healthcheck` - health check (with auth middleware)
+- `GET /api/v1/user` - authenticated user identity
+- `GET /api/v1/namespaces` - list namespaces (dev/mock mode only)
+- `/api/k8s/*` - K8s API pass-through proxy
+- `/wss/k8s/*` - WebSocket watch proxy
+
+**Config & Status:**
+- `GET /api/config` - merged DashboardConfig with defaults
+- `PATCH /api/config` - update DashboardConfig (admin)
+- `GET /api/status` - user session status and cluster info
+- `GET /api/status/:namespace/allowedUsers` - notebook users in a namespace (admin)
+- `GET /api/components` - OdhApplication list (empty when CRD absent)
+- `GET /api/components/remove` - remove app from enabled-apps ConfigMap (admin)
+- `GET/PATCH /api/dashboardConfig/:namespace/:name` - raw DashboardConfig CRUD (admin)
+- `GET/PUT /api/cluster-settings` - cluster settings with validation (admin)
+- `GET /api/connection-types` - list connection-type ConfigMaps
+- `GET /api/connection-types/:name` - get single connection type
+- `POST /api/connection-types` - create connection type (admin)
+- `PUT /api/connection-types/:name` - replace connection type (admin)
+- `PATCH /api/connection-types/:name` - patch connection type (admin)
+- `DELETE /api/connection-types/:name` - delete connection type (admin)
 
 ## Development
 
-Run the following command to build the BFF:
+Build the BFF:
 
 ```shell
 make build
 ```
 
-After building it, you can run our app with:
+Run with mock K8s client:
 
 ```shell
-make run
+make run PORT=4000 MOCK_K8S_CLIENT=true
 ```
 
-If you want to use a different port or mock kubernetes client you can run:
+Run with debug logging:
 
 ```shell
-make run PORT=8000 MOCK_K8S_CLIENT=true
-```
-
-If you want to change the log level on deployment, add the LOG_LEVEL argument when running, supported levels are: ERROR, WARN, INFO, DEBUG. The default level is INFO.
-
-```shell
-# Run with debug logging
 make run LOG_LEVEL=DEBUG
 ```
 
@@ -47,180 +59,118 @@ make run LOG_LEVEL=DEBUG
 | Flag | Env Var | Description |
 |------|---------|-------------|
 | `-port` | `PORT` | Listen port (default 4000) |
-| `-deployment-mode` | `DEPLOYMENT_MODE` | `standalone` or `federated` (default `standalone`) |
+| `-deployment-mode` | `DEPLOYMENT_MODE` | `standalone` (default) or `federated` |
+| `-platform-type` | `ODH_PLATFORM_TYPE` | `OpenShift` (probe cluster info), `XKS` (skip OpenShift detection), empty (auto-detect) |
 | `-dev-mode` | `DEV_MODE` | Enables relaxed behaviors (namespaces listing, etc.) |
-| `-mock-k8s-client` | `MOCK_K8S_CLIENT` | Use in-memory stub for namespace/user resolution |
+| `-mock-k8s-client` | `MOCK_K8S_CLIENT` | Use in-memory stub for K8s operations |
 | `-static-assets-dir` | `STATIC_ASSETS_DIR` | Directory to serve single-page frontend assets |
 | `-log-level` | `LOG_LEVEL` | ERROR, WARN, INFO, DEBUG (default INFO) |
 | `-allowed-origins` | `ALLOWED_ORIGINS` | Comma separated CORS origins |
 | `-auth-method` | `AUTH_METHOD` | `user_token` (default) or `disabled` (skips auth) |
 | `-auth-token-header` | `AUTH_TOKEN_HEADER` | Header to read token from (default `x-forwarded-access-token`) |
-| `-auth-token-prefix` | `AUTH_TOKEN_PREFIX` | Expected value prefix (default empty; use `Bearer` with standard `Authorization`) |
+| `-auth-token-prefix` | `AUTH_TOKEN_PREFIX` | Expected value prefix (default empty) |
 | `-cert-file` | (CLI only) | TLS certificate path (enables TLS when paired with key) |
 | `-key-file` | (CLI only) | TLS key path |
 | `-insecure-skip-verify` | `INSECURE_SKIP_VERIFY` | Skip upstream TLS verify (dev only) |
 | `-mock-bff-clients` | `MOCK_BFF_CLIENTS` | Use mock BFF clients (no real HTTP calls to other BFFs) |
-| `-namespace` | `NAMESPACE` | Kubernetes namespace where the dashboard is deployed (default `opendatahub`) |
+| `-namespace` | `NAMESPACE` / `OC_PROJECT` | K8s namespace for dashboard resources (default `opendatahub`, falls back to `OC_PROJECT`) |
+| `-workbench-namespace` | `WORKBENCH_NAMESPACE` | K8s namespace for workbenches (defaults to dashboard namespace) |
 | `-dashboard-config-name` | `DASHBOARD_CONFIG_NAME` | Name of the OdhDashboardConfig CR (default `odh-dashboard-config`) |
+| `-enabled-apps-cm` | `ENABLED_APPS_CM` | Name of the ConfigMap tracking enabled applications |
 | `-mf-remotes-config` | `MF_REMOTES_CONFIG` | Path to module federation remotes config file |
 
 TLS: If both `cert-file` and `key-file` are provided the server starts with HTTPS.
 
-## Running the linter locally
+## Platform Detection
 
-The BFF directory uses golangci-lint to combine multiple linters for a more comprehensive linting process. To install and run simply use:
+The BFF supports three platform modes via `ODH_PLATFORM_TYPE`:
+
+- **`XKS`** - Generic Kubernetes. Skips all OpenShift API calls at startup and applies XKS feature overrides.
+- **`OpenShift`** - Probes for ClusterVersion (cluster ID) and console-config (branding).
+- **Unset** (default) - Auto-detects by probing the ClusterVersion CRD. If found, behaves as OpenShift. If absent, behaves as XKS. The resolved platform drives both startup behavior and feature overrides.
+
+## Endpoints
+
+### Sample local calls
+
+When running with the mocked K8s client (`MOCK_K8S_CLIENT=true`), the user `user@example.com` has RBAC allowing all endpoints.
+
+```shell
+# Infrastructure
+curl -i localhost:4000/healthcheck
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/v1/user
+
+# Config & Status
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/config
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/status
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/cluster-settings
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/components
+curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/connection-types
+```
+
+### Admin Routes
+
+Admin endpoints use a `requireAdmin` wrapper that checks SSAR for `patch` on `auths/default-auth`. Non-admin users receive 401. Note: this does not yet fully match Fastify's `secureAdminRoute` semantics (e.g. namespace validation order).
+
+### Privilege Model
+
+The BFF uses two types of K8s clients:
+
+- **Service account clients** (`saDynClient`, `saClientset`) - for reading shared config (DashboardConfig, Auth, Components) and performing admin-gated mutations (connection types, cluster settings). Matches Fastify's privileged watcher model.
+- **Per-request user clients** - for SSAR checks (`IsUserAdmin`, `IsUserAllowed`) and token validation via `SelfSubjectReview`.
+
+### XKS Platform Overrides
+
+When the platform is XKS (explicit or auto-detected), the BFF disables OpenShift-dependent features:
+- `enablement` set to `false`
+- `disableProjects`, `disableBYONImageStream`, `disableISVBadges`, `disableAppLauncher`, `disablePipelines` set to `true`
+- `mlflow` set to `false`
+
+These run after feature lockouts (`disableFineTuning`, `mlflow`) and header overrides, so they take precedence.
+
+### Inter-BFF Communication
+
+The BFF includes a `bffclient` package (`internal/integrations/bffclient/`) for calling other BFF services in a multi-BFF pod deployment.
+
+## Linting
 
 ```shell
 make lint
 ```
 
-For more information on configuring golangci-lint see the [documentation](https://golangci-lint.run/).
+Uses golangci-lint. See the [documentation](https://golangci-lint.run/) for configuration.
 
 ## Building and Deploying
-
-Run the following command to build the BFF:
 
 ```shell
 make build
 ```
 
-The BFF binary will be inside the `bin` directory.
+The binary will be inside the `bin` directory.
 
-You can also build Docker images from the distribution root (`core-bff/`):
+Docker images from the distribution root (`core-bff/`):
 
 ```shell
 cd .. && make docker-build
 ```
 
-## Endpoints
-
-Four JSON endpoints are available plus static asset serving (index.html fallback):
-
-```text
-GET /healthcheck            (no auth)
-GET /api/v1/healthcheck     (with auth middleware)
-GET /api/v1/user
-GET /api/v1/namespaces      (dev / mock mode only)
-```
-
-### Sample local calls
-
-When running with the mocked Kubernetes client (MOCK_K8S_CLIENT=true), the user `user@example.com` has RBAC allowing all three endpoints.
-
-```shell
-curl -i localhost:4000/healthcheck
-curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/v1/user
-curl -i -H "x-forwarded-access-token: FAKE_CLUSTER_ADMIN_TOKEN" localhost:4000/api/v1/namespaces   # (dev / mock only)
-```
-
-### Inter-BFF Communication
-
-The BFF includes a `bffclient` package (`internal/integrations/bffclient/`) that provides the scaffolding for calling other BFF services in a multi-BFF pod deployment. The package is target-agnostic - teams wire up their own target BFF endpoints on top of this infrastructure.
-
-#### Architecture
-
-```
-+--------------------------------------------------------------+
-|                        ODH Dashboard Pod                     |
-+--------------------------------------------------------------+
-|  +--------------+  +--------------+  +------------------+   |
-|  |  Gen-AI BFF  |--|   MaaS BFF   |--|  Model Registry  |   |
-|  |    :8143     |  |    :8243     |  |   BFF :8043      |   |
-|  +--------------+  +--------------+  +------------------+   |
-|         |                  |                    |            |
-|  +--------------+          |                    |            |
-|  |  MLflow BFF  |----------+--------------------+            |
-|  |    :8343     |     Inter-BFF HTTP Calls                   |
-|  +--------------+  (K8s service DNS or localhost)            |
-+--------------------------------------------------------------+
-```
-
-#### Adding a BFF target
-
-1. Add target-specific config fields to `internal/config/environment.go` (e.g. `BFF<Target>ServiceName`, `BFF<Target>ServicePort`, etc.)
-2. Add corresponding CLI flags to `cmd/main.go`
-3. Apply config overrides in `NewApp()` in `internal/api/app.go`
-4. Create a handler in `internal/api/` using `bffclient.GetClient()` and `bffclient.AttachBFFClient()` middleware
-5. Wire routes in `Routes()`
-
-See the `bffclient` package README and the implementation spec for detailed guidance.
-
 ### Authentication modes
 
 Two modes are supported (flag `--auth-method` / env `AUTH_METHOD`):
 
-- **user_token** (default): extracts a bearer token from the configured header (default `x-forwarded-access-token`) and performs SelfSubjectAccessReview. This is the standard authentication method for ODH/RHOAI deployments and is recommended for most use cases including mock/development mode.
-- **disabled**: skips identity extraction entirely. Useful for local development or testing when no real auth is needed.
-
-### Overriding token header / prefix
-
-By default, the BFF expects the token in the `x-forwarded-access-token` header with no prefix. If using the standard `Authorization` header, set the prefix to `Bearer`.
-
-If you're integrating with a proxy or tool that uses a different header, you can override this behavior using environment variables or Makefile arguments.
-
-```shell
-make run AUTH_METHOD=user_token AUTH_TOKEN_HEADER=X-Forwarded-Access-Token AUTH_TOKEN_PREFIX=""
-```
-
-This will configure the BFF to extract the raw token from the following header:
-
-```shell
-X-Forwarded-Access-Token: <your-token>
-```
+- **user_token** (default): extracts a bearer token from the configured header and performs SelfSubjectReview.
+- **disabled**: skips identity extraction entirely. Useful for local development or testing.
 
 ### Enabling CORS
 
-When serving the UI directly from the BFF there is no need for any CORS headers to be served, by default they are turned off for security reasons.
-
-If you need to enable CORS for any reasons you can add origins to the allow-list in several ways:
-
-##### Via the make command
-
-Add the following parameter to your command: `ALLOWED_ORIGINS` this takes a comma separated list of origins to permit serving to, alterantively you can specify the value `*` to allow all origins, **Note this is not recommended in production deployments as it poses a security risk**
-
-Examples:
+CORS is disabled by default. Enable with `ALLOWED_ORIGINS`:
 
 ```shell
-# Allow only the origin http://example.com:8081
-make run ALLOWED_ORIGINS="http://example.com:8081"
-
-# Allow the origins http://example.com and http://very-nice.com
-make run ALLOWED_ORIGINS="http://example.com,http://very-nice.com"
-
-# Allow all origins
-make run ALLOWED_ORIGINS="*"
-
-# Explicitly disable CORS (default behaviour)
-make run ALLOWED_ORIGINS=""
-```
-
-#### Via environment variable
-
-Setting CORS via environment variable follows the same rules as using the Makefile, simply set the environment variable `ALLOWED_ORIGINS` with the same value as above.
-
-#### Via command line argument
-
-Setting CORS via command line arguments follows the same rules as using the Makefile. Simply add the `--allowed-origins=` flag to your command.
-
-Examples:
-
-```shell
-./bff --allowed-origins="http://my-domain.com,http://my-other-domain.com"
+make run ALLOWED_ORIGINS="http://localhost:3000"
+make run ALLOWED_ORIGINS="*"   # allow all (not for production)
 ```
 
 ### Disabling TLS verification (development only)
-
-For local installations with self-signed certificates, you may need to disable TLS certificate verification.
-
-**Kubernetes deployment:**
-
-```yaml
-env:
-  - name: INSECURE_SKIP_VERIFY
-    value: "true"
-```
-
-**Local development:**
 
 ```shell
 ./bin/bff --insecure-skip-verify

--- a/distributions/core-bff/bff/cmd/main.go
+++ b/distributions/core-bff/bff/cmd/main.go
@@ -36,7 +36,10 @@ func main() {
 	flag.IntVar(&cfg.DevModeClientPort, "dev-mode-client-port", getEnvAsInt("DEV_MODE_CLIENT_PORT", 8080), "Use port when in development mode for client")
 
 	if v := getEnvAsString("DEPLOYMENT_MODE", "standalone"); v != "" {
-		_ = cfg.DeploymentMode.Set(v)
+		if err := cfg.DeploymentMode.Set(v); err != nil {
+			fmt.Fprintf(os.Stderr, "invalid DEPLOYMENT_MODE %q: %v\n", v, err)
+			os.Exit(1)
+		}
 	}
 	flag.Var(&cfg.DeploymentMode, "deployment-mode", "Deployment mode (federated or standalone)")
 
@@ -59,7 +62,10 @@ func main() {
 
 	// ─── Core BFF ─────────────────────────────────────────────
 	if v := getEnvAsString("ODH_PLATFORM_TYPE", ""); v != "" {
-		_ = cfg.PlatformType.Set(v)
+		if err := cfg.PlatformType.Set(v); err != nil {
+			fmt.Fprintf(os.Stderr, "invalid ODH_PLATFORM_TYPE %q: %v\n", v, err)
+			os.Exit(1)
+		}
 	}
 	flag.Var(&cfg.PlatformType, "platform-type", "Platform type: OpenShift, XKS, or empty (auto-detect)")
 	flag.StringVar(&cfg.Namespace, "namespace",

--- a/distributions/core-bff/bff/cmd/main.go
+++ b/distributions/core-bff/bff/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 	flag.BoolVar(&cfg.DevMode, "dev-mode", false, "Use development mode for access to local K8s cluster")
 	flag.IntVar(&cfg.DevModeClientPort, "dev-mode-client-port", getEnvAsInt("DEV_MODE_CLIENT_PORT", 8080), "Use port when in development mode for client")
 
-	if v := getEnvAsString("DEPLOYMENT_MODE", ""); v != "" {
+	if v := getEnvAsString("DEPLOYMENT_MODE", "standalone"); v != "" {
 		_ = cfg.DeploymentMode.Set(v)
 	}
 	flag.Var(&cfg.DeploymentMode, "deployment-mode", "Deployment mode (federated or standalone)")
@@ -58,12 +58,22 @@ func main() {
 		"Enable mock BFF clients (no real HTTP calls to other BFFs)")
 
 	// ─── Core BFF ─────────────────────────────────────────────
+	if v := getEnvAsString("ODH_PLATFORM_TYPE", ""); v != "" {
+		_ = cfg.PlatformType.Set(v)
+	}
+	flag.Var(&cfg.PlatformType, "platform-type", "Platform type: OpenShift, XKS, or empty (auto-detect)")
 	flag.StringVar(&cfg.Namespace, "namespace",
-		getEnvAsString("NAMESPACE", "opendatahub"),
-		"Kubernetes namespace where the dashboard is deployed")
+		getEnvAsString("NAMESPACE", getEnvAsString("OC_PROJECT", "opendatahub")),
+		"Kubernetes namespace where the dashboard is deployed (falls back to OC_PROJECT env var)")
+	flag.StringVar(&cfg.WorkbenchNamespace, "workbench-namespace",
+		getEnvAsString("WORKBENCH_NAMESPACE", ""),
+		"Kubernetes namespace for workbenches (defaults to dashboard namespace if empty)")
 	flag.StringVar(&cfg.DashboardConfigName, "dashboard-config-name",
 		getEnvAsString("DASHBOARD_CONFIG_NAME", "odh-dashboard-config"),
 		"Name of the OdhDashboardConfig CR")
+	flag.StringVar(&cfg.EnabledAppsCM, "enabled-apps-cm",
+		getEnvAsString("ENABLED_APPS_CM", ""),
+		"Name of the ConfigMap that tracks enabled applications")
 	flag.StringVar(&cfg.MFRemotesConfig, "mf-remotes-config",
 		getEnvAsString("MF_REMOTES_CONFIG", ""),
 		"Path to module federation remotes config file")

--- a/distributions/core-bff/bff/internal/api/allowed_users_handler.go
+++ b/distributions/core-bff/bff/internal/api/allowed_users_handler.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// GetAllowedUsersHandler returns users with notebook access in a namespace.
+func (app *App) GetAllowedUsersHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName("namespace")
+
+	if !app.isAllowedNamespace(namespace) {
+		app.forbiddenResponse(w, r, fmt.Errorf("request invalid against a resource from a non-dashboard namespace"))
+		return
+	}
+
+	users, err := app.repositories.AllowedUsers.GetAllowedUsers(r.Context(), namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, users, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/app.go
+++ b/distributions/core-bff/bff/internal/api/app.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/bffclient"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/bffclient/bffmocks"
@@ -21,35 +20,11 @@ import (
 
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
-
-	"github.com/julienschmidt/httprouter"
 )
 
 const (
 	// Version is the current BFF version string.
 	Version = "1.0.0"
-	// PathPrefix is the URL prefix for BFF-scoped paths.
-	PathPrefix = "/core-bff"
-	// APIPathPrefix is the base API path prefix.
-	APIPathPrefix = "/api"
-	// APIVersion is the API version path segment.
-	APIVersion = "/v1"
-	// HealthCheckPath is the health check endpoint path.
-	HealthCheckPath = "/healthcheck"
-	// APIHealthCheckPath is the full API health check path.
-	APIHealthCheckPath = APIPathPrefix + APIVersion + "/healthcheck"
-	// UserPath is the user endpoint path.
-	UserPath = APIPathPrefix + APIVersion + "/user"
-	// NamespacePath is the namespaces endpoint path.
-	NamespacePath = APIPathPrefix + APIVersion + "/namespaces"
-	// OpenAPIPath is the OpenAPI spec endpoint path.
-	OpenAPIPath = PathPrefix + "/openapi"
-	// OpenAPIJSONPath is the OpenAPI JSON spec endpoint path.
-	OpenAPIJSONPath = PathPrefix + "/openapi.json"
-	// OpenAPIYAMLPath is the OpenAPI YAML spec endpoint path.
-	OpenAPIYAMLPath = PathPrefix + "/openapi.yaml"
-	// SwaggerUIPath is the Swagger UI endpoint path.
-	SwaggerUIPath = PathPrefix + "/swagger-ui"
 )
 
 // App holds the BFF application state and dependencies.
@@ -77,9 +52,11 @@ type App struct {
 }
 
 type k8sSetupResult struct {
-	factory   k8s.KubernetesClientFactory
-	testEnv   *envtest.Environment
-	clientset kubernetes.Interface
+	factory     k8s.KubernetesClientFactory
+	testEnv     *envtest.Environment
+	clientset   kubernetes.Interface
+	saDynClient dynamic.Interface
+	saClientset kubernetes.Interface
 }
 
 // NewApp creates a new BFF application instance with all dependencies initialized.
@@ -93,7 +70,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
-	ci := initStartupClusterInfo(cfg, k8sResult, logger)
+	ci, resolvedPlatform := initStartupClusterInfo(cfg, k8sResult, logger)
 	bffFactory := initBFFClientFactory(cfg, rootCAs, logger)
 
 	openAPIHandler, err := NewOpenAPIHandler(logger)
@@ -105,7 +82,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		config:                  cfg,
 		logger:                  logger,
 		kubernetesClientFactory: k8sResult.factory,
-		repositories:            repositories.NewRepositories(),
+		repositories:            repositories.NewRepositories(resolvedPlatform.IsXKS(), k8sResult.saDynClient, k8sResult.saClientset, cfg.Namespace),
 		testEnv:                 k8sResult.testEnv,
 		rootCAs:                 rootCAs,
 		bffClientFactory:        bffFactory,
@@ -131,29 +108,67 @@ func initKubernetesClients(cfg config.EnvConfig, logger *slog.Logger) (k8sSetupR
 			return result, fmt.Errorf("failed to setup envtest: %w", err)
 		}
 		result.factory, err = k8mocks.NewMockedKubernetesClientFactory(result.clientset, result.testEnv, cfg, logger)
+		if err != nil {
+			return result, err
+		}
+		result.saDynClient, err = dynamic.NewForConfig(result.testEnv.Config)
+		if err != nil {
+			return result, fmt.Errorf("failed to create SA dynamic client: %w", err)
+		}
+		result.saClientset, err = kubernetes.NewForConfig(result.testEnv.Config)
 	} else {
 		result.factory, err = k8s.NewKubernetesClientFactory(cfg, logger)
+		if err != nil {
+			return result, err
+		}
+		kubeconfig, kcErr := helpers.GetKubeconfig()
+		if kcErr != nil {
+			return result, fmt.Errorf("failed to get kubeconfig for SA client: %w", kcErr)
+		}
+		result.saDynClient, err = dynamic.NewForConfig(kubeconfig)
+		if err != nil {
+			return result, fmt.Errorf("failed to create SA dynamic client: %w", err)
+		}
+		result.saClientset, err = kubernetes.NewForConfig(kubeconfig)
 	}
 
 	return result, err
 }
 
-func initStartupClusterInfo(cfg config.EnvConfig, k8sResult k8sSetupResult, logger *slog.Logger) clusterInfo {
+func initStartupClusterInfo(cfg config.EnvConfig, k8sResult k8sSetupResult, logger *slog.Logger) (clusterInfo, config.PlatformType) {
 	ci := clusterInfo{clusterBranding: defaultClusterBranding}
+	explicitPlatform := cfg.PlatformType != ""
+
+	if explicitPlatform {
+		logger.Info("Using configured platform type", slog.String("platform", cfg.PlatformType.String()))
+	}
+
+	if cfg.PlatformType.IsXKS() {
+		if cfg.MockK8Client {
+			ci.serverURL = k8sResult.testEnv.Config.Host
+		} else if kubeconfig, err := helpers.GetKubeconfig(); err == nil {
+			ci.serverURL = kubeconfig.Host
+		}
+		ci.currentContext = helpers.GetCurrentContext()
+		return ci, cfg.PlatformType
+	}
 
 	if cfg.MockK8Client {
 		dynClient, dynErr := dynamic.NewForConfig(k8sResult.testEnv.Config)
 		if dynErr != nil {
 			logger.Warn("Failed to create dynamic client for startup queries", slog.Any("error", dynErr))
-			return ci
+			return ci, cfg.PlatformType
 		}
-		return queryClusterInfo(k8sResult.clientset, dynClient, logger)
+		ci, probeErr := queryClusterInfo(k8sResult.clientset, dynClient, logger)
+		ci.serverURL = k8sResult.testEnv.Config.Host
+		ci.currentContext = helpers.GetCurrentContext()
+		return ci, resolveStartupPlatform(ci, probeErr, explicitPlatform, cfg.PlatformType, logger)
 	}
 
 	kubeconfig, kcErr := helpers.GetKubeconfig()
 	if kcErr != nil {
 		logger.Warn("Failed to get kubeconfig for startup queries", slog.Any("error", kcErr))
-		return ci
+		return ci, cfg.PlatformType
 	}
 
 	typedClient, tcErr := kubernetes.NewForConfig(kubeconfig)
@@ -161,9 +176,33 @@ func initStartupClusterInfo(cfg config.EnvConfig, k8sResult k8sSetupResult, logg
 	if tcErr != nil || dcErr != nil {
 		logger.Warn("Failed to create clients for startup queries",
 			slog.Any("typedErr", tcErr), slog.Any("dynamicErr", dcErr))
-		return ci
+		return ci, cfg.PlatformType
 	}
-	return queryClusterInfo(typedClient, dynClient, logger)
+	ci, probeErr := queryClusterInfo(typedClient, dynClient, logger)
+	ci.serverURL = kubeconfig.Host
+	ci.currentContext = helpers.GetCurrentContext()
+	return ci, resolveStartupPlatform(ci, probeErr, explicitPlatform, cfg.PlatformType, logger)
+}
+
+func resolveStartupPlatform(ci clusterInfo, probeErr error, explicit bool, configured config.PlatformType, logger *slog.Logger) config.PlatformType {
+	if explicit {
+		return configured
+	}
+	if probeErr != nil {
+		logger.Warn("ClusterVersion probe returned ambiguous error, defaulting to OpenShift",
+			slog.Any("error", probeErr))
+		return config.PlatformOpenShift
+	}
+	return detectPlatform(ci, logger)
+}
+
+func detectPlatform(ci clusterInfo, logger *slog.Logger) config.PlatformType {
+	if ci.clusterID != "" {
+		logger.Info("Detected OpenShift platform")
+		return config.PlatformOpenShift
+	}
+	logger.Info("Detected XKS platform (no ClusterVersion found)")
+	return config.PlatformXKS
 }
 
 func initBFFClientFactory(cfg config.EnvConfig, rootCAs *x509.CertPool, logger *slog.Logger) bffclient.BFFClientFactory {
@@ -190,78 +229,4 @@ func (app *App) Shutdown() error {
 	}
 	app.logger.Info("shutting env test...")
 	return app.testEnv.Stop()
-}
-
-func (app *App) Routes() http.Handler {
-	// Router for /api/*
-	apiRouter := httprouter.New()
-
-	apiRouter.NotFound = http.HandlerFunc(app.notFoundResponse)
-	apiRouter.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
-
-	// Minimal Kubernetes-backed starter endpoints
-	apiRouter.GET(APIHealthCheckPath, app.HealthcheckHandler)
-	apiRouter.GET(UserPath, app.UserHandler)
-	apiRouter.GET(NamespacePath, app.GetNamespacesHandler)
-
-	// App Router
-	appMux := http.NewServeMux()
-
-	// handler for api calls
-	appMux.Handle(APIPathPrefix+"/", apiRouter)
-	appMux.Handle(PathPrefix+APIPathPrefix+"/", http.StripPrefix(PathPrefix, apiRouter))
-	appMux.HandleFunc(APIPathPrefix, func(w http.ResponseWriter, r *http.Request) {
-		app.notFoundResponse(w, r)
-	})
-	appMux.HandleFunc(PathPrefix+APIPathPrefix, func(w http.ResponseWriter, r *http.Request) {
-		app.notFoundResponse(w, r)
-	})
-
-	// K8s API proxy and WebSocket proxy
-	if app.k8sProxy != nil {
-		appMux.Handle(proxy.K8sProxyPrefix, app.k8sProxy)
-		appMux.Handle(PathPrefix+proxy.K8sProxyPrefix, http.StripPrefix(PathPrefix, app.k8sProxy))
-	}
-	if app.wsProxy != nil {
-		appMux.Handle(proxy.WssProxyPrefix, app.wsProxy)
-		appMux.Handle(PathPrefix+proxy.WssProxyPrefix, http.StripPrefix(PathPrefix, app.wsProxy))
-	}
-
-	// file server for the frontend file and SPA routes
-	staticDir := http.Dir(app.config.StaticAssetsDir)
-	fileServer := http.FileServer(staticDir)
-	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		ctxLogger := helpers.GetContextLoggerFromReq(r)
-		// Check if the requested file exists
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
-			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
-			// Serve the file if it exists
-			fileServer.ServeHTTP(w, r)
-			return
-		}
-
-		// Fallback to index.html for SPA routes
-		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
-		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
-	})
-
-	// Create a mux for the healthcheck endpoint
-	healthcheckMux := http.NewServeMux()
-	healthcheckRouter := httprouter.New()
-	healthcheckRouter.GET(HealthCheckPath, app.HealthcheckHandler)
-	healthcheckMux.Handle(HealthCheckPath, app.RecoverPanic(app.EnableTelemetry(healthcheckRouter)))
-
-	// Combines the healthcheck endpoint with the rest of the routes
-	// Apply middleware to appMux which contains the API routes
-	combinedMux := http.NewServeMux()
-	combinedMux.Handle(HealthCheckPath, healthcheckMux)
-	combinedMux.HandleFunc(OpenAPIJSONPath, app.openAPI.HandleOpenAPIJSONWrapper)
-	combinedMux.HandleFunc(OpenAPIYAMLPath, app.openAPI.HandleOpenAPIYAMLWrapper)
-	if app.config.DevMode {
-		combinedMux.HandleFunc(SwaggerUIPath, app.openAPI.HandleSwaggerUIWrapper)
-		combinedMux.HandleFunc(OpenAPIPath, app.openAPI.HandleOpenAPIRedirectWrapper)
-	}
-	combinedMux.Handle("/", app.RecoverPanic(app.EnableTelemetry(app.EnableCORS(app.InjectRequestIdentity(appMux)))))
-
-	return combinedMux
 }

--- a/distributions/core-bff/bff/internal/api/cluster_info.go
+++ b/distributions/core-bff/bff/internal/api/cluster_info.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -30,35 +33,58 @@ var clusterVersionGVR = schema.GroupVersionResource{
 type clusterInfo struct {
 	clusterID       string
 	clusterBranding string
+	serverURL       string
+	currentContext  string
 }
 
-func queryClusterInfo(client kubernetes.Interface, dynClient dynamic.Interface, logger *slog.Logger) clusterInfo {
+func (ci clusterInfo) GetClusterID() string       { return ci.clusterID }
+func (ci clusterInfo) GetClusterBranding() string { return ci.clusterBranding }
+func (ci clusterInfo) GetServerURL() string       { return ci.serverURL }
+func (ci clusterInfo) GetCurrentContext() string  { return ci.currentContext }
+
+func queryClusterInfo(client kubernetes.Interface, dynClient dynamic.Interface, logger *slog.Logger) (clusterInfo, error) {
 	info := clusterInfo{clusterBranding: defaultClusterBranding}
-	info.clusterID = queryClusterID(dynClient, logger)
+	var err error
+	info.clusterID, err = queryClusterID(dynClient, logger)
+	if err != nil {
+		return info, err
+	}
 	info.clusterBranding = queryClusterBranding(client, logger)
-	return info
+	return info, nil
 }
 
-func queryClusterID(dynClient dynamic.Interface, logger *slog.Logger) string {
+func queryClusterID(dynClient dynamic.Interface, logger *slog.Logger) (string, error) {
 	if dynClient == nil {
-		return ""
+		return "", nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), clusterInfoQueryTimeout)
 	defer cancel()
 
 	obj, err := dynClient.Resource(clusterVersionGVR).Get(ctx, clusterVersionName, metav1.GetOptions{})
 	if err != nil {
-		logger.Warn("ClusterVersion not available (expected on non-OpenShift clusters)", slog.Any("error", err))
-		return ""
+		if k8serrors.IsNotFound(err) || isClusterVersionDiscoveryError(err) {
+			logger.Debug("ClusterVersion CRD not available (non-OpenShift cluster)", slog.Any("error", err))
+			return "", nil
+		}
+		return "", fmt.Errorf("ClusterVersion probe failed: %w", err)
 	}
 
 	spec, ok := obj.Object["spec"].(map[string]any)
 	if !ok {
 		logger.Warn("ClusterVersion spec field missing or unexpected type")
-		return ""
+		return "", nil
 	}
 	clusterID, _ := spec["clusterID"].(string)
-	return clusterID
+	return clusterID, nil
+}
+
+func isClusterVersionDiscoveryError(err error) bool {
+	if k8serrors.IsMethodNotSupported(err) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "the server could not find the requested resource")
 }
 
 // consoleConfig is the minimal structure needed to extract branding from the console-config ConfigMap.
@@ -77,7 +103,7 @@ func queryClusterBranding(client kubernetes.Interface, logger *slog.Logger) stri
 
 	cm, err := client.CoreV1().ConfigMaps(consoleConfigNamespace).Get(ctx, consoleConfigName, metav1.GetOptions{})
 	if err != nil {
-		logger.Warn("console-config ConfigMap not available (expected on non-OpenShift clusters)", slog.Any("error", err))
+		logger.Debug("console-config ConfigMap not available (non-OpenShift cluster)", slog.Any("error", err))
 		return defaultClusterBranding
 	}
 

--- a/distributions/core-bff/bff/internal/api/cluster_info_test.go
+++ b/distributions/core-bff/bff/internal/api/cluster_info_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -13,6 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/config"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func testLogger() *slog.Logger {
@@ -90,20 +95,68 @@ func TestQueryClusterID_Success(t *testing.T) {
 			clusterVersionGVR: "ClusterVersionList",
 		}, cv)
 
-	clusterID := queryClusterID(dynClient, testLogger())
+	clusterID, err := queryClusterID(dynClient, testLogger())
+	require.NoError(t, err)
 	assert.Equal(t, "test-cluster-id-123", clusterID)
 }
 
 func TestQueryClusterID_NotFound(t *testing.T) {
 	scheme := runtime.NewScheme()
 	dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
-	clusterID := queryClusterID(dynClient, testLogger())
+	clusterID, err := queryClusterID(dynClient, testLogger())
+	require.NoError(t, err)
 	assert.Equal(t, "", clusterID)
 }
 
 func TestQueryClusterID_NilClient(t *testing.T) {
-	clusterID := queryClusterID(nil, testLogger())
+	clusterID, err := queryClusterID(nil, testLogger())
+	require.NoError(t, err)
 	assert.Equal(t, "", clusterID)
+}
+
+func TestQueryClusterID_ForbiddenReturnsError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			clusterVersionGVR: "ClusterVersionList",
+		})
+	dynClient.PrependReactor("get", "clusterversions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(
+			schema.GroupResource{Group: "config.openshift.io", Resource: "clusterversions"},
+			clusterVersionName, nil,
+		)
+	})
+
+	clusterID, err := queryClusterID(dynClient, testLogger())
+	assert.Error(t, err)
+	assert.Equal(t, "", clusterID)
+	assert.Contains(t, err.Error(), "ClusterVersion probe failed")
+}
+
+func TestResolveStartupPlatform_ProbeError_DefaultsToOpenShift(t *testing.T) {
+	ci := clusterInfo{}
+	probeErr := k8serrors.NewForbidden(
+		schema.GroupResource{Group: "config.openshift.io", Resource: "clusterversions"},
+		clusterVersionName, nil,
+	)
+	result := resolveStartupPlatform(ci, probeErr, false, "", testLogger())
+	assert.Equal(t, config.PlatformOpenShift, result)
+}
+
+func TestResolveStartupPlatform_NoError_DetectsXKS(t *testing.T) {
+	ci := clusterInfo{}
+	result := resolveStartupPlatform(ci, nil, false, "", testLogger())
+	assert.Equal(t, config.PlatformXKS, result)
+}
+
+func TestResolveStartupPlatform_ExplicitOverridesProbeError(t *testing.T) {
+	ci := clusterInfo{}
+	probeErr := k8serrors.NewForbidden(
+		schema.GroupResource{Group: "config.openshift.io", Resource: "clusterversions"},
+		clusterVersionName, nil,
+	)
+	result := resolveStartupPlatform(ci, probeErr, true, config.PlatformXKS, testLogger())
+	assert.Equal(t, config.PlatformXKS, result)
 }
 
 func TestQueryClusterInfo_BothFail(t *testing.T) {
@@ -111,7 +164,8 @@ func TestQueryClusterInfo_BothFail(t *testing.T) {
 	scheme := runtime.NewScheme()
 	dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
 
-	info := queryClusterInfo(typedClient, dynClient, testLogger())
+	info, err := queryClusterInfo(typedClient, dynClient, testLogger())
+	require.NoError(t, err)
 	assert.Equal(t, "", info.clusterID)
 	assert.Equal(t, defaultClusterBranding, info.clusterBranding)
 }
@@ -146,7 +200,8 @@ func TestQueryClusterInfo_BothSucceed(t *testing.T) {
 			clusterVersionGVR: "ClusterVersionList",
 		}, cv)
 
-	info := queryClusterInfo(typedClient, dynClient, testLogger())
+	info, err := queryClusterInfo(typedClient, dynClient, testLogger())
+	require.NoError(t, err)
 	assert.Equal(t, "abc-def-ghi", info.clusterID)
 	assert.Equal(t, "dedicated", info.clusterBranding)
 }

--- a/distributions/core-bff/bff/internal/api/cluster_settings_handler.go
+++ b/distributions/core-bff/bff/internal/api/cluster_settings_handler.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetClusterSettingsHandler returns cluster settings derived from DashboardConfig and ConfigMaps.
+func (app *App) GetClusterSettingsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	dashConfig, err := app.repositories.DashboardConfig.GetDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, nil,
+	)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	settings, err := app.repositories.ClusterSettings.GetClusterSettings(ctx, app.config.Namespace, dashConfig)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, settings, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// UpdateClusterSettingsHandler updates cluster settings.
+func (app *App) UpdateClusterSettingsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	var settings models.ClusterSettings
+	if err := app.ReadJSON(w, r, &settings); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	if err := validateClusterSettings(&settings); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	currentConfig, err := app.repositories.DashboardConfig.GetDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, nil,
+	)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get current config: %w", err))
+		return
+	}
+
+	patchBytes, err := app.repositories.ClusterSettings.BuildDashboardConfigPatch(&settings, currentConfig)
+	if err != nil {
+		writeClusterSettingsError(app, w, r, fmt.Sprintf("failed to build config patch: %v", err))
+		return
+	}
+
+	if _, err := app.repositories.DashboardConfig.PatchRawDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, patchBytes, types.MergePatchType,
+	); err != nil {
+		writeClusterSettingsError(app, w, r, fmt.Sprintf("unable to update cluster settings: %v", err))
+		return
+	}
+
+	if err := app.repositories.ClusterSettings.UpdateConfigMaps(ctx, app.config.Namespace, &settings, currentConfig); err != nil {
+		writeClusterSettingsError(app, w, r, fmt.Sprintf("unable to update cluster settings: %v", err))
+		return
+	}
+
+	result := &models.MutationResponse{Success: true}
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func writeClusterSettingsError(app *App, w http.ResponseWriter, r *http.Request, msg string) {
+	result := &models.MutationResponse{Success: false, Error: msg}
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+var validDeploymentStrategies = map[string]bool{
+	"":         true,
+	"rolling":  true,
+	"recreate": true,
+}
+
+func validateClusterSettings(s *models.ClusterSettings) error {
+	if s.PVCSize <= 0 {
+		return errors.New("pvcSize must be greater than 0")
+	}
+	if s.CullerTimeout < 0 {
+		return errors.New("cullerTimeout must not be negative")
+	}
+	if !validDeploymentStrategies[s.DefaultDeploymentStrategy] {
+		return fmt.Errorf("invalid defaultDeploymentStrategy: %q", s.DefaultDeploymentStrategy)
+	}
+	return nil
+}

--- a/distributions/core-bff/bff/internal/api/cluster_settings_handler.go
+++ b/distributions/core-bff/bff/internal/api/cluster_settings_handler.go
@@ -100,6 +100,9 @@ func validateClusterSettings(s *models.ClusterSettings) error {
 	if s.CullerTimeout < 0 {
 		return errors.New("cullerTimeout must not be negative")
 	}
+	if s.CullerTimeout > 0 && s.CullerTimeout%60 != 0 {
+		return errors.New("cullerTimeout must be a multiple of 60 seconds")
+	}
 	if !validDeploymentStrategies[s.DefaultDeploymentStrategy] {
 		return fmt.Errorf("invalid defaultDeploymentStrategy: %q", s.DefaultDeploymentStrategy)
 	}

--- a/distributions/core-bff/bff/internal/api/cluster_settings_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/cluster_settings_handler_test.go
@@ -53,6 +53,13 @@ func TestValidateClusterSettings_NegativeTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "cullerTimeout")
 }
 
+func TestValidateClusterSettings_NonMultipleOf60Timeout(t *testing.T) {
+	s := &models.ClusterSettings{PVCSize: 20, CullerTimeout: 90}
+	err := validateClusterSettings(s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple of 60")
+}
+
 func TestValidateClusterSettings_InvalidStrategy(t *testing.T) {
 	s := &models.ClusterSettings{
 		PVCSize:                   20,
@@ -101,17 +108,19 @@ func TestGetClusterSettingsHandler_Success(t *testing.T) {
 }
 
 func TestUpdateClusterSettingsHandler_ValidInput_Returns200(t *testing.T) {
+	ns := "cs-update-valid"
+	createTestNamespace(t, ns)
 	fakeDyn := newFakeDynWithDashboardCR()
 	app := newTestApp(func(a *App) {
-		a.config.Namespace = "dash-ns"
+		a.config.Namespace = ns
 		a.config.DashboardConfigName = "odh-dashboard-config"
 		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
 	})
 	admin := k8mocks.DefaultTestUsers[0]
 
 	body, _ := json.Marshal(models.ClusterSettings{
-		PVCSize:                   30,
-		CullerTimeout:             600,
+		PVCSize:                   20,
+		CullerTimeout:             31536000,
 		DefaultDeploymentStrategy: "rolling",
 	})
 
@@ -126,12 +135,14 @@ func TestUpdateClusterSettingsHandler_ValidInput_Returns200(t *testing.T) {
 
 	app.UpdateClusterSettingsHandler(rr, req, nil)
 
-	// Always returns 200 with MutationResponse (Fastify-compatible)
+	// Always returns 200 with MutationResponse.
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	var result models.MutationResponse
 	err := json.Unmarshal(rr.Body.Bytes(), &result)
 	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Empty(t, result.Error)
 }
 
 func TestUpdateClusterSettingsHandler_MalformedBody_Returns400(t *testing.T) {

--- a/distributions/core-bff/bff/internal/api/cluster_settings_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/cluster_settings_handler_test.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateClusterSettings_ValidInput(t *testing.T) {
+	s := &models.ClusterSettings{
+		PVCSize:                   20,
+		CullerTimeout:             31536000,
+		DefaultDeploymentStrategy: "rolling",
+	}
+	assert.NoError(t, validateClusterSettings(s))
+}
+
+func TestValidateClusterSettings_EmptyStrategy(t *testing.T) {
+	s := &models.ClusterSettings{
+		PVCSize:       20,
+		CullerTimeout: 0,
+	}
+	assert.NoError(t, validateClusterSettings(s))
+}
+
+func TestValidateClusterSettings_NegativePVC(t *testing.T) {
+	s := &models.ClusterSettings{PVCSize: -1, CullerTimeout: 0}
+	err := validateClusterSettings(s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pvcSize")
+}
+
+func TestValidateClusterSettings_ZeroPVC(t *testing.T) {
+	s := &models.ClusterSettings{PVCSize: 0, CullerTimeout: 0}
+	err := validateClusterSettings(s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pvcSize")
+}
+
+func TestValidateClusterSettings_NegativeTimeout(t *testing.T) {
+	s := &models.ClusterSettings{PVCSize: 20, CullerTimeout: -1}
+	err := validateClusterSettings(s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cullerTimeout")
+}
+
+func TestValidateClusterSettings_InvalidStrategy(t *testing.T) {
+	s := &models.ClusterSettings{
+		PVCSize:                   20,
+		CullerTimeout:             0,
+		DefaultDeploymentStrategy: "bluegreen",
+	}
+	err := validateClusterSettings(s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "defaultDeploymentStrategy")
+}
+
+func TestValidateClusterSettings_RecreateStrategy(t *testing.T) {
+	s := &models.ClusterSettings{
+		PVCSize:                   20,
+		CullerTimeout:             0,
+		DefaultDeploymentStrategy: "recreate",
+	}
+	assert.NoError(t, validateClusterSettings(s))
+}
+
+func TestGetClusterSettingsHandler_Success(t *testing.T) {
+	fakeDyn := newFakeDynWithDashboardCR()
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/cluster-settings", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetClusterSettingsHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var settings models.ClusterSettings
+	err := json.Unmarshal(rr.Body.Bytes(), &settings)
+	require.NoError(t, err)
+	assert.Greater(t, settings.PVCSize, 0)
+}
+
+func TestUpdateClusterSettingsHandler_ValidInput_Returns200(t *testing.T) {
+	fakeDyn := newFakeDynWithDashboardCR()
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body, _ := json.Marshal(models.ClusterSettings{
+		PVCSize:                   30,
+		CullerTimeout:             600,
+		DefaultDeploymentStrategy: "rolling",
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/cluster-settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.UpdateClusterSettingsHandler(rr, req, nil)
+
+	// Always returns 200 with MutationResponse (Fastify-compatible)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+}
+
+func TestUpdateClusterSettingsHandler_MalformedBody_Returns400(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, ClusterSettingsPath, bytes.NewReader([]byte("not-json")))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.UpdateClusterSettingsHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestUpdateClusterSettingsHandler_InvalidInput_Returns400(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	body, _ := json.Marshal(models.ClusterSettings{
+		PVCSize:       -1,
+		CullerTimeout: 0,
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/cluster-settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.UpdateClusterSettingsHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/distributions/core-bff/bff/internal/api/components_handler.go
+++ b/distributions/core-bff/bff/internal/api/components_handler.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// GetComponentsHandler lists OdhApplication CRDs. Returns empty array when CRD is absent.
+func (app *App) GetComponentsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
+	installedOnly := r.URL.Query().Get("installed") != ""
+
+	components, err := app.repositories.Components.ListComponents(r.Context(), app.config.Namespace, installedOnly)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, components, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// RemoveComponentHandler removes an app entry from the enabled-apps ConfigMap.
+func (app *App) RemoveComponentHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	appName := r.URL.Query().Get("appName")
+	if appName == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required query parameter: appName"))
+		return
+	}
+
+	result, err := app.repositories.Components.RemoveComponent(
+		r.Context(), app.config.Namespace, appName, app.config.EnabledAppsCM,
+	)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/components_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/components_handler_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRemoveComponentHandler_Success(t *testing.T) {
+	ns := "ct-remove"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+		a.config.EnabledAppsCM = "enabled-apps"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+
+	// Pre-create the enabled-apps ConfigMap with an app entry
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "enabled-apps", Namespace: ns},
+		Data:       map[string]string{"my-app": "true", "other-app": "true"},
+	}
+	cleanupTestCM(t, ns, "enabled-apps")
+	_, err := testSAClientset.CoreV1().ConfigMaps(ns).Create(context.Background(), cm, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ComponentsRemovePath+"?appName=my-app", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.RemoveComponentHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+
+	// Verify the entry was removed
+	updated, err := testSAClientset.CoreV1().ConfigMaps(ns).Get(context.Background(), "enabled-apps", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotContains(t, updated.Data, "my-app")
+	assert.Contains(t, updated.Data, "other-app")
+}
+
+func TestRemoveComponentHandler_MissingAppName_Returns400(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ComponentsRemovePath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.RemoveComponentHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetComponentsHandler_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ComponentsPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	app.GetComponentsHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRemoveComponentHandler_CMNotFound_ReturnsSuccessFalse(t *testing.T) {
+	ns := "ct-remove-notfound"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+		a.config.EnabledAppsCM = "enabled-apps"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ComponentsRemovePath+"?appName=my-app", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.RemoveComponentHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.NotEmpty(t, result.Error)
+}
+
+func TestGetComponentsHandler_CRDAbsent_ReturnsEmptyArray(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ComponentsPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetComponentsHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body []any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Empty(t, body)
+}

--- a/distributions/core-bff/bff/internal/api/config_handler.go
+++ b/distributions/core-bff/bff/internal/api/config_handler.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetConfigHandler returns the merged DashboardConfig with defaults.
+func (app *App) GetConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	if err := app.validateCallerToken(ctx); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
+	var featureFlagOverrides map[string]bool
+	if flagsHeader := r.Header.Get("x-odh-feature-flags"); flagsHeader != "" {
+		featureFlagOverrides = make(map[string]bool)
+		if err := json.Unmarshal([]byte(flagsHeader), &featureFlagOverrides); err != nil {
+			// Silently ignore malformed header
+			featureFlagOverrides = nil
+		}
+	}
+
+	config, err := app.repositories.DashboardConfig.GetDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, featureFlagOverrides,
+	)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-cache")
+	if err := app.WriteJSON(w, http.StatusOK, config, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// PatchConfigHandler updates the default DashboardConfig CRD.
+func (app *App) PatchConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	_, err = app.repositories.DashboardConfig.PatchRawDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, body, types.MergePatchType,
+	)
+	if err != nil {
+		if isResourceUnavailable(err) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Re-fetch the merged config to return the updated state
+	config, err := app.repositories.DashboardConfig.GetDashboardConfig(
+		ctx, app.config.Namespace, app.config.DashboardConfigName, nil,
+	)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, config, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/config_handler.go
+++ b/distributions/core-bff/bff/internal/api/config_handler.go
@@ -46,9 +46,15 @@ func (app *App) GetConfigHandler(w http.ResponseWriter, r *http.Request, _ httpr
 func (app *App) PatchConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1_048_576)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	if !json.Valid(body) {
+		app.badRequestResponse(w, r, fmt.Errorf("body contains badly-formed JSON"))
 		return
 	}
 

--- a/distributions/core-bff/bff/internal/api/config_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/config_handler_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConfigHandler_ReturnsDefaults(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConfigPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	spec := body["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
+	assert.Equal(t, true, dc["enablement"])
+	assert.Equal(t, false, dc["disableProjects"])
+}
+
+func TestGetConfigHandler_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConfigPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	app.GetConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestGetConfigHandler_XKSPlatform_DisablesProjects(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+		a.repositories = repositories.NewRepositories(true, testSADynClient, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConfigPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	spec := body["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
+	assert.Equal(t, true, dc["disableProjects"])
+	assert.Equal(t, true, dc["disableBYONImageStream"])
+	assert.Equal(t, true, dc["disableISVBadges"])
+	assert.Equal(t, true, dc["disableAppLauncher"])
+}
+
+func TestPatchConfigHandler_Success(t *testing.T) {
+	fakeDyn := newFakeDynWithDashboardCR()
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	patch := `{"spec":{"dashboardConfig":{"disableKServe":true}}}`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, ConfigPath, bytes.NewReader([]byte(patch)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PatchConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	spec := body["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
+	assert.Equal(t, true, dc["disableKServe"])
+	assert.Equal(t, true, dc["enablement"])
+}
+
+func TestGetConfigHandler_FeatureFlagOverrides(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConfigPath, nil)
+	req.Header.Set("x-odh-feature-flags", `{"disableKServe":true,"disableModelServing":true}`)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	spec := body["spec"].(map[string]any)
+	dc := spec["dashboardConfig"].(map[string]any)
+
+	// Header overrides applied
+	assert.Equal(t, true, dc["disableKServe"])
+	assert.Equal(t, true, dc["disableModelServing"])
+
+	// Lockouts still enforced after header overrides
+	assert.Equal(t, true, dc["disableFineTuning"])
+}
+
+func TestPatchConfigHandler_CRDAbsent_Returns404(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	patch := `{"spec":{"dashboardConfig":{"disableKServe":true}}}`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, ConfigPath, bytes.NewReader([]byte(patch)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.PatchConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestGetConfigHandler_MalformedFeatureFlagHeader_Ignored(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+		a.config.DashboardConfigName = "odh-dashboard-config"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConfigPath, nil)
+	req.Header.Set("x-odh-feature-flags", "not-valid-json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetConfigHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/distributions/core-bff/bff/internal/api/connection_type_handler.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler.go
@@ -101,6 +101,7 @@ func (app *App) UpdateConnectionTypeHandler(w http.ResponseWriter, r *http.Reque
 func (app *App) PatchConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	name := ps.ByName("name")
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1_048_576)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))

--- a/distributions/core-bff/bff/internal/api/connection_type_handler.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ListConnectionTypesHandler lists connection-type ConfigMaps.
+func (app *App) ListConnectionTypesHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
+	items, err := app.repositories.ConnectionType.List(r.Context(), app.config.Namespace)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+	if items == nil {
+		items = []corev1.ConfigMap{}
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, items, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// GetConnectionTypeHandler gets a single connection-type ConfigMap by name.
+func (app *App) GetConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
+	name := ps.ByName("name")
+
+	cm, err := app.repositories.ConnectionType.Get(r.Context(), app.config.Namespace, name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) || strings.Contains(err.Error(), "is not a connection type") {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, cm, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// CreateConnectionTypeHandler creates a connection-type ConfigMap.
+func (app *App) CreateConnectionTypeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var cm corev1.ConfigMap
+	if err := app.ReadJSON(w, r, &cm); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	result, err := app.repositories.ConnectionType.Create(r.Context(), app.config.Namespace, &cm)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// UpdateConnectionTypeHandler replaces a connection-type ConfigMap.
+func (app *App) UpdateConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	name := ps.ByName("name")
+
+	var cm corev1.ConfigMap
+	if err := app.ReadJSON(w, r, &cm); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	cm.Name = name
+
+	result, err := app.repositories.ConnectionType.Update(r.Context(), app.config.Namespace, name, &cm)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	writeConnectionTypeMutationResponse(app, w, r, result)
+}
+
+// PatchConnectionTypeHandler partially updates a connection-type ConfigMap.
+func (app *App) PatchConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	name := ps.ByName("name")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	result, err := app.repositories.ConnectionType.Patch(r.Context(), app.config.Namespace, name, body)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	writeConnectionTypeMutationResponse(app, w, r, result)
+}
+
+// DeleteConnectionTypeHandler deletes a connection-type ConfigMap.
+func (app *App) DeleteConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	name := ps.ByName("name")
+
+	result, err := app.repositories.ConnectionType.Delete(r.Context(), app.config.Namespace, name)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	writeConnectionTypeMutationResponse(app, w, r, result)
+}
+
+func writeConnectionTypeMutationResponse(app *App, w http.ResponseWriter, r *http.Request, result *models.MutationResponse) {
+	if err := app.WriteJSON(w, http.StatusOK, result, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/connection_type_handler.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,6 +60,11 @@ func (app *App) GetConnectionTypeHandler(w http.ResponseWriter, r *http.Request,
 
 // CreateConnectionTypeHandler creates a connection-type ConfigMap.
 func (app *App) CreateConnectionTypeHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
 	var cm corev1.ConfigMap
 	if err := app.ReadJSON(w, r, &cm); err != nil {
 		app.badRequestResponse(w, r, err)
@@ -78,6 +84,11 @@ func (app *App) CreateConnectionTypeHandler(w http.ResponseWriter, r *http.Reque
 
 // UpdateConnectionTypeHandler replaces a connection-type ConfigMap.
 func (app *App) UpdateConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
 	name := ps.ByName("name")
 
 	var cm corev1.ConfigMap
@@ -99,12 +110,22 @@ func (app *App) UpdateConnectionTypeHandler(w http.ResponseWriter, r *http.Reque
 
 // PatchConnectionTypeHandler partially updates a connection-type ConfigMap.
 func (app *App) PatchConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
 	name := ps.ByName("name")
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1_048_576)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	if !json.Valid(body) {
+		app.badRequestResponse(w, r, fmt.Errorf("body contains badly-formed JSON"))
 		return
 	}
 
@@ -119,6 +140,11 @@ func (app *App) PatchConnectionTypeHandler(w http.ResponseWriter, r *http.Reques
 
 // DeleteConnectionTypeHandler deletes a connection-type ConfigMap.
 func (app *App) DeleteConnectionTypeHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if err := app.validateCallerToken(r.Context()); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
 	name := ps.ByName("name")
 
 	result, err := app.repositories.ConnectionType.Delete(r.Context(), app.config.Namespace, name)

--- a/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
@@ -1,0 +1,510 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+)
+
+func createTestConnectionTypeCM(t *testing.T, app *App, admin k8mocks.TestUser, name string) {
+	t.Helper()
+	client, err := app.kubernetesClientFactory.GetClient(
+		reqWithIdentity(
+			httptest.NewRequest(http.MethodGet, "/", nil),
+			&k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			},
+		).Context(),
+	)
+	require.NoError(t, err)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: app.config.Namespace,
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	_, err = client.CreateConfigMap(context.Background(), app.config.Namespace, cm)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+}
+
+func TestListConnectionTypes_Empty(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "ct-list-empty"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConnectionTypesPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.ListConnectionTypesHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body []any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Empty(t, body)
+}
+
+func TestListConnectionTypes_WithItems(t *testing.T) {
+	ns := "ct-list-items"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "test-ct-1")
+	createTestConnectionTypeCM(t, app, admin, "test-ct-1")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConnectionTypesPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.ListConnectionTypesHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body []any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Len(t, body, 1)
+}
+
+func TestCreateConnectionType_Success(t *testing.T) {
+	ns := "ct-create"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "new-ct")
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "new-ct",
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+		Data: map[string]string{"key": "value"},
+	}
+
+	body, err := json.Marshal(cm)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ConnectionTypesPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateConnectionTypeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestCreateConnectionType_InvalidLabels(t *testing.T) {
+	ns := "ct-create-invalid"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "bad-ct",
+			Labels: map[string]string{},
+		},
+		Data: map[string]string{"key": "value"},
+	}
+
+	body, err := json.Marshal(cm)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ConnectionTypesPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.CreateConnectionTypeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "connection-type labels")
+}
+
+func TestDeleteConnectionType_Success(t *testing.T) {
+	ns := "ct-delete"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "ct-to-delete")
+	createTestConnectionTypeCM(t, app, admin, "ct-to-delete")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/connection-types/ct-to-delete", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "ct-to-delete"}}
+	app.DeleteConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestUpdateConnectionType_EnforcesURLName(t *testing.T) {
+	ns := "ct-update"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "ct-to-update")
+	createTestConnectionTypeCM(t, app, admin, "ct-to-update")
+
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "different-name",
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+		Data: map[string]string{"key": "updated"},
+	}
+
+	body, err := json.Marshal(cm)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/connection-types/ct-to-update", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "ct-to-update"}}
+	app.UpdateConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestUpdateConnectionType_NonConnectionType_Rejected(t *testing.T) {
+	ns := "ct-update-reject"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "plain-cm")
+
+	// Create a plain ConfigMap (not a connection type)
+	client, err := app.kubernetesClientFactory.GetClient(
+		reqWithIdentity(
+			httptest.NewRequest(http.MethodGet, "/", nil),
+			&k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			},
+		).Context(),
+	)
+	require.NoError(t, err)
+	plainCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-cm", Namespace: ns},
+		Data:       map[string]string{"key": "value"},
+	}
+	_, err = client.CreateConfigMap(context.Background(), ns, plainCM)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	updateCM := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "plain-cm",
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+		Data: map[string]string{"key": "hacked"},
+	}
+	body, err := json.Marshal(updateCM)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/connection-types/plain-cm", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "plain-cm"}}
+	app.UpdateConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "not a connection type")
+}
+
+func TestListConnectionTypes_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, ConnectionTypesPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	app.ListConnectionTypesHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestGetConnectionType_NotFound_Returns404(t *testing.T) {
+	ns := "ct-get-notfound"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/connection-types/nonexistent", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "nonexistent"}}
+	app.GetConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestDeleteConnectionType_NotFound_ReturnsSuccessFalse(t *testing.T) {
+	ns := "ct-delete-notfound"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/connection-types/nonexistent", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "nonexistent"}}
+	app.DeleteConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+}
+
+func TestPatchConnectionType_Success(t *testing.T) {
+	ns := "ct-patch-success"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "ct-to-patch")
+	createTestConnectionTypeCM(t, app, admin, "ct-to-patch")
+
+	patchData := `[{"op":"replace","path":"/data/test-key","value":"patched"}]`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/connection-types/ct-to-patch", bytes.NewReader([]byte(patchData)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "ct-to-patch"}}
+	app.PatchConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestPatchConnectionType_NonConnectionType_Rejected(t *testing.T) {
+	ns := "ct-patch-reject"
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = ns
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	createTestNamespace(t, ns)
+	cleanupTestCM(t, ns, "plain-cm-patch")
+
+	client, err := app.kubernetesClientFactory.GetClient(
+		reqWithIdentity(
+			httptest.NewRequest(http.MethodGet, "/", nil),
+			&k8s.RequestIdentity{
+				UserID: admin.UserName,
+				Groups: admin.Groups,
+				Token:  k8s.NewBearerToken(admin.Token),
+			},
+		).Context(),
+	)
+	require.NoError(t, err)
+	plainCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-cm-patch", Namespace: ns},
+		Data:       map[string]string{"key": "value"},
+	}
+	_, err = client.CreateConfigMap(context.Background(), ns, plainCM)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		require.NoError(t, err)
+	}
+
+	patchData := `[{"op":"replace","path":"/data/key","value":"hacked"}]`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/connection-types/plain-cm-patch", bytes.NewReader([]byte(patchData)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "plain-cm-patch"}}
+	app.PatchConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var result models.MutationResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &result)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "not a connection type")
+}
+
+// cleanupTestCM deletes a ConfigMap if it exists, ensuring clean state for re-runs.
+func cleanupTestCM(t *testing.T, ns, name string) {
+	t.Helper()
+	if testSAClientset == nil {
+		return
+	}
+	_ = testSAClientset.CoreV1().ConfigMaps(ns).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+// createTestNamespace creates a namespace in envtest for tests that need one.
+// Idempotent - handles already-exists gracefully for re-runs.
+func createTestNamespace(t *testing.T, ns string) {
+	t.Helper()
+	if testEnvInstance == nil || testEnvInstance.Config == nil {
+		t.Fatal("testEnvInstance not initialized")
+	}
+	clientset, err := k8sclient.NewForConfig(testEnvInstance.Config)
+	require.NoError(t, err)
+
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: ns},
+	}
+	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), nsObj, metav1.CreateOptions{})
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		t.Fatalf("unexpected error creating namespace: %v", err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
@@ -505,6 +505,69 @@ func TestPatchConnectionType_OversizedPayload_Rejected(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestCreateConnectionType_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, ConnectionTypesPath, bytes.NewReader([]byte(`{}`)))
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	app.CreateConnectionTypeHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestUpdateConnectionType_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/connection-types/any", bytes.NewReader([]byte(`{}`)))
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "any"}}
+	app.UpdateConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestPatchConnectionType_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/connection-types/any", bytes.NewReader([]byte(`[]`)))
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "any"}}
+	app.PatchConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestDeleteConnectionType_InvalidToken_Returns401(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/connection-types/any", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: "attacker",
+		Token:  k8s.NewBearerToken("garbage-token-abc123"),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "any"}}
+	app.DeleteConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
 // cleanupTestCM deletes a ConfigMap if it exists, ensuring clean state for re-runs.
 func cleanupTestCM(t *testing.T, ns, name string) {
 	t.Helper()

--- a/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/connection_type_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
@@ -479,6 +480,29 @@ func TestPatchConnectionType_NonConnectionType_Rejected(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.Success)
 	assert.Contains(t, result.Error, "not a connection type")
+}
+
+func TestPatchConnectionType_OversizedPayload_Rejected(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	largePayload := "[" + strings.Repeat("x", 1_048_576) + "]"
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/connection-types/any", bytes.NewReader([]byte(largePayload)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "name", Value: "any"}}
+	app.PatchConnectionTypeHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 // cleanupTestCM deletes a ConfigMap if it exists, ensuring clean state for re-runs.

--- a/distributions/core-bff/bff/internal/api/dashboard_config_handler.go
+++ b/distributions/core-bff/bff/internal/api/dashboard_config_handler.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// isResourceUnavailable returns true when the resource or its CRD is absent.
+// Broader than repositories.isDiscoveryError: also matches IsNotFound (instance missing).
+func isResourceUnavailable(err error) bool {
+	if k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "the server could not find the requested resource")
+}
+
+// GetDashboardConfigByNameHandler fetches a specific OdhDashboardConfig by namespace/name.
+func (app *App) GetDashboardConfigByNameHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName("namespace")
+	name := ps.ByName("name")
+
+	if !app.isAllowedNamespace(namespace) {
+		app.forbiddenResponse(w, r, fmt.Errorf("request invalid against a resource from a non-dashboard namespace"))
+		return
+	}
+
+	raw, err := app.repositories.DashboardConfig.GetRawDashboardConfig(r.Context(), namespace, name)
+	if err != nil {
+		if isResourceUnavailable(err) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, raw, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// PatchDashboardConfigByNameHandler patches a specific OdhDashboardConfig by namespace/name.
+func (app *App) PatchDashboardConfigByNameHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	namespace := ps.ByName("namespace")
+	name := ps.ByName("name")
+
+	if !app.isAllowedNamespace(namespace) {
+		app.forbiddenResponse(w, r, fmt.Errorf("request invalid against a resource from a non-dashboard namespace"))
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	raw, err := app.repositories.DashboardConfig.PatchRawDashboardConfig(r.Context(), namespace, name, body, types.JSONPatchType)
+	if err != nil {
+		if isResourceUnavailable(err) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, raw, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/dashboard_config_handler.go
+++ b/distributions/core-bff/bff/internal/api/dashboard_config_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -57,9 +58,15 @@ func (app *App) PatchDashboardConfigByNameHandler(w http.ResponseWriter, r *http
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1_048_576)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		app.badRequestResponse(w, r, fmt.Errorf("failed to read request body: %w", err))
+		return
+	}
+
+	if !json.Valid(body) {
+		app.badRequestResponse(w, r, fmt.Errorf("body contains badly-formed JSON"))
 		return
 	}
 

--- a/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
@@ -116,8 +116,8 @@ func TestGetDashboardConfigByName_WorkbenchNamespace_Allowed(t *testing.T) {
 	}
 	app.GetDashboardConfigByNameHandler(rr, req, ps)
 
-	// Workbench namespace is allowed - should not get 403
-	assert.NotEqual(t, http.StatusForbidden, rr.Code)
+	// Workbench namespace is allowed (not 403); resource absent in wb-ns yields 404.
+	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 func TestGetDashboardConfigByName_WrongNamespace_Returns403(t *testing.T) {

--- a/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/dashboard_config_handler_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestGetDashboardConfigByName_CRDAbsent_Returns404(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboardConfig/dash-ns/test-name", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "dash-ns"},
+		{Key: "name", Value: "test-name"},
+	}
+	app.GetDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestPatchDashboardConfigByName_CRDAbsent_Returns404(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	patch := `[{"op":"replace","path":"/spec/dashboardConfig/disableKServe","value":true}]`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/dashboardConfig/dash-ns/test-name", bytes.NewReader([]byte(patch)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "dash-ns"},
+		{Key: "name", Value: "test-name"},
+	}
+	app.PatchDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestPatchDashboardConfigByName_WrongNamespace_Returns403(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	patch := `[{"op":"replace","path":"/spec/dashboardConfig/disableKServe","value":true}]`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/dashboardConfig/wrong-ns/test-name", bytes.NewReader([]byte(patch)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "wrong-ns"},
+		{Key: "name", Value: "test-name"},
+	}
+	app.PatchDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestGetDashboardConfigByName_WorkbenchNamespace_Allowed(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.config.WorkbenchNamespace = "wb-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboardConfig/wb-ns/test-name", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "wb-ns"},
+		{Key: "name", Value: "test-name"},
+	}
+	app.GetDashboardConfigByNameHandler(rr, req, ps)
+
+	// Workbench namespace is allowed - should not get 403
+	assert.NotEqual(t, http.StatusForbidden, rr.Code)
+}
+
+func TestGetDashboardConfigByName_WrongNamespace_Returns403(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboardConfig/wrong-ns/test-name", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "wrong-ns"},
+		{Key: "name", Value: "test-name"},
+	}
+	app.GetDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func newFakeDynWithDashboardCR() *dynamicfake.FakeDynamicClient {
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "opendatahub.io/v1alpha",
+			"kind":       "OdhDashboardConfig",
+			"metadata": map[string]interface{}{
+				"name":      "odh-dashboard-config",
+				"namespace": "dash-ns",
+			},
+			"spec": map[string]interface{}{
+				"dashboardConfig": map[string]interface{}{
+					"disableKServe": false,
+				},
+			},
+		},
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			models.DashboardConfigGVR: "OdhDashboardConfigList",
+		},
+		cr,
+	)
+}
+
+func TestGetDashboardConfigByName_Success(t *testing.T) {
+	fakeDyn := newFakeDynWithDashboardCR()
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboardConfig/dash-ns/odh-dashboard-config", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "dash-ns"},
+		{Key: "name", Value: "odh-dashboard-config"},
+	}
+	app.GetDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "OdhDashboardConfig", body["kind"])
+}
+
+func TestPatchDashboardConfigByName_Success(t *testing.T) {
+	fakeDyn := newFakeDynWithDashboardCR()
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "dash-ns"
+		a.repositories = repositories.NewRepositories(false, fakeDyn, testSAClientset, "")
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	patch := `[{"op":"replace","path":"/spec/dashboardConfig/disableKServe","value":true}]`
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/api/dashboardConfig/dash-ns/odh-dashboard-config", bytes.NewReader([]byte(patch)))
+	req.Header.Set("Content-Type", "application/json")
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{
+		{Key: "namespace", Value: "dash-ns"},
+		{Key: "name", Value: "odh-dashboard-config"},
+	}
+	app.PatchDashboardConfigByNameHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	spec := body["spec"].(map[string]interface{})
+	dc := spec["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, true, dc["disableKServe"])
+}

--- a/distributions/core-bff/bff/internal/api/errors.go
+++ b/distributions/core-bff/bff/internal/api/errors.go
@@ -52,6 +52,12 @@ func (app *App) serverErrorResponse(w http.ResponseWriter, r *http.Request, err 
 	app.errorResponse(w, r, httpError)
 }
 
+func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, err error) {
+	app.logger.Warn("Forbidden access attempt", "error", err.Error(), "method", r.Method, "uri", r.URL.RequestURI())
+	httpError := &HTTPError{StatusCode: http.StatusForbidden, Error: ErrorPayload{Code: "FORBIDDEN", Message: err.Error()}}
+	app.errorResponse(w, r, httpError)
+}
+
 func (app *App) notFoundResponse(w http.ResponseWriter, r *http.Request) {
 
 	httpError := &HTTPError{StatusCode: http.StatusNotFound, Error: ErrorPayload{Code: "NOT_FOUND", Message: "the requested resource could not be found"}}

--- a/distributions/core-bff/bff/internal/api/middleware.go
+++ b/distributions/core-bff/bff/internal/api/middleware.go
@@ -69,7 +69,7 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 }
 
 // requireAdmin wraps a handler and rejects non-admin users with 401.
-// Uses the Fastify-specific SSAR check: patch on auths/default-auth.
+// Uses the SSAR check: patch on auths/default-auth.
 // TODO(task3): replace with secureAdminRoute once the full auth chain is implemented.
 func (app *App) requireAdmin(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {

--- a/distributions/core-bff/bff/internal/api/middleware.go
+++ b/distributions/core-bff/bff/internal/api/middleware.go
@@ -68,12 +68,70 @@ func (app *App) InjectRequestIdentity(next http.Handler) http.Handler {
 	})
 }
 
+// requireAdmin wraps a handler and rejects non-admin users with 401.
+// Uses the Fastify-specific SSAR check: patch on auths/default-auth.
+// TODO(task3): replace with secureAdminRoute once the full auth chain is implemented.
+func (app *App) requireAdmin(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		ctx := r.Context()
+		client, err := app.kubernetesClientFactory.GetClient(ctx)
+		if err != nil {
+			app.unauthorizedResponse(w, r, fmt.Errorf("failed to get Kubernetes client: %w", err))
+			return
+		}
+
+		identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+		if !ok || identity == nil {
+			app.unauthorizedResponse(w, r, fmt.Errorf("missing identity"))
+			return
+		}
+
+		isAdmin, err := client.IsUserAdmin(ctx, identity)
+		if err != nil {
+			app.logger.Warn("admin SAR check failed, denying by default", slog.Any("error", err))
+		}
+		if err != nil || !isAdmin {
+			app.unauthorizedResponse(w, r, fmt.Errorf("you lack the sufficient permissions to make this request"))
+			return
+		}
+
+		next(w, r, ps)
+	}
+}
+
+// validateCallerToken verifies the caller's token is valid by performing a SelfSubjectReview.
+// Required for handlers that serve SA-backed data and would otherwise accept garbage tokens.
+func (app *App) validateCallerToken(ctx context.Context) error {
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+	_, err = client.GetUser(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("invalid or expired token: %w", err)
+	}
+	return nil
+}
+
+// isAllowedNamespace checks if the namespace matches the dashboard or workbench namespace.
+// When WorkbenchNamespace is not configured, it defaults to the dashboard namespace.
+func (app *App) isAllowedNamespace(namespace string) bool {
+	if namespace == app.config.Namespace {
+		return true
+	}
+	wbNS := app.config.WorkbenchNamespace
+	if wbNS == "" {
+		wbNS = app.config.Namespace
+	}
+	return namespace == wbNS
+}
+
 func (app *App) EnableCORS(next http.Handler) http.Handler {
 	if len(app.config.AllowedOrigins) == 0 {
 		return next
 	}
 
-	allowedHeaders := []string{"Content-Type", "Authorization", "X-Forwarded-Access-Token"}
+	allowedHeaders := []string{"Content-Type", "Authorization", "X-Forwarded-Access-Token", "x-odh-feature-flags"}
 	if h := app.config.AuthTokenHeader; h != "" && h != "Authorization" && h != "X-Forwarded-Access-Token" {
 		allowedHeaders = append(allowedHeaders, h)
 	}

--- a/distributions/core-bff/bff/internal/api/middleware_admin_test.go
+++ b/distributions/core-bff/bff/internal/api/middleware_admin_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dummyHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+func TestRequireAdmin_AdminUserPassesThrough(t *testing.T) {
+	app := newTestApp()
+	admin := k8mocks.DefaultTestUsers[0]
+
+	handler := app.requireAdmin(dummyHandler)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	handler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestRequireAdmin_NonAdminUserGets401(t *testing.T) {
+	app := newTestApp()
+	userA := k8mocks.DefaultTestUsers[1]
+
+	handler := app.requireAdmin(dummyHandler)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: userA.UserName,
+		Groups: userA.Groups,
+		Token:  k8s.NewBearerToken(userA.Token),
+	})
+
+	handler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "UNAUTHORIZED", errObj["code"])
+}
+
+func TestRequireAdmin_MissingIdentityGets401(t *testing.T) {
+	app := newTestApp()
+
+	handler := app.requireAdmin(dummyHandler)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	handler(rr, req, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"path"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/helpers"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/proxy"
+)
+
+const (
+	// PathPrefix is the URL prefix for BFF-scoped paths.
+	PathPrefix = "/core-bff"
+	// APIPathPrefix is the base API path prefix.
+	APIPathPrefix = "/api"
+	// APIVersion is the API version path segment.
+	APIVersion = "/v1"
+
+	// Infrastructure paths
+	HealthCheckPath    = "/healthcheck"
+	APIHealthCheckPath = APIPathPrefix + APIVersion + "/healthcheck"
+	OpenAPIPath        = PathPrefix + "/openapi"
+	OpenAPIJSONPath    = PathPrefix + "/openapi.json"
+	OpenAPIYAMLPath    = PathPrefix + "/openapi.yaml"
+	SwaggerUIPath      = PathPrefix + "/swagger-ui"
+
+	// Starter endpoints (mod-arch-starter convention, /api/v1/ prefix)
+	UserPath      = APIPathPrefix + APIVersion + "/user"
+	NamespacePath = APIPathPrefix + APIVersion + "/namespaces"
+
+	// Config endpoints (Fastify-compatible, /api/ prefix)
+	ConfigPath               = APIPathPrefix + "/config"
+	ComponentsPath           = APIPathPrefix + "/components"
+	StatusPath               = APIPathPrefix + "/status"
+	DashboardConfigPath      = APIPathPrefix + "/dashboardConfig/:namespace/:name"
+	ClusterSettingsPath      = APIPathPrefix + "/cluster-settings"
+	ComponentsRemovePath     = APIPathPrefix + "/components/remove"
+	AllowedUsersPath         = APIPathPrefix + "/status/:namespace/allowedUsers"
+	ConnectionTypesPath      = APIPathPrefix + "/connection-types"
+	ConnectionTypeSinglePath = APIPathPrefix + "/connection-types/:name"
+)
+
+// Routes builds the full HTTP handler tree: API router, proxies, static files, and middleware.
+func (app *App) Routes() http.Handler {
+	apiRouter := httprouter.New()
+
+	apiRouter.NotFound = http.HandlerFunc(app.notFoundResponse)
+	apiRouter.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
+
+	app.registerStarterRoutes(apiRouter)
+	app.registerConfigRoutes(apiRouter)
+	app.registerConnectionTypeRoutes(apiRouter)
+
+	appMux := http.NewServeMux()
+
+	appMux.Handle(APIPathPrefix+"/", apiRouter)
+	appMux.Handle(PathPrefix+APIPathPrefix+"/", http.StripPrefix(PathPrefix, apiRouter))
+	appMux.HandleFunc(APIPathPrefix, func(w http.ResponseWriter, r *http.Request) {
+		app.notFoundResponse(w, r)
+	})
+	appMux.HandleFunc(PathPrefix+APIPathPrefix, func(w http.ResponseWriter, r *http.Request) {
+		app.notFoundResponse(w, r)
+	})
+
+	// K8s API proxy and WebSocket proxy
+	if app.k8sProxy != nil {
+		appMux.Handle(proxy.K8sProxyPrefix, app.k8sProxy)
+		appMux.Handle(PathPrefix+proxy.K8sProxyPrefix, http.StripPrefix(PathPrefix, app.k8sProxy))
+	}
+	if app.wsProxy != nil {
+		appMux.Handle(proxy.WssProxyPrefix, app.wsProxy)
+		appMux.Handle(PathPrefix+proxy.WssProxyPrefix, http.StripPrefix(PathPrefix, app.wsProxy))
+	}
+
+	// SPA static file server with index.html fallback
+	staticDir := http.Dir(app.config.StaticAssetsDir)
+	fileServer := http.FileServer(staticDir)
+	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ctxLogger := helpers.GetContextLoggerFromReq(r)
+		if _, err := staticDir.Open(r.URL.Path); err == nil {
+			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		ctxLogger.Debug("Static asset not found, serving index.html", slog.String("path", r.URL.Path))
+		http.ServeFile(w, r, path.Join(app.config.StaticAssetsDir, "index.html"))
+	})
+
+	// Healthcheck outside auth middleware
+	healthcheckMux := http.NewServeMux()
+	healthcheckRouter := httprouter.New()
+	healthcheckRouter.GET(HealthCheckPath, app.HealthcheckHandler)
+	healthcheckMux.Handle(HealthCheckPath, app.RecoverPanic(app.EnableTelemetry(healthcheckRouter)))
+
+	// Top-level mux: healthcheck + OpenAPI (no auth), everything else through middleware
+	combinedMux := http.NewServeMux()
+	combinedMux.Handle(HealthCheckPath, healthcheckMux)
+	combinedMux.HandleFunc(OpenAPIJSONPath, app.openAPI.HandleOpenAPIJSONWrapper)
+	combinedMux.HandleFunc(OpenAPIYAMLPath, app.openAPI.HandleOpenAPIYAMLWrapper)
+	if app.config.DevMode {
+		combinedMux.HandleFunc(SwaggerUIPath, app.openAPI.HandleSwaggerUIWrapper)
+		combinedMux.HandleFunc(OpenAPIPath, app.openAPI.HandleOpenAPIRedirectWrapper)
+	}
+	combinedMux.Handle("/", app.RecoverPanic(app.EnableTelemetry(app.EnableCORS(app.InjectRequestIdentity(appMux)))))
+
+	return combinedMux
+}
+
+func (app *App) registerStarterRoutes(r *httprouter.Router) {
+	r.GET(APIHealthCheckPath, app.HealthcheckHandler)
+	r.GET(UserPath, app.UserHandler)
+	r.GET(NamespacePath, app.GetNamespacesHandler)
+}
+
+func (app *App) registerConfigRoutes(r *httprouter.Router) {
+	r.GET(ConfigPath, app.GetConfigHandler)
+	r.PATCH(ConfigPath, app.requireAdmin(app.PatchConfigHandler))
+	r.GET(ComponentsPath, app.GetComponentsHandler)
+	r.GET(ComponentsRemovePath, app.requireAdmin(app.RemoveComponentHandler))
+	r.GET(StatusPath, app.GetStatusHandler)
+	r.GET(AllowedUsersPath, app.requireAdmin(app.GetAllowedUsersHandler))
+	r.GET(DashboardConfigPath, app.requireAdmin(app.GetDashboardConfigByNameHandler))
+	r.PATCH(DashboardConfigPath, app.requireAdmin(app.PatchDashboardConfigByNameHandler))
+	r.GET(ClusterSettingsPath, app.requireAdmin(app.GetClusterSettingsHandler))
+	r.PUT(ClusterSettingsPath, app.requireAdmin(app.UpdateClusterSettingsHandler))
+}
+
+func (app *App) registerConnectionTypeRoutes(r *httprouter.Router) {
+	r.GET(ConnectionTypesPath, app.ListConnectionTypesHandler)
+	r.GET(ConnectionTypeSinglePath, app.GetConnectionTypeHandler)
+	r.POST(ConnectionTypesPath, app.requireAdmin(app.CreateConnectionTypeHandler))
+	r.PUT(ConnectionTypeSinglePath, app.requireAdmin(app.UpdateConnectionTypeHandler))
+	r.PATCH(ConnectionTypeSinglePath, app.requireAdmin(app.PatchConnectionTypeHandler))
+	r.DELETE(ConnectionTypeSinglePath, app.requireAdmin(app.DeleteConnectionTypeHandler))
+}

--- a/distributions/core-bff/bff/internal/api/routes.go
+++ b/distributions/core-bff/bff/internal/api/routes.go
@@ -30,7 +30,7 @@ const (
 	UserPath      = APIPathPrefix + APIVersion + "/user"
 	NamespacePath = APIPathPrefix + APIVersion + "/namespaces"
 
-	// Config endpoints (Fastify-compatible, /api/ prefix)
+	// Config endpoints, /api/ prefix
 	ConfigPath               = APIPathPrefix + "/config"
 	ComponentsPath           = APIPathPrefix + "/components"
 	StatusPath               = APIPathPrefix + "/status"
@@ -79,7 +79,8 @@ func (app *App) Routes() http.Handler {
 	fileServer := http.FileServer(staticDir)
 	appMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		ctxLogger := helpers.GetContextLoggerFromReq(r)
-		if _, err := staticDir.Open(r.URL.Path); err == nil {
+		if f, err := staticDir.Open(r.URL.Path); err == nil {
+			f.Close()
 			ctxLogger.Debug("Serving static file", slog.String("path", r.URL.Path))
 			fileServer.ServeHTTP(w, r)
 			return

--- a/distributions/core-bff/bff/internal/api/status_handler.go
+++ b/distributions/core-bff/bff/internal/api/status_handler.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/constants"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+)
+
+// GetStatusHandler returns user session status and cluster info.
+func (app *App) GetStatusHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity)
+	if !ok || identity == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing RequestIdentity in context"))
+		return
+	}
+
+	if err := app.validateCallerToken(ctx); err != nil {
+		app.unauthorizedResponse(w, r, err)
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("failed to get Kubernetes client: %w", err))
+		return
+	}
+
+	status, err := app.repositories.Status.GetStatus(ctx, client, identity, app.clusterInfo)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err := app.WriteJSON(w, http.StatusOK, status, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/distributions/core-bff/bff/internal/api/status_handler_test.go
+++ b/distributions/core-bff/bff/internal/api/status_handler_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStatusHandler_AdminUser(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.clusterInfo = clusterInfo{
+			clusterID:       "test-cluster-id",
+			clusterBranding: "ocp",
+			serverURL:       "https://api.test.example.com:6443",
+			currentContext:  "test-context",
+		}
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, StatusPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	app.GetStatusHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	kube, ok := body["kube"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, kube["isAdmin"])
+	assert.Equal(t, true, kube["isAllowed"])
+	assert.Equal(t, "test-cluster-id", kube["clusterID"])
+	assert.Equal(t, "ocp", kube["clusterBranding"])
+	assert.Equal(t, "https://api.test.example.com:6443", kube["serverURL"])
+	assert.NotEmpty(t, kube["userName"])
+	assert.NotEmpty(t, kube["currentContext"])
+	currentUser, ok := kube["currentUser"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, currentUser["name"])
+}
+
+func TestGetStatusHandler_NonAdminUser(t *testing.T) {
+	app := newTestApp()
+	userA := k8mocks.DefaultTestUsers[1]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, StatusPath, nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: userA.UserName,
+		Groups: userA.Groups,
+		Token:  k8s.NewBearerToken(userA.Token),
+	})
+
+	app.GetStatusHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	kube, ok := body["kube"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, kube["isAdmin"])
+	// Auth CRD is absent in envtest. The SA client gets a clean "not found" (not 403),
+	// so GetAuth returns nil = CRD absent = all users allowed.
+	assert.Equal(t, true, kube["isAllowed"])
+}
+
+func TestGetAllowedUsersHandler_ReturnsEmptyArray(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/status/opendatahub/allowedUsers", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "namespace", Value: "opendatahub"}}
+	app.GetAllowedUsersHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body []any
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Empty(t, body)
+}
+
+func TestGetAllowedUsersHandler_WrongNamespace_Returns403(t *testing.T) {
+	app := newTestApp(func(a *App) {
+		a.config.Namespace = "opendatahub"
+	})
+	admin := k8mocks.DefaultTestUsers[0]
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/status/wrong-ns/allowedUsers", nil)
+	req = reqWithIdentity(req, &k8s.RequestIdentity{
+		UserID: admin.UserName,
+		Groups: admin.Groups,
+		Token:  k8s.NewBearerToken(admin.Token),
+	})
+
+	ps := httprouter.Params{{Key: "namespace", Value: "wrong-ns"}}
+	app.GetAllowedUsersHandler(rr, req, ps)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestGetStatusHandler_MissingIdentity(t *testing.T) {
+	app := newTestApp()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, StatusPath, nil)
+
+	app.GetStatusHandler(rr, req, nil)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/distributions/core-bff/bff/internal/api/test_setup_test.go
+++ b/distributions/core-bff/bff/internal/api/test_setup_test.go
@@ -13,12 +13,16 @@ import (
 	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/repositories"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var (
 	testK8sFactory  k8s.KubernetesClientFactory
 	testEnvInstance *envtest.Environment
+	testSADynClient dynamic.Interface
+	testSAClientset kubernetes.Interface
 )
 
 func TestMain(m *testing.M) {
@@ -46,6 +50,22 @@ func TestMain(m *testing.M) {
 	testK8sFactory = factory
 	testEnvInstance = env
 
+	saDyn, err := dynamic.NewForConfig(env.Config)
+	if err != nil {
+		logger.Error("failed to create SA dynamic client", slog.Any("error", err))
+		_ = env.Stop()
+		os.Exit(1)
+	}
+	testSADynClient = saDyn
+
+	saCS, err := kubernetes.NewForConfig(env.Config)
+	if err != nil {
+		logger.Error("failed to create SA clientset", slog.Any("error", err))
+		_ = env.Stop()
+		os.Exit(1)
+	}
+	testSAClientset = saCS
+
 	code := m.Run()
 
 	_ = env.Stop()
@@ -66,7 +86,7 @@ func newTestApp(overrides ...func(*App)) *App {
 		},
 		logger:                  logger,
 		kubernetesClientFactory: testK8sFactory,
-		repositories:            repositories.NewRepositories(),
+		repositories:            repositories.NewRepositories(false, testSADynClient, testSAClientset, ""),
 		bffClientFactory:        bffmocks.NewMockClientFactory(logger),
 		openAPI:                 openAPIHandler,
 		clusterInfo:             clusterInfo{clusterBranding: defaultClusterBranding},

--- a/distributions/core-bff/bff/internal/config/environment.go
+++ b/distributions/core-bff/bff/internal/config/environment.go
@@ -68,6 +68,41 @@ func (d DeploymentMode) IsFederatedMode() bool {
 	return d == DeploymentModeFederated
 }
 
+// PlatformType represents the target platform enum
+type PlatformType string
+
+const (
+	// PlatformOpenShift probes for OpenShift-specific cluster info at startup
+	PlatformOpenShift PlatformType = "OpenShift"
+	// PlatformXKS represents vanilla Kubernetes; skips OpenShift API detection
+	PlatformXKS PlatformType = "XKS"
+)
+
+// String implements the fmt.Stringer interface
+func (p PlatformType) String() string {
+	return string(p)
+}
+
+// Set implements the flag.Value interface
+func (p *PlatformType) Set(value string) error {
+	switch value {
+	case "OpenShift":
+		*p = PlatformOpenShift
+	case "XKS":
+		*p = PlatformXKS
+	case "":
+		*p = ""
+	default:
+		return fmt.Errorf("invalid platform type: %s (must be OpenShift, XKS, or empty for auto-detect)", value)
+	}
+	return nil
+}
+
+// IsXKS returns true if the platform is XKS (non-OpenShift)
+func (p PlatformType) IsXKS() bool {
+	return p == PlatformXKS
+}
+
 // EnvConfig holds environment-driven configuration for the BFF server.
 type EnvConfig struct {
 	// Port is the HTTP server port.
@@ -119,11 +154,21 @@ type EnvConfig struct {
 	MockBFFClients bool
 
 	// ─── CORE BFF ───────────────────────────────────────────────
+	// PlatformType indicates the target platform.
+	PlatformType PlatformType
+
 	// Namespace is the Kubernetes namespace where the dashboard is deployed.
 	Namespace string
 
+	// WorkbenchNamespace is the Kubernetes namespace for workbenches.
+	// Defaults to Namespace if not set. Used in namespace allowlist validation.
+	WorkbenchNamespace string
+
 	// DashboardConfigName is the name of the OdhDashboardConfig CR to read.
 	DashboardConfigName string
+
+	// EnabledAppsCM is the name of the ConfigMap that tracks enabled applications.
+	EnabledAppsCM string
 
 	// MFRemotesConfig is the filesystem path to the module federation remotes config file.
 	MFRemotesConfig string

--- a/distributions/core-bff/bff/internal/config/platform_type_test.go
+++ b/distributions/core-bff/bff/internal/config/platform_type_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlatformType_Set_OpenShift(t *testing.T) {
+	var p PlatformType
+	assert.NoError(t, p.Set("OpenShift"))
+	assert.Equal(t, PlatformOpenShift, p)
+	assert.False(t, p.IsXKS())
+}
+
+func TestPlatformType_Set_XKS(t *testing.T) {
+	var p PlatformType
+	assert.NoError(t, p.Set("XKS"))
+	assert.Equal(t, PlatformXKS, p)
+	assert.True(t, p.IsXKS())
+}
+
+func TestPlatformType_Set_Empty(t *testing.T) {
+	var p PlatformType
+	assert.NoError(t, p.Set(""))
+	assert.Equal(t, PlatformType(""), p)
+	assert.False(t, p.IsXKS())
+}
+
+func TestPlatformType_Set_Invalid(t *testing.T) {
+	var p PlatformType
+	err := p.Set("invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid platform type")
+}
+
+func TestPlatformType_String(t *testing.T) {
+	assert.Equal(t, "OpenShift", PlatformOpenShift.String())
+	assert.Equal(t, "XKS", PlatformXKS.String())
+	assert.Equal(t, "", PlatformType("").String())
+}

--- a/distributions/core-bff/bff/internal/helpers/k8s.go
+++ b/distributions/core-bff/bff/internal/helpers/k8s.go
@@ -35,6 +35,19 @@ func getKubeconfig(inClusterFn func() (*clientRest.Config, error)) (*clientRest.
 	return inCluster, nil
 }
 
+// GetCurrentContext returns the active kubeconfig context name.
+// Returns "inClusterContext" when running inside a cluster (no kubeconfig file).
+func GetCurrentContext() string {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, &clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil || rawConfig.CurrentContext == "" {
+		return "inClusterContext"
+	}
+	return rawConfig.CurrentContext
+}
+
 // BuildScheme creates a runtime scheme with Kubernetes types registered.
 func BuildScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()

--- a/distributions/core-bff/bff/internal/helpers/k8s_test.go
+++ b/distributions/core-bff/bff/internal/helpers/k8s_test.go
@@ -43,6 +43,17 @@ users: []
 	assert.Contains(t, err.Error(), "kubeconfig found but invalid")
 }
 
+func TestGetCurrentContext_ReturnsNonEmpty(t *testing.T) {
+	ctx := GetCurrentContext()
+	assert.NotEmpty(t, ctx)
+}
+
+func TestGetCurrentContext_FallsBackToInCluster(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/nonexistent/kubeconfig")
+	ctx := GetCurrentContext()
+	assert.Equal(t, "inClusterContext", ctx)
+}
+
 func TestGetKubeconfig_InClusterFallback(t *testing.T) {
 	t.Setenv("KUBECONFIG", "/nonexistent/kubeconfig")
 

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
@@ -17,7 +17,7 @@ type KubernetesClientInterface interface {
 	IsClusterAdmin(ctx context.Context, identity *RequestIdentity) (bool, error)
 	GetUser(ctx context.Context, identity *RequestIdentity) (string, error)
 
-	// Fastify-compatible admin/allowed checks via SSAR on auths/default-auth
+	// admin/allowed checks via SSAR on auths/default-auth
 	IsUserAdmin(ctx context.Context, identity *RequestIdentity) (bool, error)
 	IsUserAllowed(ctx context.Context, identity *RequestIdentity) (bool, error)
 

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/client.go
@@ -5,6 +5,8 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 )
 
 const ComponentLabelValue = "core"
@@ -14,4 +16,19 @@ type KubernetesClientInterface interface {
 	GetNamespaces(ctx context.Context, identity *RequestIdentity) ([]corev1.Namespace, error)
 	IsClusterAdmin(ctx context.Context, identity *RequestIdentity) (bool, error)
 	GetUser(ctx context.Context, identity *RequestIdentity) (string, error)
+
+	// Fastify-compatible admin/allowed checks via SSAR on auths/default-auth
+	IsUserAdmin(ctx context.Context, identity *RequestIdentity) (bool, error)
+	IsUserAllowed(ctx context.Context, identity *RequestIdentity) (bool, error)
+
+	// Dynamic client for CRD operations (OdhDashboardConfig, Auth, OdhApplication)
+	GetDynamicClient() (dynamic.Interface, error)
+
+	// ConfigMap operations (connection-types, cluster settings)
+	GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
+	ListConfigMaps(ctx context.Context, namespace string, labelSelector string) (*corev1.ConfigMapList, error)
+	CreateConfigMap(ctx context.Context, namespace string, cm *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	UpdateConfigMap(ctx context.Context, namespace string, cm *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	PatchConfigMap(ctx context.Context, namespace, name string, patchData []byte, patchType types.PatchType) (*corev1.ConfigMap, error)
+	DeleteConfigMap(ctx context.Context, namespace, name string) error
 }

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_factory.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/mock_factory.go
@@ -110,7 +110,7 @@ func (f *MockedTokenClientFactory) GetClient(ctx context.Context) (k8s.Kubernete
 		return nil, fmt.Errorf("failed to create impersonated client: %w", err)
 	}
 
-	client := newMockedTokenKubernetesClientFromClientset(clientset, f.logger)
+	client := newMockedTokenKubernetesClientFromClientset(clientset, impersonatedCfg, f.logger)
 	f.clients[identity.Token.Raw()] = client
 	return client, nil
 }

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/k8mocks/token_k8s_client_mock.go
@@ -5,6 +5,7 @@ import (
 
 	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // ⚠️ WHY THIS FILE EXISTS:
@@ -16,13 +17,14 @@ type TokenKubernetesClientMock struct {
 	*k8s.TokenKubernetesClient
 }
 
-func newMockedTokenKubernetesClientFromClientset(clientset kubernetes.Interface, logger *slog.Logger) k8s.KubernetesClientInterface {
+func newMockedTokenKubernetesClientFromClientset(clientset kubernetes.Interface, restConfig *rest.Config, logger *slog.Logger) k8s.KubernetesClientInterface {
 	return &TokenKubernetesClientMock{
 		TokenKubernetesClient: &k8s.TokenKubernetesClient{
 			SharedClientLogic: k8s.SharedClientLogic{
-				Client: clientset,
-				Logger: logger,
-				Token:  k8s.NewBearerToken(""), // Unused because impersonation is already handled in the client config
+				Client:     clientset,
+				Logger:     logger,
+				RestConfig: restConfig,
+				Token:      k8s.NewBearerToken(""), // Unused because impersonation is already handled in the client config
 			},
 		},
 	}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -2,20 +2,39 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // SharedClientLogic holds shared Kubernetes client logic and configuration.
 type SharedClientLogic struct {
-	Client kubernetes.Interface
-	Logger *slog.Logger
-	Token  BearerToken
-}
+	Client     kubernetes.Interface
+	Logger     *slog.Logger
+	Token      BearerToken
+	RestConfig *rest.Config
 
-// Service discovery helpers removed for minimal starter footprint.
+	dynamicClient dynamic.Interface
+	dynamicOnce   sync.Once
+	dynamicErr    error
+}
 
 func (kc *SharedClientLogic) BearerToken() (string, error) { return kc.Token.Raw(), nil }
 
 func (kc *SharedClientLogic) GetGroups(ctx context.Context) ([]string, error) { return []string{}, nil }
+
+// GetDynamicClient returns a lazily-initialized dynamic client for CRD operations.
+func (kc *SharedClientLogic) GetDynamicClient() (dynamic.Interface, error) {
+	kc.dynamicOnce.Do(func() {
+		if kc.RestConfig == nil {
+			kc.dynamicErr = fmt.Errorf("rest config not available for dynamic client creation")
+			return
+		}
+		kc.dynamicClient, kc.dynamicErr = dynamic.NewForConfig(kc.RestConfig)
+	})
+	return kc.dynamicClient, kc.dynamicErr
+}

--- a/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
+++ b/distributions/core-bff/bff/internal/integrations/kubernetes/token_k8s_client.go
@@ -12,6 +12,7 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -80,8 +81,9 @@ func NewTokenKubernetesClient(token string, logger *slog.Logger) (KubernetesClie
 
 	return &TokenKubernetesClient{
 		SharedClientLogic: SharedClientLogic{
-			Client: clientset,
-			Logger: logger,
+			Client:     clientset,
+			Logger:     logger,
+			RestConfig: cfg,
 			// Token is retained for follow-up calls; do not log it.
 			Token: NewBearerToken(token),
 		},
@@ -197,4 +199,73 @@ func (kc *TokenKubernetesClient) GetUser(ctx context.Context, _ *RequestIdentity
 	}
 
 	return username, nil
+}
+
+// IsUserAdmin checks if the user can patch the auths/default-auth singleton,
+func (kc *TokenKubernetesClient) IsUserAdmin(ctx context.Context, _ *RequestIdentity) (bool, error) {
+	return kc.checkAuthSingletonAccess(ctx, "patch")
+}
+
+// IsUserAllowed checks if the user can get the auths/default-auth singleton,
+func (kc *TokenKubernetesClient) IsUserAllowed(ctx context.Context, _ *RequestIdentity) (bool, error) {
+	return kc.checkAuthSingletonAccess(ctx, "get")
+}
+
+func (kc *TokenKubernetesClient) checkAuthSingletonAccess(ctx context.Context, verb string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	sar := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Group:    "services.platform.opendatahub.io",
+				Resource: "auths",
+				Name:     "default-auth",
+				Verb:     verb,
+			},
+		},
+	}
+
+	resp, err := kc.Client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to perform auth singleton SAR (verb=%s): %w", verb, err)
+	}
+
+	return resp.Status.Allowed, nil
+}
+
+func (kc *TokenKubernetesClient) GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (kc *TokenKubernetesClient) ListConfigMaps(ctx context.Context, namespace string, labelSelector string) (*corev1.ConfigMapList, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+func (kc *TokenKubernetesClient) CreateConfigMap(ctx context.Context, namespace string, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+}
+
+func (kc *TokenKubernetesClient) UpdateConfigMap(ctx context.Context, namespace string, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+}
+
+func (kc *TokenKubernetesClient) PatchConfigMap(ctx context.Context, namespace, name string, patchData []byte, patchType types.PatchType) (*corev1.ConfigMap, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).Patch(ctx, name, patchType, patchData, metav1.PatchOptions{})
+}
+
+func (kc *TokenKubernetesClient) DeleteConfigMap(ctx context.Context, namespace, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return kc.Client.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/distributions/core-bff/bff/internal/models/cluster_settings.go
+++ b/distributions/core-bff/bff/internal/models/cluster_settings.go
@@ -1,0 +1,31 @@
+package models
+
+// ModelServingPlatformEnabled indicates which model serving platforms are enabled.
+type ModelServingPlatformEnabled struct {
+	KServe bool `json:"kServe"`
+	LLMd   bool `json:"LLMd"`
+}
+
+// ClusterSettings holds admin-configurable cluster settings derived from DashboardConfig and ConfigMaps.
+type ClusterSettings struct {
+	PVCSize                         int                         `json:"pvcSize"`
+	CullerTimeout                   int                         `json:"cullerTimeout"`
+	UserTrackingEnabled             bool                        `json:"userTrackingEnabled"`
+	ModelServingPlatformEnabled     ModelServingPlatformEnabled `json:"modelServingPlatformEnabled"`
+	IsDistributedInferencingDefault *bool                       `json:"isDistributedInferencingDefault,omitempty"`
+	DefaultDeploymentStrategy       string                      `json:"defaultDeploymentStrategy,omitempty"`
+}
+
+// DefaultClusterSettings provides sensible defaults when no CRD or ConfigMap values are available.
+var DefaultClusterSettings = ClusterSettings{
+	PVCSize:                         20,
+	CullerTimeout:                   31536000,
+	UserTrackingEnabled:             false,
+	IsDistributedInferencingDefault: boolPtr(true),
+	ModelServingPlatformEnabled: ModelServingPlatformEnabled{
+		KServe: true,
+		LLMd:   true,
+	},
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/distributions/core-bff/bff/internal/models/constants.go
+++ b/distributions/core-bff/bff/internal/models/constants.go
@@ -1,0 +1,29 @@
+package models
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	LabelDashboardResource = "opendatahub.io/dashboard"
+	LabelConnectionType    = "opendatahub.io/connection-type"
+)
+
+// AuthGVR is the GroupVersionResource for the Auth CRD.
+var AuthGVR = schema.GroupVersionResource{
+	Group:    "services.platform.opendatahub.io",
+	Version:  "v1alpha1",
+	Resource: "auths",
+}
+
+// NotebookGVR is the GroupVersionResource for Kubeflow Notebook CRDs.
+var NotebookGVR = schema.GroupVersionResource{
+	Group:    "kubeflow.org",
+	Version:  "v1",
+	Resource: "notebooks",
+}
+
+// OdhApplicationGVR is the GroupVersionResource for OdhApplication CRDs.
+var OdhApplicationGVR = schema.GroupVersionResource{
+	Group:    "dashboard.opendatahub.io",
+	Version:  "v1",
+	Resource: "odhapplications",
+}

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -1,0 +1,193 @@
+package models
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// DashboardConfigGVR is the GroupVersionResource for OdhDashboardConfig CRDs.
+var DashboardConfigGVR = schema.GroupVersionResource{
+	Group:    "opendatahub.io",
+	Version:  "v1alpha",
+	Resource: "odhdashboardconfigs",
+}
+
+// DashboardConfig represents the OdhDashboardConfig custom resource.
+type DashboardConfig struct {
+	APIVersion string              `json:"apiVersion"`
+	Kind       string              `json:"kind"`
+	Metadata   metav1.ObjectMeta   `json:"metadata"`
+	Spec       DashboardConfigSpec `json:"spec"`
+}
+
+// DashboardConfigSpec is the spec field of an OdhDashboardConfig resource.
+type DashboardConfigSpec struct {
+	DashboardConfig      DashboardFeatureFlags `json:"dashboardConfig"`
+	NotebookController   *NotebookController   `json:"notebookController,omitempty"`
+	NotebookSizes        []map[string]any      `json:"notebookSizes,omitempty"`
+	ModelServerSizes     []map[string]any      `json:"modelServerSizes,omitempty"`
+	TemplateOrder        []string              `json:"templateOrder,omitempty"`
+	TemplateDisablement  []string              `json:"templateDisablement,omitempty"`
+	HardwareProfileOrder []string              `json:"hardwareProfileOrder,omitempty"`
+	ModelServing         *ModelServingConfig   `json:"modelServing,omitempty"`
+	GenAiStudioConfig    *GenAiStudioConfig    `json:"genAiStudioConfig,omitempty"`
+}
+
+// DashboardFeatureFlags contains all boolean feature flags for the dashboard.
+type DashboardFeatureFlags struct {
+	Enablement                   bool `json:"enablement"`
+	DisableInfo                  bool `json:"disableInfo"`
+	DisableSupport               bool `json:"disableSupport"`
+	DisableClusterManager        bool `json:"disableClusterManager"`
+	DisableTracking              bool `json:"disableTracking"`
+	DisableBYONImageStream       bool `json:"disableBYONImageStream"`
+	DisableISVBadges             bool `json:"disableISVBadges"`
+	DisableAppLauncher           bool `json:"disableAppLauncher"`
+	DisableUserManagement        bool `json:"disableUserManagement"`
+	DisableHome                  bool `json:"disableHome"`
+	DisableProjects              bool `json:"disableProjects"`
+	DisableModelServing          bool `json:"disableModelServing"`
+	DisableProjectScoped         bool `json:"disableProjectScoped"`
+	DisableProjectSharing        bool `json:"disableProjectSharing"`
+	DisableCustomServingRuntimes bool `json:"disableCustomServingRuntimes"`
+	DisableTrustyBiasMetrics     bool `json:"disableTrustyBiasMetrics"`
+	DisablePerformanceMetrics    bool `json:"disablePerformanceMetrics"`
+	DisablePipelines             bool `json:"disablePipelines"`
+	DisableKServe                bool `json:"disableKServe"`
+	DisableKServeAuth            bool `json:"disableKServeAuth"`
+	DisableKServeMetrics         bool `json:"disableKServeMetrics"`
+	DisableKServeRaw             bool `json:"disableKServeRaw"`
+	DisableDistributedWorkloads  bool `json:"disableDistributedWorkloads"`
+	DisableModelCatalog          bool `json:"disableModelCatalog"`
+	DisableModelRegistry         bool `json:"disableModelRegistry"`
+	DisableModelRegistrySecureDB bool `json:"disableModelRegistrySecureDB"`
+	DisableServingRuntimeParams  bool `json:"disableServingRuntimeParams"`
+	DisableConnectionTypes       bool `json:"disableConnectionTypes"`
+	DisableStorageClasses        bool `json:"disableStorageClasses"`
+	DisableNIMModelServing       bool `json:"disableNIMModelServing"`
+	DisableAdminConnectionTypes  bool `json:"disableAdminConnectionTypes"`
+	DisableFeatureStore          bool `json:"disableFeatureStore"`
+	DisableFineTuning            bool `json:"disableFineTuning"`
+	DisableKueue                 bool `json:"disableKueue"`
+	DisableLMEval                bool `json:"disableLMEval"`
+	DisableLLMd                  bool `json:"disableLLMd"`
+	GenAiStudio                  bool `json:"genAiStudio"`
+	Guardrails                   bool `json:"guardrails"`
+	Automl                       bool `json:"automl"`
+	Autorag                      bool `json:"autorag"`
+	ModelAsService               bool `json:"modelAsService"`
+	AiAssetCustomEndpoints       bool `json:"aiAssetCustomEndpoints"`
+	MaasAuthPolicies             bool `json:"maasAuthPolicies"`
+	Mlflow                       bool `json:"mlflow"`
+	McpCatalog                   bool `json:"mcpCatalog"`
+	ToolCalling                  bool `json:"toolCalling"`
+	TrainingJobs                 bool `json:"trainingJobs"`
+	ProjectRBAC                  bool `json:"projectRBAC"`
+	DeploymentWizardYAMLViewer   bool `json:"deploymentWizardYAMLViewer"`
+	ExternalVectorStores         bool `json:"externalVectorStores"`
+	VLLMDeploymentOnMaaS         bool `json:"vLLMDeploymentOnMaaS"`
+	LlmGatewayField              bool `json:"llmGatewayField"`
+	PromptManagement             bool `json:"promptManagement"`
+	MySubscriptions              bool `json:"mySubscriptions"`
+}
+
+type NotebookController struct {
+	Enabled          bool    `json:"enabled"`
+	PVCSize          *string `json:"pvcSize,omitempty"`
+	StorageClassName *string `json:"storageClassName,omitempty"`
+}
+
+type ModelServingConfig struct {
+	DeploymentStrategy *string `json:"deploymentStrategy,omitempty"`
+	IsLLMdDefault      *bool   `json:"isLLMdDefault,omitempty"`
+}
+
+type GenAiStudioConfig struct {
+	AiAssetCustomEndpoints *AiAssetCustomEndpointsConfig `json:"aiAssetCustomEndpoints,omitempty"`
+}
+
+type AiAssetCustomEndpointsConfig struct {
+	ExternalProviders bool     `json:"externalProviders"`
+	ClusterDomains    []string `json:"clusterDomains"`
+}
+
+// BlankDashboardCR provides defaults for all feature flags.
+// Must match backend/src/utils/constants.ts blankDashboardCR exactly.
+var BlankDashboardCR = DashboardConfig{
+	APIVersion: "opendatahub.io/v1alpha",
+	Kind:       "OdhDashboardConfig",
+	Metadata: metav1.ObjectMeta{
+		Name: "odh-dashboard-config",
+		Labels: map[string]string{
+			"opendatahub.io/dashboard": "true",
+		},
+	},
+	Spec: DashboardConfigSpec{
+		DashboardConfig: DashboardFeatureFlags{
+			Enablement:                   true,
+			DisableInfo:                  false,
+			DisableSupport:               false,
+			DisableClusterManager:        false,
+			DisableTracking:              true,
+			DisableBYONImageStream:       false,
+			DisableISVBadges:             false,
+			DisableAppLauncher:           false,
+			DisableUserManagement:        false,
+			DisableHome:                  false,
+			DisableProjects:              false,
+			DisableModelServing:          false,
+			DisableProjectScoped:         false,
+			DisableProjectSharing:        false,
+			DisableCustomServingRuntimes: false,
+			DisableTrustyBiasMetrics:     false,
+			DisablePerformanceMetrics:    false,
+			DisablePipelines:             false,
+			DisableKServe:                false,
+			DisableKServeAuth:            false,
+			DisableKServeMetrics:         false,
+			DisableKServeRaw:             false,
+			DisableDistributedWorkloads:  false,
+			DisableModelCatalog:          false,
+			DisableModelRegistry:         false,
+			DisableModelRegistrySecureDB: false,
+			DisableServingRuntimeParams:  false,
+			DisableConnectionTypes:       false,
+			DisableStorageClasses:        false,
+			DisableNIMModelServing:       false,
+			DisableAdminConnectionTypes:  false,
+			DisableFeatureStore:          false,
+			DisableFineTuning:            true,
+			DisableKueue:                 true,
+			DisableLMEval:                true,
+			DisableLLMd:                  false,
+			GenAiStudio:                  false,
+			Guardrails:                   false,
+			Automl:                       false,
+			Autorag:                      false,
+			ModelAsService:               true,
+			AiAssetCustomEndpoints:       false,
+			MaasAuthPolicies:             true,
+			Mlflow:                       true,
+			McpCatalog:                   false,
+			ToolCalling:                  false,
+			TrainingJobs:                 true,
+			ProjectRBAC:                  true,
+			DeploymentWizardYAMLViewer:   false,
+			ExternalVectorStores:         false,
+			VLLMDeploymentOnMaaS:         false,
+			LlmGatewayField:              false,
+			PromptManagement:             false,
+			MySubscriptions:              false,
+		},
+		NotebookController: &NotebookController{
+			Enabled: true,
+		},
+		TemplateOrder: []string{},
+		GenAiStudioConfig: &GenAiStudioConfig{
+			AiAssetCustomEndpoints: &AiAssetCustomEndpointsConfig{
+				ExternalProviders: false,
+				ClusterDomains:    []string{},
+			},
+		},
+	},
+}

--- a/distributions/core-bff/bff/internal/models/kube_status.go
+++ b/distributions/core-bff/bff/internal/models/kube_status.go
@@ -1,0 +1,34 @@
+package models
+
+// KubeUser represents the current kubeconfig user entry.
+type KubeUser struct {
+	Name  string `json:"name"`
+	Token string `json:"token,omitempty"`
+}
+
+// KubeStatus holds user session status and cluster metadata.
+type KubeStatus struct {
+	CurrentContext  string   `json:"currentContext"`
+	CurrentUser     KubeUser `json:"currentUser"`
+	Namespace       string   `json:"namespace"`
+	UserName        string   `json:"userName"`
+	UserID          string   `json:"userID,omitempty"`
+	ClusterID       string   `json:"clusterID"`
+	ClusterBranding string   `json:"clusterBranding"`
+	IsAdmin         bool     `json:"isAdmin"`
+	IsAllowed       bool     `json:"isAllowed"`
+	ServerURL       string   `json:"serverURL"`
+	IsImpersonating bool     `json:"isImpersonating,omitempty"`
+}
+
+// AllowedUser represents a user with notebook access in a namespace.
+type AllowedUser struct {
+	Username     string `json:"username"`
+	Privilege    string `json:"privilege"`
+	LastActivity string `json:"lastActivity"`
+}
+
+// StatusResponse wraps KubeStatus for the /api/status endpoint.
+type StatusResponse struct {
+	Kube KubeStatus `json:"kube"`
+}

--- a/distributions/core-bff/bff/internal/models/kube_status.go
+++ b/distributions/core-bff/bff/internal/models/kube_status.go
@@ -3,7 +3,7 @@ package models
 // KubeUser represents the current kubeconfig user entry.
 type KubeUser struct {
 	Name  string `json:"name"`
-	Token string `json:"token,omitempty"`
+	Token string `json:"-"`
 }
 
 // KubeStatus holds user session status and cluster metadata.

--- a/distributions/core-bff/bff/internal/models/mutation_response.go
+++ b/distributions/core-bff/bff/internal/models/mutation_response.go
@@ -1,0 +1,7 @@
+package models
+
+// MutationResponse is the standard response for create/update/patch/delete operations.
+type MutationResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+}

--- a/distributions/core-bff/bff/internal/repositories/allowed_users.go
+++ b/distributions/core-bff/bff/internal/repositories/allowed_users.go
@@ -1,0 +1,114 @@
+package repositories
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// AllowedUsersRepository lists users with notebook access in a namespace.
+type AllowedUsersRepository struct {
+	saDynClient dynamic.Interface
+}
+
+// NewAllowedUsersRepository creates a new AllowedUsersRepository.
+func NewAllowedUsersRepository(saDynClient dynamic.Interface) *AllowedUsersRepository {
+	return &AllowedUsersRepository{saDynClient: saDynClient}
+}
+
+// GetAllowedUsers lists Notebook CRDs in the namespace and extracts user info.
+// Returns empty slice when CRD is absent.
+func (r *AllowedUsersRepository) GetAllowedUsers(ctx context.Context, namespace string) ([]models.AllowedUser, error) {
+	if r.saDynClient == nil {
+		return []models.AllowedUser{}, nil
+	}
+
+	list, err := r.saDynClient.Resource(models.NotebookGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isDiscoveryError(err) {
+			return []models.AllowedUser{}, nil
+		}
+		return nil, fmt.Errorf("failed to list notebooks: %w", err)
+	}
+
+	users := make(map[string]*models.AllowedUser)
+	for _, item := range list.Items {
+		user := parseNotebookUser(item.Object)
+		if user == nil {
+			continue
+		}
+		if existing, ok := users[user.Username]; ok {
+			if user.Privilege == "Admin" {
+				existing.Privilege = "Admin"
+			}
+		} else {
+			users[user.Username] = user
+		}
+	}
+
+	result := make([]models.AllowedUser, 0, len(users))
+	for _, u := range users {
+		result = append(result, *u)
+	}
+	return result, nil
+}
+
+func parseNotebookUser(obj map[string]interface{}) *models.AllowedUser {
+	metadata, ok := obj["metadata"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	annotations, _ := metadata["annotations"].(map[string]interface{})
+	labels, _ := metadata["labels"].(map[string]interface{})
+
+	username := decodeNotebookUsername(annotations)
+	if username == "" {
+		return nil
+	}
+
+	return &models.AllowedUser{
+		Username:     username,
+		Privilege:    notebookPrivilege(labels),
+		LastActivity: notebookLastActivity(annotations),
+	}
+}
+
+func notebookPrivilege(labels map[string]interface{}) string {
+	if userType, _ := labels["opendatahub.io/user-type"].(string); userType == "admin" {
+		return "Admin"
+	}
+	return "User"
+}
+
+func notebookLastActivity(annotations map[string]interface{}) string {
+	if la, ok := annotations["notebooks.kubeflow.org/last-activity"].(string); ok && la != "" {
+		return la
+	}
+	if rs, ok := annotations["kubeflow-resource-stopped"].(string); ok && rs != "" {
+		return rs
+	}
+	return "Now"
+}
+
+const kubeSafePrefix = "b64:"
+
+func decodeNotebookUsername(annotations map[string]interface{}) string {
+	raw, _ := annotations["opendatahub.io/username"].(string)
+	if raw == "" {
+		return ""
+	}
+	if after, ok := strings.CutPrefix(raw, kubeSafePrefix); ok {
+		decoded, err := base64.StdEncoding.DecodeString(after)
+		if err == nil {
+			return string(decoded)
+		}
+	}
+	return raw
+}

--- a/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
+++ b/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
@@ -1,0 +1,117 @@
+package repositories
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func fakeNotebook(name, namespace, username, userType, lastActivity string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"annotations": map[string]interface{}{
+					"opendatahub.io/username":              username,
+					"notebooks.kubeflow.org/last-activity": lastActivity,
+				},
+				"labels": map[string]interface{}{
+					"opendatahub.io/user-type": userType,
+				},
+			},
+		},
+	}
+}
+
+func newFakeDynWithNotebooks(notebooks ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	objects := make([]runtime.Object, len(notebooks))
+	for i, n := range notebooks {
+		objects[i] = n
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.NotebookGVR: "NotebookList",
+		},
+		objects...,
+	)
+}
+
+func TestGetAllowedUsers_WithNotebooks(t *testing.T) {
+	fakeDyn := newFakeDynWithNotebooks(
+		fakeNotebook("nb-1", "test-ns", "user-a@example.com", "user", "2024-01-01T00:00:00Z"),
+		fakeNotebook("nb-2", "test-ns", "user-b@example.com", "admin", "2024-01-02T00:00:00Z"),
+	)
+	repo := NewAllowedUsersRepository(fakeDyn)
+
+	users, err := repo.GetAllowedUsers(context.Background(), "test-ns")
+	require.NoError(t, err)
+	assert.Len(t, users, 2)
+}
+
+func TestGetAllowedUsers_DeduplicatesByUsername(t *testing.T) {
+	fakeDyn := newFakeDynWithNotebooks(
+		fakeNotebook("nb-1", "test-ns", "user-a@example.com", "user", "2024-01-01T00:00:00Z"),
+		fakeNotebook("nb-2", "test-ns", "user-a@example.com", "admin", "2024-01-02T00:00:00Z"),
+	)
+	repo := NewAllowedUsersRepository(fakeDyn)
+
+	users, err := repo.GetAllowedUsers(context.Background(), "test-ns")
+	require.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, "Admin", users[0].Privilege)
+}
+
+func TestGetAllowedUsers_CRDAbsent_ReturnsEmpty(t *testing.T) {
+	emptyDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			models.NotebookGVR: "NotebookList",
+		},
+	)
+	repo := NewAllowedUsersRepository(emptyDyn)
+
+	users, err := repo.GetAllowedUsers(context.Background(), "test-ns")
+	require.NoError(t, err)
+	assert.Empty(t, users)
+}
+
+func TestGetAllowedUsers_NilClient_ReturnsEmpty(t *testing.T) {
+	repo := NewAllowedUsersRepository(nil)
+
+	users, err := repo.GetAllowedUsers(context.Background(), "test-ns")
+	require.NoError(t, err)
+	assert.Empty(t, users)
+}
+
+func TestDecodeNotebookUsername_Plain(t *testing.T) {
+	annotations := map[string]interface{}{
+		"opendatahub.io/username": "user@example.com",
+	}
+	assert.Equal(t, "user@example.com", decodeNotebookUsername(annotations))
+}
+
+func TestDecodeNotebookUsername_B64Encoded(t *testing.T) {
+	encoded := kubeSafePrefix + base64.StdEncoding.EncodeToString([]byte("user@example.com"))
+	annotations := map[string]interface{}{
+		"opendatahub.io/username": encoded,
+	}
+	assert.Equal(t, "user@example.com", decodeNotebookUsername(annotations))
+}
+
+func TestDecodeNotebookUsername_Empty(t *testing.T) {
+	assert.Equal(t, "", decodeNotebookUsername(nil))
+	assert.Equal(t, "", decodeNotebookUsername(map[string]interface{}{}))
+}

--- a/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
+++ b/distributions/core-bff/bff/internal/repositories/allowed_users_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func fakeNotebook(name, namespace, username, userType, lastActivity string) *unstructured.Unstructured {
@@ -81,6 +83,9 @@ func TestGetAllowedUsers_CRDAbsent_ReturnsEmpty(t *testing.T) {
 			models.NotebookGVR: "NotebookList",
 		},
 	)
+	emptyDyn.PrependReactor("list", models.NotebookGVR.Resource, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewNotFound(models.NotebookGVR.GroupResource(), models.NotebookGVR.Resource)
+	})
 	repo := NewAllowedUsersRepository(emptyDyn)
 
 	users, err := repo.GetAllowedUsers(context.Background(), "test-ns")

--- a/distributions/core-bff/bff/internal/repositories/auth.go
+++ b/distributions/core-bff/bff/internal/repositories/auth.go
@@ -1,0 +1,79 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// AuthRepository handles Auth CRD operations for group-based access control.
+// Uses a service-account-scoped dynamic client for reads, matching the privileged watcher model
+// privileged watcher model where auth config is read with SA credentials.
+type AuthRepository struct {
+	saDynClient dynamic.Interface
+}
+
+func NewAuthRepository(saDynClient dynamic.Interface) *AuthRepository {
+	return &AuthRepository{saDynClient: saDynClient}
+}
+
+// AuthConfig holds admin and allowed group lists from the Auth CRD.
+type AuthConfig struct {
+	AdminGroups   []string `json:"adminGroups"`
+	AllowedGroups []string `json:"allowedGroups"`
+}
+
+// GetAuth fetches the Auth CR using the SA client. Returns (nil, nil) only when the CRD
+// itself is absent. When the CRD exists but the "auth" instance is missing, returns an error
+// so callers fall through to SSAR rather than granting access.
+func (r *AuthRepository) GetAuth(ctx context.Context) (*AuthConfig, error) {
+	if r.saDynClient == nil {
+		return nil, nil
+	}
+
+	result, err := r.saDynClient.Resource(models.AuthGVR).Get(ctx, "auth", metav1.GetOptions{})
+	if err != nil {
+		if isDiscoveryError(err) {
+			return nil, nil
+		}
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("auth instance not found: %w", err)
+		}
+		return nil, classifyAuthError(err)
+	}
+
+	spec, ok := result.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("auth CR has missing or invalid spec")
+	}
+
+	return &AuthConfig{
+		AdminGroups:   extractStringSlice(spec, "adminGroups"),
+		AllowedGroups: extractStringSlice(spec, "allowedGroups"),
+	}, nil
+}
+
+func classifyAuthError(err error) error {
+	if k8serrors.IsForbidden(err) {
+		return fmt.Errorf("forbidden reading auth config: %w", err)
+	}
+	return fmt.Errorf("failed to get auth config: %w", err)
+}
+
+func extractStringSlice(m map[string]interface{}, key string) []string {
+	raw, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/distributions/core-bff/bff/internal/repositories/auth.go
+++ b/distributions/core-bff/bff/internal/repositories/auth.go
@@ -32,7 +32,7 @@ type AuthConfig struct {
 // so callers fall through to SSAR rather than granting access.
 func (r *AuthRepository) GetAuth(ctx context.Context) (*AuthConfig, error) {
 	if r.saDynClient == nil {
-		return nil, nil
+		return nil, fmt.Errorf("auth dynamic client unavailable")
 	}
 
 	result, err := r.saDynClient.Resource(models.AuthGVR).Get(ctx, "auth", metav1.GetOptions{})

--- a/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
@@ -1,0 +1,154 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func newFakeDynClientWithAuth(allowedGroups []string) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+
+	adminGroups := []interface{}{"odh-admins"}
+	allowed := make([]interface{}, len(allowedGroups))
+	for i, g := range allowedGroups {
+		allowed[i] = g
+	}
+
+	authCR := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "services.platform.opendatahub.io/v1alpha1",
+			"kind":       "Auth",
+			"metadata": map[string]interface{}{
+				"name": "auth",
+			},
+			"spec": map[string]interface{}{
+				"adminGroups":   adminGroups,
+				"allowedGroups": allowed,
+			},
+		},
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.AuthGVR: "AuthList",
+		},
+		authCR,
+	)
+}
+
+func newFakeDynClientCRDAbsent() *dynamicfake.FakeDynamicClient {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "auths", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("no matches for kind \"Auth\" in group \"services.platform.opendatahub.io\"")
+	})
+	return client
+}
+
+func newFakeDynClientInstanceAbsent() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			models.AuthGVR: "AuthList",
+		},
+	)
+}
+
+func TestGetAuth_CRDPresent_ReturnsGroups(t *testing.T) {
+	fakeDyn := newFakeDynClientWithAuth([]string{"system:authenticated", "allowed-group"})
+	repo := NewAuthRepository(fakeDyn)
+
+	auth, err := repo.GetAuth(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	assert.Equal(t, []string{"odh-admins"}, auth.AdminGroups)
+	assert.Equal(t, []string{"system:authenticated", "allowed-group"}, auth.AllowedGroups)
+}
+
+func TestGetAuth_CRDAbsent_ReturnsNil(t *testing.T) {
+	fakeDyn := newFakeDynClientCRDAbsent()
+	repo := NewAuthRepository(fakeDyn)
+
+	auth, err := repo.GetAuth(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, auth)
+}
+
+func TestGetAuth_MalformedSpec_ReturnsError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "services.platform.opendatahub.io/v1alpha1",
+			"kind":       "Auth",
+			"metadata": map[string]interface{}{
+				"name": "auth",
+			},
+		},
+	}
+	fakeDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.AuthGVR: "AuthList",
+		},
+		cr,
+	)
+	repo := NewAuthRepository(fakeDyn)
+
+	auth, err := repo.GetAuth(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, auth)
+	assert.Contains(t, err.Error(), "missing or invalid spec")
+}
+
+func TestGetAuth_InstanceAbsent_ReturnsError(t *testing.T) {
+	fakeDyn := newFakeDynClientInstanceAbsent()
+	repo := NewAuthRepository(fakeDyn)
+
+	auth, err := repo.GetAuth(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, auth)
+	assert.Contains(t, err.Error(), "auth instance not found")
+}
+
+func TestGetAuth_NilClient_ReturnsNil(t *testing.T) {
+	repo := NewAuthRepository(nil)
+
+	auth, err := repo.GetAuth(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, auth)
+}
+
+func TestResolveIsAllowed_AuthPresent_SystemAuthenticated_ReturnsTrue(t *testing.T) {
+	fakeDyn := newFakeDynClientWithAuth([]string{"system:authenticated"})
+	authRepo := NewAuthRepository(fakeDyn)
+
+	auth, err := authRepo.GetAuth(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// system:authenticated escape hatch should short-circuit to true
+	assert.True(t, hasSystemAuthenticatedGroup(auth))
+}
+
+func TestResolveIsAllowed_AuthPresent_NoEscapeHatch_FallsToSSAR(t *testing.T) {
+	fakeDyn := newFakeDynClientWithAuth([]string{"restricted-group"})
+	authRepo := NewAuthRepository(fakeDyn)
+
+	auth, err := authRepo.GetAuth(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	// No system:authenticated -> should fall to SSAR
+	assert.False(t, hasSystemAuthenticatedGroup(auth))
+}

--- a/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/auth_integration_test.go
@@ -121,12 +121,13 @@ func TestGetAuth_InstanceAbsent_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "auth instance not found")
 }
 
-func TestGetAuth_NilClient_ReturnsNil(t *testing.T) {
+func TestGetAuth_NilClient_ReturnsError(t *testing.T) {
 	repo := NewAuthRepository(nil)
 
 	auth, err := repo.GetAuth(context.Background())
-	require.NoError(t, err)
 	assert.Nil(t, auth)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "auth dynamic client unavailable")
 }
 
 func TestResolveIsAllowed_AuthPresent_SystemAuthenticated_ReturnsTrue(t *testing.T) {

--- a/distributions/core-bff/bff/internal/repositories/auth_test.go
+++ b/distributions/core-bff/bff/internal/repositories/auth_test.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetAuth_ErrorClassification(t *testing.T) {
+	// 404 (NotFound) means the CRD exists but the "auth" instance is missing.
+	// This should NOT be treated as CRD absent - it should return an error
+	// so resolveIsAllowed falls through to SSAR instead of granting access.
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Group: "services.platform.opendatahub.io", Resource: "auths"}, "auth")
+	assert.True(t, k8serrors.IsNotFound(notFound))
+	assert.False(t, isDiscoveryError(notFound))
+
+	// 403 (Forbidden) should NOT be treated as CRD absent
+	forbidden := k8serrors.NewForbidden(schema.GroupResource{Group: "services.platform.opendatahub.io", Resource: "auths"}, "auth", nil)
+	assert.True(t, k8serrors.IsForbidden(forbidden))
+	assert.False(t, isDiscoveryError(forbidden))
+}
+
+func TestGetAuth_ParsesAuthConfig(t *testing.T) {
+	spec := map[string]interface{}{
+		"adminGroups":   []interface{}{"admin-group-1", "admin-group-2"},
+		"allowedGroups": []interface{}{"system:authenticated", "allowed-group"},
+	}
+
+	auth := &AuthConfig{}
+	if groups, ok := spec["adminGroups"].([]interface{}); ok {
+		for _, g := range groups {
+			if s, ok := g.(string); ok {
+				auth.AdminGroups = append(auth.AdminGroups, s)
+			}
+		}
+	}
+	if groups, ok := spec["allowedGroups"].([]interface{}); ok {
+		for _, g := range groups {
+			if s, ok := g.(string); ok {
+				auth.AllowedGroups = append(auth.AllowedGroups, s)
+			}
+		}
+	}
+
+	assert.Equal(t, []string{"admin-group-1", "admin-group-2"}, auth.AdminGroups)
+	assert.Equal(t, []string{"system:authenticated", "allowed-group"}, auth.AllowedGroups)
+}
+
+func TestGetAuth_EmptySpec(t *testing.T) {
+	spec := map[string]interface{}{}
+
+	auth := &AuthConfig{}
+	if groups, ok := spec["adminGroups"].([]interface{}); ok {
+		for _, g := range groups {
+			if s, ok := g.(string); ok {
+				auth.AdminGroups = append(auth.AdminGroups, s)
+			}
+		}
+	}
+
+	assert.Nil(t, auth.AdminGroups)
+	assert.Nil(t, auth.AllowedGroups)
+}

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings.go
@@ -64,6 +64,13 @@ func (r *ClusterSettingsRepository) GetClusterSettings(
 func (r *ClusterSettingsRepository) BuildDashboardConfigPatch(
 	settings *models.ClusterSettings, currentConfig *models.DashboardConfig,
 ) ([]byte, error) {
+	if settings == nil {
+		return nil, fmt.Errorf("settings must not be nil")
+	}
+	if currentConfig == nil {
+		return nil, fmt.Errorf("currentConfig must not be nil")
+	}
+
 	patch := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"dashboardConfig": map[string]interface{}{

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings.go
@@ -1,0 +1,167 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	cullerConfigName           = "notebook-controller-culler-config"
+	segmentKeyConfigName       = "odh-segment-key-config"
+	defaultCullerTimeout       = 31536000
+	defaultPVCSize             = 20
+	defaultIdlenessCheckPeriod = "1"
+	notebookControllerDeploy   = "notebook-controller-deployment"
+)
+
+// ClusterSettingsRepository handles cluster settings derived from DashboardConfig and ConfigMaps.
+// Uses the SA clientset for ConfigMap operations, matching the privileged watcher model where the dashboard
+// SA performs reads and admin-gated mutations.
+type ClusterSettingsRepository struct {
+	saClientset kubernetes.Interface
+}
+
+func NewClusterSettingsRepository(saClientset kubernetes.Interface) *ClusterSettingsRepository {
+	return &ClusterSettingsRepository{saClientset: saClientset}
+}
+
+// GetClusterSettings builds a ClusterSettings from DashboardConfig and ConfigMaps.
+func (r *ClusterSettingsRepository) GetClusterSettings(
+	ctx context.Context,
+	namespace string, dashConfig *models.DashboardConfig,
+) (*models.ClusterSettings, error) {
+	settings := models.DefaultClusterSettings
+
+	applyDashboardConfigToSettings(dashConfig, &settings)
+
+	cullerTimeout, err := readCullerTimeout(ctx, r.saClientset, namespace)
+	if err != nil {
+		return nil, err
+	}
+	settings.CullerTimeout = cullerTimeout
+
+	if dashConfig != nil && !dashConfig.Spec.DashboardConfig.DisableTracking {
+		tracking, err := readUserTrackingEnabled(ctx, r.saClientset, namespace)
+		if err != nil {
+			slog.Warn("failed to read segment key config, defaulting to tracking disabled", slog.Any("error", err))
+		} else {
+			settings.UserTrackingEnabled = tracking
+		}
+	}
+
+	return &settings, nil
+}
+
+// BuildDashboardConfigPatch builds the JSON merge patch for DashboardConfig fields
+// affected by cluster settings.
+func (r *ClusterSettingsRepository) BuildDashboardConfigPatch(
+	settings *models.ClusterSettings, currentConfig *models.DashboardConfig,
+) ([]byte, error) {
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"disableKServe": !settings.ModelServingPlatformEnabled.KServe,
+				"disableLLMd":   !settings.ModelServingPlatformEnabled.LLMd,
+			},
+		},
+	}
+
+	modelServing := map[string]interface{}{}
+	if settings.IsDistributedInferencingDefault != nil {
+		modelServing["isLLMdDefault"] = *settings.IsDistributedInferencingDefault
+	}
+	currentStrategy := ""
+	if currentConfig.Spec.ModelServing != nil && currentConfig.Spec.ModelServing.DeploymentStrategy != nil {
+		currentStrategy = *currentConfig.Spec.ModelServing.DeploymentStrategy
+	}
+	if settings.DefaultDeploymentStrategy != currentStrategy {
+		modelServing["deploymentStrategy"] = settings.DefaultDeploymentStrategy
+	}
+	if len(modelServing) > 0 {
+		patch["spec"].(map[string]interface{})["modelServing"] = modelServing
+	}
+
+	currentPVC := currentPVCSize(currentConfig)
+	if settings.PVCSize != currentPVC {
+		isJupyterEnabled := true
+		if currentConfig.Spec.NotebookController != nil {
+			isJupyterEnabled = currentConfig.Spec.NotebookController.Enabled
+		}
+		pvcStr := fmt.Sprintf("%dGi", settings.PVCSize)
+		patch["spec"].(map[string]interface{})["notebookController"] = map[string]interface{}{
+			"enabled": isJupyterEnabled,
+			"pvcSize": pvcStr,
+		}
+	}
+
+	return json.Marshal(patch)
+}
+
+// UpdateConfigMaps updates culler and segment-key ConfigMaps, and rolls out
+// notebook-controller-deployment when culler or PVC settings changed.
+// All operations use the SA clientset, matching the privileged watcher model.
+func (r *ClusterSettingsRepository) UpdateConfigMaps(
+	ctx context.Context,
+	namespace string, settings *models.ClusterSettings, currentConfig *models.DashboardConfig,
+) error {
+	needsRollout := r.detectChanges(ctx, namespace, settings, currentConfig)
+
+	if err := r.updateCullerConfig(ctx, namespace, settings.CullerTimeout); err != nil {
+		return fmt.Errorf("failed to update culler config: %w", err)
+	}
+	if err := r.updateSegmentKeyConfig(ctx, namespace, settings.UserTrackingEnabled); err != nil {
+		return fmt.Errorf("failed to update segment key config: %w", err)
+	}
+
+	if needsRollout {
+		if err := r.rolloutDeployment(ctx, namespace, notebookControllerDeploy); err != nil {
+			return fmt.Errorf("failed to rollout %s: %w", notebookControllerDeploy, err)
+		}
+	}
+
+	return nil
+}
+
+// --- Pure helpers ---
+
+func applyDashboardConfigToSettings(dashConfig *models.DashboardConfig, settings *models.ClusterSettings) {
+	if dashConfig == nil {
+		return
+	}
+
+	settings.ModelServingPlatformEnabled.KServe = !dashConfig.Spec.DashboardConfig.DisableKServe
+	settings.ModelServingPlatformEnabled.LLMd = !dashConfig.Spec.DashboardConfig.DisableLLMd
+
+	if dashConfig.Spec.ModelServing != nil {
+		settings.IsDistributedInferencingDefault = dashConfig.Spec.ModelServing.IsLLMdDefault
+		if dashConfig.Spec.ModelServing.DeploymentStrategy != nil {
+			settings.DefaultDeploymentStrategy = *dashConfig.Spec.ModelServing.DeploymentStrategy
+		}
+	}
+
+	settings.PVCSize = currentPVCSize(dashConfig)
+}
+
+func currentPVCSize(config *models.DashboardConfig) int {
+	if config == nil || config.Spec.NotebookController == nil || config.Spec.NotebookController.PVCSize == nil {
+		return defaultPVCSize
+	}
+	return parsePVCSize(*config.Spec.NotebookController.PVCSize)
+}
+
+func parsePVCSize(size string) int {
+	size = strings.TrimSuffix(size, "Gi")
+	size = strings.TrimSuffix(size, "G")
+	val, err := strconv.Atoi(size)
+	if err != nil {
+		return defaultPVCSize
+	}
+	return val
+}

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings_configmaps.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings_configmaps.go
@@ -1,0 +1,144 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// --- ConfigMap readers ---
+
+func readCullerTimeout(ctx context.Context, saClientset kubernetes.Interface, namespace string) (int, error) {
+	cm, err := saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, cullerConfigName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return defaultCullerTimeout, nil
+		}
+		return 0, fmt.Errorf("failed to get culler config: %w", err)
+	}
+	if cm.Data == nil || cm.Data["ENABLE_CULLING"] != "true" {
+		return defaultCullerTimeout, nil
+	}
+	if idleTime, ok := cm.Data["CULL_IDLE_TIME"]; ok {
+		if mins, parseErr := strconv.Atoi(idleTime); parseErr == nil {
+			return mins * 60, nil
+		}
+	}
+	return defaultCullerTimeout, nil
+}
+
+func readUserTrackingEnabled(ctx context.Context, saClientset kubernetes.Interface, namespace string) (bool, error) {
+	cm, err := saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, segmentKeyConfigName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get segment key config: %w", err)
+	}
+	if cm.Data == nil {
+		return false, nil
+	}
+	return cm.Data["segmentKeyEnabled"] == "true", nil
+}
+
+// --- ConfigMap writers ---
+
+func (r *ClusterSettingsRepository) detectChanges(
+	ctx context.Context,
+	namespace string, settings *models.ClusterSettings, currentConfig *models.DashboardConfig,
+) bool {
+	if settings.PVCSize != currentPVCSize(currentConfig) {
+		return true
+	}
+	currentTimeout, err := readCullerTimeout(ctx, r.saClientset, namespace)
+	if err != nil {
+		return true
+	}
+	return settings.CullerTimeout != currentTimeout
+}
+
+func (r *ClusterSettingsRepository) updateCullerConfig(ctx context.Context, namespace string, cullerTimeout int) error {
+	cmClient := r.saClientset.CoreV1().ConfigMaps(namespace)
+	cullerMinutes := cullerTimeout / 60
+	isEnabled := cullerTimeout != defaultCullerTimeout
+
+	if !isEnabled {
+		err := cmClient.Delete(ctx, cullerConfigName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete culler config: %w", err)
+		}
+		return nil
+	}
+
+	cm, err := cmClient.Get(ctx, cullerConfigName, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+		return r.createCullerConfigMap(ctx, namespace, isEnabled, cullerMinutes)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["ENABLE_CULLING"] = strconv.FormatBool(isEnabled)
+	cm.Data["CULL_IDLE_TIME"] = strconv.Itoa(cullerMinutes)
+	_, err = cmClient.Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *ClusterSettingsRepository) createCullerConfigMap(ctx context.Context, namespace string, isEnabled bool, cullerMinutes int) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cullerConfigName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"opendatahub.io/dashboard": "true",
+			},
+		},
+		Data: map[string]string{
+			"ENABLE_CULLING":        strconv.FormatBool(isEnabled),
+			"CULL_IDLE_TIME":        strconv.Itoa(cullerMinutes),
+			"IDLENESS_CHECK_PERIOD": defaultIdlenessCheckPeriod,
+		},
+	}
+	_, err := r.saClientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+func (r *ClusterSettingsRepository) updateSegmentKeyConfig(ctx context.Context, namespace string, enabled bool) error {
+	cmClient := r.saClientset.CoreV1().ConfigMaps(namespace)
+	cm, err := cmClient.Get(ctx, segmentKeyConfigName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data["segmentKeyEnabled"] = strconv.FormatBool(enabled)
+	_, err = cmClient.Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// --- Deployment rollout ---
+
+func (r *ClusterSettingsRepository) rolloutDeployment(ctx context.Context, namespace, name string) error {
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`,
+		time.Now().UTC().Format(time.RFC3339))
+
+	_, err := r.saClientset.AppsV1().Deployments(namespace).Patch(
+		ctx, name, types.MergePatchType, []byte(patch), metav1.PatchOptions{},
+	)
+	return err
+}

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -111,7 +112,7 @@ func TestUpdateCullerConfig_DisablesCulling(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = cs.CoreV1().ConfigMaps(testNS).Get(ctx, cullerConfigName, metav1.GetOptions{})
-	assert.True(t, err != nil, "culler CM should be deleted")
+	assert.True(t, k8serrors.IsNotFound(err), "culler CM should be deleted")
 }
 
 func TestUpdateCullerConfig_UpdatesExisting(t *testing.T) {

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings_integration_test.go
@@ -1,0 +1,206 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testNS = "test-ns"
+
+func cullerCM(enableCulling bool, idleTime string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cullerConfigName, Namespace: testNS},
+		Data: map[string]string{
+			"ENABLE_CULLING": func() string {
+				if enableCulling {
+					return "true"
+				}
+				return "false"
+			}(),
+			"CULL_IDLE_TIME": idleTime,
+		},
+	}
+}
+
+func segmentCM(enabled bool) *corev1.ConfigMap {
+	val := "false"
+	if enabled {
+		val = "true"
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: segmentKeyConfigName, Namespace: testNS},
+		Data:       map[string]string{"segmentKeyEnabled": val},
+	}
+}
+
+func defaultDashConfig() *models.DashboardConfig {
+	return &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			DashboardConfig: models.DashboardFeatureFlags{},
+			NotebookController: &models.NotebookController{
+				Enabled: true,
+			},
+		},
+	}
+}
+
+func TestGetClusterSettings_WithCullerEnabled(t *testing.T) {
+	cs := fake.NewSimpleClientset(cullerCM(true, "30"))
+	repo := NewClusterSettingsRepository(cs)
+
+	settings, err := repo.GetClusterSettings(context.Background(), testNS, defaultDashConfig())
+	require.NoError(t, err)
+	assert.Equal(t, 1800, settings.CullerTimeout) // 30 min * 60
+}
+
+func TestGetClusterSettings_WithCullerDisabled(t *testing.T) {
+	cs := fake.NewSimpleClientset(cullerCM(false, "30"))
+	repo := NewClusterSettingsRepository(cs)
+
+	settings, err := repo.GetClusterSettings(context.Background(), testNS, defaultDashConfig())
+	require.NoError(t, err)
+	assert.Equal(t, defaultCullerTimeout, settings.CullerTimeout)
+}
+
+func TestGetClusterSettings_NoCullerCM(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewClusterSettingsRepository(cs)
+
+	settings, err := repo.GetClusterSettings(context.Background(), testNS, defaultDashConfig())
+	require.NoError(t, err)
+	assert.Equal(t, defaultCullerTimeout, settings.CullerTimeout)
+}
+
+func TestGetClusterSettings_TrackingEnabled(t *testing.T) {
+	cs := fake.NewSimpleClientset(segmentCM(true))
+	repo := NewClusterSettingsRepository(cs)
+
+	settings, err := repo.GetClusterSettings(context.Background(), testNS, defaultDashConfig())
+	require.NoError(t, err)
+	assert.True(t, settings.UserTrackingEnabled)
+}
+
+func TestUpdateCullerConfig_EnablesCulling(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewClusterSettingsRepository(cs)
+	ctx := context.Background()
+
+	err := repo.updateCullerConfig(ctx, testNS, 1800) // 30 minutes
+	require.NoError(t, err)
+
+	cm, err := cs.CoreV1().ConfigMaps(testNS).Get(ctx, cullerConfigName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", cm.Data["ENABLE_CULLING"])
+	assert.Equal(t, "30", cm.Data["CULL_IDLE_TIME"])
+	assert.Equal(t, defaultIdlenessCheckPeriod, cm.Data["IDLENESS_CHECK_PERIOD"])
+}
+
+func TestUpdateCullerConfig_DisablesCulling(t *testing.T) {
+	cs := fake.NewSimpleClientset(cullerCM(true, "30"))
+	repo := NewClusterSettingsRepository(cs)
+	ctx := context.Background()
+
+	err := repo.updateCullerConfig(ctx, testNS, defaultCullerTimeout)
+	require.NoError(t, err)
+
+	_, err = cs.CoreV1().ConfigMaps(testNS).Get(ctx, cullerConfigName, metav1.GetOptions{})
+	assert.True(t, err != nil, "culler CM should be deleted")
+}
+
+func TestUpdateCullerConfig_UpdatesExisting(t *testing.T) {
+	cs := fake.NewSimpleClientset(cullerCM(true, "30"))
+	repo := NewClusterSettingsRepository(cs)
+	ctx := context.Background()
+
+	err := repo.updateCullerConfig(ctx, testNS, 3600) // 60 minutes
+	require.NoError(t, err)
+
+	cm, err := cs.CoreV1().ConfigMaps(testNS).Get(ctx, cullerConfigName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", cm.Data["ENABLE_CULLING"])
+	assert.Equal(t, "60", cm.Data["CULL_IDLE_TIME"])
+}
+
+func TestUpdateSegmentKeyConfig(t *testing.T) {
+	cs := fake.NewSimpleClientset(segmentCM(false))
+	repo := NewClusterSettingsRepository(cs)
+	ctx := context.Background()
+
+	err := repo.updateSegmentKeyConfig(ctx, testNS, true)
+	require.NoError(t, err)
+
+	cm, err := cs.CoreV1().ConfigMaps(testNS).Get(ctx, segmentKeyConfigName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", cm.Data["segmentKeyEnabled"])
+}
+
+func TestDetectChanges_PVCChanged(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewClusterSettingsRepository(cs)
+
+	pvc := "20Gi"
+	config := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			NotebookController: &models.NotebookController{PVCSize: &pvc},
+		},
+	}
+	settings := &models.ClusterSettings{PVCSize: 50}
+
+	assert.True(t, repo.detectChanges(context.Background(), testNS, settings, config))
+}
+
+func TestDetectChanges_CullerChanged(t *testing.T) {
+	cs := fake.NewSimpleClientset(cullerCM(true, "30"))
+	repo := NewClusterSettingsRepository(cs)
+
+	settings := &models.ClusterSettings{PVCSize: defaultPVCSize, CullerTimeout: 7200}
+
+	assert.True(t, repo.detectChanges(context.Background(), testNS, settings, defaultDashConfig()))
+}
+
+func TestDetectChanges_NoChanges(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewClusterSettingsRepository(cs)
+
+	settings := &models.ClusterSettings{PVCSize: defaultPVCSize, CullerTimeout: defaultCullerTimeout}
+
+	assert.False(t, repo.detectChanges(context.Background(), testNS, settings, defaultDashConfig()))
+}
+
+func TestApplyDashboardConfigToSettings(t *testing.T) {
+	strategy := "rolling"
+	isDefault := true
+	pvc := "50Gi"
+
+	config := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			DashboardConfig: models.DashboardFeatureFlags{
+				DisableKServe: true,
+				DisableLLMd:   false,
+			},
+			ModelServing: &models.ModelServingConfig{
+				DeploymentStrategy: &strategy,
+				IsLLMdDefault:      &isDefault,
+			},
+			NotebookController: &models.NotebookController{
+				PVCSize: &pvc,
+			},
+		},
+	}
+
+	settings := models.DefaultClusterSettings
+	applyDashboardConfigToSettings(config, &settings)
+
+	assert.False(t, settings.ModelServingPlatformEnabled.KServe)
+	assert.True(t, settings.ModelServingPlatformEnabled.LLMd)
+	assert.Equal(t, "rolling", settings.DefaultDeploymentStrategy)
+	assert.Equal(t, true, *settings.IsDistributedInferencingDefault)
+	assert.Equal(t, 50, settings.PVCSize)
+}

--- a/distributions/core-bff/bff/internal/repositories/cluster_settings_test.go
+++ b/distributions/core-bff/bff/internal/repositories/cluster_settings_test.go
@@ -1,0 +1,142 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePVCSize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"20Gi", 20},
+		{"50Gi", 50},
+		{"100G", 100},
+		{"10", 10},
+		{"invalid", 20},
+		{"", 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parsePVCSize(tt.input))
+		})
+	}
+}
+
+func TestBuildDashboardConfigPatch_Basic(t *testing.T) {
+	repo := NewClusterSettingsRepository(nil)
+	pvcSize := "20Gi"
+	settings := &models.ClusterSettings{
+		PVCSize: 30,
+		ModelServingPlatformEnabled: models.ModelServingPlatformEnabled{
+			KServe: true,
+			LLMd:   false,
+		},
+	}
+	currentConfig := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			NotebookController: &models.NotebookController{
+				Enabled: true,
+				PVCSize: &pvcSize,
+			},
+		},
+	}
+
+	patchBytes, err := repo.BuildDashboardConfigPatch(settings, currentConfig)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchBytes)
+
+	// Verify it's valid JSON containing expected fields
+	patchStr := string(patchBytes)
+	assert.Contains(t, patchStr, `"disableKServe":false`)
+	assert.Contains(t, patchStr, `"disableLLMd":true`)
+	assert.Contains(t, patchStr, `"pvcSize":"30Gi"`)
+}
+
+func TestBuildDashboardConfigPatch_NoPVCChangeWhenSame(t *testing.T) {
+	repo := NewClusterSettingsRepository(nil)
+	pvcSize := "20Gi"
+	settings := &models.ClusterSettings{
+		PVCSize: 20,
+		ModelServingPlatformEnabled: models.ModelServingPlatformEnabled{
+			KServe: true,
+			LLMd:   true,
+		},
+	}
+	currentConfig := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			NotebookController: &models.NotebookController{
+				Enabled: true,
+				PVCSize: &pvcSize,
+			},
+		},
+	}
+
+	patchBytes, err := repo.BuildDashboardConfigPatch(settings, currentConfig)
+	require.NoError(t, err)
+
+	patchStr := string(patchBytes)
+	assert.NotContains(t, patchStr, "notebookController")
+}
+
+func TestBuildDashboardConfigPatch_PreservesNotebookDisabled(t *testing.T) {
+	repo := NewClusterSettingsRepository(nil)
+	pvcSize := "20Gi"
+	settings := &models.ClusterSettings{
+		PVCSize: 50,
+		ModelServingPlatformEnabled: models.ModelServingPlatformEnabled{
+			KServe: true,
+			LLMd:   true,
+		},
+	}
+	currentConfig := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			NotebookController: &models.NotebookController{
+				Enabled: false,
+				PVCSize: &pvcSize,
+			},
+		},
+	}
+
+	patchBytes, err := repo.BuildDashboardConfigPatch(settings, currentConfig)
+	require.NoError(t, err)
+
+	patchStr := string(patchBytes)
+	assert.Contains(t, patchStr, `"enabled":false`)
+	assert.Contains(t, patchStr, `"pvcSize":"50Gi"`)
+}
+
+func TestBuildDashboardConfigPatch_WithModelServing(t *testing.T) {
+	repo := NewClusterSettingsRepository(nil)
+	isDefault := true
+	pvcSize := "20Gi"
+	settings := &models.ClusterSettings{
+		PVCSize:                         20,
+		IsDistributedInferencingDefault: &isDefault,
+		DefaultDeploymentStrategy:       "rolling",
+		ModelServingPlatformEnabled: models.ModelServingPlatformEnabled{
+			KServe: true,
+			LLMd:   true,
+		},
+	}
+	currentConfig := &models.DashboardConfig{
+		Spec: models.DashboardConfigSpec{
+			NotebookController: &models.NotebookController{
+				Enabled: true,
+				PVCSize: &pvcSize,
+			},
+		},
+	}
+
+	patchBytes, err := repo.BuildDashboardConfigPatch(settings, currentConfig)
+	require.NoError(t, err)
+
+	patchStr := string(patchBytes)
+	assert.Contains(t, patchStr, `"isLLMdDefault":true`)
+	assert.Contains(t, patchStr, `"deploymentStrategy":"rolling"`)
+}

--- a/distributions/core-bff/bff/internal/repositories/components.go
+++ b/distributions/core-bff/bff/internal/repositories/components.go
@@ -57,6 +57,9 @@ func (r *ComponentsRepository) RemoveComponent(ctx context.Context, namespace, a
 	if enabledAppsCM == "" {
 		return &models.MutationResponse{Success: false, Error: "enabled apps ConfigMap not configured"}, nil
 	}
+	if r.saClientset == nil {
+		return &models.MutationResponse{Success: false, Error: "service account clientset not configured"}, nil
+	}
 
 	cm, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, enabledAppsCM, metav1.GetOptions{})
 	if err != nil {

--- a/distributions/core-bff/bff/internal/repositories/components.go
+++ b/distributions/core-bff/bff/internal/repositories/components.go
@@ -1,0 +1,87 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ComponentsRepository handles OdhApplication CRD listing and removal.
+// Uses the SA clients for all operations, matching the privileged watcher model.
+type ComponentsRepository struct {
+	saDynClient dynamic.Interface
+	saClientset kubernetes.Interface
+}
+
+func NewComponentsRepository(saDynClient dynamic.Interface, saClientset kubernetes.Interface) *ComponentsRepository {
+	return &ComponentsRepository{saDynClient: saDynClient, saClientset: saClientset}
+}
+
+// ListComponents lists OdhApplication CRDs. Returns empty slice when CRD is absent.
+// Full RHOAI logic (CSV resolution, link resolution, app filtering) is deferred to Task 9.
+func (r *ComponentsRepository) ListComponents(
+	ctx context.Context,
+	namespace string, installedOnly bool,
+) ([]map[string]interface{}, error) {
+	if r.saDynClient == nil {
+		return []map[string]interface{}{}, nil
+	}
+
+	list, err := r.saDynClient.Resource(models.OdhApplicationGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isDiscoveryError(err) {
+			return []map[string]interface{}{}, nil
+		}
+		return nil, fmt.Errorf("failed to list components: %w", err)
+	}
+
+	result := make([]map[string]interface{}, 0, len(list.Items))
+	for _, item := range list.Items {
+		if installedOnly && !isShownOnEnabledPage(item) {
+			continue
+		}
+		result = append(result, item.Object)
+	}
+
+	return result, nil
+}
+
+// RemoveComponent removes an app entry from the enabled-apps ConfigMap.
+func (r *ComponentsRepository) RemoveComponent(ctx context.Context, namespace, appName, enabledAppsCM string) (*models.MutationResponse, error) {
+	if enabledAppsCM == "" {
+		return &models.MutationResponse{Success: false, Error: "enabled apps ConfigMap not configured"}, nil
+	}
+
+	cm, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, enabledAppsCM, metav1.GetOptions{})
+	if err != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("failed to read enabled apps ConfigMap: %v", err)}, nil
+	}
+
+	if cm.Data == nil {
+		return &models.MutationResponse{Success: true, Error: ""}, nil
+	}
+
+	delete(cm.Data, appName)
+
+	_, err = r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	if err != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("failed to update enabled apps ConfigMap: %v", err)}, nil
+	}
+
+	return &models.MutationResponse{Success: true, Error: ""}, nil
+}
+
+func isShownOnEnabledPage(item unstructured.Unstructured) bool {
+	spec, ok := item.Object["spec"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	shown, ok := spec["shownOnEnabledPage"].(bool)
+	return ok && shown
+}

--- a/distributions/core-bff/bff/internal/repositories/components_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/components_integration_test.go
@@ -1,0 +1,67 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func newFakeDynClientWithApps(apps ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	objs := make([]runtime.Object, len(apps))
+	for i, a := range apps {
+		objs[i] = a
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.OdhApplicationGVR: "OdhApplicationList",
+		},
+		objs...,
+	)
+}
+
+func odhApp(name string, shownOnEnabledPage bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "dashboard.opendatahub.io/v1",
+			"kind":       "OdhApplication",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"shownOnEnabledPage": shownOnEnabledPage,
+			},
+		},
+	}
+}
+
+func TestListComponents_InstalledOnly_FiltersCorrectly(t *testing.T) {
+	fakeDyn := newFakeDynClientWithApps(
+		odhApp("visible-app", true),
+		odhApp("hidden-app", false),
+	)
+	repo := NewComponentsRepository(fakeDyn, nil)
+
+	t.Run("installedOnly=true returns only shownOnEnabledPage apps", func(t *testing.T) {
+		result, err := repo.ListComponents(context.Background(), "test-ns", true)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		meta := result[0]["metadata"].(map[string]interface{})
+		assert.Equal(t, "visible-app", meta["name"])
+	})
+
+	t.Run("installedOnly=false returns all apps", func(t *testing.T) {
+		result, err := repo.ListComponents(context.Background(), "test-ns", false)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+	})
+}

--- a/distributions/core-bff/bff/internal/repositories/connection_type.go
+++ b/distributions/core-bff/bff/internal/repositories/connection_type.go
@@ -2,13 +2,14 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -97,30 +98,49 @@ func (r *ConnectionTypeRepository) Update(ctx context.Context, namespace, name s
 }
 
 func (r *ConnectionTypeRepository) Patch(ctx context.Context, namespace, name string, patchData []byte) (*models.MutationResponse, error) {
-	if err := r.validateExistingConnectionType(ctx, namespace, name); err != nil {
-		return err, nil
-	}
-
-	existing, getErr := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
-	if getErr != nil {
-		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("failed to fetch baseline for revert: %v", getErr)}, nil
-	}
-
-	patched, patchErr := r.saClientset.CoreV1().ConfigMaps(namespace).Patch(ctx, name, types.JSONPatchType, patchData, metav1.PatchOptions{})
-	if patchErr != nil {
-		return &models.MutationResponse{Success: false, Error: patchErr.Error()}, nil
-	}
-
-	if !isConnectionTypeConfigMap(patched) {
-		errMsg := "patch would remove required connection-type labels"
-		existing.ResourceVersion = patched.ResourceVersion
-		if _, revertErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); revertErr != nil {
-			errMsg = fmt.Sprintf("%s (revert failed: %v)", errMsg, revertErr)
-		}
+	existing, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
 		return &models.MutationResponse{
 			Success: false,
-			Error:   errMsg,
+			Error:   fmt.Sprintf("unable to find connection type %q: %v", name, err),
 		}, nil
+	}
+	if !isConnectionTypeConfigMap(existing) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("unable to update connection type, object %q is not a connection type", name),
+		}, nil
+	}
+
+	originalBytes, marshalErr := json.Marshal(existing)
+	if marshalErr != nil {
+		return nil, fmt.Errorf("failed to marshal existing configmap: %w", marshalErr)
+	}
+
+	patch, decodeErr := jsonpatch.DecodePatch(patchData)
+	if decodeErr != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("invalid JSON patch: %v", decodeErr)}, nil
+	}
+
+	modifiedBytes, applyErr := patch.Apply(originalBytes)
+	if applyErr != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("failed to apply patch: %v", applyErr)}, nil
+	}
+
+	var modified corev1.ConfigMap
+	if unmarshalErr := json.Unmarshal(modifiedBytes, &modified); unmarshalErr != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("patch produced invalid ConfigMap: %v", unmarshalErr)}, nil
+	}
+
+	if !isConnectionTypeConfigMap(&modified) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   "patch would remove required connection-type labels",
+		}, nil
+	}
+
+	if _, updateErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, &modified, metav1.UpdateOptions{}); updateErr != nil {
+		return &models.MutationResponse{Success: false, Error: updateErr.Error()}, nil
 	}
 
 	return &models.MutationResponse{Success: true, Error: ""}, nil

--- a/distributions/core-bff/bff/internal/repositories/connection_type.go
+++ b/distributions/core-bff/bff/internal/repositories/connection_type.go
@@ -101,7 +101,10 @@ func (r *ConnectionTypeRepository) Patch(ctx context.Context, namespace, name st
 		return err, nil
 	}
 
-	existing, _ := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	existing, getErr := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return &models.MutationResponse{Success: false, Error: fmt.Sprintf("failed to fetch baseline for revert: %v", getErr)}, nil
+	}
 
 	patched, patchErr := r.saClientset.CoreV1().ConfigMaps(namespace).Patch(ctx, name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	if patchErr != nil {
@@ -110,11 +113,9 @@ func (r *ConnectionTypeRepository) Patch(ctx context.Context, namespace, name st
 
 	if !isConnectionTypeConfigMap(patched) {
 		errMsg := "patch would remove required connection-type labels"
-		if existing != nil {
-			existing.ResourceVersion = patched.ResourceVersion
-			if _, revertErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); revertErr != nil {
-				errMsg = fmt.Sprintf("%s (revert failed: %v)", errMsg, revertErr)
-			}
+		existing.ResourceVersion = patched.ResourceVersion
+		if _, revertErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); revertErr != nil {
+			errMsg = fmt.Sprintf("%s (revert failed: %v)", errMsg, revertErr)
 		}
 		return &models.MutationResponse{
 			Success: false,

--- a/distributions/core-bff/bff/internal/repositories/connection_type.go
+++ b/distributions/core-bff/bff/internal/repositories/connection_type.go
@@ -1,0 +1,169 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const connectionTypeLabelSelector = models.LabelDashboardResource + "=true," + models.LabelConnectionType + "=true"
+
+// ConnectionTypeRepository handles CRUD operations for connection-type ConfigMaps.
+// Uses the SA clientset for all operations, matching the privileged watcher model.
+type ConnectionTypeRepository struct {
+	saClientset kubernetes.Interface
+}
+
+func NewConnectionTypeRepository(saClientset kubernetes.Interface) *ConnectionTypeRepository {
+	return &ConnectionTypeRepository{saClientset: saClientset}
+}
+
+func (r *ConnectionTypeRepository) List(ctx context.Context, namespace string) ([]corev1.ConfigMap, error) {
+	allItems := []corev1.ConfigMap{}
+	continueToken := ""
+
+	for {
+		cmList, err := r.saClientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: connectionTypeLabelSelector,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list connection types: %w", err)
+		}
+
+		allItems = append(allItems, cmList.Items...)
+
+		if cmList.Continue == "" {
+			break
+		}
+		continueToken = cmList.Continue
+	}
+
+	return allItems, nil
+}
+
+func (r *ConnectionTypeRepository) Get(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
+	cm, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get connection type %q: %w", name, err)
+	}
+	if !isConnectionTypeConfigMap(cm) {
+		return nil, fmt.Errorf("configmap %q is not a connection type", name)
+	}
+	return cm, nil
+}
+
+func (r *ConnectionTypeRepository) Create(ctx context.Context, namespace string, cm *corev1.ConfigMap) (*models.MutationResponse, error) {
+	if !isConnectionTypeConfigMap(cm) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   "configmap must have connection-type labels",
+		}, nil
+	}
+
+	_, err := r.saClientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		return &models.MutationResponse{Success: false, Error: err.Error()}, nil
+	}
+	return &models.MutationResponse{Success: true, Error: ""}, nil
+}
+
+func (r *ConnectionTypeRepository) Update(ctx context.Context, namespace, name string, cm *corev1.ConfigMap) (*models.MutationResponse, error) {
+	if !isConnectionTypeConfigMap(cm) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   "configmap must have connection-type labels",
+		}, nil
+	}
+
+	if err := r.validateExistingConnectionType(ctx, namespace, name); err != nil {
+		return err, nil
+	}
+
+	_, updateErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	if updateErr != nil {
+		return &models.MutationResponse{Success: false, Error: updateErr.Error()}, nil
+	}
+	return &models.MutationResponse{Success: true, Error: ""}, nil
+}
+
+func (r *ConnectionTypeRepository) Patch(ctx context.Context, namespace, name string, patchData []byte) (*models.MutationResponse, error) {
+	if err := r.validateExistingConnectionType(ctx, namespace, name); err != nil {
+		return err, nil
+	}
+
+	existing, _ := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+
+	patched, patchErr := r.saClientset.CoreV1().ConfigMaps(namespace).Patch(ctx, name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+	if patchErr != nil {
+		return &models.MutationResponse{Success: false, Error: patchErr.Error()}, nil
+	}
+
+	if !isConnectionTypeConfigMap(patched) {
+		errMsg := "patch would remove required connection-type labels"
+		if existing != nil {
+			existing.ResourceVersion = patched.ResourceVersion
+			if _, revertErr := r.saClientset.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); revertErr != nil {
+				errMsg = fmt.Sprintf("%s (revert failed: %v)", errMsg, revertErr)
+			}
+		}
+		return &models.MutationResponse{
+			Success: false,
+			Error:   errMsg,
+		}, nil
+	}
+
+	return &models.MutationResponse{Success: true, Error: ""}, nil
+}
+
+func (r *ConnectionTypeRepository) validateExistingConnectionType(ctx context.Context, namespace, name string) *models.MutationResponse {
+	existing, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("unable to find connection type %q: %v", name, err),
+		}
+	}
+	if !isConnectionTypeConfigMap(existing) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("unable to update connection type, object %q is not a connection type", name),
+		}
+	}
+	return nil
+}
+
+func (r *ConnectionTypeRepository) Delete(ctx context.Context, namespace, name string) (*models.MutationResponse, error) {
+	cm, err := r.saClientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return &models.MutationResponse{Success: false, Error: err.Error()}, nil
+	}
+	if !isConnectionTypeConfigMap(cm) {
+		return &models.MutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("configmap %q is not a connection type", name),
+		}, nil
+	}
+
+	if err := r.saClientset.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return &models.MutationResponse{Success: false, Error: err.Error()}, nil
+	}
+	return &models.MutationResponse{Success: true, Error: ""}, nil
+}
+
+func isConnectionTypeConfigMap(cm *corev1.ConfigMap) bool {
+	if cm == nil || cm.Labels == nil {
+		return false
+	}
+	return cm.Labels[models.LabelDashboardResource] == "true" &&
+		cm.Labels[models.LabelConnectionType] == "true"
+}

--- a/distributions/core-bff/bff/internal/repositories/connection_type_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/connection_type_integration_test.go
@@ -1,0 +1,171 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func ctConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNS,
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+		Data: map[string]string{"key": "value"},
+	}
+}
+
+func plainConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNS,
+		},
+		Data: map[string]string{"key": "value"},
+	}
+}
+
+func TestConnectionTypeList_WithItems(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("ct-1"), ctConfigMap("ct-2"))
+	repo := NewConnectionTypeRepository(cs)
+
+	items, err := repo.List(context.Background(), testNS)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestConnectionTypeList_Empty(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewConnectionTypeRepository(cs)
+
+	items, err := repo.List(context.Background(), testNS)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestConnectionTypeGet_Success(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("my-ct"))
+	repo := NewConnectionTypeRepository(cs)
+
+	cm, err := repo.Get(context.Background(), testNS, "my-ct")
+	require.NoError(t, err)
+	assert.Equal(t, "my-ct", cm.Name)
+}
+
+func TestConnectionTypeGet_NotConnectionType(t *testing.T) {
+	cs := fake.NewSimpleClientset(plainConfigMap("plain"))
+	repo := NewConnectionTypeRepository(cs)
+
+	_, err := repo.Get(context.Background(), testNS, "plain")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a connection type")
+}
+
+func TestConnectionTypeCreate_Success(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewConnectionTypeRepository(cs)
+
+	result, err := repo.Create(context.Background(), testNS, ctConfigMap("new-ct"))
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestConnectionTypeCreate_InvalidLabels(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	repo := NewConnectionTypeRepository(cs)
+
+	result, err := repo.Create(context.Background(), testNS, plainConfigMap("bad"))
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "connection-type labels")
+}
+
+func TestConnectionTypeUpdate_ValidatesExisting(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("existing"))
+	repo := NewConnectionTypeRepository(cs)
+
+	updated := ctConfigMap("existing")
+	updated.Data["key"] = "updated"
+
+	result, err := repo.Update(context.Background(), testNS, "existing", updated)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestConnectionTypeUpdate_RejectsNonConnectionType(t *testing.T) {
+	cs := fake.NewSimpleClientset(plainConfigMap("plain"))
+	repo := NewConnectionTypeRepository(cs)
+
+	result, err := repo.Update(context.Background(), testNS, "plain", ctConfigMap("plain"))
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "not a connection type")
+}
+
+func TestConnectionTypePatch_ValidatesExisting(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("patch-me"))
+	repo := NewConnectionTypeRepository(cs)
+
+	patch := []byte(`[{"op":"replace","path":"/data/key","value":"patched"}]`)
+	result, err := repo.Patch(context.Background(), testNS, "patch-me", patch)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestConnectionTypePatch_RejectsNonConnectionType(t *testing.T) {
+	cs := fake.NewSimpleClientset(plainConfigMap("plain"))
+	repo := NewConnectionTypeRepository(cs)
+
+	patch := []byte(`{"data":{"key":"patched"}}`)
+	result, err := repo.Patch(context.Background(), testNS, "plain", patch)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "not a connection type")
+}
+
+func TestConnectionTypePatch_RejectsLabelRemoval(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("patch-labels"))
+	repo := NewConnectionTypeRepository(cs)
+	ctx := context.Background()
+
+	patch := []byte(`[{"op":"remove","path":"/metadata/labels/opendatahub.io~1connection-type"}]`)
+	result, err := repo.Patch(ctx, testNS, "patch-labels", patch)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "connection-type labels")
+
+	// Verify the object was reverted - labels should still be intact
+	cm, err := cs.CoreV1().ConfigMaps(testNS).Get(ctx, "patch-labels", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, isConnectionTypeConfigMap(cm))
+}
+
+func TestConnectionTypeDelete_Success(t *testing.T) {
+	cs := fake.NewSimpleClientset(ctConfigMap("del-me"))
+	repo := NewConnectionTypeRepository(cs)
+
+	result, err := repo.Delete(context.Background(), testNS, "del-me")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestConnectionTypeDelete_NonConnectionType(t *testing.T) {
+	cs := fake.NewSimpleClientset(plainConfigMap("plain"))
+	repo := NewConnectionTypeRepository(cs)
+
+	result, err := repo.Delete(context.Background(), testNS, "plain")
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "not a connection type")
+}

--- a/distributions/core-bff/bff/internal/repositories/connection_type_test.go
+++ b/distributions/core-bff/bff/internal/repositories/connection_type_test.go
@@ -1,0 +1,67 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsConnectionTypeConfigMap_Valid(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+				models.LabelConnectionType:    "true",
+			},
+		},
+	}
+	assert.True(t, isConnectionTypeConfigMap(cm))
+}
+
+func TestIsConnectionTypeConfigMap_MissingConnectionTypeLabel(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				models.LabelDashboardResource: "true",
+			},
+		},
+	}
+	assert.False(t, isConnectionTypeConfigMap(cm))
+}
+
+func TestIsConnectionTypeConfigMap_MissingDashboardLabel(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				models.LabelConnectionType: "true",
+			},
+		},
+	}
+	assert.False(t, isConnectionTypeConfigMap(cm))
+}
+
+func TestIsConnectionTypeConfigMap_NoLabels(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+	assert.False(t, isConnectionTypeConfigMap(cm))
+}
+
+func TestIsConnectionTypeConfigMap_Nil(t *testing.T) {
+	assert.False(t, isConnectionTypeConfigMap(nil))
+}
+
+func TestIsConnectionTypeConfigMap_FalseValues(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				models.LabelDashboardResource: "false",
+				models.LabelConnectionType:    "true",
+			},
+		},
+	}
+	assert.False(t, isConnectionTypeConfigMap(cm))
+}

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config.go
@@ -1,0 +1,177 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// DashboardConfigRepository handles OdhDashboardConfig CRD operations.
+// Uses a service-account-scoped dynamic client for reads, matching the privileged watcher model
+// privileged watcher model where config is read with SA credentials.
+type DashboardConfigRepository struct {
+	isXKS       bool
+	saDynClient dynamic.Interface
+}
+
+// NewDashboardConfigRepository creates a new repository. When isXKS is true (XKS platform),
+// OpenShift-dependent features are disabled in the default config.
+// saDynClient is used for privileged reads so non-admin users still see the real config.
+func NewDashboardConfigRepository(isXKS bool, saDynClient dynamic.Interface) *DashboardConfigRepository {
+	return &DashboardConfigRepository{isXKS: isXKS, saDynClient: saDynClient}
+}
+
+func (r *DashboardConfigRepository) GetDashboardConfig(
+	ctx context.Context,
+	namespace, name string, featureFlagOverrides map[string]bool,
+) (*models.DashboardConfig, error) {
+	raw, err := r.fetchOrCreateDashboardCR(ctx, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultsMap, err := toUnstructuredMap(models.BlankDashboardCR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert defaults: %w", err)
+	}
+
+	merged := deepMerge(defaultsMap, raw)
+
+	if len(featureFlagOverrides) > 0 {
+		applyFeatureFlagOverrides(merged, featureFlagOverrides)
+	}
+
+	// Lockouts and XKS overrides run last so they cannot be undone by request headers.
+	applyFeatureLockouts(merged)
+
+	if r.isXKS {
+		applyXKSOverrides(merged)
+	}
+
+	var config models.DashboardConfig
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(merged, &config); err != nil {
+		return nil, fmt.Errorf("failed to convert merged config: %w", err)
+	}
+
+	return &config, nil
+}
+
+func (r *DashboardConfigRepository) GetRawDashboardConfig(
+	ctx context.Context,
+	namespace, name string,
+) (map[string]interface{}, error) {
+	if r.saDynClient == nil {
+		return nil, fmt.Errorf("service account dynamic client not available")
+	}
+
+	result, err := r.saDynClient.Resource(models.DashboardConfigGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard config %s/%s: %w", namespace, name, err)
+	}
+
+	return result.Object, nil
+}
+
+func (r *DashboardConfigRepository) PatchRawDashboardConfig(
+	ctx context.Context,
+	namespace, name string, patchData []byte, patchType types.PatchType,
+) (map[string]interface{}, error) {
+	if r.saDynClient == nil {
+		return nil, fmt.Errorf("service account dynamic client not available")
+	}
+
+	result, err := r.saDynClient.Resource(models.DashboardConfigGVR).Namespace(namespace).Patch(
+		ctx, name, patchType, patchData, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to patch dashboard config %s/%s: %w", namespace, name, err)
+	}
+
+	return result.Object, nil
+}
+
+func (r *DashboardConfigRepository) fetchOrCreateDashboardCR(
+	ctx context.Context,
+	namespace, name string,
+) (map[string]interface{}, error) {
+	if r.saDynClient == nil {
+		return nil, fmt.Errorf("service account dynamic client not available")
+	}
+
+	result, err := r.saDynClient.Resource(models.DashboardConfigGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return result.Object, nil
+	}
+
+	if !k8serrors.IsNotFound(err) {
+		return r.handleFetchError(err, namespace, name)
+	}
+
+	return r.autoCreateDashboardCR(ctx, namespace, name)
+}
+
+func (r *DashboardConfigRepository) handleFetchError(err error, namespace, name string) (map[string]interface{}, error) {
+	if isDiscoveryError(err) {
+		slog.Debug("OdhDashboardConfig CRD not installed, using defaults",
+			slog.String("namespace", namespace), slog.String("name", name))
+		return blankDefaults()
+	}
+	return nil, fmt.Errorf("failed to get dashboard config: %w", err)
+}
+
+func (r *DashboardConfigRepository) autoCreateDashboardCR(
+	ctx context.Context,
+	namespace, name string,
+) (map[string]interface{}, error) {
+	// Deliberately sparse: omit spec.dashboardConfig so code-level defaults apply at read time.
+	// Matches Fastify's _.omit(blankDashboardCR, 'spec.dashboardConfig').
+	defaultCR := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "opendatahub.io/v1alpha",
+			"kind":       "OdhDashboardConfig",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]interface{}{
+					"opendatahub.io/dashboard": "true",
+				},
+			},
+			"spec": map[string]interface{}{
+				"notebookController": map[string]interface{}{
+					"enabled": true,
+				},
+				"templateOrder": []interface{}{},
+				"genAiStudioConfig": map[string]interface{}{
+					"aiAssetCustomEndpoints": map[string]interface{}{
+						"externalProviders": false,
+						"clusterDomains":    []interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	created, createErr := r.saDynClient.Resource(models.DashboardConfigGVR).Namespace(namespace).Create(ctx, defaultCR, metav1.CreateOptions{})
+	if createErr == nil {
+		return created.Object, nil
+	}
+
+	if k8serrors.IsAlreadyExists(createErr) {
+		retryResult, retryErr := r.saDynClient.Resource(models.DashboardConfigGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if retryErr == nil {
+			return retryResult.Object, nil
+		}
+	}
+
+	slog.Debug("failed to auto-create OdhDashboardConfig, falling back to defaults",
+		slog.String("namespace", namespace), slog.String("name", name), slog.Any("error", createErr))
+	return blankDefaults()
+}

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config.go
@@ -132,7 +132,6 @@ func (r *DashboardConfigRepository) autoCreateDashboardCR(
 	namespace, name string,
 ) (map[string]interface{}, error) {
 	// Deliberately sparse: omit spec.dashboardConfig so code-level defaults apply at read time.
-	// Matches Fastify's _.omit(blankDashboardCR, 'spec.dashboardConfig').
 	defaultCR := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "opendatahub.io/v1alpha",

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"fmt"
+
 	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func newFakeDynClientWithDashboardConfig(disableProjects bool) *dynamicfake.FakeDynamicClient {
@@ -70,6 +73,9 @@ func TestGetDashboardConfig_CRDAbsent_FallsBackToDefaults(t *testing.T) {
 			models.DashboardConfigGVR: "OdhDashboardConfigList",
 		},
 	)
+	emptyDyn.PrependReactor("get", "odhdashboardconfigs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("the server could not find the requested resource")
+	})
 	repo := NewDashboardConfigRepository(false, emptyDyn)
 
 	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
@@ -107,7 +113,7 @@ func TestGetDashboardConfig_AutoCreatesWhenInstanceMissing(t *testing.T) {
 	require.NoError(t, getErr)
 	require.NotNil(t, persisted)
 
-	// Persisted CR is deliberately sparse (no spec.dashboardConfig) - matches Fastify.
+	// Persisted CR is deliberately sparse (no spec.dashboardConfig).
 	// Defaults are applied at read time via deepMerge, not persisted.
 	spec, ok := persisted.Object["spec"].(map[string]interface{})
 	require.True(t, ok, "persisted CR should have spec")

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_integration_test.go
@@ -1,0 +1,172 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func newFakeDynClientWithDashboardConfig(disableProjects bool) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "opendatahub.io/v1alpha",
+			"kind":       "OdhDashboardConfig",
+			"metadata": map[string]interface{}{
+				"name":      "odh-dashboard-config",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"dashboardConfig": map[string]interface{}{
+					"disableProjects": disableProjects,
+					"disableKServe":   true,
+				},
+			},
+		},
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.DashboardConfigGVR: "OdhDashboardConfigList",
+		},
+		cr,
+	)
+}
+
+func TestGetDashboardConfig_PrivilegedRead_ReturnsRealConfig(t *testing.T) {
+	fakeDyn := newFakeDynClientWithDashboardConfig(true)
+	repo := NewDashboardConfigRepository(false, fakeDyn)
+
+	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// The real CR has disableKServe=true, which differs from the default (false).
+	// This proves the SA client reads the real config, not just defaults.
+	assert.True(t, config.Spec.DashboardConfig.DisableKServe)
+
+	// disableProjects=true from the CR is preserved
+	assert.True(t, config.Spec.DashboardConfig.DisableProjects)
+
+	// Defaults are merged in for fields not in the CR
+	assert.True(t, config.Spec.DashboardConfig.Enablement)
+}
+
+func TestGetDashboardConfig_CRDAbsent_FallsBackToDefaults(t *testing.T) {
+	scheme := runtime.NewScheme()
+	emptyDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.DashboardConfigGVR: "OdhDashboardConfigList",
+		},
+	)
+	repo := NewDashboardConfigRepository(false, emptyDyn)
+
+	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Falls back to BlankDashboardCR defaults
+	assert.True(t, config.Spec.DashboardConfig.Enablement)
+	assert.False(t, config.Spec.DashboardConfig.DisableKServe)
+}
+
+func TestGetDashboardConfig_AutoCreatesWhenInstanceMissing(t *testing.T) {
+	// Fake client with the GVR registered but no CR instance - simulates "CRD exists but instance missing"
+	scheme := runtime.NewScheme()
+	fakeDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			models.DashboardConfigGVR: "OdhDashboardConfigList",
+		},
+	)
+	repo := NewDashboardConfigRepository(false, fakeDyn)
+
+	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Should get merged defaults since auto-create fallback returns defaults
+	assert.True(t, config.Spec.DashboardConfig.Enablement)
+	assert.Equal(t, "OdhDashboardConfig", config.Kind)
+
+	// Verify the CR was actually persisted in the cluster
+	persisted, getErr := fakeDyn.Resource(models.DashboardConfigGVR).Namespace("test-ns").Get(
+		context.Background(), "odh-dashboard-config", metav1.GetOptions{},
+	)
+	require.NoError(t, getErr)
+	require.NotNil(t, persisted)
+
+	// Persisted CR is deliberately sparse (no spec.dashboardConfig) - matches Fastify.
+	// Defaults are applied at read time via deepMerge, not persisted.
+	spec, ok := persisted.Object["spec"].(map[string]interface{})
+	require.True(t, ok, "persisted CR should have spec")
+
+	_, hasDC := spec["dashboardConfig"]
+	assert.False(t, hasDC, "persisted CR should NOT contain spec.dashboardConfig")
+
+	nc, ok := spec["notebookController"].(map[string]interface{})
+	require.True(t, ok, "persisted CR should have spec.notebookController")
+	assert.Equal(t, true, nc["enabled"])
+
+	gasc, ok := spec["genAiStudioConfig"].(map[string]interface{})
+	require.True(t, ok, "persisted CR should have spec.genAiStudioConfig")
+	endpoints, ok := gasc["aiAssetCustomEndpoints"].(map[string]interface{})
+	require.True(t, ok, "genAiStudioConfig should have aiAssetCustomEndpoints")
+	assert.Equal(t, false, endpoints["externalProviders"])
+}
+
+func TestGetDashboardConfig_IndependentCRDHandling(t *testing.T) {
+	// DashboardConfig CRD present with a real CR
+	fakeDyn := newFakeDynClientWithDashboardConfig(false)
+	repo := NewDashboardConfigRepository(false, fakeDyn)
+
+	// This should succeed even though Auth CRD and OdhApplication CRD are absent
+	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Auth CRD absent should not affect config
+	authRepo := NewAuthRepository(newFakeDynClientCRDAbsent())
+	auth, err := authRepo.GetAuth(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, auth)
+
+	// Components CRD absent should not affect config or auth
+	emptyCompDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			models.OdhApplicationGVR: "OdhApplicationList",
+		},
+	)
+	compRepo := NewComponentsRepository(emptyCompDyn, nil)
+	components, err := compRepo.ListComponents(context.Background(), "test-ns", false)
+	require.NoError(t, err)
+	assert.Empty(t, components)
+
+	// All three operate independently - config got real data, auth and components degraded gracefully
+	assert.NotNil(t, config)
+}
+
+func TestGetDashboardConfig_XKSPlatform_OverridesCRValues(t *testing.T) {
+	// CR has disableProjects=false, but XKS platform should force it to true
+	fakeDyn := newFakeDynClientWithDashboardConfig(false)
+	repo := NewDashboardConfigRepository(true, fakeDyn)
+
+	config, err := repo.GetDashboardConfig(context.Background(), "test-ns", "odh-dashboard-config", nil)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	assert.True(t, config.Spec.DashboardConfig.DisableProjects)
+	assert.True(t, config.Spec.DashboardConfig.DisableBYONImageStream)
+}

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_overrides.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_overrides.go
@@ -1,0 +1,113 @@
+package repositories
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+)
+
+// deepMerge recursively merges overrides into defaults.
+// Override values take precedence. Maps are merged recursively.
+// Nested maps from defaults are deep-copied so the original defaults are never mutated.
+func deepMerge(defaults, overrides map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(defaults))
+	for k, v := range defaults {
+		if vMap, ok := v.(map[string]interface{}); ok {
+			result[k] = deepCopyMap(vMap)
+		} else {
+			result[k] = v
+		}
+	}
+	for k, v := range overrides {
+		if vMap, ok := v.(map[string]interface{}); ok {
+			if dMap, ok := result[k].(map[string]interface{}); ok {
+				result[k] = deepMerge(dMap, vMap)
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
+}
+
+func deepCopyMap(m map[string]any) map[string]any {
+	cp := make(map[string]any, len(m))
+	for k, v := range m {
+		if vMap, ok := v.(map[string]any); ok {
+			cp[k] = deepCopyMap(vMap)
+		} else {
+			cp[k] = v
+		}
+	}
+	return cp
+}
+
+// applyFeatureLockouts forces specific flags that must not be changed by CRD values.
+// Matches backend/src/utils/resourceUtils.ts applyFeatureLockouts().
+func applyFeatureLockouts(config map[string]interface{}) {
+	spec, ok := config["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	dc["disableFineTuning"] = true
+	dc["mlflow"] = true
+}
+
+func applyFeatureFlagOverrides(config map[string]interface{}, overrides map[string]bool) {
+	spec, ok := config["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	for k, v := range overrides {
+		dc[k] = v
+	}
+}
+
+// applyXKSOverrides disables OpenShift-dependent features for XKS platform deployments.
+func applyXKSOverrides(config map[string]interface{}) {
+	spec, ok := config["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	dc, ok := spec["dashboardConfig"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	dc["enablement"] = false
+	dc["disableProjects"] = true
+	dc["disableBYONImageStream"] = true
+	dc["disableISVBadges"] = true
+	dc["disableAppLauncher"] = true
+	dc["disablePipelines"] = true
+	dc["mlflow"] = false
+}
+
+func blankDefaults() (map[string]interface{}, error) {
+	defaultsMap, err := toUnstructuredMap(models.BlankDashboardCR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert defaults: %w", err)
+	}
+	return defaultsMap, nil
+}
+
+// toUnstructuredMap converts a typed Go struct to a map[string]interface{} via JSON round-trip.
+func toUnstructuredMap(obj interface{}) (map[string]interface{}, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/distributions/core-bff/bff/internal/repositories/dashboard_config_test.go
+++ b/distributions/core-bff/bff/internal/repositories/dashboard_config_test.go
@@ -1,0 +1,201 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepMerge_OverridesTakePrecedence(t *testing.T) {
+	defaults := map[string]interface{}{
+		"a": "default",
+		"b": "default",
+	}
+	overrides := map[string]interface{}{
+		"a": "override",
+	}
+
+	result := deepMerge(defaults, overrides)
+
+	assert.Equal(t, "override", result["a"])
+	assert.Equal(t, "default", result["b"])
+}
+
+func TestDeepMerge_NestedMaps(t *testing.T) {
+	defaults := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"enablement":    true,
+				"disableInfo":   false,
+				"disableKServe": false,
+			},
+		},
+	}
+	overrides := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"disableKServe": true,
+			},
+		},
+	}
+
+	result := deepMerge(defaults, overrides)
+
+	spec := result["spec"].(map[string]interface{})
+	dc := spec["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, true, dc["enablement"])
+	assert.Equal(t, false, dc["disableInfo"])
+	assert.Equal(t, true, dc["disableKServe"])
+}
+
+func TestDeepMerge_OverrideDoesNotMutateDefaults(t *testing.T) {
+	defaults := map[string]interface{}{"key": "original"}
+	overrides := map[string]interface{}{"key": "changed"}
+
+	_ = deepMerge(defaults, overrides)
+
+	assert.Equal(t, "original", defaults["key"])
+}
+
+func TestDeepMerge_NestedDefaultsNotMutated(t *testing.T) {
+	defaults := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"nested": map[string]interface{}{
+				"flag": false,
+			},
+		},
+	}
+
+	result := deepMerge(defaults, map[string]interface{}{})
+
+	// Mutate the result's nested map
+	result["spec"].(map[string]interface{})["nested"].(map[string]interface{})["flag"] = true
+
+	// Original defaults must be unchanged
+	nested := defaults["spec"].(map[string]interface{})["nested"].(map[string]interface{})
+	assert.Equal(t, false, nested["flag"])
+}
+
+func TestApplyFeatureLockouts(t *testing.T) {
+	config := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"disableFineTuning": false,
+				"mlflow":            false,
+				"disableKServe":     false,
+			},
+		},
+	}
+
+	applyFeatureLockouts(config)
+
+	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, true, dc["disableFineTuning"])
+	assert.Equal(t, true, dc["mlflow"])
+	assert.Equal(t, false, dc["disableKServe"])
+}
+
+func TestApplyFeatureLockouts_MissingSpec(t *testing.T) {
+	config := map[string]interface{}{}
+	applyFeatureLockouts(config)
+	// Should not panic
+}
+
+func TestApplyFeatureFlagOverrides(t *testing.T) {
+	config := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"disableKServe": false,
+				"enablement":    true,
+			},
+		},
+	}
+
+	overrides := map[string]bool{
+		"disableKServe": true,
+		"newFlag":       true,
+	}
+
+	applyFeatureFlagOverrides(config, overrides)
+
+	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, true, dc["disableKServe"])
+	assert.Equal(t, true, dc["newFlag"])
+	assert.Equal(t, true, dc["enablement"])
+}
+
+func TestApplyXKSOverrides(t *testing.T) {
+	config := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"enablement":             true,
+				"disableProjects":        false,
+				"disableBYONImageStream": false,
+				"disableISVBadges":       false,
+				"disableAppLauncher":     false,
+				"disablePipelines":       false,
+				"mlflow":                 true,
+				"disableKServe":          false,
+			},
+		},
+	}
+
+	applyXKSOverrides(config)
+
+	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, false, dc["enablement"])
+	assert.Equal(t, true, dc["disableProjects"])
+	assert.Equal(t, true, dc["disableBYONImageStream"])
+	assert.Equal(t, true, dc["disableISVBadges"])
+	assert.Equal(t, true, dc["disableAppLauncher"])
+	assert.Equal(t, true, dc["disablePipelines"])
+	assert.Equal(t, false, dc["mlflow"])
+	assert.Equal(t, false, dc["disableKServe"])
+}
+
+func TestLockoutsAndXKSOverridesCannotBeOverriddenByHeaders(t *testing.T) {
+	config := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"dashboardConfig": map[string]interface{}{
+				"enablement":        true,
+				"disableFineTuning": false,
+				"mlflow":            true,
+				"disableProjects":   false,
+				"disablePipelines":  false,
+			},
+		},
+	}
+
+	// Simulate header overrides trying to undo lockouts and XKS overrides
+	applyFeatureFlagOverrides(config, map[string]bool{
+		"enablement":        true,
+		"disableFineTuning": false,
+		"mlflow":            true,
+		"disableProjects":   false,
+		"disablePipelines":  false,
+	})
+
+	// Lockouts and XKS overrides run after headers
+	applyFeatureLockouts(config)
+	applyXKSOverrides(config)
+
+	dc := config["spec"].(map[string]interface{})["dashboardConfig"].(map[string]interface{})
+	assert.Equal(t, true, dc["disableFineTuning"])
+	assert.Equal(t, false, dc["enablement"])
+	assert.Equal(t, false, dc["mlflow"])
+	assert.Equal(t, true, dc["disableProjects"])
+	assert.Equal(t, true, dc["disablePipelines"])
+}
+
+func TestToUnstructuredMap(t *testing.T) {
+	type sample struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	result, err := toUnstructuredMap(sample{Name: "test", Value: 42})
+	require.NoError(t, err)
+	assert.Equal(t, "test", result["name"])
+	assert.Equal(t, float64(42), result["value"])
+}

--- a/distributions/core-bff/bff/internal/repositories/helpers.go
+++ b/distributions/core-bff/bff/internal/repositories/helpers.go
@@ -2,6 +2,9 @@ package repositories
 
 import (
 	"net/url"
+	"strings"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // FilterPageValues extracts pagination-related query parameters from URL values.
@@ -47,4 +50,20 @@ func URLWithParams(rawURL string, values url.Values) string {
 func URLWithPageParams(url string, values url.Values) string {
 	pageValues := FilterPageValues(values)
 	return URLWithParams(url, pageValues)
+}
+
+// isDiscoveryError returns true when the error indicates a CRD is not installed.
+// Handles MethodNotSupported and NoMatch-style errors which can occur
+// when a GVR is unregistered on different cluster types.
+// NotFound is NOT included because it can also mean the CRD exists but a specific
+// instance is missing - callers must handle IsNotFound separately when the distinction matters.
+// 403 (Forbidden) is NOT treated as a discovery error because it means the CRD
+// exists but the user lacks access - silencing that would hide misconfiguration.
+func isDiscoveryError(err error) bool {
+	if k8serrors.IsMethodNotSupported(err) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "the server could not find the requested resource")
 }

--- a/distributions/core-bff/bff/internal/repositories/repositories.go
+++ b/distributions/core-bff/bff/internal/repositories/repositories.go
@@ -1,18 +1,41 @@
 // Package repositories implements data access patterns for Kubernetes resources.
 package repositories
 
-// Repositories struct is a single convenient container to hold and represent all our repositories.
+import (
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Repositories is a convenient container that holds all repository instances.
 type Repositories struct {
-	HealthCheck *HealthCheckRepository
-	User        *UserRepository
-	Namespace   *NamespaceRepository
+	HealthCheck     *HealthCheckRepository
+	User            *UserRepository
+	Namespace       *NamespaceRepository
+	DashboardConfig *DashboardConfigRepository
+	Status          *StatusRepository
+	Auth            *AuthRepository
+	Components      *ComponentsRepository
+	ClusterSettings *ClusterSettingsRepository
+	ConnectionType  *ConnectionTypeRepository
+	AllowedUsers    *AllowedUsersRepository
 }
 
 // NewRepositories creates a new Repositories instance with all repositories initialized.
-func NewRepositories() *Repositories {
+// isXKS should be true for XKS platform deployments to disable OpenShift-dependent features.
+// saDynClient and saClientset are service-account-scoped clients for privileged operations,
+// matching the privileged watcher model where the dashboard SA performs reads and admin-gated mutations.
+func NewRepositories(isXKS bool, saDynClient dynamic.Interface, saClientset kubernetes.Interface, namespace string) *Repositories {
+	auth := NewAuthRepository(saDynClient)
 	return &Repositories{
-		HealthCheck: NewHealthCheckRepository(),
-		User:        NewUserRepository(),
-		Namespace:   NewNamespaceRepository(),
+		HealthCheck:     NewHealthCheckRepository(),
+		User:            NewUserRepository(),
+		Namespace:       NewNamespaceRepository(),
+		DashboardConfig: NewDashboardConfigRepository(isXKS, saDynClient),
+		Status:          NewStatusRepository(saDynClient, namespace, auth),
+		Auth:            auth,
+		Components:      NewComponentsRepository(saDynClient, saClientset),
+		ClusterSettings: NewClusterSettingsRepository(saClientset),
+		ConnectionType:  NewConnectionTypeRepository(saClientset),
+		AllowedUsers:    NewAllowedUsersRepository(saDynClient),
 	}
 }

--- a/distributions/core-bff/bff/internal/repositories/status.go
+++ b/distributions/core-bff/bff/internal/repositories/status.go
@@ -45,9 +45,8 @@ func (r *StatusRepository) GetStatus(
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
-	// Uses Fastify-compatible SSAR: patch on auths/default-auth.
-	// Errors degrade to false (matching Fastify's .catch(() => false)) so that
-	// transient SAR failures don't break dashboard bootstrap with a 500.
+	// Uses SSAR: patch on auths/default-auth.
+	// Errors degrade to false so that transient SAR failures don't break dashboard bootstrap with a 500.
 	isAdmin, err := client.IsUserAdmin(ctx, identity)
 	if err != nil {
 		slog.Warn("admin SAR check failed, defaulting to non-admin", slog.Any("error", err))
@@ -84,7 +83,7 @@ const systemAuthenticated = "system:authenticated"
 
 // resolveIsAllowed determines if a non-admin user is allowed to access the dashboard.
 // 1. If Auth CRD is absent (discovery error): all users allowed (no group restrictions).
-// 2. If Auth CR has system:authenticated in allowedGroups: all authenticated users allowed (Fastify escape hatch).
+// 2. If Auth CR has system:authenticated in allowedGroups: all authenticated users allowed.
 // 3. If Auth CR instance missing or error reading it (e.g. 403): fall through to SSAR check.
 // 4. Otherwise: SSAR for get on auths/default-auth.
 func resolveIsAllowed(

--- a/distributions/core-bff/bff/internal/repositories/status.go
+++ b/distributions/core-bff/bff/internal/repositories/status.go
@@ -1,0 +1,163 @@
+package repositories
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/models"
+	"k8s.io/client-go/dynamic"
+)
+
+// ClusterInfoProvider exposes startup-time cluster metadata for status responses.
+type ClusterInfoProvider interface {
+	GetClusterID() string
+	GetClusterBranding() string
+	GetServerURL() string
+	GetCurrentContext() string
+}
+
+// StatusRepository handles user session status aggregation.
+type StatusRepository struct {
+	saDynClient dynamic.Interface
+	namespace   string
+	authRepo    *AuthRepository
+}
+
+func NewStatusRepository(saDynClient dynamic.Interface, namespace string, authRepo *AuthRepository) *StatusRepository {
+	return &StatusRepository{saDynClient: saDynClient, namespace: namespace, authRepo: authRepo}
+}
+
+func (r *StatusRepository) GetStatus(
+	ctx context.Context, client k8s.KubernetesClientInterface,
+	identity *k8s.RequestIdentity, clusterInfo ClusterInfoProvider,
+) (*models.StatusResponse, error) {
+	namespace := r.namespace
+	authRepo := r.authRepo
+	userName, err := client.GetUser(ctx, identity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	// Uses Fastify-compatible SSAR: patch on auths/default-auth.
+	// Errors degrade to false (matching Fastify's .catch(() => false)) so that
+	// transient SAR failures don't break dashboard bootstrap with a 500.
+	isAdmin, err := client.IsUserAdmin(ctx, identity)
+	if err != nil {
+		slog.Warn("admin SAR check failed, defaulting to non-admin", slog.Any("error", err))
+		isAdmin = false
+	}
+
+	// Check if Auth CRD is present. When absent, all users are allowed (no group restrictions).
+	// When present, non-admin users need SSAR for get on auths/default-auth.
+	isAllowed := true
+	if !isAdmin {
+		isAllowed, err = resolveIsAllowed(ctx, client, identity, authRepo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check allowed status: %w", err)
+		}
+	}
+
+	return &models.StatusResponse{
+		Kube: models.KubeStatus{
+			CurrentContext:  clusterInfo.GetCurrentContext(),
+			CurrentUser:     models.KubeUser{Name: userName},
+			Namespace:       namespace,
+			UserName:        userName,
+			UserID:          segmentUserID(identity.Token, userName),
+			ClusterID:       clusterInfo.GetClusterID(),
+			ClusterBranding: clusterInfo.GetClusterBranding(),
+			IsAdmin:         isAdmin,
+			IsAllowed:       isAllowed,
+			ServerURL:       clusterInfo.GetServerURL(),
+		},
+	}, nil
+}
+
+const systemAuthenticated = "system:authenticated"
+
+// resolveIsAllowed determines if a non-admin user is allowed to access the dashboard.
+// 1. If Auth CRD is absent (discovery error): all users allowed (no group restrictions).
+// 2. If Auth CR has system:authenticated in allowedGroups: all authenticated users allowed (Fastify escape hatch).
+// 3. If Auth CR instance missing or error reading it (e.g. 403): fall through to SSAR check.
+// 4. Otherwise: SSAR for get on auths/default-auth.
+func resolveIsAllowed(
+	ctx context.Context, client k8s.KubernetesClientInterface,
+	identity *k8s.RequestIdentity, authRepo *AuthRepository,
+) (bool, error) {
+	authConfig, authErr := authRepo.GetAuth(ctx)
+
+	if authErr == nil && authConfig == nil {
+		// CRD absent - all users allowed
+		return true, nil
+	}
+
+	if authErr == nil && authConfig != nil {
+		if hasSystemAuthenticatedGroup(authConfig) {
+			return true, nil
+		}
+	}
+
+	if authErr != nil {
+		slog.Warn("failed to fetch Auth CR, falling through to SSAR check", slog.Any("error", authErr))
+	}
+
+	allowed, ssarErr := client.IsUserAllowed(ctx, identity)
+	if ssarErr != nil {
+		slog.Warn("allowed SAR check failed, defaulting to not allowed", slog.Any("error", ssarErr))
+		return false, nil
+	}
+	return allowed, nil
+}
+
+// segmentUserID returns a privacy-safe user identifier for Segment analytics.
+func segmentUserID(token k8s.BearerToken, userName string) string {
+	if sub := jwtSubClaim(token.Raw()); sub != "" {
+		return sha256Hex(sub)
+	}
+	if userName != "" {
+		return sha256Hex(userName)
+	}
+	return ""
+}
+
+func jwtSubClaim(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Sub
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func hasSystemAuthenticatedGroup(auth *AuthConfig) bool {
+	if auth == nil {
+		return false
+	}
+	for _, g := range auth.AllowedGroups {
+		if g == systemAuthenticated {
+			return true
+		}
+	}
+	return false
+}

--- a/distributions/core-bff/bff/internal/repositories/status_integration_test.go
+++ b/distributions/core-bff/bff/internal/repositories/status_integration_test.go
@@ -1,0 +1,57 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockUserAllowedClient implements a minimal KubernetesClientInterface for testing resolveIsAllowed.
+type mockUserAllowedClient struct {
+	k8s.KubernetesClientInterface
+	allowed bool
+	err     error
+}
+
+func (m *mockUserAllowedClient) IsUserAllowed(_ context.Context, _ *k8s.RequestIdentity) (bool, error) {
+	return m.allowed, m.err
+}
+
+func TestResolveIsAllowed_CRDAbsent_AllowsEveryone(t *testing.T) {
+	authRepo := NewAuthRepository(newFakeDynClientCRDAbsent())
+	client := &mockUserAllowedClient{allowed: false}
+
+	allowed, err := resolveIsAllowed(context.Background(), client, &k8s.RequestIdentity{}, authRepo)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestResolveIsAllowed_SystemAuthenticated_AllowsEveryone(t *testing.T) {
+	authRepo := NewAuthRepository(newFakeDynClientWithAuth([]string{"system:authenticated"}))
+	client := &mockUserAllowedClient{allowed: false}
+
+	allowed, err := resolveIsAllowed(context.Background(), client, &k8s.RequestIdentity{}, authRepo)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestResolveIsAllowed_NoEscapeHatch_FallsToSSAR_Allowed(t *testing.T) {
+	authRepo := NewAuthRepository(newFakeDynClientWithAuth([]string{"restricted-group"}))
+	client := &mockUserAllowedClient{allowed: true}
+
+	allowed, err := resolveIsAllowed(context.Background(), client, &k8s.RequestIdentity{}, authRepo)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestResolveIsAllowed_NoEscapeHatch_FallsToSSAR_Denied(t *testing.T) {
+	authRepo := NewAuthRepository(newFakeDynClientWithAuth([]string{"restricted-group"}))
+	client := &mockUserAllowedClient{allowed: false}
+
+	allowed, err := resolveIsAllowed(context.Background(), client, &k8s.RequestIdentity{}, authRepo)
+	require.NoError(t, err)
+	assert.False(t, allowed)
+}

--- a/distributions/core-bff/bff/internal/repositories/status_test.go
+++ b/distributions/core-bff/bff/internal/repositories/status_test.go
@@ -1,0 +1,106 @@
+package repositories
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	k8s "github.com/opendatahub-io/odh-dashboard/distributions/core-bff/bff/internal/integrations/kubernetes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSystemAuthenticatedGroup_Present(t *testing.T) {
+	auth := &AuthConfig{
+		AllowedGroups: []string{"some-group", systemAuthenticated},
+	}
+	assert.True(t, hasSystemAuthenticatedGroup(auth))
+}
+
+func TestHasSystemAuthenticatedGroup_Absent(t *testing.T) {
+	auth := &AuthConfig{
+		AllowedGroups: []string{"some-group", "another-group"},
+	}
+	assert.False(t, hasSystemAuthenticatedGroup(auth))
+}
+
+func TestHasSystemAuthenticatedGroup_Empty(t *testing.T) {
+	auth := &AuthConfig{
+		AllowedGroups: []string{},
+	}
+	assert.False(t, hasSystemAuthenticatedGroup(auth))
+}
+
+func TestHasSystemAuthenticatedGroup_Nil(t *testing.T) {
+	assert.False(t, hasSystemAuthenticatedGroup(nil))
+}
+
+func TestHasSystemAuthenticatedGroup_OnlySystemAuthenticated(t *testing.T) {
+	auth := &AuthConfig{
+		AllowedGroups: []string{systemAuthenticated},
+	}
+	assert.True(t, hasSystemAuthenticatedGroup(auth))
+}
+
+func expectedSHA256(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func fakeJWT(sub string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"sub":"%s","iss":"test"}`, sub)))
+	return header + "." + payload + ".signature"
+}
+
+func TestSha256Hex(t *testing.T) {
+	result := sha256Hex("hello")
+	assert.Len(t, result, 64)
+	assert.Equal(t, expectedSHA256("hello"), result)
+}
+
+func TestJwtSubClaim_ValidJWT(t *testing.T) {
+	token := fakeJWT("user-uuid-123")
+	assert.Equal(t, "user-uuid-123", jwtSubClaim(token))
+}
+
+func TestJwtSubClaim_NotAJWT(t *testing.T) {
+	assert.Equal(t, "", jwtSubClaim("not-a-jwt"))
+}
+
+func TestJwtSubClaim_EmptyToken(t *testing.T) {
+	assert.Equal(t, "", jwtSubClaim(""))
+}
+
+func TestJwtSubClaim_NoSubClaim(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"test"}`))
+	token := header + "." + payload + ".sig"
+	assert.Equal(t, "", jwtSubClaim(token))
+}
+
+func TestSegmentUserID_WithJWTSub(t *testing.T) {
+	token := k8s.NewBearerToken(fakeJWT("user-uuid-123"))
+	result := segmentUserID(token, "some-username")
+	assert.Equal(t, expectedSHA256("user-uuid-123"), result)
+}
+
+func TestSegmentUserID_NonJWT_FallsToHashedUsername(t *testing.T) {
+	token := k8s.NewBearerToken("not-a-jwt-token")
+	result := segmentUserID(token, "admin-user")
+	assert.Equal(t, expectedSHA256("admin-user"), result)
+}
+
+func TestSegmentUserID_EmptyTokenAndUsername(t *testing.T) {
+	token := k8s.NewBearerToken("")
+	assert.Equal(t, "", segmentUserID(token, ""))
+}
+
+func TestSegmentUserID_JWTPreferredOverUsername(t *testing.T) {
+	token := k8s.NewBearerToken(fakeJWT("jwt-sub-value"))
+	jwtResult := segmentUserID(token, "fallback-user")
+	usernameResult := expectedSHA256("fallback-user")
+	assert.NotEqual(t, usernameResult, jwtResult)
+	assert.Equal(t, expectedSHA256("jwt-sub-value"), jwtResult)
+}

--- a/distributions/core-bff/bff/openapi/src/core-bff.yaml
+++ b/distributions/core-bff/bff/openapi/src/core-bff.yaml
@@ -719,8 +719,6 @@ components:
           properties:
             name:
               type: string
-            token:
-              type: string
         namespace:
           type: string
         userName:

--- a/distributions/core-bff/bff/openapi/src/core-bff.yaml
+++ b/distributions/core-bff/bff/openapi/src/core-bff.yaml
@@ -208,6 +208,395 @@ paths:
         '502':
           $ref: '#/components/responses/BadGateway'
 
+  /api/config:
+    get:
+      tags:
+        - Config
+      operationId: getConfig
+      summary: Get merged dashboard config
+      description: Returns the OdhDashboardConfig CRD merged with defaults. Supports feature flag overrides via x-odh-feature-flags header.
+      parameters:
+        - name: x-odh-feature-flags
+          in: header
+          required: false
+          schema:
+            type: string
+          description: JSON-encoded feature flag overrides
+      responses:
+        '200':
+          description: Dashboard config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Config
+      operationId: patchConfig
+      summary: Update dashboard config (admin)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated dashboard config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardConfig'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/components:
+    get:
+      tags:
+        - Components
+      operationId: getComponents
+      summary: List OdhApplication components
+      description: Returns OdhApplication CRDs. Returns empty array when CRD is absent (RHAII).
+      parameters:
+        - name: installed
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: Filter to installed/enabled applications only
+      responses:
+        '200':
+          $ref: '#/components/responses/ComponentsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/components/remove:
+    get:
+      tags:
+        - Components
+      operationId: removeComponent
+      summary: Remove an app from the enabled-apps ConfigMap (admin)
+      parameters:
+        - name: appName
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Removal result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/status/{namespace}/allowedUsers:
+    get:
+      tags:
+        - Status
+      operationId: getAllowedUsers
+      summary: List users with notebook access in a namespace (admin)
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of allowed users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AllowedUser'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/status:
+    get:
+      tags:
+        - Status
+      operationId: getStatus
+      summary: Get user session status
+      description: Returns user identity, admin status, cluster info, and access status.
+      responses:
+        '200':
+          $ref: '#/components/responses/StatusResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/dashboardConfig/{namespace}/{name}:
+    parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - DashboardConfig
+      operationId: getDashboardConfigByName
+      summary: Get raw dashboard config by namespace/name (admin)
+      responses:
+        '200':
+          description: Raw dashboard config CRD
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - DashboardConfig
+      operationId: patchDashboardConfigByName
+      summary: Patch dashboard config by namespace/name (admin)
+      requestBody:
+        content:
+          application/json-patch+json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  op:
+                    type: string
+                    enum: [add, remove, replace, move, copy, test]
+                  path:
+                    type: string
+                  from:
+                    type: string
+                  value: {}
+      responses:
+        '200':
+          description: Updated dashboard config CRD
+          content:
+            application/json:
+              schema:
+                type: object
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/cluster-settings:
+    get:
+      tags:
+        - ClusterSettings
+      operationId: getClusterSettings
+      summary: Get cluster settings (admin)
+      responses:
+        '200':
+          description: Cluster settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterSettings'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - ClusterSettings
+      operationId: updateClusterSettings
+      summary: Update cluster settings (admin)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClusterSettings'
+      responses:
+        '200':
+          description: Update result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/connection-types:
+    get:
+      tags:
+        - ConnectionTypes
+      operationId: listConnectionTypes
+      summary: List connection types
+      description: Returns ConfigMaps with connection-type labels. No admin required.
+      responses:
+        '200':
+          $ref: '#/components/responses/ConnectionTypesResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - ConnectionTypes
+      operationId: createConnectionType
+      summary: Create connection type (admin)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Creation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/connection-types/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - ConnectionTypes
+      operationId: getConnectionType
+      summary: Get connection type by name
+      responses:
+        '200':
+          description: Connection type ConfigMap
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - ConnectionTypes
+      operationId: updateConnectionType
+      summary: Replace connection type (admin)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Update result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - ConnectionTypes
+      operationId: patchConnectionType
+      summary: Patch connection type (admin)
+      requestBody:
+        content:
+          application/json-patch+json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  op:
+                    type: string
+                    enum: [add, remove, replace, move, copy, test]
+                  path:
+                    type: string
+                  from:
+                    type: string
+                  value: {}
+      responses:
+        '200':
+          description: Patch result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - ConnectionTypes
+      operationId: deleteConnectionType
+      summary: Delete connection type (admin)
+      responses:
+        '200':
+          description: Delete result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
 components:
   schemas:
     HealthCheckResponse:
@@ -294,6 +683,116 @@ components:
               description: 'Human-readable error description'
               example: 'An unexpected error occurred'
 
+    DashboardConfig:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+            dashboardConfig:
+              type: object
+              description: Feature flags (40+ boolean fields)
+            notebookController:
+              type: object
+            templateOrder:
+              type: array
+              items:
+                type: string
+            modelServing:
+              type: object
+            genAiStudioConfig:
+              type: object
+
+    KubeStatus:
+      type: object
+      properties:
+        currentContext:
+          type: string
+        currentUser:
+          type: object
+          properties:
+            name:
+              type: string
+            token:
+              type: string
+        namespace:
+          type: string
+        userName:
+          type: string
+        userID:
+          type: string
+        clusterID:
+          type: string
+        clusterBranding:
+          type: string
+        isAdmin:
+          type: boolean
+        isAllowed:
+          type: boolean
+        serverURL:
+          type: string
+        isImpersonating:
+          type: boolean
+
+    StatusEnvelope:
+      type: object
+      required:
+        - kube
+      properties:
+        kube:
+          $ref: '#/components/schemas/KubeStatus'
+
+    ClusterSettings:
+      type: object
+      properties:
+        pvcSize:
+          type: integer
+          example: 20
+        cullerTimeout:
+          type: integer
+          example: 31536000
+        userTrackingEnabled:
+          type: boolean
+        modelServingPlatformEnabled:
+          type: object
+          properties:
+            kServe:
+              type: boolean
+            LLMd:
+              type: boolean
+        isDistributedInferencingDefault:
+          type: boolean
+        defaultDeploymentStrategy:
+          type: string
+
+    AllowedUser:
+      type: object
+      properties:
+        username:
+          type: string
+        privilege:
+          type: string
+          enum: [Admin, User]
+        lastActivity:
+          type: string
+
+    MutationResponse:
+      type: object
+      required:
+        - success
+        - error
+      properties:
+        success:
+          type: boolean
+        error:
+          type: string
+
   responses:
     HealthCheckResponse:
       description: Service is healthy
@@ -329,6 +828,31 @@ components:
                 displayName: 'Open Data Hub'
               - name: 'my-project'
                 displayName: 'My Project'
+
+    StatusResponse:
+      description: User session status
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/StatusEnvelope'
+
+    ComponentsResponse:
+      description: List of OdhApplication components
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+
+    ConnectionTypesResponse:
+      description: List of connection-type ConfigMaps
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
 
     BadRequest:
       description: Bad request

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConfig.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConfig.test.ts
@@ -102,6 +102,36 @@ describe('Core BFF Config Endpoints', () => {
     });
   });
 
+  describe('Config PATCH', () => {
+    it('should return 401 for non-admin on PATCH', async () => {
+      expectError(await restrictedClient.patch('/api/config', { spec: {} }), 401);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.patch('/api/config', { spec: {} }), 401);
+    });
+  });
+
+  describe('DashboardConfig PATCH', () => {
+    it('should return 401 for non-admin on PATCH', async () => {
+      expectError(
+        await restrictedClient.patch('/api/dashboardConfig/opendatahub/odh-dashboard-config', [
+          { op: 'replace', path: '/spec/dashboardConfig/enablement', value: true },
+        ]),
+        401,
+      );
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.patch('/api/dashboardConfig/opendatahub/odh-dashboard-config', [
+          { op: 'replace', path: '/spec/dashboardConfig/enablement', value: true },
+        ]),
+        401,
+      );
+    });
+  });
+
   describe('Cluster Settings Endpoint', () => {
     it('should return cluster settings', async () => {
       const result = await apiClient.get('/api/cluster-settings');

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConfig.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConfig.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ */
+import { ApiTestResultError } from '@odh-dashboard/contract-tests';
+import {
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectSuccess,
+  expectError,
+} from '../helpers';
+
+describe('Core BFF Config Endpoints', () => {
+  describe('Config Endpoint', () => {
+    it('should return merged dashboard config', async () => {
+      const result = await apiClient.get('/api/config');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/DashboardConfig',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      const body = response.data as {
+        apiVersion: string;
+        kind: string;
+        spec: { dashboardConfig: Record<string, unknown> };
+      };
+      expect(body.apiVersion).toBe('opendatahub.io/v1alpha');
+      expect(body.kind).toBe('OdhDashboardConfig');
+      expect(body.spec.dashboardConfig).toHaveProperty('enablement');
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/config'), 401);
+    });
+
+    it('should return config for non-admin authenticated user', async () => {
+      expectSuccess(await restrictedClient.get('/api/config'));
+    });
+  });
+
+  describe('Components Endpoint', () => {
+    it('should return an array (empty when CRD is absent)', async () => {
+      const result = await apiClient.get('/api/components');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/ComponentsResponse/content/application/json/schema',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/components'), 401);
+    });
+
+    it('should return components for non-admin authenticated user', async () => {
+      const { response } = expectSuccess(await restrictedClient.get('/api/components'));
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+  });
+
+  describe('Components Remove', () => {
+    it('should return 401 for non-admin', async () => {
+      expectError(await restrictedClient.get('/api/components/remove?appName=test'), 401);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/components/remove?appName=test'), 401);
+    });
+  });
+
+  describe('DashboardConfig By Name Endpoint', () => {
+    it('should return 401 for non-admin user on GET', async () => {
+      expectError(
+        await restrictedClient.get('/api/dashboardConfig/opendatahub/odh-dashboard-config'),
+        401,
+      );
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.get('/api/dashboardConfig/opendatahub/odh-dashboard-config'),
+        401,
+      );
+    });
+
+    it('should not reject admin with 401 or 403', async () => {
+      const result = await apiClient.get('/api/dashboardConfig/opendatahub/odh-dashboard-config');
+      const status = result.success
+        ? result.response.status
+        : (result as ApiTestResultError).error.status;
+      expect(status).not.toBe(401);
+      expect(status).not.toBe(403);
+    });
+
+    it('should return 404 when CRD is absent in mock mode', async () => {
+      expectError(
+        await apiClient.get('/api/dashboardConfig/opendatahub/odh-dashboard-config'),
+        404,
+      );
+    });
+  });
+
+  describe('Cluster Settings Endpoint', () => {
+    it('should return cluster settings', async () => {
+      const result = await apiClient.get('/api/cluster-settings');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/ClusterSettings',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      const body = response.data as Record<string, unknown>;
+      expect(body).toHaveProperty('pvcSize');
+      expect(body).toHaveProperty('cullerTimeout');
+      expect(body).toHaveProperty('modelServingPlatformEnabled');
+    });
+
+    it('should reject invalid PUT with 400', async () => {
+      expectError(
+        await apiClient.put('/api/cluster-settings', {
+          pvcSize: -1,
+          cullerTimeout: 0,
+          userTrackingEnabled: false,
+          modelServingPlatformEnabled: { kServe: true, LLMd: true },
+        }),
+        400,
+      );
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/cluster-settings'), 401);
+    });
+
+    it('should return 401 for non-admin on GET', async () => {
+      expectError(await restrictedClient.get('/api/cluster-settings'), 401);
+    });
+
+    it('should return 401 for non-admin on PUT', async () => {
+      expectError(
+        await restrictedClient.put('/api/cluster-settings', {
+          pvcSize: 20,
+          cullerTimeout: 600,
+          userTrackingEnabled: false,
+          modelServingPlatformEnabled: { kServe: true, LLMd: true },
+        }),
+        401,
+      );
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConnectionTypes.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConnectionTypes.test.ts
@@ -103,8 +103,57 @@ describe('Core BFF Connection Types', () => {
       );
     });
 
+    it('should return 401 for non-admin on PATCH', async () => {
+      expectError(
+        await restrictedClient.patch('/api/connection-types/test', [
+          { op: 'replace', path: '/data/key', value: 'val' },
+        ]),
+        401,
+      );
+    });
+
     it('should return 401 for non-admin on DELETE', async () => {
       expectError(await restrictedClient.delete('/api/connection-types/test'), 401);
+    });
+  });
+
+  describe('Patch Paths', () => {
+    const ctName = 'contract-test-ct-patch';
+
+    afterAll(async () => {
+      await apiClient.delete(`/api/connection-types/${ctName}`);
+    });
+
+    it('should patch a connection type with valid JSON patch', async () => {
+      await apiClient.post('/api/connection-types', {
+        metadata: {
+          name: ctName,
+          labels: {
+            'opendatahub.io/dashboard': 'true',
+            'opendatahub.io/connection-type': 'true',
+          },
+        },
+        data: { key: 'original' },
+      });
+
+      const result = await apiClient.patch(`/api/connection-types/${ctName}`, [
+        { op: 'replace', path: '/data/key', value: 'patched' },
+      ]);
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/MutationResponse',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      expect((response.data as { success: boolean }).success).toBe(true);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(
+        await unauthenticatedClient.patch(`/api/connection-types/${ctName}`, [
+          { op: 'replace', path: '/data/key', value: 'val' },
+        ]),
+        401,
+      );
     });
   });
 });

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConnectionTypes.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffConnectionTypes.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+import {
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectSuccess,
+  expectError,
+} from '../helpers';
+
+describe('Core BFF Connection Types', () => {
+  describe('List Endpoint', () => {
+    it('should return an array of connection types', async () => {
+      const result = await apiClient.get('/api/connection-types');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/ConnectionTypesResponse/content/application/json/schema',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/connection-types'), 401);
+    });
+
+    it('should return connection types for non-admin authenticated user', async () => {
+      const { response } = expectSuccess(await restrictedClient.get('/api/connection-types'));
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+  });
+
+  describe('By Name', () => {
+    it('should return 404 for non-existent connection type', async () => {
+      expectError(await apiClient.get('/api/connection-types/nonexistent-ct-12345'), 404);
+    });
+
+    it('should return 401 for non-admin on PUT', async () => {
+      expectError(
+        await restrictedClient.put('/api/connection-types/test', {
+          metadata: { name: 'test', labels: {} },
+        }),
+        401,
+      );
+    });
+  });
+
+  describe('Write Paths', () => {
+    const ctName = 'contract-test-ct';
+
+    afterAll(async () => {
+      await apiClient.delete(`/api/connection-types/${ctName}`);
+    });
+
+    it('should create a connection type with valid labels', async () => {
+      const result = await apiClient.post('/api/connection-types', {
+        metadata: {
+          name: ctName,
+          labels: {
+            'opendatahub.io/dashboard': 'true',
+            'opendatahub.io/connection-type': 'true',
+          },
+        },
+        data: { key: 'value' },
+      });
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/MutationResponse',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      expect((response.data as { success: boolean }).success).toBe(true);
+    });
+
+    it('should reject create without connection-type labels', async () => {
+      const result = await apiClient.post('/api/connection-types', {
+        metadata: { name: 'bad-ct', labels: {} },
+        data: { key: 'value' },
+      });
+      const { response } = expectSuccess(result);
+      const body = response.data as { success: boolean; error: string };
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('connection-type labels');
+    });
+
+    it('should delete a connection type', async () => {
+      const result = await apiClient.delete(`/api/connection-types/${ctName}`);
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/schemas/MutationResponse',
+        status: 200,
+      });
+    });
+  });
+
+  describe('Admin Enforcement', () => {
+    it('should return 401 for non-admin on POST', async () => {
+      expectError(
+        await restrictedClient.post('/api/connection-types', {
+          metadata: { name: 'test', labels: {} },
+        }),
+        401,
+      );
+    });
+
+    it('should return 401 for non-admin on DELETE', async () => {
+      expectError(await restrictedClient.delete('/api/connection-types/test'), 401);
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffInfra.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffInfra.test.ts
@@ -2,29 +2,15 @@
  * @jest-environment node
  */
 import {
-  ContractApiClient,
-  ApiTestResultError,
-  loadOpenAPISchema,
-} from '@odh-dashboard/contract-tests';
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectSuccess,
+  expectError,
+} from '../helpers';
 
-describe('Core BFF API Contract Tests', () => {
-  const baseUrl = process.env.CONTRACT_MOCK_BFF_URL || 'http://localhost:8080';
-  const apiClient = new ContractApiClient({
-    baseUrl,
-    defaultHeaders: {
-      'x-forwarded-access-token': 'FAKE_CLUSTER_ADMIN_TOKEN',
-    },
-  });
-  const unauthenticatedClient = new ContractApiClient({ baseUrl });
-  const restrictedClient = new ContractApiClient({
-    baseUrl,
-    defaultHeaders: {
-      'x-forwarded-access-token': 'FAKE_USER_B_TOKEN',
-    },
-  });
-
-  const apiSchema = loadOpenAPISchema('../bff/openapi/src/core-bff.yaml');
-
+describe('Core BFF Infrastructure', () => {
   describe('Health Check Endpoints', () => {
     it('should return health status from infrastructure endpoint', async () => {
       const result = await apiClient.get('/healthcheck');
@@ -50,22 +36,22 @@ describe('Core BFF API Contract Tests', () => {
         ref: '#/components/responses/UserResponse/content/application/json/schema',
         status: 200,
       });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const body = result.response.data as { data: { userId: string; clusterAdmin: boolean } };
-        expect(body.data).toHaveProperty('userId');
-        expect(body.data).toHaveProperty('clusterAdmin');
-      }
+      const { response } = expectSuccess(result);
+      const body = response.data as { data: { userId: string; clusterAdmin: boolean } };
+      expect(body.data).toHaveProperty('userId');
+      expect(body.data).toHaveProperty('clusterAdmin');
     });
 
     it('should return 401 when no auth token is provided', async () => {
       const result = await unauthenticatedClient.get('/api/v1/user');
-      expect(result.success).toBe(false);
-      const { status, data, headers } = (result as ApiTestResultError).error;
-      expect({ status, data, headers }).toMatchContract(apiSchema, {
-        ref: '#/components/responses/Unauthorized/content/application~1json/schema',
-        status: 401,
-      });
+      const err = expectError(result, 401);
+      expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+        apiSchema,
+        {
+          ref: '#/components/responses/Unauthorized/content/application~1json/schema',
+          status: 401,
+        },
+      );
     });
   });
 
@@ -76,22 +62,22 @@ describe('Core BFF API Contract Tests', () => {
         ref: '#/components/responses/NamespacesResponse/content/application/json/schema',
         status: 200,
       });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const body = result.response.data as { data: { name: string }[] };
-        expect(Array.isArray(body.data)).toBe(true);
-        expect(body.data.length).toBeGreaterThan(0);
-      }
+      const { response } = expectSuccess(result);
+      const body = response.data as { data: { name: string }[] };
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(body.data.length).toBeGreaterThan(0);
     });
 
     it('should return 401 when no auth token is provided', async () => {
       const result = await unauthenticatedClient.get('/api/v1/namespaces');
-      expect(result.success).toBe(false);
-      const { status, data, headers } = (result as ApiTestResultError).error;
-      expect({ status, data, headers }).toMatchContract(apiSchema, {
-        ref: '#/components/responses/Unauthorized/content/application~1json/schema',
-        status: 401,
-      });
+      const err = expectError(result, 401);
+      expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+        apiSchema,
+        {
+          ref: '#/components/responses/Unauthorized/content/application~1json/schema',
+          status: 401,
+        },
+      );
     });
   });
 
@@ -99,12 +85,14 @@ describe('Core BFF API Contract Tests', () => {
     describe('GET', () => {
       it('should return 401 when no auth token is provided', async () => {
         const result = await unauthenticatedClient.get('/api/k8s/api/v1/namespaces');
-        expect(result.success).toBe(false);
-        const { status, data, headers } = (result as ApiTestResultError).error;
-        expect({ status, data, headers }).toMatchContract(apiSchema, {
-          ref: '#/components/responses/Unauthorized/content/application~1json/schema',
-          status: 401,
-        });
+        const err = expectError(result, 401);
+        expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+          apiSchema,
+          {
+            ref: '#/components/responses/Unauthorized/content/application~1json/schema',
+            status: 401,
+          },
+        );
       });
 
       it('should proxy GET to K8s API and return namespaces', async () => {
@@ -117,24 +105,28 @@ describe('Core BFF API Contract Tests', () => {
 
       it('should return 403 for unauthorized K8s resources', async () => {
         const result = await restrictedClient.get('/api/k8s/api/v1/namespaces');
-        expect(result.success).toBe(false);
-        const { status, data, headers } = (result as ApiTestResultError).error;
-        expect({ status, data, headers }).toMatchContract(apiSchema, {
-          ref: '#/components/responses/Forbidden/content/application~1json/schema',
-          status: 403,
-        });
+        const err = expectError(result, 403);
+        expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+          apiSchema,
+          {
+            ref: '#/components/responses/Forbidden/content/application~1json/schema',
+            status: 403,
+          },
+        );
       });
 
       it('should return 404 for non-existent K8s resources', async () => {
         const result = await apiClient.get(
           '/api/k8s/api/v1/namespaces/nonexistent-namespace-12345',
         );
-        expect(result.success).toBe(false);
-        const { status, data, headers } = (result as ApiTestResultError).error;
-        expect({ status, data, headers }).toMatchContract(apiSchema, {
-          ref: '#/components/responses/NotFound/content/application~1json/schema',
-          status: 404,
-        });
+        const err = expectError(result, 404);
+        expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+          apiSchema,
+          {
+            ref: '#/components/responses/NotFound/content/application~1json/schema',
+            status: 404,
+          },
+        );
       });
     });
 
@@ -153,24 +145,22 @@ describe('Core BFF API Contract Tests', () => {
           metadata: { name: 'contract-test-post-cm', namespace },
           data: { key: 'value' },
         });
-        expect(result.success).toBe(true);
-        if (result.success) {
-          const body = result.response.data as { metadata: { name: string } };
-          expect(result.response.status).toBe(201);
-          expect(body.metadata.name).toBe('contract-test-post-cm');
-        }
+        const { response } = expectSuccess(result);
+        expect(response.status).toBe(201);
+        const body = response.data as { metadata: { name: string } };
+        expect(body.metadata.name).toBe('contract-test-post-cm');
       });
 
       it('should return 403 when restricted user creates in unauthorized namespace', async () => {
-        const result = await restrictedClient.post(configMapPath, {
-          apiVersion: 'v1',
-          kind: 'ConfigMap',
-          metadata: { name: 'unauthorized-cm', namespace },
-          data: { key: 'value' },
-        });
-        expect(result.success).toBe(false);
-        const { status } = (result as ApiTestResultError).error;
-        expect(status).toBe(403);
+        expectError(
+          await restrictedClient.post(configMapPath, {
+            apiVersion: 'v1',
+            kind: 'ConfigMap',
+            metadata: { name: 'unauthorized-cm', namespace },
+            data: { key: 'value' },
+          }),
+          403,
+        );
       });
     });
 
@@ -203,10 +193,9 @@ describe('Core BFF API Contract Tests', () => {
           ref: '#/components/responses/K8sProxySuccess/content/application/json/schema',
           status: 200,
         });
-        if (result.success) {
-          const body = result.response.data as { data: { key: string } };
-          expect(body.data.key).toBe('updated');
-        }
+        const { response } = expectSuccess(result);
+        const body = response.data as { data: { key: string } };
+        expect(body.data.key).toBe('updated');
       });
     });
 
@@ -234,16 +223,21 @@ describe('Core BFF API Contract Tests', () => {
 
       it('should return 404 when deleting a non-existent resource', async () => {
         const result = await apiClient.delete(`${configMapPath}/nonexistent-cm-12345`);
-        expect(result.success).toBe(false);
-        const { status, data, headers } = (result as ApiTestResultError).error;
-        expect({ status, data, headers }).toMatchContract(apiSchema, {
-          ref: '#/components/responses/NotFound/content/application~1json/schema',
-          status: 404,
-        });
+        const err = expectError(result, 404);
+        expect({ status: err.status, data: err.data, headers: err.headers }).toMatchContract(
+          apiSchema,
+          {
+            ref: '#/components/responses/NotFound/content/application~1json/schema',
+            status: 404,
+          },
+        );
       });
     });
+  });
 
-    // PATCH is not tested because ContractApiClient does not expose a patch method.
-    // The proxy layer handles PATCH identically to POST/PUT/DELETE.
+  describe('Unmatched API Path', () => {
+    it('should return 404 for GET /api/nonexistent', async () => {
+      expectError(await apiClient.get('/api/nonexistent-path-12345'), 404);
+    });
   });
 });

--- a/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffStatus.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/foundation/testCoreBffStatus.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import {
+  apiClient,
+  unauthenticatedClient,
+  restrictedClient,
+  apiSchema,
+  expectSuccess,
+  expectError,
+} from '../helpers';
+
+describe('Core BFF Status Endpoints', () => {
+  describe('Status Endpoint', () => {
+    it('should return user session status', async () => {
+      const result = await apiClient.get('/api/status');
+      expect(result).toMatchContract(apiSchema, {
+        ref: '#/components/responses/StatusResponse/content/application/json/schema',
+        status: 200,
+      });
+      const { response } = expectSuccess(result);
+      const body = response.data as { kube: Record<string, unknown> };
+      expect(body.kube).toHaveProperty('userName');
+      expect(body.kube).toHaveProperty('isAdmin');
+      expect(body.kube).toHaveProperty('isAllowed');
+      expect(body.kube).toHaveProperty('clusterBranding');
+      expect(body.kube).toHaveProperty('currentContext');
+      expect(body.kube).toHaveProperty('currentUser');
+      expect(body.kube.currentUser).toHaveProperty('name');
+    });
+
+    it('should return 401 when no auth token is provided', async () => {
+      expectError(await unauthenticatedClient.get('/api/status'), 401);
+    });
+
+    it('should return status for non-admin authenticated user', async () => {
+      const { response } = expectSuccess(await restrictedClient.get('/api/status'));
+      const body = response.data as { kube: Record<string, unknown> };
+      expect(body.kube).toHaveProperty('userName');
+    });
+  });
+
+  describe('Allowed Users', () => {
+    it('should return 401 for non-admin', async () => {
+      expectError(await restrictedClient.get('/api/status/opendatahub/allowedUsers'), 401);
+    });
+
+    it('should return an array for admin (empty when no notebooks)', async () => {
+      const { response } = expectSuccess(
+        await apiClient.get('/api/status/opendatahub/allowedUsers'),
+      );
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/helpers.ts
+++ b/distributions/core-bff/contract-tests/__tests__/helpers.ts
@@ -1,0 +1,43 @@
+import {
+  ContractApiClient,
+  ApiTestResultError,
+  loadOpenAPISchema,
+} from '@odh-dashboard/contract-tests';
+
+export type ApiResult = Awaited<ReturnType<ContractApiClient['get']>>;
+export type SuccessResult = Exclude<ApiResult, { success: false }>;
+
+export const expectSuccess = (result: ApiResult): SuccessResult => {
+  expect(result.success).toBe(true);
+  return result;
+};
+
+export const expectError = (
+  result: ApiResult,
+  expectedStatus: number,
+): ApiTestResultError['error'] => {
+  expect(result.success).toBe(false);
+  const { status, data, headers } = (result as ApiTestResultError).error;
+  expect(status).toBe(expectedStatus);
+  return { status, data, headers };
+};
+
+const baseUrl = process.env.CONTRACT_MOCK_BFF_URL || 'http://localhost:8080';
+
+export const apiClient = new ContractApiClient({
+  baseUrl,
+  defaultHeaders: {
+    'x-forwarded-access-token': 'FAKE_CLUSTER_ADMIN_TOKEN',
+  },
+});
+
+export const unauthenticatedClient = new ContractApiClient({ baseUrl });
+
+export const restrictedClient = new ContractApiClient({
+  baseUrl,
+  defaultHeaders: {
+    'x-forwarded-access-token': 'FAKE_USER_B_TOKEN',
+  },
+});
+
+export const apiSchema = loadOpenAPISchema('../bff/openapi/src/core-bff.yaml');

--- a/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffConfig.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/openshift/testCoreBffConfig.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+import { apiClient, expectSuccess } from '../helpers';
+
+describe('Core BFF Config - OpenShift Platform', () => {
+  it('should have OpenShift-default feature flags', async () => {
+    const { response } = expectSuccess(await apiClient.get('/api/config'));
+    const dc = (response.data as { spec: { dashboardConfig: Record<string, unknown> } }).spec
+      .dashboardConfig;
+    expect(dc.enablement).toBe(true);
+    expect(dc.disableProjects).toBe(false);
+    expect(dc.disableBYONImageStream).toBe(false);
+    expect(dc.disableISVBadges).toBe(false);
+    expect(dc.disableAppLauncher).toBe(false);
+    expect(dc.disablePipelines).toBe(false);
+  });
+});

--- a/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffConfig.test.ts
+++ b/distributions/core-bff/contract-tests/__tests__/xks/testCoreBffConfig.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment node
+ */
+import { apiClient, expectSuccess } from '../helpers';
+
+describe('Core BFF Config - XKS Platform', () => {
+  it('should have XKS feature overrides applied', async () => {
+    const { response } = expectSuccess(await apiClient.get('/api/config'));
+    const dc = (response.data as { spec: { dashboardConfig: Record<string, unknown> } }).spec
+      .dashboardConfig;
+    expect(dc.enablement).toBe(false);
+    expect(dc.disableProjects).toBe(true);
+    expect(dc.disableBYONImageStream).toBe(true);
+    expect(dc.disableISVBadges).toBe(true);
+    expect(dc.disableAppLauncher).toBe(true);
+    expect(dc.disablePipelines).toBe(true);
+    expect(dc.mlflow).toBe(false);
+  });
+});

--- a/distributions/core-bff/frontend/config/webpack.dev.js
+++ b/distributions/core-bff/frontend/config/webpack.dev.js
@@ -80,18 +80,14 @@ module.exports = smp.wrap(
         proxy: [
           {
             context: ['/api', '/core-bff/api'],
-            target: {
-              host: PROXY_HOST,
-              protocol: PROXY_PROTOCOL,
-              port: PROXY_PORT,
-            },
+            target: `${PROXY_PROTOCOL}://${PROXY_HOST}:${PROXY_PORT}`,
             changeOrigin: true,
             headers: getProxyHeaders(),
             pathRewrite: { '^/core-bff': '' },
           },
           {
             context: ['/wss/k8s', '/core-bff/wss/k8s'],
-            target: `${PROXY_PROTOCOL === 'https:' ? 'wss' : 'ws'}://${PROXY_HOST}:${PROXY_PORT}`,
+            target: `${PROXY_PROTOCOL === 'https' ? 'wss' : 'ws'}://${PROXY_HOST}:${PROXY_PORT}`,
             ws: true,
             headers: getProxyHeaders(),
             pathRewrite: { '^/core-bff': '' },

--- a/distributions/core-bff/frontend/src/app/App.tsx
+++ b/distributions/core-bff/frontend/src/app/App.tsx
@@ -21,6 +21,8 @@ import {
 } from 'mod-arch-core';
 import AppRoutes from '~/app/AppRoutes';
 import { AppContext } from '~/app/context/AppContext';
+import { BffStatusProvider } from '~/app/context/BffStatusContext';
+import { NamespaceProvider } from '~/app/context/NamespaceContext';
 
 const App: React.FC = () => {
   const {
@@ -93,9 +95,13 @@ const App: React.FC = () => {
     </Bullseye>
   ) : (
     <AppContext.Provider value={contextValue}>
-      <Page mainContainerId="primary-app-container" isManagedSidebar={isStandalone}>
-        <AppRoutes />
-      </Page>
+      <BffStatusProvider>
+        <NamespaceProvider>
+          <Page mainContainerId="primary-app-container" isManagedSidebar={isStandalone}>
+            <AppRoutes />
+          </Page>
+        </NamespaceProvider>
+      </BffStatusProvider>
     </AppContext.Provider>
   );
 };

--- a/distributions/core-bff/frontend/src/app/components/AllowedUsersCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/AllowedUsersCard.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import { useNamespaceSelector } from '~/app/context/NamespaceContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import NamespaceSelect from '~/app/components/NamespaceSelect';
+import type { AllowedUser } from '~/app/types';
+
+const UserLabels: React.FC<{ users: AllowedUser[] }> = ({ users }) => (
+  <LabelGroup>
+    {users.map((user) => (
+      <Label key={user.username} color={user.privilege === 'Admin' ? 'green' : 'blue'} isCompact>
+        {user.username} ({user.privilege})
+      </Label>
+    ))}
+  </LabelGroup>
+);
+
+const getErrorMessage = (error: string): string => {
+  if (error.includes('403')) {
+    return 'Namespace not allowed';
+  }
+  if (error.includes('401')) {
+    return 'Admin only';
+  }
+  return error;
+};
+
+const AllowedUsersCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  users: AllowedUser[];
+}> = ({ connected, loaded, error, users }) => {
+  if (!connected) {
+    return (
+      <Label color="grey" isCompact>
+        Unavailable
+      </Label>
+    );
+  }
+  if (error) {
+    return (
+      <Label color="orange" isCompact>
+        {getErrorMessage(error)}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  if (users.length > 0) {
+    return <UserLabels users={users} />;
+  }
+  return (
+    <Label color="grey" isCompact>
+      0 users
+    </Label>
+  );
+};
+
+const AllowedUsersCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { selectedNamespace } = useNamespaceSelector();
+  const { data, loaded, error } = useFetchJson<AllowedUser[]>(
+    connected && selectedNamespace ? `/api/status/${selectedNamespace}/allowedUsers` : null,
+  );
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Allowed Users ({loaded && !error ? (data ?? []).length : '...'})</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/status/:ns/allowedUsers
+            </Label>
+          </FlexItem>
+          <FlexItem>
+            <NamespaceSelect />
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <AllowedUsersCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          users={data ?? []}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default AllowedUsersCard;

--- a/distributions/core-bff/frontend/src/app/components/BffStatusAlert.tsx
+++ b/distributions/core-bff/frontend/src/app/components/BffStatusAlert.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+
+const BffStatusAlert: React.FC = () => {
+  const { connected, loaded, version, error } = useBffStatus();
+
+  if (!loaded) {
+    return <Alert variant="info" isInline title="Checking BFF connectivity..." />;
+  }
+  if (error) {
+    return (
+      <Alert variant="danger" isInline title="BFF is not reachable">
+        Proxy and WebSocket features require a running BFF. {error}
+      </Alert>
+    );
+  }
+  return (
+    <Alert
+      variant="success"
+      isInline
+      title={connected && version ? `BFF connected (${version})` : 'BFF connected'}
+    />
+  );
+};
+
+export default BffStatusAlert;

--- a/distributions/core-bff/frontend/src/app/components/ClusterSettingsCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/ClusterSettingsCard.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Label,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import type { ClusterSettings } from '~/app/types';
+
+const DEFAULT_CULLER_TIMEOUT = 31536000;
+
+const formatTimeout = (seconds: number): string => {
+  if (seconds >= DEFAULT_CULLER_TIMEOUT) {
+    return 'disabled';
+  }
+  if (seconds >= 86400) {
+    return `${Math.floor(seconds / 86400)}d`;
+  }
+  if (seconds >= 3600) {
+    return `${Math.floor(seconds / 3600)}h`;
+  }
+  return `${Math.floor(seconds / 60)}m`;
+};
+
+const SettingsDetails: React.FC<{ settings: ClusterSettings }> = ({ settings }) => (
+  <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '15ch' }}>
+    <DescriptionListGroup>
+      <DescriptionListTerm>PVC Size</DescriptionListTerm>
+      <DescriptionListDescription>{settings.pvcSize} Gi</DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>Culler Timeout</DescriptionListTerm>
+      <DescriptionListDescription>
+        {settings.cullerTimeout >= DEFAULT_CULLER_TIMEOUT ? (
+          <Label color="grey" isCompact>
+            disabled
+          </Label>
+        ) : (
+          formatTimeout(settings.cullerTimeout)
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>KServe</DescriptionListTerm>
+      <DescriptionListDescription>
+        <Label color={settings.modelServingPlatformEnabled.kServe ? 'green' : 'grey'} isCompact>
+          {settings.modelServingPlatformEnabled.kServe ? 'enabled' : 'disabled'}
+        </Label>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>llm-d</DescriptionListTerm>
+      <DescriptionListDescription>
+        <Label color={settings.modelServingPlatformEnabled.LLMd ? 'green' : 'grey'} isCompact>
+          {settings.modelServingPlatformEnabled.LLMd ? 'enabled' : 'disabled'}
+        </Label>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+    {settings.defaultDeploymentStrategy ? (
+      <DescriptionListGroup>
+        <DescriptionListTerm>Strategy</DescriptionListTerm>
+        <DescriptionListDescription>
+          {settings.defaultDeploymentStrategy}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    ) : null}
+  </DescriptionList>
+);
+
+const ClusterSettingsCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  settings: ClusterSettings | null;
+}> = ({ connected, loaded, error, settings }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  if (settings) {
+    return <SettingsDetails settings={settings} />;
+  }
+  return null;
+};
+
+const ClusterSettingsCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<ClusterSettings>(
+    connected ? '/api/cluster-settings' : null,
+  );
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Cluster Settings</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/cluster-settings
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <ClusterSettingsCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          settings={data}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ClusterSettingsCard;

--- a/distributions/core-bff/frontend/src/app/components/ComponentsCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/ComponentsCard.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+
+type OdhApplication = {
+  metadata?: { name?: string };
+};
+
+const ApplicationLabels: React.FC<{ apps: OdhApplication[] }> = ({ apps }) => {
+  if (apps.length === 0) {
+    return (
+      <Label color="grey" isCompact>
+        0 applications
+      </Label>
+    );
+  }
+  return (
+    <LabelGroup>
+      {apps.map((app) => (
+        <Label key={app.metadata?.name} color="blue" isCompact>
+          {app.metadata?.name ?? 'unknown'}
+        </Label>
+      ))}
+    </LabelGroup>
+  );
+};
+
+const ComponentsCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  apps: OdhApplication[];
+}> = ({ connected, loaded, error, apps }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  return <ApplicationLabels apps={apps} />;
+};
+
+const ComponentsCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<OdhApplication[]>(
+    connected ? '/api/components' : null,
+  );
+  const apps = data ?? [];
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Components ({loaded ? apps.length : '...'})</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/components
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <ComponentsCardBody connected={connected} loaded={loaded} error={error} apps={apps} />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ComponentsCard;

--- a/distributions/core-bff/frontend/src/app/components/ConnectionTypesCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/ConnectionTypesCard.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import type { K8sConfigMap } from '~/app/types';
+
+const ConnectionTypeLabels: React.FC<{ items: K8sConfigMap[] }> = ({ items }) => {
+  if (items.length === 0) {
+    return (
+      <Label color="grey" isCompact>
+        0 connection types
+      </Label>
+    );
+  }
+  return (
+    <LabelGroup>
+      {items.map((ct) => (
+        <Label key={ct.metadata.name} color="blue" isCompact>
+          {ct.metadata.name}
+        </Label>
+      ))}
+    </LabelGroup>
+  );
+};
+
+const ConnectionTypesCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  items: K8sConfigMap[];
+}> = ({ connected, loaded, error, items }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  return <ConnectionTypeLabels items={items} />;
+};
+
+const ConnectionTypesCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<K8sConfigMap[]>(
+    connected ? '/api/connection-types' : null,
+  );
+  const items = data ?? [];
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Connection Types ({loaded ? items.length : '...'})</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/connection-types
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <ConnectionTypesCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          items={items}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ConnectionTypesCard;

--- a/distributions/core-bff/frontend/src/app/components/DashboardConfigCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/DashboardConfigCard.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import type { DashboardConfigResponse } from '~/app/types';
+
+type FlagDef = { key: string; label: string; inverted?: boolean };
+
+const FLAGS: FlagDef[] = [
+  { key: 'enablement', label: 'Enablement' },
+  { key: 'disableProjects', label: 'Projects', inverted: true },
+  { key: 'disableKServe', label: 'KServe', inverted: true },
+  { key: 'disableModelServing', label: 'Model Serving', inverted: true },
+  { key: 'disableTracking', label: 'Tracking', inverted: true },
+  { key: 'disablePipelines', label: 'Pipelines', inverted: true },
+  { key: 'modelAsService', label: 'Model as Service' },
+  { key: 'disableConnectionTypes', label: 'Connection Types', inverted: true },
+  { key: 'disableFineTuning', label: 'Fine Tuning', inverted: true },
+  { key: 'mlflow', label: 'MLflow' },
+];
+
+const FlagLabels: React.FC<{ flags: Record<string, boolean> }> = ({ flags }) => (
+  <LabelGroup>
+    {FLAGS.map(({ key, label, inverted }) => {
+      const enabled = inverted ? !flags[key] : flags[key];
+      return (
+        <Label key={key} color={enabled ? 'green' : 'grey'} isCompact>
+          {label}: {enabled ? 'enabled' : 'disabled'}
+        </Label>
+      );
+    })}
+  </LabelGroup>
+);
+
+const DashboardConfigCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  flags: Record<string, boolean> | undefined;
+}> = ({ connected, loaded, error, flags }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  if (flags) {
+    return <FlagLabels flags={flags} />;
+  }
+  return (
+    <Label color="orange" isCompact>
+      No config loaded
+    </Label>
+  );
+};
+
+const DashboardConfigCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<DashboardConfigResponse>(
+    connected ? '/api/config' : null,
+  );
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Dashboard Config ({FLAGS.length})</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/config
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <DashboardConfigCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          flags={data?.spec.dashboardConfig}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default DashboardConfigCard;

--- a/distributions/core-bff/frontend/src/app/components/K8sWatchCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/K8sWatchCard.tsx
@@ -189,7 +189,7 @@ const K8sWatchCard: React.FC<K8sWatchCardProps> = ({ bffConnected, clusterReacha
         <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>K8s Watch</FlexItem>
           <FlexItem>
-            <Label color="teal" isCompact>
+            <Label color="purple" isCompact>
               /wss/k8s
             </Label>
           </FlexItem>

--- a/distributions/core-bff/frontend/src/app/components/NamespaceSelect.tsx
+++ b/distributions/core-bff/frontend/src/app/components/NamespaceSelect.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { MenuToggle, Select, SelectList, SelectOption } from '@patternfly/react-core';
+import { useNamespaceSelector } from '~/app/context/NamespaceContext';
+
+const NamespaceSelect: React.FC = () => {
+  const { namespaces, selectedNamespace, setSelectedNamespace, loaded } = useNamespaceSelector();
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (!loaded || namespaces.length === 0) {
+    return null;
+  }
+
+  const toggle = (toggleRef: React.Ref<HTMLButtonElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      size="sm"
+    >
+      {selectedNamespace}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selectedNamespace}
+      onSelect={(_event, value) => {
+        setSelectedNamespace(String(value));
+        setIsOpen(false);
+      }}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+    >
+      <SelectList style={{ maxHeight: '200px', overflow: 'auto' }}>
+        {namespaces.map((ns) => (
+          <SelectOption key={ns} value={ns}>
+            {ns}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default NamespaceSelect;

--- a/distributions/core-bff/frontend/src/app/components/NamespacesCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/NamespacesCard.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+
+type K8sNamespaceList = {
+  items: { metadata?: { name?: string }; status?: { phase?: string } }[];
+};
+
+type Namespace = { name: string; status: string };
+
+const NamespaceLabels: React.FC<{ namespaces: Namespace[] }> = ({ namespaces }) => (
+  <LabelGroup>
+    {namespaces.map((ns) => (
+      <Label key={ns.name} color={ns.status === 'Active' ? 'blue' : 'orange'}>
+        {ns.name}
+      </Label>
+    ))}
+  </LabelGroup>
+);
+
+const NamespacesCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  namespaces: Namespace[];
+}> = ({ connected, loaded, error, namespaces }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  return <NamespaceLabels namespaces={namespaces} />;
+};
+
+const NamespacesCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<K8sNamespaceList>(
+    connected ? '/api/k8s/api/v1/namespaces' : null,
+  );
+
+  const namespaces: Namespace[] = (data?.items ?? []).map((item) => ({
+    name: item.metadata?.name ?? 'unknown',
+    status: item.status?.phase ?? 'unknown',
+  }));
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Namespaces ({loaded ? namespaces.length : '...'})</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/k8s
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <NamespacesCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          namespaces={namespaces}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default NamespacesCard;

--- a/distributions/core-bff/frontend/src/app/components/SessionStatusCard.tsx
+++ b/distributions/core-bff/frontend/src/app/components/SessionStatusCard.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Label,
+  Spinner,
+} from '@patternfly/react-core';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import type { KubeStatus, StatusResponse } from '~/app/types';
+
+const StatusDetails: React.FC<{ kube: KubeStatus }> = ({ kube }) => (
+  <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '15ch' }}>
+    <DescriptionListGroup>
+      <DescriptionListTerm>User</DescriptionListTerm>
+      <DescriptionListDescription>
+        {kube.userName || 'Unknown'}
+        {kube.isAdmin ? (
+          <>
+            {' '}
+            <Label color="green" isCompact>
+              admin
+            </Label>
+          </>
+        ) : null}
+        {kube.isAllowed ? null : (
+          <>
+            {' '}
+            <Label color="red" isCompact>
+              not allowed
+            </Label>
+          </>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>Cluster</DescriptionListTerm>
+      <DescriptionListDescription>
+        {kube.clusterBranding}{' '}
+        <Label color="blue" isCompact>
+          {kube.clusterID ? `${kube.clusterID.slice(0, 8)}...` : 'no ID'}
+        </Label>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>Context</DescriptionListTerm>
+      <DescriptionListDescription>{kube.currentContext}</DescriptionListDescription>
+    </DescriptionListGroup>
+    <DescriptionListGroup>
+      <DescriptionListTerm>Server</DescriptionListTerm>
+      <DescriptionListDescription>{kube.serverURL}</DescriptionListDescription>
+    </DescriptionListGroup>
+  </DescriptionList>
+);
+
+const SessionStatusCardBody: React.FC<{
+  connected: boolean;
+  loaded: boolean;
+  error?: string;
+  kube: KubeStatus | undefined;
+}> = ({ connected, loaded, error, kube }) => {
+  if (!connected || error) {
+    return (
+      <Label color="grey" isCompact>
+        {error ?? 'Unavailable'}
+      </Label>
+    );
+  }
+  if (!loaded) {
+    return <Spinner size="md" />;
+  }
+  if (kube) {
+    return <StatusDetails kube={kube} />;
+  }
+  return null;
+};
+
+const SessionStatusCard: React.FC = () => {
+  const { connected } = useBffStatus();
+  const { data, loaded, error } = useFetchJson<StatusResponse>(connected ? '/api/status' : null);
+
+  return (
+    <Card isCompact>
+      <CardTitle>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>Session & Status</FlexItem>
+          <FlexItem>
+            <Label color="purple" isCompact>
+              /api/status
+            </Label>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <SessionStatusCardBody
+          connected={connected}
+          loaded={loaded}
+          error={error}
+          kube={data?.kube}
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+export default SessionStatusCard;

--- a/distributions/core-bff/frontend/src/app/context/BffStatusContext.tsx
+++ b/distributions/core-bff/frontend/src/app/context/BffStatusContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { URL_PREFIX, BFF_API_VERSION } from '~/app/utilities/const';
+
+type BffStatus = {
+  connected: boolean;
+  loaded: boolean;
+  version?: string;
+  error?: string;
+};
+
+const BffStatusContext = createContext<BffStatus>({
+  connected: false,
+  loaded: false,
+});
+
+export const BffStatusProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [status, setStatus] = useState<BffStatus>({ connected: false, loaded: false });
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      try {
+        const resp = await fetch(`${URL_PREFIX}/api/${BFF_API_VERSION}/healthcheck`);
+        if (!resp.ok) {
+          setStatus({ connected: false, loaded: true, error: `HTTP ${resp.status}` });
+          return;
+        }
+        const data = await resp.json().catch(() => null);
+        setStatus({ connected: true, loaded: true, version: data?.systemInfo?.version });
+      } catch (err) {
+        setStatus({ connected: false, loaded: true, error: String(err) });
+      }
+    };
+    fetchStatus();
+  }, []);
+
+  const value = useMemo(() => status, [status]);
+
+  return <BffStatusContext.Provider value={value}>{children}</BffStatusContext.Provider>;
+};
+
+export const useBffStatus = (): BffStatus => useContext(BffStatusContext);

--- a/distributions/core-bff/frontend/src/app/context/NamespaceContext.tsx
+++ b/distributions/core-bff/frontend/src/app/context/NamespaceContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useBffStatus } from '~/app/context/BffStatusContext';
+import useFetchJson from '~/app/hooks/useFetchJson';
+import type { StatusResponse } from '~/app/types';
+
+type K8sNamespaceList = {
+  items: { metadata?: { name?: string } }[];
+};
+
+type NamespaceContextType = {
+  namespaces: string[];
+  selectedNamespace: string;
+  setSelectedNamespace: (ns: string) => void;
+  loaded: boolean;
+};
+
+const NamespaceContext = createContext<NamespaceContextType>({
+  namespaces: [],
+  selectedNamespace: '',
+  setSelectedNamespace: () => undefined,
+  loaded: false,
+});
+
+export const NamespaceProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { connected } = useBffStatus();
+  const { data: statusData } = useFetchJson<StatusResponse>(connected ? '/api/status' : null);
+  const { data, loaded } = useFetchJson<K8sNamespaceList>(
+    connected ? '/api/k8s/api/v1/namespaces' : null,
+  );
+  const [selected, setSelected] = useState('');
+
+  const namespaces = useMemo(
+    () =>
+      (data?.items ?? [])
+        .map((item) => item.metadata?.name ?? '')
+        .filter(Boolean)
+        .toSorted(),
+    [data],
+  );
+
+  useEffect(() => {
+    if (!selected && statusData?.kube.namespace) {
+      setSelected(statusData.kube.namespace);
+    }
+  }, [statusData, selected]);
+
+  useEffect(() => {
+    if (namespaces.length > 0 && selected && !namespaces.includes(selected)) {
+      setSelected(namespaces[0]);
+    }
+  }, [namespaces, selected]);
+
+  const value = useMemo(
+    () => ({
+      namespaces,
+      selectedNamespace: selected,
+      setSelectedNamespace: setSelected,
+      loaded,
+    }),
+    [namespaces, selected, loaded],
+  );
+
+  return <NamespaceContext.Provider value={value}>{children}</NamespaceContext.Provider>;
+};
+
+export const useNamespaceSelector = (): NamespaceContextType => useContext(NamespaceContext);

--- a/distributions/core-bff/frontend/src/app/hooks/useFetchJson.ts
+++ b/distributions/core-bff/frontend/src/app/hooks/useFetchJson.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { URL_PREFIX } from '~/app/utilities/const';
+
+type FetchState<T> = { data: T | null; loaded: boolean; error?: string };
+
+const useFetchJson = <T>(path: string | null): FetchState<T> => {
+  const [state, setState] = useState<FetchState<T>>({ data: null, loaded: false });
+
+  useEffect(() => {
+    if (path === null) {
+      setState({ data: null, loaded: true });
+      return;
+    }
+
+    let cancelled = false;
+    const doFetch = async () => {
+      try {
+        const resp = await fetch(`${URL_PREFIX}${path}`);
+        if (!resp.ok) {
+          if (!cancelled) {
+            setState({ data: null, loaded: true, error: `HTTP ${resp.status}` });
+          }
+          return;
+        }
+        const data: T = await resp.json();
+        if (!cancelled) {
+          setState({ data, loaded: true });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState({ data: null, loaded: true, error: String(err) });
+        }
+      }
+    };
+
+    setState({ data: null, loaded: false });
+    doFetch();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  return state;
+};
+
+export default useFetchJson;

--- a/distributions/core-bff/frontend/src/app/pages/MainPage.tsx
+++ b/distributions/core-bff/frontend/src/app/pages/MainPage.tsx
@@ -1,138 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import {
-  Alert,
-  Card,
-  CardBody,
-  CardTitle,
-  DescriptionList,
-  DescriptionListDescription,
-  DescriptionListGroup,
-  DescriptionListTerm,
-  Flex,
-  FlexItem,
-  Label,
-  LabelGroup,
-  Spinner,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
-import { UserIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import ApplicationsPage from '~/app/components/ApplicationsPage';
+import BffStatusAlert from '~/app/components/BffStatusAlert';
+import SessionStatusCard from '~/app/components/SessionStatusCard';
+import NamespacesCard from '~/app/components/NamespacesCard';
 import K8sWatchCard from '~/app/components/K8sWatchCard';
-import useUser from '~/app/hooks/useUser';
-import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
-
-type BffStatus = { loaded: boolean; error?: string; version?: string };
-
-type K8sNamespace = {
-  name: string;
-  status: string;
-};
-
-type NamespaceState = {
-  loaded: boolean;
-  error?: string;
-  namespaces: K8sNamespace[];
-};
-
-const BffStatusAlert: React.FC<{ status: BffStatus }> = ({ status }) => {
-  if (status.loaded && status.error) {
-    return (
-      <Alert variant="danger" isInline title="BFF is not reachable">
-        Proxy and WebSocket features require a running BFF. {status.error}
-      </Alert>
-    );
-  }
-  if (status.loaded) {
-    return (
-      <Alert
-        variant="success"
-        isInline
-        title={status.version ? `BFF connected (${status.version})` : 'BFF connected'}
-      />
-    );
-  }
-  return <Alert variant="info" isInline title="Checking BFF connectivity..." />;
-};
-
-const NamespaceCardBody: React.FC<{
-  bffConnected: boolean;
-  loaded: boolean;
-  error?: string;
-  namespaces: K8sNamespace[];
-}> = ({ bffConnected, loaded, error, namespaces }) => {
-  if (!bffConnected || error) {
-    return (
-      <Label color="grey" isCompact>
-        Unavailable
-      </Label>
-    );
-  }
-  if (loaded) {
-    return (
-      <LabelGroup>
-        {namespaces.map((ns) => (
-          <Label key={ns.name} color={ns.status === 'Active' ? 'blue' : 'yellow'}>
-            {ns.name}
-          </Label>
-        ))}
-      </LabelGroup>
-    );
-  }
-  return <Spinner size="md" />;
-};
+import DashboardConfigCard from '~/app/components/DashboardConfigCard';
+import ClusterSettingsCard from '~/app/components/ClusterSettingsCard';
+import ComponentsCard from '~/app/components/ComponentsCard';
+import ConnectionTypesCard from '~/app/components/ConnectionTypesCard';
+import AllowedUsersCard from '~/app/components/AllowedUsersCard';
+import { useBffStatus } from '~/app/context/BffStatusContext';
 
 const MainPage: React.FC = () => {
-  const [bffStatus, setBffStatus] = useState<BffStatus>({ loaded: false });
-  const [nsState, setNsState] = useState<NamespaceState>({ loaded: false, namespaces: [] });
-  const user = useUser();
-
-  useEffect(() => {
-    const fetchBffStatus = async () => {
-      try {
-        const resp = await fetch(`${URL_PREFIX}/api/${BFF_API_VERSION}/healthcheck`);
-        if (!resp.ok) {
-          setBffStatus({ loaded: true, error: `HTTP ${resp.status}` });
-          return;
-        }
-        const data = await resp.json().catch(() => null);
-        setBffStatus({ loaded: true, version: data?.systemInfo?.version });
-      } catch (err) {
-        setBffStatus({ loaded: true, error: String(err) });
-      }
-    };
-    fetchBffStatus();
-  }, []);
-
-  const bffConnected = bffStatus.loaded && !bffStatus.error;
-
-  useEffect(() => {
-    if (!bffConnected) {
-      return;
-    }
-    const fetchNamespaces = async () => {
-      try {
-        const resp = await fetch(`${URL_PREFIX}/api/k8s/api/v1/namespaces`);
-        if (!resp.ok) {
-          setNsState({ loaded: true, error: `HTTP ${resp.status}`, namespaces: [] });
-          return;
-        }
-        const data = await resp.json();
-        const items: K8sNamespace[] = (data.items ?? []).map(
-          (item: { metadata?: { name?: string }; status?: { phase?: string } }) => ({
-            name: item.metadata?.name ?? 'unknown',
-            status: item.status?.phase ?? 'unknown',
-          }),
-        );
-        setNsState({ loaded: true, namespaces: items });
-      } catch (err) {
-        setNsState({ loaded: true, error: String(err), namespaces: [] });
-      }
-    };
-    fetchNamespaces();
-  }, [bffConnected]);
-
-  const clusterReachable = bffConnected && nsState.loaded && !nsState.error;
+  const { connected, loaded } = useBffStatus();
+  const clusterReachable = connected && loaded;
 
   return (
     <ApplicationsPage
@@ -145,79 +27,43 @@ const MainPage: React.FC = () => {
     >
       <Stack hasGutter>
         <StackItem>
-          <Stack hasGutter>
-            <BffStatusAlert status={bffStatus} />
-            {bffConnected && nsState.loaded && nsState.error ? (
-              <Alert variant="warning" isInline title="Cluster may not be accessible">
-                Features that depend on the K8s API will not work without a reachable cluster.
-              </Alert>
-            ) : null}
-          </Stack>
+          <BffStatusAlert />
         </StackItem>
         <StackItem>
-          <Card isCompact>
-            <CardTitle>
-              <Flex
-                spaceItems={{ default: 'spaceItemsSm' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-              >
-                <FlexItem>Session Info</FlexItem>
-                <FlexItem>
-                  <Label color="purple" isCompact>
-                    /api/v1
-                  </Label>
-                </FlexItem>
-              </Flex>
-            </CardTitle>
-            <CardBody>
-              <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '15ch' }}>
-                <DescriptionListGroup>
-                  <DescriptionListTerm icon={<UserIcon />}>User</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {user.userId || 'Unknown'}
-                    {user.clusterAdmin ? (
-                      <>
-                        {' '}
-                        <Label color="green" isCompact>
-                          admin
-                        </Label>
-                      </>
-                    ) : null}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              </DescriptionList>
-            </CardBody>
-          </Card>
-        </StackItem>
-        <StackItem>
-          <Card isCompact>
-            <CardTitle>
-              <Flex
-                spaceItems={{ default: 'spaceItemsSm' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-              >
-                <FlexItem>
-                  Namespaces ({nsState.loaded ? nsState.namespaces.length : '...'})
-                </FlexItem>
-                <FlexItem>
-                  <Label color="teal" isCompact>
-                    /api/k8s
-                  </Label>
-                </FlexItem>
-              </Flex>
-            </CardTitle>
-            <CardBody>
-              <NamespaceCardBody
-                bffConnected={bffConnected}
-                loaded={nsState.loaded}
-                error={nsState.error}
-                namespaces={nsState.namespaces}
-              />
-            </CardBody>
-          </Card>
-        </StackItem>
-        <StackItem>
-          <K8sWatchCard bffConnected={bffConnected} clusterReachable={clusterReachable} />
+          <Grid hasGutter>
+            <GridItem md={6}>
+              <Stack hasGutter>
+                <StackItem>
+                  <SessionStatusCard />
+                </StackItem>
+                <StackItem>
+                  <NamespacesCard />
+                </StackItem>
+                <StackItem>
+                  <K8sWatchCard bffConnected={connected} clusterReachable={clusterReachable} />
+                </StackItem>
+              </Stack>
+            </GridItem>
+            <GridItem md={6}>
+              <Stack hasGutter>
+                <StackItem>
+                  <DashboardConfigCard />
+                </StackItem>
+                <StackItem>
+                  <ClusterSettingsCard />
+                </StackItem>
+                <StackItem>
+                  <ComponentsCard />
+                </StackItem>
+                <StackItem>
+                  <ConnectionTypesCard />
+                </StackItem>
+                <StackItem>
+                  <AllowedUsersCard />
+                </StackItem>
+              </Stack>
+            </GridItem>
+          </Grid>
         </StackItem>
       </Stack>
     </ApplicationsPage>

--- a/distributions/core-bff/frontend/src/app/types.ts
+++ b/distributions/core-bff/frontend/src/app/types.ts
@@ -27,3 +27,48 @@ export type NamespaceKind = {
   name: string;
   displayName?: string;
 };
+
+export type KubeStatus = {
+  currentContext: string;
+  currentUser: { name: string };
+  namespace: string;
+  userName: string;
+  userID: string;
+  clusterID: string;
+  clusterBranding: string;
+  isAdmin: boolean;
+  isAllowed: boolean;
+  serverURL: string;
+};
+
+export type StatusResponse = {
+  kube: KubeStatus;
+};
+
+export type DashboardConfigResponse = {
+  apiVersion: string;
+  kind: string;
+  spec: {
+    dashboardConfig: Record<string, boolean>;
+  };
+};
+
+export type ClusterSettings = {
+  pvcSize: number;
+  cullerTimeout: number;
+  userTrackingEnabled: boolean;
+  modelServingPlatformEnabled: { kServe: boolean; LLMd: boolean };
+  isDistributedInferencingDefault?: boolean;
+  defaultDeploymentStrategy?: string;
+};
+
+export type AllowedUser = {
+  username: string;
+  privilege: string;
+  lastActivity: string;
+};
+
+export type K8sConfigMap = {
+  metadata: { name: string; labels?: Record<string, string> };
+  data?: Record<string, string>;
+};

--- a/distributions/core-bff/package.json
+++ b/distributions/core-bff/package.json
@@ -40,7 +40,9 @@
     "cypress:server": "cd frontend && serve ./public-cypress -p 9112 -s -L",
     "cypress:server:dev": "cd frontend && cross-env DEPLOYMENT_MODE=federated PORT=9112 PROXY_PORT=4020 npm run start:dev",
     "cypress:server:wait": "npx wait-on -i 1000 http://localhost:9112",
-    "test:contract": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token' odh-ct-bff-consumer --bff-dir bff",
+    "test:contract": "npm run test:contract:openshift && npm run test:contract:xks",
+    "test:contract:openshift": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token --platform-type=OpenShift' CONTRACT_TEST_PATH='(foundation|openshift)' odh-ct-bff-consumer --bff-dir bff",
+    "test:contract:xks": "cross-env BFF_MOCK_FLAGS='--mock-k8s-client --auth-method=user_token --platform-type=XKS' CONTRACT_TEST_PATH='(foundation|xks)' odh-ct-bff-consumer --bff-dir bff",
     "lint": "cd frontend && npm run lint",
     "lint:fix": "cd frontend && npm run lint:fix"
   },

--- a/packages/contract-tests/scripts/run-consumer-with-mock-bff.sh
+++ b/packages/contract-tests/scripts/run-consumer-with-mock-bff.sh
@@ -102,6 +102,9 @@ fi
 if [[ "$WATCH_MODE" == true ]]; then
   CMD+=(--watch)
 fi
+if [[ -n "${CONTRACT_TEST_PATH:-}" ]]; then
+  CMD+=(--testPathPattern "$CONTRACT_TEST_PATH")
+fi
 
 TEST_LOG="$RESULTS_DIR/contract-test-output.log"
 log_info "Test output: $TEST_LOG"

--- a/packages/contract-tests/src/utils/api-client.ts
+++ b/packages/contract-tests/src/utils/api-client.ts
@@ -297,6 +297,57 @@ export class ContractApiClient {
   }
 
   /**
+   * Make a PATCH request and log the results
+   */
+  async patch(
+    path: string,
+    data: unknown,
+    options: {
+      headers?: Record<string, string>;
+    } = {},
+    testName?: string,
+  ): Promise<ApiTestResult> {
+    const url = `${this.config.baseUrl}${path}`;
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(this.config.defaultHeaders ?? {}),
+      ...(options.headers ?? {}),
+    };
+    const controller = new AbortController();
+
+    try {
+      logApiCall('PATCH', url, ContractApiClient.getCurrentTestName(testName || ''), headers);
+
+      const response: AxiosResponse = await axios.patch(url, data, {
+        headers,
+        timeout: this.config.timeout,
+        signal: controller.signal,
+      });
+
+      const apiResponse: ApiResponse = {
+        status: response.status,
+        headers: ContractApiClient.normalizeHeaders(response.headers),
+        data: response.data,
+      };
+
+      logApiResponse(apiResponse, ContractApiClient.getCurrentTestName(testName || ''));
+
+      return {
+        success: true,
+        response: apiResponse,
+      };
+    } catch (error) {
+      const apiError = this.handleAxiosError(error, testName);
+      return {
+        success: false,
+        error: apiError,
+      };
+    } finally {
+      controller.abort();
+    }
+  }
+
+  /**
    * Make a DELETE request and log the results
    */
   async delete(


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
https://redhat.atlassian.net/browse/RHOAIENG-64749

Implements config endpoints and connection-types handler for the Core BFF (Task 4 from the Core BFF design doc). This adds on-demand fetching for DashboardConfig, Auth, Components, Status, Cluster Settings, Connection Types, and two sub-routes (components/remove, status/allowedUsers), replacing the corresponding Fastify endpoints with Go handlers. Admin auth uses an interim `requireAdmin` guard; full `secureAdminRoute` parity is deferred to Task 3.

### Backend (Go)

16 new endpoints across config, status, components, cluster-settings, dashboardConfig, and connection-types (full CRUD). Authenticated users can read config/components/status/connection-types; admin-only endpoints are gated by `requireAdmin` (SSAR check). See `routes.go` for the full list.

**Key decisions:**

- **Service account clients** for reading shared config and performing admin-gated mutations, matching Fastify's privileged watcher model
- **Admin guard**: interim `requireAdmin` via SSAR on `auths/default-auth`; full `secureAdminRoute` parity deferred to Task 3
- **On-demand fetching** with no caching or background watchers (design doc ADR D1)
- **Platform detection**: `ODH_PLATFORM_TYPE` (`XKS`, `OpenShift`, or unset for auto-detect via ClusterVersion CRD). XKS disables OpenShift-dependent features. Auto-detection distinguishes CRD-absent (genuinely non-OpenShift) from RBAC/network errors
- **Segment userID parity**: Status endpoint returns a privacy-safe `userID` matching Fastify's `getSegmentUserId` - SHA-256 of JWT `sub` claim with fallback to SHA-256 of username. DevSandbox SSO annotation path deferred as a narrow follow-up
- **Namespace** falls back to `OC_PROJECT` env var

### Frontend (React)

Reorganized the Core BFF test page (`MainPage.tsx`) into a two-column grid with dedicated card components exercising each Task 4 endpoint:

- **Left column**: Session & Status, Namespaces, K8s Watch
- **Right column**: Dashboard Config, Cluster Settings, Components, Connection Types, Allowed Users

Each card is self-contained with its own data fetching via a shared `useFetchJson` hook. BFF connectivity is provided via `BffStatusContext`. A namespace selector (backed by `NamespaceContext`) allows switching namespaces for the Allowed Users card.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- **Go unit tests**: 90+ tests covering handlers, repositories, middleware (admin guard, token validation), pure logic (deep merge, feature lockouts, PVC parsing, username decoding, segment userID hashing, JWT sub extraction, platform auto-detection error differentiation), and integration tests with fake K8s clients.
- **Contract tests**: 49 tests across 6 files (4 foundation + 1 OpenShift + 1 XKS), run separately per platform via `test:contract:openshift` and `test:contract:xks`. Foundation tests validate response schemas, admin enforcement (401 for non-admin), non-admin read access (200 for authenticated users), write path validation, and 404 catch-all. Platform-specific tests verify feature flag defaults (OpenShift) and XKS overrides.
- **Manual verification**: Tested against a live OpenShift/RHOAI cluster and a Kind cluster (both via `make dev-start-federated`), and locally with mocked clients (`make dev-start`). Verified all cards display correct data, CRD-absent degradation, admin-only endpoints, and namespace guard behavior.
- **Flakiness check**: `go test -count=2` passes with idempotent test fixtures.
- `go build`, `go vet`, `make lint` (golangci-lint) - zero issues.
- `npm run test:contract` - 49/49 pass on both OpenShift and XKS platforms.
- Frontend: `npm run test:lint` and `npm run test:type-check` - zero errors.

**Test page**:

Running on kind

<img width="600" alt="Screenshot 2026-06-05 at 3 12 15 PM" src="https://github.com/user-attachments/assets/c982b0dd-9dcc-4741-a1e6-d39b66e89642" />


Running on OpenShift

<img width="600" alt="Screenshot 2026-06-05 at 1 48 10 PM" src="https://github.com/user-attachments/assets/b5f8c013-d15b-4056-83dc-b9ebc3dbb5fd" />

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- **New Go unit/integration test files** across `internal/api/` and `internal/repositories/` covering handlers, repositories, middleware, and pure logic
- **New contract test files** split by platform: `foundation/` (platform-agnostic), `openshift/` and `xks/` (platform-specific feature flag assertions)

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New BFF REST APIs for config, dashboard config (by namespace/name), cluster settings, status/allowed-users, components, and full connection-type CRUD; frontend cards and hooks for these endpoints plus a BFF status and namespace selector.

* **Platform**
  * Explicit OpenShift/XKS platform detection and configuration with matching behavior and CLI/env support; contract tests can run per-platform.

* **Documentation**
  * README and OpenAPI updated to reflect new endpoints and platform nuances.

* **Tests**
  * Expanded unit, integration, and contract test coverage across APIs and repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->