### PR TITLE
RHOAIENG-66939, RHOAIENG-66940: View Code snippets for ASR and Vision multimodal features

### DIFF
--- a/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
@@ -866,4 +866,77 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, code, "NEMO_GUARDRAILS_URL = \"\"")
 	})
+
+	t.Run("should generate Python code with ASR transcription section when ASRModel is set", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input:    "Hello, world!",
+			Model:    "llama3.2:3b",
+			ASRModel: "whisper-large-v3-turbo",
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.Contains(t, code, "ASR_MODEL_URL = \"\"")
+		assert.Contains(t, code, `ASR_MODEL_NAME = "whisper-large-v3-turbo"`)
+		assert.Contains(t, code, "AUDIO_FILE_PATH = \"\"")
+		assert.Contains(t, code, "from openai import OpenAI")
+		assert.Contains(t, code, "asr_client = OpenAI(")
+		assert.Contains(t, code, "audio.transcriptions.create")
+		assert.Contains(t, code, "input_text = transcription.text")
+		assert.Contains(t, code, "pip install llama-stack-client openai")
+		assert.Contains(t, code, "Audio Transcription (ASR)")
+		assert.Contains(t, code, `The model "whisper-large-v3-turbo" will be used for transcription`)
+	})
+
+	t.Run("should not include ASR section when ASRModel is empty", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input: "Hello, world!",
+			Model: "llama3.2:3b",
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.NotContains(t, code, "ASR_MODEL_URL")
+		assert.NotContains(t, code, "ASR_MODEL_NAME")
+		assert.NotContains(t, code, "AUDIO_FILE_PATH")
+		assert.NotContains(t, code, "from openai import OpenAI")
+		assert.NotContains(t, code, "asr_client")
+		assert.NotContains(t, code, "audio.transcriptions.create")
+		assert.NotContains(t, code, "Audio Transcription (ASR)")
+	})
+
+	t.Run("should include openai in pip install when both ASR and guardrails are active", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input:    "Hello, world!",
+			Model:    "llama3.2:3b",
+			ASRModel: "whisper-large-v3-turbo",
+			GuardrailConfig: &models.CodeExportGuardrailConfig{
+				GuardrailModel: "mistral-7b",
+				InputPrompt:    "Check this: {{ user_input }}",
+			},
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.Contains(t, code, "pip install llama-stack-client requests openai")
+		assert.Contains(t, code, "from openai import OpenAI")
+		assert.Contains(t, code, "import requests")
+		assert.Contains(t, code, "ASR_MODEL_URL")
+		assert.Contains(t, code, "NEMO_GUARDRAILS_URL")
+	})
 }

--- a/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
@@ -388,7 +388,7 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.Contains(t, code, "file_search")
 		assert.Contains(t, code, "vector_store.id")
 		assert.Contains(t, code, "FILES_BASE_PATH")
-		assert.Contains(t, code, "LLAMA_STACK_URL")
+		assert.Contains(t, code, "OGX_URL")
 	})
 
 	t.Run("should generate Python code with MCP servers", func(t *testing.T) {
@@ -742,7 +742,7 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.Contains(t, code, inputPrompt)
 		assert.Contains(t, code, `if _input_result.get("status") == "blocked"`)
 		assert.Contains(t, code, "def _guardrail_check(")
-		assert.Contains(t, code, "pip install llama-stack-client requests")
+		assert.Contains(t, code, "pip install ogx-client requests")
 	})
 
 	t.Run("should include output guardrail check when guardrail config has output prompt", func(t *testing.T) {
@@ -822,7 +822,7 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.NotContains(t, code, "import requests")
 		assert.NotContains(t, code, "NEMO_GUARDRAILS_URL")
 		assert.NotContains(t, code, "guardrail/checks")
-		assert.Contains(t, code, "pip install llama-stack-client\n")
+		assert.Contains(t, code, "pip install ogx-client\n")
 	})
 
 	t.Run("should not include guardrail code when input prompt is empty", func(t *testing.T) {
@@ -888,7 +888,7 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.Contains(t, code, "asr_client = OpenAI(")
 		assert.Contains(t, code, "audio.transcriptions.create")
 		assert.Contains(t, code, "input_text = transcription.text")
-		assert.Contains(t, code, "pip install llama-stack-client openai")
+		assert.Contains(t, code, "pip install ogx-client openai")
 		assert.Contains(t, code, "Audio Transcription (ASR)")
 		assert.Contains(t, code, `The model "whisper-large-v3-turbo" will be used for transcription`)
 	})
