### PR TITLE
RHOAIENG-50649: add total_count and substring filter to prompts list

### DIFF
--- a/packages/gen-ai/bff/internal/api/mlflow_prompts_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/mlflow_prompts_handler_test.go
@@ -130,7 +130,25 @@ var _ = Describe("MLflow Prompts Handler", func() {
 
 			Expect(len(envelope.Data.Prompts)).To(BeNumerically(">=", 2))
 			for _, p := range envelope.Data.Prompts {
-				Expect(p.Name).To(HavePrefix("pet"), "all returned prompts should start with 'pet'")
+				Expect(p.Name).To(ContainSubstring("pet"), "all returned prompts should contain 'pet'")
+			}
+		})
+
+		It("should filter prompts by name substring using filter_name", func() {
+			resp := MakeRequest(TestRequest{
+				Method: http.MethodGet,
+				Path:   "/gen-ai/api/v1/mlflow/prompts?namespace=default&filter_name=reminder",
+			})
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var envelope MLflowPromptsEnvelope
+			ReadJSONResponse(resp, &envelope)
+
+			Expect(len(envelope.Data.Prompts)).To(BeNumerically(">=", 1))
+			for _, p := range envelope.Data.Prompts {
+				Expect(p.Name).To(ContainSubstring("reminder"), "all returned prompts should contain 'reminder'")
 			}
 		})
 	})

--- a/packages/gen-ai/bff/internal/models/mlflow.go
+++ b/packages/gen-ai/bff/internal/models/mlflow.go
@@ -15,6 +15,7 @@ type MLflowPrompt struct {
 type MLflowPromptsResponse struct {
 	Prompts       []MLflowPrompt `json:"prompts"`
 	NextPageToken string         `json:"next_page_token,omitempty"`
+	TotalCount    int            `json:"total_count"`
 }
 
 // MLflowMessage represents a single message in a chat prompt.

--- a/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
+++ b/packages/gen-ai/bff/internal/repositories/mlflow_prompts.go
@@ -19,8 +19,15 @@ func NewMLflowPromptsRepository() *MLflowPromptsRepository {
 	return &MLflowPromptsRepository{}
 }
 
+// maxCountResults is the maximum number of results to fetch for counting.
+// MLflow's API maximum is 1000. For registries larger than this, the total
+// count will be capped at 1000.
+const maxCountResults = 1000
+
 // ListPrompts retrieves available MLflow prompts with optional pagination and filtering.
-// The MLflow client is expected to be in the context (set by AttachMLflowClient middleware).
+// It also returns a total count of matching prompts by performing a single large fetch
+// (up to 1000 results). If the paginated request fits within a single page and has no
+// next_page_token, the count is derived directly without an extra query.
 func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken string, maxResults string, nameFilter string) (*models.MLflowPromptsResponse, error) {
 	client, err := helper.GetContextMLflowClient(ctx)
 	if err != nil {
@@ -38,7 +45,7 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 		}
 	}
 	if nameFilter != "" {
-		opts = append(opts, promptregistry.WithNameFilter(nameFilter+"%"))
+		opts = append(opts, promptregistry.WithNameFilter("%"+nameFilter+"%"))
 	}
 
 	promptList, err := client.ListPrompts(ctx, opts...)
@@ -57,10 +64,47 @@ func (r *MLflowPromptsRepository) ListPrompts(ctx context.Context, pageToken str
 		}
 	}
 
+	totalCount := len(prompts)
+	if pageToken != "" || promptList.NextPageToken != "" {
+		totalCount, err = r.countPrompts(ctx, nameFilter)
+		if err != nil {
+			if promptList.NextPageToken != "" {
+				totalCount = len(prompts) + 1
+				if totalCount > maxCountResults {
+					totalCount = maxCountResults
+				}
+			} else {
+				totalCount = len(prompts)
+			}
+		}
+	}
+
 	return &models.MLflowPromptsResponse{
 		Prompts:       prompts,
 		NextPageToken: promptList.NextPageToken,
+		TotalCount:    totalCount,
 	}, nil
+}
+
+// countPrompts fetches up to maxCountResults prompts with the same filter
+// to determine the total count. This avoids N+1 page iteration.
+func (r *MLflowPromptsRepository) countPrompts(ctx context.Context, nameFilter string) (int, error) {
+	client, err := helper.GetContextMLflowClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var countOpts []promptregistry.ListPromptsOption
+	countOpts = append(countOpts, promptregistry.WithMaxResults(maxCountResults))
+	if nameFilter != "" {
+		countOpts = append(countOpts, promptregistry.WithNameFilter("%"+nameFilter+"%"))
+	}
+
+	countList, err := client.ListPrompts(ctx, countOpts...)
+	if err != nil {
+		return 0, err
+	}
+	return len(countList.Prompts), nil
 }
 
 // RegisterPrompt creates a new prompt or adds a new version to an existing prompt.

