### PR TITLE
feat(gen-ai): AgentProfile serialize/deserialize and URL-param load

### DIFF
--- a/packages/gen-ai/frontend/src/__mocks__/mockGenAiContext.ts
+++ b/packages/gen-ai/frontend/src/__mocks__/mockGenAiContext.ts
@@ -58,6 +58,7 @@ export const mockGenAiContextValue: React.ContextType<typeof GenAiContext> = {
         response_time_ms: 500,
       }),
       deleteExternalModel: jest.fn().mockResolvedValue('Model deleted successfully'),
+      getAgentProfile: jest.fn().mockResolvedValue({ data: null }),
     },
   },
   refreshAPIState: jest.fn(),

--- a/packages/gen-ai/frontend/src/__mocks__/mockGenAiContext.ts
+++ b/packages/gen-ai/frontend/src/__mocks__/mockGenAiContext.ts
@@ -59,6 +59,7 @@ export const mockGenAiContextValue: React.ContextType<typeof GenAiContext> = {
       }),
       deleteExternalModel: jest.fn().mockResolvedValue('Model deleted successfully'),
       getAgentProfile: jest.fn().mockResolvedValue({ data: null }),
+      createAgentProfile: jest.fn().mockResolvedValue({ data: null }),
     },
   },
   refreshAPIState: jest.fn(),

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -83,24 +83,13 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
     (state) => state.updateSelectedVectorStoreId,
   );
 
