### PR TITLE
support prompt variables in view code

### DIFF
--- a/packages/gen-ai/bff/internal/constants/templates.go
+++ b/packages/gen-ai/bff/internal/constants/templates.go
@@ -123,7 +123,16 @@ mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 _request_header_provider_registry.register(_make_workspace_header_provider(MLFLOW_WORKSPACE))
 
 prompt = mlflow.genai.load_prompt(f"prompts:/{prompt_name}/{prompt_version}")
+{{- if .PromptVariableValues }}
+prompt_variable_values = {
+  {{- range $key, $value := .PromptVariableValues }}
+    "{{$key}}": "{{$value}}",
+  {{- end }}
+}
+system_instructions = next(m["content"] for m in prompt.format(**prompt_variable_values) if m["role"] == "system")
+{{- else }}
 system_instructions = next(m["content"] for m in prompt.format() if m["role"] == "system")
+{{- end }}
 {{- end }}
 {{- if and .VectorStore .VectorStore.ID }}
 

--- a/packages/gen-ai/bff/internal/models/code_export.go
+++ b/packages/gen-ai/bff/internal/models/code_export.go
@@ -54,17 +54,18 @@ type CodeExportGuardrailConfig struct {
 }
 
 type CodeExportRequest struct {
-	Input           string                     `json:"input"`
-	Model           string                     `json:"model"`
-	Temperature     *float64                   `json:"temperature,omitempty"`
-	Instructions    string                     `json:"instructions,omitempty"`
-	Stream          bool                       `json:"stream,omitempty"`
-	MCPServers      []MCPServer                `json:"mcp_servers,omitempty"`
-	Tools           []CodeExportTool           `json:"tools,omitempty"`
-	VectorStore     *VectorStoreConfig         `json:"vector_store,omitempty"`
-	Files           []FileUpload               `json:"files,omitempty"`
-	Prompt          *PromptConfig              `json:"prompt,omitempty"`
-	GuardrailConfig *CodeExportGuardrailConfig `json:"guardrail_config,omitempty"`
+	Input                string                     `json:"input"`
+	Model                string                     `json:"model"`
+	Temperature          *float64                   `json:"temperature,omitempty"`
+	Instructions         string                     `json:"instructions,omitempty"`
+	Stream               bool                       `json:"stream,omitempty"`
+	MCPServers           []MCPServer                `json:"mcp_servers,omitempty"`
+	Tools                []CodeExportTool           `json:"tools,omitempty"`
+	VectorStore          *VectorStoreConfig         `json:"vector_store,omitempty"`
+	Files                []FileUpload               `json:"files,omitempty"`
+	Prompt               *PromptConfig              `json:"prompt,omitempty"`
+	PromptVariableValues map[string]string          `json:"prompt_variable_values,omitempty"`
+	GuardrailConfig      *CodeExportGuardrailConfig `json:"guardrail_config,omitempty"`
 }
 
 type CodeExportResponse struct {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/ViewCodeModal.tsx
@@ -13,6 +13,7 @@ import {
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { CodeExportRequest, FileModel, MCPServerFromAPI, TokenInfo } from '~/app/types';
 import { GUARDRAIL_INPUT_PROMPT, GUARDRAIL_OUTPUT_PROMPT } from '~/app/Chatbot/const';
+import { substituteTemplateVariables } from '~/app/Chatbot/promptTemplateUtils';
 import { generateMCPServerConfig, getLlamaModelDisplayName } from '~/app/utilities';
 import useFetchVectorStores from '~/app/hooks/useFetchVectorStores';
 import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
@@ -131,7 +132,6 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
 
   const [vectorStores, vectorStoresLoaded] = useFetchVectorStores();
   const { api, apiAvailable } = useGenAiAPI();
-
   // Get tool selections callback
   const toolSelections = React.useCallback(
     (cfgId: string, ns: string, url: string) =>
@@ -151,6 +151,7 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
       const {
         selectedModel,
         systemInstruction,
+        variableValues,
         selectedMcpServerIds,
         isRagEnabled,
         knowledgeMode,
@@ -211,7 +212,7 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
         const request: CodeExportRequest = {
           input,
           model: selectedModel,
-          instructions: systemInstruction,
+          instructions: substituteTemplateVariables(systemInstruction, variableValues),
           stream: false,
           mcp_servers: mcpServersToUse.map((server) => {
             const serverConfig = generateMCPServerConfig(server, mcpServerTokens);
@@ -248,6 +249,9 @@ const ViewCodeModal: React.FunctionComponent<ViewCodeModalProps> = ({
             }),
           ...(activePrompt && {
             prompt: { name: activePrompt.name, version: activePrompt.version },
+            ...(Object.keys(variableValues).length > 0 && {
+              prompt_variable_values: variableValues,
+            }),
           }),
           ...(guardrail &&
             (guardrailUserInputEnabled || guardrailModelOutputEnabled) && {

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/__tests__/ViewCodeModal.spec.tsx
@@ -40,6 +40,7 @@ const createMockStore = (configOverrides = {}) => {
     isRagEnabled: false,
     knowledgeMode: 'inline' as const,
     selectedVectorStoreId: null as string | null,
+    variableValues: {} as Record<string, string>,
     ...configOverrides,
   };
 
@@ -463,6 +464,114 @@ describe('ViewCodeModal', () => {
     const callArg = mockExportCode.mock.calls[0][0];
     expect(callArg.files).toBeUndefined();
     expect(callArg.tools).toBeUndefined();
+  });
+
+  it('substitutes template variables in instructions before exporting', async () => {
+    setupMockStore({
+      systemInstruction: 'You are a {{role}} assistant for {{topic}}.',
+      variableValues: { role: 'coding', topic: 'TypeScript' },
+    });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instructions: 'You are a coding assistant for TypeScript.',
+        }),
+      );
+    });
+  });
+
+  it('replaces unfilled template variables with empty string in exported code', async () => {
+    setupMockStore({
+      systemInstruction: 'You are a {{role}} for {{company}}.',
+      variableValues: { role: 'assistant' },
+    });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instructions: 'You are a assistant for .',
+        }),
+      );
+    });
+  });
+
+  it('sends prompt_variable_values when an active prompt has variable values', async () => {
+    setupMockStore({
+      systemInstruction: 'Review {{language}} code for {{name}}.',
+      variableValues: { language: 'TypeScript', name: 'Alice' },
+      activePrompt: { name: 'Code_reviewer', version: 2 },
+    });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: { name: 'Code_reviewer', version: 2 },
+          prompt_variable_values: { language: 'TypeScript', name: 'Alice' },
+        }),
+      );
+    });
+  });
+
+  it('does not send prompt_variable_values when variable values are empty', async () => {
+    setupMockStore({
+      systemInstruction: 'You are a helpful assistant.',
+      variableValues: {},
+      activePrompt: { name: 'Basic_prompt', version: 1 },
+    });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalled();
+    });
+
+    const callArg = mockExportCode.mock.calls[0][0];
+    expect(callArg.prompt).toEqual({ name: 'Basic_prompt', version: 1 });
+    expect(callArg.prompt_variable_values).toBeUndefined();
+  });
+
+  it('does not send prompt_variable_values without an active prompt', async () => {
+    setupMockStore({
+      systemInstruction: 'You are a {{role}} assistant.',
+      variableValues: { role: 'coding' },
+    });
+
+    render(
+      <TestWrapper>
+        <ViewCodeModal {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(mockExportCode).toHaveBeenCalled();
+    });
+
+    const callArg = mockExportCode.mock.calls[0][0];
+    expect(callArg.prompt).toBeUndefined();
+    expect(callArg.prompt_variable_values).toBeUndefined();
   });
 
   it('does not include tools when RAG is enabled but no files are present', async () => {

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -321,6 +321,7 @@ export type CodeExportRequest = {
     name: string;
     version: number;
   };
+  prompt_variable_values?: Record<string, string>;
   guardrail_config?: CodeExportGuardrailConfig;
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-67497

## Description

The View Code modal didn't handle `{{variable}}` template variables in system instructions. Two issues:

1. **Without an MLflow prompt:** Raw `{{variable}}` placeholders got consumed by the BFF's Go template engine (same `{{ }}` syntax) and silently disappeared from the generated Python.
2. **With an MLflow prompt:** The generated code called `prompt.format()` with no arguments, so variables were never substituted. The exported script wouldn't reproduce the playground's behavior if run.

**Fix:**
- Resolve `{{variable}}` placeholders via `substituteTemplateVariables()` in `ViewCodeModal` before building the request, matching what `ChatbotConfigInstance` already does for inference
- Send `prompt_variable_values` in the `CodeExportRequest` when an MLflow prompt is active and variables have been filled in
- BFF template now generates `prompt.format(**prompt_variable_values)` when values are provided, falling back to bare `prompt.format()` otherwise

## How Has This Been Tested?

- Typed a system instruction with `{{variable}}` placeholders (no MLflow prompt), opened View Code, confirmed resolved values appear in the export
- Loaded an MLflow prompt with variables, filled in values, sent a message, opened View Code, confirmed the generated Python includes `prompt_variable_values` dict and passes it to `prompt.format()`
- Verified unfilled variables resolve to empty string, consistent with inference behavior

## Test Impact

- 5 new unit tests in `ViewCodeModal.spec.tsx`:
  - Substitutes template variables in instructions before exporting
  - Replaces unfilled template variables with empty string
  - Sends `prompt_variable_values` when an active prompt has variable values
  - Does not send `prompt_variable_values` when variable values are empty
  - Does not send `prompt_variable_values` without an active prompt
- Existing BFF handler tests pass, Go builds clean

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Code export now supports optional prompt variable substitution for dynamic customization of generated output
  - Export requests can include variable values to automatically populate and format code generation parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->