### PR TITLE
fix: bump react-router to >=7.13.2 for CVE-2026-33245

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,8 +101,8 @@
     "react-dropzone": "^14.2.3",
     "react-markdown": "^10.1.0",
     "react-redux": "^8.0.4",
-    "react-router": "^7.6.2",
-    "react-router-dom": "^7.6.2",
+    "react-router": "^7.13.2",
+    "react-router-dom": "^7.13.2",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
     "rehype-raw": "^7.0.0",
@@ -232,8 +232,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.6.2",
-      "react-router-dom": "^7.6.2",
+      "react-router": "^7.13.2",
+      "react-router-dom": "^7.13.2",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.4.1",
@@ -245,7 +245,7 @@
     "@patternfly/react-topology": {
       "react": "^18.2.0"
     },
-    "react-router": "^7.6.2",
+    "react-router": "^7.13.2",
     "ws": "^8.17.1",
     "dompurify": "^3.2.4",
     "redux": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,8 +147,8 @@
         "react-dropzone": "^14.2.3",
         "react-markdown": "^10.1.0",
         "react-redux": "^8.0.4",
-        "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2",
+        "react-router": "^7.13.2",
+        "react-router-dom": "^7.13.2",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",
         "rehype-raw": "^7.0.0",
@@ -450,6 +450,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "frontend/node_modules/react-router-dom": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.17.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "frontend/node_modules/supports-color": {
@@ -29116,9 +29132,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -29142,6 +29158,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
       "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-router": "7.9.4"
       },

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
   "overrides": {
     "@openshift/dynamic-plugin-sdk-utils": {
       "react-redux": "^8.0.4",
-      "react-router": "^7.6.2",
-      "react-router-dom": "^7.6.2",
+      "react-router": "^7.13.2",
+      "react-router-dom": "^7.13.2",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
       "@patternfly/react-core": "^6.4.1",
@@ -111,7 +111,8 @@
     "@patternfly/react-topology": {
       "react": "^18.2.0"
     },
-    "react-router": "^7.6.2",
+    "react-router": "^7.13.2",
+    "react-router-dom": "^7.13.2",
     "ws": "^8.18.1",
     "dompurify": "^3.2.4",
     "@types/tar": "^6.1.13",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65875

## Description

Bumps `react-router` and `react-router-dom` version constraints from `^7.6.2` to `^7.13.2` to remediate **CVE-2026-33245** (CVSS 8.0 HIGH — XSS via untrusted React Server Component redirects in versions 7.7.0–7.13.1, patched in 7.13.2).

Changes made in:
- **`package.json`** (root): Updated overrides for `react-router`, `react-router-dom`, and scoped overrides under `@openshift/dynamic-plugin-sdk-utils`
- **`frontend/package.json`**: Updated direct dependencies and overrides for `react-router` and `react-router-dom`
- **`package-lock.json`**: Regenerated via `npm install` — `react-router` now resolves to 7.17.0

The project does not use React Server Component APIs, so the XSS is not exploitable in practice, but the bump is required for CVE compliance. All 17 duplicate Jira trackers for other container images were closed as false positives since this is a shared transitive dependency in the monorepo.

## How Has This Been Tested?

- `npm run type-check` — passed, no type breakages from the version bump
- `npm audit` — no react-router findings
- Verified only one `react-router` binary resolves on disk at 7.17.0

## Test Impact

This is a dependency-only version bump with no code changes. The existing test suite covers routing behavior. No new tests are needed for a transitive dependency update.

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React Router and React Router DOM dependencies to version 7.13.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->