### PR TITLE
feat(gen-ai): add "Enable tracing" toggle to Configure Playground modal

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -3,6 +3,7 @@ import { SupportedArea, SupportedAreasState, DataScienceStackComponent } from '.
 
 export const techPreviewFlags = {
   genAiStudio: false,
+  tracing: false,
   automl: false,
   autorag: false,
   guardrails: false,

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1319,6 +1319,7 @@ export type DashboardCommonConfig = {
   disableFeatureStore?: boolean;
   genAiStudio?: boolean;
   guardrails?: boolean;
+  tracing?: boolean;
   automl?: boolean;
   autorag?: boolean;
   modelAsService?: boolean;

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -577,35 +577,33 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
             onClose={onSuccessClose}
           />
         ) : (
-          <>
-            {currentStep.component}
-            {tracingEnabled && isFirstStep && (
-              <FormGroup
-                fieldId="enable-tracing"
-                style={{ marginTop: 'var(--pf-t--global--spacer--lg)' }}
-              >
-                <Switch
-                  id="enable-tracing-switch"
-                  label="Enable tracing"
-                  isChecked={enableTracing}
-                  onChange={(_event, checked) => setEnableTracing(checked)}
-                  aria-label="Toggle tracing for this playground"
-                  data-testid="enable-tracing-switch"
-                />
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem>
-                      When enabled, execution traces are collected for debugging and observability.
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              </FormGroup>
-            )}
-          </>
+          currentStep.component
         )}
       </ModalBody>
       {!configuringPlayground && (
-        <ModalFooter>
+        <ModalFooter style={tracingEnabled && isFirstStep ? { flexWrap: 'wrap' } : undefined}>
+          {tracingEnabled && isFirstStep && (
+            <FormGroup
+              fieldId="enable-tracing"
+              style={{ flexBasis: '100%', marginBottom: 'var(--pf-t--global--spacer--md)' }}
+            >
+              <Switch
+                id="enable-tracing-switch"
+                label="Enable tracing"
+                isChecked={enableTracing}
+                onChange={(_event, checked) => setEnableTracing(checked)}
+                aria-label="Toggle tracing for this playground"
+                data-testid="enable-tracing-switch"
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    When enabled, execution traces are collected for debugging and observability.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+          )}
           {!isStepsLoading && isLastStep ? (
             <Button
               variant="primary"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -3,11 +3,16 @@ import React from 'react';
 import {
   Alert,
   Button,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
   ModalVariant,
+  Switch,
 } from '@patternfly/react-core';
 import { ArrowLeftIcon } from '@patternfly/react-icons';
 import { fireFormTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
@@ -29,6 +34,7 @@ import {
 } from '~/app/utilities/utils';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useGuardrailsEnabled from '~/app/Chatbot/hooks/useGuardrailsEnabled';
+import useTracingEnabled from '~/app/Chatbot/hooks/useTracingEnabled';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import ChatbotConfigurationTable from './ChatbotConfigurationTable';
 import ChatbotConfigurationCollectionsTable from './ChatbotConfigurationCollectionsTable';
@@ -91,6 +97,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   const { namespace } = React.useContext(GenAiContext);
   const { api, apiAvailable } = useGenAiAPI();
   const guardrailsEnabled = useGuardrailsEnabled();
+  const tracingEnabled = useTracingEnabled();
   const vectorStoresEnabled = useAiAssetVectorStoresEnabled();
 
   const maasAsAIModels: AIModel[] = React.useMemo(
@@ -282,6 +289,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   const [configuringPlayground, setConfiguringPlayground] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [alertTitle, setAlertTitle] = React.useState<string>();
+  const [enableTracing, setEnableTracing] = React.useState(lsdStatus?.enableTracing ?? false);
 
   const isUpdate = !!lsdStatus;
 
@@ -442,6 +450,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
           };
         }),
         enable_guardrails: guardrailsEnabled,
+        ...(tracingEnabled && { enable_tracing: enableTracing }),
         ...(selectedCollections.length > 0 && {
           vector_stores: selectedCollections.map((c) => ({ vector_store_id: c.vector_store_id })),
         }),
@@ -568,7 +577,28 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
             onClose={onSuccessClose}
           />
         ) : (
-          currentStep.component
+          <>
+            {currentStep.component}
+            {tracingEnabled && isLastStep && (
+              <FormGroup fieldId="enable-tracing" style={{ marginTop: 'var(--pf-t--global--spacer--lg)' }}>
+                <Switch
+                  id="enable-tracing-switch"
+                  label="Enable tracing"
+                  isChecked={enableTracing}
+                  onChange={(_event, checked) => setEnableTracing(checked)}
+                  aria-label="Toggle tracing for this playground"
+                  data-testid="enable-tracing-switch"
+                />
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>
+                      When enabled, execution traces are collected for debugging and observability.
+                    </HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              </FormGroup>
+            )}
+          </>
         )}
       </ModalBody>
       {!configuringPlayground && (

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -289,7 +289,7 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
   const [configuringPlayground, setConfiguringPlayground] = React.useState(false);
   const [error, setError] = React.useState<Error>();
   const [alertTitle, setAlertTitle] = React.useState<string>();
-  const [enableTracing, setEnableTracing] = React.useState(lsdStatus?.enableTracing ?? false);
+  const [enableTracing, setEnableTracing] = React.useState(false);
 
   const isUpdate = !!lsdStatus;
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal.tsx
@@ -579,8 +579,11 @@ const ChatbotConfigurationModal: React.FC<ChatbotConfigurationModalProps> = ({
         ) : (
           <>
             {currentStep.component}
-            {tracingEnabled && isLastStep && (
-              <FormGroup fieldId="enable-tracing" style={{ marginTop: 'var(--pf-t--global--spacer--lg)' }}>
+            {tracingEnabled && isFirstStep && (
+              <FormGroup
+                fieldId="enable-tracing"
+                style={{ marginTop: 'var(--pf-t--global--spacer--lg)' }}
+              >
                 <Switch
                   id="enable-tracing-switch"
                   label="Enable tracing"

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -14,6 +14,7 @@ import {
 import type { MaaSModel } from '~/app/types';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import useGuardrailsEnabled from '~/app/Chatbot/hooks/useGuardrailsEnabled';
+import useTracingEnabled from '~/app/Chatbot/hooks/useTracingEnabled';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
 import useAiAssetVectorStoresEnabled from '~/app/hooks/useAiAssetVectorStoresEnabled';
 import { GenAiContext } from '~/app/context/GenAiContext';
@@ -24,6 +25,7 @@ jest.mock('@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils', (
 }));
 
 jest.mock('~/app/Chatbot/hooks/useGuardrailsEnabled');
+jest.mock('~/app/Chatbot/hooks/useTracingEnabled');
 jest.mock('~/app/hooks/useGenAiAPI');
 jest.mock('~/app/hooks/useAiAssetVectorStoresEnabled');
 jest.mock('~/app/hooks/useChatPlaygroundEnabled', () => ({
@@ -40,6 +42,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   (useGuardrailsEnabled as jest.Mock).mockReturnValue(false);
+  (useTracingEnabled as jest.Mock).mockReturnValue(false);
   (useAiAssetVectorStoresEnabled as jest.Mock).mockReturnValue(false);
 
   mockUseGenAiAPI.mockReturnValue({
@@ -762,5 +765,87 @@ describe('ChatbotConfigurationModal form tracking', () => {
         namespace: 'test-namespace',
       });
     });
+  });
+});
+
+// ─── Tracing ──────────────────────────────────────────────────────────────────
+
+describe('ChatbotConfigurationModal tracing configuration', () => {
+  const allModels = [createAIModel({ model_name: 'test-model' })];
+
+  it('does not render tracing toggle when feature flag is disabled', () => {
+    (useTracingEnabled as jest.Mock).mockReturnValue(false);
+    renderModalWithContext({ allModels });
+
+    expect(screen.queryByTestId('enable-tracing-switch')).not.toBeInTheDocument();
+  });
+
+  it('renders tracing toggle when feature flag is enabled', () => {
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    expect(screen.getByTestId('enable-tracing-switch')).toBeInTheDocument();
+  });
+
+  it('does not include enable_tracing in payload when feature flag is disabled', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(false);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.not.objectContaining({ enable_tracing: expect.anything() }),
+      );
+    });
+  });
+
+  it('includes enable_tracing: true in payload when toggle is checked', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByTestId('enable-tracing-switch'));
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.objectContaining({ enable_tracing: true }),
+      );
+    });
+  });
+
+  it('does not include enable_tracing when toggle is left unchecked', async () => {
+    const user = userEvent.setup();
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    renderModalWithContext({ allModels });
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockInstallLSD).toHaveBeenCalledWith(
+        expect.not.objectContaining({ enable_tracing: true }),
+      );
+    });
+  });
+
+  it('pre-populates toggle from lsdStatus in update mode', () => {
+    (useTracingEnabled as jest.Mock).mockReturnValue(true);
+    const lsdStatus: LlamaStackDistributionModel = {
+      name: 'test-lsd',
+      phase: 'Ready',
+      version: 'v1',
+      enableTracing: true,
+      distributionConfig: {
+        activeDistribution: 'test',
+        providers: [],
+        availableDistributions: {},
+      },
+    };
+    renderModalWithContext({ allModels, lsdStatus });
+
+    const toggle = screen.getByTestId('enable-tracing-switch');
+    expect(toggle).toBeChecked();
   });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/chatbotConfiguration/__tests__/ChatbotConfigurationModal.spec.tsx
