### PR TITLE
[TLS] Upgrade workspaces Go from 1.22 to 1.24 for ML-KEM readiness

### DIFF
--- a/packages/notebooks/upstream/workspaces/backend/Dockerfile
+++ b/packages/notebooks/upstream/workspaces/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use the golang image to build the application
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packages/notebooks/upstream/workspaces/backend/go.mod
+++ b/packages/notebooks/upstream/workspaces/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/workspaces/backend
 
-go 1.22.12
+go 1.24.4
 
 replace github.com/kubeflow/notebooks/workspaces/controller => ../controller
 

--- a/packages/notebooks/upstream/workspaces/controller/Dockerfile
+++ b/packages/notebooks/upstream/workspaces/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/packages/notebooks/upstream/workspaces/controller/go.mod
+++ b/packages/notebooks/upstream/workspaces/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/notebooks/workspaces/controller
 
-go 1.22.12
+go 1.24.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-61057

## Description

Upgrade workspaces-controller and workspaces-backend from Go 1.22.12 to Go 1.24.4 to enable ML-KEM (X25519MLKEM768) support.

This is a pre-requisite for OCP 5.0 TLS profile compliance ([OCPSTRAT-2611](https://redhat.atlassian.net/browse/OCPSTRAT-2611)). Go 1.24+ automatically enables ML-KEM for TLS 1.3 connections, which is required for the upcoming `tlsAdherence: StrictAllComponents` enforcement in OCP 5.0.

Changes:
- `go.mod`: 1.22.12 -> 1.24.4 (both controller and backend)
- `Dockerfile`: `golang:1.22` -> `golang:1.24` (both)

No dependency changes needed. controller-runtime v0.19.1 is compatible with Go 1.24.

## How Has This Been Tested?

- `go build ./...` passes for both controller and backend
- `go vet ./...` clean for both
- `go mod tidy` produces no changes (no dependency churn)
- Backend `internal/helper` unit tests pass
- Controller and backend envtest-based tests require envtest binaries (etcd/kube-apiserver) which are CI-only, not available locally. These tests are unaffected by the Go version change.

## Test Impact

This is a toolchain-only upgrade with no code changes. Existing tests cover the same functionality. The Go version bump does not change any APIs or behavior, it only adds ML-KEM support at the TLS layer.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
