### PR TITLE
RHOAIENG-62255, RHOAIENG-62257, RHOAIENG-62256: Frontend ASR model discovery, selector, and audio transcription UX

### DIFF
--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockAAModels.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockAAModels.ts
@@ -26,6 +26,7 @@ export const mockAAModel = (overrides?: Partial<AAModelResponse>): AAModelRespon
   // Must be 'Running' for the model to be selectable
   status: 'Running',
   display_name: 'Llama 3.2 3B Instruct',
+  model_source_type: 'namespace',
   sa_token: {
     name: 'model-sa',
     token_name: 'model-token',

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelTableRow.tsx
@@ -33,7 +33,7 @@ import {
 } from '~/app/types';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import { genAiAiAssetsTabRoute, genAiChatPlaygroundRoute } from '~/app/utilities/routes';
-import { isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
+import { isPlaygroundModelMatchForAIModel, isASRModel } from '~/app/utilities/utils';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import AIModelsTableRowInfo from './AIModelsTableRowInfo';
@@ -101,8 +101,10 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
         <Td dataLabel="Model">
           <TableRowTitleDescription title={<AIModelsTableRowInfo model={model} />} />
           <Truncate
+            data-testid="model-id-text"
             content={model.model_id}
             className="pf-v6-u-font-family-monospace pf-v6-u-font-size-xs pf-v6-u-color-200 pf-v6-u-mt-xs"
+            style={{ userSelect: 'all' }}
           />
           {model.description && (
             <Truncate
@@ -166,7 +168,14 @@ const AIModelTableRow: React.FC<AIModelTableRowProps> = ({
         </Td>
         {showPlaygroundColumn && (
           <Td dataLabel="Playground">
-            {enabledModel ? (
+            {isASRModel(model) ? (
+              <span
+                className="pf-v6-u-color-200 pf-v6-u-font-size-sm"
+                data-testid="asr-playground-info"
+              >
+                Used in Playground settings
+              </span>
+            ) : enabledModel ? (
               <>
                 {model.model_type === 'embedding' && isVectorStoresEnabled ? (
                   <Button

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTableRowInfo.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/AIModelsTableRowInfo.tsx
@@ -1,78 +1,30 @@
 import * as React from 'react';
-import {
-  ClipboardCopy,
-  Content,
-  StackItem,
-  Stack,
-  Popover,
-  Flex,
-  FlexItem,
-  Label,
-} from '@patternfly/react-core';
-import { DashboardPopupIconButton } from 'mod-arch-shared';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem, Label } from '@patternfly/react-core';
 import { AIModel } from '~/app/types';
-import { copyToClipboardWithTracking } from '~/app/utilities/utils';
+import { isASRModel } from '~/app/utilities/utils';
 
 type AIModelsTableRowInfoProps = {
   model: AIModel;
 };
 
-const AIModelsTableRowInfo: React.FC<AIModelsTableRowInfoProps> = ({ model }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  return (
-    <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }}>
-      <FlexItem>{model.display_name}</FlexItem>
-      {model.model_type === 'embedding' && (
-        <FlexItem style={{ fontWeight: 'normal' }}>
-          <Label color="blue" isCompact>
-            Embedding
-          </Label>
-        </FlexItem>
-      )}
-      <Popover
-        position="right"
-        isVisible={isOpen}
-        shouldClose={() => setIsOpen(false)}
-        bodyContent={
-          <Stack hasGutter>
-            <StackItem>
-              The model ID is a unique identifier required to locate and access this model.
-            </StackItem>
-            <StackItem>
-              <Content style={{ fontWeight: 'var(--pf-t--global--font--weight--body--bold)' }}>
-                Model ID
-              </Content>
-              <ClipboardCopy
-                data-testid="clipboard-copy-model-id"
-                hoverTip="Copy model ID"
-                clickTip="Model ID copied"
-                aria-label="Copy model ID"
-                onCopy={() =>
-                  copyToClipboardWithTracking(
-                    model.model_id,
-                    'Available Endpoints Model Id Copied',
-                    {},
-                  )
-                }
-              >
-                {model.model_id}
-              </ClipboardCopy>
-            </StackItem>
-          </Stack>
-        }
-      >
-        <DashboardPopupIconButton
-          data-testid="model-id-icon-button"
-          icon={<OutlinedQuestionCircleIcon />}
-          aria-label="More info"
-          style={{ paddingTop: 0, paddingBottom: 0 }}
-          onClick={() => setIsOpen(!isOpen)}
-        />
-      </Popover>
-    </Flex>
-  );
-};
+const AIModelsTableRowInfo: React.FC<AIModelsTableRowInfoProps> = ({ model }) => (
+  <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+    <FlexItem>{model.display_name}</FlexItem>
+    {model.model_type === 'embedding' && (
+      <FlexItem style={{ fontWeight: 'normal' }}>
+        <Label color="blue" isCompact>
+          Embedding
+        </Label>
+      </FlexItem>
+    )}
+    {isASRModel(model) && (
+      <FlexItem style={{ fontWeight: 'normal' }}>
+        <Label color="purple" isCompact data-testid="asr-badge">
+          ASR
+        </Label>
+      </FlexItem>
+    )}
+  </Flex>
+);
 
 export default AIModelsTableRowInfo;

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelTableRow.spec.tsx
@@ -377,6 +377,44 @@ describe('AIModelTableRow', () => {
       // The modal should be open with the model pre-selected
       expect(screen.getByTestId('configuration-modal')).toBeInTheDocument();
     });
+
+    it('should show "Used in Playground settings" for ASR models instead of Try button', () => {
+      const model = createMockAIModel({ modality: 'audio-transcription' });
+      render(
+        <TestWrapper>
+          <AIModelTableRow {...defaultProps} model={model} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByTestId('asr-playground-info')).toHaveTextContent(
+        'Used in Playground settings',
+      );
+      expect(screen.queryByText('Try in playground')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add to playground')).not.toBeInTheDocument();
+    });
+
+    it('should not show "Add to playground" button for ASR models', () => {
+      const model = createMockAIModel({ modality: 'audio-transcription' });
+      render(
+        <TestWrapper>
+          <AIModelTableRow {...defaultProps} model={model} />
+        </TestWrapper>,
+      );
+
+      expect(screen.queryByRole('button', { name: /playground/i })).not.toBeInTheDocument();
+    });
+
+    it('should show normal playground buttons for non-ASR namespace models', () => {
+      const model = createMockAIModel({ model_source_type: 'namespace' });
+      render(
+        <TestWrapper>
+          <AIModelTableRow {...defaultProps} model={model} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText('Add to playground')).toBeInTheDocument();
+      expect(screen.queryByTestId('asr-playground-info')).not.toBeInTheDocument();
+    });
   });
 
   describe('Tracking', () => {

--- a/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTableRowInfo.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/AIAssets/components/__tests__/AIModelsTableRowInfo.spec.tsx
@@ -1,72 +1,9 @@
 /* eslint-disable camelcase */
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import type { AIModel } from '~/app/types';
 import AIModelsTableRowInfo from '~/app/AIAssets/components/AIModelsTableRowInfo';
-
-// Mock tracking
-jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', () => ({
-  fireMiscTrackingEvent: jest.fn(),
-}));
-
-jest.mock('mod-arch-shared', () => ({
-  ...jest.requireActual('mod-arch-shared'),
-  DashboardPopupIconButton: ({
-    icon,
-    onClick,
-    children,
-    ...props
-  }: {
-    icon: React.ReactNode;
-    onClick?: () => void;
-    children?: React.ReactNode;
-  }) => (
-    <button onClick={onClick} {...props}>
-      {icon}
-      {children}
-    </button>
-  ),
-}));
-
-// Mock ClipboardCopy to trigger onCopy callback
-jest.mock('@patternfly/react-core', () => {
-  const actual = jest.requireActual('@patternfly/react-core');
-  return {
-    ...actual,
-    ClipboardCopy: ({
-      children,
-      onCopy,
-      'data-testid': dataTestId,
-      ...props
-    }: {
-      children: string;
-      onCopy?: (event: React.ClipboardEvent<HTMLDivElement>, text?: React.ReactNode) => void;
-      'data-testid'?: string;
-      [key: string]: unknown;
-    }) => {
-      const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-        if (onCopy) {
-          onCopy(e as unknown as React.ClipboardEvent<HTMLDivElement>, children);
-        }
-      };
-      return (
-        <div data-testid={dataTestId}>
-          <input readOnly value={children} />
-          <button
-            aria-label={(props['aria-label'] as string) || 'Copy to clipboard'}
-            onClick={handleClick}
-            data-testid={dataTestId ? `${dataTestId}-copy-button` : undefined}
-          >
-            Copy
-          </button>
-        </div>
-      );
-    },
-  };
-});
 
 const createMockAIModel = (overrides?: Partial<AIModel>): AIModel => ({
   model_name: 'test-model',
@@ -89,10 +26,6 @@ const createMockAIModel = (overrides?: Partial<AIModel>): AIModel => ({
 });
 
 describe('AIModelsTableRowInfo', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should render model display name', () => {
     const model = createMockAIModel({ display_name: 'My Custom Model' });
     render(<AIModelsTableRowInfo model={model} />);
@@ -100,108 +33,58 @@ describe('AIModelsTableRowInfo', () => {
     expect(screen.getByText('My Custom Model')).toBeInTheDocument();
   });
 
-  it('should render info icon button', () => {
-    const model = createMockAIModel();
-    render(<AIModelsTableRowInfo model={model} />);
-
-    const infoButton = screen.getByTestId('model-id-icon-button');
-    expect(infoButton).toBeInTheDocument();
-  });
-
-  it('should show popover with model ID when info button is clicked', async () => {
-    const user = userEvent.setup();
-    const model = createMockAIModel({ model_id: 'unique-model-id' });
-    render(<AIModelsTableRowInfo model={model} />);
-
-    const infoButton = screen.getByTestId('model-id-icon-button');
-    await user.click(infoButton);
-
-    expect(screen.getByText(/The model ID is a unique identifier required/i)).toBeInTheDocument();
-    expect(screen.getByText('Model ID')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('unique-model-id')).toBeInTheDocument();
-  });
-
-  it('should render ClipboardCopy component with model ID', async () => {
-    const user = userEvent.setup();
-    const model = createMockAIModel({ model_id: 'test-model-id-456' });
-    render(<AIModelsTableRowInfo model={model} />);
-
-    const infoButton = screen.getByTestId('model-id-icon-button');
-    await user.click(infoButton);
-
-    const clipboardInput = screen.getByDisplayValue('test-model-id-456');
-    expect(clipboardInput).toBeInTheDocument();
-  });
-
   it('should render model info with correct structure', () => {
-    const model = createMockAIModel({
-      display_name: 'Test Display',
-      model_id: 'test-id',
-    });
+    const model = createMockAIModel({ display_name: 'Test Display' });
     render(<AIModelsTableRowInfo model={model} />);
 
-    // Check that display name and button are in the same container
     expect(screen.getByText('Test Display')).toBeInTheDocument();
-    expect(screen.getByTestId('model-id-icon-button')).toBeInTheDocument();
   });
 
-  it('should show explanation text in popover', async () => {
-    const user = userEvent.setup();
+  it('should render Embedding badge for embedding models', () => {
+    const model = createMockAIModel({ model_type: 'embedding' });
+    render(<AIModelsTableRowInfo model={model} />);
+
+    expect(screen.getByText('Embedding')).toBeInTheDocument();
+  });
+
+  it('should not render Embedding badge for non-embedding models', () => {
     const model = createMockAIModel();
     render(<AIModelsTableRowInfo model={model} />);
 
-    const infoButton = screen.getByTestId('model-id-icon-button');
-    await user.click(infoButton);
-
-    expect(
-      screen.getByText(/unique identifier required to locate and access this model/i),
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Embedding')).not.toBeInTheDocument();
   });
 
-  describe('Event Tracking', () => {
-    it('should fire Model_ID_Copied event when model ID is copied', async () => {
-      const user = userEvent.setup();
-      const model = createMockAIModel({ model_id: 'test-copy-id' });
+  describe('ASR badge', () => {
+    it('should render ASR badge when model has audio-transcription modality', () => {
+      const model = createMockAIModel({ modality: 'audio-transcription' });
       render(<AIModelsTableRowInfo model={model} />);
 
-      // Open the popover first
-      const infoButton = screen.getByTestId('model-id-icon-button');
-      await user.click(infoButton);
-
-      // Clear the initial tracking event
-      jest.clearAllMocks();
-
-      // Find and click the copy button
-      const copyButton = screen.getByRole('button', { name: /copy model id/i });
-      await user.click(copyButton);
-
-      expect(fireMiscTrackingEvent).toHaveBeenCalledWith('Available Endpoints Model Id Copied', {});
-    });
-  });
-
-  describe('Clipboard functionality', () => {
-    let writeTextSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      writeTextSpy = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      expect(screen.getByText('ASR')).toBeInTheDocument();
     });
 
-    afterEach(() => {
-      writeTextSpy.mockRestore();
-    });
-
-    it('should copy model ID to clipboard when copy button is clicked', async () => {
-      const user = userEvent.setup();
-      const model = createMockAIModel({ model_id: 'unique-model-id-789' });
+    it('should render ASR badge with data-testid asr-badge', () => {
+      const model = createMockAIModel({ modality: 'audio-transcription' });
       render(<AIModelsTableRowInfo model={model} />);
 
-      const infoButton = screen.getByTestId('model-id-icon-button');
-      await user.click(infoButton);
+      expect(screen.getByTestId('asr-badge')).toBeInTheDocument();
+    });
 
-      const copyButton = screen.getByTestId('clipboard-copy-model-id-copy-button');
-      await user.click(copyButton);
+    it('should not render ASR badge for standard LLM models', () => {
+      const model = createMockAIModel();
+      render(<AIModelsTableRowInfo model={model} />);
 
-      expect(writeTextSpy).toHaveBeenCalledWith('unique-model-id-789');
+      expect(screen.queryByText('ASR')).not.toBeInTheDocument();
+    });
+
+    it('should render both Embedding and ASR badges if model has both', () => {
+      const model = createMockAIModel({
+        model_type: 'embedding',
+        modality: 'audio-transcription',
+      });
+      render(<AIModelsTableRowInfo model={model} />);
+
+      expect(screen.getByText('Embedding')).toBeInTheDocument();
+      expect(screen.getByText('ASR')).toBeInTheDocument();
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   Divider,
   Drawer,
   DrawerContent,
@@ -21,6 +22,7 @@ import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { GenAiContext } from '~/app/context/GenAiContext';
 import useFetchBFFConfig from '~/app/hooks/useFetchBFFConfig';
 import { uploadMediaFile } from '~/app/services/llamaStackService';
+import { useAudioTranscription } from '~/app/Chatbot/hooks/useAudioTranscription';
 import { isLlamaModelEnabled, URL_PREFIX } from '~/app/utilities';
 import { getId } from '~/app/utilities/utils';
 import { TokenInfo, ResponseMetrics } from '~/app/types';
@@ -221,6 +223,13 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   const previewUrlRef = React.useRef<string | null>(null);
   previewUrlRef.current = imageUploadState.previewUrl;
 
+  // Audio transcription state
+  const audioTranscription = useAudioTranscription();
+  const [hasAudioInCurrentMessage, setHasAudioInCurrentMessage] = React.useState(false);
+  const audioUploadLatchRef = React.useRef(false);
+  const [showAudioPerMessageModal, setShowAudioPerMessageModal] = React.useState(false);
+  const [messageBarValue, setMessageBarValue] = React.useState<string>('');
+
   // Revoke unsent image preview blob URL on unmount
   React.useEffect(
     () => () => {
@@ -335,6 +344,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
       }
 
       setPendingDocChips([]);
+      audioUploadLatchRef.current = false;
+      setHasAudioInCurrentMessage(false);
+      setMessageBarValue('');
     },
     [
       setLastInput,
@@ -535,6 +547,64 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     });
   }, [imageUploadState.uploading, imageUploadState.previewUrl]);
 
+  // Audio upload handler
+  const handleAudioUpload = React.useCallback(
+    (file: File) => {
+      if (hasAudioInCurrentMessage || audioUploadLatchRef.current) {
+        setShowAudioPerMessageModal(true);
+        return;
+      }
+      if (!primarySelectedAsrModel) {
+        return;
+      }
+      audioUploadLatchRef.current = true;
+      setHasAudioInCurrentMessage(true);
+      audioTranscription.startUpload(file, primarySelectedAsrModel, namespace?.name || '');
+    },
+    [hasAudioInCurrentMessage, primarySelectedAsrModel, namespace?.name, audioTranscription],
+  );
+
+  const handleAudioCancel = React.useCallback(() => {
+    audioTranscription.abort();
+    audioUploadLatchRef.current = false;
+    setHasAudioInCurrentMessage(false);
+  }, [audioTranscription]);
+
+  // Append transcribed text to message bar on completion
+  const { phase, transcribedText } = audioTranscription.state;
+  React.useEffect(() => {
+    if (phase === 'complete' && transcribedText) {
+      setMessageBarValue((prev) => {
+        const trimmed = prev.trim();
+        if (trimmed) {
+          return `${trimmed}\n${transcribedText}`;
+        }
+        return transcribedText;
+      });
+      audioUploadLatchRef.current = false;
+      audioTranscription.reset();
+    }
+  }, [phase, transcribedText, audioTranscription]);
+
+  // Reset audio state on error
+  React.useEffect(() => {
+    if (audioTranscription.state.phase === 'error') {
+      audioUploadLatchRef.current = false;
+      setHasAudioInCurrentMessage(false);
+    }
+  }, [audioTranscription.state.phase]);
+
+  // Allow re-upload when user clears transcribed text from input
+  React.useEffect(() => {
+    if (
+      hasAudioInCurrentMessage &&
+      !messageBarValue.trim() &&
+      audioTranscription.state.phase === 'idle'
+    ) {
+      setHasAudioInCurrentMessage(false);
+    }
+  }, [messageBarValue, hasAudioInCurrentMessage, audioTranscription.state.phase]);
+
   const openSettingsToTab = location.state?.openSettingsToTab;
 
   // Effects
@@ -624,6 +694,10 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         setHasImageInConversation(false);
         handleRemoveImage();
         setPendingDocChips([]);
+        audioTranscription.abort();
+        audioUploadLatchRef.current = false;
+        setHasAudioInCurrentMessage(false);
+        setMessageBarValue('');
       };
     }
     return () => {
@@ -631,7 +705,7 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         ref.current = null;
       }
     };
-  }, [clearAllMessagesRef, handleRemoveImage]);
+  }, [clearAllMessagesRef, handleRemoveImage, audioTranscription]);
 
   // Expose hasConversationMessages to parent (beyond the initial welcome message)
   React.useEffect(() => {
@@ -741,6 +815,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
             setHasImageInConversation(false);
             handleRemoveImage();
             setPendingDocChips([]);
+            audioTranscription.abort();
+            setHasAudioInCurrentMessage(false);
+            setMessageBarValue('');
             if (isCompareMode) {
               fireMiscTrackingEvent('Playground Compare Chat Cleared', { success: true });
             }
@@ -834,7 +911,10 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                   !primarySelectedModel ||
                   Array.from(disabledStates.values()).some(Boolean) ||
                   imageUploadState.uploading ||
-                  pendingDocChips.some((c) => c.status === 'uploading')
+                  pendingDocChips.some((c) => c.status === 'uploading') ||
+                  audioTranscription.state.phase === 'uploading' ||
+                  audioTranscription.state.phase === 'transcribing' ||
+                  audioTranscription.state.phase === 'complete'
                 }
                 showAttachButton={!isCompareMode && !isEmbedded}
                 onDocumentAttach={handleAttach}
@@ -849,9 +929,14 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                     ? 'Select a transcription model in settings to enable audio upload'
                     : undefined
                 }
+                onAudioUpload={handleAudioUpload}
+                audioTranscriptionState={audioTranscription.state}
+                onAudioCancel={handleAudioCancel}
                 pendingDocChips={pendingDocChips}
                 onRemoveDocChip={handleRemoveDocChip}
                 alwaysShowSendButton={hasReadyAttachments}
+                messageBarValue={messageBarValue}
+                onMessageBarValueChange={setMessageBarValue}
               />
             </div>
           </DrawerContentBody>
@@ -893,6 +978,30 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
               onSubmit={handleReplaceMediaConfirm}
               onCancel={handleReplaceMediaCancel}
             />
+          </ModalFooter>
+        </Modal>
+      )}
+
+      {showAudioPerMessageModal && (
+        <Modal
+          isOpen
+          onClose={() => setShowAudioPerMessageModal(false)}
+          variant="small"
+          data-testid="audio-per-message-modal"
+        >
+          <ModalHeader title="Audio already attached" />
+          <ModalBody>
+            Only one audio file can be transcribed per message. Send the current message or clear
+            the transcription to attach another audio file.
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="primary"
+              onClick={() => setShowAudioPerMessageModal(false)}
+              data-testid="audio-per-message-modal-ok"
+            >
+              OK
+            </Button>
           </ModalFooter>
         </Modal>
       )}

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -49,6 +49,8 @@ import CloseChatCompareModal from './components/CloseChatCompareModal';
 import {
   useChatbotConfigStore,
   selectSelectedModel,
+  selectSelectedAsrModel,
+  selectIsAsrModelEnabled,
   selectConfigIds,
   DEFAULT_CONFIG_ID,
   getConfigDisplayLabel,
@@ -147,6 +149,10 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
   const isCompareMode = configIds.length > 1;
   const primaryConfigId = configIds[0] || DEFAULT_CONFIG_ID;
   const primarySelectedModel = useChatbotConfigStore(selectSelectedModel(primaryConfigId));
+  const primarySelectedAsrModel = useChatbotConfigStore(selectSelectedAsrModel(primaryConfigId));
+  const primaryIsAsrEnabled = useChatbotConfigStore(selectIsAsrModelEnabled(primaryConfigId));
+
+  const isAudioUploadDisabled = !primaryIsAsrEnabled || !primarySelectedAsrModel;
 
   // Router state
   const location = useLocation();
@@ -837,7 +843,12 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
                 imageUploadState={imageUploadState}
                 onRemoveImage={handleRemoveImage}
                 isImageUploadDisabled={hasImageInConversation}
-                isAudioUploadDisabled
+                isAudioUploadDisabled={isAudioUploadDisabled}
+                audioDisabledTooltip={
+                  isAudioUploadDisabled
+                    ? 'Select a transcription model in settings to enable audio upload'
+                    : undefined
+                }
                 pendingDocChips={pendingDocChips}
                 onRemoveDocChip={handleRemoveDocChip}
                 alwaysShowSendButton={hasReadyAttachments}

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotPlayground.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotPlayground.spec.tsx
@@ -120,6 +120,7 @@ jest.mock('~/app/hooks/useMCPServerStatuses', () => ({
 
 jest.mock('~/app/services/llamaStackService', () => ({
   uploadMediaFile: jest.fn(),
+  transcribeAudio: jest.fn(),
 }));
 
 jest.mock('~/app/context/UserContext', () => ({
@@ -254,6 +255,8 @@ jest.mock('@patternfly/chatbot', () => {
       hasStopButton?: boolean;
       handleStopButton?: () => void;
       alwayShowSendButton?: boolean;
+      value?: string;
+      onChange?: (e: unknown, val: string) => void;
       attachMenuProps?: {
         isAttachMenuOpen: boolean;
         setIsAttachMenuOpen: (v: boolean) => void;
@@ -289,6 +292,17 @@ jest.mock('@patternfly/chatbot', () => {
           },
           'Send Empty',
         ),
+        props.onChange
+          ? React.createElement(
+              'button',
+              {
+                'data-testid': 'clear-message-button',
+                onClick: () => props.onChange!(null, ''),
+                type: 'button',
+              },
+              'Clear',
+            )
+          : null,
         props.hasAttachButton && props.attachMenuProps
           ? React.createElement(
               'button',
@@ -1304,5 +1318,238 @@ describe('ChatbotPlayground — inline document chips', () => {
       expect(screen.queryByTestId('replace-media-modal')).not.toBeInTheDocument();
       expect(uploadMediaFile).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('ChatbotPlayground — audio transcription', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uuidCounter = 0;
+    mockFilesWithSettings = [];
+    mockFileManagementFiles = [];
+
+    act(() => {
+      useChatbotConfigStore.setState({
+        configurations: {
+          [DEFAULT_CONFIG_ID]: {
+            ...DEFAULT_CONFIGURATION,
+            selectedModel: 'test-model',
+          },
+        },
+        configIds: [DEFAULT_CONFIG_ID],
+      });
+    });
+  });
+
+  const enableAsrAndRender = () => {
+    renderPlayground();
+    act(() => {
+      useChatbotConfigStore.getState().updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-model');
+      useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+    });
+  };
+
+  it('renders audio file input', () => {
+    renderPlayground();
+    expect(screen.getByTestId('audio-file-input')).toBeInTheDocument();
+  });
+
+  it('audio upload triggers uploadMediaFile with audio type', async () => {
+    const { uploadMediaFile } = require('~/app/services/llamaStackService');
+    uploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: { abort: jest.fn() },
+    });
+
+    enableAsrAndRender();
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file = new File(['audio-data'], 'test.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(uploadMediaFile).toHaveBeenCalledWith(
+        expect.stringContaining('namespace=test-ns'),
+        file,
+        'audio',
+        expect.any(Function),
+      );
+    });
+  });
+
+  it('per-message modal shows when trying to attach second audio', async () => {
+    const { uploadMediaFile } = require('~/app/services/llamaStackService');
+    uploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: { abort: jest.fn() },
+    });
+
+    enableAsrAndRender();
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file1 = new File(['audio-data'], 'first.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file1] } });
+    });
+
+    const file2 = new File(['audio-data'], 'second.wav', { type: 'audio/wav' });
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file2] } });
+    });
+
+    expect(screen.getByTestId('audio-per-message-modal')).toBeInTheDocument();
+  });
+
+  it('send resets hasAudioInCurrentMessage allowing new audio', async () => {
+    const { uploadMediaFile, transcribeAudio } = require('~/app/services/llamaStackService');
+    uploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: { abort: jest.fn() },
+    });
+    transcribeAudio.mockResolvedValue({ text: 'Hello world' });
+
+    enableAsrAndRender();
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file = new File(['audio-data'], 'test.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(transcribeAudio).toHaveBeenCalled();
+    });
+
+    // Send the message
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('send-button'));
+    });
+
+    // Now a new audio upload should work (no per-message modal)
+    const file2 = new File(['audio-data'], 'second.wav', { type: 'audio/wav' });
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file2] } });
+    });
+
+    expect(screen.queryByTestId('audio-per-message-modal')).not.toBeInTheDocument();
+  });
+
+  it('clearing transcribed text resets hasAudioInCurrentMessage allowing new audio', async () => {
+    const { uploadMediaFile, transcribeAudio } = require('~/app/services/llamaStackService');
+    uploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: { abort: jest.fn() },
+    });
+    transcribeAudio.mockResolvedValue({ text: 'Hello world' });
+
+    enableAsrAndRender();
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file = new File(['audio-data'], 'test.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(transcribeAudio).toHaveBeenCalled();
+    });
+
+    // Clear the transcribed text (simulates user selecting all + deleting)
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('clear-message-button'));
+    });
+
+    // Now a new audio upload should work (no per-message modal)
+    const file2 = new File(['audio-data'], 'second.wav', { type: 'audio/wav' });
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file2] } });
+    });
+
+    expect(screen.queryByTestId('audio-per-message-modal')).not.toBeInTheDocument();
+  });
+
+  it('namespace is included in the audio transcription API URL', async () => {
+    const { uploadMediaFile, transcribeAudio } = require('~/app/services/llamaStackService');
+    uploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: { abort: jest.fn() },
+    });
+    transcribeAudio.mockResolvedValue({ text: 'Hello' });
+
+    enableAsrAndRender();
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file = new File(['audio-data'], 'test.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(transcribeAudio).toHaveBeenCalledWith(
+        expect.stringContaining('namespace=test-ns'),
+        'file-123',
+        'whisper-model',
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
+  it('clearAllMessagesRef aborts in-flight audio upload', async () => {
+    const { uploadMediaFile } = require('~/app/services/llamaStackService');
+    const mockXhrAbort = jest.fn();
+    uploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: { abort: mockXhrAbort },
+    });
+
+    const clearAllMessagesRef = { current: null } as React.MutableRefObject<(() => void) | null>;
+
+    render(
+      <MemoryRouter initialEntries={['/gen-ai-studio/playground/test-ns']}>
+        <ChatbotPlayground
+          isViewCodeModalOpen={false}
+          setIsViewCodeModalOpen={jest.fn()}
+          isNewChatModalOpen={false}
+          setIsNewChatModalOpen={jest.fn()}
+          clearAllMessagesRef={clearAllMessagesRef}
+        />
+      </MemoryRouter>,
+    );
+
+    act(() => {
+      useChatbotConfigStore.getState().updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-model');
+      useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+    });
+
+    const audioInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+    const file = new File(['audio-data'], 'test.wav', { type: 'audio/wav' });
+
+    await act(async () => {
+      fireEvent.change(audioInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(uploadMediaFile).toHaveBeenCalled();
+    });
+
+    // Invoke clearAllMessages (same as New Chat confirm)
+    act(() => {
+      clearAllMessagesRef.current?.();
+    });
+
+    expect(mockXhrAbort).toHaveBeenCalled();
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
@@ -5,6 +5,7 @@ import {
   DropEvent,
   MenuItem,
   MenuList,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ChatbotFootnote, FileDetailsLabel, MessageBar } from '@patternfly/chatbot';
 import { FileRejection } from 'react-dropzone';
@@ -47,6 +48,7 @@ interface ChatbotMessageInputProps {
   onRemoveImage: () => void;
   isImageUploadDisabled: boolean;
   isAudioUploadDisabled: boolean;
+  audioDisabledTooltip?: string;
   pendingDocChips?: PendingDocChip[];
   onRemoveDocChip?: (chipId: string) => void;
   alwaysShowSendButton?: boolean;
@@ -65,6 +67,7 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
   onRemoveImage,
   isImageUploadDisabled,
   isAudioUploadDisabled,
+  audioDisabledTooltip,
   pendingDocChips,
   onRemoveDocChip,
   alwaysShowSendButton,
@@ -161,9 +164,21 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
         >
           Upload image
         </MenuItem>
-        <MenuItem icon={<VolumeUpIcon />} isDisabled={isAudioUploadDisabled}>
-          Upload audio
-        </MenuItem>
+        {isAudioUploadDisabled && audioDisabledTooltip ? (
+          <Tooltip content={audioDisabledTooltip} position="left">
+            <MenuItem icon={<VolumeUpIcon />} isAriaDisabled data-testid="upload-audio-menu-item">
+              Upload audio
+            </MenuItem>
+          </Tooltip>
+        ) : (
+          <MenuItem
+            icon={<VolumeUpIcon />}
+            isDisabled={isAudioUploadDisabled}
+            data-testid="upload-audio-menu-item"
+          >
+            Upload audio
+          </MenuItem>
+        )}
         <MenuItem
           icon={<OutlinedFileAltIcon />}
           onClick={() => handleMenuSelect('upload-documents')}
@@ -172,7 +187,7 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
         </MenuItem>
       </MenuList>
     ),
-    [isImageUploadDisabled, isAudioUploadDisabled, handleMenuSelect],
+    [isImageUploadDisabled, isAudioUploadDisabled, audioDisabledTooltip, handleMenuSelect],
   );
 
   return (

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotMessageInput.tsx
@@ -15,7 +15,9 @@ import {
   FILE_UPLOAD_CONFIG,
   ERROR_MESSAGES,
   ALERT_TIMEOUT_MS,
+  AUDIO_UPLOAD_CONFIG,
 } from '~/app/Chatbot/const';
+import { AudioTranscriptionState } from '~/app/Chatbot/hooks/useAudioTranscription';
 
 export interface ImageUploadState {
   uploading: boolean;
@@ -49,9 +51,14 @@ interface ChatbotMessageInputProps {
   isImageUploadDisabled: boolean;
   isAudioUploadDisabled: boolean;
   audioDisabledTooltip?: string;
+  onAudioUpload?: (file: File) => void;
+  audioTranscriptionState?: AudioTranscriptionState;
+  onAudioCancel?: () => void;
   pendingDocChips?: PendingDocChip[];
   onRemoveDocChip?: (chipId: string) => void;
   alwaysShowSendButton?: boolean;
+  messageBarValue?: string;
+  onMessageBarValueChange?: (value: string) => void;
 }
 
 const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
@@ -68,14 +75,45 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
   isImageUploadDisabled,
   isAudioUploadDisabled,
   audioDisabledTooltip,
+  onAudioUpload,
+  audioTranscriptionState,
+  onAudioCancel,
   pendingDocChips,
   onRemoveDocChip,
   alwaysShowSendButton,
+  messageBarValue,
+  onMessageBarValueChange,
 }) => {
   const [isAttachMenuOpen, setIsAttachMenuOpen] = React.useState(false);
   const [validationError, setValidationError] = React.useState<string | null>(null);
   const imageInputRef = React.useRef<HTMLInputElement>(null);
+  const audioInputRef = React.useRef<HTMLInputElement>(null);
   const documentInputRef = React.useRef<HTMLInputElement>(null);
+  const messageBarTextareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const audioPhase = audioTranscriptionState?.phase || 'idle';
+  const isAudioActive = audioPhase === 'uploading' || audioPhase === 'transcribing';
+
+  // PatternFly MessageBar only reads the `value` prop at mount time (internal useState).
+  // When messageBarValue changes programmatically (e.g. from transcription), we must
+  // force-sync the textarea via native setter + event dispatch.
+  React.useEffect(() => {
+    const textarea = messageBarTextareaRef.current;
+    if (!textarea || messageBarValue === undefined) {
+      return;
+    }
+    if (textarea.value === messageBarValue) {
+      return;
+    }
+    const nativeTextAreaValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      'value',
+    )?.set;
+    if (nativeTextAreaValueSetter) {
+      nativeTextAreaValueSetter.call(textarea, messageBarValue);
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }, [messageBarValue]);
 
   React.useEffect(() => {
     if (!validationError) {
@@ -89,6 +127,8 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
     setIsAttachMenuOpen(false);
     if (action === 'upload-image') {
       imageInputRef.current?.click();
+    } else if (action === 'upload-audio') {
+      audioInputRef.current?.click();
     } else if (action === 'upload-documents') {
       documentInputRef.current?.click();
     }
@@ -117,6 +157,38 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
       onImageUpload(file);
     },
     [onImageUpload],
+  );
+
+  const handleAudioFileSelect = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      // eslint-disable-next-line no-param-reassign
+      event.target.value = '';
+
+      let mimeType = file.type;
+      if (!mimeType) {
+        const ext = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+        mimeType = AUDIO_UPLOAD_CONFIG.EXTENSION_TO_MIME[ext] || '';
+      }
+
+      if (!AUDIO_UPLOAD_CONFIG.ALLOWED_MIME_TYPES.includes(mimeType)) {
+        setValidationError(
+          `${file.name} is not a supported audio file type. Accepted types: WAV, MP3.`,
+        );
+        return;
+      }
+      if (file.size > AUDIO_UPLOAD_CONFIG.MAX_FILE_SIZE) {
+        setValidationError(
+          `${file.name} exceeds maximum size of ${AUDIO_UPLOAD_CONFIG.MAX_FILE_SIZE / (1024 * 1024)} MB. Try a smaller file.`,
+        );
+        return;
+      }
+      onAudioUpload?.(file);
+    },
+    [onAudioUpload],
   );
 
   const handleDocumentFileSelect = React.useCallback(
@@ -154,6 +226,24 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
     [onDocumentAttach],
   );
 
+  const audioAnnounceText = React.useMemo(() => {
+    if (!audioTranscriptionState) {
+      return '';
+    }
+    switch (audioTranscriptionState.phase) {
+      case 'uploading':
+        return `Uploading ${audioTranscriptionState.fileName}`;
+      case 'transcribing':
+        return `Transcribing audio with speech recognition model`;
+      case 'complete':
+        return 'Transcription ready';
+      case 'error':
+        return `Transcription failed: ${audioTranscriptionState.error?.title ?? 'Unknown error'}`;
+      default:
+        return '';
+    }
+  }, [audioTranscriptionState]);
+
   const attachMenuItems = React.useMemo(
     () => (
       <MenuList>
@@ -174,6 +264,7 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           <MenuItem
             icon={<VolumeUpIcon />}
             isDisabled={isAudioUploadDisabled}
+            onClick={() => handleMenuSelect('upload-audio')}
             data-testid="upload-audio-menu-item"
           >
             Upload audio
@@ -199,7 +290,17 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           ? 'var(--pf-t--global--dark--background--color--100)'
           : 'var(--pf-t--global--background--color--100)',
       }}
+      aria-busy={isAudioActive}
     >
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="pf-v6-screen-reader"
+        data-testid="audio-aria-live"
+      >
+        {audioAnnounceText}
+      </div>
       {validationError && (
         <div style={{ paddingBottom: '0.5rem' }}>
           <Alert
@@ -211,7 +312,22 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
           />
         </div>
       )}
-      {(imageUploadState.fileName || (pendingDocChips && pendingDocChips.length > 0)) && (
+      {audioTranscriptionState?.phase === 'error' && audioTranscriptionState.error && (
+        <div style={{ paddingBottom: '0.5rem' }}>
+          <Alert
+            variant={audioTranscriptionState.error.variant}
+            isInline
+            title={audioTranscriptionState.error.title}
+            actionClose={<AlertActionCloseButton onClose={onAudioCancel} />}
+            data-testid="audio-transcription-error"
+          >
+            <p>{audioTranscriptionState.error.description}</p>
+          </Alert>
+        </div>
+      )}
+      {(imageUploadState.fileName ||
+        isAudioActive ||
+        (pendingDocChips && pendingDocChips.length > 0)) && (
         <div
           style={{
             display: 'flex',
@@ -219,6 +335,7 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
             gap: '0.5rem',
             paddingBottom: '0.5rem',
           }}
+          aria-busy={isAudioActive}
         >
           {imageUploadState.fileName && (
             <FileDetailsLabel
@@ -228,6 +345,16 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
               hasTruncation
               variant="outline"
               data-testid="vision-file-preview"
+            />
+          )}
+          {isAudioActive && audioTranscriptionState && (
+            <FileDetailsLabel
+              fileName={audioTranscriptionState.fileName}
+              isLoading
+              onClose={onAudioCancel}
+              hasTruncation
+              variant="outline"
+              data-testid="audio-file-chip"
             />
           )}
           {pendingDocChips?.map((chip) => (
@@ -255,19 +382,37 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
               onSendMessage(message);
             }
           }}
+          innerRef={messageBarTextareaRef}
           handleStopButton={onStopStreaming}
           hasAttachButton={showAttachButton}
           isSendButtonDisabled={isSendDisabled}
           hasStopButton={isLoading}
           alwayShowSendButton={alwaysShowSendButton}
           data-testid="chatbot-message-bar"
+          {...(messageBarValue !== undefined
+            ? {
+                value: messageBarValue,
+                onChange: (_e: React.ChangeEvent<HTMLTextAreaElement>, val: string | number) =>
+                  onMessageBarValueChange?.(String(val)),
+              }
+            : {})}
+          {...(audioPhase === 'transcribing'
+            ? {
+                placeholder: 'Transcribing audio… This may take up to 2 minutes.',
+                readOnly: true,
+              }
+            : {})}
           {...(showAttachButton
             ? {
                 attachMenuProps: {
-                  isAttachMenuOpen,
+                  isAttachMenuOpen: isAudioActive ? false : isAttachMenuOpen,
                   setIsAttachMenuOpen,
                   attachMenuItems,
-                  onAttachMenuToggleClick: () => setIsAttachMenuOpen(!isAttachMenuOpen),
+                  onAttachMenuToggleClick: () => {
+                    if (!isAudioActive) {
+                      setIsAttachMenuOpen(!isAttachMenuOpen);
+                    }
+                  },
                 },
               }
             : {})}
@@ -275,6 +420,11 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
             attach: {
               tooltipContent: 'Attach',
               inputTestId: 'chatbot-attach-input',
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              props: {
+                disabled: isAudioActive,
+                'aria-disabled': isAudioActive,
+              } as React.ComponentProps<'button'>,
             },
             send: {
               // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -292,6 +442,14 @@ const ChatbotMessageInput: React.FC<ChatbotMessageInputProps> = ({
         style={{ display: 'none' }}
         onChange={handleImageFileSelect}
         data-testid="vision-file-input"
+      />
+      <input
+        ref={audioInputRef}
+        type="file"
+        accept={AUDIO_UPLOAD_CONFIG.ACCEPTED_EXTENSIONS}
+        style={{ display: 'none' }}
+        onChange={handleAudioFileSelect}
+        data-testid="audio-file-input"
       />
       <input
         ref={documentInputRef}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ChatbotSettingsPanel.tsx
@@ -267,6 +267,7 @@ const ChatbotSettingsPanel: React.FunctionComponent<ChatbotSettingsPanelProps> =
             data-testid="chatbot-settings-page-tab-model"
           >
             <ModelTabContent
+              configId={configId}
               temperature={temperature}
               onTemperatureChange={handleTemperatureChange}
               isStreamingEnabled={isStreamingEnabled}

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
@@ -95,19 +95,22 @@ jest.mock('@patternfly/react-core', () => ({
     children,
     icon,
     isDisabled,
+    isAriaDisabled,
     onClick,
   }: {
     children: React.ReactNode;
     icon?: React.ReactNode;
     isDisabled?: boolean;
+    isAriaDisabled?: boolean;
     onClick?: () => void;
   }) => {
     const label = typeof children === 'string' ? children : 'unknown';
     return (
       <button
         data-testid={`menu-item-${label.replace(/\s+/g, '-').toLowerCase()}`}
-        onClick={isDisabled ? undefined : onClick}
+        onClick={isDisabled || isAriaDisabled ? undefined : onClick}
         disabled={isDisabled}
+        aria-disabled={isAriaDisabled}
         type="button"
       >
         {icon}
@@ -117,6 +120,23 @@ jest.mock('@patternfly/react-core', () => ({
   },
   MenuList: ({ children }: { children: React.ReactNode }) => (
     <ul data-testid="mock-menu-list">{children}</ul>
+  ),
+  Tooltip: ({
+    children,
+    content,
+    position,
+  }: {
+    children: React.ReactNode;
+    content?: string;
+    position?: string;
+  }) => (
+    <span
+      data-testid="tooltip-wrapper"
+      data-tooltip-content={content}
+      data-tooltip-position={position}
+    >
+      {children}
+    </span>
   ),
 }));
 
@@ -221,14 +241,62 @@ describe('ChatbotMessageInput', () => {
       expect(imageItem).toBeDisabled();
     });
 
-    it('"Upload audio" is always disabled', async () => {
+    it('"Upload audio" is disabled when isAudioUploadDisabled is true', async () => {
       const user = userEvent.setup();
-      render(<ChatbotMessageInput {...defaultProps} />);
+      render(<ChatbotMessageInput {...defaultProps} isAudioUploadDisabled />);
 
       await user.click(screen.getByTestId('mock-attach-toggle'));
 
       const audioItem = screen.getByTestId('menu-item-upload-audio');
       expect(audioItem).toBeDisabled();
+    });
+
+    it('"Upload audio" uses isAriaDisabled with tooltip when audioDisabledTooltip is provided', async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled
+          audioDisabledTooltip="Select a transcription model"
+        />,
+      );
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+
+      const audioItem = screen.getByTestId('menu-item-upload-audio');
+      expect(audioItem).toHaveAttribute('aria-disabled', 'true');
+      expect(audioItem).not.toBeDisabled();
+      const tooltipWrapper = screen.getByTestId('tooltip-wrapper');
+      expect(tooltipWrapper).toHaveAttribute(
+        'data-tooltip-content',
+        'Select a transcription model',
+      );
+    });
+
+    it('tooltip is positioned to the left of the disabled audio menu item', async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled
+          audioDisabledTooltip="Select a transcription model"
+        />,
+      );
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+
+      const tooltipWrapper = screen.getByTestId('tooltip-wrapper');
+      expect(tooltipWrapper).toHaveAttribute('data-tooltip-position', 'left');
+    });
+
+    it('"Upload audio" is enabled when isAudioUploadDisabled is false', async () => {
+      const user = userEvent.setup();
+      render(<ChatbotMessageInput {...defaultProps} isAudioUploadDisabled={false} />);
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+
+      const audioItem = screen.getByTestId('menu-item-upload-audio');
+      expect(audioItem).not.toBeDisabled();
     });
 
     it('clicking "Upload image" triggers the hidden file input', async () => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ChatbotMessageInput.spec.tsx
@@ -5,7 +5,8 @@ import ChatbotMessageInput, {
   ImageUploadState,
   PendingDocChip,
 } from '~/app/Chatbot/components/ChatbotMessageInput';
-import { VISION_UPLOAD_CONFIG } from '~/app/Chatbot/const';
+import { VISION_UPLOAD_CONFIG, AUDIO_UPLOAD_CONFIG } from '~/app/Chatbot/const';
+import { AudioTranscriptionState } from '~/app/Chatbot/hooks/useAudioTranscription';
 
 jest.mock('@patternfly/chatbot', () => ({
   MessageBar: ({
@@ -756,6 +757,276 @@ describe('ChatbotMessageInput', () => {
       );
       const messageBar = container.querySelector('[data-testid="chatbot-message-bar"]');
       expect(messageBar).toBeInTheDocument();
+    });
+  });
+
+  describe('audio upload', () => {
+    const defaultAudioState: AudioTranscriptionState = {
+      phase: 'idle',
+      fileName: '',
+      uploadProgress: 0,
+      error: null,
+      transcribedText: '',
+    };
+
+    it('clicking "Upload audio" triggers the hidden audio file input', async () => {
+      const user = userEvent.setup();
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const clickSpy = jest.spyOn(fileInput, 'click');
+
+      await user.click(screen.getByTestId('mock-attach-toggle'));
+      await user.click(screen.getByTestId('menu-item-upload-audio'));
+
+      expect(clickSpy).toHaveBeenCalled();
+      clickSpy.mockRestore();
+    });
+
+    it('calls onAudioUpload with valid WAV file', () => {
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const file = new File(['audio-data'], 'recording.wav', { type: 'audio/wav' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnAudioUpload).toHaveBeenCalledWith(file);
+    });
+
+    it('calls onAudioUpload with valid MP3 file', () => {
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const file = new File(['audio-data'], 'song.mp3', { type: 'audio/mpeg' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnAudioUpload).toHaveBeenCalledWith(file);
+    });
+
+    it('rejects unsupported audio file type', () => {
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const file = new File(['audio-data'], 'track.ogg', { type: 'audio/ogg' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnAudioUpload).not.toHaveBeenCalled();
+      expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      expect(screen.getByText(/not a supported audio file type/)).toBeInTheDocument();
+    });
+
+    it('rejects audio file exceeding size limit', () => {
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const largeContent = new Uint8Array(AUDIO_UPLOAD_CONFIG.MAX_FILE_SIZE + 1);
+      const file = new File([largeContent], 'big.wav', { type: 'audio/wav' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnAudioUpload).not.toHaveBeenCalled();
+      expect(screen.getByTestId('vision-validation-error')).toBeInTheDocument();
+      expect(screen.getByText(/exceeds maximum size/)).toBeInTheDocument();
+    });
+
+    it('uses extension fallback when MIME type is empty', () => {
+      const mockOnAudioUpload = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          onAudioUpload={mockOnAudioUpload}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const fileInput = screen.getByTestId('audio-file-input') as HTMLInputElement;
+      const file = new File(['audio-data'], 'recording.wav', { type: '' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      expect(mockOnAudioUpload).toHaveBeenCalledWith(file);
+    });
+
+    it('shows audio chip during uploading phase', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'uploading',
+            fileName: 'recording.wav',
+          }}
+          onAudioCancel={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('audio-file-chip')).toBeInTheDocument();
+    });
+
+    it('shows audio chip during transcribing phase', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'transcribing',
+            fileName: 'recording.wav',
+          }}
+          onAudioCancel={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('audio-file-chip')).toBeInTheDocument();
+    });
+
+    it('passes onAudioCancel as onClose to audio chip', () => {
+      const mockOnAudioCancel = jest.fn();
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'uploading',
+            fileName: 'recording.wav',
+          }}
+          onAudioCancel={mockOnAudioCancel}
+        />,
+      );
+
+      expect(screen.getByTestId('audio-file-chip')).toBeInTheDocument();
+    });
+
+    it('shows error Alert when audio transcription fails', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'error',
+            error: {
+              pattern: 'full-failure',
+              variant: 'danger',
+              title: 'Transcription timed out',
+              description:
+                'The transcription took too long. The audio file may be too large or the model is overloaded.',
+              details: {
+                component: 'Audio Transcription',
+                errorCode: 'timeout',
+                rawMessage: 'Client-side timeout exceeded',
+              },
+              isRetriable: true,
+            },
+          }}
+          onAudioCancel={jest.fn()}
+        />,
+      );
+
+      const alert = screen.getByTestId('audio-transcription-error');
+      expect(alert).toBeInTheDocument();
+      expect(screen.getByText('Transcription timed out')).toBeInTheDocument();
+      expect(screen.getByText(/The transcription took too long/)).toBeInTheDocument();
+    });
+
+    it('shows aria-live announcement during transcription', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'transcribing',
+            fileName: 'recording.wav',
+          }}
+        />,
+      );
+
+      const liveRegion = screen.getByTestId('audio-aria-live');
+      expect(liveRegion).toHaveTextContent('Transcribing audio');
+    });
+
+    it('sets aria-busy on wrapper during active transcription phases', () => {
+      const { container } = render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={{
+            ...defaultAudioState,
+            phase: 'uploading',
+            fileName: 'recording.wav',
+          }}
+        />,
+      );
+
+      const outerDiv = container.firstChild as HTMLElement;
+      expect(outerDiv).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('does not set aria-busy when idle', () => {
+      const { container } = render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      const outerDiv = container.firstChild as HTMLElement;
+      expect(outerDiv).toHaveAttribute('aria-busy', 'false');
+    });
+
+    it('does not show audio chip when idle', () => {
+      render(
+        <ChatbotMessageInput
+          {...defaultProps}
+          isAudioUploadDisabled={false}
+          audioTranscriptionState={defaultAudioState}
+        />,
+      );
+
+      expect(screen.queryByTestId('audio-file-chip')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/ModelTabContent.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/ModelTabContent.tsx
@@ -5,6 +5,7 @@ import TabContentWrapper from '~/app/Chatbot/components/settingsPanelTabs/TabCon
 import ModelParameterFormGroup from '~/app/Chatbot/components/ModelParameterFormGroup';
 import ModelDetailsDropdown from '~/app/Chatbot/components/ModelDetailsDropdown';
 import SubscriptionDropdown from '~/app/Chatbot/components/SubscriptionDropdown';
+import TranscriptionModelSection from '~/app/Chatbot/components/settingsPanelTabs/TranscriptionModelSection';
 
 interface ModelTabContentProps {
   temperature: number;
@@ -17,6 +18,7 @@ interface ModelTabContentProps {
   onModelChange: (model: string) => void;
   selectedSubscription: string;
   onSubscriptionChange: (subscription: string) => void;
+  configId: string;
 }
 
 const ModelTabContent: React.FunctionComponent<ModelTabContentProps> = ({
@@ -29,6 +31,7 @@ const ModelTabContent: React.FunctionComponent<ModelTabContentProps> = ({
   onModelChange,
   selectedSubscription,
   onSubscriptionChange,
+  configId,
 }) => (
   <TabContentWrapper title={title}>
     <Form>
@@ -71,6 +74,7 @@ const ModelTabContent: React.FunctionComponent<ModelTabContentProps> = ({
           data-testid="streaming-toggle"
         />
       </FormGroup>
+      <TranscriptionModelSection configId={configId} />
     </Form>
   </TabContentWrapper>
 );

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/TranscriptionModelSection.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/TranscriptionModelSection.tsx
@@ -1,0 +1,269 @@
+import * as React from 'react';
+import {
+  Button,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  Tooltip,
+} from '@patternfly/react-core';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+
+type CSSCustomProperties = { [key: `--${string}`]: string | number };
+type ExtendedCSSProperties = React.CSSProperties & CSSCustomProperties;
+import FieldGroupHelpLabelIcon from '@odh-dashboard/internal/components/FieldGroupHelpLabelIcon';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { AIModel } from '~/app/types';
+import useASRModels from '~/app/hooks/useASRModels';
+import { getLlamaModelDisplayName } from '~/app/utilities';
+import {
+  useChatbotConfigStore,
+  selectSelectedAsrModel,
+  selectIsAsrModelEnabled,
+  selectSelectedModel,
+} from '~/app/Chatbot/store';
+
+interface TranscriptionModelSectionProps {
+  configId: string;
+}
+
+const TranscriptionModelSection: React.FunctionComponent<TranscriptionModelSectionProps> = ({
+  configId,
+}) => {
+  const { aiModels, aiModelsLoaded } = React.useContext(ChatbotContext);
+  const asrModels = useASRModels(aiModels);
+
+  const selectedAsrModel = useChatbotConfigStore(selectSelectedAsrModel(configId));
+  const isAsrModelEnabled = useChatbotConfigStore(selectIsAsrModelEnabled(configId));
+  const selectedMainModel = useChatbotConfigStore(selectSelectedModel(configId));
+  const updateSelectedAsrModel = useChatbotConfigStore((s) => s.updateSelectedAsrModel);
+  const updateAsrModelEnabled = useChatbotConfigStore((s) => s.updateAsrModelEnabled);
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [staleWarning, setStaleWarning] = React.useState(false);
+
+  const selectContainerRef = React.useRef<HTMLDivElement>(null);
+  const addButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  // Combined effect: auto-select (N=1) + stale detection, gated on aiModelsLoaded
+  React.useEffect(() => {
+    if (!isAsrModelEnabled || !aiModelsLoaded) {
+      return;
+    }
+
+    // Stale: selected model no longer exists in the available list
+    if (selectedAsrModel && !asrModels.some((m) => m.model_id === selectedAsrModel)) {
+      updateSelectedAsrModel(configId, '');
+      setStaleWarning(true);
+      return;
+    }
+
+    // Auto-select when exactly one model available and none selected
+    if (asrModels.length === 1 && !selectedAsrModel) {
+      updateSelectedAsrModel(configId, asrModels[0].model_id);
+      setStaleWarning(false);
+    }
+  }, [
+    isAsrModelEnabled,
+    aiModelsLoaded,
+    asrModels,
+    selectedAsrModel,
+    configId,
+    updateSelectedAsrModel,
+  ]);
+
+  const handleEnable = React.useCallback(() => {
+    updateAsrModelEnabled(configId, true);
+    requestAnimationFrame(() => {
+      const toggle = selectContainerRef.current?.querySelector<HTMLButtonElement>(
+        '[data-testid="asr-model-selector-toggle"]',
+      );
+      toggle?.focus();
+    });
+  }, [configId, updateAsrModelEnabled]);
+
+  const handleRemove = React.useCallback(() => {
+    updateAsrModelEnabled(configId, false);
+    updateSelectedAsrModel(configId, '');
+    setStaleWarning(false);
+    requestAnimationFrame(() => {
+      addButtonRef.current?.focus();
+    });
+  }, [configId, updateAsrModelEnabled, updateSelectedAsrModel]);
+
+  const handleSelect = React.useCallback(
+    (
+      _event: React.MouseEvent<Element, MouseEvent> | undefined,
+      value: string | number | undefined,
+    ) => {
+      if (typeof value === 'string') {
+        updateSelectedAsrModel(configId, value);
+        setStaleWarning(false);
+      }
+      setIsOpen(false);
+    },
+    [configId, updateSelectedAsrModel],
+  );
+
+  const getSelectedDisplayName = (models: AIModel[], modelId: string): string => {
+    const model = models.find((m) => m.model_id === modelId);
+    return model?.display_name || modelId;
+  };
+
+  if (!aiModelsLoaded) {
+    return (
+      <div data-testid="transcription-model-loading">
+        <Spinner size="md" aria-label="Loading transcription models" />
+      </div>
+    );
+  }
+
+  // State 1: Add button (disabled with tooltip when N=0 ASR models)
+  if (!isAsrModelEnabled) {
+    const noModelsAvailable = asrModels.length === 0;
+    const disabledLinkStyle: ExtendedCSSProperties = {
+      '--pf-v6-c-button--disabled--BackgroundColor': 'transparent',
+      '--pf-v6-c-button--disabled--Color': 'var(--pf-t--global--text--color--subtle)',
+      '--pf-v6-c-button--disabled__icon--Color': 'currentColor',
+    };
+    const addButton = (
+      <Button
+        ref={addButtonRef}
+        variant="link"
+        icon={<PlusCircleIcon />}
+        onClick={handleEnable}
+        isAriaDisabled={noModelsAvailable}
+        data-testid="add-transcription-model-btn"
+        aria-label="Add audio transcription model"
+        style={noModelsAvailable ? disabledLinkStyle : undefined}
+      >
+        Add audio transcription model
+      </Button>
+    );
+
+    return (
+      <div
+        className="pf-v6-u-p-md pf-v6-u-mt-md"
+        style={{
+          border: '1px dashed var(--pf-t--global--border--color--default)',
+          borderRadius: 'var(--pf-t--global--border--radius--small)',
+          textAlign: 'center',
+        }}
+        data-testid="transcription-model-add-section"
+      >
+        {noModelsAvailable ? (
+          <Tooltip content="Deploy an ASR model to enable audio transcription">{addButton}</Tooltip>
+        ) : (
+          addButton
+        )}
+      </div>
+    );
+  }
+
+  // State 2/2b: Enabled section
+  const toggleLabel = selectedAsrModel
+    ? getSelectedDisplayName(asrModels, selectedAsrModel)
+    : 'Select a transcription model';
+
+  const mainModelDisplayName = selectedMainModel
+    ? getLlamaModelDisplayName(selectedMainModel, aiModels)
+    : '';
+
+  const helperContent = (() => {
+    if (staleWarning) {
+      return (
+        <HelperTextItem variant="warning">
+          Previously selected model is no longer available.
+        </HelperTextItem>
+      );
+    }
+    if (asrModels.length === 0) {
+      return (
+        <HelperTextItem>
+          No ASR models available.{' '}
+          <a
+            href="https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Deploy an ASR model
+          </a>{' '}
+          to enable audio transcription.
+        </HelperTextItem>
+      );
+    }
+    if (selectedAsrModel && mainModelDisplayName) {
+      return (
+        <HelperTextItem>
+          Audio is transcribed to text, then sent to {mainModelDisplayName}.
+        </HelperTextItem>
+      );
+    }
+    return null;
+  })();
+
+  return (
+    <FormGroup
+      fieldId="asr-model-selector"
+      label="Transcription model"
+      labelHelp={
+        <FieldGroupHelpLabelIcon content="Transcribes audio files to text before sending to the chat model." />
+      }
+      className="pf-v6-u-mt-md"
+    >
+      <div ref={selectContainerRef}>
+        <Select
+          id="asr-model-selector"
+          isOpen={isOpen}
+          selected={selectedAsrModel || undefined}
+          onSelect={handleSelect}
+          onOpenChange={setIsOpen}
+          toggle={(toggleRef) => (
+            <MenuToggle
+              ref={toggleRef}
+              onClick={() => setIsOpen(!isOpen)}
+              isExpanded={isOpen}
+              isDisabled={asrModels.length === 0}
+              isFullWidth
+              data-testid="asr-model-selector-toggle"
+              aria-label="Select a transcription model"
+            >
+              {toggleLabel}
+            </MenuToggle>
+          )}
+        >
+          <SelectList>
+            {asrModels.map((model) => (
+              <SelectOption
+                key={model.model_id}
+                value={model.model_id}
+                data-testid={`asr-model-option-${model.model_id}`}
+              >
+                {model.display_name || model.model_id}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </div>
+      <div aria-live="polite" aria-atomic="true">
+        {helperContent && <HelperText className="pf-v6-u-mt-xs">{helperContent}</HelperText>}
+      </div>
+      <Button
+        variant="link"
+        icon={<MinusCircleIcon />}
+        onClick={handleRemove}
+        className="pf-v6-u-mt-sm"
+        data-testid="remove-transcription-model-btn"
+        aria-label="Remove transcription model"
+      >
+        Remove
+      </Button>
+    </FormGroup>
+  );
+};
+
+export default TranscriptionModelSection;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/ModelTabContent.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/ModelTabContent.spec.tsx
@@ -57,6 +57,13 @@ jest.mock('../../SubscriptionDropdown', () => ({
   default: () => <div data-testid="subscription-dropdown" />,
 }));
 
+jest.mock('../TranscriptionModelSection', () => ({
+  __esModule: true,
+  default: ({ configId }: { configId: string }) => (
+    <div data-testid="transcription-model-section" data-config-id={configId} />
+  ),
+}));
+
 const mockFireMiscTrackingEvent = jest.mocked(fireMiscTrackingEvent);
 
 describe('ModelTabContent', () => {
@@ -69,6 +76,7 @@ describe('ModelTabContent', () => {
     onModelChange: jest.fn(),
     selectedSubscription: '',
     onSubscriptionChange: jest.fn(),
+    configId: 'default',
   };
 
   beforeEach(() => {
@@ -144,5 +152,13 @@ describe('ModelTabContent', () => {
     await user.click(streamingSwitch);
 
     expect(mockOnStreamingToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('renders TranscriptionModelSection with configId', () => {
+    render(<ModelTabContent {...defaultProps} configId="custom-config" />);
+
+    const section = screen.getByTestId('transcription-model-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute('data-config-id', 'custom-config');
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/TranscriptionModelSection.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/TranscriptionModelSection.spec.tsx
@@ -24,7 +24,7 @@ const mockAsrModel = {
   version: '1',
   usecase: 'asr',
   description: '',
-  endpoints: ['http://whisper:8080'],
+  endpoints: ['http://whisper:80'],
   status: 'Running',
   sa_token: { name: '', token_name: '', token: '' },
 } as AIModel;
@@ -40,7 +40,7 @@ const mockAsrModel2 = {
   version: '1',
   usecase: 'asr',
   description: '',
-  endpoints: ['http://whisper-small:8080'],
+  endpoints: ['http://whisper-small:80'],
   status: 'Running',
   sa_token: { name: '', token_name: '', token: '' },
 } as AIModel;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/TranscriptionModelSection.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/TranscriptionModelSection.spec.tsx
@@ -1,0 +1,305 @@
+/* eslint-disable camelcase */
+import * as React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TranscriptionModelSection from '~/app/Chatbot/components/settingsPanelTabs/TranscriptionModelSection';
+import { useChatbotConfigStore, DEFAULT_CONFIG_ID } from '~/app/Chatbot/store';
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { AIModel } from '~/app/types';
+
+jest.mock('@odh-dashboard/internal/components/FieldGroupHelpLabelIcon', () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+const mockAsrModel = {
+  model_id: 'whisper-large-v3',
+  model_name: 'whisper-large-v3',
+  display_name: 'Whisper Large V3',
+  model_source_type: 'namespace',
+  modality: 'audio-transcription',
+  serving_runtime: 'vllm',
+  api_protocol: 'REST',
+  version: '1',
+  usecase: 'asr',
+  description: '',
+  endpoints: ['http://whisper:8080'],
+  status: 'Running',
+  sa_token: { name: '', token_name: '', token: '' },
+} as AIModel;
+
+const mockAsrModel2 = {
+  model_id: 'whisper-small',
+  model_name: 'whisper-small',
+  display_name: 'Whisper Small',
+  model_source_type: 'namespace',
+  modality: 'audio-transcription',
+  serving_runtime: 'vllm',
+  api_protocol: 'REST',
+  version: '1',
+  usecase: 'asr',
+  description: '',
+  endpoints: ['http://whisper-small:8080'],
+  status: 'Running',
+  sa_token: { name: '', token_name: '', token: '' },
+} as AIModel;
+
+const mockChatModel = {
+  model_id: 'llama-3-8b',
+  model_name: 'llama-3-8b',
+  display_name: 'Llama 3 8B',
+  model_source_type: 'namespace',
+  modality: undefined,
+  serving_runtime: 'vllm',
+  api_protocol: 'REST',
+  version: '1',
+  usecase: 'llm',
+  description: '',
+  endpoints: ['http://llama:8080'],
+  status: 'Running',
+  sa_token: { name: '', token_name: '', token: '' },
+} as AIModel;
+
+const baseContextValue = {
+  lsdStatus: null,
+  modelsLoaded: true,
+  lsdStatusLoaded: true,
+  aiModels: [mockChatModel, mockAsrModel, mockAsrModel2],
+  aiModelsLoaded: true,
+  aiModelsError: undefined,
+  maasModels: [],
+  maasModelsLoaded: true,
+  maasModelsError: undefined,
+  models: [],
+  modelsError: undefined,
+  lsdStatusError: undefined,
+  nemoGuardrailsStatus: null,
+  nemoGuardrailsStatusLoaded: true,
+  nemoGuardrailsStatusError: undefined,
+  refresh: jest.fn(),
+  lastInput: '',
+  setLastInput: jest.fn(),
+};
+
+const renderWithContext = (
+  contextOverrides: Partial<React.ContextType<typeof ChatbotContext>> = {},
+  configId = DEFAULT_CONFIG_ID,
+) =>
+  render(
+    <ChatbotContext.Provider
+      value={
+        { ...baseContextValue, ...contextOverrides } as React.ContextType<typeof ChatbotContext>
+      }
+    >
+      <TranscriptionModelSection configId={configId} />
+    </ChatbotContext.Provider>,
+  );
+
+describe('TranscriptionModelSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    act(() => {
+      useChatbotConfigStore.setState({
+        configurations: { [DEFAULT_CONFIG_ID]: { ...DEFAULT_CONFIGURATION } },
+        configIds: [DEFAULT_CONFIG_ID],
+      });
+    });
+  });
+
+  describe('State 1: Add button (not enabled)', () => {
+    it('renders add button when ASR is not enabled', () => {
+      renderWithContext();
+      expect(screen.getByTestId('add-transcription-model-btn')).toBeInTheDocument();
+      expect(screen.queryByTestId('asr-model-selector-toggle')).not.toBeInTheDocument();
+    });
+
+    it('enables ASR section when add button is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithContext();
+
+      await user.click(screen.getByTestId('add-transcription-model-btn'));
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.isAsrModelEnabled).toBe(true);
+    });
+
+    it('disables the add button with aria-disabled when no ASR models exist', () => {
+      renderWithContext({ aiModels: [mockChatModel] });
+      const btn = screen.getByTestId('add-transcription-model-btn');
+      expect(btn).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not enable section when clicking disabled add button (N=0)', async () => {
+      const user = userEvent.setup();
+      renderWithContext({ aiModels: [mockChatModel] });
+
+      await user.click(screen.getByTestId('add-transcription-model-btn'));
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.isAsrModelEnabled).toBe(false);
+    });
+  });
+
+  describe('State 2: Enabled with models available', () => {
+    beforeEach(() => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+      });
+    });
+
+    it('renders the dropdown when enabled', () => {
+      renderWithContext();
+      expect(screen.getByTestId('asr-model-selector-toggle')).toBeInTheDocument();
+    });
+
+    it('renders the remove button when enabled', () => {
+      renderWithContext();
+      expect(screen.getByTestId('remove-transcription-model-btn')).toBeInTheDocument();
+    });
+
+    it('shows model options in dropdown', async () => {
+      const user = userEvent.setup();
+      renderWithContext();
+
+      await user.click(screen.getByTestId('asr-model-selector-toggle'));
+      expect(screen.getByTestId('asr-model-option-whisper-large-v3')).toBeInTheDocument();
+      expect(screen.getByTestId('asr-model-option-whisper-small')).toBeInTheDocument();
+    });
+
+    it('selects a model and updates store', async () => {
+      const user = userEvent.setup();
+      renderWithContext();
+
+      await user.click(screen.getByTestId('asr-model-selector-toggle'));
+      await user.click(screen.getByText('Whisper Large V3'));
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('whisper-large-v3');
+    });
+
+    it('shows helper text with chat model name after selection', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateSelectedModel(DEFAULT_CONFIG_ID, 'llama-3-8b');
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+
+      renderWithContext();
+      expect(screen.getByText(/Audio is transcribed to text/)).toBeInTheDocument();
+    });
+
+    it('removes the section and clears selection', async () => {
+      const user = userEvent.setup();
+      act(() => {
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+      renderWithContext();
+
+      await user.click(screen.getByTestId('remove-transcription-model-btn'));
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.isAsrModelEnabled).toBe(false);
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('');
+    });
+  });
+
+  describe('State 2b: Enabled with no models available', () => {
+    beforeEach(() => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+      });
+    });
+
+    it('shows empty state message when no ASR models', () => {
+      renderWithContext({ aiModels: [mockChatModel] });
+      expect(screen.getByText(/No ASR models available/)).toBeInTheDocument();
+    });
+
+    it('disables the dropdown when no ASR models', () => {
+      renderWithContext({ aiModels: [mockChatModel] });
+      const toggle = screen.getByTestId('asr-model-selector-toggle');
+      expect(toggle).toBeDisabled();
+    });
+  });
+
+  describe('auto-select and stale detection', () => {
+    it('auto-selects when only one ASR model is available', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+      });
+
+      renderWithContext({ aiModels: [mockChatModel, mockAsrModel] });
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('whisper-large-v3');
+    });
+
+    it('shows stale warning when selected model is no longer available', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore.getState().updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'removed-model');
+      });
+
+      renderWithContext();
+
+      expect(
+        screen.getByText(/Previously selected model is no longer available/),
+      ).toBeInTheDocument();
+    });
+
+    it('clears stale model from store when detected', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore.getState().updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'removed-model');
+      });
+
+      renderWithContext();
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('');
+    });
+
+    it('clears stale model when ALL ASR models are removed', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+
+      renderWithContext({ aiModels: [mockChatModel] });
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('');
+      expect(
+        screen.getByText(/Previously selected model is no longer available/),
+      ).toBeInTheDocument();
+    });
+
+    it('clears stale warning when auto-selecting after stale detection', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore.getState().updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'removed-model');
+      });
+
+      renderWithContext({ aiModels: [mockChatModel, mockAsrModel] });
+
+      expect(
+        screen.queryByText(/Previously selected model is no longer available/),
+      ).not.toBeInTheDocument();
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('whisper-large-v3');
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows spinner when models are loading', () => {
+      renderWithContext({ aiModelsLoaded: false });
+      expect(screen.getByTestId('transcription-model-loading')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/const.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/const.ts
@@ -51,6 +51,21 @@ export const VISION_UPLOAD_CONFIG = {
   ACCEPTED_EXTENSIONS: '.jpg,.jpeg,.png',
 } as const;
 
+// Audio upload constants (ASR transcription)
+export const AUDIO_UPLOAD_ALLOWED_MIME_TYPES: readonly string[] = ['audio/wav', 'audio/mpeg'];
+const AUDIO_EXTENSION_TO_MIME: Record<string, string> = {
+  '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg',
+};
+export const AUDIO_UPLOAD_CONFIG = {
+  MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB
+  ALLOWED_MIME_TYPES: AUDIO_UPLOAD_ALLOWED_MIME_TYPES,
+  ACCEPTED_EXTENSIONS: '.wav,.mp3',
+  EXTENSION_TO_MIME: AUDIO_EXTENSION_TO_MIME,
+};
+
+export const AUDIO_TRANSCRIPTION_TIMEOUT_MS = 105_000;
+
 // Job polling constants
 export const JOB_POLLING_CONFIG = {
   INITIAL_DELAY: 1000, // 1 second

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useAudioTranscription.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/__tests__/useAudioTranscription.spec.ts
@@ -1,0 +1,413 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAudioTranscription } from '~/app/Chatbot/hooks/useAudioTranscription';
+import { uploadMediaFile, transcribeAudio } from '~/app/services/llamaStackService';
+
+jest.mock('~/app/services/llamaStackService', () => ({
+  uploadMediaFile: jest.fn(),
+  transcribeAudio: jest.fn(),
+}));
+
+const mockUploadMediaFile = uploadMediaFile as jest.MockedFunction<typeof uploadMediaFile>;
+const mockTranscribeAudio = transcribeAudio as jest.MockedFunction<typeof transcribeAudio>;
+
+const createMockFile = (name = 'test.wav'): File =>
+  new File(['audio-data'], name, { type: 'audio/wav' });
+
+describe('useAudioTranscription', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should initialize with idle state', () => {
+    const { result } = renderHook(() => useAudioTranscription());
+
+    expect(result.current.state.phase).toBe('idle');
+    expect(result.current.state.fileName).toBe('');
+    expect(result.current.state.error).toBeNull();
+    expect(result.current.state.transcribedText).toBe('');
+  });
+
+  it('should transition to uploading on startUpload', () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: xhrMock,
+    });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    expect(result.current.state.phase).toBe('uploading');
+    expect(result.current.state.fileName).toBe('test.wav');
+    expect(mockUploadMediaFile).toHaveBeenCalledWith(
+      expect.stringContaining('namespace=test-ns'),
+      file,
+      'audio',
+      expect.any(Function),
+    );
+  });
+
+  it('should transition to transcribing after upload success', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockReturnValue(
+      new Promise(() => {
+        /* never resolves */
+      }),
+    );
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('transcribing');
+    });
+
+    expect(mockTranscribeAudio).toHaveBeenCalledWith(
+      expect.stringContaining('namespace=test-ns'),
+      'file-123',
+      'whisper-model',
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('should transition to complete after successful transcription', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockResolvedValue({ text: 'Hello world' });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('complete');
+    });
+
+    expect(result.current.state.transcribedText).toBe('Hello world');
+  });
+
+  it('should transition to error on upload failure', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.reject(new Error('Network error during upload')),
+      xhr: xhrMock,
+    });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('error');
+    });
+
+    expect(result.current.state.error).not.toBeNull();
+    expect(result.current.state.error?.title).toBe('Audio transcription failed');
+    expect(result.current.state.error?.description).toBe('Network error during upload');
+    expect(result.current.state.error?.variant).toBe('danger');
+  });
+
+  it('should transition to error on transcription failure', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockRejectedValue(new Error('ASR model unavailable'));
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('error');
+    });
+
+    expect(result.current.state.error).not.toBeNull();
+    expect(result.current.state.error?.title).toBe('Audio transcription failed');
+    expect(result.current.state.error?.description).toBe('ASR model unavailable');
+  });
+
+  it('should handle structured ApiError from transcription', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    const apiError = {
+      error: {
+        component: 'asr' as const,
+        code: 'no_speech',
+        message: 'No speech detected — try a clearer recording',
+        retriable: false,
+      },
+    };
+    mockTranscribeAudio.mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile('interview.wav');
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('error');
+    });
+
+    expect(result.current.state.error).not.toBeNull();
+    expect(result.current.state.error?.title).toBe('No speech detected');
+    expect(result.current.state.error?.description).toContain('No speech was found');
+    expect(result.current.state.error?.isRetriable).toBe(false);
+  });
+
+  it('should handle empty transcription result', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockResolvedValue({ text: '   ' });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile('silence.wav');
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('error');
+    });
+
+    expect(result.current.state.error).not.toBeNull();
+    expect(result.current.state.error?.title).toBe('No speech detected');
+    expect(result.current.state.error?.description).toContain('silence.wav');
+  });
+
+  it('should timeout after AUDIO_TRANSCRIPTION_TIMEOUT_MS', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockReturnValue(
+      new Promise(() => {
+        /* never resolves */
+      }),
+    );
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('transcribing');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(105_000);
+    });
+
+    expect(result.current.state.phase).toBe('error');
+    expect(result.current.state.error).not.toBeNull();
+    expect(result.current.state.error?.title).toBe('Transcription timed out');
+    expect(result.current.state.error?.isRetriable).toBe(true);
+  });
+
+  it('should abort on explicit abort call', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: xhrMock,
+    });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    expect(result.current.state.phase).toBe('uploading');
+
+    act(() => {
+      result.current.abort();
+    });
+
+    expect(result.current.state.phase).toBe('idle');
+    expect(xhrMock.abort).toHaveBeenCalled();
+  });
+
+  it('should reset state', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.resolve({ data: { id: 'file-123' } }),
+      xhr: xhrMock,
+    });
+    mockTranscribeAudio.mockResolvedValue({ text: 'Hello' });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('complete');
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state.phase).toBe('idle');
+    expect(result.current.state.transcribedText).toBe('');
+  });
+
+  it('should ignore stale upload responses when a new upload starts', async () => {
+    const xhrMock1 = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    const xhrMock2 = { abort: jest.fn() } as unknown as XMLHttpRequest;
+
+    let resolveFirst: (value: { data: { id: string } }) => void;
+    const firstUploadPromise = new Promise<{ data: { id: string } }>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    mockUploadMediaFile
+      .mockReturnValueOnce({ promise: firstUploadPromise, xhr: xhrMock1 })
+      .mockReturnValueOnce({
+        promise: Promise.resolve({ data: { id: 'file-456' } }),
+        xhr: xhrMock2,
+      });
+    mockTranscribeAudio.mockResolvedValue({ text: 'Second recording' });
+
+    const { result } = renderHook(() => useAudioTranscription());
+
+    act(() => {
+      result.current.startUpload(createMockFile('first.wav'), 'model', 'ns');
+    });
+
+    act(() => {
+      result.current.startUpload(createMockFile('second.wav'), 'model', 'ns');
+    });
+
+    expect(xhrMock1.abort).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(result.current.state.phase).toBe('complete');
+    });
+
+    expect(result.current.state.transcribedText).toBe('Second recording');
+
+    // Late resolution of first upload should not affect state
+    resolveFirst!({ data: { id: 'file-old' } });
+    await waitFor(() => {
+      expect(result.current.state.transcribedText).toBe('Second recording');
+    });
+  });
+
+  it('should not transition to error on upload abort', async () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: Promise.reject(new Error('Upload aborted')),
+      xhr: xhrMock,
+    });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    // Should stay in uploading briefly, then cleanup silently
+    await waitFor(() => {
+      expect(result.current.state.phase).not.toBe('error');
+    });
+  });
+
+  it('should track upload progress', () => {
+    let progressCallback: ((percent: number) => void) | undefined;
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockImplementation((_url, _file, _type, onProgress) => {
+      progressCallback = onProgress;
+      return {
+        promise: new Promise(() => {
+          /* never resolves */
+        }),
+        xhr: xhrMock,
+      };
+    });
+
+    const { result } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    act(() => {
+      progressCallback?.(50);
+    });
+
+    expect(result.current.state.uploadProgress).toBe(50);
+  });
+
+  it('should cleanup on unmount', () => {
+    const xhrMock = { abort: jest.fn() } as unknown as XMLHttpRequest;
+    mockUploadMediaFile.mockReturnValue({
+      promise: new Promise(() => {
+        /* never resolves */
+      }),
+      xhr: xhrMock,
+    });
+
+    const { result, unmount } = renderHook(() => useAudioTranscription());
+    const file = createMockFile();
+
+    act(() => {
+      result.current.startUpload(file, 'whisper-model', 'test-ns');
+    });
+
+    unmount();
+    expect(xhrMock.abort).toHaveBeenCalled();
+  });
+});

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useAudioTranscription.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useAudioTranscription.ts
@@ -1,0 +1,213 @@
+import * as React from 'react';
+import { uploadMediaFile, transcribeAudio } from '~/app/services/llamaStackService';
+import { AUDIO_TRANSCRIPTION_TIMEOUT_MS } from '~/app/Chatbot/const';
+import { URL_PREFIX } from '~/app/utilities';
+import { classifyError } from '~/app/utilities/errorClassifier';
+import { ClassifiedError, isApiError } from '~/app/types';
+
+export type AudioTranscriptionPhase = 'idle' | 'uploading' | 'transcribing' | 'complete' | 'error';
+
+export interface AudioTranscriptionState {
+  phase: AudioTranscriptionPhase;
+  fileName: string;
+  uploadProgress: number;
+  error: ClassifiedError | null;
+  transcribedText: string;
+}
+
+const INITIAL_STATE: AudioTranscriptionState = {
+  phase: 'idle',
+  fileName: '',
+  uploadProgress: 0,
+  error: null,
+  transcribedText: '',
+};
+
+interface UseAudioTranscriptionReturn {
+  state: AudioTranscriptionState;
+  startUpload: (file: File, asrModelId: string, namespace: string) => void;
+  abort: () => void;
+  reset: () => void;
+}
+
+export const useAudioTranscription = (): UseAudioTranscriptionReturn => {
+  const [state, setState] = React.useState<AudioTranscriptionState>(INITIAL_STATE);
+
+  const abortControllerRef = React.useRef<AbortController | null>(null);
+  const xhrRef = React.useRef<XMLHttpRequest | null>(null);
+  const uploadGenRef = React.useRef(0);
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cleanup = React.useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    if (xhrRef.current) {
+      xhrRef.current.abort();
+      xhrRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => cleanup, [cleanup]);
+
+  const abort = React.useCallback(() => {
+    cleanup();
+    uploadGenRef.current += 1;
+    setState(INITIAL_STATE);
+  }, [cleanup]);
+
+  const reset = React.useCallback(() => {
+    setState(INITIAL_STATE);
+  }, []);
+
+  const startUpload = React.useCallback(
+    (file: File, asrModelId: string, namespace: string) => {
+      cleanup();
+      uploadGenRef.current += 1;
+      const gen = uploadGenRef.current;
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setState({
+        phase: 'uploading',
+        fileName: file.name,
+        uploadProgress: 0,
+        error: null,
+        transcribedText: '',
+      });
+
+      const url = `${URL_PREFIX}/api/v1/lsd/files/media?namespace=${encodeURIComponent(namespace)}`;
+      const { promise, xhr } = uploadMediaFile(url, file, 'audio', (percent) => {
+        if (uploadGenRef.current === gen) {
+          setState((prev) => ({ ...prev, uploadProgress: percent }));
+        }
+      });
+      xhrRef.current = xhr;
+
+      promise
+        .then((response) => {
+          if (uploadGenRef.current !== gen) {
+            return;
+          }
+          xhrRef.current = null;
+
+          setState((prev) => ({ ...prev, phase: 'transcribing', uploadProgress: 100 }));
+
+          timeoutRef.current = setTimeout(() => {
+            if (uploadGenRef.current === gen) {
+              controller.abort();
+              setState((prev) => ({
+                ...prev,
+                phase: 'error',
+                error: {
+                  pattern: 'full-failure',
+                  variant: 'danger',
+                  title: 'Transcription timed out',
+                  description:
+                    'The transcription took too long. The audio file may be too large or the model is overloaded.',
+                  details: {
+                    component: 'Audio Transcription',
+                    errorCode: 'timeout',
+                    rawMessage: 'Client-side timeout exceeded',
+                  },
+                  isRetriable: true,
+                },
+              }));
+            }
+          }, AUDIO_TRANSCRIPTION_TIMEOUT_MS);
+
+          const transcribeUrl = `${URL_PREFIX}/api/v1/lsd/audio/transcriptions?namespace=${encodeURIComponent(namespace)}`;
+          return transcribeAudio(transcribeUrl, response.data.id, asrModelId, controller.signal);
+        })
+        .then((result) => {
+          if (uploadGenRef.current !== gen || !result) {
+            return;
+          }
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+          }
+
+          if (!result.text || !result.text.trim()) {
+            setState((prev) => ({
+              ...prev,
+              phase: 'error',
+              error: {
+                pattern: 'full-failure',
+                variant: 'danger',
+                title: 'No speech detected',
+                description: `No speech was found in ${file.name}. Try a clearer recording.`,
+                details: {
+                  component: 'Audio Transcription',
+                  errorCode: 'no_speech',
+                  rawMessage: 'Empty transcription result',
+                },
+                isRetriable: false,
+              },
+            }));
+            return;
+          }
+
+          setState((prev) => ({
+            ...prev,
+            phase: 'complete',
+            transcribedText: result.text,
+          }));
+        })
+        .catch((error: unknown) => {
+          if (uploadGenRef.current !== gen) {
+            return;
+          }
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+          }
+
+          if (error instanceof Error && error.name === 'AbortError') {
+            return;
+          }
+          if (error instanceof Error && error.message === 'Upload aborted') {
+            return;
+          }
+
+          let classified: ClassifiedError;
+          if (isApiError(error)) {
+            classified = classifyError(error);
+          } else {
+            const rawMessage =
+              error instanceof Error ? error.message : 'An unexpected error occurred.';
+            classified = {
+              pattern: 'full-failure',
+              variant: 'danger',
+              title: 'Audio transcription failed',
+              description: rawMessage,
+              details: {
+                component: 'Audio Transcription',
+                errorCode: 'UNKNOWN',
+                rawMessage,
+              },
+              isRetriable: false,
+            };
+          }
+
+          setState((prev) => ({
+            ...prev,
+            phase: 'error',
+            error: classified,
+          }));
+        });
+    },
+    [cleanup],
+  );
+
+  return React.useMemo(
+    () => ({ state, startUpload, abort, reset }),
+    [state, startUpload, abort, reset],
+  );
+};

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/__tests__/useChatbotConfigStore.test.ts
@@ -1311,4 +1311,63 @@ describe('useChatbotConfigStore', () => {
       );
     });
   });