@@ -830,22 +830,4 @@ describe('ChatbotConfigurationModal tracing configuration', () => {
     });
   });
 
-  it('pre-populates toggle from lsdStatus in update mode', () => {
-    (useTracingEnabled as jest.Mock).mockReturnValue(true);
-    const lsdStatus: LlamaStackDistributionModel = {
-      name: 'test-lsd',
-      phase: 'Ready',
-      version: 'v1',
-      enableTracing: true,
-      distributionConfig: {
-        activeDistribution: 'test',
-        providers: [],
-        availableDistributions: {},
-      },
-    };
-    renderModalWithContext({ allModels, lsdStatus });
-
-    const toggle = screen.getByTestId('enable-tracing-switch');
-    expect(toggle).toBeChecked();
-  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/hooks/useTracingEnabled.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/hooks/useTracingEnabled.ts
@@ -1,0 +1,9 @@
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { TRACING } from '~/odh/extensions';
+
+const useTracingEnabled = (): boolean => {
+  const [tracingEnabled] = useFeatureFlag(TRACING);
+  return tracingEnabled;
+};
+
+export default useTracingEnabled;

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -332,6 +332,7 @@ export type LlamaStackDistributionModel = {
   name: string;
   phase: 'Initializing' | 'Ready' | 'Failed' | 'Terminating' | 'Pending';
   version: string;
+  enableTracing?: boolean;
   distributionConfig: {
     activeDistribution: string;
     providers: Array<{
@@ -524,6 +525,7 @@ export type MLflowPromptVersionsResponse = {
 export type InstallLSDRequest = {
   models: LSDInstallModel[];
   enable_guardrails?: boolean; // If true, adds safety configuration with guardrail shields for all selected models
+  enable_tracing?: boolean; // If true, enables OTel tracing for the playground session
   vector_stores?: { vector_store_id: string }[]; // Optional vector stores to register; embedding models must be in models
 };
 

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -332,7 +332,6 @@ export type LlamaStackDistributionModel = {
   name: string;
   phase: 'Initializing' | 'Ready' | 'Failed' | 'Terminating' | 'Pending';
   version: string;
-  enableTracing?: boolean;
   distributionConfig: {
     activeDistribution: string;
     providers: Array<{

--- a/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
+++ b/packages/gen-ai/frontend/src/odh/PluginStoreContextProvider.tsx
@@ -10,6 +10,7 @@ import extensions, {
   MODEL_AS_SERVICE_CAMEL,
   PLUGIN_GEN_AI,
   PROMPT_MANAGEMENT,
+  TRACING,
 } from './extensions';
 
 export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
@@ -24,6 +25,7 @@ export const PluginStoreContextProvider: React.FC<React.PropsWithChildren> = ({ 
       [PROMPT_MANAGEMENT]: true,
       [EXTERNAL_VECTOR_STORES]: true,
       [AI_ASSET_CUSTOM_ENDPOINTS]: true,
+      [TRACING]: true,
     };
 
     const params = new URLSearchParams(window.location.search);

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -21,6 +21,7 @@ export const GEN_AI_STUDIO = 'genAiStudio';
 export const MODEL_AS_SERVICE = 'model-as-service';
 export const MODEL_AS_SERVICE_CAMEL = 'modelAsService';
 export const GUARDRAILS = 'guardrails';
+export const TRACING = 'tracing';
 export const PROMPT_MANAGEMENT = 'promptManagement';
 export const AI_ASSET_CUSTOM_ENDPOINTS = 'aiAssetCustomEndpoints';
 export const EXTERNAL_VECTOR_STORES = 'externalVectorStores';
@@ -84,6 +85,14 @@ const extensions: (
       id: EXTERNAL_VECTOR_STORES,
       reliantAreas: [PLUGIN_GEN_AI],
       featureFlags: [EXTERNAL_VECTOR_STORES],
+    },
+  },
+  {
+    type: 'app.area',
+    properties: {
+      id: TRACING,
+      reliantAreas: [PLUGIN_GEN_AI],
+      featureFlags: [TRACING],
     },
   },
   {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAISTRAT-133
https://issues.redhat.com/browse/RHOAIENG-66356

## Description

Adds a feature-flag-gated "Enable tracing" toggle to the Configure Playground modal, following the same pattern as the existing `enable_guardrails` implementation.

When the `tracing` feature flag is enabled in `OdhDashboardConfig`, users see a PatternFly Switch at the bottom of the configuration wizard to opt-in to OTel tracing for the playground session. The preference is passed as `enable_tracing` in the `installLSD` request payload.

This is the first story in E2 (Debug/Verbose Mode Toggle & OTel Pipeline Activation) for [RHAISTRAT-133](https://redhat.atlassian.net/browse/RHAISTRAT-133). The BFF counterpart to accept and act on `enable_tracing` will follow in a subsequent PR.

**Changes:**
- New `useTracingEnabled` hook (mirrors `useGuardrailsEnabled`)
- `TRACING` area constant registered in `extensions.ts`
- `enable_tracing` added to `InstallLSDRequest` type
- Switch + FormHelperText added to `ChatbotConfigurationModal`, conditionally rendered on the last wizard step when the feature flag is active
- 5 new unit tests covering toggle visibility, payload inclusion/exclusion

**UX Prototype:** [Figma — Tracing](https://www.figma.com/design/NrpimaIWiGMlli40QCRfqP/Tracing?node-id=192-4811&p=f&t=pcjG2mFB1j57IRv4-0)

## How Has This Been Tested?

- Unit tests: 41 passing (36 existing + 5 new tracing tests)
- Toggle renders only when `tracing` feature flag is enabled
- `enable_tracing` included in install payload only when flag is on and toggle is checked
- No regression to existing guardrails, collections, or model selection behaviour

## Test Impact

5 new test cases added to `ChatbotConfigurationModal.spec.tsx`:
- Toggle hidden when feature flag disabled
- Toggle visible when feature flag enabled
- Payload excludes `enable_tracing` when flag disabled
- Payload includes `enable_tracing: true` when toggled on
- Payload excludes `enable_tracing` when toggle left unchecked

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


[RHAISTRAT-133]: https://redhat.atlassian.net/browse/RHAISTRAT-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