-  // Keep selectedVectorStoreId in sync with the active knowledge mode:
-  // - inline: always the auto-provisioned store ID
-  // - external: cleared to null only when transitioning FROM inline, not on remount
-  //   (remount occurs when entering compare mode; we must not clobber the user's existing selection)
-  // When applyAgentProfile() was the cause of the transition, profileApplied is true and
-  // we skip the clear so the profile's external vector store ID is preserved.
-  const prevKnowledgeModeRef = React.useRef<string | null>(null);
+  // Keep selectedVectorStoreId in sync when in inline mode: always point at the
+  // auto-provisioned store. Clearing on inline→external switch is handled explicitly
+  // in KnowledgeTabContent's radio onChange, so no transition tracking is needed here.
   React.useEffect(() => {
     if (knowledgeMode === 'inline') {
       updateSelectedVectorStoreId(configId, currentVectorStoreId);
-    } else if (prevKnowledgeModeRef.current === 'inline') {
-      if (useChatbotConfigStore.getState().profileApplied) {
-        useChatbotConfigStore.setState({ profileApplied: false });
-      } else {
-        updateSelectedVectorStoreId(configId, null);
-      }
     }
-    prevKnowledgeModeRef.current = knowledgeMode;
   }, [knowledgeMode, currentVectorStoreId, configId, updateSelectedVectorStoreId]);
 
   // Prompt state from store (for analytics)

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotConfigInstance.tsx
@@ -87,13 +87,18 @@ export const ChatbotConfigInstance: React.FC<ChatbotConfigInstanceProps> = ({
   // - inline: always the auto-provisioned store ID
   // - external: cleared to null only when transitioning FROM inline, not on remount
   //   (remount occurs when entering compare mode; we must not clobber the user's existing selection)
+  // When applyAgentProfile() was the cause of the transition, profileApplied is true and
+  // we skip the clear so the profile's external vector store ID is preserved.
   const prevKnowledgeModeRef = React.useRef<string | null>(null);
   React.useEffect(() => {
     if (knowledgeMode === 'inline') {
       updateSelectedVectorStoreId(configId, currentVectorStoreId);
     } else if (prevKnowledgeModeRef.current === 'inline') {
-      // Only clear when the user explicitly switches from inline → external
-      updateSelectedVectorStoreId(configId, null);
+      if (useChatbotConfigStore.getState().profileApplied) {
+        useChatbotConfigStore.setState({ profileApplied: false });
+      } else {
+        updateSelectedVectorStoreId(configId, null);
+      }
     }
     prevKnowledgeModeRef.current = knowledgeMode;
   }, [knowledgeMode, currentVectorStoreId, configId, updateSelectedVectorStoreId]);

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -21,10 +21,14 @@ type ChatbotHeaderActionsProps = {
   onDeletePlayground: () => void;
   onNewChat: () => void;
   onCompareChat: () => void;
+  onSaveAs: () => void;
   onSettingsClick: () => void;
   isSettingsOpen: boolean;
   isCompareMode: boolean;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+const RENDER_SAVE_AS_BUTTON = false;
 
 const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   onViewCode,
@@ -32,6 +36,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   onDeletePlayground,
   onNewChat,
   onCompareChat,
+  onSaveAs,
   onSettingsClick,
   isSettingsOpen,
   isCompareMode,
@@ -62,6 +67,20 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
       <ActionListGroup>
         {lsdStatus?.phase === 'Ready' && (
           <>
+            {/* Temp: serializer test button — remove before feature delivery */}
+            {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
+            {!isCompareMode && RENDER_SAVE_AS_BUTTON && (
+              <ActionListItem>
+                <Button
+                  variant="link"
+                  aria-label="Save as"
+                  onClick={onSaveAs}
+                  data-testid="save-as-agent-profile-button"
+                >
+                  Save as
+                </Button>
+              </ActionListItem>
+            )}
             {/* Hide compare button when in compare mode - use close button on pane to exit */}
             {!isCompareMode && (
               <ActionListItem>

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotMain.tsx
@@ -16,6 +16,10 @@ import useFetchVectorStores from '~/app/hooks/useFetchVectorStores';
 import ChatbotConfigurationModal from '~/app/Chatbot/components/chatbotConfiguration/ChatbotConfigurationModal';
 import DeletePlaygroundModal from '~/app/Chatbot/components/DeletePlaygroundModal';
 import ChatModal from '~/app/Chatbot/components/ChatModal';
+import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
+import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
+import { serializeToAgentProfileSpec } from '~/app/agentProfile/serialize';
+import { isPlaygroundModelMatchForAIModel } from '~/app/utilities/utils';
 import ChatbotHeader from './ChatbotHeader';
 import ChatbotPlayground from './ChatbotPlayground';
 import ChatbotHeaderActions from './ChatbotHeaderActions';
@@ -45,6 +49,8 @@ const ChatbotMain: React.FunctionComponent = () => {
     modelsError,
   } = React.useContext(ChatbotContext);
   const { namespace } = React.useContext(GenAiContext);
+  const { api } = useGenAiAPI();
+  const { data: mcpServers = [] } = useFetchMCPServers();
   const { data: bffConfig } = useFetchBFFConfig();
   const { data: allCollections, loaded: collectionsLoaded } = useFetchAAEVectorStores();
   const [existingCollections] = useFetchVectorStores();
@@ -82,6 +88,36 @@ const ChatbotMain: React.FunctionComponent = () => {
     setActivePaneConfigId(remainingConfigId || DEFAULT_CONFIG_ID);
     fireMiscTrackingEvent('Playground Compare Mode Exited', { success: true });
   }, []);
+
+  // Temp: serializer test — will be updated before feature delivery
+  const handleSaveAsAgentProfile = React.useCallback(() => {
+    const config = useChatbotConfigStore.getState().configurations[primaryConfigId];
+    if (!config || !namespace?.name) {
+      return;
+    }
+    const llamaModel = models.find((m) => m.id === config.selectedModel);
+    const model = llamaModel
+      ? aiModels.find((ai) => isPlaygroundModelMatchForAIModel(llamaModel, ai))
+      : undefined;
+    const displayName = `Agent Profile - ${new Date().toISOString()}`;
+    const spec = serializeToAgentProfileSpec(config, displayName, 'Test description', {
+      model,
+      mcpServers,
+      mcpConfigMapName: 'gen-ai-aa-mcp-servers',
+    });
+    api
+      .createAgentProfile({ spec })
+      .then((response) => {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[AgentProfile] Created: http://localhost:4010/gen-ai-studio/playground/${namespace.name}?agentProfileId=${response.profileId}`,
+        );
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('[AgentProfile] Create failed:', err);
+      });
+  }, [primaryConfigId, namespace?.name, models, aiModels, mcpServers, api]);
 
   // Handle compare chat confirmation - clears messages and enters compare mode
   const handleCompareConfirm = React.useCallback(() => {
@@ -165,6 +201,7 @@ const ChatbotMain: React.FunctionComponent = () => {
         headerAction={
           hasNoModelsOrSelectedModelDisabled ? undefined : (
             <ChatbotHeaderActions
+              onSaveAs={handleSaveAsAgentProfile}
               onViewCode={() => {
                 setIsViewCodeModalOpen(true);
                 fireSimpleTrackingEvent('Playground View Code Selected');

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotPlayground.tsx
@@ -27,6 +27,7 @@ import { isLlamaModelEnabled, URL_PREFIX } from '~/app/utilities';
 import { getId } from '~/app/utilities/utils';
 import { TokenInfo, ResponseMetrics } from '~/app/types';
 import useFetchMCPServers from '~/app/hooks/useFetchMCPServers';
+import useAgentProfileUrlParam from '~/app/agentProfile/useAgentProfileUrlParam';
 import useMCPServerStatuses from '~/app/hooks/useMCPServerStatuses';
 import { ChatbotSourceSettingsModal } from './sourceUpload/ChatbotSourceSettingsModal';
 import useSourceManagement from './hooks/useSourceManagement';
@@ -197,6 +198,9 @@ const ChatbotPlayground: React.FC<ChatbotPlaygroundProps> = ({
     uploadedFiles: fileManagement.files,
     isFilesLoading: fileManagement.isLoading,
   });
+
+  // Load AgentProfile from URL query param (?agentProfileId=<uuid>)
+  useAgentProfileUrlParam({ mcpServers, mcpServersLoaded });
 
   // Message hooks tracking
   const messageHooksRef = React.useRef<Map<string, UseChatbotMessagesReturn>>(new Map());

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotConfigInstance.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotConfigInstance.spec.tsx
@@ -65,27 +65,6 @@ describe('ChatbotConfigInstance', () => {
       ).toBe('vs-inline-abc');
     });
 
-    it('clears selectedVectorStoreId to null when switching from inline to external while mounted', () => {
-      act(() => {
-        useChatbotConfigStore.getState().updateKnowledgeMode(DEFAULT_CONFIG_ID, 'inline');
-        useChatbotConfigStore
-          .getState()
-          .updateSelectedVectorStoreId(DEFAULT_CONFIG_ID, 'vs-inline-abc');
-      });
-
-      const { rerender } = render(<ChatbotConfigInstance {...defaultProps} />);
-
-      act(() => {
-        useChatbotConfigStore.getState().updateKnowledgeMode(DEFAULT_CONFIG_ID, 'external');
-      });
-
-      rerender(<ChatbotConfigInstance {...defaultProps} />);
-
-      expect(
-        useChatbotConfigStore.getState().configurations[DEFAULT_CONFIG_ID]?.selectedVectorStoreId,
-      ).toBeNull();
-    });
-
     it('preserves selectedVectorStoreId on remount when knowledgeMode is already external', () => {
       // Simulates compare mode entry: the component unmounts and remounts with external mode
       // already active and a store already selected — the selection must not be wiped.

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
@@ -51,6 +51,7 @@ describe('ChatbotHeaderActions', () => {
     onDeletePlayground: jest.fn(),
     onNewChat: jest.fn(),
     onCompareChat: jest.fn(),
+    onSaveAs: jest.fn(),
     onSettingsClick: jest.fn(),
     isSettingsOpen: false,
     isCompareMode: false,

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/KnowledgeTabContent.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/KnowledgeTabContent.tsx
@@ -320,6 +320,7 @@ const KnowledgeTabContent: React.FunctionComponent<KnowledgeTabContentProps> = (
             label={externalLabel}
             isChecked={knowledgeMode === 'external'}
             onChange={() => {
+              updateSelectedVectorStoreId(configId, null);
               updateKnowledgeMode(configId, 'external');
               fireMiscTrackingEvent('Playground Knowledge Source Switched', {
                 selectedSource: 'vectorstore',

--- a/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/KnowledgeTabContent.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/components/settingsPanelTabs/__tests__/KnowledgeTabContent.spec.tsx
@@ -340,6 +340,22 @@ describe('KnowledgeTabContent', () => {
       );
     });
 
+    it('clears selectedVectorStoreId when switching from inline to external via radio button', async () => {
+      const user = userEvent.setup();
+      useChatbotConfigStore.getState().updateKnowledgeMode(DEFAULT_CONFIG_ID, 'inline');
+      useChatbotConfigStore
+        .getState()
+        .updateSelectedVectorStoreId(DEFAULT_CONFIG_ID, 'vs-inline-abc');
+
+      render(<KnowledgeTabContent {...defaultProps} />);
+
+      await user.click(screen.getByTestId('knowledge-mode-external-radio'));
+
+      expect(
+        useChatbotConfigStore.getState().configurations[DEFAULT_CONFIG_ID]?.selectedVectorStoreId,
+      ).toBeNull();
+    });
+
     it('fires tracking event when switching back to upload mode', async () => {
       const user = userEvent.setup();
       useChatbotConfigStore.getState().updateKnowledgeMode(DEFAULT_CONFIG_ID, 'external');

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -79,9 +79,9 @@ export interface ChatbotConfigStoreState {
   configurations: { [id: string]: ChatbotConfiguration | undefined };
   configIds: string[];
   /**
-   * Transient signal set by applyAgentProfile(). Consumed and cleared by
-   * ChatbotConfigInstance's knowledge-mode sync effect to distinguish a profile
-   * load from a user-initiated inline→external switch.
+   * True when the current configuration was loaded from an AgentProfile.
+   * Set by applyAgentProfile(), cleared by resetConfiguration().
+   * Use this to drive loaded-profile UI state (e.g. header indicators, save/discard flows).
    */
   profileApplied: boolean;
 }

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/types.ts
@@ -78,6 +78,12 @@ export const DEFAULT_CONFIGURATION: ChatbotConfiguration = {
 export interface ChatbotConfigStoreState {
   configurations: { [id: string]: ChatbotConfiguration | undefined };
   configIds: string[];
+  /**
+   * Transient signal set by applyAgentProfile(). Consumed and cleared by
+   * ChatbotConfigInstance's knowledge-mode sync effect to distinguish a profile
+   * load from a user-initiated inline→external switch.
+   */
+  profileApplied: boolean;
 }
 
 /**
@@ -135,6 +141,12 @@ export interface ChatbotConfigStoreActions {
 
   // Configuration management
   resetConfiguration: (initialValues?: Partial<ChatbotConfiguration>) => void;
+  /**
+   * Apply an AgentProfile to the store. Behaves like resetConfiguration but sets
+   * profileApplied: true so the knowledge-mode sync effect in ChatbotConfigInstance
+   * knows not to clear an external vector store ID that came from the profile.
+   */
+  applyAgentProfile: (config: Partial<ChatbotConfiguration>) => void;
 
   // Utility
   getConfiguration: (id: string) => ChatbotConfiguration | undefined;

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -640,7 +640,9 @@ const createStoreActions = (
           default: {
             ...DEFAULT_CONFIGURATION,
             ...config,
-            mcpToolSelections: skipSessionStorage ? {} : loadMcpToolSelectionsForConfig('default'),
+            // Profile load always starts with a clean slate — never read from sessionStorage.
+            // The correct tool selections are applied explicitly via saveToolSelections afterward.
+            mcpToolSelections: config.mcpToolSelections ?? {},
           },
         },
       }),

--- a/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
+++ b/packages/gen-ai/frontend/src/app/Chatbot/store/useChatbotConfigStore.ts
@@ -151,6 +151,7 @@ export const createChatbotConfigStore = (
       },
     },
     configIds: ['default'],
+    profileApplied: false,
   };
 
   return create<ChatbotConfigStore>()(
@@ -627,6 +628,24 @@ const createStoreActions = (
       }),
       false,
       'resetConfiguration',
+    );
+  },
+
+  applyAgentProfile: (config: Partial<ChatbotConfiguration>) => {
+    set(
+      () => ({
+        ...storeInitialState,
+        profileApplied: true,
+        configurations: {
+          default: {
+            ...DEFAULT_CONFIGURATION,
+            ...config,
+            mcpToolSelections: skipSessionStorage ? {} : loadMcpToolSelectionsForConfig('default'),
+          },
+        },
+      }),
+      false,
+      'applyAgentProfile',
     );
   },
 

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/deserialize.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/deserialize.spec.ts
@@ -249,7 +249,7 @@ describe('deserializeAgentProfile', () => {
       expect(mcpToolsPending).toEqual({ 'weather-server': ['get_forecast', 'get_alerts'] });
     });
 
-    it('should return undefined mcpToolsPending when no servers have tools', () => {
+    it('should return undefined mcpToolsPending when no servers have allowedTools defined', () => {
       const profile = makeProfile({
         mcpServers: [
           { serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'weather-server' } },
@@ -258,6 +258,20 @@ describe('deserializeAgentProfile', () => {
       const { mcpToolsPending } = deserializeAgentProfile(profile, makeContext());
 
       expect(mcpToolsPending).toBeUndefined();
+    });
+
+    it('should preserve allowedTools: [] (block all tools) in mcpToolsPending', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          {
+            serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'weather-server' },
+            allowedTools: [],
+          },
+        ],
+      });
+      const { mcpToolsPending } = deserializeAgentProfile(profile, makeContext());
+
+      expect(mcpToolsPending).toEqual({ 'weather-server': [] });
     });
 
     it('should clear selectedMcpServerIds and mcpToolSelections when no servers', () => {

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/deserialize.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/deserialize.spec.ts
@@ -1,0 +1,288 @@
+/* eslint-disable camelcase */
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { LlamaModel } from '~/app/types';
+import { AgentProfile } from '~/app/agentProfile/types';
+import {
+  AgentProfileDeserializationContext,
+  deserializeAgentProfile,
+} from '~/app/agentProfile/deserialize';
+
+const makeLlamaModel = (overrides: Partial<LlamaModel> = {}): LlamaModel => ({
+  id: 'vllm-inference-1/llama-3-70b',
+  modelId: 'ai-asset-llama-3-70b',
+  object: 'model',
+  created: 0,
+  owned_by: '',
+  ...overrides,
+});
+
+const makeContext = (
+  overrides: Partial<AgentProfileDeserializationContext> = {},
+): AgentProfileDeserializationContext => ({
+  playgroundModels: [],
+  ...overrides,
+});
+
+const makeProfile = (overrides: Partial<AgentProfile['spec']> = {}): AgentProfile => ({
+  apiVersion: 'genai.redhat.com/v1alpha1',
+  kind: 'AgentProfile',
+  metadata: { name: 'test-uuid', resourceVersion: '999' },
+  spec: {
+    displayName: 'Test Agent',
+    model: { id: 'ai-asset-llama-3-70b', uri: 'http://llama.svc/v1', sourceType: 'namespace' },
+    temperature: 0.7,
+    stream: true,
+    ...overrides,
+  },
+});
+
+describe('deserializeAgentProfile', () => {
+  describe('model resolution', () => {
+    it('should resolve AI Asset model_id to Llama Stack runtime ID via playgroundModels', () => {
+      const llamaModel = makeLlamaModel();
+      const { config } = deserializeAgentProfile(
+        makeProfile(),
+        makeContext({ playgroundModels: [llamaModel] }),
+      );
+
+      expect(config.selectedModel).toBe('vllm-inference-1/llama-3-70b');
+    });
+
+    it('should fall back to spec.model.id when no matching playground model is found', () => {
+      const { config } = deserializeAgentProfile(makeProfile(), makeContext());
+
+      expect(config.selectedModel).toBe('ai-asset-llama-3-70b');
+    });
+
+    it('should match MaaS model using maas- provider prefix', () => {
+      const maasLlamaModel = makeLlamaModel({ id: 'maas-vllm/granite-3b', modelId: 'granite-3b' });
+      const profile = makeProfile({
+        model: { id: 'granite-3b', uri: 'https://api.com', sourceType: 'maas' },
+      });
+      const { config } = deserializeAgentProfile(
+        profile,
+        makeContext({ playgroundModels: [maasLlamaModel] }),
+      );
+
+      expect(config.selectedModel).toBe('maas-vllm/granite-3b');
+    });
+
+    it('should not match a MaaS playground model for a non-MaaS profile model', () => {
+      const maasLlamaModel = makeLlamaModel({
+        id: 'maas-vllm/ai-asset-llama-3-70b',
+        modelId: 'ai-asset-llama-3-70b',
+      });
+      // profile sourceType is 'namespace', not 'maas'
+      const { config } = deserializeAgentProfile(
+        makeProfile(),
+        makeContext({ playgroundModels: [maasLlamaModel] }),
+      );
+
+      // Should not match — falls back to the AI Asset ID
+      expect(config.selectedModel).toBe('ai-asset-llama-3-70b');
+    });
+  });
+
+  describe('inference params', () => {
+    it('should restore temperature and stream', () => {
+      const { config } = deserializeAgentProfile(
+        makeProfile({ temperature: 0.3, stream: false }),
+        makeContext(),
+      );
+      expect(config.temperature).toBe(0.3);
+      expect(config.isStreamingEnabled).toBe(false);
+    });
+
+    it('should fall back to defaults when temperature and stream are absent', () => {
+      const profile = makeProfile();
+      delete profile.spec.temperature;
+      delete profile.spec.stream;
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.temperature).toBe(DEFAULT_CONFIGURATION.temperature);
+      expect(config.isStreamingEnabled).toBe(DEFAULT_CONFIGURATION.isStreamingEnabled);
+    });
+
+    it('should restore maasSubscription from model authorization', () => {
+      const { config } = deserializeAgentProfile(
+        makeProfile({
+          model: {
+            id: 'granite',
+            uri: 'https://api.com',
+            authorization: { maasSubscription: 'sub-abc' },
+          },
+        }),
+        makeContext(),
+      );
+      expect(config.selectedSubscription).toBe('sub-abc');
+    });
+
+    it('should set empty subscription when no authorization', () => {
+      const { config } = deserializeAgentProfile(makeProfile(), makeContext());
+      expect(config.selectedSubscription).toBe('');
+    });
+  });
+
+  describe('prompt handling', () => {
+    it('should return promptRef when spec.prompt is present', () => {
+      const profile = makeProfile({
+        prompt: { name: 'my-prompt', source: 'mlflow', version: '3' },
+      });
+      const { promptRef } = deserializeAgentProfile(profile, makeContext());
+
+      expect(promptRef).toEqual({ name: 'my-prompt', version: 3, source: 'mlflow' });
+    });
+
+    it('should return promptRef without version when version is absent', () => {
+      const profile = makeProfile({ prompt: { name: 'my-prompt', source: 'mlflow' } });
+      const { promptRef } = deserializeAgentProfile(profile, makeContext());
+
+      expect(promptRef?.version).toBeUndefined();
+    });
+
+    it('should set activePrompt to null (async load required)', () => {
+      const profile = makeProfile({ prompt: { name: 'my-prompt', source: 'mlflow' } });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.activePrompt).toBeNull();
+    });
+
+    it('should restore variableValues from spec.prompt.variables', () => {
+      const profile = makeProfile({
+        prompt: {
+          name: 'my-prompt',
+          source: 'mlflow',
+          variables: {
+            company_name: { text: 'Acme Corp', type: 'string' },
+            tone: { text: 'friendly', type: 'string' },
+          },
+        },
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.variableValues).toEqual({ company_name: 'Acme Corp', tone: 'friendly' });
+    });
+
+    it('should return no promptRef when spec.prompt is absent', () => {
+      const { promptRef } = deserializeAgentProfile(makeProfile(), makeContext());
+      expect(promptRef).toBeUndefined();
+    });
+  });
+
+  describe('vectorStores', () => {
+    it('should restore external RAG from storeRef', () => {
+      const profile = makeProfile({
+        vectorStores: {
+          stores: [
+            { storeRef: { kind: 'ConfigMap', name: 'gen-ai-aa-vector-stores', key: 'vs-abc123' } },
+          ],
+        },
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.isRagEnabled).toBe(true);
+      expect(config.knowledgeMode).toBe('external');
+      expect(config.selectedVectorStoreId).toBe('vs-abc123');
+    });
+
+    it('should restore inline RAG from direct id', () => {
+      const profile = makeProfile({
+        vectorStores: { stores: [{ id: 'vs_203e7612-0bb8-41db-89f1-18f054985139' }] },
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.isRagEnabled).toBe(true);
+      expect(config.knowledgeMode).toBe('inline');
+      expect(config.selectedVectorStoreId).toBe('vs_203e7612-0bb8-41db-89f1-18f054985139');
+    });
+
+    it('should disable RAG when vectorStores is absent', () => {
+      const { config } = deserializeAgentProfile(makeProfile(), makeContext());
+
+      expect(config.isRagEnabled).toBe(false);
+      expect(config.selectedVectorStoreId).toBeNull();
+    });
+
+    it('should set selectedVectorStoreId to null when storeRef has no key', () => {
+      const profile = makeProfile({
+        vectorStores: { stores: [{ storeRef: { kind: 'ConfigMap', name: 'vs', key: '' } }] },
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.selectedVectorStoreId).toBeNull();
+    });
+  });
+
+  describe('mcpServers', () => {
+    it('should restore selectedMcpServerIds from serverRef.key', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          { serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'weather-server' } },
+          { serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'code-server' } },
+        ],
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.selectedMcpServerIds).toEqual(['weather-server', 'code-server']);
+    });
+
+    it('should fall back to serverRef.name when key is absent', () => {
+      const profile = makeProfile({
+        mcpServers: [{ serverRef: { kind: 'MCPServer', name: 'my-server' } }],
+      });
+      const { config } = deserializeAgentProfile(profile, makeContext());
+
+      expect(config.selectedMcpServerIds).toEqual(['my-server']);
+    });
+
+    it('should return mcpToolsPending with allowedTools keyed by server name', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          {
+            serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'weather-server' },
+            allowedTools: ['get_forecast', 'get_alerts'],
+          },
+        ],
+      });
+      const { mcpToolsPending } = deserializeAgentProfile(profile, makeContext());
+
+      expect(mcpToolsPending).toEqual({ 'weather-server': ['get_forecast', 'get_alerts'] });
+    });
+
+    it('should return undefined mcpToolsPending when no servers have tools', () => {
+      const profile = makeProfile({
+        mcpServers: [
+          { serverRef: { kind: 'ConfigMap', name: 'mcp-config', key: 'weather-server' } },
+        ],
+      });
+      const { mcpToolsPending } = deserializeAgentProfile(profile, makeContext());
+
+      expect(mcpToolsPending).toBeUndefined();
+    });
+
+    it('should clear selectedMcpServerIds and mcpToolSelections when no servers', () => {
+      const { config } = deserializeAgentProfile(makeProfile(), makeContext());
+
+      expect(config.selectedMcpServerIds).toEqual([]);
+      expect(config.mcpToolSelections).toEqual({});
+    });
+  });
+
+  describe('guardrails', () => {
+    it('should always clear guardrail state regardless of profile contents', () => {
+      const profileWithGuardrail = makeProfile({
+        guardrails: [
+          {
+            provider: 'nvidia-guardian-8b',
+            guardrailRef: { kind: 'ConfigMap', name: 'nvidia-guardian-8b', key: 'guardrail.yaml' },
+          },
+        ],
+      });
+      const { config } = deserializeAgentProfile(profileWithGuardrail, makeContext());
+
+      expect(config.guardrail).toBe('');
+      expect(config.guardrailUserInputEnabled).toBe(false);
+      expect(config.guardrailModelOutputEnabled).toBe(false);
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/roundtrip.spec.ts
@@ -1,0 +1,220 @@
+/* eslint-disable camelcase */
+/**
+ * Round-trip tests: serialize → deserialize → settings match.
+ * Covers the acceptance criterion: "serialize → deserialize → all settings match"
+ */
+import { ChatbotConfiguration, DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { AIModel, LlamaModel } from '~/app/types';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+import {
+  AgentProfileDeserializationContext,
+  deserializeAgentProfile,
+} from '~/app/agentProfile/deserialize';
+import {
+  serializeToAgentProfileSpec,
+  AgentProfileSerializationContext,
+} from '~/app/agentProfile/serialize';
+import { AgentProfile } from '~/app/agentProfile/types';
+
+const FAKE_RESOURCE_VERSION = '42';
+
+const wrapSpec = (spec: ReturnType<typeof serializeToAgentProfileSpec>): AgentProfile => ({
+  apiVersion: 'genai.redhat.com/v1alpha1',
+  kind: 'AgentProfile',
+  metadata: { name: 'test-uuid', resourceVersion: FAKE_RESOURCE_VERSION },
+  spec,
+});
+
+const makeModel = (overrides: Partial<AIModel> = {}): AIModel => ({
+  model_name: 'llama-3-70b',
+  model_id: 'ai-asset-llama-3-70b', // AI Asset catalog ID written to spec.model.id
+  serving_runtime: 'vllm',
+  api_protocol: 'openai',
+  version: '1',
+  usecase: '',
+  description: '',
+  endpoints: ['http://llama.svc/v1'],
+  status: 'Running',
+  display_name: 'Llama 3 70B',
+  sa_token: { name: '', token_name: '', token: '' },
+  model_source_type: 'namespace',
+  internalEndpoint: 'http://llama.svc/v1',
+  externalEndpoint: undefined,
+  ...overrides,
+});
+
+const makeMcpServer = (overrides: Partial<MCPServerFromAPI> = {}): MCPServerFromAPI => ({
+  name: 'weather-server',
+  url: 'http://weather-mcp.svc/sse',
+  transport: 'sse',
+  description: '',
+  logo: null,
+  status: 'healthy',
+  ...overrides,
+});
+
+const makeLlamaModel = (modelId: string, llamaId: string): LlamaModel => ({
+  id: llamaId,
+  modelId,
+  object: 'model',
+  created: 0,
+  owned_by: '',
+});
+
+const roundTrip = (
+  config: ChatbotConfiguration,
+  displayName: string,
+  serializeCtx: AgentProfileSerializationContext,
+  deserializeCtx?: AgentProfileDeserializationContext,
+) => {
+  const spec = serializeToAgentProfileSpec(
+    config,
+    displayName,
+    config.systemInstruction || undefined,
+    serializeCtx,
+  );
+  const profile = wrapSpec(spec);
+  return deserializeAgentProfile(profile, deserializeCtx ?? { playgroundModels: [] });
+};
+
+describe('serialize → deserialize round-trip', () => {
+  it('should resolve model back to Llama Stack runtime ID via playgroundModels', () => {
+    const llamaModel = makeLlamaModel('ai-asset-llama-3-70b', 'vllm-inference-1/llama-3-70b');
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      selectedModel: 'vllm-inference-1/llama-3-70b',
+      temperature: 0.8,
+      isStreamingEnabled: false,
+    };
+    const { config: restored } = roundTrip(
+      config,
+      'Test',
+      { model: makeModel(), mcpServers: [] },
+      { playgroundModels: [llamaModel] },
+    );
+
+    expect(restored.selectedModel).toBe('vllm-inference-1/llama-3-70b');
+    expect(restored.temperature).toBe(0.8);
+    expect(restored.isStreamingEnabled).toBe(false);
+  });
+
+  it('should restore MaaS subscription', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      selectedModel: 'granite-3b',
+      selectedSubscription: 'sub-abc',
+    };
+    const { config: restored } = roundTrip(config, 'Test', {
+      model: makeModel({ model_source_type: 'maas' }),
+      mcpServers: [],
+    });
+
+    expect(restored.selectedSubscription).toBe('sub-abc');
+  });
+
+  it('should restore external RAG vector store via storeRef round-trip', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      isRagEnabled: true,
+      knowledgeMode: 'external',
+      selectedVectorStoreId: 'vs-xyz',
+    };
+    const { config: restored } = roundTrip(config, 'Test', { model: makeModel(), mcpServers: [] });
+
+    expect(restored.isRagEnabled).toBe(true);
+    expect(restored.knowledgeMode).toBe('external');
+    expect(restored.selectedVectorStoreId).toBe('vs-xyz'); // restored from storeRef.key
+  });
+
+  it('should restore inline RAG vector store via id round-trip', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      isRagEnabled: true,
+      knowledgeMode: 'inline',
+      selectedVectorStoreId: 'vs_203e7612-0bb8-41db-89f1-18f054985139',
+    };
+    const { config: restored } = roundTrip(config, 'Test', { model: makeModel(), mcpServers: [] });
+
+    expect(restored.isRagEnabled).toBe(true);
+    expect(restored.knowledgeMode).toBe('inline');
+    expect(restored.selectedVectorStoreId).toBe('vs_203e7612-0bb8-41db-89f1-18f054985139');
+  });
+
+  it('should restore disabled RAG state', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      isRagEnabled: false,
+      selectedVectorStoreId: null,
+    };
+    const { config: restored } = roundTrip(config, 'Test', { model: makeModel(), mcpServers: [] });
+
+    expect(restored.isRagEnabled).toBe(false);
+    expect(restored.selectedVectorStoreId).toBeNull();
+  });
+
+  it('should restore selected MCP servers and pending tool selections', () => {
+    const server = makeMcpServer();
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      selectedMcpServerIds: ['weather-server'],
+      mcpToolSelections: {
+        'default-ns': { 'http://weather-mcp.svc/sse': ['get_forecast', 'get_alerts'] },
+      },
+    };
+    const { config: restored, mcpToolsPending } = roundTrip(config, 'Test', {
+      model: makeModel(),
+      mcpServers: [server],
+      mcpConfigMapName: 'mcp-servers-config',
+    });
+
+    expect(restored.selectedMcpServerIds).toEqual(['weather-server']);
+    expect(mcpToolsPending).toEqual({ 'weather-server': ['get_forecast', 'get_alerts'] });
+  });
+
+  it('should always produce cleared guardrail state (unsupported mapping)', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      guardrail: 'nvidia-guardian-8b',
+      guardrailUserInputEnabled: true,
+      guardrailModelOutputEnabled: true,
+    };
+    const { config: restored } = roundTrip(config, 'Test', { model: makeModel(), mcpServers: [] });
+
+    expect(restored.guardrail).toBe('');
+    expect(restored.guardrailUserInputEnabled).toBe(false);
+    expect(restored.guardrailModelOutputEnabled).toBe(false);
+  });
+
+  it('should restore prompt ref with version and variable values', () => {
+    const config: ChatbotConfiguration = {
+      ...DEFAULT_CONFIGURATION,
+      activePrompt: {
+        name: 'support-agent-v2',
+        version: 5,
+        template: 'You are a support agent.',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+      },
+      variableValues: { company: 'Acme', tone: 'professional' },
+    };
+    const { config: restored, promptRef } = roundTrip(config, 'Test', {
+      model: makeModel(),
+      mcpServers: [],
+    });
+
+    expect(promptRef).toEqual({ name: 'support-agent-v2', version: 5, source: 'mlflow' });
+    expect(restored.variableValues).toEqual({ company: 'Acme', tone: 'professional' });
+    expect(restored.activePrompt).toBeNull(); // requires async load
+  });
+
+  it('should produce empty MCP state when no servers are configured', () => {
+    const { config: restored, mcpToolsPending } = roundTrip(DEFAULT_CONFIGURATION, 'Test', {
+      model: makeModel(),
+      mcpServers: [],
+    });
+
+    expect(restored.selectedMcpServerIds).toEqual([]);
+    expect(restored.mcpToolSelections).toEqual({});
+    expect(mcpToolsPending).toBeUndefined();
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/__tests__/serialize.spec.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/__tests__/serialize.spec.ts
@@ -1,0 +1,354 @@
+/* eslint-disable camelcase */
+import { DEFAULT_CONFIGURATION } from '~/app/Chatbot/store/types';
+import { AIModel } from '~/app/types';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+import {
+  AgentProfileSerializationContext,
+  serializeToAgentProfileSpec,
+} from '~/app/agentProfile/serialize';
+
+const makeModel = (overrides: Partial<AIModel> = {}): AIModel => ({
+  model_name: 'llama-3-70b',
+  model_id: 'ai-asset-llama-3-70b',
+  serving_runtime: 'vllm',
+  api_protocol: 'openai',
+  version: '1',
+  usecase: '',
+  description: '',
+  endpoints: ['http://llama.svc/v1'],
+  status: 'Running',
+  display_name: 'Llama 3 70B',
+  sa_token: { name: '', token_name: '', token: '' },
+  model_source_type: 'namespace',
+  internalEndpoint: 'http://llama.svc/v1',
+  externalEndpoint: undefined,
+  ...overrides,
+});
+
+const makeMcpServer = (overrides: Partial<MCPServerFromAPI> = {}): MCPServerFromAPI => ({
+  name: 'weather-server',
+  url: 'http://weather-mcp.svc/sse',
+  transport: 'sse',
+  description: 'Weather data server',
+  logo: null,
+  status: 'healthy',
+  ...overrides,
+});
+
+const makeContext = (
+  overrides: Partial<AgentProfileSerializationContext> = {},
+): AgentProfileSerializationContext => ({
+  model: makeModel(),
+  mcpServers: [],
+  mcpConfigMapName: undefined,
+  ...overrides,
+});
+
+describe('serializeToAgentProfileSpec', () => {
+  describe('model field', () => {
+    it('should use the AI Asset model_id (not the Llama Stack selectedModel)', () => {
+      const config = { ...DEFAULT_CONFIGURATION, selectedModel: 'llama-3.1-8b-instruct' };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.model.id).toBe('ai-asset-llama-3-70b'); // model_id from AIModel, not selectedModel
+      expect(result.model.uri).toBe('http://llama.svc/v1');
+      expect(result.model.sourceType).toBe('namespace');
+    });
+
+    it('should use externalEndpoint when no internalEndpoint', () => {
+      const model = makeModel({
+        internalEndpoint: undefined,
+        externalEndpoint: 'https://api.example.com',
+      });
+      const config = { ...DEFAULT_CONFIGURATION, selectedModel: 'llama-3-70b' };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ model }),
+      );
+
+      expect(result.model.uri).toBe('https://api.example.com');
+    });
+
+    it('should include maasSubscription in authorization when selectedSubscription is set', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        selectedModel: 'granite-3b',
+        selectedSubscription: 'sub-123',
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.model.authorization?.maasSubscription).toBe('sub-123');
+    });
+
+    it('should omit authorization when no subscription', () => {
+      const config = { ...DEFAULT_CONFIGURATION, selectedSubscription: '' };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.model.authorization).toBeUndefined();
+    });
+
+    it('should fall back to selectedModel when model context is undefined', () => {
+      const config = { ...DEFAULT_CONFIGURATION, selectedModel: 'llama-3.1-8b-instruct' };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ model: undefined }),
+      );
+
+      expect(result.model.id).toBe('llama-3.1-8b-instruct');
+      expect(result.model.uri).toBe('');
+    });
+  });
+
+  describe('inference params', () => {
+    it('should map temperature and stream', () => {
+      const config = { ...DEFAULT_CONFIGURATION, temperature: 0.8, isStreamingEnabled: false };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.temperature).toBe(0.8);
+      expect(result.stream).toBe(false);
+    });
+  });
+
+  describe('displayName and description', () => {
+    it('should include displayName and description', () => {
+      const result = serializeToAgentProfileSpec(
+        DEFAULT_CONFIGURATION,
+        'Customer Support Agent',
+        'Handles tier-1 queries',
+        makeContext(),
+      );
+
+      expect(result.displayName).toBe('Customer Support Agent');
+      expect(result.description).toBe('Handles tier-1 queries');
+    });
+
+    it('should omit description when empty string', () => {
+      const result = serializeToAgentProfileSpec(
+        DEFAULT_CONFIGURATION,
+        'My Agent',
+        '',
+        makeContext(),
+      );
+
+      expect(result.description).toBeUndefined();
+    });
+  });
+
+  describe('prompt field', () => {
+    it('should serialize activePrompt as MLflow reference', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        activePrompt: {
+          name: 'customer-support-v2',
+          version: 3,
+          template: 'You are a support agent.',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.prompt).toEqual({
+        name: 'customer-support-v2',
+        source: 'mlflow',
+        version: '3',
+        variables: undefined,
+      });
+    });
+
+    it('should include variable values in prompt', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        activePrompt: {
+          name: 'my-prompt',
+          version: 1,
+          created_at: '',
+          updated_at: '',
+        },
+        variableValues: { company_name: 'Acme Corp', tone: 'professional' },
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.prompt?.variables).toEqual({
+        company_name: { text: 'Acme Corp', type: 'string' },
+        tone: { text: 'professional', type: 'string' },
+      });
+    });
+
+    it('should omit prompt when no activePrompt', () => {
+      const config = { ...DEFAULT_CONFIGURATION, activePrompt: null };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.prompt).toBeUndefined();
+    });
+  });
+
+  describe('vectorStores field', () => {
+    it('should serialize external RAG vector store as storeRef', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        isRagEnabled: true,
+        knowledgeMode: 'external' as const,
+        selectedVectorStoreId: 'vs-abc123',
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.vectorStores).toEqual({
+        stores: [
+          { storeRef: { kind: 'ConfigMap', name: 'gen-ai-aa-vector-stores', key: 'vs-abc123' } },
+        ],
+      });
+    });
+
+    it('should serialize inline RAG vector store as direct id', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        isRagEnabled: true,
+        knowledgeMode: 'inline' as const,
+        selectedVectorStoreId: 'vs_203e7612-0bb8-41db-89f1-18f054985139',
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.vectorStores).toEqual({
+        stores: [{ id: 'vs_203e7612-0bb8-41db-89f1-18f054985139' }],
+      });
+    });
+
+    it('should omit vectorStores when RAG is disabled', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        isRagEnabled: false,
+        selectedVectorStoreId: 'vs-abc123',
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.vectorStores).toBeUndefined();
+    });
+
+    it('should omit vectorStores when no vector store is selected in inline mode', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        isRagEnabled: true,
+        knowledgeMode: 'inline' as const,
+        selectedVectorStoreId: null,
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.vectorStores).toBeUndefined();
+    });
+
+    it('should omit vectorStores when no vector store is selected', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        isRagEnabled: true,
+        knowledgeMode: 'external' as const,
+        selectedVectorStoreId: null,
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.vectorStores).toBeUndefined();
+    });
+  });
+
+  describe('mcpServers field', () => {
+    it('should serialize selected MCP servers with ConfigMap ref', () => {
+      const server = makeMcpServer();
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        selectedMcpServerIds: ['weather-server'],
+        mcpToolSelections: {},
+      };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ mcpServers: [server], mcpConfigMapName: 'mcp-servers-config' }),
+      );
+
+      expect(result.mcpServers).toEqual([
+        {
+          serverRef: { kind: 'ConfigMap', name: 'mcp-servers-config', key: 'weather-server' },
+          allowedTools: undefined,
+        },
+      ]);
+    });
+
+    it('should include allowedTools from mcpToolSelections', () => {
+      const server = makeMcpServer();
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        selectedMcpServerIds: ['weather-server'],
+        mcpToolSelections: {
+          'default-ns': { 'http://weather-mcp.svc/sse': ['get_forecast', 'get_alerts'] },
+        },
+      };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ mcpServers: [server], mcpConfigMapName: 'mcp-servers-config' }),
+      );
+
+      expect(result.mcpServers?.[0].allowedTools).toEqual(['get_forecast', 'get_alerts']);
+    });
+
+    it('should omit mcpServers when none selected', () => {
+      const result = serializeToAgentProfileSpec(
+        DEFAULT_CONFIGURATION,
+        'My Agent',
+        undefined,
+        makeContext({ mcpServers: [makeMcpServer()], mcpConfigMapName: 'mcp-config' }),
+      );
+
+      expect(result.mcpServers).toBeUndefined();
+    });
+
+    it('should omit mcpServers when mcpConfigMapName is not provided', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        selectedMcpServerIds: ['weather-server'],
+      };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ mcpServers: [makeMcpServer()], mcpConfigMapName: undefined }),
+      );
+
+      expect(result.mcpServers).toBeUndefined();
+    });
+
+    it('should skip servers not found in available server list', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        selectedMcpServerIds: ['unknown-server'],
+      };
+      const result = serializeToAgentProfileSpec(
+        config,
+        'My Agent',
+        undefined,
+        makeContext({ mcpServers: [makeMcpServer()], mcpConfigMapName: 'mcp-config' }),
+      );
+
+      expect(result.mcpServers).toBeUndefined();
+    });
+  });
+
+  describe('guardrails field', () => {
+    it('should never serialize guardrails (unsupported mapping)', () => {
+      const config = {
+        ...DEFAULT_CONFIGURATION,
+        guardrail: 'nvidia-guardian-8b',
+        guardrailUserInputEnabled: true,
+        guardrailModelOutputEnabled: true,
+      };
+      const result = serializeToAgentProfileSpec(config, 'My Agent', undefined, makeContext());
+
+      expect(result.guardrails).toBeUndefined();
+    });
+  });
+});