@@ -933,7 +933,7 @@ func TestGeneratePythonCode(t *testing.T) {
 		}
 
 		assert.NoError(t, err)
-		assert.Contains(t, code, "pip install llama-stack-client requests openai")
+		assert.Contains(t, code, "pip install ogx-client requests openai")
 		assert.Contains(t, code, "from openai import OpenAI")
 		assert.Contains(t, code, "import requests")
 		assert.Contains(t, code, "ASR_MODEL_URL")
@@ -1006,6 +1006,6 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.Contains(t, code, `"type": "input_image"`)
 		assert.Contains(t, code, "vision_file.id")
 		assert.Contains(t, code, "from openai import OpenAI")
-		assert.Contains(t, code, "pip install llama-stack-client openai")
+		assert.Contains(t, code, "pip install ogx-client openai")
 	})
 }

--- a/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
+++ b/packages/gen-ai/bff/internal/api/code_exporter_handler_test.go
@@ -939,4 +939,73 @@ func TestGeneratePythonCode(t *testing.T) {
 		assert.Contains(t, code, "ASR_MODEL_URL")
 		assert.Contains(t, code, "NEMO_GUARDRAILS_URL")
 	})
+
+	t.Run("should generate Python code with vision image upload section when VisionImage is true", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input:       "Describe the image",
+			Model:       "llama3.2:3b",
+			VisionImage: true,
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.Contains(t, code, `IMAGE_FILE_PATH = ""`)
+		assert.Contains(t, code, "Vision (Image Input)")
+		assert.Contains(t, code, "client.files.create(file=image_file, purpose=\"vision\")")
+		assert.Contains(t, code, `"type": "input_text"`)
+		assert.Contains(t, code, `"type": "input_image"`)
+		assert.Contains(t, code, "vision_file.id")
+		assert.NotContains(t, code, `"input": input_text,`)
+	})
+
+	t.Run("should not include vision section when VisionImage is false", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input: "Hello, world!",
+			Model: "llama3.2:3b",
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.NotContains(t, code, "IMAGE_FILE_PATH")
+		assert.NotContains(t, code, "Vision (Image Input)")
+		assert.NotContains(t, code, "client.files.create(file=image_file")
+		assert.NotContains(t, code, `"type": "input_image"`)
+		assert.Contains(t, code, `"input": input_text,`)
+	})
+
+	t.Run("should compose vision and ASR correctly when both are active", func(t *testing.T) {
+		config := models.CodeExportRequest{
+			Input:       "Describe the image",
+			Model:       "llama3.2:3b",
+			ASRModel:    "whisper-large-v3-turbo",
+			VisionImage: true,
+		}
+
+		code, err := app.generatePythonCode(config, "", app.repositories.Template)
+
+		if err != nil {
+			t.Skipf("Template system not available in test environment: %v", err)
+		}
+
+		assert.NoError(t, err)
+		assert.Contains(t, code, "ASR_MODEL_URL")
+		assert.Contains(t, code, "input_text = transcription.text")
+		assert.Contains(t, code, "IMAGE_FILE_PATH")
+		assert.Contains(t, code, "client.files.create(file=image_file, purpose=\"vision\")")
+		assert.Contains(t, code, `"type": "input_text"`)
+		assert.Contains(t, code, `"type": "input_image"`)
+		assert.Contains(t, code, "vision_file.id")
+		assert.Contains(t, code, "from openai import OpenAI")
+		assert.Contains(t, code, "pip install llama-stack-client openai")
+	})
 }

