### PR TITLE
ci: tilt setup for rhaii distribution

### DIFF
--- a/distributions/core-bff/Makefile
+++ b/distributions/core-bff/Makefile
@@ -132,12 +132,6 @@ docker-push-standalone:
 docker-push-federated:
 	${CONTAINER_TOOL} push ${IMG_UI_FEDERATED}
 
-############ Deployment ############
-
-.PHONY: kind-deployment
-kind-deployment:
-	./scripts/deploy_kind_cluster.sh
-
 ############ Build ############
 .PHONY: frontend-build
 frontend-build:

--- a/distributions/core-bff/manifests/base/deployment.yaml
+++ b/distributions/core-bff/manifests/base/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhaii-dashboard
+  labels:
+    app.kubernetes.io/name: rhaii-dashboard
+    app.kubernetes.io/part-of: odh-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: rhaii-dashboard
+  template:
+    metadata:
+      labels:
+        deployment: rhaii-dashboard
+        app.kubernetes.io/name: rhaii-dashboard
+        app.kubernetes.io/part-of: odh-dashboard
+    spec:
+      serviceAccountName: rhaii-dashboard
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: rhaii-dashboard
+          image: $(rhaii-dashboard-image)
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4000
+              name: core-bff-api
+              protocol: TCP
+          env:
+            - name: AUTH_METHOD
+              value: disabled
+            - name: DEV_MODE
+              value: "true"
+            - name: DEPLOYMENT_MODE
+              value: standalone
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 4000
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 4000
+            initialDelaySeconds: 3
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/distributions/core-bff/manifests/base/deployment.yaml
+++ b/distributions/core-bff/manifests/base/deployment.yaml
@@ -34,9 +34,9 @@ spec:
               protocol: TCP
           env:
             - name: AUTH_METHOD
-              value: disabled
+              value: user_token
             - name: DEV_MODE
-              value: "true"
+              value: "false"
             - name: DEPLOYMENT_MODE
               value: standalone
             - name: POD_NAMESPACE

--- a/distributions/core-bff/manifests/base/kustomization.yaml
+++ b/distributions/core-bff/manifests/base/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - service-account.yaml
+  - role.yaml
+  - role-binding.yaml
+
+configMapGenerator:
+  - name: core-bff-params
+    env: params.env
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - name: rhaii-dashboard-image
+    objref:
+      kind: ConfigMap
+      name: core-bff-params
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.rhaii-dashboard-image
+
+configurations:
+  - params.yaml

--- a/distributions/core-bff/manifests/base/params.env
+++ b/distributions/core-bff/manifests/base/params.env
@@ -1,0 +1,1 @@
+rhaii-dashboard-image=rhaii-dashboard:latest

--- a/distributions/core-bff/manifests/base/params.yaml
+++ b/distributions/core-bff/manifests/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers/image
+    kind: Deployment

--- a/distributions/core-bff/manifests/base/role-binding.yaml
+++ b/distributions/core-bff/manifests/base/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhaii-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhaii-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: rhaii-dashboard
+    namespace: opendatahub

--- a/distributions/core-bff/manifests/base/role-binding.yaml
+++ b/distributions/core-bff/manifests/base/role-binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhaii-dashboard
-    namespace: opendatahub

--- a/distributions/core-bff/manifests/base/role.yaml
+++ b/distributions/core-bff/manifests/base/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhaii-dashboard
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - opendatahub.io
+    resources:
+      - odhdashboardconfigs
+    verbs:
+      - get
+      - create
+      - patch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - odhapplications
+    verbs:
+      - list

--- a/distributions/core-bff/manifests/base/service-account.yaml
+++ b/distributions/core-bff/manifests/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhaii-dashboard

--- a/distributions/core-bff/manifests/base/service.yaml
+++ b/distributions/core-bff/manifests/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rhaii-dashboard
+  labels:
+    app.kubernetes.io/name: rhaii-dashboard
+    app.kubernetes.io/part-of: odh-dashboard
+spec:
+  selector:
+    deployment: rhaii-dashboard
+  ports:
+    - name: core-bff-api
+      protocol: TCP
+      port: 4000
+      targetPort: 4000