+
+  describe('ASR model selection', () => {
+    it('should update selectedAsrModel', () => {
+      act(() => {
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('whisper-large-v3');
+    });
+
+    it('should update isAsrModelEnabled', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+      });
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.isAsrModelEnabled).toBe(true);
+    });
+
+    it('should not affect ASR fields when updating selectedModel', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+
+      act(() => {
+        useChatbotConfigStore.getState().updateSelectedModel(DEFAULT_CONFIG_ID, 'new-chat-model');
+      });
+
+      const state = useChatbotConfigStore.getState();
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.selectedAsrModel).toBe('whisper-large-v3');
+      expect(state.configurations[DEFAULT_CONFIG_ID]?.isAsrModelEnabled).toBe(true);
+    });
+
+    it('should copy ASR fields in duplicateConfiguration', () => {
+      act(() => {
+        useChatbotConfigStore.getState().updateAsrModelEnabled(DEFAULT_CONFIG_ID, true);
+        useChatbotConfigStore
+          .getState()
+          .updateSelectedAsrModel(DEFAULT_CONFIG_ID, 'whisper-large-v3');
+      });
+
+      act(() => {
+        useChatbotConfigStore.getState().duplicateConfiguration(DEFAULT_CONFIG_ID);
+      });
+
+      const state = useChatbotConfigStore.getState();
+      const newConfigId = state.configIds[1];
+      const newConfig = state.configurations[newConfigId];
+
+      expect(newConfig?.selectedAsrModel).toBe('whisper-large-v3');
+      expect(newConfig?.isAsrModelEnabled).toBe(true);
+    });
+  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
@@ -96,5 +96,16 @@ export const selectVariableValues =
   (state: ChatbotConfigStore): Record<string, string> =>
     state.configurations[configId]?.variableValues ?? {};
 