--- a/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
@@ -1,0 +1,141 @@
+import { DEFAULT_CONFIGURATION, ChatbotConfiguration } from '~/app/Chatbot/store/types';
+import { LlamaModel } from '~/app/types';
+import { isMaasLlamaModelId } from '~/app/utilities/utils';
+import { AgentProfile } from './types';
+
+export type AgentProfileDeserializationContext = {
+  /**
+   * Playground models from useFetchLlamaModels. Used to resolve the AI Asset model_id
+   * (spec.model.id) back to the Llama Stack runtime model ID (LlamaModel.id) that
+   * selectedModel in the store expects.
+   */
+  playgroundModels: LlamaModel[];
+};
+
+export type AgentProfilePromptRef = {
+  name: string;
+  version?: number;
+  source: string;
+};
+
+export type AgentProfileDeserializeResult = {
+  /** Apply to the store via resetConfiguration(result.config) */
+  config: Partial<ChatbotConfiguration>;
+  /**
+   * When present, fetch this prompt from MLflow and call updateActivePrompt().
+   * Not applied synchronously because it requires an async API call.
+   */
+  promptRef?: AgentProfilePromptRef;
+  /**
+   * Maps MCP server name (ConfigMap key) → allowed tools from the profile.
+   * Cannot be written to mcpToolSelections synchronously because the store
+   * structure requires the server's runtime URL, which is only available after
+   * the MCP server list is loaded. Pass this to applyMcpToolSelections() once
+   * server data is available.
+   */
+  mcpToolsPending?: Record<string, string[]>;
+};
+
+/**
+ * Converts an AgentProfile API response into Playground store configuration.
+ *
+ * Call resetConfiguration(result.config) to apply the synchronous fields.
+ * Then handle result.promptRef and result.mcpToolsPending asynchronously.
+ */
+export const deserializeAgentProfile = (
+  profile: AgentProfile,
+  context: AgentProfileDeserializationContext,
+): AgentProfileDeserializeResult => {
+  const { spec } = profile;
+  const { playgroundModels } = context;
+
+  // Resolve AI Asset model_id → Llama Stack runtime ID (LlamaModel.id).
+  // Mirrors the isPlaygroundModelMatchForAIModel logic to handle the MaaS provider prefix.
+  const matchingPlaygroundModel = playgroundModels.find((m) => {
+    if (m.modelId !== spec.model.id) {
+      return false;
+    }
+    return spec.model.sourceType === 'maas' ? isMaasLlamaModelId(m.id) : !isMaasLlamaModelId(m.id);
+  });
+  const selectedModel = matchingPlaygroundModel?.id ?? spec.model.id;
+
+  const config: Partial<ChatbotConfiguration> = {
+    selectedModel,
+    selectedSubscription: spec.model.authorization?.maasSubscription ?? '',
+    temperature: spec.temperature ?? DEFAULT_CONFIGURATION.temperature,
+    isStreamingEnabled: spec.stream ?? DEFAULT_CONFIGURATION.isStreamingEnabled,
+    // Prompt is handled via promptRef below
+    activePrompt: null,
+    dirtyPrompt: null,
+    variableValues: {},
+  };
+
+  // RAG: storeRef (ConfigMap-backed) → external mode; id (direct Llama Stack ID) → inline mode
+  if (spec.vectorStores?.stores.length) {
+    const firstStore = spec.vectorStores.stores[0];
+    config.isRagEnabled = true;
+    if (firstStore.storeRef) {
+      config.knowledgeMode = 'external';
+      // storeRef.key is the vector_store_id the external vector store dropdown expects
+      config.selectedVectorStoreId = firstStore.storeRef.key || null;
+    } else {
+      config.knowledgeMode = 'inline';
+      config.selectedVectorStoreId = firstStore.id ?? null;
+    }
+  } else {
+    config.isRagEnabled = false;
+    config.knowledgeMode = DEFAULT_CONFIGURATION.knowledgeMode;
+    config.selectedVectorStoreId = null;
+  }
+
+  // MCP servers: restore selected server IDs from ConfigMap key field
+  if (spec.mcpServers?.length) {
+    config.selectedMcpServerIds = spec.mcpServers
+      .map((s) => s.serverRef.key ?? s.serverRef.name)
+      .filter(Boolean);
+    // mcpToolSelections restored after server list is available (see mcpToolsPending)
+    config.mcpToolSelections = {};
+  } else {
+    config.selectedMcpServerIds = [];
+    config.mcpToolSelections = {};
+  }
+
+  // Guardrails are intentionally not deserialized — see serialize.ts for the rationale.
+  // Any guardrails in the profile are ignored; the Playground starts with guardrails cleared.
+  config.guardrail = '';
+  config.guardrailUserInputEnabled = false;
+  config.guardrailModelOutputEnabled = false;
+  config.guardrailSubscription = '';
+
+  // Prompt ref for async loading
+  const promptRef: AgentProfilePromptRef | undefined = spec.prompt
+    ? {
+        name: spec.prompt.name,
+        version: spec.prompt.version !== undefined ? Number(spec.prompt.version) : undefined,
+        source: spec.prompt.source,
+      }
+    : undefined;
+
+  // If the profile had variable values, carry them forward for after prompt load
+  if (promptRef && spec.prompt?.variables) {
+    config.variableValues = Object.fromEntries(
+      Object.entries(spec.prompt.variables).map(([key, v]) => [key, v.text]),
+    );
+  }
+
+  // MCP tool selections pending: server name → allowed tools
+  const mcpToolsPending: Record<string, string[]> | undefined = spec.mcpServers?.length
+    ? Object.fromEntries(
+        spec.mcpServers
+          .filter((s) => s.allowedTools?.length)
+          .map((s) => [s.serverRef.key ?? s.serverRef.name, s.allowedTools ?? []]),
+      )
+    : undefined;
+
+  return {
+    config,
+    promptRef,
+    mcpToolsPending:
+      mcpToolsPending && Object.keys(mcpToolsPending).length > 0 ? mcpToolsPending : undefined,
+  };
+};

