### PR TITLE
[WIP]feat: gate nimWizard feature flag behind NIM operator installation

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -194,6 +194,7 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.NIM_MODEL]: {
     featureFlags: ['disableNIMModelServing'],
+    requiredComponents: [DataScienceStackComponent.NIM],
     reliantAreas: [SupportedArea.K_SERVE],
   },
   [SupportedArea.ADMIN_CONNECTION_TYPES]: {
@@ -276,4 +277,5 @@ export const DataScienceStackComponentMap: Record<string, string> = {
   [DataScienceStackComponent.WORKBENCHES]: 'Workbenches',
   [DataScienceStackComponent.TRAINER]: 'Trainer',
   [DataScienceStackComponent.MLFLOW]: 'MLflow',
+  [DataScienceStackComponent.NIM]: 'NVIDIA NIM',
 };

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -131,6 +131,7 @@ export enum DataScienceStackComponent {
   OGX_OPERATOR = 'ogx',
   TRAINER = 'trainer',
   MLFLOW = 'mlflowoperator',
+  NIM = 'nim',
 }
 
 /**


### PR DESCRIPTION
<!--- Reference related issues; see example below -->

https://issues.redhat.com/browse/RHOAIENG-60439

## Description

Gates the `nimWizard` feature flag behind the NIM operator being installed on the cluster. Previously, enabling the `nimWizard` dev feature flag would activate the NIM wizard UI unconditionally. Now, the NIM wizard UI only appears when the NIM operator is actually installed and reports `managementState: Managed` in the DSC (DataScienceCluster) status.

This follows the same pattern used by other operator-gated features (Pipelines, KServe, TrustyAI, Feast, Model Registry, etc.).

**Note:** This PR requires a corresponding odh-operator change to expose the NIM operator installation status in DSC status as a `nim` component. Without the operator change, the NIM wizard UI will be hidden even with the feature flag enabled (which is the correct/safe behavior).
https://github.com/opendatahub-io/opendatahub-operator/pull/3630#pullrequestreview-4460360362 
Current PR will need rebase and final verification once the PR above merges

## How Has This Been Tested?
- Negative test: on a cluster without the NIM operator DSC component, enabling `nimWizard` feature flag will NOT show the NIM wizard UI (gating works correctly)
- Full positive test requires the operator-side change to expose `nim` in DSC status (WIP)

## Test Impact

No unit or Cypress tests added. This is a configuration-only change (3 lines across 2 files) that plugs into the existing `requiredComponents` / `useIsAreaAvailable` infrastructure which is already tested. The area availability checks are covered by existing tests in `frontend/src/concepts/areas/`.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`