--- a/distributions/rhaii/.env
+++ b/distributions/rhaii/.env
@@ -1,0 +1,1 @@
+DEPLOYMENT_MODE=standalone

--- a/distributions/rhaii/.env.development
+++ b/distributions/rhaii/.env.development
@@ -1,0 +1,2 @@
+APP_ENV=development
+DEPLOYMENT_MODE=standalone

--- a/distributions/rhaii/Dockerfile
+++ b/distributions/rhaii/Dockerfile
@@ -67,6 +67,6 @@ COPY --from=bff-builder /usr/src/app/openapi/ ./openapi/
 COPY --from=ui-builder /usr/src/workspace/distributions/rhaii/public ./static/
 USER 65532:65532
 
-EXPOSE 8080
+EXPOSE 4000
 
 ENTRYPOINT ["/bff"]

--- a/distributions/rhaii/Dockerfile
+++ b/distributions/rhaii/Dockerfile
@@ -1,0 +1,72 @@
+# Multi-stage Dockerfile for the RHAII distribution.
+# Builds the RHAII frontend shell and packages it with the core-bff Go binary.
+#
+# Build from repository root:
+#   docker build -f distributions/rhaii/Dockerfile -t rhaii-dashboard:latest .
+
+ARG NODE_BASE_IMAGE=node:22
+ARG GOLANG_BASE_IMAGE=golang:1.25
+ARG DISTROLESS_BASE_IMAGE=gcr.io/distroless/static:nonroot
+
+# ── Stage 1: UI Builder ──────────────────────────────────────────────────────
+FROM ${NODE_BASE_IMAGE} AS ui-builder
+
+WORKDIR /usr/src/workspace
+
+# Copy root workspace manifest (npm needs it to resolve workspace graph)
+COPY package.json package-lock.json* ./
+
+# Copy workspace packages required by the RHAII distribution
+COPY frontend/package.json ./frontend/
+COPY frontend/src/ ./frontend/src/
+COPY packages/plugin-core/ ./packages/plugin-core/
+COPY packages/tsconfig/ ./packages/tsconfig/
+
+# Copy the base distribution (shell components + shared webpack config)
+COPY distributions/base/ ./distributions/base/
+
+# Copy the RHAII distribution
+COPY distributions/rhaii/ ./distributions/rhaii/
+
+# Install workspace dependencies
+# Cannot use --omit=optional or --ignore-scripts: @swc/core distributes its
+# native bindings as optional deps and needs its postinstall to set them up.
+RUN npm cache clean --force
+RUN npm ci
+
+# Build the RHAII frontend
+WORKDIR /usr/src/workspace/distributions/rhaii
+RUN npm run build
+
+# ── Stage 2: BFF Builder ─────────────────────────────────────────────────────
+FROM ${GOLANG_BASE_IMAGE} AS bff-builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /usr/src/app
+
+# Copy Go module files and download dependencies
+COPY distributions/core-bff/bff/go.mod distributions/core-bff/bff/go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY distributions/core-bff/bff/cmd/ cmd/
+COPY distributions/core-bff/bff/internal/ internal/
+COPY distributions/core-bff/bff/openapi/ openapi/
+
+# Build the Go binary
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bff ./cmd
+
+# ── Stage 3: Final ───────────────────────────────────────────────────────────
+FROM ${DISTROLESS_BASE_IMAGE}
+
+WORKDIR /
+COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=bff-builder /usr/src/app/openapi/ ./openapi/
+COPY --from=ui-builder /usr/src/workspace/distributions/rhaii/public ./static/
+USER 65532:65532
+
+EXPOSE 8080
+
+ENTRYPOINT ["/bff"]