--- a/packages/gen-ai/bff/internal/constants/templates.go
+++ b/packages/gen-ai/bff/internal/constants/templates.go
@@ -9,7 +9,9 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 # Required Packages:
 #    - Install the required dependencies using pip:
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
-#      pip install llama-stack-client requests
+#      pip install llama-stack-client requests{{if .ASRModel}} openai{{end}}
+{{- else if .ASRModel }}
+#      pip install llama-stack-client openai
 {{- else }}
 #      pip install llama-stack-client
 {{- end }}
@@ -33,6 +35,12 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 #    - Set GUARDRAIL_MODEL_ENDPOINT to your guardrail model's inference endpoint URL
 #    - Set GUARDRAIL_API_KEY if your guardrail model endpoint requires authentication
 {{- end }}
+{{- if .ASRModel }}
+#
+# Audio Transcription (ASR):
+#    - Set ASR_MODEL_URL to the URL of your ASR model
+#    - The model "{{.ASRModel}}" will be used for transcription
+{{- end }}
 {{- if and .VectorStore .VectorStore.ID }}
 #
 # External Vector Store:
@@ -55,6 +63,11 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 
 # Configuration adjust as needed:
 LLAMA_STACK_URL = ""
+{{- if .ASRModel }}
+ASR_MODEL_URL = ""
+ASR_MODEL_NAME = "{{.ASRModel}}"
+AUDIO_FILE_PATH = ""  # Path to your audio file (.wav or .mp3)
+{{- end }}
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
 NEMO_GUARDRAILS_URL = "{{if .NemoGuardrailsURL}}{{.NemoGuardrailsURL}}{{end}}"
 NEMO_GUARDRAILS_OC_TOKEN = ""  # Set to your OpenShift user token (oc whoami -t)
@@ -100,10 +113,25 @@ import os
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
 import requests
 {{- end }}
+{{- if .ASRModel }}
+from openai import OpenAI
+{{- end }}
 
 from llama_stack_client import LlamaStackClient
 
 client = LlamaStackClient(base_url=LLAMA_STACK_URL)
+{{- if .ASRModel }}
+
+# --- Audio Transcription ---
+asr_client = OpenAI(base_url=f"{ASR_MODEL_URL}/v1", api_key="unused")
+with open(AUDIO_FILE_PATH, "rb") as audio_file:
+    transcription = asr_client.audio.transcriptions.create(
+        model=ASR_MODEL_NAME,
+        file=audio_file,
+    )
+input_text = transcription.text
+# ---
+{{- end }}
 {{- if .Prompt }}
 
 import mlflow

--- a/packages/gen-ai/bff/internal/constants/templates.go
+++ b/packages/gen-ai/bff/internal/constants/templates.go
@@ -1,32 +1,32 @@
 package constants
 
-const PythonCodeTemplate = `# Llama Stack Quickstart Script
+const PythonCodeTemplate = `# OGX Quickstart Script
 #
 # README:
-# This example shows how to configure an assistant using the Llama Stack client.
+# This example shows how to configure an assistant using the OGX client.
 # Before using this code, make sure of the following:
 #
 # Required Packages:
 #    - Install the required dependencies using pip:
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
-#      pip install llama-stack-client requests{{if .ASRModel}} openai{{end}}
+#      pip install ogx-client requests{{if .ASRModel}} openai{{end}}
 {{- else if .ASRModel }}
-#      pip install llama-stack-client openai
+#      pip install ogx-client openai
 {{- else }}
-#      pip install llama-stack-client
+#      pip install ogx-client
 {{- end }}
-#    - NOTE: Verify the correct llama-stack-client version for your Llama Stack server instance,
+#    - NOTE: Verify the correct ogx-client version for your OGX server instance,
 #      then install that version as needed.
 #