+// ASR model selectors
+export const selectSelectedAsrModel =
+  (configId: string) =>
+  (state: ChatbotConfigStore): string =>
+    state.configurations[configId]?.selectedAsrModel ?? DEFAULT_CONFIGURATION.selectedAsrModel;
+
+export const selectIsAsrModelEnabled =
+  (configId: string) =>
+  (state: ChatbotConfigStore): boolean =>
+    state.configurations[configId]?.isAsrModelEnabled ?? DEFAULT_CONFIGURATION.isAsrModelEnabled;
+
 // Configuration management selectors
 export const selectConfigIds = (state: ChatbotConfigStore): string[] => state.configIds;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -36,6 +36,10 @@ export interface ChatbotConfiguration {
   activePrompt: MLflowPromptVersion | null;
   dirtyPrompt: MLflowPromptVersion | null;
   variableValues: Record<string, string>;
+  /** The model_id of the selected ASR (audio transcription) model, or '' if none */
+  selectedAsrModel: string;
+  /** Whether the user has opted in to the transcription model section */
+  isAsrModelEnabled: boolean;
 }
 
 /**
@@ -61,6 +65,8 @@ export const DEFAULT_CONFIGURATION: ChatbotConfiguration = {
   activePrompt: null,
   dirtyPrompt: null,
   variableValues: {},
+  selectedAsrModel: '',
+  isAsrModelEnabled: false,
 };
 
 /**
@@ -105,6 +111,10 @@ export interface ChatbotConfigStoreActions {
   updateGuardrailSubscription: (id: string, value: string) => void;
 
   updateSelectedSubscription: (id: string, value: string) => void;
+
+  // ASR model selection (per-pane)
+  updateSelectedAsrModel: (id: string, value: string) => void;
+  updateAsrModelEnabled: (id: string, value: boolean) => void;
 
   // RAG toggle (per-pane)
   updateRagEnabled: (id: string, value: boolean) => void;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -271,6 +271,8 @@ const createStoreActions = (
       activePrompt: deepCopyPrompt(sourceConfig.activePrompt),
       dirtyPrompt: deepCopyPrompt(sourceConfig.dirtyPrompt),
       variableValues: { ...sourceConfig.variableValues },
+      selectedAsrModel: sourceConfig.selectedAsrModel,
+      isAsrModelEnabled: sourceConfig.isAsrModelEnabled,
     };
 
     set(
@@ -566,6 +568,33 @@ const createStoreActions = (
       },
       false,
       'updateVariableValues',
+    );
+  },
+
+  // ASR model actions
+  updateSelectedAsrModel: (id: string, value: string) => {
+    set(
+      (state) => {
+        const config = state.configurations[id];
+        if (config && config.selectedAsrModel !== value) {
+          config.selectedAsrModel = value;
+        }
+      },
+      false,
+      'updateSelectedAsrModel',
+    );
+  },
+
+  updateAsrModelEnabled: (id: string, value: boolean) => {
+    set(
+      (state) => {
+        const config = state.configurations[id];
+        if (config && config.isAsrModelEnabled !== value) {
+          config.isAsrModelEnabled = value;
+        }
+      },
+      false,
+      'updateAsrModelEnabled',
     );
   },
 

--- a/packages/gen-ai/frontend/src/app/hooks/__tests__/useASRModels.spec.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/__tests__/useASRModels.spec.ts
@@ -1,0 +1,79 @@
+/* eslint-disable camelcase */
+import { renderHook } from '@testing-library/react';
+import type { AIModel } from '~/app/types';
+import useASRModels from '~/app/hooks/useASRModels';
+
+const makeModel = (overrides: Partial<AIModel> = {}): AIModel => ({
+  model_name: 'test',
+  model_id: 'test',
+  serving_runtime: 'vllm',
+  api_protocol: 'REST',
+  version: '',
+  usecase: 'LLM',
+  description: '',
+  endpoints: [],
+  status: 'Running',
+  display_name: 'Test',
+  sa_token: { name: '', token_name: '', token: '' },
+  model_source_type: 'namespace',
+  ...overrides,
+});
+
+describe('useASRModels', () => {
+  it('should return only models with modality audio-transcription and source_type namespace', () => {
+    const models: AIModel[] = [
+      makeModel({ model_id: 'whisper', modality: 'audio-transcription' }),
+      makeModel({ model_id: 'llama', model_type: 'llm' }),
+      makeModel({ model_id: 'embed', model_type: 'embedding' }),
+    ];
+
+    const { result } = renderHook(() => useASRModels(models));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].model_id).toBe('whisper');
+  });
+
+  it('should return empty array when no ASR models exist', () => {
+    const models: AIModel[] = [
+      makeModel({ model_id: 'llama', model_type: 'llm' }),
+      makeModel({ model_id: 'embed', model_type: 'embedding' }),
+    ];
+
+    const { result } = renderHook(() => useASRModels(models));
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('should exclude custom_endpoint and maas models even with ASR modality', () => {
+    const models: AIModel[] = [
+      makeModel({
+        model_id: 'whisper-ns',
+        modality: 'audio-transcription',
+        model_source_type: 'namespace',
+      }),
+      makeModel({
+        model_id: 'whisper-ext',
+        modality: 'audio-transcription',
+        model_source_type: 'custom_endpoint',
+      }),
+      makeModel({
+        model_id: 'whisper-maas',
+        modality: 'audio-transcription',
+        model_source_type: 'maas',
+      }),
+    ];
+
+    const { result } = renderHook(() => useASRModels(models));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].model_id).toBe('whisper-ns');
+  });
+
+  it('should exclude models with empty string modality', () => {
+    const models: AIModel[] = [
+      makeModel({ model_id: 'empty-mod', modality: '' }),
+      makeModel({ model_id: 'whisper', modality: 'audio-transcription' }),
+    ];
+
+    const { result } = renderHook(() => useASRModels(models));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].model_id).toBe('whisper');
+  });
+});