--- a/distributions/rhaii/Makefile
+++ b/distributions/rhaii/Makefile
@@ -1,0 +1,38 @@
+DEFAULT_ENV_FILE := .env
+ifneq ("$(wildcard $(DEFAULT_ENV_FILE))","")
+include ${DEFAULT_ENV_FILE}
+export $(shell sed 's/=.*//' ${DEFAULT_ENV_FILE})
+endif
+
+ENV_FILE := .env.local
+ifneq ("$(wildcard $(ENV_FILE))","")
+include ${ENV_FILE}
+export $(shell sed 's/=.*//' ${ENV_FILE})
+endif
+
+CONTAINER_TOOL ?= docker
+IMG ?= rhaii-dashboard:latest
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: dev-start
+dev-start: ## Start in mock mode (BFF + webpack dev server, no cluster needed)
+	npm run start:dev
+
+##@ Build
+
+.PHONY: build-frontend
+build-frontend: ## Build the RHAII frontend
+	npm run build
+
+.PHONY: docker-build
+docker-build: ## Build container image
+	cd ../.. && $(CONTAINER_TOOL) build -f distributions/rhaii/Dockerfile -t $(IMG) .
+
+.PHONY: docker-push
+docker-push: ## Push container image to registry
+	$(CONTAINER_TOOL) push $(IMG)

--- a/distributions/rhaii/Makefile
+++ b/distributions/rhaii/Makefile
@@ -31,8 +31,8 @@ build-frontend: ## Build the RHAII frontend
 
 .PHONY: docker-build
 docker-build: ## Build container image
-	cd ../.. && $(CONTAINER_TOOL) build -f distributions/rhaii/Dockerfile -t $(IMG) .
+	cd ../.. && "$(CONTAINER_TOOL)" build -f distributions/rhaii/Dockerfile -t "$(IMG)" .
 
 .PHONY: docker-push
 docker-push: ## Push container image to registry
-	$(CONTAINER_TOOL) push $(IMG)
+	"$(CONTAINER_TOOL)" push "$(IMG)"

--- a/distributions/rhaii/developing/Makefile
+++ b/distributions/rhaii/developing/Makefile
@@ -1,0 +1,39 @@
+# Export KIND_EXPERIMENTAL_PROVIDER to honor it if set in user's environment
+# (e.g., KIND_EXPERIMENTAL_PROVIDER=podman for podman support)
+export KIND_EXPERIMENTAL_PROVIDER
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development Environment
+
+.PHONY: check-tilt
+check-tilt:
+	@if ! command -v tilt >/dev/null 2>&1; then \
+		echo "ERROR: tilt is not installed. Please install tilt first:"; \
+		echo "  curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash"; \
+		echo "  or visit: https://docs.tilt.dev/install.html"; \
+		exit 1; \
+	fi
+
+.PHONY: setup-kind
+setup-kind: ## Create Kind cluster (idempotent)
+	@./scripts/setup-kind.sh
+
+API_TOKEN_DURATION ?= 4h
+TILT_PORT ?= 10351
+
+.PHONY: tilt-up
+tilt-up: check-tilt setup-kind ## Start Tilt — builds, deploys, and port-forwards automatically
+	@echo "Starting Tilt..."
+	@tilt up --port $(TILT_PORT)
+
+.PHONY: tilt-down
+tilt-down: check-tilt ## Stop Tilt
+	@echo "Stopping Tilt..."
+	@tilt down
+
+.PHONY: api-token
+api-token: ## Generate a bearer token for the api-tester ServiceAccount (default 4h)
+	@kubectl create token api-tester -n opendatahub --duration=$(API_TOKEN_DURATION)

--- a/distributions/rhaii/developing/Makefile
+++ b/distributions/rhaii/developing/Makefile
@@ -11,9 +11,7 @@ help: ## Display this help.
 .PHONY: check-tilt
 check-tilt:
 	@if ! command -v tilt >/dev/null 2>&1; then \
-		echo "ERROR: tilt is not installed. Please install tilt first:"; \
-		echo "  curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash"; \
-		echo "  or visit: https://docs.tilt.dev/install.html"; \
+		echo "ERROR: tilt is not installed. Install instructions: https://docs.tilt.dev/install.html"; \
 		exit 1; \
 	fi
 
@@ -27,7 +25,7 @@ TILT_PORT ?= 10351
 .PHONY: tilt-up
 tilt-up: check-tilt setup-kind ## Start Tilt — builds, deploys, and port-forwards automatically
 	@echo "Starting Tilt..."
-	@tilt up --port $(TILT_PORT)
+	@tilt up --port "$(TILT_PORT)"
 
 .PHONY: tilt-down
 tilt-down: check-tilt ## Stop Tilt