-# Llama Stack Server:
-#    - Your Llama Stack instance must be running and accessible
-#    - Set the LLAMA_STACK_URL variable to the base URL of your Llama Stack server
+# OGX Server:
+#    - Your OGX instance must be running and accessible
+#    - Set the OGX_URL variable to the base URL of your OGX server
 #
 # Model Configuration:
-#    - The selected model (e.g., "llama3.2:3b") must be available in your Llama Stack deployment with the correct API key.
+#    - The selected model (e.g., "llama3.2:3b") must be available in your OGX deployment with the correct API key.
 #
 # Tools (MCP Integration):
-#    - Any tools used must be properly pre-configured in your Llama Stack setup.
+#    - Any tools used must be properly pre-configured in your OGX setup.
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
 #
 # NeMo Guardrails:
@@ -50,12 +50,12 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 {{- if and .VectorStore .VectorStore.ID }}
 #
 # External Vector Store:
-#    - This script uses an existing vector store (ID: {{.VectorStore.ID}}), which must be registered in your Llama Stack instance.
-#    - The vector store provider "{{.VectorStore.ProviderID}}" must be installed in your Llama Stack instance.
+#    - This script uses an existing vector store (ID: {{.VectorStore.ID}}), which must be registered in your OGX instance.
+#    - The vector store provider "{{.VectorStore.ProviderID}}" must be installed in your OGX instance.
 {{- if .VectorStore.EmbeddingModel }}
-#    - The embedding model "{{.VectorStore.EmbeddingModel}}" must be registered in your Llama Stack instance.
+#    - The embedding model "{{.VectorStore.EmbeddingModel}}" must be registered in your OGX instance.
 {{- else }}
-#    - The embedding model used by this vector store must be registered in your Llama Stack instance.
+#    - The embedding model used by this vector store must be registered in your OGX instance.
 {{- end }}
 {{- end }}
 {{- if .Prompt }}
@@ -68,7 +68,7 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 {{- end }}
 
 # Configuration adjust as needed:
-LLAMA_STACK_URL = ""
+OGX_URL = ""
 {{- if .ASRModel }}
 ASR_MODEL_URL = ""
 ASR_MODEL_NAME = "{{.ASRModel}}"
@@ -126,9 +126,9 @@ import requests
 from openai import OpenAI
 {{- end }}
 
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
-client = LlamaStackClient(base_url=LLAMA_STACK_URL)
+client = OgxClient(base_url=OGX_URL)
 {{- if .ASRModel }}
 
 # --- Audio Transcription ---

