### PR TITLE
chore: add OWNERS entry for dashboard-operator directory

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -50,6 +50,15 @@ filters:
     labels:
       - area/manifests
 
+  # Dashboard Module Controller (operator)
+  'dashboard-operator/.*':
+    approvers:
+      - platform-approvers
+    reviewers:
+      - platform-reviewers
+    labels:
+      - 'area/platform'
+
   # Cypress tests
   'packages/cypress/.*':
     approvers:


### PR DESCRIPTION
## Description

The `dashboard-operator/` directory had no specific OWNERS filter, so it only matched the catchall `'.*'` pattern which has no `reviewers` defined. This meant platform team members (Monarch / `platform-reviewers`) couldn't `/lgtm` PRs touching operator code, and `platform-approvers` couldn't `/approve` them either.

This was discovered when [PR #7797](https://github.com/opendatahub-io/odh-dashboard/pull/7797) couldn't get `/lgtm` or `/approve` from `liday-rh` despite being in `platform-reviewers`.

Adds a `dashboard-operator/.*` filter with:
- **approvers**: `platform-approvers`
- **reviewers**: `platform-reviewers`
- **labels**: `area/platform`

## How Has This Been Tested?

Verified by reading the Prow OWNERS spec and confirming the regex pattern matches the directory structure.

## Test Impact

No tests needed — this is a CI/Prow configuration change.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review approval configuration to assign specific reviewers and approvers for the dashboard-operator area, along with a corresponding label assignment for better organization of pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->