--- a/packages/gen-ai/frontend/src/app/hooks/useASRModels.ts
+++ b/packages/gen-ai/frontend/src/app/hooks/useASRModels.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { AIModel } from '~/app/types';
+import { isASRModel } from '~/app/utilities/utils';
+
+const useASRModels = (aiModels: AIModel[]): AIModel[] =>
+  React.useMemo(
+    () => aiModels.filter((m) => isASRModel(m) && m.model_source_type === 'namespace'),
+    [aiModels],
+  );
+
+export default useASRModels;

--- a/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.spec.ts
+++ b/packages/gen-ai/frontend/src/app/services/__tests__/llamaStackService.spec.ts
@@ -18,6 +18,7 @@ import {
   looksLikeRawToolCall,
   RAW_TOOL_CALL_WARNING,
   uploadMediaFile,
+  transcribeAudio,
 } from '~/app/services/llamaStackService';
 import { URL_PREFIX } from '~/app/utilities';
 import { mockLlamaModels } from '~/__mocks__/mockLlamaStackModels';
@@ -1833,6 +1834,120 @@ describe('llamaStackService', () => {
 
       xhr.abort();
       expect(mockXhr.abort).toHaveBeenCalled();
+    });
+  });
+
+  describe('transcribeAudio', () => {
+    beforeEach(() => {
+      mockFetch.mockReset();
+    });
+
+    it('sends POST with file_id and asr_model_id', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: 'Hello world' }),
+      });
+
+      const result = await transcribeAudio('/api/transcriptions', 'file-123', 'whisper-model');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/transcriptions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_id: 'file-123', asr_model_id: 'whisper-model' }),
+        signal: undefined,
+      });
+      expect(result).toEqual({ text: 'Hello world' });
+    });
+
+    it('passes AbortSignal when provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ text: 'result' }),
+      });
+
+      const controller = new AbortController();
+      await transcribeAudio('/api/transcriptions', 'file-123', 'model', controller.signal);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/transcriptions',
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it('throws ApiErrorClass for structured FrontendErrorResponse', async () => {
+      const structuredError = {
+        error: {
+          component: 'asr',
+          code: 'unreachable',
+          message: 'ASR endpoint unreachable',
+          retriable: true,
+        },
+      };
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: () => Promise.resolve(structuredError),
+      });
+
+      try {
+        await transcribeAudio('/api/transcriptions', 'file-123', 'model');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toHaveProperty('error');
+        expect((error as { error: { component: string } }).error.component).toBe('asr');
+        expect((error as { error: { code: string } }).error.code).toBe('unreachable');
+        expect((error as { error: { retriable: boolean } }).error.retriable).toBe(true);
+      }
+    });
+
+    it('throws legacy error with server message on non-structured response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: { message: 'ASR model unavailable' } }),
+      });
+
+      await expect(transcribeAudio('/api/transcriptions', 'file-123', 'model')).rejects.toThrow(
+        'ASR model unavailable',
+      );
+    });
+
+    it('throws fallback error when response body is not JSON', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new Error('not json')),
+      });
+
+      await expect(transcribeAudio('/api/transcriptions', 'file-123', 'model')).rejects.toThrow(
+        'Transcription failed (502)',
+      );
+    });
+
+    it('propagates AbortError when signal is aborted', async () => {
+      const controller = new AbortController();
+      const abortError = new DOMException('The operation was aborted.', 'AbortError');
+      mockFetch.mockRejectedValue(abortError);
+
+      await expect(
+        transcribeAudio('/api/transcriptions', 'file-123', 'model', controller.signal),
+      ).rejects.toEqual(abortError);
+    });
+
+    it('attaches status code to thrown error for legacy format', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: () => Promise.resolve({ message: 'No speech detected' }),
+      });
+
+      try {
+        await transcribeAudio('/api/transcriptions', 'file-123', 'model');
+        fail('Expected error to be thrown');
+      } catch (error) {
+        expect((error as Error & { status?: number }).status).toBe(422);
+        expect((error as Error).message).toBe('No speech detected');
+      }
     });
   });
 });

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -874,6 +874,31 @@ export const uploadMediaFile = (
   return { promise, xhr };
 };
 