--- a/packages/gen-ai/bff/openapi/src/gen-ai.yaml
+++ b/packages/gen-ai/bff/openapi/src/gen-ai.yaml
@@ -972,7 +972,7 @@ paths:
             example: 10
         - name: filter_name
           in: query
-          description: Filter prompts by name prefix (e.g. "pet" matches "pet-health-bella", "pet-adoption-letter")
+          description: Filter prompts by name substring (e.g. "reminder" matches "medication-reminder-patient")
           required: false
           schema:
             type: string
@@ -995,8 +995,12 @@ paths:
                       next_page_token:
                         type: string
                         description: Token for fetching the next page of results
+                      total_count:
+                        type: integer
+                        description: Total number of prompts matching the filter criteria (up to 1000)
                     required:
                       - prompts
+                      - total_count
                   metadata:
                     type: object
                     nullable: true

--- a/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockMLflowPrompts.ts
+++ b/packages/gen-ai/frontend/src/__tests__/cypress/cypress/__mocks__/mockMLflowPrompts.ts
@@ -13,24 +13,28 @@ export const mockMLflowPrompt = (overrides: Partial<MLflowPrompt> = {}): MLflowP
 export const mockMLflowPromptsList = (
   prompts?: MLflowPrompt[],
   nextPageToken?: string,
-): { data: { prompts: MLflowPrompt[]; next_page_token?: string } } => ({
-  data: {
-    prompts: prompts ?? [
-      mockMLflowPrompt({ name: 'summarization-prompt', description: 'Summarize content' }),
-      mockMLflowPrompt({
-        name: 'code-review-prompt',
-        description: 'Review code',
-        latest_version: 3,
-      }),
-      mockMLflowPrompt({
-        name: 'translation-prompt',
-        description: 'Translate text',
-        latest_version: 2,
-      }),
-    ],
-    next_page_token: nextPageToken,
-  },
-});
+): { data: { prompts: MLflowPrompt[]; next_page_token?: string; total_count: number } } => {
+  const promptsList = prompts ?? [
+    mockMLflowPrompt({ name: 'summarization-prompt', description: 'Summarize content' }),
+    mockMLflowPrompt({
+      name: 'code-review-prompt',
+      description: 'Review code',
+      latest_version: 3,
+    }),
+    mockMLflowPrompt({
+      name: 'translation-prompt',
+      description: 'Translate text',
+      latest_version: 2,
+    }),
+  ];
+  return {
+    data: {
+      prompts: promptsList,
+      total_count: promptsList.length,
+      next_page_token: nextPageToken,
+    },
+  };
+};
 
 export const mockMLflowPromptVersion = (
   overrides: Partial<MLflowPromptVersion> = {},

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/promptTable.spec.tsx
@@ -69,6 +69,7 @@ describe('PromptTable', () => {
   it('should render loading spinner when fetching prompts', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: [],
+      totalCount: 0,
       isLoading: true,
       error: null,
     });
@@ -81,6 +82,7 @@ describe('PromptTable', () => {
   it('should render error state when API fails', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: [],
+      totalCount: 0,
       isLoading: false,
       error: new Error('Network error occurred'),
     });
@@ -94,6 +96,7 @@ describe('PromptTable', () => {
   it('should render empty state when no prompts exist', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: [],
+      totalCount: 0,
       isLoading: false,
       error: null,
     });
@@ -107,6 +110,7 @@ describe('PromptTable', () => {
   it('should render table with prompts when data is loaded', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });
@@ -121,6 +125,7 @@ describe('PromptTable', () => {
   it('should render table column headers', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });
@@ -136,6 +141,7 @@ describe('PromptTable', () => {
   it('should call onClose when Cancel button is clicked', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });
@@ -150,6 +156,7 @@ describe('PromptTable', () => {
   it('should select row when clicked', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });
@@ -165,6 +172,7 @@ describe('PromptTable', () => {
   it('should call onClickLoad when Load button is clicked with selected version', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });
@@ -187,6 +195,7 @@ describe('PromptTable', () => {
   it('should show loading state in Load button when fetching version details', () => {
     mockUsePromptsList.mockReturnValue({
       prompts: mockPrompts,
+      totalCount: mockPrompts.length,
       isLoading: false,
       error: null,
     });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/usePromptQueries.spec.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/__tests__/usePromptQueries.spec.ts
@@ -107,7 +107,7 @@ describe('usePromptsList', () => {
 
   it('should return prompts when loaded successfully', () => {
     mockUseInfiniteQuery.mockReturnValue({
-      data: mockPrompts,
+      data: [{ prompts: mockPrompts, total_count: mockPrompts.length }],
       isLoading: false,
       isFetchingNextPage: false,
       hasNextPage: false,
@@ -118,13 +118,14 @@ describe('usePromptsList', () => {
     const { result } = testHook(usePromptsList)();
 
     expect(result.current.prompts).toEqual(mockPrompts);
+    expect(result.current.totalCount).toBe(mockPrompts.length);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
   });
 
   it('should return empty array when no prompts exist', () => {
     mockUseInfiniteQuery.mockReturnValue({
-      data: [],
+      data: [{ prompts: [], total_count: 0 }],
       isLoading: false,
       isFetchingNextPage: false,
       hasNextPage: false,
@@ -135,6 +136,7 @@ describe('usePromptsList', () => {
     const { result } = testHook(usePromptsList)();
 
     expect(result.current.prompts).toEqual([]);
+    expect(result.current.totalCount).toBe(0);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
   });
@@ -158,9 +160,9 @@ describe('usePromptsList', () => {
   });
 
   it('should pass filter options to query', async () => {
-    mockListMLflowPrompts.mockResolvedValue({ prompts: [] });
+    mockListMLflowPrompts.mockResolvedValue({ prompts: [], total_count: 0 });
     mockUseInfiniteQuery.mockReturnValue({
-      data: [],
+      data: [{ prompts: [], total_count: 0 }],
       isLoading: false,
       isFetchingNextPage: false,
       hasNextPage: false,
@@ -190,7 +192,7 @@ describe('usePromptsList', () => {
 
   it('should expose pagination state', () => {
     mockUseInfiniteQuery.mockReturnValue({
-      data: mockPrompts,
+      data: [{ prompts: mockPrompts, total_count: mockPrompts.length }],
       isLoading: false,
       isFetchingNextPage: true,
       hasNextPage: true,

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/promptTable.tsx
@@ -59,9 +59,9 @@ export default function PromptTable({
   );
 
   const {
-    hasNextPage,
     fetchNextPage,
     prompts: rows,
+    totalCount,
     isLoading: isLoadingList,
     isFetchingNextPage,
     error: listError,
@@ -144,7 +144,7 @@ export default function PromptTable({
       <Pagination
         isStatic
         isCompact={isCompact}
-        itemCount={hasNextPage ? rows.length + 1 : rows.length}
+        itemCount={totalCount}
         page={activePage}
         perPage={perPage}
         onSetPage={(_, newPage) => {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/usePromptQueries.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/promptManagementModal/usePromptQueries.ts
@@ -16,6 +16,7 @@ type UsePromptsListOptions = {
 
 type UsePromptsListResult = {
   prompts: MLflowPrompt[];
+  totalCount: number;
   isLoading: boolean;
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
@@ -28,45 +29,50 @@ export function usePromptsList(options: UsePromptsListOptions = {}): UsePromptsL
   const { maxResults, filterName } = options;
   const { namespace } = useContext(GenAiContext);
 
-  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error } =
-    useInfiniteQuery<
-      MLflowPromptsResponse,
-      Error,
-      MLflowPrompt[],
-      [string, string, { maxResults?: number; filterName?: string }],
-      string | undefined
-    >({
-      queryKey: [`${namespace?.name}_prompts`, 'list', { maxResults, filterName }],
-      queryFn: async ({ pageParam }) => {
-        const queryParams: Record<string, unknown> = {};
-        if (maxResults !== undefined) {
-          // eslint-disable-next-line camelcase -- MLflow API uses snake_case
-          queryParams.max_results = maxResults;
-        }
-        if (filterName !== undefined) {
-          // eslint-disable-next-line camelcase -- MLflow API uses snake_case
-          queryParams.filter_name = filterName;
-        }
-        if (pageParam) {
-          // eslint-disable-next-line camelcase -- MLflow API uses snake_case
-          queryParams.page_token = pageParam;
-        }
-        return api.listMLflowPrompts(queryParams);
-      },
-      initialPageParam: undefined,
-      getNextPageParam: (lastPage) => lastPage.next_page_token,
-      select: (queryData) => queryData.pages.flatMap((page) => page.prompts),
-      enabled: apiAvailable,
-      staleTime: 60000,
-    });
+  const queryResult = useInfiniteQuery<
+    MLflowPromptsResponse,
+    Error,
+    MLflowPromptsResponse[],
+    [string, string, { maxResults?: number; filterName?: string }],
+    string | undefined
+  >({
+    queryKey: [`${namespace?.name}_prompts`, 'list', { maxResults, filterName }],
+    queryFn: async ({ pageParam }) => {
+      const queryParams: Record<string, unknown> = {};
+      if (maxResults !== undefined) {
+        // eslint-disable-next-line camelcase -- MLflow API uses snake_case
+        queryParams.max_results = maxResults;
+      }
+      if (filterName !== undefined) {
+        // eslint-disable-next-line camelcase -- MLflow API uses snake_case
+        queryParams.filter_name = filterName;
+      }
+      if (pageParam) {
+        // eslint-disable-next-line camelcase -- MLflow API uses snake_case
+        queryParams.page_token = pageParam;
+      }
+      return api.listMLflowPrompts(queryParams);
+    },
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.next_page_token,
+    select: (queryData) => queryData.pages,
+    enabled: apiAvailable,
+    staleTime: 60000,
+  });
+
+  const pages = queryResult.data ?? [];
+  const prompts = pages.flatMap((page) => page.prompts);
+  // eslint-disable-next-line camelcase -- MLflow API uses snake_case
+  const totalCount = pages[0]?.total_count ?? 0;
 
   return {
-    prompts: data ?? [],
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    error: error ?? null,
+    prompts,
+    totalCount,
+    isLoading: queryResult.isLoading,
+    isFetchingNextPage: queryResult.isFetchingNextPage,
+    hasNextPage: queryResult.hasNextPage,
+    fetchNextPage: queryResult.fetchNextPage,
+    error: queryResult.error ?? null,
   };
 }
 

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -479,6 +479,7 @@ export type MLflowPrompt = {
 export type MLflowPromptsResponse = {
   prompts: MLflowPrompt[];
   next_page_token?: string;
+  total_count: number;
 };
 
 export type MLflowMessage = {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-50649

## Description

Adds `total_count` to the prompts list response and changes the name filter from prefix-only to substring matching.

**What changed (10 files, +148/-66):**

- **mlflow_prompts.go** — Added `countPrompts` function that fetches up to 1000 prompts (MLflow max per request) to determine the total count. The count query only runs when there is a `next_page_token` (more than one page of results). If no pagination is needed, the count is derived directly from the results without an extra query. Also changed the name filter from `nameFilter+"%"` (prefix-only) to `"%"+nameFilter+"%"` (substring).
- **mlflow.go** — Added `TotalCount int` field to `MLflowPromptsResponse`, serialized as `total_count`.
- **gen-ai.yaml** — Added `total_count` (integer, required) to the response schema. Updated `filter_name` parameter description from "name prefix" to "name substring".
- **types.ts** — Added `total_count: number` to `MLflowPromptsResponse`.
- **usePromptQueries.ts** — Changed `select` to return full pages, then extracts `total_count` from first page. Exposes `totalCount` in the return type.
- **promptTable.tsx** — Replaced `itemCount={hasNextPage ? rows.length + 1 : rows.length}` with `itemCount={totalCount}`. Removed unused `hasNextPage` destructuring.
- **mlflow_prompts_handler_test.go** — Updated prefix filter test to use `ContainSubstring`. Added new substring filter test case.
- **usePromptQueries.spec.ts** — Updated mock data to page objects with `total_count`.
- **promptTable.spec.tsx** — Added `totalCount` to all 9 mock return values.
- **mockMLflowPrompts.ts** — Added `total_count` to the Cypress mock factory.

**Key design decisions:**

- **Single large fetch for count** — benchmarked on a cluster with 112 prompts: `max_results=1000` has identical latency to `max_results=10` (~0.45s). The count query only fires when pagination is active. For registries with 1000+ prompts, the count caps at 1000.
- **Graceful degradation** — if the count query fails, falls back to `len(prompts)` from the current page.
- **Explicit wrapping** — uses `"%"+nameFilter+"%"` instead of relying on MLflow auto-wrap behavior, for consistency across MLflow versions.

## How Has This Been Tested?

- BFF Go tests: all 13 packages pass, including integration tests against local MLflow with seed data.
- BFF Go lint: 0 issues.
- Frontend TypeScript type-check: passes.
- Frontend ESLint: 0 errors with `--max-warnings 0`.
- Frontend Jest: 20 tests pass (usePromptQueries + promptTable).
- Contract tests: 15/15 pass, validating the new `total_count` field against OpenAPI schema.
- Manual testing: verified on a live RHOAI 3.5-ea2 cluster with 112 prompts. Pagination shows "1-10 of 112", substring search for "reminder" returns `medication-reminder-patient`.

## Test Impact

- **mlflow_prompts_handler_test.go** — 1 new test (substring filter), 1 updated test (prefix to substring assertion).
- **usePromptQueries.spec.ts** — 4 mocks updated to page-based data format with `total_count`.
- **promptTable.spec.tsx** — 9 mocks updated to include `totalCount`.
- **mockMLflowPrompts.ts** — Cypress mock factory updated with `total_count`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added total item count to prompt listings so pagination displays the exact number of available prompts.

* **Improvements**
  * Prompt name filtering now uses substring matching for more flexible searches.
  * Prompt management pagination now relies on the reported total count for accurate page sizing and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->