--- a/packages/gen-ai/bff/internal/constants/templates.go
+++ b/packages/gen-ai/bff/internal/constants/templates.go
@@ -41,6 +41,12 @@ const PythonCodeTemplate = `# Llama Stack Quickstart Script
 #    - Set ASR_MODEL_URL to the URL of your ASR model
 #    - The model "{{.ASRModel}}" will be used for transcription
 {{- end }}
+{{- if .VisionImage }}
+#
+# Vision (Image Input):
+#    - Set IMAGE_FILE_PATH to the path of your local image file (.jpg or .png)
+#    - The image will be uploaded to the OGX Files API and passed to the model
+{{- end }}
 {{- if and .VectorStore .VectorStore.ID }}
 #
 # External Vector Store:
@@ -67,6 +73,9 @@ LLAMA_STACK_URL = ""
 ASR_MODEL_URL = ""
 ASR_MODEL_NAME = "{{.ASRModel}}"
 AUDIO_FILE_PATH = ""  # Path to your audio file (.wav or .mp3)
+{{- end }}
+{{- if .VisionImage }}
+IMAGE_FILE_PATH = ""  # Path to your image file (.jpg or .png)
 {{- end }}
 {{- if and .GuardrailConfig (or .GuardrailConfig.InputPrompt .GuardrailConfig.OutputPrompt) }}
 NEMO_GUARDRAILS_URL = "{{if .NemoGuardrailsURL}}{{.NemoGuardrailsURL}}{{end}}"
@@ -130,6 +139,13 @@ with open(AUDIO_FILE_PATH, "rb") as audio_file:
         file=audio_file,
     )
 input_text = transcription.text
+# ---
+{{- end }}
+{{- if .VisionImage }}
+
+# --- Vision Image Upload ---
+with open(IMAGE_FILE_PATH, "rb") as image_file:
+    vision_file = client.files.create(file=image_file, purpose="vision")
 # ---
 {{- end }}
 {{- if .Prompt }}
@@ -232,7 +248,14 @@ for file_info in files_to_upload:
 {{- end }}
 
 config = {
+{{- if .VisionImage }}
+    "input": [
+        {"type": "input_text", "text": input_text},
+        {"type": "input_image", "file_id": vision_file.id},
+    ],
+{{- else }}
     "input": input_text,
+{{- end }}
     "model": model_name{{- if .Temperature }},
     "temperature": temperature{{- end }}{{- if or .Instructions .Prompt }},
     "instructions": system_instructions{{- end }}{{- if .Stream }},

--- a/packages/gen-ai/bff/internal/models/code_export.go
+++ b/packages/gen-ai/bff/internal/models/code_export.go
@@ -67,6 +67,7 @@ type CodeExportRequest struct {
 	PromptVariableValues map[string]string          `json:"prompt_variable_values,omitempty"`
 	GuardrailConfig      *CodeExportGuardrailConfig `json:"guardrail_config,omitempty"`
 	ASRModel             string                     `json:"asr_model,omitempty"`
+	VisionImage          bool                       `json:"vision_image,omitempty"`
 }
 
 type CodeExportResponse struct {

--- a/packages/gen-ai/bff/internal/models/code_export.go
+++ b/packages/gen-ai/bff/internal/models/code_export.go
@@ -66,6 +66,7 @@ type CodeExportRequest struct {
 	Prompt               *PromptConfig              `json:"prompt,omitempty"`
 	PromptVariableValues map[string]string          `json:"prompt_variable_values,omitempty"`
 	GuardrailConfig      *CodeExportGuardrailConfig `json:"guardrail_config,omitempty"`
+	ASRModel             string                     `json:"asr_model,omitempty"`
 }
 
 type CodeExportResponse struct {

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -470,6 +470,12 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
             uploading: false,
             fileId: response.data.id,
           }));
+          const { configIds: allConfigIds, configurations } = useChatbotConfigStore.getState();
+          allConfigIds.forEach((cId) => {
+            if (configurations[cId]) {
+              useChatbotConfigStore.getState().updateHasVisionImage(cId, true);
+            }
+          });
         })
         .catch((error) => {
           if (uploadGenRef.current !== gen) {
@@ -545,7 +551,15 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
       previewUrl: null,
       fileName: null,
     });
-  }, [imageUploadState.uploading, imageUploadState.previewUrl]);
+    if (!hasImageInConversation) {
+      const { configIds: ids, configurations: configs } = useChatbotConfigStore.getState();
+      ids.forEach((cId) => {
+        if (configs[cId]) {
+          useChatbotConfigStore.getState().updateHasVisionImage(cId, false);
+        }
+      });
+    }
+  }, [imageUploadState.uploading, imageUploadState.previewUrl, hasImageInConversation]);
 
   // Audio upload handler
   const handleAudioUpload = React.useCallback(
@@ -695,6 +709,12 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
         handleRemoveImage();
         setPendingDocChips([]);
         audioTranscription.abort();
+        const { configIds: allCIds, configurations: allConfigs } = useChatbotConfigStore.getState();
+        allCIds.forEach((cId) => {
+          if (allConfigs[cId]) {
+            useChatbotConfigStore.getState().updateHasVisionImage(cId, false);
+          }
+        });
         audioUploadLatchRef.current = false;
         setHasAudioInCurrentMessage(false);
         setMessageBarValue('');
@@ -817,6 +837,12 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
             setPendingDocChips([]);
             audioTranscription.abort();
             setHasAudioInCurrentMessage(false);
+            const { configIds: cIds, configurations: cfgs } = useChatbotConfigStore.getState();
+            cIds.forEach((cId) => {
+              if (cfgs[cId]) {
+                useChatbotConfigStore.getState().updateHasVisionImage(cId, false);
+              }
+            });
             setMessageBarValue('');
             if (isCompareMode) {
               fireMiscTrackingEvent('Playground Compare Chat Cleared', { success: true });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
@@ -160,6 +160,8 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
         guardrail,
         guardrailUserInputEnabled,
         guardrailModelOutputEnabled,
+        selectedAsrModel,
+        isAsrModelEnabled,
       } = config;
       const mcpServersToUse = mcpServers.filter((server) =>
         selectedMcpServerIds.includes(server.url),
@@ -261,6 +263,7 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
                 ...(guardrailModelOutputEnabled && { output_prompt: GUARDRAIL_OUTPUT_PROMPT }),
               },
             }),
+          ...(isAsrModelEnabled && selectedAsrModel && { asr_model: selectedAsrModel }),
         };
         /* eslint-enable camelcase */
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
@@ -162,6 +162,7 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
         guardrailModelOutputEnabled,
         selectedAsrModel,
         isAsrModelEnabled,
+        hasVisionImage,
       } = config;
       const mcpServersToUse = mcpServers.filter((server) =>
         selectedMcpServerIds.includes(server.url),
@@ -264,6 +265,7 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
               },
             }),
           ...(isAsrModelEnabled && selectedAsrModel && { asr_model: selectedAsrModel }),
+          ...(hasVisionImage && { vision_image: true }),
         };
         /* eslint-enable camelcase */
 

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
@@ -593,4 +593,56 @@ describe('ViewCodeModal', () => {
     expect(callArg.files).toBeUndefined();
     expect(callArg.tools).toEqual([{ type: 'file_search', vector_store_ids: ['vs-1'] }]);
   });
+
+  it('includes asr_model in request when ASR is enabled and model is selected', async () => {
+    setupMockStore({ isAsrModelEnabled: true, selectedAsrModel: 'whisper-large-v3-turbo' });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          asr_model: 'whisper-large-v3-turbo',
+        }),
+      );
+    });
+  });
+
+  it('does not include asr_model when ASR is disabled', async () => {
+    setupMockStore({ isAsrModelEnabled: false, selectedAsrModel: 'whisper-large-v3-turbo' });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalled();
+    });
+
+    const callArg = mockExportCode.mock.calls[0][0];
+    expect(callArg.asr_model).toBeUndefined();
+  });
+
+  it('does not include asr_model when ASR is enabled but no model is selected', async () => {
+    setupMockStore({ isAsrModelEnabled: true, selectedAsrModel: '' });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalled();
+    });
+
+    const callArg = mockExportCode.mock.calls[0][0];
+    expect(callArg.asr_model).toBeUndefined();
+  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
@@ -645,4 +645,39 @@ describe('ViewCodeModal', () => {
     const callArg = mockExportCode.mock.calls[0][0];
     expect(callArg.asr_model).toBeUndefined();
   });
+
+  it('includes vision_image in request when hasVisionImage is true', async () => {
+    setupMockStore({ hasVisionImage: true });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vision_image: true,
+        }),
+      );
+    });
+  });
+
+  it('does not include vision_image when hasVisionImage is false', async () => {
+    setupMockStore({ hasVisionImage: false });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalled();
+    });
+
+    const callArg = mockExportCode.mock.calls[0][0];
+    expect(callArg.vision_image).toBeUndefined();
+  });
 });

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/selectors.ts
@@ -107,5 +107,11 @@ export const selectIsAsrModelEnabled =
   (state: ChatbotConfigStore): boolean =>
     state.configurations[configId]?.isAsrModelEnabled ?? DEFAULT_CONFIGURATION.isAsrModelEnabled;
 
+// Vision image selector
+export const selectHasVisionImage =
+  (configId: string) =>
+  (state: ChatbotConfigStore): boolean =>
+    state.configurations[configId]?.hasVisionImage ?? DEFAULT_CONFIGURATION.hasVisionImage;
+
 // Configuration management selectors
 export const selectConfigIds = (state: ChatbotConfigStore): string[] => state.configIds;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -40,6 +40,8 @@ export interface ChatbotConfiguration {
   selectedAsrModel: string;
   /** Whether the user has opted in to the transcription model section */
   isAsrModelEnabled: boolean;
+  /** Whether a vision image has been attached/sent in this conversation */
+  hasVisionImage: boolean;
 }
 
 /**
@@ -67,6 +69,7 @@ export const DEFAULT_CONFIGURATION: ChatbotConfiguration = {
   variableValues: {},
   selectedAsrModel: '',
   isAsrModelEnabled: false,
+  hasVisionImage: false,
 };
 
 /**
@@ -115,6 +118,9 @@ export interface ChatbotConfigStoreActions {
   // ASR model selection (per-pane)
   updateSelectedAsrModel: (id: string, value: string) => void;
   updateAsrModelEnabled: (id: string, value: boolean) => void;
+
+  // Vision image state
+  updateHasVisionImage: (id: string, value: boolean) => void;
 
   // RAG toggle (per-pane)
   updateRagEnabled: (id: string, value: boolean) => void;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -273,6 +273,7 @@ const createStoreActions = (
       variableValues: { ...sourceConfig.variableValues },
       selectedAsrModel: sourceConfig.selectedAsrModel,
       isAsrModelEnabled: sourceConfig.isAsrModelEnabled,
+      hasVisionImage: sourceConfig.hasVisionImage,
     };
 
     set(
@@ -595,6 +596,19 @@ const createStoreActions = (
       },
       false,
       'updateAsrModelEnabled',
+    );
+  },
+
+  updateHasVisionImage: (id: string, value: boolean) => {
+    set(
+      (state) => {
+        const config = state.configurations[id];
+        if (config && config.hasVisionImage !== value) {
+          config.hasVisionImage = value;
+        }
+      },
+      false,
+      'updateHasVisionImage',
     );
   },
 

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -324,6 +324,7 @@ export type CodeExportRequest = {
   prompt_variable_values?: Record<string, string>;
   guardrail_config?: CodeExportGuardrailConfig;
   asr_model?: string;
+  vision_image?: boolean;
 };
 
 export type CodeExportData = {

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -323,6 +323,7 @@ export type CodeExportRequest = {
   };
   prompt_variable_values?: Record<string, string>;
   guardrail_config?: CodeExportGuardrailConfig;
+  asr_model?: string;
 };
 
 export type CodeExportData = {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66939
https://issues.redhat.com/browse/RHOAIENG-66940

## Description

Implements two stories from Epic 4 ([RHOAIENG-62259](https://issues.redhat.com/browse/RHOAIENG-62259) — View Code Snippets for Multimodal Features) for the Gen AI Studio Playground. Builds on top of #7898 (Stories 3.2–3.4: Frontend ASR model discovery, selector, and audio transcription UX).

### Story 4.2: View Code — ASR Audio Transcription code snippet ([RHOAIENG-66940](https://issues.redhat.com/browse/RHOAIENG-66940))

- When `isAsrModelEnabled=true` and `selectedAsrModel` is set, View Code modal includes `asr_model` in BFF request
- BFF `CodeExportRequest` struct gains `ASRModel string` field
- Go template conditionally renders ASR Python code:
  - `pip install ogx-client openai` (adds `openai` when ASR active)
  - `from openai import OpenAI` import
  - Config variables: `ASR_MODEL_URL`, `ASR_MODEL_NAME`, `AUDIO_FILE_PATH`
  - Transcription block using vLLM-compatible Whisper API
  - `input_text = transcription.text` overwrites default input

### Story 4.1: View Code — Image/Vision code snippet ([RHOAIENG-66939](https://issues.redhat.com/browse/RHOAIENG-66939))

- `hasVisionImage: boolean` added to `ChatbotConfiguration` in Zustand store
  - Set `true` on all config IDs when image upload succeeds
  - Reset `false` on conversation clear and image removal (guarded by `!hasImageInConversation`)
- `ViewCodeModal` conditionally includes `vision_image: true` in BFF request
- BFF `CodeExportRequest` struct gains `VisionImage bool` field
- Go template conditionally renders Vision Python code:
  - `IMAGE_FILE_PATH = ""` config variable
  - Vision upload block: `vision_file = client.files.create(file=image_file, purpose="vision")`
  - Multimodal `input` array: `[{"type": "input_text", "text": input_text}, {"type": "input_image", "file_id": vision_file.id}]`
  - Replaces plain string `"input": input_text` when vision is active
- ASR + Vision compose naturally: ASR overwrites `input_text`, Vision uses it in multimodal array

### OGX Rename (cross-cutting)

- All generated Python code updated from Llama Stack to OGX branding:
  - `pip install llama-stack-client` → `pip install ogx-client`
  - `from llama_stack_client import LlamaStackClient` → `from ogx_client import OgxClient`
  - `LLAMA_STACK_URL` → `OGX_URL`
  - `client = LlamaStackClient(...)` → `client = OgxClient(...)`
- Confirmed against PyPI `ogx-client@1.0.2`

### Depends on

- #7808 — [RHOAIENG-62254](https://redhat.atlassian.net/browse/RHOAIENG-62254): BFF audio transcription endpoint and generalized media upload (Story 3.1)
- #7898 — [RHOAIENG-62255, RHOAIENG-62257, [RHOAIENG-62256](https://redhat.atlassian.net/browse/RHOAIENG-62256)](https://redhat.atlassian.net/browse/RHOAIENG-62255): Frontend ASR model discovery, selector, and audio transcription UX (Stories 3.2–3.4)

## How Has This Been Tested?

### Unit tests

**Frontend (`packages/gen-ai/frontend`):**

`npx jest --testPathPattern="ViewCodeModal" --no-coverage` — all tests pass.

- `ViewCodeModal.spec.tsx` (+87 lines):
  - `vision_image: true` included in request when `hasVisionImage` is true
  - `vision_image` absent from request when `hasVisionImage` is false

**BFF (`packages/gen-ai/bff`):**

`go test ./internal/api/ -run "TestCodeExporter" -v` — all tests pass.

- `code_exporter_handler_test.go` (+148 lines):
  - ASR section renders when `ASRModel` is set (README, config vars, openai import, transcription block)
  - ASR section absent when `ASRModel` is empty
  - Vision section renders when `VisionImage` is true (IMAGE_FILE_PATH, upload block, multimodal input)
  - Vision section absent when `VisionImage` is false (plain string input)
  - ASR + Vision composition produces correct combined output
  - OGX branding in all generated code (`ogx-client`, `OgxClient`, `OGX_URL`)

### Manual testing

Verified generated Python output in the View Code modal with all combinations:
- No features active (baseline)
- ASR only
- Vision only
- ASR + Vision combined
- With guardrails
- With RAG inline files (confirms `vision_file` / `uploaded_file` no collision)

## Test Impact

**New:**
- `ViewCodeModal.spec.tsx` (+87 lines) — frontend payload tests for vision flag
- `code_exporter_handler_test.go` (+148 lines) — BFF template rendering tests for ASR, Vision, composition, and OGX branding

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio transcription (ASR) functionality allowing users to transcribe audio files in the chatbot playground.
  * Added ASR model selection in playground settings with visual badges for ASR-capable models.
  * Generalized media upload to support both audio and vision file types.
  * Extended code export to include ASR setup and transcription logic in generated Python code.

* **Documentation**
  * Added local ASR development guidance with configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->