+// Audio transcription via ASR model
+export const transcribeAudio = async (
+  url: string,
+  fileId: string,
+  asrModelId: string,
+  signal?: AbortSignal,
+): Promise<{ text: string }> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ file_id: fileId, asr_model_id: asrModelId }),
+    signal,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    if (body?.error?.component && body?.error?.code) {
+      throw new ApiErrorClass(body.error);
+    }
+    const message =
+      body?.error?.message || body?.message || `Transcription failed (${response.status})`;
+    throw Object.assign(new Error(message), { status: response.status });
+  }
+  return response.json();
+};
+
 // LSD Models
 export const getLSDModels = modArchRestGET<LlamaModel[]>('/lsd/models');
 

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -672,6 +672,7 @@ export const ERROR_COMPONENTS = {
   MODEL: 'model',
   OGX: 'ogx',
   BFF: 'bff',
+  ASR: 'asr',
 } as const;
 
 export type ErrorComponent = (typeof ERROR_COMPONENTS)[keyof typeof ERROR_COMPONENTS];
@@ -696,6 +697,7 @@ export const ERROR_COMPONENT_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   [ERROR_COMPONENTS.MODEL]: 'Model',
   [ERROR_COMPONENTS.OGX]: 'OGX',
   [ERROR_COMPONENTS.BFF]: 'BFF',
