### PR TITLE
[Cypress-e2e] remove flaky assertions in testRetainCustomProperties

### DIFF
--- a/packages/cypress/cypress/tests/e2e/modelRegistry/testRetainCustomProperties.cy.ts
+++ b/packages/cypress/cypress/tests/e2e/modelRegistry/testRetainCustomProperties.cy.ts
@@ -36,7 +36,6 @@ describe('Verify custom properties and labels are retained during Model Registry
 
   let modelCustomPropertyKeys: string[];
   let versionCustomPropertyKeys: string[];
-  let allVersionProperties: { key: string; value: string }[];
   let extendedVersionPropertyKeys: string[];
 
   before(() => {
@@ -50,11 +49,10 @@ describe('Verify custom properties and labels are retained during Model Registry
 
         modelCustomPropertyKeys = testData.modelCustomProperties.map((prop) => prop.key);
         versionCustomPropertyKeys = testData.versionCustomProperties.map((prop) => prop.key);
-        allVersionProperties = [
-          ...testData.versionCustomProperties,
-          { key: testData.newVersionPropertyKey, value: testData.newVersionPropertyValue },
+        extendedVersionPropertyKeys = [
+          ...versionCustomPropertyKeys,
+          testData.newVersionPropertyKey,
         ];
-        extendedVersionPropertyKeys = allVersionProperties.map((p) => p.key);
 
         cy.step('Ensure operator has optimal memory for testing');
         ensureOperatorMemoryLimit(deploymentName).should('be.true');
@@ -151,12 +149,6 @@ describe('Verify custom properties and labels are retained during Model Registry
         registeredModelDetails.findPropertyKeyInput().should('not.exist');
       });
 
-      cy.step('Verify model custom properties are visible in UI');
-      registeredModelDetails.ensurePropertiesExpanded();
-      testData.modelCustomProperties.forEach((prop) => {
-        registeredModelDetails.shouldHaveCustomProperty(prop.key, prop.value);
-      });
-
       cy.step('Verify model custom properties exist in database');
       checkCustomPropertiesInDatabase(
         modelName,
@@ -184,11 +176,6 @@ describe('Verify custom properties and labels are retained during Model Registry
         modelVersionDetails.findPropertyKeyInput().should('not.exist');
       });
 
-      cy.step('Verify version custom properties are visible in UI');
-      testData.versionCustomProperties.forEach((prop) => {
-        modelVersionDetails.shouldHaveCustomProperty(prop.key, prop.value);
-      });
-
       cy.step('Verify version custom properties exist in database');
       checkCustomPropertiesInDatabase(
         testData.versionName,
@@ -202,34 +189,6 @@ describe('Verify custom properties and labels are retained during Model Registry
         testData.newVersionPropertyKey,
         testData.newVersionPropertyValue,
       );
-
-      cy.step('Verify new property was added');
-      modelVersionDetails.shouldHaveCustomProperty(
-        testData.newVersionPropertyKey,
-        testData.newVersionPropertyValue,
-      );
-
-      cy.step('Navigate back to model and verify model properties are intact');
-      modelRegistry.findModelVersionBreadcrumbItem().click();
-
-      registeredModelDetails.ensurePropertiesExpanded();
-      testData.modelCustomProperties.forEach((prop) => {
-        registeredModelDetails.shouldHaveCustomProperty(prop.key, prop.value);
-      });
-
-      cy.step('Navigate to version and verify all version properties are intact');
-      modelRegistry.findModelVersionsTab().click();
-      modelRegistry
-        .getModelVersionRow(testData.versionName)
-        .findModelVersionName()
-        .find('a')
-        .click();
-      cy.url().should('include', '/details');
-      modelVersionDetails.ensurePropertiesExpanded();
-
-      allVersionProperties.forEach((prop) => {
-        modelVersionDetails.shouldHaveCustomProperty(prop.key, prop.value);
-      });
 
       cy.step('Verify in database that both model and version properties are retained');
       checkCustomPropertiesInDatabase(


### PR DESCRIPTION
## Description
- Removes flaky shouldHaveCustomProperty UI assertions from testRetainCustomProperties that fail intermittently due to PF v6 ExpandableSection.
- Property retention is still validated via direct database checks (checkCustomPropertiesInDatabase).

## How Has This Been Tested?
Jenkins: 1210

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test verification for Model Registry custom properties retention with improved reliability through database-level validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->