### PR TITLE
Add sorting to API key table in subscription details

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -173,6 +173,10 @@ class MySubscriptionsPage {
   findCreateApiKeyButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('create-api-key-button');
   }
+
+  findColumnSortButton(columnLabel: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return this.findApiKeysTable().find('thead').contains('th', columnLabel).findByRole('button');
+  }
 }
 
 class APIKeyTableRow extends TableRow {

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -1112,4 +1112,75 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
       expect(interception.response?.statusCode).to.eq(200);
     });
   });
+
+  it('should sort subscription details api keys by column', () => {
+    mySubscriptionsPage.visit('premium-team-sub');
+    cy.wait('@initialSearch');
+    mySubscriptionsPage.findApiKeysTable().should('exist');
+
+    const premiumKeys = mockAPIKeys().filter(
+      (k) => k.subscription === 'premium-team-sub' && k.status !== 'revoked',
+    );
+    const nameAsc = premiumKeys.toSorted((a, b) => a.name.localeCompare(b.name));
+    const expiresAsc = premiumKeys.toSorted(
+      (a, b) =>
+        new Date(a.expirationDate ?? 0).getTime() - new Date(b.expirationDate ?? 0).getTime(),
+    );
+
+    cy.intercept('POST', '/maas/api/v1/api-keys/search', (req) => {
+      req.reply(mockSearchResponse(nameAsc));
+    }).as('sortNameAsc');
+    mySubscriptionsPage.findColumnSortButton('Name').click();
+
+    cy.wait('@sortNameAsc').then((interception) => {
+      expect(interception.request.body.data).to.have.nested.property('sort.by', 'name');
+    });
+    mySubscriptionsPage
+      .findApiKeysTable()
+      .find('tbody tr')
+      .eq(0)
+      .should('contain.text', 'old-service-key');
+    mySubscriptionsPage
+      .findApiKeysTable()
+      .find('tbody tr')
+      .eq(1)
+      .should('contain.text', 'production-backend');
+
+    cy.intercept('POST', '/maas/api/v1/api-keys/search', (req) => {
+      req.reply(mockSearchResponse(expiresAsc));
+    }).as('sortExpiresAsc');
+    mySubscriptionsPage.findColumnSortButton('Expires').click();
+
+    cy.wait('@sortExpiresAsc').then((interception) => {
+      expect(interception.request.body.data).to.have.nested.property('sort.by', 'expires_at');
+    });
+    mySubscriptionsPage
+      .findApiKeysTable()
+      .find('tbody tr')
+      .eq(0)
+      .should('contain.text', 'old-service-key');
+    mySubscriptionsPage
+      .findApiKeysTable()
+      .find('tbody tr')
+      .eq(1)
+      .should('contain.text', 'production-backend');
+
+    const mockReply = () => mockSearchResponse(premiumKeys);
+
+    cy.intercept('POST', '/maas/api/v1/api-keys/search', (req) => {
+      req.reply(mockReply());
+    }).as('sortCreated');
+    mySubscriptionsPage.findColumnSortButton('Created').click();
+    cy.wait('@sortCreated').then((interception) => {
+      expect(interception.request.body.data).to.have.nested.property('sort.by', 'created_at');
+    });
+
+    cy.intercept('POST', '/maas/api/v1/api-keys/search', (req) => {
+      req.reply(mockReply());
+    }).as('sortLastUsed');
+    mySubscriptionsPage.findColumnSortButton('Last used').click();
+    cy.wait('@sortLastUsed').then((interception) => {
+      expect(interception.request.body.data).to.have.nested.property('sort.by', 'last_used_at');
+    });
+  });
 });

--- a/packages/maas/frontend/src/app/hooks/useSubscriptionApiKeysTableState.ts
+++ b/packages/maas/frontend/src/app/hooks/useSubscriptionApiKeysTableState.ts
@@ -1,8 +1,13 @@
 import React from 'react';
 import { APIKeyListResponse, APIKeySearchRequest } from '~/app/types/api-key';
+import { ApiKeySortField } from '~/app/pages/keys-and-subs/apiKeys/allKeys/columns';
 import { useFetchApiKeys } from './useFetchApiKeys';
 
+type SortDirection = 'asc' | 'desc';
+
 const DEFAULT_PER_PAGE = 5;