+  [ERROR_COMPONENTS.ASR]: 'Audio Transcription',
 };
 
 export interface ErrorDetails {

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -379,6 +379,7 @@ export interface AAModelResponse {
   model_source_type: 'namespace' | 'custom_endpoint' | 'maas';
   model_type?: 'llm' | 'embedding';
   embedding_dimension?: number;
+  modality?: string;
 }
 
 export interface AIModel extends AAModelResponse {

--- a/packages/gen-ai/frontend/src/app/utilities/__tests__/utils.spec.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import type { AIModel, MaaSModel } from '~/app/types';
 import {
   convertMaaSModelToAIModel,
   getSourceLabel,
+  isASRModel,
   splitLlamaModelId,
 } from '~/app/utilities/utils';
 
@@ -20,6 +21,28 @@ const makeModel = (overrides: Partial<AIModel> = {}): AIModel => ({
   sa_token: { name: '', token_name: '', token: '' },
   model_source_type: 'namespace',
   ...overrides,
+});
+
+describe('isASRModel', () => {
+  it('should return true for model with modality audio-transcription', () => {
+    expect(isASRModel(makeModel({ modality: 'audio-transcription' }))).toBe(true);
+  });
+
+  it('should return false for model with undefined modality', () => {
+    expect(isASRModel(makeModel())).toBe(false);
+  });
+
+  it('should return false for model with empty string modality', () => {
+    expect(isASRModel(makeModel({ modality: '' }))).toBe(false);
+  });
+
+  it('should return false for model with different modality value', () => {
+    expect(isASRModel(makeModel({ modality: 'image-generation' }))).toBe(false);
+  });
+
+  it('should be case-sensitive', () => {
+    expect(isASRModel(makeModel({ modality: 'Audio-Transcription' }))).toBe(false);
+  });
 });
 
 describe('getSourceLabel', () => {

--- a/packages/gen-ai/frontend/src/app/utilities/microcopy.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/microcopy.ts
@@ -62,6 +62,57 @@ const fullFailureTemplates: Record<string, MicrocopyTemplate> = {
     title: 'Request was rate limited',
     description: 'Too many requests to the model server. Wait a moment before trying again.',
   },
+  // ASR error codes (from ASRCode* constants in constants/asr.go)
+  'asr:model_not_found': {
+    title: 'Transcription model not found',
+    description: 'The selected transcription model is no longer available in this namespace.',
+  },
+  'asr:model_not_running': {
+    title: 'Transcription model not ready',
+    description: 'The transcription model is starting up. Wait a moment and try again.',
+  },
+  'asr:model_no_endpoint': {
+    title: 'Transcription model has no endpoint',
+    description: 'The model has no reachable endpoint. Check its deployment status.',
+  },
+  'asr:model_invalid': {
+    title: 'Invalid transcription model',
+    description: 'The selected model cannot be used for audio transcription.',
+  },
+  'asr:unreachable': {
+    title: 'Transcription model unreachable',
+    description:
+      'Could not connect to the transcription model. Ensure it is running and accessible.',
+  },
+  'asr:timeout': {
+    title: 'Transcription timed out',
+    description:
+      'The transcription took too long. The audio file may be too large or the model is overloaded.',
+  },
+  'asr:auth_failed': {
+    title: 'Transcription model access denied',
+    description: 'Authentication to the transcription model failed. Verify access configuration.',
+  },
+  'asr:service_error': {
+    title: 'Transcription model error',
+    description: 'The transcription model returned an error. Try again or check model health.',
+  },
+  'asr:invalid_response': {
+    title: 'Unexpected response from model',
+    description: 'The transcription model returned an unexpected response. Try again.',
+  },
+  'asr:no_speech': {
+    title: 'No speech detected',
+    description: 'No speech was found in the audio file. Try a clearer recording.',
+  },
+  'asr:file_retrieval_failed': {
+    title: 'Audio file unavailable',
+    description: 'Could not retrieve the uploaded audio file. It may have expired.',
+  },
+  'asr:invalid_format': {
+    title: 'Unsupported audio format',
+    description: 'The file does not appear to be a valid WAV or MP3 audio file.',
+  },
 };
 
 const partialFailureTemplates: Record<string, MicrocopyTemplate> = {

--- a/packages/gen-ai/frontend/src/app/utilities/utils.ts
+++ b/packages/gen-ai/frontend/src/app/utilities/utils.ts
@@ -203,6 +203,11 @@ const MODEL_TYPE_LABELS: Record<string, string> = {
 export const getModelTypeLabel = (modelType?: string): string =>
   MODEL_TYPE_LABELS[modelType || 'llm'] || 'Inferencing';
 
+export const MODALITY_AUDIO_TRANSCRIPTION = 'audio-transcription';
+
+export const isASRModel = (model: { modality?: string }): boolean =>
+  model.modality === MODALITY_AUDIO_TRANSCRIPTION;
+
 export const getSourceLabel = (model: AIModel): string => {
   const source = model.model_source_type;
   const label = SOURCE_LABELS[source];


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62255
https://issues.redhat.com/browse/RHOAIENG-62257
https://issues.redhat.com/browse/RHOAIENG-62256

## Description

Implements three stories from Epic 3 ([RHOAIENG-61007](https://issues.redhat.com/browse/RHOAIENG-61007) — ASR/Audio Transcription Support) for the Gen AI Studio Playground frontend. Builds on top of #7808 (Story 3.1: BFF audio transcription endpoint).

### Story 3.2: Frontend ASR model discovery ([RHOAIENG-62255](https://issues.redhat.com/browse/RHOAIENG-62255))

- Reads modality field from existing `GET /aaa/models` API response
- Models with `opendatahub.io/modality: audio-transcription` label shown with "ASR" badge on AI Assets page
- `useASRModels` hook filters model list for ASR-capable models
- ASR models display "Used in Playground settings" in the Playground column (no misleading Add/Try buttons)

### Story 3.4: Frontend ASR model selector ([RHOAIENG-62257](https://issues.redhat.com/browse/RHOAIENG-62257))

- `TranscriptionModelSection` in Model Tab of Playground settings panel
- Dropdown populated from `useASRModels` hook (label-based discovery)
- Auto-select when exactly one ASR model deployed; dropdown remains interactive
- Selected model persisted per pane in `useChatbotConfigStore` (Zustand)
- When no ASR model selected, audio upload option disabled with tooltip
- Stale model warning when selected model disappears from list

### Story 3.3: Frontend audio upload and transcription UX ([RHOAIENG-62256](https://issues.redhat.com/browse/RHOAIENG-62256))

- **`useAudioTranscription` hook** — full state machine (idle → uploading → transcribing → complete/error)
  - XHR upload with progress tracking and `AbortController`
  - Generation counter (`uploadGenRef`) prevents stale async responses
  - Client-side 105s timeout with structured error
  - `useMemo`-wrapped return for stable references
- **ChatbotPlayground integration**
  - Per-message audio gating (one audio per message, modal on second attempt)
  - `audioUploadLatchRef` prevents double-click race condition
  - Transcribed text auto-appended to message bar on completion
  - Send disabled during all active phases (upload/transcribe/complete)
- **ChatbotMessageInput changes**
  - Hidden file input (`.wav,.mp3`) triggered by attach menu
  - Client-side MIME and size validation (WAV/MP3, 10MB)
  - `FileDetailsLabel` chip with spinner during upload
  - `readOnly` textarea with placeholder during transcription
  - Structured error Alert with microcopy templates
  - `aria-live` announcements + `aria-busy` on composer
- **Error classification**
  - 12 `asr:*` microcopy templates for user-friendly error alerts
  - `classifyError` maps `FrontendErrorResponse` to alerts with retriability indicator

### Depends on

- #7808 — [RHOAIENG-62254](https://redhat.atlassian.net/browse/RHOAIENG-62254): BFF audio transcription endpoint and generalized media upload (Story 3.1)

## How Has This Been Tested?

### Unit tests

`npm test` in `packages/gen-ai/frontend` — all 214 tests pass across 4 suites. `eslint` — 0 errors.

**Hook tests (`useAudioTranscription.spec.ts`, 413 lines):**
- All phase transitions (idle → uploading → transcribing → complete)
- Abort during upload and transcription phases
- 105s timeout fires and produces ClassifiedError
- Stale upload rejection via generation counter
- Structured API error propagation
- Progress callback updates
- Cleanup on unmount

**Playground tests (`ChatbotPlayground.spec.tsx`, +247 lines):**
- Audio upload triggers `uploadMediaFile` with audio type
- Per-message modal shows on second audio attempt
- Clearing transcribed text resets `hasAudioInCurrentMessage`
- Clear-all conversation aborts in-flight audio

**Message input tests (`ChatbotMessageInput.spec.tsx`, +273 lines):**
- MIME validation (rejects non-WAV/MP3)
- File size validation (rejects > 10MB)
- Audio chip renders during upload phase
- Error Alert renders with structured error title/description
- `aria-live` announcements for all phase transitions
- Validation error auto-dismisses after timeout

**Service tests (`llamaStackService.spec.ts`, +115 lines):**
- `transcribeAudio` success, structured error, generic error, abort

**Store tests (`useChatbotConfigStore.test.ts`, +59 lines):**
- `selectedAsrModel` and `isAsrModelEnabled` per-pane persistence

### Playwright E2E testing (manual)

Tested on local dev server against real OGX + Whisper cluster:
- Happy path: upload WAV → transcribe → text in composer → send
- Cancel during upload and transcription
- Error recovery: dismiss alert → upload again
- File validation: rejected `.ogg`, oversized files
- Per-message modal: second upload blocked until first completes or clears
- BFF error scenarios (model not found, model not running, unreachable) triggered via `oc label`/`oc scale`

## Test Impact

**New:**
- `useAudioTranscription.spec.ts` (413 lines) — full hook coverage
- `ChatbotPlayground.spec.tsx` (+247 lines) — audio integration tests
- `ChatbotMessageInput.spec.tsx` (+273 lines) — input validation and UI state tests
- `llamaStackService.spec.ts` (+115 lines) — transcription service tests
- `useChatbotConfigStore.test.ts` (+59 lines) — ASR store tests
- `TranscriptionModelSection.spec.tsx` (305 lines) — selector component tests
- `useASRModels.spec.ts` (79 lines) — model discovery hook tests

**Updated:**
- `ModelTabContent.spec.tsx` — includes TranscriptionModelSection render

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio transcription support: Upload audio files in the playground to transcribe them automatically
  * ASR model selection and configuration in playground settings
  * Generalized media upload endpoint supporting both images and audio files

* **Refactor**
  * Unified image and audio file uploads under a single media upload endpoint

* **Documentation**
  * Added local development guide for audio transcription setup and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->