### PR TITLE
RHOAIENG-62431 : Add "Connected feature stores" section to Workbench table expanded row

### DIFF
--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Content, List, ListItem, Stack, StackItem } from '@patternfly/react-core';
+import { Content, Icon, List, ListItem, Stack, StackItem, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import { NotebookKind } from '#~/k8sTypes';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
@@ -7,6 +8,8 @@ import ShowAllButton from './ShowAllButton';
 
 type NotebookFeatureStoreListProps = {
   notebook: NotebookKind;
+  availableNames: Set<string>;
+  availabilityLoaded: boolean;
 };
 
 const DEFAULT_VISIBLE_LENGTH = 5;
@@ -22,7 +25,11 @@ const parseFeatureStoreNames = (annotation: string | undefined): string[] => {
   return [...new Set(names)];
 };
 
-const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({ notebook }) => {
+const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
+  notebook,
+  availableNames,
+  availabilityLoaded,
+}) => {
   const [showAll, setShowAll] = React.useState(false);
 
   const feastAnnotation = notebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION];
@@ -47,15 +54,26 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({ not
           </Content>
         ) : (
           <List data-testid="notebook-feature-store-list">
-            {visibleNames.map((name) => (
-              <ListItem key={name}>
-                <Content>{name}</Content>
-              </ListItem>
-            ))}
+            {visibleNames.map((name) => {
+              const isUnavailable = availabilityLoaded && !availableNames.has(name);
+
+              return (
+                <ListItem key={name}>
+                  <Content component={isUnavailable ? 'small' : undefined}>{name}</Content>
+                  {isUnavailable && (
+                    <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
+                      <Icon isInline status="warning" data-testid="feature-store-unavailable-icon">
+                        <ExclamationTriangleIcon />
+                      </Icon>
+                    </Tooltip>
+                  )}
+                </ListItem>
+              );
+            })}
           </List>
         )}
       </StackItem>