@@ -36,4 +34,4 @@ tilt-down: check-tilt ## Stop Tilt
 
 .PHONY: api-token
 api-token: ## Generate a bearer token for the api-tester ServiceAccount (default 4h)
-	@kubectl create token api-tester -n opendatahub --duration=$(API_TOKEN_DURATION)
+	@kubectl create token api-tester -n opendatahub --duration="$(API_TOKEN_DURATION)"

--- a/distributions/rhaii/developing/Tiltfile
+++ b/distributions/rhaii/developing/Tiltfile
@@ -1,0 +1,50 @@
+# RHAII Distribution — Tilt Development Environment
+#
+# Usage:
+#   make tilt-up     # creates kind cluster (if needed) and starts Tilt
+#   make tilt-down   # stops Tilt
+#
+# Prerequisites: docker/podman, kind, tilt
+
+analytics_settings(False)
+version_settings(check_updates=True, constraint=">=0.33.0")
+update_settings(k8s_upsert_timeout_secs=120)
+
+# Allow the kind-tilt context (created by setup-kind.sh)
+allow_k8s_contexts("kind-rhaii-tilt")
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+
+tilt_root = os.path.dirname(os.path.abspath(__file__))
+
+# Go up from developing/ -> rhaii/ -> distributions/ -> repo root
+dist_root = os.path.join(tilt_root, "..")
+repo_root = os.path.join(tilt_root, "../../..")
+
+# ── RHAII Dashboard ───────────────────────────────────────────────────────────
+
+docker_build(
+    "rhaii-dashboard",
+    context=repo_root,
+    dockerfile=os.path.join(dist_root, "Dockerfile"),
+    ignore=[
+        "distributions/rhaii/node_modules",
+        "distributions/rhaii/public",
+        "distributions/rhaii/developing",
+        "distributions/base/public",
+        "distributions/base/node_modules",
+        "distributions/core-bff/bff/bin",
+        "node_modules",
+        "frontend/node_modules",
+        "packages/*/node_modules",
+        "**/*.md",
+    ],
+)
+
+k8s_yaml(kustomize(os.path.join(tilt_root, "manifests")))
+
+k8s_resource(
+    "rhaii-dashboard",
+    port_forwards=[port_forward(4000, 4000, name="RHAII Dashboard")],
+    labels=["rhaii"],
+)

--- a/distributions/rhaii/developing/kind-cluster.yaml
+++ b/distributions/rhaii/developing/kind-cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  image: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f

--- a/distributions/rhaii/developing/manifests/api-tester.yaml
+++ b/distributions/rhaii/developing/manifests/api-tester.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-tester
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: api-tester-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: api-tester
+    namespace: opendatahub

--- a/distributions/rhaii/developing/manifests/kustomization.yaml
+++ b/distributions/rhaii/developing/manifests/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+resources:
+- ../../../core-bff/manifests/base
+- api-tester.yaml
+
+patches:
+- target:
+    kind: Deployment
+    name: rhaii-dashboard
+  patch: |
+    - op: replace
+      path: /spec/template/spec/containers/0/env/0/value
+      value: user_token

--- a/distributions/rhaii/developing/manifests/kustomization.yaml
+++ b/distributions/rhaii/developing/manifests/kustomization.yaml
@@ -12,6 +12,15 @@ patches:
     kind: Deployment
     name: rhaii-dashboard
   patch: |
-    - op: replace
-      path: /spec/template/spec/containers/0/env/0/value
-      value: user_token
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: rhaii-dashboard
+    spec:
+      template:
+        spec:
+          containers:
+            - name: rhaii-dashboard
+              env:
+                - name: DEV_MODE
+                  value: "true"