--- a/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/deserialize.ts
@@ -123,11 +123,13 @@ export const deserializeAgentProfile = (
     );
   }
 
-  // MCP tool selections pending: server name → allowed tools
+  // MCP tool selections pending: server name → allowed tools.
+  // Filter on !== undefined so allowedTools: [] (block all tools) is preserved;
+  // allowedTools: undefined means "all tools allowed" and needs no restriction applied.
   const mcpToolsPending: Record<string, string[]> | undefined = spec.mcpServers?.length
     ? Object.fromEntries(
         spec.mcpServers
-          .filter((s) => s.allowedTools?.length)
+          .filter((s) => s.allowedTools !== undefined)
           .map((s) => [s.serverRef.key ?? s.serverRef.name, s.allowedTools ?? []]),
       )
     : undefined;

--- a/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
@@ -1,7 +1,7 @@
 import { ChatbotConfiguration, McpToolSelectionsMap } from '~/app/Chatbot/store/types';
 import { AIModel } from '~/app/types';
 import { MCPServerFromAPI } from '~/app/types/mcp';
-import { AgentProfileMcpServer, AgentProfileSpec } from './types';
+import { AgentProfileMcpServer, AgentProfileSpec, AgentProfilePromptVariable } from './types';
 
 export type AgentProfileSerializationContext = {
   /** Full model object needed for URI and sourceType (not stored in config) */
@@ -20,7 +20,8 @@ export type AgentProfileSerializationContext = {
 const getToolsForServer = (toolSelections: McpToolSelectionsMap, serverUrl: string): string[] => {
   const tools: string[] = [];
   for (const nsMap of Object.values(toolSelections)) {
-    const serverTools = nsMap?.[serverUrl];
+    const serverMap: Record<string, string[]> | undefined = nsMap;
+    const serverTools = serverMap?.[serverUrl];
     if (serverTools) {
       tools.push(...serverTools);
     }
@@ -66,8 +67,12 @@ export const serializeToAgentProfileSpec = (
       version: String(config.activePrompt.version),
       variables:
         variableEntries.length > 0
-          ? Object.fromEntries(
-              variableEntries.map(([key, text]) => [key, { text, type: 'string' }]),
+          ? variableEntries.reduce<Record<string, AgentProfilePromptVariable>>(
+              (acc, [key, text]) => {
+                acc[key] = { text, type: 'string' };
+                return acc;
+              },
+              {},
             )
           : undefined,
     };

--- a/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/serialize.ts
@@ -1,0 +1,126 @@
+import { ChatbotConfiguration, McpToolSelectionsMap } from '~/app/Chatbot/store/types';
+import { AIModel } from '~/app/types';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+import { AgentProfileMcpServer, AgentProfileSpec } from './types';
+
+export type AgentProfileSerializationContext = {
+  /** Full model object needed for URI and sourceType (not stored in config) */
+  model: AIModel | undefined;
+  /** Available MCP servers, used to resolve server name → URL for tool lookup */
+  mcpServers: MCPServerFromAPI[];
+  /**
+   * Name of the ConfigMap that holds all MCP server configs.
+   * From MCPServersResponse.config_map_info.name.
+   * When absent, MCP servers are omitted from the output.
+   */
+  mcpConfigMapName?: string;
+};
+
+/** Collect all tool names for a given server URL across all namespaces */
+const getToolsForServer = (toolSelections: McpToolSelectionsMap, serverUrl: string): string[] => {
+  const tools: string[] = [];
+  for (const nsMap of Object.values(toolSelections)) {
+    const serverTools = nsMap?.[serverUrl];
+    if (serverTools) {
+      tools.push(...serverTools);
+    }
+  }
+  return tools;
+};
+
+/**
+ * Converts Playground store configuration into an AgentProfile spec body
+ * suitable for POST or PUT to the AgentProfile BFF API.
+ */
+export const serializeToAgentProfileSpec = (
+  config: ChatbotConfiguration,
+  displayName: string,
+  description: string | undefined,
+  context: AgentProfileSerializationContext,
+): AgentProfileSpec => {
+  const { model, mcpServers: availableServers, mcpConfigMapName } = context;
+
+  const spec: AgentProfileSpec = {
+    displayName,
+    description: description || undefined,
+    model: {
+      // Use the AI Asset catalog ID (model_id), not the Llama Stack runtime ID (selectedModel)
+      id: model?.model_id ?? config.selectedModel,
+      // Prefer internal endpoint (cluster-local); fall back to external
+      uri: model?.internalEndpoint ?? model?.externalEndpoint ?? '',
+      sourceType: model?.model_source_type,
+      authorization: config.selectedSubscription
+        ? { maasSubscription: config.selectedSubscription }
+        : undefined,
+    },
+    temperature: config.temperature,
+    stream: config.isStreamingEnabled,
+  };
+
+  // Prompt: reference the active MLflow prompt by name + version
+  if (config.activePrompt) {
+    const variableEntries = Object.entries(config.variableValues);
+    spec.prompt = {
+      name: config.activePrompt.name,
+      source: 'mlflow',
+      version: String(config.activePrompt.version),
+      variables:
+        variableEntries.length > 0
+          ? Object.fromEntries(
+              variableEntries.map(([key, text]) => [key, { text, type: 'string' }]),
+            )
+          : undefined,
+    };
+  }
+
+  // Vector stores
+  if (config.isRagEnabled && config.selectedVectorStoreId) {
+    if (config.knowledgeMode === 'external') {
+      // External vector stores are ConfigMap-backed (gen-ai-aa-vector-stores).
+      // The vector_store_id is the key within that ConfigMap's config.yaml.
+      spec.vectorStores = {
+        stores: [
+          {
+            storeRef: {
+              kind: 'ConfigMap',
+              name: 'gen-ai-aa-vector-stores',
+              key: config.selectedVectorStoreId,
+            },
+          },
+        ],
+      };
+    } else {
+      // Inline vector stores are identified by their direct Llama Stack ID
+      spec.vectorStores = {
+        stores: [{ id: config.selectedVectorStoreId }],
+      };
+    }
+  }
+
+  // MCP servers: each selected server name maps to its key in the shared ConfigMap
+  if (config.selectedMcpServerIds.length > 0 && mcpConfigMapName) {
+    const entries: AgentProfileMcpServer[] = [];
+    for (const serverId of config.selectedMcpServerIds) {
+      const server = availableServers.find((s) => s.name === serverId);
+      if (!server) {
+        continue;
+      }
+      const allowedTools = getToolsForServer(config.mcpToolSelections, server.url);
+      entries.push({
+        serverRef: { kind: 'ConfigMap', name: mcpConfigMapName, key: server.name },
+        allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
+      });
+    }
+    if (entries.length > 0) {
+      spec.mcpServers = entries;
+    }
+  }
+
+  // Guardrails are intentionally not serialized.
+  // The Playground uses an inline model reference (GuardrailInlineConfig) while
+  // AgentProfile.spec.guardrails expects a K8s ConfigMap resource reference — a
+  // different abstraction level. Mapping between the two requires the guardrail
+  // ConfigMap schema to be defined first.
+
+  return spec;
+};

--- a/packages/gen-ai/frontend/src/app/agentProfile/types.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/types.ts
@@ -1,0 +1,123 @@
+/** Frontend types matching the AgentProfile BFF API contract */
+
+export type AgentProfileModelAuth = {
+  credentialsRef?: { kind: string; name: string; key: string };
+  maasSubscription?: string;
+};
+
+export type AgentProfileModel = {
+  id: string;
+  uri: string;
+  sourceType?: string;
+  authorization?: AgentProfileModelAuth;
+};
+
+export type AgentProfilePromptVariable = {
+  text: string;
+  type: string;
+};
+
+export type AgentProfilePrompt = {
+  name: string;
+  source: string;
+  namespace?: string;
+  version?: string;
+  variables?: Record<string, AgentProfilePromptVariable>;
+};
+
+export type AgentProfileResourceRef = {
+  kind: string;
+  name: string;
+  key: string;
+};
+
+export type AgentProfileVectorStoreEntry = {
+  storeRef?: AgentProfileResourceRef;
+  id?: string;
+};
+
+export type AgentProfileVectorStores = {
+  stores: AgentProfileVectorStoreEntry[];
+  maxNumResults?: number;
+};
+
+export type AgentProfileMcpServerRef = {
+  kind: string;
+  name: string;
+  key?: string;
+};
+
+export type AgentProfileMcpServer = {
+  serverRef: AgentProfileMcpServerRef;
+  credentialsRef?: AgentProfileResourceRef;
+  allowedTools?: string[];
+};
+
+export type AgentProfileGuardrail = {
+  provider: string;
+  guardrailRef: AgentProfileResourceRef;
+};
+
+export type AgentProfileSpec = {
+  displayName: string;
+  description?: string;
+  model: AgentProfileModel;
+  prompt?: AgentProfilePrompt;
+  temperature?: number;
+  stream?: boolean;
+  maxOutputTokens?: number;
+  vectorStores?: AgentProfileVectorStores;
+  mcpServers?: AgentProfileMcpServer[];
+  guardrails?: AgentProfileGuardrail[];
+};
+
+export type AgentProfileMetadata = {
+  name: string;
+  resourceVersion: string;
+};
+
+export type AgentProfile = {
+  apiVersion: string;
+  kind: string;
+  metadata: AgentProfileMetadata;
+  spec: AgentProfileSpec;
+};
+
+export type AgentProfileCreateRequest = {
+  spec: AgentProfileSpec;
+};
+
+export type AgentProfileCreateResponse = {
+  name: string;
+  profileId: string;
+  displayName: string;
+  namespace: string;
+  resourceVersion: string;
+};
+
+export type AgentProfileSummary = {
+  name: string;
+  profileId: string;
+  displayName: string;
+  description?: string;
+  namespace: string;
+  lastModified: string;
+};
+
+export type AgentProfileListResponse = {
+  profiles: AgentProfileSummary[];
+  totalCount: number;
+};
+
+export type AgentProfileUpdateRequest = {
+  spec: AgentProfileSpec;
+  resourceVersion: string;
+};
+
+export type AgentProfileUpdateResponse = {
+  name: string;
+  profileId: string;
+  displayName: string;
+  namespace: string;
+  resourceVersion: string;
+};

--- a/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
+++ b/packages/gen-ai/frontend/src/app/agentProfile/useAgentProfileUrlParam.ts
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { GenAiContext } from '~/app/context/GenAiContext';
+import { useGenAiAPI } from '~/app/hooks/useGenAiAPI';
+import { MCPServerFromAPI } from '~/app/types/mcp';
+import { DEFAULT_CONFIG_ID, useChatbotConfigStore } from '~/app/Chatbot/store';
+import { deserializeAgentProfile } from './deserialize';
+
+const AGENT_PROFILE_ID_PARAM = 'agentProfileId';
+
+type UseAgentProfileUrlParamResult = {
+  loading: boolean;
+  error: Error | undefined;
+};
+
+/**
+ * Reads `?agentProfileId=<uuid>` from the URL, fetches the profile from the BFF,
+ * and applies it to the Playground store. Runs once on mount per profile ID.
+ *
+ * Waits for mcpServersLoaded before fetching so that MCP tool selections from the
+ * profile can always be applied immediately without a separate retry.
+ *
+ * Requires GenAiContext (namespace) and ChatbotContext (playground models) to be in scope.
+ */
+const useAgentProfileUrlParam = ({
+  mcpServers,
+  mcpServersLoaded,
+}: {
+  mcpServers: MCPServerFromAPI[];
+  mcpServersLoaded: boolean;
+}): UseAgentProfileUrlParamResult => {
+  const [searchParams] = useSearchParams();
+  const agentProfileId = searchParams.get(AGENT_PROFILE_ID_PARAM);
+
+  const { namespace } = React.useContext(GenAiContext);
+  const { models: playgroundModels } = React.useContext(ChatbotContext);
+  const { api, apiAvailable } = useGenAiAPI();
+
+  const applyAgentProfile = useChatbotConfigStore((s) => s.applyAgentProfile);
+  const updateActivePrompt = useChatbotConfigStore((s) => s.updateActivePrompt);
+  const saveToolSelections = useChatbotConfigStore((s) => s.saveToolSelections);
+
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | undefined>();
+
+  // Track the last profile ID we applied to prevent double-application in StrictMode
+  const appliedProfileId = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (
+      !agentProfileId ||
+      !namespace?.name ||
+      !apiAvailable ||
+      !mcpServersLoaded ||
+      appliedProfileId.current === agentProfileId
+    ) {
+      return;
+    }
+
+    appliedProfileId.current = agentProfileId;
+    setLoading(true);
+    setError(undefined);
+
+    api
+      .getAgentProfile({ id: agentProfileId, namespace: namespace.name })
+      .then((profile) => {
+        const { config, promptRef, mcpToolsPending } = deserializeAgentProfile(profile, {
+          playgroundModels,
+        });
+
+        applyAgentProfile(config);
+
+        // Restore MCP tool selections — mcpServers is guaranteed loaded at this point
+        if (mcpToolsPending) {
+          for (const [serverName, tools] of Object.entries(mcpToolsPending)) {
+            const server = mcpServers.find((s) => s.name === serverName);
+            if (server) {
+              saveToolSelections(DEFAULT_CONFIG_ID, namespace.name, server.url, tools);
+            }
+          }
+        }
+
+        // Load the MLflow prompt asynchronously — doesn't block the profile load
+        if (promptRef) {
+          const versionParam =
+            promptRef.version !== undefined ? { version: String(promptRef.version) } : {};
+          api
+            .getMLflowPrompt({ name: promptRef.name, ...versionParam })
+            .then((prompt) => {
+              updateActivePrompt(DEFAULT_CONFIG_ID, prompt);
+            })
+            .catch((promptErr) => {
+              // Prompt load failure is non-fatal — the rest of the profile is already applied
+              // eslint-disable-next-line no-console
+              console.error('[useAgentProfileUrlParam] Failed to load MLflow prompt', promptErr);
+            });
+        }
+
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        appliedProfileId.current = null; // allow retry if caller re-mounts
+        setError(err);
+        setLoading(false);
+      });
+  }, [
+    agentProfileId,
+    namespace?.name,
+    apiAvailable,
+    mcpServersLoaded,
+    api,
+    playgroundModels,
+    mcpServers,
+    applyAgentProfile,
+    updateActivePrompt,
+    saveToolSelections,
+  ]);
+
+  return { loading, error };
+};
+
+export default useAgentProfileUrlParam;

--- a/packages/gen-ai/frontend/src/app/hooks/useGenAiAPIState.tsx
+++ b/packages/gen-ai/frontend/src/app/hooks/useGenAiAPIState.tsx
@@ -32,6 +32,7 @@ import {
   verifyExternalModel,
   deleteExternalModel,
   getAgentProfile,
+  createAgentProfile,
 } from '~/app/services/llamaStackService';
 
 export type GenAiAPIState = APIState<GenAiAPIs>;
@@ -72,6 +73,7 @@ const useGenAiAPIState = (
       verifyExternalModel: verifyExternalModel(path, queryParameters),
       deleteExternalModel: deleteExternalModel(path, queryParameters),
       getAgentProfile: getAgentProfile(path, queryParameters),
+      createAgentProfile: createAgentProfile(path, queryParameters),
     }),
     [queryParameters],
   );

--- a/packages/gen-ai/frontend/src/app/hooks/useGenAiAPIState.tsx
+++ b/packages/gen-ai/frontend/src/app/hooks/useGenAiAPIState.tsx
@@ -31,6 +31,7 @@ import {
   createExternalModel,
   verifyExternalModel,
   deleteExternalModel,
+  getAgentProfile,
 } from '~/app/services/llamaStackService';
 
 export type GenAiAPIState = APIState<GenAiAPIs>;
@@ -70,6 +71,7 @@ const useGenAiAPIState = (
       createExternalModel: createExternalModel(path, queryParameters),
       verifyExternalModel: verifyExternalModel(path, queryParameters),
       deleteExternalModel: deleteExternalModel(path, queryParameters),
+      getAgentProfile: getAgentProfile(path, queryParameters),
     }),
     [queryParameters],
   );

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -8,7 +8,11 @@ import {
   restGET,
 } from 'mod-arch-core';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
