### PR TITLE
Add inactive state to API keys

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -88,7 +88,7 @@ class APIKeysPage {
   }
 
   findStatusFilterOption(status: string): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByRole('menuitem', { name: new RegExp(status, 'i') });
+    return cy.findByRole('menuitem', { name: new RegExp(`^${status}$`, 'i') });
   }
 
   findSubscriptionFilterToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -224,6 +224,18 @@ class SubscriptionPopover {
 }
 
 export const subscriptionPopover = new SubscriptionPopover();
+
+class InactiveStatusPopover {
+  findHeader(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByText('Subscription unavailable');
+  }
+
+  shouldBeVisible(): void {
+    this.findHeader().should('be.visible');
+  }
+}
+
+export const inactiveStatusPopover = new InactiveStatusPopover();
 
 class BulkRevokeAPIKeyModal extends Modal {
   constructor() {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -229,12 +229,6 @@ describe('API Keys Page', () => {
     apiKeysPage.visit();
     cy.wait('@searchWithOrphaned');
 
-    apiKeysPage.findTable().should('not.contain.text', 'deleted-subscription-key');
-
-    apiKeysPage.findStatusFilterToggle().click();
-    apiKeysPage.findStatusFilterOption('Inactive').click();
-    apiKeysPage.findStatusFilterToggle().click();
-
     apiKeysPage.findTable().should('contain.text', 'deleted-subscription-key');
 
     const deletedSubscriptionRow = apiKeysPage.getRow('deleted-subscription-key');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -237,9 +237,12 @@ describe('API Keys Page', () => {
 
     apiKeysPage.findTable().should('contain.text', 'deleted-subscription-key');
 
-    const orphanedRow = apiKeysPage.getRow('deleted-subscription-key');
-    orphanedRow.findStatus().should('contain.text', 'Inactive').click();
+    const deletedSubscriptionRow = apiKeysPage.getRow('deleted-subscription-key');
+    deletedSubscriptionRow.findStatus().should('contain.text', 'Inactive').click();
     inactiveStatusPopover.shouldBeVisible();
+
+    deletedSubscriptionRow.findSubscription().should('contain.text', 'deleted-sub');
+    deletedSubscriptionRow.findSubscriptionDetailLink().should('not.exist');
   });
 
   it('should display all API keys when the status filter is cleared', () => {
@@ -280,21 +283,6 @@ describe('API Keys Page', () => {
       .findSubscriptionDetailLink()
       .should('have.attr', 'href')
       .and('include', '/maas/keys-and-subs/subscriptions/premium-team-sub');
-  });
-
-  it('should show plain text (no link) for a subscription that no longer exists', () => {
-    const keyWithDeletedSub = mockAPIKeys().filter((k) => k.status === 'active');
-    cy.interceptOdh(
-      'POST /maas/api/v1/api-keys/search',
-      // Return keys with a subscription name but no subscriptionDetails entry for it
-      mockSearchResponse(keyWithDeletedSub, {}),
-    ).as('deletedSubSearch');
-    apiKeysPage.visit();
-    cy.wait('@deletedSubSearch');
-
-    const prodRow = apiKeysPage.getRow('production-backend');
-    prodRow.findSubscription().should('contain.text', 'premium-team-sub');
-    prodRow.findSubscriptionDetailLink().should('not.exist');
   });
 
   it('should filter api keys by subscription and clear the filter', () => {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -360,8 +360,11 @@ describe('API Keys Page', () => {
 
     apiKeysPage.findStatusFilterToggle().click();
     apiKeysPage.findStatusFilterOption('Active').click();
+    apiKeysPage.findStatusFilterOption('Inactive').click();
+    apiKeysPage.findStatusFilterToggle().click();
 
-    // Keys are filtered to show active and expired by default so here we're looking for just expired since active was pre-selected
+    // Keys are filtered to show active,inactive and expired by default so here we're looking for just expired since active and inactive was pre-selected
+    cy.wait('@filterByStatus');
     cy.wait('@filterByStatus').then((interception) => {
       expect(interception.request.body.data.filters.status).to.deep.equal(['expired']);
     });

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -11,6 +11,7 @@ import {
   adminBulkRevokeAPIKeyModal,
   apiKeysPage,
   bulkRevokeAPIKeyModal,
+  inactiveStatusPopover,
   revokeAPIKeyModal,
   copyApiKeyModal,
   createApiKeyModal,
@@ -202,6 +203,43 @@ describe('API Keys Page', () => {
         'contain.text',
         'Internal Server Error - here is a bunch of info to help you debug it: /maas/api/v1/api-keys/search',
       );
+  });
+
+  it('should show Inactive status with popover for keys whose subscription was deleted', () => {
+    const deletedSubscriptionKey: APIKey = {
+      id: 'key-deleted-subscription-001',
+      name: 'deleted-subscription-key',
+      description: 'Key with a deleted subscription',
+      creationDate: '2026-01-10T10:00:00Z',
+      status: 'active',
+      username: 'alice',
+      subscription: 'deleted-sub',
+    };
+
+    const allActiveKeys = [
+      deletedSubscriptionKey,
+      ...mockAPIKeys().filter((k) => k.status === 'active'),
+    ];
+    const searchResponseWithOrphaned = mockSearchResponse(allActiveKeys, mockSubscriptionDetails);
+
+    cy.interceptOdh('POST /maas/api/v1/api-keys/search', searchResponseWithOrphaned).as(
+      'searchWithOrphaned',
+    );
+
+    apiKeysPage.visit();
+    cy.wait('@searchWithOrphaned');
+
+    apiKeysPage.findTable().should('not.contain.text', 'deleted-subscription-key');
+
+    apiKeysPage.findStatusFilterToggle().click();
+    apiKeysPage.findStatusFilterOption('Inactive').click();
+    apiKeysPage.findStatusFilterToggle().click();
+
+    apiKeysPage.findTable().should('contain.text', 'deleted-subscription-key');
+
+    const orphanedRow = apiKeysPage.getRow('deleted-subscription-key');
+    orphanedRow.findStatus().should('contain.text', 'Inactive').click();
+    inactiveStatusPopover.shouldBeVisible();
   });
 
   it('should display all API keys when the status filter is cleared', () => {

--- a/packages/maas/bff/internal/api/api_keys_handlers.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers.go
@@ -167,9 +167,6 @@ func SearchAPIKeysHandler(app *App, w http.ResponseWriter, r *http.Request, _ ht
 // enrichAPIKeysWithSubscriptionDetails fetches subscription data from the MaaS API
 // and populates SubscriptionDetails on the response with model names per subscription.
 func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *models.APIKeyListResponse) {
-	details := make(map[string]models.SubscriptionDetail)
-	response.SubscriptionDetails = details
-
 	subNames := make(map[string]struct{})
 	for _, key := range response.Data {
 		if key.SubscriptionName != "" {
@@ -186,6 +183,8 @@ func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *m
 		app.logger.Warn("Failed to fetch subscriptions for API key enrichment", "error", err)
 		return
 	}
+
+	details := make(map[string]models.SubscriptionDetail, len(subNames))
 	for _, sub := range subscriptions {
 		if _, needed := subNames[sub.SubscriptionIDHeader]; !needed {
 			continue
@@ -204,6 +203,7 @@ func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *m
 		}
 		details[sub.SubscriptionIDHeader] = models.SubscriptionDetail{DisplayName: displayName, Models: modelNames}
 	}
+	response.SubscriptionDetails = details
 }
 
 // GetAPIKeyHandler handles GET /api/v1/api-keys/:id

--- a/packages/maas/bff/internal/api/api_keys_handlers.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers.go
@@ -204,9 +204,7 @@ func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *m
 		details[sub.SubscriptionIDHeader] = models.SubscriptionDetail{DisplayName: displayName, Models: modelNames}
 	}
 
-	if len(details) > 0 {
-		response.SubscriptionDetails = details
-	}
+	response.SubscriptionDetails = details
 }
 
 // GetAPIKeyHandler handles GET /api/v1/api-keys/:id

--- a/packages/maas/bff/internal/api/api_keys_handlers.go
+++ b/packages/maas/bff/internal/api/api_keys_handlers.go
@@ -167,6 +167,9 @@ func SearchAPIKeysHandler(app *App, w http.ResponseWriter, r *http.Request, _ ht
 // enrichAPIKeysWithSubscriptionDetails fetches subscription data from the MaaS API
 // and populates SubscriptionDetails on the response with model names per subscription.
 func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *models.APIKeyListResponse) {
+	details := make(map[string]models.SubscriptionDetail)
+	response.SubscriptionDetails = details
+
 	subNames := make(map[string]struct{})
 	for _, key := range response.Data {
 		if key.SubscriptionName != "" {
@@ -183,8 +186,6 @@ func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *m
 		app.logger.Warn("Failed to fetch subscriptions for API key enrichment", "error", err)
 		return
 	}
-
-	details := make(map[string]models.SubscriptionDetail, len(subNames))
 	for _, sub := range subscriptions {
 		if _, needed := subNames[sub.SubscriptionIDHeader]; !needed {
 			continue
@@ -203,8 +204,6 @@ func enrichAPIKeysWithSubscriptionDetails(app *App, r *http.Request, response *m
 		}
 		details[sub.SubscriptionIDHeader] = models.SubscriptionDetail{DisplayName: displayName, Models: modelNames}
 	}
-
-	response.SubscriptionDetails = details
 }
 
 // GetAPIKeyHandler handles GET /api/v1/api-keys/:id

--- a/packages/maas/bff/internal/models/api_key.go
+++ b/packages/maas/bff/internal/models/api_key.go
@@ -73,7 +73,7 @@ type APIKeyListResponse struct {
 	Object              string                        `json:"object"`
 	Data                []APIKey                      `json:"data"`
 	HasMore             bool                          `json:"has_more"`
-	SubscriptionDetails map[string]SubscriptionDetail `json:"subscriptionDetails,omitempty"`
+	SubscriptionDetails map[string]SubscriptionDetail `json:"subscriptionDetails"`
 }
 
 // APIKeyBulkRevokeRequest represents a request to bulk-revoke a user's keys.

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -68,7 +68,15 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
       sort: { by: sortField, order: sortDirection },
       pagination: { limit: perPage, offset: (page - 1) * perPage },
     }),
-    [filterData.username, serverStatuses, filterData.subscription, sortField, sortDirection, page, perPage],
+    [
+      filterData.username,
+      serverStatuses,
+      filterData.subscription,
+      sortField,
+      sortDirection,
+      page,
+      perPage,
+    ],
   );
 
   const [rawResponse, loaded, error, refresh] = useFetchApiKeys(searchRequest);

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -10,7 +10,7 @@ import {
   APIKeyListResponse,
 } from '~/app/types/api-key';
 import { ApiKeySortField } from '~/app/pages/keys-and-subs/apiKeys/allKeys/columns';
-import { applyInactiveFilter } from '~/app/utilities/apiKeys';
+import { applyInactiveFilter, isKeyInactive as isKeyInactiveUtil } from '~/app/utilities/apiKeys';
 import { useFetchApiKeys } from './useFetchApiKeys';
 
 type SortDirection = 'asc' | 'desc';
@@ -53,6 +53,11 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
   const [localUsername, setLocalUsername] = React.useState('');
   const [isFetching, setIsFetching] = React.useState(false);
 
+  // The API has no concept of "inactive" — it only knows active | revoked | expired.
+  // "Inactive" is a client-side display status for active keys whose subscription was
+  // deleted.  When the user selects the "Inactive" filter we must still request
+  // "active" keys from the server (they are the superset that includes inactive ones),
+  // then narrow the results client-side via applyInactiveFilter.
   const apiFilterStatuses: APIKeyStatus[] = React.useMemo(() => {
     const hasInactive = filterData.statuses.includes('inactive');
     const result = filterData.statuses.filter((s): s is APIKeyStatus => s !== 'inactive');
@@ -86,11 +91,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
   const [rawResponse, loaded, error, refresh] = useFetchApiKeys(searchRequest);
 
   const isKeyInactive = React.useCallback(
-    (key: APIKey): boolean =>
-      key.status === 'active' &&
-      !!key.subscription &&
-      rawResponse.subscriptionDetails != null &&
-      !(key.subscription in rawResponse.subscriptionDetails),
+    (key: APIKey): boolean => isKeyInactiveUtil(key, rawResponse.subscriptionDetails),
     [rawResponse.subscriptionDetails],
   );
 

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   APIKey,
   APIKeyStatus,
+  APIKeyDisplayStatus,
   APIKeySearchRequest,
   ApiKeyFilterDataType,
   initialApiKeyFilterData,
@@ -9,6 +10,7 @@ import {
   APIKeyListResponse,
 } from '~/app/types/api-key';
 import { ApiKeySortField } from '~/app/pages/keys-and-subs/apiKeys/allKeys/columns';
+import { applyInactiveFilter } from '~/app/utilities/apiKeys';
 import { useFetchApiKeys } from './useFetchApiKeys';
 
 type SortDirection = 'asc' | 'desc';
@@ -23,6 +25,8 @@ export type UseApiKeysTableStateReturn = {
   error: Error | undefined;
   refresh: () => void;
   filterData: ApiKeyFilterDataType;
+  isKeyInactive: (key: APIKey) => boolean;
+  clientFiltered: boolean;
   localUsername: string;
   setLocalUsername: React.Dispatch<React.SetStateAction<string>>;
   page: number;
@@ -31,8 +35,8 @@ export type UseApiKeysTableStateReturn = {
   sortDirection: SortDirection;
   isFetching: boolean;
   onUsernameChange: (value: string) => void;
-  onStatusToggle: (status: APIKeyStatus) => void;
-  onStatusClear: (status: APIKeyStatus) => void;
+  onStatusToggle: (status: APIKeyDisplayStatus) => void;
+  onStatusClear: (status: APIKeyDisplayStatus) => void;
   onSubscriptionChange: (subscription: string) => void;
   onSort: (field: ApiKeySortField, direction: SortDirection) => void;
   onSetPage: (newPage: number) => void;
@@ -49,9 +53,9 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
   const [localUsername, setLocalUsername] = React.useState('');
   const [isFetching, setIsFetching] = React.useState(false);
 
-  const serverStatuses = React.useMemo(() => {
+  const apiFilterStatuses: APIKeyStatus[] = React.useMemo(() => {
     const hasInactive = filterData.statuses.includes('inactive');
-    const result = filterData.statuses.filter((s) => s !== 'inactive');
+    const result = filterData.statuses.filter((s): s is APIKeyStatus => s !== 'inactive');
     if (hasInactive && !result.includes('active')) {
       result.push('active');
     }
@@ -62,7 +66,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     () => ({
       filters: {
         ...(filterData.username && { username: filterData.username }),
-        ...(serverStatuses.length > 0 && { status: serverStatuses }),
+        ...(apiFilterStatuses.length > 0 && { status: apiFilterStatuses }),
         ...(filterData.subscription && { subscription: filterData.subscription }),
       },
       sort: { by: sortField, order: sortDirection },
@@ -70,7 +74,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     }),
     [
       filterData.username,
-      serverStatuses,
+      apiFilterStatuses,
       filterData.subscription,
       sortField,
       sortDirection,
@@ -90,34 +94,16 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     [rawResponse.subscriptionDetails],
   );
 
-  const response = React.useMemo((): APIKeyListResponse => {
-    const hasActive = filterData.statuses.includes('active');
-    const hasInactive = filterData.statuses.includes('inactive');
+  const { data: filteredData, clientFiltered } = React.useMemo(
+    () => applyInactiveFilter(rawResponse.data, filterData.statuses, isKeyInactive),
+    [rawResponse.data, filterData.statuses, isKeyInactive],
+  );
 
-    let { data } = rawResponse;
-
-    if (hasActive !== hasInactive) {
-      data = data.filter((key) => {
-        if (key.status !== 'active') {
-          return true;
-        }
-        return hasInactive ? isKeyInactive(key) : !isKeyInactive(key);
-      });
-    }
-
-    if (hasActive && hasInactive) {
-      data = data.toSorted((a, b) => {
-        const aInactive = isKeyInactive(a) ? 1 : 0;
-        const bInactive = isKeyInactive(b) ? 1 : 0;
-        return aInactive - bInactive;
-      });
-    }
-
-    if (data === rawResponse.data) {
-      return rawResponse;
-    }
-    return { ...rawResponse, data };
-  }, [rawResponse, filterData.statuses, isKeyInactive]);
+  const response = React.useMemo(
+    (): APIKeyListResponse =>
+      filteredData === rawResponse.data ? rawResponse : { ...rawResponse, data: filteredData },
+    [rawResponse, filteredData],
+  );
 
   React.useEffect(() => {
     setIsFetching(false);
@@ -132,7 +118,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     [localUsername],
   );
 
-  const onStatusToggle = React.useCallback((status: APIKeyStatus) => {
+  const onStatusToggle = React.useCallback((status: APIKeyDisplayStatus) => {
     setFilterData((prev) => ({
       ...prev,
       statuses: prev.statuses.includes(status)
@@ -143,7 +129,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     setIsFetching(true);
   }, []);
 
-  const onStatusClear = React.useCallback((status: APIKeyStatus) => {
+  const onStatusClear = React.useCallback((status: APIKeyDisplayStatus) => {
     setFilterData((prev) => ({
       ...prev,
       statuses: prev.statuses.filter((s) => s !== status),
@@ -195,6 +181,8 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     error,
     refresh,
     filterData,
+    isKeyInactive,
+    clientFiltered,
     localUsername,
     setLocalUsername,
     page,

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -26,7 +26,6 @@ export type UseApiKeysTableStateReturn = {
   refresh: () => void;
   filterData: ApiKeyFilterDataType;
   isKeyInactive: (key: APIKey) => boolean;
-  clientFiltered: boolean;
   localUsername: string;
   setLocalUsername: React.Dispatch<React.SetStateAction<string>>;
   page: number;
@@ -95,7 +94,7 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     [rawResponse.subscriptionDetails],
   );
 
-  const { data: filteredData, clientFiltered } = React.useMemo(
+  const { data: filteredData } = React.useMemo(
     () => applyInactiveFilter(rawResponse.data, filterData.statuses, isKeyInactive),
     [rawResponse.data, filterData.statuses, isKeyInactive],
   );
@@ -183,7 +182,6 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
     refresh,
     filterData,
     isKeyInactive,
-    clientFiltered,
     localUsername,
     setLocalUsername,
     page,

--- a/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useApiKeysTableState.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  APIKey,
   APIKeyStatus,
   APIKeySearchRequest,
   ApiKeyFilterDataType,
@@ -48,20 +49,67 @@ export const useApiKeysTableState = (): UseApiKeysTableStateReturn => {
   const [localUsername, setLocalUsername] = React.useState('');
   const [isFetching, setIsFetching] = React.useState(false);
 
+  const serverStatuses = React.useMemo(() => {
+    const hasInactive = filterData.statuses.includes('inactive');
+    const result = filterData.statuses.filter((s) => s !== 'inactive');
+    if (hasInactive && !result.includes('active')) {
+      result.push('active');
+    }
+    return result;
+  }, [filterData.statuses]);
+
   const searchRequest: APIKeySearchRequest = React.useMemo(
     () => ({
       filters: {
         ...(filterData.username && { username: filterData.username }),
-        ...(filterData.statuses.length > 0 && { status: filterData.statuses }),
+        ...(serverStatuses.length > 0 && { status: serverStatuses }),
         ...(filterData.subscription && { subscription: filterData.subscription }),
       },
       sort: { by: sortField, order: sortDirection },
       pagination: { limit: perPage, offset: (page - 1) * perPage },
     }),
-    [filterData, sortField, sortDirection, page, perPage],
+    [filterData.username, serverStatuses, filterData.subscription, sortField, sortDirection, page, perPage],
   );
 
-  const [response, loaded, error, refresh] = useFetchApiKeys(searchRequest);
+  const [rawResponse, loaded, error, refresh] = useFetchApiKeys(searchRequest);
+
+  const isKeyInactive = React.useCallback(
+    (key: APIKey): boolean =>
+      key.status === 'active' &&
+      !!key.subscription &&
+      rawResponse.subscriptionDetails != null &&
+      !(key.subscription in rawResponse.subscriptionDetails),
+    [rawResponse.subscriptionDetails],
+  );
+
+  const response = React.useMemo((): APIKeyListResponse => {
+    const hasActive = filterData.statuses.includes('active');
+    const hasInactive = filterData.statuses.includes('inactive');
+
+    let { data } = rawResponse;
+
+    if (hasActive !== hasInactive) {
+      data = data.filter((key) => {
+        if (key.status !== 'active') {
+          return true;
+        }
+        return hasInactive ? isKeyInactive(key) : !isKeyInactive(key);
+      });
+    }
+
+    if (hasActive && hasInactive) {
+      data = data.toSorted((a, b) => {
+        const aInactive = isKeyInactive(a) ? 1 : 0;
+        const bInactive = isKeyInactive(b) ? 1 : 0;
+        return aInactive - bInactive;
+      });
+    }
+
+    if (data === rawResponse.data) {
+      return rawResponse;
+    }
+    return { ...rawResponse, data };
+  }, [rawResponse, filterData.statuses, isKeyInactive]);
 
   React.useEffect(() => {
     setIsFetching(false);

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
@@ -28,6 +28,7 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions, showD
     loaded,
     refreshAll,
     filterData,
+    isKeyInactive,
     localUsername,
     setLocalUsername,
     page,
@@ -106,6 +107,7 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions, showD
           onRevokeApiKey={setRevokeApiKey}
           apiKeys={apiKeys}
           subscriptionDetails={subscriptionDetails}
+          isKeyInactive={isKeyInactive}
           hasMore={hasMore}
           page={page}
           perPage={perPage}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTable.tsx
@@ -142,6 +142,11 @@ const ApiKeysTable: React.FC<ApiKeysTableProps> = ({
                   subscriptionDetail={
                     apiKey.subscription ? subscriptionDetails?.[apiKey.subscription] : undefined
                   }
+                  isSubscriptionUnavailable={
+                    !!apiKey.subscription &&
+                    subscriptionDetails != null &&
+                    !(apiKey.subscription in subscriptionDetails)
+                  }
                   onRevokeApiKey={onRevokeApiKey}
                 />
               ))

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTable.tsx
@@ -11,6 +11,7 @@ type SortDirection = 'asc' | 'desc';
 type ApiKeysTableProps = {
   apiKeys: APIKey[];
   subscriptionDetails?: Record<string, SubscriptionDetail>;
+  isKeyInactive: (key: APIKey) => boolean;
   hasMore: boolean;
   page: number;
   perPage: number;
@@ -29,6 +30,7 @@ type ApiKeysTableProps = {
 const ApiKeysTable: React.FC<ApiKeysTableProps> = ({
   apiKeys,
   subscriptionDetails,
+  isKeyInactive,
   hasMore,
   page,
   perPage,
@@ -46,11 +48,14 @@ const ApiKeysTable: React.FC<ApiKeysTableProps> = ({
   const visibleColumns = React.useMemo(() => getVisibleApiKeyColumns(isMaasAdmin), [isMaasAdmin]);
   const activeSortIndex = visibleColumns.findIndex((c) => c.serverSortField === sortField);
 
+  const firstIndex = (page - 1) * perPage + 1;
+  const lastIndex = firstIndex + apiKeys.length - 1;
+
   const pagination = (variant: 'top' | 'bottom') => (
     <Pagination
       toggleTemplate={
         hasMore
-          ? ({ firstIndex, lastIndex }) => (
+          ? () => (
               <>
                 <b>
                   {firstIndex} - {lastIndex}
@@ -142,11 +147,7 @@ const ApiKeysTable: React.FC<ApiKeysTableProps> = ({
                   subscriptionDetail={
                     apiKey.subscription ? subscriptionDetails?.[apiKey.subscription] : undefined
                   }
-                  isSubscriptionUnavailable={
-                    !!apiKey.subscription &&
-                    subscriptionDetails != null &&
-                    !(apiKey.subscription in subscriptionDetails)
-                  }
+                  isInactive={isKeyInactive(apiKey)}
                   onRevokeApiKey={onRevokeApiKey}
                 />
               ))

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
@@ -10,12 +10,12 @@ import {
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import TableRowTitleDescription from '@odh-dashboard/internal/components/table/TableRowTitleDescription';
-import { APIKey, APIKeyStatus, SubscriptionDetail } from '~/app/types/api-key';
+import { APIKey, APIKeyDisplayStatus, SubscriptionDetail } from '~/app/types/api-key';
 import { ApiKeyColumn } from './columns';
 import SubscriptionCell from './SubscriptionCell';
 
 const getApiKeyStatusProps = (
-  status: APIKeyStatus,
+  status: APIKeyDisplayStatus,
 ): { icon: React.ReactNode; status?: LabelProps['status']; variant?: LabelProps['variant'] } => {
   switch (status) {
     case 'active':
@@ -46,14 +46,14 @@ const formatDate = (dateString?: string, fallback = '—'): string => {
   });
 };
 
-const getDisplayStatus = (apiKey: APIKey, isSubscriptionUnavailable: boolean): APIKeyStatus =>
-  apiKey.status === 'active' && isSubscriptionUnavailable ? 'inactive' : apiKey.status;
+const getDisplayStatus = (apiKey: APIKey, isInactive: boolean): APIKeyDisplayStatus =>
+  isInactive ? 'inactive' : apiKey.status;
 
 const renderApiKeyCell = (
   col: ApiKeyColumn,
   apiKey: APIKey,
   subscriptionDetail: SubscriptionDetail | undefined,
-  isSubscriptionUnavailable: boolean,
+  isInactive: boolean,
 ): React.ReactNode => {
   switch (col.field) {
     case 'name':
@@ -65,7 +65,7 @@ const renderApiKeyCell = (
         />
       );
     case 'status': {
-      const displayStatus = getDisplayStatus(apiKey, isSubscriptionUnavailable);
+      const displayStatus = getDisplayStatus(apiKey, isInactive);
       const { variant, ...labelProps } = getApiKeyStatusProps(displayStatus);
       const label = (
         <Label variant={variant ?? 'outline'} {...labelProps}>
@@ -110,7 +110,7 @@ type ApiKeysTableRowProps = {
   apiKey: APIKey;
   columns: ApiKeyColumn[];
   subscriptionDetail?: SubscriptionDetail;
-  isSubscriptionUnavailable: boolean;
+  isInactive: boolean;
   onRevokeApiKey: (apiKey: APIKey) => void;
 };
 
@@ -118,13 +118,13 @@ const ApiKeysTableRow: React.FC<ApiKeysTableRowProps> = ({
   apiKey,
   columns,
   subscriptionDetail,
-  isSubscriptionUnavailable,
+  isInactive,
   onRevokeApiKey,
 }) => (
   <Tr>
     {columns.map((col) => (
       <Td key={col.field} dataLabel={col.label}>
-        {renderApiKeyCell(col, apiKey, subscriptionDetail, isSubscriptionUnavailable)}
+        {renderApiKeyCell(col, apiKey, subscriptionDetail, isInactive)}
       </Td>
     ))}
     <Td isActionCell>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
-import { capitalize, Label } from '@patternfly/react-core';
+import { capitalize, Label, Popover } from '@patternfly/react-core';
 import type { LabelProps } from '@patternfly/react-core';
 import {
   BanIcon,
   CheckCircleIcon,
+  MinusCircleIcon,
   OutlinedClockIcon,
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
@@ -15,10 +16,12 @@ import SubscriptionCell from './SubscriptionCell';
 
 const getApiKeyStatusProps = (
   status: APIKeyStatus,
-): { icon: React.ReactNode; status?: LabelProps['status'] } => {
+): { icon: React.ReactNode; status?: LabelProps['status']; variant?: LabelProps['variant'] } => {
   switch (status) {
     case 'active':
       return { icon: <CheckCircleIcon />, status: 'success' };
+    case 'inactive':
+      return { icon: <MinusCircleIcon />, variant: 'filled' };
     case 'expired':
       return { icon: <OutlinedClockIcon /> };
     case 'revoked':
@@ -43,10 +46,14 @@ const formatDate = (dateString?: string, fallback = '—'): string => {
   });
 };
 
+const getDisplayStatus = (apiKey: APIKey, isSubscriptionUnavailable: boolean): APIKeyStatus =>
+  apiKey.status === 'active' && isSubscriptionUnavailable ? 'inactive' : apiKey.status;
+
 const renderApiKeyCell = (
   col: ApiKeyColumn,
   apiKey: APIKey,
   subscriptionDetail: SubscriptionDetail | undefined,
+  isSubscriptionUnavailable: boolean,
 ): React.ReactNode => {
   switch (col.field) {
     case 'name':
@@ -57,12 +64,28 @@ const renderApiKeyCell = (
           truncateDescriptionLines={2}
         />
       );
-    case 'status':
-      return (
-        <Label variant="outline" {...getApiKeyStatusProps(apiKey.status)}>
-          {capitalize(apiKey.status)}
+    case 'status': {
+      const displayStatus = getDisplayStatus(apiKey, isSubscriptionUnavailable);
+      const { variant, ...labelProps } = getApiKeyStatusProps(displayStatus);
+      const label = (
+        <Label variant={variant ?? 'outline'} {...labelProps}>
+          {capitalize(displayStatus)}
         </Label>
       );
+
+      if (displayStatus !== 'inactive') {
+        return label;
+      }
+
+      return (
+        <Popover
+          headerContent="Subscription unavailable"
+          bodyContent="The subscription this key was created for has been deleted or is not ready. The key itself has not been revoked, but it cannot authenticate requests until the subscription is restored."
+        >
+          <span style={{ cursor: 'pointer' }}>{label}</span>
+        </Popover>
+      );
+    }
     case 'subscription':
       return (
         <SubscriptionCell
@@ -87,6 +110,7 @@ type ApiKeysTableRowProps = {
   apiKey: APIKey;
   columns: ApiKeyColumn[];
   subscriptionDetail?: SubscriptionDetail;
+  isSubscriptionUnavailable: boolean;
   onRevokeApiKey: (apiKey: APIKey) => void;
 };
 
@@ -94,12 +118,13 @@ const ApiKeysTableRow: React.FC<ApiKeysTableRowProps> = ({
   apiKey,
   columns,
   subscriptionDetail,
+  isSubscriptionUnavailable,
   onRevokeApiKey,
 }) => (
   <Tr>
     {columns.map((col) => (
       <Td key={col.field} dataLabel={col.label}>
-        {renderApiKeyCell(col, apiKey, subscriptionDetail)}
+        {renderApiKeyCell(col, apiKey, subscriptionDetail, isSubscriptionUnavailable)}
       </Td>
     ))}
     <Td isActionCell>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysTableRow.tsx
@@ -49,61 +49,57 @@ const formatDate = (dateString?: string, fallback = '—'): string => {
 const getDisplayStatus = (apiKey: APIKey, isInactive: boolean): APIKeyDisplayStatus =>
   isInactive ? 'inactive' : apiKey.status;
 
-const renderApiKeyCell = (
-  col: ApiKeyColumn,
-  apiKey: APIKey,
-  subscriptionDetail: SubscriptionDetail | undefined,
-  isInactive: boolean,
-): React.ReactNode => {
-  switch (col.field) {
-    case 'name':
-      return (
-        <TableRowTitleDescription
-          title={apiKey.name}
-          description={apiKey.description}
-          truncateDescriptionLines={2}
-        />
-      );
-    case 'status': {
-      const displayStatus = getDisplayStatus(apiKey, isInactive);
-      const { variant, ...labelProps } = getApiKeyStatusProps(displayStatus);
-      const label = (
-        <Label variant={variant ?? 'outline'} {...labelProps}>
-          {capitalize(displayStatus)}
-        </Label>
-      );
+type CellRenderContext = {
+  apiKey: APIKey;
+  subscriptionDetail: SubscriptionDetail | undefined;
+  isInactive: boolean;
+};
 
-      if (displayStatus !== 'inactive') {
-        return label;
-      }
+type CellRenderer = (ctx: CellRenderContext) => React.ReactNode;
 
-      return (
-        <Popover
-          headerContent="Subscription unavailable"
-          bodyContent="The subscription this key was created for has been deleted or is not ready. The key itself has not been revoked, but it cannot authenticate requests until the subscription is restored."
-        >
-          <span style={{ cursor: 'pointer' }}>{label}</span>
-        </Popover>
-      );
+const cellRenderers: Record<string, CellRenderer> = {
+  name: ({ apiKey }) => (
+    <TableRowTitleDescription
+      title={apiKey.name}
+      description={apiKey.description}
+      truncateDescriptionLines={2}
+    />
+  ),
+
+  status: ({ apiKey, isInactive }) => {
+    const displayStatus = getDisplayStatus(apiKey, isInactive);
+    const { variant, ...labelProps } = getApiKeyStatusProps(displayStatus);
+    const label = (
+      <Label variant={variant ?? 'outline'} {...labelProps}>
+        {capitalize(displayStatus)}
+      </Label>
+    );
+
+    if (displayStatus !== 'inactive') {
+      return label;
     }
-    case 'subscription':
-      return (
-        <SubscriptionCell
-          subscriptionName={apiKey.subscription}
-          subscriptionDetail={subscriptionDetail}
-        />
-      );
-    case 'username':
-      return apiKey.username ?? '—';
-    case 'creationDate':
-      return formatDate(apiKey.creationDate, '—');
-    case 'lastUsedAt':
-      return formatDate(apiKey.lastUsedAt, 'Never');
-    case 'expirationDate':
-      return formatDate(apiKey.expirationDate, 'Never');
-    default:
-      return null;
-  }
+
+    return (
+      <Popover
+        headerContent="Subscription unavailable"
+        bodyContent="The subscription this key was created for has been deleted or is not ready. The key itself has not been revoked, but it cannot authenticate requests until the subscription is restored."
+      >
+        <span style={{ cursor: 'pointer' }}>{label}</span>
+      </Popover>
+    );
+  },
+
+  subscription: ({ apiKey, subscriptionDetail }) => (
+    <SubscriptionCell
+      subscriptionName={apiKey.subscription}
+      subscriptionDetail={subscriptionDetail}
+    />
+  ),
+
+  username: ({ apiKey }) => apiKey.username ?? '—',
+  creationDate: ({ apiKey }) => formatDate(apiKey.creationDate, '—'),
+  lastUsedAt: ({ apiKey }) => formatDate(apiKey.lastUsedAt, 'Never'),
+  expirationDate: ({ apiKey }) => formatDate(apiKey.expirationDate, 'Never'),
 };
 
 type ApiKeysTableRowProps = {
@@ -120,26 +116,30 @@ const ApiKeysTableRow: React.FC<ApiKeysTableRowProps> = ({
   subscriptionDetail,
   isInactive,
   onRevokeApiKey,
-}) => (
-  <Tr>
-    {columns.map((col) => (
-      <Td key={col.field} dataLabel={col.label}>
-        {renderApiKeyCell(col, apiKey, subscriptionDetail, isInactive)}
+}) => {
+  const ctx: CellRenderContext = { apiKey, subscriptionDetail, isInactive };
+
+  return (
+    <Tr>
+      {columns.map((col) => (
+        <Td key={col.field} dataLabel={col.label}>
+          {cellRenderers[col.field](ctx)}
+        </Td>
+      ))}
+      <Td isActionCell>
+        <ActionsColumn
+          data-testid="api-key-actions"
+          items={[
+            {
+              title: 'Revoke',
+              onClick: () => onRevokeApiKey(apiKey),
+              isDisabled: apiKey.status !== 'active',
+            },
+          ]}
+        />
       </Td>
-    ))}
-    <Td isActionCell>
-      <ActionsColumn
-        data-testid="api-key-actions"
-        items={[
-          {
-            title: 'Revoke',
-            onClick: () => onRevokeApiKey(apiKey),
-            isDisabled: apiKey.status !== 'active',
-          },
-        ]}
-      />
-    </Td>
-  </Tr>
-);
+    </Tr>
+  );
+};
 
 export default ApiKeysTableRow;

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
@@ -24,6 +24,11 @@ import {
   SubscriptionOption,
 } from '~/app/types/api-key';
 
+const STATUS_SET: ReadonlySet<string> = new Set(STATUS_OPTIONS);
+
+const isAPIKeyStatus = (value: unknown): value is APIKeyStatus =>
+  typeof value === 'string' && STATUS_SET.has(value);
+
 type ApiKeysToolbarProps = {
   setIsModalOpen: (isOpen: boolean) => void;
   filterData: ApiKeyFilterDataType;
@@ -89,7 +94,7 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
               }))}
               deleteLabel={(_category, label) => {
                 const key = typeof label === 'string' ? label : label.key;
-                if (key === 'active' || key === 'expired' || key === 'revoked') {
+                if (isAPIKeyStatus(key)) {
                   onStatusClear(key);
                 }
               }}
@@ -100,7 +105,7 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
                 isOpen={isStatusSelectOpen}
                 selected={filterData.statuses}
                 onSelect={(_event, value) => {
-                  if (value === 'active' || value === 'expired' || value === 'revoked') {
+                  if (isAPIKeyStatus(value)) {
                     onStatusToggle(value);
                   }
                 }}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/allKeys/ApiKeysToolbar.tsx
@@ -18,7 +18,7 @@ import { FilterIcon } from '@patternfly/react-icons';
 import ApiKeysActions from '~/app/pages/keys-and-subs/apiKeys/ApiKeysActions';
 import {
   APIKey,
-  APIKeyStatus,
+  APIKeyDisplayStatus,
   ApiKeyFilterDataType,
   STATUS_OPTIONS,
   SubscriptionOption,
@@ -26,7 +26,7 @@ import {
 
 const STATUS_SET: ReadonlySet<string> = new Set(STATUS_OPTIONS);
 
-const isAPIKeyStatus = (value: unknown): value is APIKeyStatus =>
+const isAPIKeyDisplayStatus = (value: unknown): value is APIKeyDisplayStatus =>
   typeof value === 'string' && STATUS_SET.has(value);
 
 type ApiKeysToolbarProps = {
@@ -35,8 +35,8 @@ type ApiKeysToolbarProps = {
   localUsername: string;
   setLocalUsername: (value: string) => void;
   onUsernameChange: (value: string) => void;
-  onStatusToggle: (status: APIKeyStatus) => void;
-  onStatusClear: (status: APIKeyStatus) => void;
+  onStatusToggle: (status: APIKeyDisplayStatus) => void;
+  onStatusClear: (status: APIKeyDisplayStatus) => void;
   subscriptions: SubscriptionOption[];
   onSubscriptionChange: (subscription: string) => void;
   activeApiKeys: APIKey[];
@@ -94,7 +94,7 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
               }))}
               deleteLabel={(_category, label) => {
                 const key = typeof label === 'string' ? label : label.key;
-                if (isAPIKeyStatus(key)) {
+                if (isAPIKeyDisplayStatus(key)) {
                   onStatusClear(key);
                 }
               }}
@@ -105,7 +105,7 @@ const ApiKeysToolbar: React.FC<ApiKeysToolbarProps> = ({
                 isOpen={isStatusSelectOpen}
                 selected={filterData.statuses}
                 onSelect={(_event, value) => {
-                  if (isAPIKeyStatus(value)) {
+                  if (isAPIKeyDisplayStatus(value)) {
                     onStatusToggle(value);
                   }
                 }}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
@@ -227,7 +227,7 @@ const MySubscriptionsApiKeyTable: React.FC<MySubscriptionsApiKeyTableProps> = ({
                 apiKey={apiKey}
                 columns={subscriptionApiKeyColumns}
                 onRevokeApiKey={setRevokeApiKey}
-                isSubscriptionUnavailable={false}
+                isInactive={false}
               />
             ))
           )}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
@@ -227,6 +227,7 @@ const MySubscriptionsApiKeyTable: React.FC<MySubscriptionsApiKeyTableProps> = ({
                 apiKey={apiKey}
                 columns={subscriptionApiKeyColumns}
                 onRevokeApiKey={setRevokeApiKey}
+                isSubscriptionUnavailable={false}
               />
             ))
           )}

--- a/packages/maas/frontend/src/app/types/api-key.ts
+++ b/packages/maas/frontend/src/app/types/api-key.ts
@@ -1,4 +1,4 @@
-export type APIKeyStatus = 'active' | 'revoked' | 'expired';
+export type APIKeyStatus = 'active' | 'revoked' | 'expired' | 'inactive';
 
 export type APIKey = {
   id: string;
@@ -67,7 +67,7 @@ export type SubscriptionOption = {
   displayName: string;
 };
 
-export const STATUS_OPTIONS: APIKeyStatus[] = ['active', 'expired', 'revoked'];
+export const STATUS_OPTIONS: APIKeyStatus[] = ['active', 'inactive', 'expired', 'revoked'];
 
 export type ApiKeyFilterDataType = {
   username: string;

--- a/packages/maas/frontend/src/app/types/api-key.ts
+++ b/packages/maas/frontend/src/app/types/api-key.ts
@@ -1,4 +1,5 @@
-export type APIKeyStatus = 'active' | 'revoked' | 'expired' | 'inactive';
+export type APIKeyStatus = 'active' | 'revoked' | 'expired';
+export type APIKeyDisplayStatus = APIKeyStatus | 'inactive';
 
 export type APIKey = {
   id: string;
@@ -67,11 +68,11 @@ export type SubscriptionOption = {
   displayName: string;
 };
 
-export const STATUS_OPTIONS: APIKeyStatus[] = ['active', 'inactive', 'expired', 'revoked'];
+export const STATUS_OPTIONS: APIKeyDisplayStatus[] = ['active', 'inactive', 'expired', 'revoked'];
 
 export type ApiKeyFilterDataType = {
   username: string;
-  statuses: APIKeyStatus[];
+  statuses: APIKeyDisplayStatus[];
   subscription: string;
 };
 

--- a/packages/maas/frontend/src/app/types/api-key.ts
+++ b/packages/maas/frontend/src/app/types/api-key.ts
@@ -77,7 +77,7 @@ export type ApiKeyFilterDataType = {
 
 export const initialApiKeyFilterData: ApiKeyFilterDataType = {
   username: '',
-  statuses: ['active', 'expired'],
+  statuses: ['active', 'inactive', 'expired'],
   subscription: '',
 };
 

--- a/packages/maas/frontend/src/app/utilities/apiKeys.ts
+++ b/packages/maas/frontend/src/app/utilities/apiKeys.ts
@@ -1,4 +1,24 @@
-import { APIKey, APIKeyDisplayStatus } from '~/app/types/api-key';
+import { APIKey, APIKeyDisplayStatus, SubscriptionDetail } from '~/app/types/api-key';
+
+/**
+ * Determines whether an API key should be displayed as "inactive".
+ *
+ * A key is inactive when it has `active` status on the server but its
+ * subscription no longer appears in the enrichment map returned alongside the
+ * key list — meaning the subscription was deleted or is otherwise unavailable.
+ *
+ * When `subscriptionDetails` is `undefined` (enrichment was not returned at
+ * all, e.g. due to a transient fetch failure), no key is classified as
+ * inactive so we avoid false positives.
+ */
+export const isKeyInactive = (
+  key: APIKey,
+  subscriptionDetails: Record<string, SubscriptionDetail> | undefined,
+): boolean =>
+  key.status === 'active' &&
+  !!key.subscription &&
+  subscriptionDetails != null &&
+  !(key.subscription in subscriptionDetails);
 
 export type InactiveFilterResult = {
   data: APIKey[];
@@ -7,14 +27,15 @@ export type InactiveFilterResult = {
 };
 
 /**
- * Applies client-side inactive-status filtering and sorting to API key data.
+ * Applies client-side inactive-status filtering to API key data.
  *
  * "Inactive" is a UI-derived status: an active key whose subscription is no longer
  * available. The server only knows `active | revoked | expired`, so the inactive
  * distinction must be applied client-side after the response arrives.
  *
- * When only one of `active` / `inactive` is selected the data is filtered;
- * when both are selected inactive keys are sorted to the end.
+ * When only one of `active` / `inactive` is selected the data is filtered
+ * to show only the matching subset; when both (or neither) are selected the
+ * data is returned as-is in the server's original order.
  *
  * **Pagination caveat:** because the server paginates before this filter runs,
  * the server's `has_more` flag and page size do not account for removed rows.
@@ -24,7 +45,7 @@ export type InactiveFilterResult = {
 export const applyInactiveFilter = (
   data: APIKey[],
   statuses: APIKeyDisplayStatus[],
-  isKeyInactive: (key: APIKey) => boolean,
+  checkInactive: (key: APIKey) => boolean,
 ): InactiveFilterResult => {
   const hasActive = statuses.includes('active');
   const hasInactive = statuses.includes('inactive');
@@ -35,20 +56,9 @@ export const applyInactiveFilter = (
         if (key.status !== 'active') {
           return true;
         }
-        return hasInactive ? isKeyInactive(key) : !isKeyInactive(key);
+        return hasInactive ? checkInactive(key) : !checkInactive(key);
       }),
       clientFiltered: true,
-    };
-  }
-
-  if (hasActive && hasInactive) {
-    return {
-      data: data.toSorted((a, b) => {
-        const aInactive = isKeyInactive(a) ? 1 : 0;
-        const bInactive = isKeyInactive(b) ? 1 : 0;
-        return aInactive - bInactive;
-      }),
-      clientFiltered: false,
     };
   }
 

--- a/packages/maas/frontend/src/app/utilities/apiKeys.ts
+++ b/packages/maas/frontend/src/app/utilities/apiKeys.ts
@@ -1,0 +1,56 @@
+import { APIKey, APIKeyDisplayStatus } from '~/app/types/api-key';
+
+export type InactiveFilterResult = {
+  data: APIKey[];
+  /** True when client-side filtering removed rows from the server response. */
+  clientFiltered: boolean;
+};
+
+/**
+ * Applies client-side inactive-status filtering and sorting to API key data.
+ *
+ * "Inactive" is a UI-derived status: an active key whose subscription is no longer
+ * available. The server only knows `active | revoked | expired`, so the inactive
+ * distinction must be applied client-side after the response arrives.
+ *
+ * When only one of `active` / `inactive` is selected the data is filtered;
+ * when both are selected inactive keys are sorted to the end.
+ *
+ * **Pagination caveat:** because the server paginates before this filter runs,
+ * the server's `has_more` flag and page size do not account for removed rows.
+ * Callers that display pagination counts should use the returned `data.length`
+ * rather than the server's page size when `clientFiltered` is true.
+ */
+export const applyInactiveFilter = (
+  data: APIKey[],
+  statuses: APIKeyDisplayStatus[],
+  isKeyInactive: (key: APIKey) => boolean,
+): InactiveFilterResult => {
+  const hasActive = statuses.includes('active');
+  const hasInactive = statuses.includes('inactive');
+
+  if (hasActive !== hasInactive) {
+    return {
+      data: data.filter((key) => {
+        if (key.status !== 'active') {
+          return true;
+        }
+        return hasInactive ? isKeyInactive(key) : !isKeyInactive(key);
+      }),
+      clientFiltered: true,
+    };
+  }
+
+  if (hasActive && hasInactive) {
+    return {
+      data: data.toSorted((a, b) => {
+        const aInactive = isKeyInactive(a) ? 1 : 0;
+        const bInactive = isKeyInactive(b) ? 1 : 0;
+        return aInactive - bInactive;
+      }),
+      clientFiltered: false,
+    };
+  }
+
+  return { data, clientFiltered: false };
+};


### PR DESCRIPTION
Closes: [RHOAIENG-64755](https://redhat.atlassian.net/browse/RHOAIENG-64755)

## Description
Adds an 'Inactive' state to API keys that appears when the subscription associated with the API key gets deleted. The state was added to the status toolbar, so that API keys with inactive can be sorted, and will show up by default. Also adds a popover when 'Inactive' is clicked explaining that the subscription is unavailable.

## How Has This Been Tested?
Tested locally. 

- Go to your API keys, and create a key. 
- Then go to subscriptions and delete the sub you used for your API key
- Go back to API keys, 'Inactive' should be selected by default

## Test Impact
Added a cypress test for new status 

## Screenshots
<img width="353" height="313" alt="Screenshot 2026-06-08 at 10 33 08 AM" src="https://github.com/user-attachments/assets/4f78c195-b8be-4546-8d15-0c16ab94b217" />
<img width="1417" height="742" alt="Screenshot 2026-06-08 at 10 33 24 AM" src="https://github.com/user-attachments/assets/147aeca9-91ec-43b5-831b-f44d29796bcb" />
<img width="1394" height="491" alt="Screenshot 2026-06-08 at 10 33 36 AM" src="https://github.com/user-attachments/assets/2169675e-d2c9-4969-9bb5-205414959ffe" />


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features & Enhancements**
  * API keys whose subscriptions were deleted are now shown as **“Inactive”**, including an **Inactive** status filter in defaults; inactive keys are ordered consistently. Status rendering now shows an informational popover when a subscription is unavailable.  
* **Bug Fixes**
  * API responses now always include subscription detail data so the client can reliably mark keys as inactive.  
  * Status filter selection is now matched using a case-insensitive exact match to prevent incorrect menu selection.  
* **Tests**
  * Updated/added Cypress coverage for orphaned/inactive keys, popover behavior, and status filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->