### PR TITLE
Add Start stop for NIMService extension

### DIFF
--- a/packages/nim-serving/extensions.ts
+++ b/packages/nim-serving/extensions.ts
@@ -6,6 +6,7 @@ import type {
   DeployedModelServingDetails,
   ModelServingExcludeDeploymentExtension,
   ModelServingPlatformWatchDeploymentsExtension,
+  ModelServingStartStopAction,
 } from '@odh-dashboard/model-serving/extension-points';
 import type {
   AssembleModelResourceExtension,
@@ -146,6 +147,7 @@ const extensions: (
   | ModelServingPlatformWatchDeploymentsExtension<NIMDeployment>
   | DeployedModelServingDetails<NIMDeployment>
   | ModelServingExcludeDeploymentExtension
+  | ModelServingStartStopAction<NIMDeployment>
   | ModelServingDeploy<NIMDeployment>
   | AssembleModelResourceExtension<NIMDeployment>
   | DeploymentWizardFieldOverrideExtension
@@ -250,6 +252,17 @@ const extensions: (
   nimPVCApplyExtension,
   nimPVCExtractorExtension,
   nimPVCDeployFunctionsExtension,
+  {
+    type: 'model-serving.deployments-table/start-stop-action',
+    properties: {
+      platform: NIM_ID,
+      patchDeploymentStoppedStatus: () =>
+        import('./src/api/deployments/status').then((m) => m.patchDeploymentStoppedStatus),
+    },
+    flags: {
+      required: [SupportedArea.NIM_WIZARD],
+    },
+  },
 ];
 
 export default extensions;

--- a/packages/nim-serving/src/api/deployments/status.ts
+++ b/packages/nim-serving/src/api/deployments/status.ts
@@ -56,6 +56,11 @@ export const getNIMDeploymentStatus = (
   return { state, message, stoppedStates };
 };
 
+/**
+ * Set the stopped status of the NIM deployment.
+ * The NIM Operator propagates the stopped annotation from `spec.annotations`
+ * to the child InferenceService's `metadata.annotations`.
+ */
 export const patchDeploymentStoppedStatus = (
   deployment: NIMDeployment,
   isStopped: boolean,

--- a/packages/nim-serving/src/api/deployments/status.ts
+++ b/packages/nim-serving/src/api/deployments/status.ts
@@ -4,9 +4,13 @@ import {
   getInferenceServiceModelState,
   getInferenceServiceStatusMessage,
 } from '@odh-dashboard/internal/concepts/modelServingKServe/kserveStatusUtils';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
 import { ModelDeploymentState } from '@odh-dashboard/internal/pages/modelServing/screens/types';
 import type { DeploymentStatus } from '@odh-dashboard/model-serving/extension-points';
 import { getModelDeploymentStoppedStates } from '@odh-dashboard/model-serving/utils';
+import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import type { NIMDeployment } from '../nimservices/types';
+import { NIMServiceModel } from '../nimservices/types';
 
 /**
  * Derive deployment status from the InferenceService created by the NIM Operator.
@@ -51,3 +55,22 @@ export const getNIMDeploymentStatus = (
 
   return { state, message, stoppedStates };
 };
+
+export const patchDeploymentStoppedStatus = (
+  deployment: NIMDeployment,
+  isStopped: boolean,
+): Promise<NIMDeployment['model']> =>
+  k8sPatchResource({
+    model: NIMServiceModel,
+    queryOptions: {
+      name: deployment.model.metadata.name,
+      ns: deployment.model.metadata.namespace,
+    },
+    patches: [
+      {
+        op: 'add',
+        path: '/spec/annotations/serving.kserve.io~1stop',
+        value: isStopped ? 'true' : 'false',
+      },
+    ],
+  });


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Closes(?) https://redhat.atlassian.net/browse/RHOAIENG-60282

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Adds the simple patch operation for the stop start
<img width="1167" height="403" alt="Screenshot 2026-06-08 at 5 36 00 PM" src="https://github.com/user-attachments/assets/856fda86-21f0-423a-a854-2ceaba32552c" />
<img width="1177" height="382" alt="Screenshot 2026-06-08 at 5 36 06 PM" src="https://github.com/user-attachments/assets/ff5ae7b8-b65e-45c8-9e3d-8f8d9692bbd8" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a new NIMService
- See that the Start stop is no longer `-` and is now a `Stop` hyperlink button
Click the Stop button
- Verify it becomes "Stopping" and then "Stopped"

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
This is very simple and the exact same pattern as the other platforms so I haven't done any new tests. The only risky part is asserting that it actually stops, which is only available with e2e. 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added start/stop controls for NVIDIA NIM deployments in the deployments table. Users can toggle deployment running/stopped state directly from the table (available in the NIM area), making it faster to manage deployment lifecycles without navigating away.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->