-import { AgentProfile } from '~/app/agentProfile/types';
+import {
+  AgentProfile,
+  AgentProfileCreateRequest,
+  AgentProfileCreateResponse,
+} from '~/app/agentProfile/types';
 import {
   ApiErrorClass,
   BackendResponseData,
@@ -1107,6 +1111,11 @@ export const listMLflowPromptVersions =
       throw new Error('Invalid response format');
     });
   };
+
+export const createAgentProfile = modArchRestCREATE<
+  AgentProfileCreateResponse,
+  AgentProfileCreateRequest
+>('/agent-profiles');
 
 export const getAgentProfile =
   (hostPath: string, baseQueryParams: Record<string, unknown> = {}): ModArchRestGET<AgentProfile> =>

--- a/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
+++ b/packages/gen-ai/frontend/src/app/services/llamaStackService.ts
@@ -8,6 +8,7 @@ import {
   restGET,
 } from 'mod-arch-core';
 import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import { AgentProfile } from '~/app/agentProfile/types';
 import {
   ApiErrorClass,
   BackendResponseData,
@@ -1101,6 +1102,24 @@ export const listMLflowPromptVersions =
       ),
     ).then((response) => {
       if (isModArchResponse<MLflowPromptVersionsResponse>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+  };
+
+export const getAgentProfile =
+  (hostPath: string, baseQueryParams: Record<string, unknown> = {}): ModArchRestGET<AgentProfile> =>
+  (queryParams: Record<string, unknown> = {}, opts: APIOptions = {}) => {
+    const { id, ...restParams } = queryParams;
+    if (!id || typeof id !== 'string') {
+      return Promise.reject(new Error('id parameter is required'));
+    }
+    const path = `/agent-profiles/${encodeURIComponent(id)}`;
+    return handleRestFailures(
+      restGET<AgentProfile>(hostPath, path, { ...baseQueryParams, ...restParams }, opts),
+    ).then((response) => {
+      if (isModArchResponse<AgentProfile>(response)) {
         return response.data;
       }
       throw new Error('Invalid response format');

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -570,6 +570,7 @@ export type GenAiAPIs = {
   createExternalModel: CreateExternalModel;
   verifyExternalModel: VerifyExternalModel;
   deleteExternalModel: DeleteExternalModel;
+  getAgentProfile: GetAgentProfile;
 };
 
 export interface SubscriptionInfo {
@@ -660,6 +661,7 @@ type VerifyExternalModel = ModArchRestCREATE<
   VerifyExternalModelRequest
 >;
 type DeleteExternalModel = ModArchRestDELETE<string, Record<string, never>>;
+type GetAgentProfile = ModArchRestGET<import('./agentProfile/types').AgentProfile>;
 
 export type ErrorPattern = 'full-failure' | 'partial-failure' | 'streaming-interruption';
 export type ErrorVariant = 'danger' | 'warning';

--- a/packages/gen-ai/frontend/src/app/types.ts
+++ b/packages/gen-ai/frontend/src/app/types.ts
@@ -571,6 +571,7 @@ export type GenAiAPIs = {
   verifyExternalModel: VerifyExternalModel;
   deleteExternalModel: DeleteExternalModel;
   getAgentProfile: GetAgentProfile;
+  createAgentProfile: CreateAgentProfile;
 };
 
 export interface SubscriptionInfo {
@@ -662,6 +663,10 @@ type VerifyExternalModel = ModArchRestCREATE<
 >;
 type DeleteExternalModel = ModArchRestDELETE<string, Record<string, never>>;
 type GetAgentProfile = ModArchRestGET<import('./agentProfile/types').AgentProfile>;
+type CreateAgentProfile = ModArchRestCREATE<
+  import('./agentProfile/types').AgentProfileCreateResponse,
+  import('./agentProfile/types').AgentProfileCreateRequest
+>;
 
 export type ErrorPattern = 'full-failure' | 'partial-failure' | 'streaming-interruption';
 export type ErrorVariant = 'danger' | 'warning';


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66524
https://issues.redhat.com/browse/RHOAIENG-66525

## Description

**The primary purpose of this PR is to establish the AgentProfile ConfigMap ↔ Playground UI state serialization layer.** This is foundational work — the Save/Load UI flows, profile management, and related features will be built on top in subsequent PRs.

Implements Playground state ↔ AgentProfile schema serialization/deserialization and URL-based profile loading.

**Serialize** (`PlaygroundState → AgentProfile spec`):
- Model: writes AI Asset `model_id`; URI from `internalEndpoint` / `externalEndpoint`
- Vector stores: `storeRef` (ConfigMap-backed, `gen-ai-aa-vector-stores`) → external mode; direct `id` → inline mode
- MCP servers: server name → ConfigMap key mapping with allowed tools
- Prompt: MLflow reference (name + version); variables preserved
- Guardrails: intentionally not serialized — see Known Issues

**Deserialize** (`AgentProfile → PlaygroundState`):
- Model: AI Asset `model_id` resolved back to Llama Stack runtime ID via `isPlaygroundModelMatchForAIModel`
- Returns `promptRef` (loaded async via `getMLflowPrompt`) and `mcpToolsPending` (applied once MCP server list loads)
- `storeRef` → `knowledgeMode: external`; direct `id` → `knowledgeMode: inline`

**URL-param loading** (`useAgentProfileUrlParam`):
- Reads `?agentProfileId=<uuid>` from URL, waits for `mcpServersLoaded`, fetches profile, applies via `applyAgentProfile()`
- `applyAgentProfile` store action sets `profileApplied: true` as a persistent "profile is loaded" signal for future save/discard UI

**Refactor**: moved `selectedVectorStoreId` clear on inline→external switch from a reactive effect to the radio button `onChange` — cleaner separation of user action vs reactive sync.

**Test button**: `ChatbotHeaderActions` has a temporary "Save as" button (left of Compare chat). Disabled by default via `RENDER_SAVE_AS_BUTTON = false` — flip to `true` locally to test. Logs the resulting playground URL to the browser console.

To load a profile:
```
/gen-ai-studio/playground/<namespace>?agentProfileId=<uuid>
```

**Video (After enabling RENDER_SAVE_AS_BUTTON)**

https://github.com/user-attachments/assets/61793264-054a-4d23-ab30-30c590014de6



## Not In Scope

These will be addressed in follow-up PRs:
- UI for saving and loading Agent profiles (Save modal, Load/browse flow)
- UI for showing that an Agent profile is currently loaded (header state, unsaved indicator)
- Support in comparison mode
- Creating a prompt in MLflow when saving an Agent profile with an unsaved/dirty prompt

## Known Issues

- **No guardrail support** — the Playground uses an inline model reference (`GuardrailInlineConfig`) while the AgentProfile schema expects a K8s ConfigMap resource reference; these are different abstractions and require schema alignment before the mapping can be implemented (blocked)
- **No ASR model support** — `selectedAsrModel` is not part of the AgentProfile schema
- **Missing UI state for MCP servers without auth** — MCP servers that require a token but haven't had one added yet are selected in the store but the UI does not reflect the auth-required state after a profile load
- Flicker when loading Agent Profiles detailed - will be handled in a future PR when solidifying saving/loading

## How Has This Been Tested?

- 54 unit tests covering all field mappings and round-trip AC (serialize → deserialize → settings match)
- Manually tested URL-param loading with profiles containing model, external/inline vector store, MCP server with tool restrictions, and MLflow prompt

## Test Impact

- 54 new unit tests in `packages/gen-ai/frontend/src/app/agentProfile/__tests__/`
- `ChatbotHeaderActions.spec.tsx` updated for new `onSaveAs` prop

To enable the "Save as" test button locally: set `RENDER_SAVE_AS_BUTTON = true` in `ChatbotHeaderActions.tsx` — the handler POSTs the current Playground config as an AgentProfile and logs the load URL to the console.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Save As" functionality to save current chatbot configurations as reusable agent profiles.
  * Added support for loading previously saved agent profiles via URL parameters.

* **Bug Fixes**
  * Improved vector store selection logic for more reliable knowledge source handling.

* **Tests**
  * Added comprehensive test coverage for agent profile workflows, including creation and loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->