--- a/distributions/rhaii/developing/scripts/setup-kind.sh
+++ b/distributions/rhaii/developing/scripts/setup-kind.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Setup script for Kind cluster
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+CLUSTER_NAME="rhaii-tilt"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVELOPING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KIND_CONFIG="${DEVELOPING_DIR}/kind-cluster.yaml"
+
+# Check prerequisites
+if ! command -v kind >/dev/null 2>&1; then
+  echo "ERROR: kind is not installed. Please install kind first:"
+  echo "  brew install kind  # macOS"
+  echo "  or visit: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+  exit 1
+fi
+
+# Create cluster if it doesn't exist
+if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Creating Kind cluster '${CLUSTER_NAME}' with config from ${KIND_CONFIG}..."
+  kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --wait 60s
+  echo "Kind cluster created successfully"
+else
+  echo "Kind cluster '${CLUSTER_NAME}' already exists"
+fi
+
+# Ensure kubectl context is set
+kubectl config use-context "kind-${CLUSTER_NAME}" || {
+  echo "ERROR: Failed to set kubectl context to kind-${CLUSTER_NAME}"
+  exit 1
+}
+
+# Ensure the target namespace exists
+kubectl create namespace opendatahub --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Kind cluster setup complete"

--- a/distributions/rhaii/developing/scripts/setup-kind.sh
+++ b/distributions/rhaii/developing/scripts/setup-kind.sh
@@ -17,6 +17,11 @@ if ! command -v kind >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl is not installed. Install instructions: https://kubernetes.io/docs/tasks/tools/"
+  exit 1
+fi
+
 # Create cluster if it doesn't exist
 if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
   echo "Creating Kind cluster '${CLUSTER_NAME}' with config from ${KIND_CONFIG}..."

--- a/distributions/rhaii/package.json
+++ b/distributions/rhaii/package.json
@@ -11,6 +11,7 @@
     "dev": "npm run start:dev",
     "start:dev": "concurrently -k -n bff,shell \"make -C ../core-bff dev-bff\" \"webpack serve --hot --color --config ./config/webpack.dev.js\"",
     "build": "webpack --config ./config/webpack.prod.js",
+    "build:prod": "webpack --config ./config/webpack.prod.js",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
No Jira reference needed — this is developer tooling, not a product change.
---

Description

Introduce a complete local development workflow for the RHAII distribution
using Tilt + Kind, along with production-ready Kubernetes manifests and a
multi-stage Dockerfile.

The Tilt setup automates cluster creation, image building, deployment, and
port-forwarding behind `make tilt-up` / `make tilt-down`, replacing the
previous shell-script-based Kind deployment in core-bff.

What's included:

- Kustomize base manifests for core-bff (Deployment, Service, ServiceAccount,
  Role, RoleBinding) with security-hardened pod spec (read-only rootfs,
  non-root user, dropped capabilities, seccomp RuntimeDefault)
- Multi-stage Dockerfile: Node 22 frontend build → Go 1.25 BFF build →
  distroless final image, built from repo root with a single context
- Tiltfile wired to the Dockerfile and Kustomize overlay, port-forwarding
  the BFF API on :4000
- Idempotent Kind cluster setup script (cluster name: rhaii-tilt) pinned
  to K8s 1.35.0
- Dev-only api-tester ServiceAccount (cluster-admin) for generating bearer
 ens to exercise the API without a real auth provider
- Kustomize overlay patches AUTH_METHOD to user_token for the dev environment

The core-bff base manifests use a kustomize var to inject the container
image reference, allowing the Tilt overlay and future deployment overlays
to share the same base without duplication.

How Has This Been Tested?

Tested locally by running the full Tilt workflow:
- make tilt-up provisions a Kind cluster and deploys the RHAII distribution
- Verified the distribution shell loads and serves correctly in-browser
- Verified live-reload picks up source changes

Test Impact

No automated tests added. These are build/deploy scripts and Kubernetes manifests for local development — they run outside the application test surface and are validated by the developer workflow itself.

Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately
obvious).
- [x] The developer has added tests or explained why testing cannot be added
- [x] The code follows our Best Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new container image build for the RHAII Dashboard that packages the frontend and backend into a single runtime image.
  * Introduced Kubernetes manifests for the dashboard Deployment, Service, ServiceAccount, and RBAC, including readiness/liveness health checks and hardened security settings.
  * Enabled local development with Kind + Tilt, including an API tester workflow for authenticated testing.

* **Chores**
  * Added distribution-specific build/start/push automation, environment-mode configuration, and a production webpack build script.
  * Removed the older Kind deployment helper target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->