+const DEFAULT_SORT_FIELD: ApiKeySortField = 'created_at';
+const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
 
 type UseSubscriptionApiKeysTableStateReturn = {
   response: APIKeyListResponse;
@@ -11,9 +16,12 @@ type UseSubscriptionApiKeysTableStateReturn = {
   refresh: () => void;
   page: number;
   perPage: number;
+  sortField: ApiKeySortField;
+  sortDirection: SortDirection;
   isFetching: boolean;
   onSetPage: (newPage: number) => void;
   onPerPageSelect: (newPerPage: number, newPage: number) => void;
+  onSort: (field: ApiKeySortField, direction: SortDirection) => void;
 };
 
 export const useSubscriptionApiKeysTableState = (
@@ -21,14 +29,17 @@ export const useSubscriptionApiKeysTableState = (
 ): UseSubscriptionApiKeysTableStateReturn => {
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(DEFAULT_PER_PAGE);
+  const [sortField, setSortField] = React.useState<ApiKeySortField>(DEFAULT_SORT_FIELD);
+  const [sortDirection, setSortDirection] = React.useState<SortDirection>(DEFAULT_SORT_DIRECTION);
   const [isFetching, setIsFetching] = React.useState(false);
 
   const searchRequest: APIKeySearchRequest = React.useMemo(
     () => ({
       filters: { subscription: subscriptionId, status: ['active', 'expired'] },
+      sort: { by: sortField, order: sortDirection },
       pagination: { limit: perPage, offset: (page - 1) * perPage },
     }),
-    [subscriptionId, page, perPage],
+    [subscriptionId, sortField, sortDirection, page, perPage],
   );
 
   const [response, loaded, error, refresh] = useFetchApiKeys(
@@ -55,6 +66,13 @@ export const useSubscriptionApiKeysTableState = (
     setIsFetching(true);
   }, []);
 
+  const onSort = React.useCallback((field: ApiKeySortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+    setPage(1);
+    setIsFetching(true);
+  }, []);
+
   return {
     response,
     loaded,
@@ -62,8 +80,11 @@ export const useSubscriptionApiKeysTableState = (
     refresh,
     page,
     perPage,
+    sortField,
+    sortDirection,
     isFetching,
     onSetPage,
     onPerPageSelect,
+    onSort,
   };
 };

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
@@ -40,18 +40,18 @@ const subscriptionApiKeyColumns: ApiKeyColumn[] = [
     serverSortField: 'created_at',
   },
   {
-    field: 'expirationDate',
-    label: 'Expires',
-    width: 15,
-    sortable: true,
-    serverSortField: 'expires_at',
-  },
-  {
     field: 'lastUsedAt',
     label: 'Last used',
     width: 15,
     sortable: true,
     serverSortField: 'last_used_at',
+  },
+  {
+    field: 'expirationDate',
+    label: 'Expires',
+    width: 15,
+    sortable: true,
+    serverSortField: 'expires_at',
   },
 ];
 

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionsApiKeyTable.tsx
@@ -24,11 +24,35 @@ import CreateApiKeyModal from '~/app/pages/keys-and-subs/apiKeys/CreateApiKeyMod
 import RevokeApiKeyModal from '~/app/pages/keys-and-subs/apiKeys/RevokeApiKeyModal';
 
 const subscriptionApiKeyColumns: ApiKeyColumn[] = [
-  { field: 'name', label: 'Name', width: 25, sortable: false },
+  {
+    field: 'name',
+    label: 'Name',
+    width: 25,
+    sortable: true,
+    serverSortField: 'name',
+  },
   { field: 'status', label: 'Status', width: 10, sortable: false },
-  { field: 'creationDate', label: 'Created', width: 15, sortable: false },
-  { field: 'expirationDate', label: 'Expires', width: 15, sortable: false },
-  { field: 'lastUsedAt', label: 'Last used', width: 15, sortable: false },
+  {
+    field: 'creationDate',
+    label: 'Created',
+    width: 15,
+    sortable: true,
+    serverSortField: 'created_at',
+  },
+  {
+    field: 'expirationDate',
+    label: 'Expires',
+    width: 15,
+    sortable: true,
+    serverSortField: 'expires_at',
+  },
+  {
+    field: 'lastUsedAt',
+    label: 'Last used',
+    width: 15,
+    sortable: true,
+    serverSortField: 'last_used_at',
+  },
 ];
 
 type MySubscriptionsApiKeyTableProps = {
@@ -77,13 +101,19 @@ const MySubscriptionsApiKeyTable: React.FC<MySubscriptionsApiKeyTableProps> = ({
     refresh,
     page,
     perPage,
+    sortField,
+    sortDirection,
     isFetching,
     onSetPage,
     onPerPageSelect,
+    onSort,
   } = useSubscriptionApiKeysTableState(subscriptionId);
 
   const apiKeys = response.data;
   const showTableLoading = !loaded || isFetching;
+  const activeSortIndex = subscriptionApiKeyColumns.findIndex(
+    (c) => c.serverSortField === sortField,
+  );
 
   return (
     <>
@@ -143,8 +173,28 @@ const MySubscriptionsApiKeyTable: React.FC<MySubscriptionsApiKeyTableProps> = ({
       <Table data-testid="subscription-api-keys-table" aria-label="Subscription API keys table">
         <Thead noWrap>
           <Tr>
-            {subscriptionApiKeyColumns.map((col) => (
-              <Th key={col.field} width={col.width}>
+            {subscriptionApiKeyColumns.map((col, i) => (
+              <Th
+                key={col.field}
+                width={col.width}
+                sort={
+                  col.serverSortField
+                    ? {
+                        sortBy: {
+                          index: activeSortIndex,
+                          direction: sortDirection,
+                          defaultDirection: 'asc',
+                        },
+                        onSort: (_e, _index, direction) => {
+                          if (col.serverSortField) {
+                            onSort(col.serverSortField, direction);
+                          }
+                        },
+                        columnIndex: i,
+                      }
+                    : undefined
+                }
+              >
                 {col.label}
               </Th>
             ))}


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-66826

## Description
Adds the same filtering the API keys table uses to the API table within the subscription details page

## How Has This Been Tested?
Tested locally

- Navigate to the subscriptions details page, and to the API keys table at the bottom.
- Test sorting by name, created, expires, and last used. 

## Test Impact
No tests changed

## Screengrab



https://github.com/user-attachments/assets/121b5194-2616-46fb-bd48-f3a71a233a98





## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side sorting to the API keys table (sortable: Name, Creation date, Expiration date, Last used). Sorting is applied to server requests and resets pagination to page 1 when changed.
  * Table headers now show interactive sort controls and reflect loading while fetching.

* **Tests**
  * Added end-to-end tests verifying sorting behavior for multiple columns and associated request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->