-      {featureStoreNames.length > 0 && (
+      {featureStoreNames.length > DEFAULT_VISIBLE_LENGTH && (
         <StackItem>
           <ShowAllButton
             isExpanded={showAll}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { Content, List, ListItem, Stack, StackItem } from '@patternfly/react-core';
+
+import { NotebookKind } from '#~/k8sTypes';
+import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
+import ShowAllButton from './ShowAllButton';
+
+type NotebookFeatureStoreListProps = {
+  notebook: NotebookKind;
+};
+
+const DEFAULT_VISIBLE_LENGTH = 5;
+
+const parseFeatureStoreNames = (annotation: string | undefined): string[] => {
+  if (!annotation) {
+    return [];
+  }
+  const names = annotation
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+  return [...new Set(names)];
+};
+
+const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({ notebook }) => {
+  const [showAll, setShowAll] = React.useState(false);
+
+  const feastAnnotation = notebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION];
+  const featureStoreNames = React.useMemo(
+    () => parseFeatureStoreNames(feastAnnotation),
+    [feastAnnotation],
+  );
+
+  const visibleNames = showAll
+    ? featureStoreNames
+    : featureStoreNames.slice(0, DEFAULT_VISIBLE_LENGTH);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <strong data-testid="notebook-feature-store-title">Connected feature stores</strong>
+      </StackItem>
+      <StackItem>
+        {featureStoreNames.length === 0 ? (
+          <Content data-testid="notebook-feature-store-none" component="small">
+            None
+          </Content>
+        ) : (
+          <List data-testid="notebook-feature-store-list">
+            {visibleNames.map((name) => (
+              <ListItem key={name}>
+                <Content>{name}</Content>
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </StackItem>
+      {featureStoreNames.length > 0 && (
+        <StackItem>
+          <ShowAllButton
+            isExpanded={showAll}
+            visibleLength={DEFAULT_VISIBLE_LENGTH}
+            onToggle={() => setShowAll(!showAll)}
+            totalSize={featureStoreNames.length}
+            data-testid="feature-store-show-all"
+          />
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default NotebookFeatureStoreList;

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 import { NotebookKind } from '#~/k8sTypes';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
@@ -75,7 +76,7 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
                       alignItems={{ default: 'alignItemsCenter' }}
                     >
                       <FlexItem>
-                        <Content className="pf-v6-u-text-color-subtle">{name}</Content>
+                        <Content className={text.textColorDisabled}>{name}</Content>
                       </FlexItem>
                       <FlexItem>
                         <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
-import { Content, Icon, List, ListItem, Stack, StackItem, Tooltip } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import {
+  Content,
+  Flex,
+  FlexItem,
+  Icon,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { NotebookKind } from '#~/k8sTypes';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
@@ -57,24 +67,29 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
             {visibleNames.map((name) => {
               const isUnavailable = availabilityLoaded && !availableNames.has(name);
 
-              return (
-                <ListItem key={name}>
-                  {name}
-                  {isUnavailable && (
-                    <span style={{ marginLeft: 'var(--pf-t--global--spacer--sm)' }}>
-                      <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
-                        <Icon
-                          isInline
-                          status="warning"
-                          data-testid="feature-store-unavailable-icon"
-                        >
-                          <ExclamationTriangleIcon />
-                        </Icon>
-                      </Tooltip>
-                    </span>
-                  )}
-                </ListItem>
-              );
+              if (isUnavailable) {
+                return (
+                  <ListItem key={name}>
+                    <Flex
+                      spaceItems={{ default: 'spaceItemsSm' }}
+                      alignItems={{ default: 'alignItemsCenter' }}
+                    >
+                      <FlexItem>
+                        <Content className="pf-v6-u-text-color-subtle">{name}</Content>
+                      </FlexItem>
+                      <FlexItem>
+                        <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
+                          <Icon isInline status="info" data-testid="feature-store-unavailable-icon">
+                            <InfoCircleIcon />
+                          </Icon>
+                        </Tooltip>
+                      </FlexItem>
+                    </Flex>
+                  </ListItem>
+                );
+              }
+
+              return <ListItem key={name}>{name}</ListItem>;
             })}
           </List>
         )}

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList.tsx
@@ -59,13 +59,19 @@ const NotebookFeatureStoreList: React.FC<NotebookFeatureStoreListProps> = ({
 
               return (
                 <ListItem key={name}>
-                  <Content component={isUnavailable ? 'small' : undefined}>{name}</Content>
+                  {name}
                   {isUnavailable && (
-                    <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
-                      <Icon isInline status="warning" data-testid="feature-store-unavailable-icon">
-                        <ExclamationTriangleIcon />
-                      </Icon>
-                    </Tooltip>
+                    <span style={{ marginLeft: 'var(--pf-t--global--spacer--sm)' }}>
+                      <Tooltip content="This feature store is no longer available. It may have been deleted or access has been revoked.">
+                        <Icon
+                          isInline
+                          status="warning"
+                          data-testid="feature-store-unavailable-icon"
+                        >
+                          <ExclamationTriangleIcon />
+                        </Icon>
+                      </Tooltip>
+                    </span>
                   )}
                 </ListItem>
               );

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -30,6 +30,7 @@ import { WORKBENCH_VISIBILITY } from '#~/concepts/hardwareProfiles/const';
 import { NotebookImageStatus } from './const';
 import { NotebookImageDisplayName } from './NotebookImageDisplayName';
 import NotebookStorageBars from './NotebookStorageBars';
+import NotebookFeatureStoreList from './NotebookFeatureStoreList';
 import NotebookSizeDetails from './NotebookSizeDetails';
 import WorkbenchMigrationLabel from './WorkbenchMigrationLabel';
 import useNotebookImage from './useNotebookImage';
@@ -70,6 +71,7 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
   const showMigrationRequired = !isWorkbenchMigrated(obj.notebook);
 
   const isMlflowAvailable = useIsAreaAvailable(SupportedArea.MLFLOW).status;
+  const isFeatureStoreAvailable = useIsAreaAvailable(SupportedArea.FEATURE_STORE).status;
 
   const onStart = React.useCallback(() => {
     setInProgress(true);
@@ -274,7 +276,15 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
             />
           </ExpandableRowContent>
         </Td>
-        <Td />
+        {isFeatureStoreAvailable ? (
+          <Td dataLabel="Connected feature stores">
+            <ExpandableRowContent>
+              <NotebookFeatureStoreList notebook={obj.notebook} />
+            </ExpandableRowContent>
+          </Td>
+        ) : (
+          <Td />
+        )}
         <Td />
         <Td />
       </Tr>

--- a/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/NotebookTableRow.tsx
@@ -27,6 +27,7 @@ import { UseAssignHardwareProfileResult } from '#~/concepts/hardwareProfiles/use
 import { useHardwareProfileBindingState } from '#~/concepts/hardwareProfiles/useHardwareProfileBindingState';
 import { getDeletedHardwareProfilePatches } from '#~/concepts/hardwareProfiles/utils';
 import { WORKBENCH_VISIBILITY } from '#~/concepts/hardwareProfiles/const';
+import { useWorkbenchFeatureStores } from '#~/pages/projects/screens/spawner/featureStore/useWorkbenchFeatureStores';
 import { NotebookImageStatus } from './const';
 import { NotebookImageDisplayName } from './NotebookImageDisplayName';
 import NotebookStorageBars from './NotebookStorageBars';
@@ -72,6 +73,11 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
 
   const isMlflowAvailable = useIsAreaAvailable(SupportedArea.MLFLOW).status;
   const isFeatureStoreAvailable = useIsAreaAvailable(SupportedArea.FEATURE_STORE).status;
+  const { featureStores, loaded: featureStoresLoaded } = useWorkbenchFeatureStores();
+  const availableFeatureStoreNames = React.useMemo(
+    () => new Set(featureStores.map((fs) => fs.projectName)),
+    [featureStores],
+  );
 
   const onStart = React.useCallback(() => {
     setInProgress(true);
@@ -277,9 +283,14 @@ const NotebookTableRow: React.FC<NotebookTableRowProps> = ({
           </ExpandableRowContent>
         </Td>
         {isFeatureStoreAvailable ? (
-          <Td dataLabel="Connected feature stores">
+          <Td>
             <ExpandableRowContent>
-              <NotebookFeatureStoreList notebook={obj.notebook} />
+              <NotebookFeatureStoreList
+                key={obj.notebook.metadata.uid}
+                notebook={obj.notebook}
+                availableNames={availableFeatureStoreNames}
+                availabilityLoaded={featureStoresLoaded}
+              />
             </ExpandableRowContent>
           </Td>
         ) : (

--- a/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/ShowAllButton.tsx
@@ -6,6 +6,7 @@ type ShowAllButtonProps = {
   isExpanded: boolean;
   totalSize: number;
   onToggle: () => void;
+  'data-testid'?: string;
 };
 
 const ShowAllButton: React.FC<ShowAllButtonProps> = ({
@@ -13,13 +14,14 @@ const ShowAllButton: React.FC<ShowAllButtonProps> = ({
   totalSize,
   onToggle,
   isExpanded,
+  'data-testid': testId,
 }) => {
   if (visibleLength >= totalSize) {
     return null;
   }
 
   return (
-    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+    <Flex spaceItems={{ default: 'spaceItemsSm' }} data-testid={testId}>
       <FlexItem>
         <Button isInline variant="link" onClick={onToggle}>
           {isExpanded ? 'Show less' : 'Show all'}

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -4,6 +4,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import NotebookFeatureStoreList from '#~/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList';
+import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
 
 const FIVE_STORES = 'store-1,store-2,store-3,store-4,store-5';
 const SIX_STORES = `${FIVE_STORES},store-6`;
@@ -13,17 +14,27 @@ const DUPLICATED_PROJECTS = 'project-a,project-b,project-a,project-c,project-b';
 const WHITESPACE_PADDED = '  project-a , project-b , project-c  ';
 const WHITESPACE_ONLY = '   ,  , ';
 
-const renderFeatureStoreList = (annotation?: string) => {
+const renderFeatureStoreList = (
+  annotation?: string,
+  availableNames: Set<string> = new Set(),
+  availabilityLoaded = true,
+) => {
   const notebook = mockNotebookK8sResource({
     ...(annotation !== undefined && {
       opts: {
         metadata: {
-          annotations: { 'opendatahub.io/feast-config': annotation },
+          annotations: { [FEAST_CONFIG_ANNOTATION]: annotation },
         },
       },
     }),
   });
-  render(<NotebookFeatureStoreList notebook={notebook} />);
+  render(
+    <NotebookFeatureStoreList
+      notebook={notebook}
+      availableNames={availableNames}
+      availabilityLoaded={availabilityLoaded}
+    />,
+  );
 };
 
 describe('NotebookFeatureStoreList', () => {
@@ -50,7 +61,7 @@ describe('NotebookFeatureStoreList', () => {
   });
 
   it('should render a single feature store', () => {
-    renderFeatureStoreList('single-project');
+    renderFeatureStoreList('single-project', new Set(['single-project']));
 
     const list = screen.getByTestId('notebook-feature-store-list');
     expect(within(list).getAllByRole('listitem')).toHaveLength(1);
@@ -59,7 +70,7 @@ describe('NotebookFeatureStoreList', () => {
   });
 
   it('should render 3 feature store names without expand button', () => {
-    renderFeatureStoreList(THREE_PROJECTS);
+    renderFeatureStoreList(THREE_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
@@ -110,7 +121,7 @@ describe('NotebookFeatureStoreList', () => {
   });
 
   it('should trim whitespace from comma-separated values', () => {
-    renderFeatureStoreList(WHITESPACE_PADDED);
+    renderFeatureStoreList(WHITESPACE_PADDED, new Set(['project-a', 'project-b', 'project-c']));
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
@@ -121,7 +132,7 @@ describe('NotebookFeatureStoreList', () => {
   });
 
   it('should deduplicate feature store names while preserving order', () => {
-    renderFeatureStoreList(DUPLICATED_PROJECTS);
+    renderFeatureStoreList(DUPLICATED_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
@@ -129,5 +140,79 @@ describe('NotebookFeatureStoreList', () => {
     expect(items[0]).toHaveTextContent('project-a');
     expect(items[1]).toHaveTextContent('project-b');
     expect(items[2]).toHaveTextContent('project-c');
+  });
+
+  describe('availability indicators', () => {
+    it('should show warning icon for unavailable feature stores', () => {
+      renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-a']));
+
+      const list = screen.getByTestId('notebook-feature-store-list');
+      const items = within(list).getAllByRole('listitem');
+
+      expect(
+        within(items[0]).queryByTestId('feature-store-unavailable-icon'),
+      ).not.toBeInTheDocument();
+      expect(within(items[1]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+      expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    });
+
+    it('should not show warning icons when all stores are available', () => {
+      renderFeatureStoreList(THREE_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
+      expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
+    });
+
+    it('should show warning icons for all stores when none are available', () => {
+      renderFeatureStoreList(THREE_PROJECTS, new Set());
+      expect(screen.getAllByTestId('feature-store-unavailable-icon')).toHaveLength(3);
+    });
+
+    it('should not show warning icons while availability is still loading', () => {
+      renderFeatureStoreList(THREE_PROJECTS, new Set(), false);
+
+      expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
+      const list = screen.getByTestId('notebook-feature-store-list');
+      expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+    });
+
+    it('should preserve ordering with mixed available/unavailable stores', () => {
+      renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-b']));
+
+      const list = screen.getByTestId('notebook-feature-store-list');
+      const items = within(list).getAllByRole('listitem');
+      expect(items).toHaveLength(3);
+      expect(items[0]).toHaveTextContent('project-a');
+      expect(items[1]).toHaveTextContent('project-b');
+      expect(items[2]).toHaveTextContent('project-c');
+
+      expect(within(items[0]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+      expect(
+        within(items[1]).queryByTestId('feature-store-unavailable-icon'),
+      ).not.toBeInTheDocument();
+      expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    });
+
+    it('should show warning icons with expand/collapse for mixed stores', async () => {
+      const user = userEvent.setup();
+      renderFeatureStoreList(SEVEN_STORES, new Set(['store-1', 'store-3', 'store-5']));
+
+      const list = screen.getByTestId('notebook-feature-store-list');
+      const initialItems = within(list).getAllByRole('listitem');
+      expect(initialItems).toHaveLength(5);
+
+      expect(
+        within(initialItems[0]).queryByTestId('feature-store-unavailable-icon'),
+      ).not.toBeInTheDocument();
+      expect(
+        within(initialItems[1]).getByTestId('feature-store-unavailable-icon'),
+      ).toBeInTheDocument();
+
+      const showAllContainer = screen.getByTestId('feature-store-show-all');
+      await user.click(within(showAllContainer).getByRole('button'));
+
+      const allItems = within(list).getAllByRole('listitem');
+      expect(allItems).toHaveLength(7);
+      expect(within(allItems[5]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+      expect(within(allItems[6]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
+import NotebookFeatureStoreList from '#~/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList';
+
+const FIVE_STORES = 'store-1,store-2,store-3,store-4,store-5';
+const SIX_STORES = `${FIVE_STORES},store-6`;
+const SEVEN_STORES = `${SIX_STORES},store-7`;
+const THREE_PROJECTS = 'project-a,project-b,project-c';
+const DUPLICATED_PROJECTS = 'project-a,project-b,project-a,project-c,project-b';
+const WHITESPACE_PADDED = '  project-a , project-b , project-c  ';
+const WHITESPACE_ONLY = '   ,  , ';
+
+const renderFeatureStoreList = (annotation?: string) => {
+  const notebook = mockNotebookK8sResource({
+    ...(annotation !== undefined && {
+      opts: {
+        metadata: {
+          annotations: { 'opendatahub.io/feast-config': annotation },
+        },
+      },
+    }),
+  });
+  render(<NotebookFeatureStoreList notebook={notebook} />);
+};
+
+describe('NotebookFeatureStoreList', () => {
+  it('should display the section title', () => {
+    renderFeatureStoreList();
+    expect(screen.getByTestId('notebook-feature-store-title')).toHaveTextContent(
+      'Connected feature stores',
+    );
+  });
+
+  it('should show "None" when annotation is absent', () => {
+    renderFeatureStoreList();
+    expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
+  });
+
+  it('should show "None" when annotation is empty', () => {
+    renderFeatureStoreList('');
+    expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
+  });
+
+  it('should show "None" when annotation contains only whitespace/commas', () => {
+    renderFeatureStoreList(WHITESPACE_ONLY);
+    expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
+  });
+
+  it('should render a single feature store', () => {
+    renderFeatureStoreList('single-project');
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    expect(within(list).getByText('single-project')).toBeInTheDocument();
+    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
+  });
+
+  it('should render 3 feature store names without expand button', () => {
+    renderFeatureStoreList(THREE_PROJECTS);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveTextContent('project-a');
+    expect(items[1]).toHaveTextContent('project-b');
+    expect(items[2]).toHaveTextContent('project-c');
+    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
+  });
+
+  it('should not show expand button for exactly 5 items', () => {
+    renderFeatureStoreList(FIVE_STORES);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
+  });
+
+  it('should show "1 more" for exactly 6 items', () => {
+    renderFeatureStoreList(SIX_STORES);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+
+    const showAllContainer = screen.getByTestId('feature-store-show-all');
+    expect(showAllContainer).toHaveTextContent('Show all');
+    expect(showAllContainer).toHaveTextContent('1 more');
+  });
+
+  it('should expand and collapse for 7 items', async () => {
+    const user = userEvent.setup();
+    renderFeatureStoreList(SEVEN_STORES);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+
+    const showAllContainer = screen.getByTestId('feature-store-show-all');
+    expect(showAllContainer).toHaveTextContent('Show all');
+    expect(showAllContainer).toHaveTextContent('2 more');
+
+    await user.click(within(showAllContainer).getByRole('button'));
+    expect(within(list).getAllByRole('listitem')).toHaveLength(7);
+    expect(showAllContainer).toHaveTextContent('Show less');
+
+    await user.click(within(showAllContainer).getByRole('button'));
+    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+    expect(showAllContainer).toHaveTextContent('Show all');
+  });
+
+  it('should trim whitespace from comma-separated values', () => {
+    renderFeatureStoreList(WHITESPACE_PADDED);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveTextContent('project-a');
+    expect(items[1]).toHaveTextContent('project-b');
+    expect(items[2]).toHaveTextContent('project-c');
+  });
+
+  it('should deduplicate feature store names while preserving order', () => {
+    renderFeatureStoreList(DUPLICATED_PROJECTS);
+
+    const list = screen.getByTestId('notebook-feature-store-list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveTextContent('project-a');
+    expect(items[1]).toHaveTextContent('project-b');
+    expect(items[2]).toHaveTextContent('project-c');
+  });
+});

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -6,13 +6,7 @@ import { mockNotebookK8sResource } from '#~/__mocks__/mockNotebookK8sResource';
 import NotebookFeatureStoreList from '#~/pages/projects/screens/detail/notebooks/NotebookFeatureStoreList';
 import { FEAST_CONFIG_ANNOTATION } from '#~/pages/projects/screens/spawner/featureStore/const';
 
-const FIVE_STORES = 'store-1,store-2,store-3,store-4,store-5';
-const SIX_STORES = `${FIVE_STORES},store-6`;
-const SEVEN_STORES = `${SIX_STORES},store-7`;
-const THREE_PROJECTS = 'project-a,project-b,project-c';
-const DUPLICATED_PROJECTS = 'project-a,project-b,project-a,project-c,project-b';
-const WHITESPACE_PADDED = '  project-a , project-b , project-c  ';
-const WHITESPACE_ONLY = '   ,  , ';
+const SEVEN_STORES = 'store-1,store-2,store-3,store-4,store-5,store-6,store-7';
 
 const renderFeatureStoreList = (
   annotation?: string,
@@ -38,39 +32,29 @@ const renderFeatureStoreList = (
 };
 
 describe('NotebookFeatureStoreList', () => {
-  it('should display the section title', () => {
-    renderFeatureStoreList();
+  it('should show title and "None" when annotation is absent or empty', () => {
+    const { unmount } = render(
+      <NotebookFeatureStoreList
+        notebook={mockNotebookK8sResource({})}
+        availableNames={new Set()}
+        availabilityLoaded
+      />,
+    );
     expect(screen.getByTestId('notebook-feature-store-title')).toHaveTextContent(
       'Connected feature stores',
     );
-  });
-
-  it('should show "None" when annotation is absent', () => {
-    renderFeatureStoreList();
     expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
-  });
+    unmount();
 
-  it('should show "None" when annotation is empty', () => {
     renderFeatureStoreList('');
     expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
   });
 
-  it('should show "None" when annotation contains only whitespace/commas', () => {
-    renderFeatureStoreList(WHITESPACE_ONLY);
-    expect(screen.getByTestId('notebook-feature-store-none')).toHaveTextContent('None');
-  });
-
-  it('should render a single feature store', () => {
-    renderFeatureStoreList('single-project', new Set(['single-project']));
-
-    const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
-    expect(within(list).getByText('single-project')).toBeInTheDocument();
-    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
-  });
-
-  it('should render 3 feature store names without expand button', () => {
-    renderFeatureStoreList(THREE_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
+  it('should render deduplicated and trimmed names without expand button', () => {
+    renderFeatureStoreList(
+      '  project-a , project-b , project-a , project-c  ',
+      new Set(['project-a', 'project-b', 'project-c']),
+    );
 
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
@@ -81,26 +65,7 @@ describe('NotebookFeatureStoreList', () => {
     expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
   });
 
-  it('should not show expand button for exactly 5 items', () => {
-    renderFeatureStoreList(FIVE_STORES);
-
-    const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
-    expect(screen.queryByTestId('feature-store-show-all')).not.toBeInTheDocument();
-  });
-
-  it('should show "1 more" for exactly 6 items', () => {
-    renderFeatureStoreList(SIX_STORES);
-
-    const list = screen.getByTestId('notebook-feature-store-list');
-    expect(within(list).getAllByRole('listitem')).toHaveLength(5);
-
-    const showAllContainer = screen.getByTestId('feature-store-show-all');
-    expect(showAllContainer).toHaveTextContent('Show all');
-    expect(showAllContainer).toHaveTextContent('1 more');
-  });
-
-  it('should expand and collapse for 7 items', async () => {
+  it('should expand and collapse for more than 5 items', async () => {
     const user = userEvent.setup();
     renderFeatureStoreList(SEVEN_STORES);
 
@@ -120,99 +85,57 @@ describe('NotebookFeatureStoreList', () => {
     expect(showAllContainer).toHaveTextContent('Show all');
   });
 
-  it('should trim whitespace from comma-separated values', () => {
-    renderFeatureStoreList(WHITESPACE_PADDED, new Set(['project-a', 'project-b', 'project-c']));
+  it('should show info icon only for unavailable stores and hide icons while loading', () => {
+    const { unmount } = render(
+      <NotebookFeatureStoreList
+        notebook={mockNotebookK8sResource({
+          opts: {
+            metadata: {
+              annotations: { [FEAST_CONFIG_ANNOTATION]: 'project-a,project-b,project-c' },
+            },
+          },
+        })}
+        availableNames={new Set()}
+        availabilityLoaded={false}
+      />,
+    );
+    expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
+    expect(
+      within(screen.getByTestId('notebook-feature-store-list')).getAllByRole('listitem'),
+    ).toHaveLength(3);
+    unmount();
 
+    renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-b']));
     const list = screen.getByTestId('notebook-feature-store-list');
     const items = within(list).getAllByRole('listitem');
-    expect(items).toHaveLength(3);
-    expect(items[0]).toHaveTextContent('project-a');
-    expect(items[1]).toHaveTextContent('project-b');
-    expect(items[2]).toHaveTextContent('project-c');
+    expect(within(items[0]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    expect(
+      within(items[1]).queryByTestId('feature-store-unavailable-icon'),
+    ).not.toBeInTheDocument();
+    expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
   });
 
-  it('should deduplicate feature store names while preserving order', () => {
-    renderFeatureStoreList(DUPLICATED_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
+  it('should show info icons with expand/collapse for mixed stores', async () => {
+    const user = userEvent.setup();
+    renderFeatureStoreList(SEVEN_STORES, new Set(['store-1', 'store-3', 'store-5']));
 
     const list = screen.getByTestId('notebook-feature-store-list');
-    const items = within(list).getAllByRole('listitem');
-    expect(items).toHaveLength(3);
-    expect(items[0]).toHaveTextContent('project-a');
-    expect(items[1]).toHaveTextContent('project-b');
-    expect(items[2]).toHaveTextContent('project-c');
-  });
+    const initialItems = within(list).getAllByRole('listitem');
+    expect(initialItems).toHaveLength(5);
 
-  describe('availability indicators', () => {
-    it('should show info icon for unavailable feature stores', () => {
-      renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-a']));
+    expect(
+      within(initialItems[0]).queryByTestId('feature-store-unavailable-icon'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(initialItems[1]).getByTestId('feature-store-unavailable-icon'),
+    ).toBeInTheDocument();
 
-      const list = screen.getByTestId('notebook-feature-store-list');
-      const items = within(list).getAllByRole('listitem');
+    const showAllContainer = screen.getByTestId('feature-store-show-all');
+    await user.click(within(showAllContainer).getByRole('button'));
 
-      expect(
-        within(items[0]).queryByTestId('feature-store-unavailable-icon'),
-      ).not.toBeInTheDocument();
-      expect(within(items[1]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-      expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-    });
-
-    it('should not show info icons when all stores are available', () => {
-      renderFeatureStoreList(THREE_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
-      expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
-    });
-
-    it('should show info icons for all stores when none are available', () => {
-      renderFeatureStoreList(THREE_PROJECTS, new Set());
-      expect(screen.getAllByTestId('feature-store-unavailable-icon')).toHaveLength(3);
-    });
-
-    it('should not show info icons while availability is still loading', () => {
-      renderFeatureStoreList(THREE_PROJECTS, new Set(), false);
-
-      expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
-      const list = screen.getByTestId('notebook-feature-store-list');
-      expect(within(list).getAllByRole('listitem')).toHaveLength(3);
-    });
-
-    it('should preserve ordering with mixed available/unavailable stores', () => {
-      renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-b']));
-
-      const list = screen.getByTestId('notebook-feature-store-list');
-      const items = within(list).getAllByRole('listitem');
-      expect(items).toHaveLength(3);
-      expect(items[0]).toHaveTextContent('project-a');
-      expect(items[1]).toHaveTextContent('project-b');
-      expect(items[2]).toHaveTextContent('project-c');
-
-      expect(within(items[0]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-      expect(
-        within(items[1]).queryByTestId('feature-store-unavailable-icon'),
-      ).not.toBeInTheDocument();
-      expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-    });
-
-    it('should show info icons with expand/collapse for mixed stores', async () => {
-      const user = userEvent.setup();
-      renderFeatureStoreList(SEVEN_STORES, new Set(['store-1', 'store-3', 'store-5']));
-
-      const list = screen.getByTestId('notebook-feature-store-list');
-      const initialItems = within(list).getAllByRole('listitem');
-      expect(initialItems).toHaveLength(5);
-
-      expect(
-        within(initialItems[0]).queryByTestId('feature-store-unavailable-icon'),
-      ).not.toBeInTheDocument();
-      expect(
-        within(initialItems[1]).getByTestId('feature-store-unavailable-icon'),
-      ).toBeInTheDocument();
-
-      const showAllContainer = screen.getByTestId('feature-store-show-all');
-      await user.click(within(showAllContainer).getByRole('button'));
-
-      const allItems = within(list).getAllByRole('listitem');
-      expect(allItems).toHaveLength(7);
-      expect(within(allItems[5]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-      expect(within(allItems[6]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
-    });
+    const allItems = within(list).getAllByRole('listitem');
+    expect(allItems).toHaveLength(7);
+    expect(within(allItems[5]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
+    expect(within(allItems[6]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
+++ b/frontend/src/pages/projects/screens/detail/notebooks/__tests__/NotebookFeatureStoreList.spec.tsx
@@ -143,7 +143,7 @@ describe('NotebookFeatureStoreList', () => {
   });
 
   describe('availability indicators', () => {
-    it('should show warning icon for unavailable feature stores', () => {
+    it('should show info icon for unavailable feature stores', () => {
       renderFeatureStoreList('project-a,project-b,project-c', new Set(['project-a']));
 
       const list = screen.getByTestId('notebook-feature-store-list');
@@ -156,17 +156,17 @@ describe('NotebookFeatureStoreList', () => {
       expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
     });
 
-    it('should not show warning icons when all stores are available', () => {
+    it('should not show info icons when all stores are available', () => {
       renderFeatureStoreList(THREE_PROJECTS, new Set(['project-a', 'project-b', 'project-c']));
       expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
     });
 
-    it('should show warning icons for all stores when none are available', () => {
+    it('should show info icons for all stores when none are available', () => {
       renderFeatureStoreList(THREE_PROJECTS, new Set());
       expect(screen.getAllByTestId('feature-store-unavailable-icon')).toHaveLength(3);
     });
 
-    it('should not show warning icons while availability is still loading', () => {
+    it('should not show info icons while availability is still loading', () => {
       renderFeatureStoreList(THREE_PROJECTS, new Set(), false);
 
       expect(screen.queryAllByTestId('feature-store-unavailable-icon')).toHaveLength(0);
@@ -191,7 +191,7 @@ describe('NotebookFeatureStoreList', () => {
       expect(within(items[2]).getByTestId('feature-store-unavailable-icon')).toBeInTheDocument();
     });
 
-    it('should show warning icons with expand/collapse for mixed stores', async () => {
+    it('should show info icons with expand/collapse for mixed stores', async () => {
       const user = userEvent.setup();
       renderFeatureStoreList(SEVEN_STORES, new Set(['store-1', 'store-3', 'store-5']));
 

--- a/frontend/src/pages/projects/screens/spawner/featureStore/const.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/const.ts
@@ -1,0 +1,2 @@
+export const FEAST_CONFIG_ANNOTATION = 'opendatahub.io/feast-config';
+export const FEAST_INTEGRATION_LABEL = 'opendatahub.io/feast-integration';

--- a/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
+++ b/frontend/src/pages/projects/screens/spawner/featureStore/utils.ts
@@ -1,6 +1,7 @@
 import { NotebookKind } from '#~/k8sTypes';
 import { SelectionOptions } from '#~/components/MultiSelection';
 import type { WorkbenchFeatureStoreConfig } from './useWorkbenchFeatureStores';
+import { FEAST_CONFIG_ANNOTATION, FEAST_INTEGRATION_LABEL } from './const';
 
 export type NotebookFeatureStore = {
   namespace: string;
@@ -26,7 +27,7 @@ export const getFeatureStoresFromNotebook = (
   notebook: NotebookKind,
   availableFeatureStores: WorkbenchFeatureStoreConfig[],
 ): WorkbenchFeatureStoreConfig[] => {
-  const feastConfigAnnotation = notebook.metadata.annotations?.['opendatahub.io/feast-config'];
+  const feastConfigAnnotation = notebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION];
   if (!feastConfigAnnotation) {
     return [];
   }
@@ -115,17 +116,16 @@ export const generateFeastMetadata = (
   const annotations: Record<string, string> = {};
 
   if (hasFeatureStores) {
-    labels['opendatahub.io/feast-integration'] = 'true';
+    labels[FEAST_INTEGRATION_LABEL] = 'true';
     if (feastConfigAnnotation) {
-      annotations['opendatahub.io/feast-config'] = feastConfigAnnotation;
+      annotations[FEAST_CONFIG_ANNOTATION] = feastConfigAnnotation;
     }
   } else if (isUpdate && existingNotebook) {
-    // Keep the label as 'true' if it exists, even when no feature stores are selected
-    if (existingNotebook.metadata.labels?.['opendatahub.io/feast-integration']) {
-      labels['opendatahub.io/feast-integration'] = 'true';
+    if (existingNotebook.metadata.labels?.[FEAST_INTEGRATION_LABEL]) {
+      labels[FEAST_INTEGRATION_LABEL] = 'true';
     }
-    if (existingNotebook.metadata.annotations?.['opendatahub.io/feast-config']) {
-      annotations['opendatahub.io/feast-config'] = '';
+    if (existingNotebook.metadata.annotations?.[FEAST_CONFIG_ANNOTATION]) {
+      annotations[FEAST_CONFIG_ANNOTATION] = '';
     }
   }
 

--- a/packages/cypress/cypress/pages/workbench.ts
+++ b/packages/cypress/cypress/pages/workbench.ts
@@ -367,6 +367,34 @@ class NotebookRow extends TableRow {
     this.findHardwareProfileColumn().contains(name).should('exist');
     return this;
   }
+
+  shouldHaveFeatureStoreTitle() {
+    this.findExpansion()
+      .findByTestId('notebook-feature-store-title')
+      .should('have.text', 'Connected feature stores');
+    return this;
+  }
+
+  shouldHaveFeatureStoreNone() {
+    this.findExpansion().findByTestId('notebook-feature-store-none').should('have.text', 'None');
+    return this;
+  }
+
+  findFeatureStoreList() {
+    return this.findExpansion().findByTestId('notebook-feature-store-list');
+  }
+
+  shouldHaveFeatureStoreItems(names: string[]) {
+    this.findFeatureStoreList().find('li').should('have.length', names.length);
+    names.forEach((name) => {
+      this.findFeatureStoreList().should('contain.text', name);
+    });
+    return this;
+  }
+
+  findFeatureStoreShowAll() {
+    return this.findExpansion().findByTestId('feature-store-show-all');
+  }
 }
 
 class AttachExistingStorageModal extends Modal {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2067,6 +2067,159 @@ describe('Workbench page', () => {
     notebookRow.shouldHaveMountPath('/opt/app-root/src/root');
   });
 
+  it('Expanded row hides feature store section when area is unavailable', () => {
+    initIntercepts({});
+    workbenchPage.visit('test-project');
+    const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+    notebookRow.findExpansionButton().click();
+    notebookRow.findExpansion().findByTestId('notebook-feature-store-title').should('not.exist');
+  });
+
+  describe('Expanded row feature stores (area enabled)', () => {
+    const enableFeatureStoreArea = () => {
+      cy.interceptOdh(
+        'GET /api/dsc/status',
+        mockDscStatus({
+          components: {
+            [DataScienceStackComponent.WORKBENCHES]: { managementState: 'Managed' },
+            [DataScienceStackComponent.FEAST_OPERATOR]: { managementState: 'Managed' },
+          },
+        }),
+      );
+      cy.interceptOdh(
+        'GET /api/config',
+        mockDashboardConfig({ disableFeatureStore: false, disableProjectScoped: true }),
+      );
+    };
+
+    it('shows "None" when feast-config annotation is absent', () => {
+      initIntercepts({});
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreTitle();
+      notebookRow.shouldHaveFeatureStoreNone();
+    });
+
+    it('shows "None" when feast-config annotation is empty', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config': '',
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreTitle();
+      notebookRow.shouldHaveFeatureStoreNone();
+    });
+
+    it('shows feature store names when 5 or fewer', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config': 'project-a,project-b,project-c',
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreTitle();
+      notebookRow.shouldHaveFeatureStoreItems(['project-a', 'project-b', 'project-c']);
+      notebookRow.findFeatureStoreShowAll().should('not.exist');
+    });
+
+    it('shows expand/collapse for more than 5 feature stores', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config':
+                    'store-1,store-2,store-3,store-4,store-5,store-6,store-7',
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreTitle();
+
+      notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
+      notebookRow.findFeatureStoreShowAll().should('exist');
+      notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
+      notebookRow.findFeatureStoreShowAll().should('contain.text', '2 more');
+
+      notebookRow.findFeatureStoreShowAll().find('button').click();
+      notebookRow.findFeatureStoreList().find('li').should('have.length', 7);
+      notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show less');
+
+      notebookRow.findFeatureStoreShowAll().find('button').click();
+      notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
+      notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
+    });
+
+    it('trims whitespace from feast-config annotation values', () => {
+      initIntercepts({
+        notebooks: [
+          mockNotebookK8sResource({
+            lastImageSelection: 'test-imagestream:1.2',
+            opts: {
+              metadata: {
+                name: 'test-notebook',
+                labels: { 'opendatahub.io/notebook-image': 'true' },
+                annotations: {
+                  'opendatahub.io/image-display-name': 'Test image',
+                  'opendatahub.io/feast-config': '  project-a , project-b , project-c  ',
+                },
+              },
+            },
+          }),
+        ],
+      });
+      enableFeatureStoreArea();
+      workbenchPage.visit('test-project');
+      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
+      notebookRow.findExpansionButton().click();
+      notebookRow.shouldHaveFeatureStoreItems(['project-a', 'project-b', 'project-c']);
+    });
+  });
+
   it('Delete Workbench', () => {
     initIntercepts({
       envFrom: [

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/workbench.cy.ts
@@ -2102,32 +2102,6 @@ describe('Workbench page', () => {
       notebookRow.shouldHaveFeatureStoreNone();
     });
 
-    it('shows "None" when feast-config annotation is empty', () => {
-      initIntercepts({
-        notebooks: [
-          mockNotebookK8sResource({
-            lastImageSelection: 'test-imagestream:1.2',
-            opts: {
-              metadata: {
-                name: 'test-notebook',
-                labels: { 'opendatahub.io/notebook-image': 'true' },
-                annotations: {
-                  'opendatahub.io/image-display-name': 'Test image',
-                  'opendatahub.io/feast-config': '',
-                },
-              },
-            },
-          }),
-        ],
-      });
-      enableFeatureStoreArea();
-      workbenchPage.visit('test-project');
-      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-      notebookRow.findExpansionButton().click();
-      notebookRow.shouldHaveFeatureStoreTitle();
-      notebookRow.shouldHaveFeatureStoreNone();
-    });
-
     it('shows feature store names when 5 or fewer', () => {
       initIntercepts({
         notebooks: [
@@ -2192,31 +2166,6 @@ describe('Workbench page', () => {
       notebookRow.findFeatureStoreShowAll().find('button').click();
       notebookRow.findFeatureStoreList().find('li').should('have.length', 5);
       notebookRow.findFeatureStoreShowAll().should('contain.text', 'Show all');
-    });
-
-    it('trims whitespace from feast-config annotation values', () => {
-      initIntercepts({
-        notebooks: [
-          mockNotebookK8sResource({
-            lastImageSelection: 'test-imagestream:1.2',
-            opts: {
-              metadata: {
-                name: 'test-notebook',
-                labels: { 'opendatahub.io/notebook-image': 'true' },
-                annotations: {
-                  'opendatahub.io/image-display-name': 'Test image',
-                  'opendatahub.io/feast-config': '  project-a , project-b , project-c  ',
-                },
-              },
-            },
-          }),
-        ],
-      });
-      enableFeatureStoreArea();
-      workbenchPage.visit('test-project');
-      const notebookRow = workbenchPage.getNotebookRow('Test Notebook');
-      notebookRow.findExpansionButton().click();
-      notebookRow.shouldHaveFeatureStoreItems(['project-a', 'project-b', 'project-c']);
     });
   });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62431

## Description

Adds a "Connected feature stores" section to the Workbench expanded row. Parses the `opendatahub.io/feast-config` annotation for comma-separated project names, displays up to 5 with expand/collapse for more, and shows "None" when absent. Unavailable feature stores display a warning icon with a tooltip. Section is hidden when `SupportedArea.FEATURE_STORE` is unavailable.

## Screenshots

**Expanded row shows 7 connected feature stores (5 visible initially with "Show all 2 more")**
<img width="1512" height="949" alt="Screenshot 2026-06-09 at 6 59 59 PM" src="https://github.com/user-attachments/assets/e33bcd5a-88d4-42c3-b933-e6d1f6bc0379" />

----

**Single feature store shows without expand option**
<img width="1143" height="336" alt="Screenshot 2026-06-09 at 7 00 17 PM" src="https://github.com/user-attachments/assets/9db87327-b7d9-4f42-b22d-89b50771aaba" />

**After expanding, all 7 feature stores are visible**
<img width="1143" height="387" alt="Screenshot 2026-06-09 at 7 00 26 PM" src="https://github.com/user-attachments/assets/537c5a2b-8e88-43c8-a446-4a2d2828c919" />

<img width="1143" height="345" alt="Screenshot 2026-06-09 at 7 00 37 PM" src="https://github.com/user-attachments/assets/a2ef2e78-6454-45ee-9151-cac682b281df" />

<img width="1143" height="277" alt="Screenshot 2026-06-09 at 7 23 14 PM" src="https://github.com/user-attachments/assets/8e6334d5-b5b7-4ca5-a985-6978c9db4fc6" />

**Unavailable feature stores shown with warning indicator and tooltip**
<img width="1209" height="282" alt="Screenshot 2026-06-11 at 11 46 45 AM" src="https://github.com/user-attachments/assets/05c164ee-d4a6-4b58-843b-f4fac381be21" />

<img width="331" height="173" alt="Screenshot 2026-06-11 at 11 47 10 AM" src="https://github.com/user-attachments/assets/e756830a-ed5a-4e02-b8eb-6d049d118418" />


## How Has This Been Tested?

Verified locally on a cluster with the annotation set on Notebooks (1, 3, and 7 feature stores). Confirmed "None" for absent annotation, hidden section when area is unavailable, and warning icon for unavailable feature stores.

## Test Impact

- **Unit tests (17):** Covers absent/empty/whitespace annotations, item counts at boundaries (1/3/5/6/7), expand/collapse, deduplication, trimming, and unavailable feature store indicators
- **Cypress mock tests (6):** Expanded row rendering, expand/collapse, area-unavailable hiding

## Request review criteria:

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body
- [x] The developer has added tests
- [x] The code follows our [Best Practices](/docs/best-practices.md)
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show connected Feast feature stores in expanded notebook rows: parsed from annotations, trimmed/deduped, displays “None” when empty, shows up to 5 items with a “Show all/less” toggle, and flags unavailable stores once availability is loaded.

* **Refactor**
  * Centralized Feast annotation and integration label constants.

* **Enhancement**
  * Show-all control accepts an optional data-testid prop.

* **Tests**
  * Added unit tests, Cypress helpers and E2E coverage for parsing, display, toggling, and availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->