### PR TITLE
Use SA-based cluster-wide CR discovery for multi-tenancy

### DIFF
--- a/manifests/modular-architecture/modules/eval-hub/cluster-role.yaml
+++ b/manifests/modular-architecture/modules/eval-hub/cluster-role.yaml
@@ -9,3 +9,10 @@ rules:
       - create
     resources:
       - subjectaccessreviews
+  - apiGroups:
+      - trustyai.opendatahub.io
+    verbs:
+      - list
+      - get
+    resources:
+      - evalhubs

--- a/manifests/modular-architecture/modules/eval-hub/cluster-role.yaml
+++ b/manifests/modular-architecture/modules/eval-hub/cluster-role.yaml
@@ -13,6 +13,5 @@ rules:
       - trustyai.opendatahub.io
     verbs:
       - list
-      - get
     resources:
       - evalhubs

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -161,7 +161,10 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		var discErr error
 		crDiscoverer, discErr = k8s.NewSADiscoverer(logger)
 		if discErr != nil {
-			logger.Warn("Failed to create SA-based CR discoverer; cluster-wide CR discovery will be unavailable",
+			if cfg.EvalHubURL == "" {
+				return nil, fmt.Errorf("SA-based CR discoverer init failed and no EVAL_HUB_URL override is set: %w", discErr)
+			}
+			logger.Warn("Failed to create SA-based CR discoverer; using EVAL_HUB_URL override only",
 				slog.Any("error", discErr))
 		}
 	}

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -161,7 +161,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		var discErr error
 		crDiscoverer, discErr = k8s.NewSADiscoverer(logger)
 		if discErr != nil {
-			if cfg.EvalHubURL == "" {
+			if strings.TrimSpace(cfg.EvalHubURL) == "" {
 				return nil, fmt.Errorf("SA-based CR discoverer init failed and no EVAL_HUB_URL override is set: %w", discErr)
 			}
 			logger.Warn("Failed to create SA-based CR discoverer; using EVAL_HUB_URL override only",

--- a/packages/eval-hub/bff/internal/api/app.go
+++ b/packages/eval-hub/bff/internal/api/app.go
@@ -70,6 +70,7 @@ type App struct {
 	config                  config.EnvConfig
 	logger                  *slog.Logger
 	kubernetesClientFactory k8s.KubernetesClientFactory
+	crDiscoverer            k8s.EvalHubCRDiscoverer
 	evalHubClientFactory    evalhub.EvalHubClientFactory
 	repositories            *repositories.Repositories
 	testEnv                 *envtest.Environment
@@ -152,6 +153,19 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 	}
 	logger.Info("Detected dashboard namespace", slog.String("namespace", dashboardNamespace))
 
+	// SA-based CR discoverer for cluster-wide EvalHub CR discovery.
+	// Uses the pod's service account (or local kubeconfig in dev) instead of user tokens,
+	// so any tenant namespace can discover the CR regardless of where it was created.
+	var crDiscoverer k8s.EvalHubCRDiscoverer
+	if !cfg.MockK8Client {
+		var discErr error
+		crDiscoverer, discErr = k8s.NewSADiscoverer(logger)
+		if discErr != nil {
+			logger.Warn("Failed to create SA-based CR discoverer; cluster-wide CR discovery will be unavailable",
+				slog.Any("error", discErr))
+		}
+	}
+
 	var ehFactory evalhub.EvalHubClientFactory
 	if cfg.MockEvalHubClient {
 		ehFactory = ehmocks.NewMockClientFactory()
@@ -170,6 +184,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		config:                  cfg,
 		logger:                  logger,
 		kubernetesClientFactory: k8sFactory,
+		crDiscoverer:            crDiscoverer,
 		evalHubClientFactory:    ehFactory,
 		repositories:            repositories.NewRepositories(),
 		testEnv:                 testEnv,

--- a/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
+++ b/packages/eval-hub/bff/internal/api/evalhub_health_handler.go
@@ -30,17 +30,15 @@ type EvalHubServiceHealth struct {
 
 type EvalHubServiceHealthEnvelope Envelope[EvalHubServiceHealth, None]
 
-// EvalHubServiceHealthHandler performs per-request CR discovery using the caller's bearer
-// token and then pings the discovered EvalHub service. Because this endpoint does not have
-// the AttachNamespace middleware, it only checks app.dashboardNamespace. It always returns
-// HTTP 200 with one of the three EvalHubHealthStatus values so the frontend always reaches
-// a loaded state.
+// EvalHubServiceHealthHandler performs cluster-wide CR discovery using the pod's service
+// account and then pings the discovered EvalHub service. It always returns HTTP 200 with
+// one of the three EvalHubHealthStatus values so the frontend always reaches a loaded state.
 //
 // Priority:
 //  1. MockEvalHubClient=true — return healthy immediately (dev/test mode, no K8s call).
 //  2. EVAL_HUB_URL env override — skip CR discovery, ping the override URL directly.
-//  3. CR discovery — list evalhubs.trustyai.opendatahub.io in app.dashboardNamespace via
-//     the caller's bearer token; if no CR found → cr-not-found; if found, ping status.url.
+//  3. SA-based cluster-wide CR discovery — find the EvalHub CR in any namespace; if no CR
+//     found → cr-not-found; if found, ping status.url.
 func (app *App) EvalHubServiceHealthHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 

--- a/packages/eval-hub/bff/internal/api/evalhub_status_handler.go
+++ b/packages/eval-hub/bff/internal/api/evalhub_status_handler.go
@@ -6,12 +6,18 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
+	helper "github.com/opendatahub-io/eval-hub/bff/internal/helpers"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/eval-hub/bff/internal/models"
 )
 
 type EvalHubCRStatusEnvelope Envelope[*models.EvalHubCRStatus, None]
 
+// EvalHubCRStatusHandler returns the status of the EvalHub CR.
+//
+// It first attempts to find the CR in the user-selected namespace (from ?namespace=).
+// If not found there, it falls back to SA-based cluster-wide discovery so that tenant
+// namespaces can always find the CR regardless of where it was created.
 func (app *App) EvalHubCRStatusHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ctx := r.Context()
 
@@ -37,6 +43,20 @@ func (app *App) EvalHubCRStatusHandler(w http.ResponseWriter, r *http.Request, _
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
+	}
+
+	// If the CR is not in the user's namespace, fall back to cluster-wide SA discovery
+	// so tenant namespaces can see the CR status regardless of where it was created.
+	if crStatus == nil && app.crDiscoverer != nil {
+		logger := helper.GetContextLoggerFromReq(r)
+		logger.Debug("EvalHub CR not found in user namespace, falling back to cluster-wide SA discovery",
+			"namespace", namespace)
+
+		crStatus, err = app.crDiscoverer.DiscoverCRStatus(ctx)
+		if err != nil {
+			app.serverErrorResponse(w, r, fmt.Errorf("cluster-wide EvalHub CR discovery failed: %w", err))
+			return
+		}
 	}
 
 	envelope := EvalHubCRStatusEnvelope{Data: crStatus}

--- a/packages/eval-hub/bff/internal/api/evalhub_status_handler_test.go
+++ b/packages/eval-hub/bff/internal/api/evalhub_status_handler_test.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,4 +43,37 @@ func TestEvalHubCRStatusHandlerMissingNamespace(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+}
+
+func TestEvalHubCRStatusHandler_FallbackToClusterWideDiscovery(t *testing.T) {
+	// When the CR is not in the user's namespace, the handler should fall back
+	// to SA-based cluster-wide discovery.
+	identity := &kubernetes.RequestIdentity{UserID: "user@example.com"}
+
+	// K8s client returns nil for the user's namespace (CR not there).
+	k8sClient := &crStatusOverrideK8sClient{
+		fn: func(_ context.Context, _ *kubernetes.RequestIdentity, _ string) (*models.EvalHubCRStatus, error) {
+			return nil, nil
+		},
+	}
+
+	crFromCluster := &models.EvalHubCRStatus{
+		Name: "evalhub", Namespace: "custom-ns", Phase: "Ready",
+		Ready: "True", URL: "http://evalhub.custom-ns.svc:8080",
+		ReadyReplicas: 1, Replicas: 1,
+	}
+
+	result, response, err := setupApiTestForCRStatus[EvalHubCRStatusEnvelope](
+		http.MethodGet,
+		EvalHubCRStatusPath+"?namespace=tenant-b",
+		identity,
+		&crStatusK8sFactory{client: k8sClient},
+		&mockCRDiscoverer{crStatus: crFromCluster},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "evalhub", result.Data.Name)
+	assert.Equal(t, "custom-ns", result.Data.Namespace)
+	assert.Equal(t, "http://evalhub.custom-ns.svc:8080", result.Data.URL)
 }

--- a/packages/eval-hub/bff/internal/api/middleware.go
+++ b/packages/eval-hub/bff/internal/api/middleware.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -17,7 +16,6 @@ import (
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/evalhub"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
 	"github.com/rs/cors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 func (app *App) RecoverPanic(next http.Handler) http.Handler {
@@ -95,15 +93,16 @@ func (app *App) EnableTelemetry(next http.Handler) http.Handler {
 //   - serviceURL  — the URL to use for the EvalHub REST client.
 //   - authToken   — the caller's bearer token (empty when using an env-override URL and no
 //     identity is present, e.g. in dev mode).
-//   - crNotFound  — true when no EvalHub CR exists in either namespace (not an error;
+//   - crNotFound  — true when no EvalHub CR exists anywhere in the cluster (not an error;
 //     callers should surface this as a distinct state rather than 500).
 //   - err         — a real unexpected error (K8s API failure, missing identity, etc.).
 //
 // Priority (evaluated per-request):
 //  1. EVAL_HUB_URL env override — used directly; no K8s call needed.
-//  2. CR discovery in the user-selected namespace (from context, if present).
-//  3. Fallback CR discovery in app.dashboardNamespace (covers the health endpoint and cases
-//     where the CR lives in the platform namespace).
+//  2. SA-based cluster-wide CR discovery — uses the pod's service account to list EvalHub CRs
+//     across all namespaces, so tenant namespaces can discover the CR regardless of where it
+//     was created. This replaces the previous user-token per-namespace lookup which broke
+//     multi-tenancy when the CR lived outside the user's namespace and the dashboard namespace.
 //
 // Mock mode is NOT handled here; callers must short-circuit before calling this function.
 func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken string, crNotFound bool, err error) {
@@ -122,42 +121,19 @@ func (app *App) evalHubServiceURL(ctx context.Context) (serviceURL, authToken st
 	}
 	authToken = identity.Token
 
-	k8sClient, err := app.kubernetesClientFactory.GetClient(ctx)
-	if err != nil {
-		return "", "", false, fmt.Errorf("failed to get Kubernetes client: %w", err)
+	if app.crDiscoverer == nil {
+		return "", "", false, fmt.Errorf("SA-based CR discoverer is not available; cannot discover EvalHub service")
 	}
 
-	// Try the user-selected namespace first (set by AttachNamespace middleware on API routes).
-	// Permission errors (Forbidden/NotFound) are non-fatal — fall through to the dashboard
-	// namespace where the CR typically lives.  Operational failures (API unavailable, network
-	// errors, etc.) are surfaced immediately so they are not silently masked.
-	if userNS, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string); ok && userNS != "" {
-		crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, userNS)
-		if err != nil {
-			var statusErr *k8serrors.StatusError
-			if errors.As(err, &statusErr) && (k8serrors.IsForbidden(statusErr) || k8serrors.IsNotFound(statusErr)) {
-				if logger := helper.GetContextLogger(ctx); logger != nil {
-					logger.Debug("EvalHub CR lookup not permitted in user namespace, falling through to dashboard namespace",
-						"namespace", userNS, "reason", statusErr.Status().Reason)
-				}
-			} else {
-				return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", userNS, err)
-			}
-		} else if crStatus != nil && strings.TrimSpace(crStatus.URL) != "" {
-			return crStatus.URL, authToken, false, nil
-		}
-	}
-
-	// Fallback to the dashboard (platform) namespace for the health endpoint and clusters
-	// where the CR still lives in the operator-managed namespace.
-	crStatus, err := k8sClient.GetEvalHubCRStatus(ctx, identity, app.dashboardNamespace)
+	url, err := app.crDiscoverer.DiscoverServiceURL(ctx)
 	if err != nil {
-		return "", "", false, fmt.Errorf("EvalHub CR lookup failed in namespace %q: %w", app.dashboardNamespace, err)
+		return "", "", false, fmt.Errorf("EvalHub CR cluster-wide discovery failed: %w", err)
 	}
-	if crStatus == nil || strings.TrimSpace(crStatus.URL) == "" {
+	if url == "" {
 		return "", authToken, true, nil
 	}
-	return crStatus.URL, authToken, false, nil
+
+	return url, authToken, false, nil
 }
 
 // AttachEvalHubClient middleware creates an EvalHub client and attaches it to context.

--- a/packages/eval-hub/bff/internal/api/middleware_test.go
+++ b/packages/eval-hub/bff/internal/api/middleware_test.go
@@ -11,94 +11,61 @@ import (
 	"github.com/opendatahub-io/eval-hub/bff/internal/config"
 	"github.com/opendatahub-io/eval-hub/bff/internal/constants"
 	"github.com/opendatahub-io/eval-hub/bff/internal/integrations/kubernetes"
-	"github.com/opendatahub-io/eval-hub/bff/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// namespaceAwareCRClient returns different CR statuses depending on the namespace queried.
-type namespaceAwareCRClient struct {
-	testK8sClient
-	crByNamespace map[string]*models.EvalHubCRStatus
-	errByNS       map[string]error
-}
-
-func (c *namespaceAwareCRClient) GetEvalHubCRStatus(_ context.Context, _ *kubernetes.RequestIdentity, namespace string) (*models.EvalHubCRStatus, error) {
-	if c.errByNS != nil {
-		if err, ok := c.errByNS[namespace]; ok {
-			return nil, err
-		}
-	}
-	if c.crByNamespace != nil {
-		return c.crByNamespace[namespace], nil
-	}
-	return nil, nil
-}
-
-func newTestApp(k8sClient kubernetes.KubernetesClientInterface, dashboardNS string) *App {
+func newTestAppWithDiscoverer(discoverer kubernetes.EvalHubCRDiscoverer, dashboardNS string) *App {
 	return &App{
 		config:                  config.EnvConfig{AuthMethod: config.AuthMethodInternal},
 		logger:                  testLogger,
-		kubernetesClientFactory: &crStatusK8sFactory{client: k8sClient},
+		kubernetesClientFactory: &testK8sFactory{},
+		crDiscoverer:            discoverer,
 		dashboardNamespace:      dashboardNS,
 	}
 }
 
-func TestEvalHubServiceURL_UserNamespaceHasCR(t *testing.T) {
-	client := &namespaceAwareCRClient{
-		crByNamespace: map[string]*models.EvalHubCRStatus{
-			"user-project": {
-				Name: "evalhub", Namespace: "user-project", Phase: "Ready",
-				URL: "http://evalhub.user-project.svc:8080",
-			},
-			"redhat-ods-applications": {
-				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
-				URL: "http://evalhub.platform.svc:8080",
-			},
-		},
+func TestEvalHubServiceURL_ClusterWideSADiscovery(t *testing.T) {
+	discoverer := &mockCRDiscoverer{
+		serviceURL: "http://evalhub.custom-ns.svc:8080",
 	}
 
-	app := newTestApp(client, "redhat-ods-applications")
+	app := newTestAppWithDiscoverer(discoverer, "redhat-ods-applications")
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
-	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "tenant-a")
 
 	serviceURL, authToken, crNotFound, err := app.evalHubServiceURL(ctx)
 
 	require.NoError(t, err)
 	assert.False(t, crNotFound)
-	assert.Equal(t, "http://evalhub.user-project.svc:8080", serviceURL)
+	assert.Equal(t, "http://evalhub.custom-ns.svc:8080", serviceURL)
 	assert.Equal(t, "tok", authToken)
 }
 
-func TestEvalHubServiceURL_FallbackToDashboardNamespace(t *testing.T) {
-	client := &namespaceAwareCRClient{
-		crByNamespace: map[string]*models.EvalHubCRStatus{
-			"redhat-ods-applications": {
-				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
-				URL: "http://evalhub.platform.svc:8080",
-			},
-		},
+func TestEvalHubServiceURL_CRInCustomNamespace_DiscoverableFromAnyTenant(t *testing.T) {
+	discoverer := &mockCRDiscoverer{
+		serviceURL: "http://evalhub.namespace-a.svc:8080",
 	}
 
-	app := newTestApp(client, "redhat-ods-applications")
+	app := newTestAppWithDiscoverer(discoverer, "redhat-ods-applications")
+
+	// Tenant B can discover CR created in namespace A
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
-	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "tenant-b")
 
 	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
 
 	require.NoError(t, err)
 	assert.False(t, crNotFound)
-	assert.Equal(t, "http://evalhub.platform.svc:8080", serviceURL)
+	assert.Equal(t, "http://evalhub.namespace-a.svc:8080", serviceURL)
 }
 
 func TestEvalHubServiceURL_CRNotFoundAnywhere(t *testing.T) {
-	client := &namespaceAwareCRClient{
-		crByNamespace: map[string]*models.EvalHubCRStatus{},
+	discoverer := &mockCRDiscoverer{
+		serviceURL: "", // no CR found
 	}
 
-	app := newTestApp(client, "redhat-ods-applications")
+	app := newTestAppWithDiscoverer(discoverer, "redhat-ods-applications")
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
 	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
 
@@ -110,16 +77,11 @@ func TestEvalHubServiceURL_CRNotFoundAnywhere(t *testing.T) {
 }
 
 func TestEvalHubServiceURL_NoUserNamespaceInContext(t *testing.T) {
-	client := &namespaceAwareCRClient{
-		crByNamespace: map[string]*models.EvalHubCRStatus{
-			"opendatahub": {
-				Name: "evalhub", Namespace: "opendatahub", Phase: "Ready",
-				URL: "http://evalhub.odh.svc:8080",
-			},
-		},
+	discoverer := &mockCRDiscoverer{
+		serviceURL: "http://evalhub.odh.svc:8080",
 	}
 
-	app := newTestApp(client, "opendatahub")
+	app := newTestAppWithDiscoverer(discoverer, "opendatahub")
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
 
 	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
@@ -129,85 +91,23 @@ func TestEvalHubServiceURL_NoUserNamespaceInContext(t *testing.T) {
 	assert.Equal(t, "http://evalhub.odh.svc:8080", serviceURL)
 }
 
-func TestEvalHubServiceURL_ForbiddenInUserNS_FallsThroughToDashboard(t *testing.T) {
-	forbiddenErr := k8serrors.NewForbidden(
-		schema.GroupResource{Group: "trustyai.opendatahub.io", Resource: "evalhubs"},
-		"", fmt.Errorf("user cannot list evalhubs"),
-	)
-	client := &namespaceAwareCRClient{
-		errByNS: map[string]error{
-			"user-project": fmt.Errorf("failed to list EvalHub CRs: %w", forbiddenErr),
-		},
-		crByNamespace: map[string]*models.EvalHubCRStatus{
-			"redhat-ods-applications": {
-				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
-				URL: "http://evalhub.platform.svc:8080",
-			},
-		},
+func TestEvalHubServiceURL_SADiscoveryError_SurfacedImmediately(t *testing.T) {
+	discoverer := &mockCRDiscoverer{
+		urlErr: fmt.Errorf("failed to list EvalHub CRs cluster-wide: connection refused"),
 	}
 
-	app := newTestApp(client, "redhat-ods-applications")
-	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
-	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
-
-	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
-
-	require.NoError(t, err)
-	assert.False(t, crNotFound)
-	assert.Equal(t, "http://evalhub.platform.svc:8080", serviceURL)
-}
-
-func TestEvalHubServiceURL_ForbiddenInUserNS_NoCRAnywhere(t *testing.T) {
-	forbiddenErr := k8serrors.NewForbidden(
-		schema.GroupResource{Group: "trustyai.opendatahub.io", Resource: "evalhubs"},
-		"", fmt.Errorf("user cannot list evalhubs"),
-	)
-	client := &namespaceAwareCRClient{
-		errByNS: map[string]error{
-			"user-project": fmt.Errorf("failed to list EvalHub CRs: %w", forbiddenErr),
-		},
-		crByNamespace: map[string]*models.EvalHubCRStatus{},
-	}
-
-	app := newTestApp(client, "redhat-ods-applications")
-	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
-	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
-
-	serviceURL, _, crNotFound, err := app.evalHubServiceURL(ctx)
-
-	require.NoError(t, err)
-	assert.True(t, crNotFound)
-	assert.Empty(t, serviceURL)
-}
-
-func TestEvalHubServiceURL_OperationalErrorInUserNS_SurfacedImmediately(t *testing.T) {
-	client := &namespaceAwareCRClient{
-		errByNS: map[string]error{
-			"user-project": fmt.Errorf("failed to create dynamic client: connection refused"),
-		},
-		crByNamespace: map[string]*models.EvalHubCRStatus{
-			"redhat-ods-applications": {
-				Name: "evalhub", Namespace: "redhat-ods-applications", Phase: "Ready",
-				URL: "http://evalhub.platform.svc:8080",
-			},
-		},
-	}
-
-	app := newTestApp(client, "redhat-ods-applications")
+	app := newTestAppWithDiscoverer(discoverer, "redhat-ods-applications")
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
 	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
 
 	_, _, _, err := app.evalHubServiceURL(ctx)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "user-project")
 	assert.Contains(t, err.Error(), "connection refused")
 }
 
 func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {
-	client := &namespaceAwareCRClient{}
-
-	app := newTestApp(client, "redhat-ods-applications")
+	app := newTestAppWithDiscoverer(nil, "redhat-ods-applications")
 	app.config.EvalHubURL = "http://override:9090"
 	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
 	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
@@ -217,6 +117,17 @@ func TestEvalHubServiceURL_EnvOverrideBypassesCRDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, crNotFound)
 	assert.Equal(t, "http://override:9090", serviceURL)
+}
+
+func TestEvalHubServiceURL_NilDiscoverer_ReturnsError(t *testing.T) {
+	app := newTestAppWithDiscoverer(nil, "redhat-ods-applications")
+	ctx := context.WithValue(context.Background(), constants.RequestIdentityKey, &kubernetes.RequestIdentity{UserID: "user@test.com", Token: "tok"})
+	ctx = context.WithValue(ctx, constants.NamespaceHeaderParameterKey, "user-project")
+
+	_, _, _, err := app.evalHubServiceURL(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SA-based CR discoverer is not available")
 }
 
 func TestAttachNamespace_ValidNamespace(t *testing.T) {

--- a/packages/eval-hub/bff/internal/api/test_app.go
+++ b/packages/eval-hub/bff/internal/api/test_app.go
@@ -14,6 +14,7 @@ func NewTestApp( //nolint:unused
 	cfg config.EnvConfig,
 	logger *slog.Logger,
 	k8sFactory k8s.KubernetesClientFactory,
+	crDiscoverer k8s.EvalHubCRDiscoverer,
 	ehFactory evalhub.EvalHubClientFactory,
 	repos *repositories.Repositories,
 ) *App {
@@ -24,6 +25,7 @@ func NewTestApp( //nolint:unused
 		config:                  cfg,
 		logger:                  logger,
 		kubernetesClientFactory: k8sFactory,
+		crDiscoverer:            crDiscoverer,
 		evalHubClientFactory:    ehFactory,
 		repositories:            repos,
 	}

--- a/packages/eval-hub/bff/internal/api/test_utils.go
+++ b/packages/eval-hub/bff/internal/api/test_utils.go
@@ -52,6 +52,22 @@ func (f *crStatusK8sFactory) ValidateRequestIdentity(_ *kubernetes.RequestIdenti
 	return nil
 }
 
+// mockCRDiscoverer is a test double for EvalHubCRDiscoverer.
+type mockCRDiscoverer struct {
+	serviceURL string
+	urlErr     error
+	crStatus   *models.EvalHubCRStatus
+	statusErr  error
+}
+
+func (d *mockCRDiscoverer) DiscoverServiceURL(_ context.Context) (string, error) {
+	return d.serviceURL, d.urlErr
+}
+
+func (d *mockCRDiscoverer) DiscoverCRStatus(_ context.Context) (*models.EvalHubCRStatus, error) {
+	return d.crStatus, d.statusErr
+}
+
 var testLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 // setupApiTestWithEvalHub exercises handlers that require an EvalHub client in context.
@@ -198,9 +214,9 @@ func (e *erroringEHClient) ListProviders(_ context.Context, _ string, _, _ int) 
 }
 
 // setupApiTestForHealth exercises the EvalHub service health handler with injectable
-// CR discovery (via the user's bearer token) and EvalHub client behaviour.
+// SA-based CR discovery and EvalHub client behaviour.
 //
-//   - crStatus / crErr control what GetEvalHubCRStatus returns for the test.
+//   - crStatus / crErr control what the SA discoverer returns for the test.
 //   - ehClient controls the EvalHub REST client used for the service ping; pass nil to use
 //     the default mock (healthy response).
 func setupApiTestForHealth[T any](
@@ -224,17 +240,69 @@ func setupApiTestForHealth[T any](
 		mockFactory.SetMockClient(ehClient)
 	}
 
-	k8sClient := &crStatusOverrideK8sClient{
-		fn: func(_ context.Context, _ *kubernetes.RequestIdentity, _ string) (*models.EvalHubCRStatus, error) {
-			return crStatus, crErr
-		},
+	var serviceURL string
+	if crStatus != nil {
+		serviceURL = crStatus.URL
 	}
 
 	app := &App{
 		config:                  config.EnvConfig{AllowedOrigins: []string{"*"}, AuthMethod: config.AuthMethodInternal},
 		logger:                  testLogger,
-		kubernetesClientFactory: &crStatusK8sFactory{client: k8sClient},
+		kubernetesClientFactory: &testK8sFactory{},
+		crDiscoverer:            &mockCRDiscoverer{serviceURL: serviceURL, urlErr: crErr, crStatus: crStatus, statusErr: crErr},
 		evalHubClientFactory:    mockFactory,
+		repositories:            repositories.NewRepositories(),
+		dashboardNamespace:      "test-dashboard-ns",
+	}
+
+	ctx := context.WithValue(req.Context(), constants.RequestIdentityKey, identity)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	app.Routes().ServeHTTP(rr, req)
+	res := rr.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return empty, nil, err
+	}
+	if len(data) == 0 {
+		return empty, res, nil
+	}
+	var out T
+	if err := json.Unmarshal(data, &out); err != nil && err != io.EOF {
+		return empty, nil, err
+	}
+	return out, res, nil
+}
+
+// setupApiTestForCRStatus exercises the EvalHub CR status handler with injectable K8s factory
+// and SA discoverer.
+func setupApiTestForCRStatus[T any](
+	method, url string,
+	identity *kubernetes.RequestIdentity,
+	k8Factory kubernetes.KubernetesClientFactory,
+	discoverer kubernetes.EvalHubCRDiscoverer,
+) (T, *http.Response, error) {
+	var empty T
+	req, err := http.NewRequest(method, url, http.NoBody)
+	if err != nil {
+		return empty, nil, err
+	}
+	if identity != nil && identity.UserID != "" {
+		req.Header.Set(constants.KubeflowUserIDHeader, identity.UserID)
+	}
+
+	if k8Factory == nil {
+		k8Factory = &testK8sFactory{}
+	}
+
+	app := &App{
+		config:                  config.EnvConfig{AllowedOrigins: []string{"*"}, AuthMethod: config.AuthMethodInternal},
+		logger:                  testLogger,
+		kubernetesClientFactory: k8Factory,
+		crDiscoverer:            discoverer,
+		evalHubClientFactory:    ehmocks.NewMockClientFactory(),
 		repositories:            repositories.NewRepositories(),
 		dashboardNamespace:      "test-dashboard-ns",
 	}

--- a/packages/eval-hub/bff/internal/integrations/kubernetes/evalhub_discovery.go
+++ b/packages/eval-hub/bff/internal/integrations/kubernetes/evalhub_discovery.go
@@ -1,0 +1,128 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/opendatahub-io/eval-hub/bff/internal/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	helper "github.com/opendatahub-io/eval-hub/bff/internal/helpers"
+)
+
+const crDiscoveryTimeout = 10 * time.Second
+
+// EvalHubCRDiscoverer abstracts cluster-wide EvalHub CR discovery so the App layer
+// can swap in a mock for tests without needing real SA credentials.
+type EvalHubCRDiscoverer interface {
+	// DiscoverServiceURL lists EvalHub CRs across all namespaces using the pod's
+	// service account and returns the service URL from the first found CR.
+	// Returns ("", nil) when no CR exists anywhere in the cluster.
+	DiscoverServiceURL(ctx context.Context) (string, error)
+
+	// DiscoverCRStatus lists EvalHub CRs across all namespaces using the pod's
+	// service account and returns the full status of the first found CR.
+	// Returns (nil, nil) when no CR exists anywhere in the cluster.
+	DiscoverCRStatus(ctx context.Context) (*models.EvalHubCRStatus, error)
+}
+
+// SADiscoverer discovers EvalHub CRs using the pod's service account credentials.
+// This decouples CR discovery (privileged, cluster-wide) from user request auth,
+// matching the pattern used by the MLflow BFF.
+type SADiscoverer struct {
+	logger    *slog.Logger
+	dynClient dynamic.Interface
+}
+
+// NewSADiscoverer creates a discoverer that uses in-cluster SA credentials.
+// Falls back to kubeconfig for local development.
+func NewSADiscoverer(logger *slog.Logger) (*SADiscoverer, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Debug("In-cluster config not available, falling back to kubeconfig", "error", err)
+		cfg, err = helper.GetKubeconfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get kubeconfig for SA discovery: %w", err)
+		}
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client for SA discovery: %w", err)
+	}
+
+	return &SADiscoverer{logger: logger, dynClient: dynClient}, nil
+}
+
+// NewSADiscovererFromClient creates a SADiscoverer with a pre-built dynamic client.
+// Intended for tests that inject a fake dynamic client.
+func NewSADiscovererFromClient(logger *slog.Logger, dynClient dynamic.Interface) *SADiscoverer {
+	return &SADiscoverer{logger: logger, dynClient: dynClient}
+}
+
+func (d *SADiscoverer) DiscoverServiceURL(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, crDiscoveryTimeout)
+	defer cancel()
+
+	list, err := d.dynClient.Resource(EvalHubGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("SA discovery: failed to list EvalHub CRs cluster-wide: %w", err)
+	}
+
+	if len(list.Items) == 0 {
+		d.logger.Debug("SA discovery: no EvalHub CR found in the cluster")
+		return "", nil
+	}
+
+	if len(list.Items) > 1 {
+		d.logger.Warn("SA discovery: multiple EvalHub CRs found cluster-wide, using first",
+			"count", len(list.Items))
+	}
+
+	item := &list.Items[0]
+	status, ok := item.Object["status"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("SA discovery: EvalHub CR %q in namespace %q has no status field",
+			item.GetName(), item.GetNamespace())
+	}
+
+	serviceURL, ok := status["url"].(string)
+	if !ok || strings.TrimSpace(serviceURL) == "" {
+		return "", fmt.Errorf("SA discovery: EvalHub CR %q in namespace %q has no status.url",
+			item.GetName(), item.GetNamespace())
+	}
+
+	d.logger.Debug("SA discovery: resolved EvalHub service URL",
+		"namespace", item.GetNamespace(),
+		"crName", item.GetName(),
+		"serviceURL", serviceURL)
+
+	return serviceURL, nil
+}
+
+func (d *SADiscoverer) DiscoverCRStatus(ctx context.Context) (*models.EvalHubCRStatus, error) {
+	ctx, cancel := context.WithTimeout(ctx, crDiscoveryTimeout)
+	defer cancel()
+
+	list, err := d.dynClient.Resource(EvalHubGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("SA discovery: failed to list EvalHub CRs cluster-wide: %w", err)
+	}
+
+	if len(list.Items) == 0 {
+		d.logger.Debug("SA discovery: no EvalHub CR found in the cluster")
+		return nil, nil
+	}
+
+	if len(list.Items) > 1 {
+		d.logger.Warn("SA discovery: multiple EvalHub CRs found cluster-wide, using first",
+			"count", len(list.Items))
+	}
+
+	return ParseEvalHubCRStatus(&list.Items[0])
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
Issue: https://redhat.atlassian.net/browse/RHOAIENG-67669

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Use SA-based cluster-wide CR discovery for multi-tenancy

EvalHub CR discovery used the user's bearer token and only searched the user's namespace + the dashboard namespace. When the CR lived in a custom namespace (not a platform namespace), tenant namespaces could not discover it — breaking multi-tenancy.

Switch to service-account-based cluster-wide discovery (matching the MLflow BFF pattern) so the CR is found regardless of which namespace it was created in. User tokens are still used for SAR checks and EvalHub REST client auth.

- Add SADiscoverer using rest.InClusterConfig() for cluster-wide CR listing
- Update evalHubServiceURL middleware to use SA discovery
- Add cluster-wide fallback to EvalHubCRStatusHandler
- Grant SA list/get on trustyai.opendatahub.io/evalhubs in ClusterRole
- Update tests for cross-tenant discovery scenarios

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on cluster

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster-wide EvalHub discovery using the pod's service account, with fallback when not present in the user namespace.

* **Refactor**
  * EvalHub service URL/status resolution now relies on service-account-based cluster discovery instead of per-request token lookups.

* **Chores / Security**
  * Added RBAC permission to permit cluster-wide EvalHub discovery.

* **Tests**
  * Added and updated tests covering cluster-wide discovery, fallback, and error cases.

* **Documentation**
  * Updated handler and middleware docs to describe the new discovery precedence and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->