### PR TITLE
Fix(RHOAIENG-58677): Global search issues and lineage toolbar filtering improvements

### DIFF
--- a/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
+++ b/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
@@ -1,0 +1,373 @@
+/* eslint-disable camelcase */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  mockGlobalSearchResponse,
+  mockGlobalSearchPagination,
+  mockGlobalSearchResult,
+} from '../../__mocks__/mockGlobalSearch';
+import { mockFeatureStoreProject } from '../../__mocks__/mockFeatureStoreProject';
+import { ProjectList } from '../../types/featureStoreProjects';
+import { GlobalSearchResponse } from '../../types/search';
+import { useFeatureStoreSearch } from '../useFeatureStoreSearch';
+
+jest.mock('../useGlobalSearch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../useFeatureStoreProjects', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockUseGlobalSearch = jest.mocked(require('../useGlobalSearch').default);
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockUseFeatureStoreProjects = jest.mocked(require('../useFeatureStoreProjects').default);
+
+const mockSearch = jest.fn();
+
+const mockProjectList: ProjectList = {
+  projects: [mockFeatureStoreProject({ spec: { name: 'project-1' } })],
+  pagination: {
+    page: 1,
+    limit: 10,
+    total_count: 1,
+    total_pages: 1,
+    has_next: false,
+    has_previous: false,
+  },
+};
+
+const emptyProjectList: ProjectList = {
+  projects: [],
+  pagination: {
+    page: 0,
+    limit: 0,
+    total_count: 0,
+    total_pages: 0,
+    has_next: false,
+    has_previous: false,
+  },
+};
+
+const makeProjectsState = (overrides?: Partial<{ projects: ProjectList; loaded: boolean }>) => ({
+  data: overrides?.projects ?? mockProjectList,
+  loaded: overrides?.loaded ?? true,
+  error: undefined,
+  refresh: jest.fn(),
+});
+
+describe('useFeatureStoreSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseGlobalSearch.mockReturnValue({ search: mockSearch, apiAvailable: true });
+    mockUseFeatureStoreProjects.mockReturnValue(makeProjectsState());
+  });
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => useFeatureStoreSearch());
+
+    expect(result.current.convertedSearchData).toEqual([]);
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.isLoadingMore).toBe(false);
+    expect(result.current.hasMorePages).toBe(false);
+    expect(result.current.totalCount).toBe(0);
+    expect(result.current.searchErrors).toEqual([]);
+  });
+
+  describe('handleSearchChange', () => {
+    it('should reset state when query is empty', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [mockGlobalSearchResult({ name: 'user_id' })],
+          pagination: mockGlobalSearchPagination({ totalCount: 1 }),
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+      expect(result.current.convertedSearchData).toHaveLength(1);
+
+      await act(async () => {
+        await result.current.handleSearchChange('');
+      });
+
+      expect(result.current.convertedSearchData).toEqual([]);
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.searchErrors).toEqual([]);
+    });
+
+    it.each([
+      [
+        'API is unavailable',
+        () => mockUseGlobalSearch.mockReturnValue({ search: mockSearch, apiAvailable: false }),
+      ],
+      [
+        'no projects are available',
+        () =>
+          mockUseFeatureStoreProjects.mockReturnValue(
+            makeProjectsState({ projects: emptyProjectList, loaded: true }),
+          ),
+      ],
+    ])('should not fire search and clear isSearching when %s', async (_, setup) => {
+      setup();
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+
+      expect(mockSearch).not.toHaveBeenCalled();
+      expect(result.current.isSearching).toBe(false);
+    });
+
+    it('should update results, pagination, and map result shape on successful search', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [
+            mockGlobalSearchResult({
+              name: 'user_id',
+              type: 'entity',
+              description: 'Unique user identifier',
+              project: 'project-1',
+              matched_tags: { team: 'platform' },
+            }),
+            mockGlobalSearchResult({ name: 'credit_score', type: 'feature' }),
+          ],
+          pagination: mockGlobalSearchPagination({ totalCount: 2, hasNext: true }),
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+
+      expect(result.current.convertedSearchData).toHaveLength(2);
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.totalCount).toBe(2);
+      expect(result.current.hasMorePages).toBe(true);
+      expect(result.current.searchErrors).toEqual([]);
+
+      const first = result.current.convertedSearchData[0];
+      expect(first.title).toBe('user_id');
+      expect(first.description).toBe('Unique user identifier');
+      expect(first.type).toBe('entity');
+      expect(first.project).toBe('project-1');
+      expect(first.matched_tags).toEqual({ team: 'platform' });
+      expect(first.id).toContain('project-1-entity-user_id');
+
+      expect(result.current.convertedSearchData[1].title).toBe('credit_score');
+    });
+
+    it('should surface API errors returned alongside results', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [],
+          pagination: mockGlobalSearchPagination({ totalCount: 0 }),
+          errors: ['Search service temporarily unavailable', 'Index rebuild in progress'],
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+
+      expect(result.current.searchErrors).toEqual([
+        'Search service temporarily unavailable',
+        'Index rebuild in progress',
+      ]);
+    });
+
+    it('should discard results from a superseded search (race condition fix)', async () => {
+      let resolveFirst!: (value: GlobalSearchResponse) => void;
+      let resolveSecond!: (value: GlobalSearchResponse) => void;
+
+      const firstPromise = new Promise<GlobalSearchResponse>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const secondPromise = new Promise<GlobalSearchResponse>((resolve) => {
+        resolveSecond = resolve;
+      });
+
+      mockSearch.mockReturnValueOnce(firstPromise).mockReturnValueOnce(secondPromise);
+
+      const firstResponse = mockGlobalSearchResponse({
+        results: [mockGlobalSearchResult({ name: 'stale_result' })],
+        pagination: mockGlobalSearchPagination({ totalCount: 1 }),
+      });
+      const secondResponse = mockGlobalSearchResponse({
+        results: [mockGlobalSearchResult({ name: 'fresh_result' })],
+        pagination: mockGlobalSearchPagination({ totalCount: 1 }),
+      });
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      // Fire both searches without awaiting to simulate rapid consecutive keystrokes
+      act(() => {
+        void result.current.handleSearchChange('first');
+      });
+      act(() => {
+        void result.current.handleSearchChange('second');
+      });
+
+      // Resolve the second (newer) search first
+      await act(async () => {
+        resolveSecond(secondResponse);
+      });
+
+      expect(result.current.convertedSearchData).toHaveLength(1);
+      expect(result.current.convertedSearchData[0].title).toBe('fresh_result');
+      expect(result.current.isSearching).toBe(false);
+
+      // Now resolve the first (stale) search — its results must be discarded
+      await act(async () => {
+        resolveFirst(firstResponse);
+      });
+
+      expect(result.current.convertedSearchData).toHaveLength(1);
+      expect(result.current.convertedSearchData[0].title).toBe('fresh_result');
+    });
+
+    it('should reset results on non-abort network error', async () => {
+      mockSearch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+
+      expect(result.current.convertedSearchData).toEqual([]);
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.hasMorePages).toBe(false);
+    });
+
+    it('should clear searchErrors when a new search starts', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({ errors: ['Error from first search'] }),
+      );
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('first');
+      });
+      expect(result.current.searchErrors).toHaveLength(1);
+
+      mockSearch.mockResolvedValueOnce(mockGlobalSearchResponse({ errors: [] }));
+
+      await act(async () => {
+        await result.current.handleSearchChange('second');
+      });
+
+      expect(result.current.searchErrors).toEqual([]);
+    });
+  });
+
+  describe('clearSearch', () => {
+    it('should reset all state to initial values', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [mockGlobalSearchResult({ name: 'user_id' })],
+          pagination: mockGlobalSearchPagination({ totalCount: 1 }),
+          errors: ['some error'],
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+      expect(result.current.convertedSearchData).toHaveLength(1);
+
+      act(() => {
+        result.current.clearSearch();
+      });
+
+      expect(result.current.convertedSearchData).toEqual([]);
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.hasMorePages).toBe(false);
+      expect(result.current.searchErrors).toEqual([]);
+    });
+
+    it('should abort an in-flight search request', async () => {
+      let capturedSignal: AbortSignal | undefined;
+
+      mockSearch.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+        capturedSignal = signal;
+        return new Promise<GlobalSearchResponse>(() => {
+          // intentionally never resolves — simulates a pending in-flight request
+        });
+      });
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      act(() => {
+        void result.current.handleSearchChange('user');
+      });
+
+      await waitFor(() => expect(capturedSignal).toBeDefined());
+
+      act(() => {
+        result.current.clearSearch();
+      });
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(result.current.isSearching).toBe(false);
+    });
+  });
+
+  describe('loadMoreResults', () => {
+    it('should append results and advance page on success', async () => {
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [mockGlobalSearchResult({ name: 'page1_result' })],
+          pagination: mockGlobalSearchPagination({ totalCount: 2, hasNext: true }),
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('user');
+      });
+      expect(result.current.hasMorePages).toBe(true);
+
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [mockGlobalSearchResult({ name: 'page2_result' })],
+          pagination: mockGlobalSearchPagination({ totalCount: 2, hasNext: false }),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.loadMoreResults();
+      });
+
+      expect(result.current.convertedSearchData).toHaveLength(2);
+      expect(result.current.convertedSearchData[1].title).toBe('page2_result');
+      expect(result.current.hasMorePages).toBe(false);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+
+    it('should not fetch when hasMorePages is false', async () => {
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.loadMoreResults();
+      });
+
+      expect(mockSearch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
+++ b/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
@@ -369,5 +369,58 @@ describe('useFeatureStoreSearch', () => {
 
       expect(mockSearch).not.toHaveBeenCalled();
     });
+
+    it('should not overwrite new search results when loadMore fires during the async gap', async () => {
+      // Step 1: complete a pageable search so hasMorePages is true
+      mockSearch.mockResolvedValueOnce(
+        mockGlobalSearchResponse({
+          results: [mockGlobalSearchResult({ name: 'page1_old' })],
+          pagination: mockGlobalSearchPagination({ totalCount: 2, hasNext: true }),
+        }),
+      );
+
+      const { result } = renderHook(() => useFeatureStoreSearch());
+
+      await act(async () => {
+        await result.current.handleSearchChange('old');
+      });
+      expect(result.current.hasMorePages).toBe(true);
+
+      // Step 2: start a new search — keep it pending so hasMorePages is still true
+      let resolveNewSearch!: (value: GlobalSearchResponse) => void;
+      const newSearchPromise = new Promise<GlobalSearchResponse>((resolve) => {
+        resolveNewSearch = resolve;
+      });
+      mockSearch.mockReturnValueOnce(newSearchPromise);
+
+      act(() => {
+        void result.current.handleSearchChange('new');
+      });
+
+      // hasMorePages is now false (reset at start of new search) so loadMore is a no-op
+      expect(result.current.hasMorePages).toBe(false);
+
+      // Step 3: attempt loadMoreResults — it must be blocked by hasMorePages = false
+      await act(async () => {
+        await result.current.loadMoreResults();
+      });
+
+      // Only 2 calls so far: old search + new search. loadMore must NOT have fired.
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+
+      // Step 4: resolve the new search — results should land correctly
+      const newResponse = mockGlobalSearchResponse({
+        results: [mockGlobalSearchResult({ name: 'new_result' })],
+        pagination: mockGlobalSearchPagination({ totalCount: 1, hasNext: false }),
+      });
+
+      await act(async () => {
+        resolveNewSearch(newResponse);
+      });
+
+      expect(result.current.convertedSearchData).toHaveLength(1);
+      expect(result.current.convertedSearchData[0].title).toBe('new_result');
+      expect(result.current.isSearching).toBe(false);
+    });
   });
 });

--- a/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
+++ b/packages/feature-store/src/apiHooks/__tests__/useFeatureStoreSearch.spec.ts
@@ -60,7 +60,7 @@ const makeProjectsState = (overrides?: Partial<{ projects: ProjectList; loaded: 
 
 describe('useFeatureStoreSearch', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     mockUseGlobalSearch.mockReturnValue({ search: mockSearch, apiAvailable: true });
     mockUseFeatureStoreProjects.mockReturnValue(makeProjectsState());
   });

--- a/packages/feature-store/src/apiHooks/useFeatureServiceByName.ts
+++ b/packages/feature-store/src/apiHooks/useFeatureServiceByName.ts
@@ -23,7 +23,7 @@ const useFeatureServiceByName = (
       }
 
       if (!featureServiceName) {
-        return Promise.reject(new Error('Feature name is required'));
+        return Promise.reject(new Error('Feature service name is required'));
       }
 
       return api.getFeatureServiceByName(opts, project, featureServiceName);

--- a/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
+++ b/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import useFeatureStoreProjects from './useFeatureStoreProjects';
 import useGlobalSearch from './useGlobalSearch';
 import { GlobalSearchResponse } from '../types/search';
@@ -19,6 +19,7 @@ export const useFeatureStoreSearch = (): {
   isLoadingMore: boolean;
   hasMorePages: boolean;
   totalCount: number;
+  searchErrors: string[];
   handleSearchChange: (query: string) => Promise<void>;
   loadMoreResults: () => Promise<void>;
   clearSearch: () => void;
@@ -35,21 +36,18 @@ export const useFeatureStoreSearch = (): {
   const [currentPage, setCurrentPage] = useState(1);
   const [hasMorePages, setHasMorePages] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
+  const [searchErrors, setSearchErrors] = useState<string[]>([]);
 
-  const [currentAbortController, setCurrentAbortController] = useState<AbortController | null>(
-    null,
-  );
+  // Use a ref so abort-controller identity is always current inside callbacks,
+  // avoiding stale-closure race conditions that `useState` would introduce.
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const convertedSearchData = useMemo(() => {
-    if (allResults.length === 0) {
+    if (allResults.length === 0 || !Array.isArray(allResults)) {
       return [];
     }
 
-    if (!Array.isArray(allResults)) {
-      return [];
-    }
-
-    const converted = allResults.map((result, index) => ({
+    return allResults.map((result, index) => ({
       id: `${result.project}-${result.type}-${result.name}-${index}`,
       title: result.name,
       description: result.description,
@@ -60,42 +58,47 @@ export const useFeatureStoreSearch = (): {
       // eslint-disable-next-line camelcase
       matched_tags: result.matched_tags,
     }));
-    return converted;
   }, [allResults]);
 
   const handleSearchChange = useCallback(
     async (query: string) => {
       if (!query || !query.trim() || !apiAvailable) {
+        // Abort any in-flight request before resetting state
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort();
+          abortControllerRef.current = null;
+        }
         setAllResults([]);
         setCurrentSearchQuery('');
         setCurrentPage(1);
         setHasMorePages(false);
         setTotalCount(0);
-        return;
-      }
-
-      if (currentSearchQuery === query && isSearching) {
+        setSearchErrors([]);
         return;
       }
 
       // Cancel any existing search request
-      if (currentAbortController) {
-        currentAbortController.abort();
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
       }
 
-      // Create new AbortController for this search
-      const abortController = new AbortController();
-      setCurrentAbortController(abortController);
+      // Create a new controller for this search and capture it locally so
+      // the finally/catch blocks can check identity before mutating state.
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
 
       setCurrentSearchQuery(query);
       setCurrentPage(1);
       setAllResults([]);
       setIsSearching(true);
+      setSearchErrors([]);
 
       try {
         if (!hasAvailableProjects) {
-          setIsSearching(false);
-          setCurrentAbortController(null);
+          if (abortControllerRef.current === controller) {
+            abortControllerRef.current = null;
+            setIsSearching(false);
+          }
           return;
         }
 
@@ -106,35 +109,38 @@ export const useFeatureStoreSearch = (): {
           query,
           page: 1,
           limit: 50,
-          signal: abortController.signal,
+          signal: controller.signal,
         });
 
-        setAllResults(results.results);
-        setHasMorePages(results.pagination.hasNext);
-        setTotalCount(results.pagination.totalCount);
-        setCurrentAbortController(null);
+        // Only update state if this controller is still the active one
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+          setAllResults(results.results);
+          setHasMorePages(results.pagination.hasNext);
+          setTotalCount(results.pagination.totalCount);
+          if (results.errors.length > 0) {
+            setSearchErrors(results.errors);
+          }
+        }
       } catch (error) {
-        // Don't update state if the request was aborted
         if (error instanceof Error && error.name === 'AbortError') {
           return;
         }
-        setAllResults([]);
-        setHasMorePages(false);
-        setTotalCount(0);
-        setCurrentAbortController(null);
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+          setAllResults([]);
+          setHasMorePages(false);
+          setTotalCount(0);
+        }
       } finally {
-        setIsSearching(false);
+        // The try/catch success paths null the ref when done; if it's still null
+        // here we know no newer request has taken over and it's safe to clear loading.
+        if (abortControllerRef.current === null) {
+          setIsSearching(false);
+        }
       }
     },
-    [
-      search,
-      apiAvailable,
-      hasAvailableProjects,
-      featureStoreProjects.projects,
-      currentSearchQuery,
-      isSearching,
-      currentAbortController,
-    ],
+    [search, apiAvailable, hasAvailableProjects, featureStoreProjects.projects],
   );
 
   const loadMoreResults = useCallback(async () => {
@@ -143,9 +149,13 @@ export const useFeatureStoreSearch = (): {
     }
 
     setIsLoadingMore(true);
+
+    // Give load-more its own controller so clear/unmount can cancel it
+    const loadMoreController = new AbortController();
+    abortControllerRef.current = loadMoreController;
+
     try {
       if (!hasAvailableProjects) {
-        setIsLoadingMore(false);
         return;
       }
 
@@ -157,18 +167,23 @@ export const useFeatureStoreSearch = (): {
         query: currentSearchQuery,
         page: nextPage,
         limit: 50,
-        signal: currentAbortController?.signal,
+        signal: loadMoreController.signal,
       });
 
-      setAllResults((prevResults) => [...prevResults, ...results.results]);
-      setCurrentPage(nextPage);
-      setHasMorePages(results.pagination.hasNext);
+      if (abortControllerRef.current === loadMoreController) {
+        abortControllerRef.current = null;
+        setAllResults((prevResults) => [...prevResults, ...results.results]);
+        setCurrentPage(nextPage);
+        setHasMorePages(results.pagination.hasNext);
+      }
     } catch (error) {
-      // Don't log error if the request was aborted
       if (!(error instanceof Error && error.name === 'AbortError')) {
         console.error('Load more search results failed:', error);
       }
     } finally {
+      if (abortControllerRef.current === loadMoreController) {
+        abortControllerRef.current = null;
+      }
       setIsLoadingMore(false);
     }
   }, [
@@ -180,14 +195,12 @@ export const useFeatureStoreSearch = (): {
     currentPage,
     search,
     featureStoreProjects.projects,
-    currentAbortController?.signal,
   ]);
 
   const clearSearch = useCallback(() => {
-    // Cancel any in-flight request
-    if (currentAbortController) {
-      currentAbortController.abort();
-      setCurrentAbortController(null);
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
     }
 
     setAllResults([]);
@@ -197,16 +210,18 @@ export const useFeatureStoreSearch = (): {
     setCurrentPage(1);
     setHasMorePages(false);
     setTotalCount(0);
-  }, [currentAbortController]);
+    setSearchErrors([]);
+  }, []);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (currentAbortController) {
-        currentAbortController.abort();
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
       }
     };
-  }, [currentAbortController]);
+  }, []);
 
   return {
     convertedSearchData,
@@ -214,6 +229,7 @@ export const useFeatureStoreSearch = (): {
     isLoadingMore,
     hasMorePages,
     totalCount,
+    searchErrors,
     handleSearchChange,
     loadMoreResults,
     clearSearch,

--- a/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
+++ b/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
@@ -90,6 +90,8 @@ export const useFeatureStoreSearch = (): {
       setCurrentSearchQuery(query);
       setCurrentPage(1);
       setAllResults([]);
+      setHasMorePages(false);
+      setTotalCount(0);
       setIsSearching(true);
       setSearchErrors([]);
 

--- a/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
+++ b/packages/feature-store/src/apiHooks/useFeatureStoreSearch.ts
@@ -43,7 +43,7 @@ export const useFeatureStoreSearch = (): {
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const convertedSearchData = useMemo(() => {
-    if (allResults.length === 0 || !Array.isArray(allResults)) {
+    if (!Array.isArray(allResults) || allResults.length === 0) {
       return [];
     }
 
@@ -73,6 +73,7 @@ export const useFeatureStoreSearch = (): {
         setCurrentPage(1);
         setHasMorePages(false);
         setTotalCount(0);
+        setIsSearching(false);
         setSearchErrors([]);
         return;
       }

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/GlobalSearchInput.tsx
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/GlobalSearchInput.tsx
@@ -29,7 +29,7 @@ import FeatureStoreLabels from '../FeatureStoreLabels';
 const highlightText = (textContent: string, searchTerm: string): React.ReactNode => {
   if (!searchTerm.trim()) return textContent;
 
-  const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+  const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'i');
   const parts = textContent.split(regex);
 
   return parts.map((part, index) =>

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/hooks/useSearchHandlers.ts
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/hooks/useSearchHandlers.ts
@@ -62,6 +62,10 @@ export const useSearchHandlers = (
       setSearchValue(trimmedValue);
 
       if (trimmedValue === '') {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = undefined;
+        }
         if (onClear) {
           onClear();
         }
@@ -99,6 +103,10 @@ export const useSearchHandlers = (
   );
 
   const handleSearchClear = React.useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
     setSearchValue('');
     setIsSearching(false);
     if (onClear) {
@@ -109,6 +117,10 @@ export const useSearchHandlers = (
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && (state.isSearchOpen || state.searchValue.trim() !== '')) {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = undefined;
+        }
         setSearchValue('');
         setIsSearchOpen(false);
         setIsSearching(false);
@@ -138,6 +150,10 @@ export const useSearchHandlers = (
         !searchInputRef.current.contains(target) &&
         !searchMenuRef.current.contains(target)
       ) {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = undefined;
+        }
         setSearchValue('');
         setIsSearchOpen(false);
         setIsSearching(false);

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/__tests__/searchUtils.spec.ts
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/__tests__/searchUtils.spec.ts
@@ -35,7 +35,7 @@ describe('searchUtils', () => {
 
     it('should return features route for feature type without featureView', () => {
       const result = getFeatureStoreRoute('feature', testProject, testName);
-      expect(result).toBe(`/develop-train/feature-store/features/${testProject}//${testName}`);
+      expect(result).toBe(`/develop-train/feature-store/${testProject}`);
     });
 
     it('should return feature view route for featureView type', () => {

--- a/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/searchUtils.ts
+++ b/packages/feature-store/src/components/FeatureStoreGlobalSearch/utils/searchUtils.ts
@@ -20,7 +20,10 @@ export const getFeatureStoreRoute = (
     case 'dataSource':
       return featureDataSourceRoute(name, project);
     case 'feature':
-      return featureRoute(name, featureView ?? '', project);
+      if (!featureView) {
+        return `/develop-train/feature-store/${project}`;
+      }
+      return featureRoute(name, featureView, project);
     case 'featureView':
       return featureViewRoute(name, project);
     case 'featureService':

--- a/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
+++ b/packages/feature-store/src/components/FeatureStoreLineageToolbar.tsx
@@ -42,7 +42,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
 }) => {
   React.useEffect(() => {
     const hasFilters = Object.values(searchFilters).some(
-      (filter) => filter && filter.trim() !== '',
+      (filter) => Array.isArray(filter) && filter.length > 0,
     );
 
     if (hasFilters) {
@@ -93,7 +93,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
           .filter((s) => s.selected && !s.isAriaDisabled)
           .map((s) => s.name);
         if (selectedNames.length > 0) {
-          newFilters[filterType] = selectedNames.join(', ');
+          newFilters[filterType] = selectedNames;
         } else {
           delete newFilters[filterType];
         }
@@ -105,7 +105,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
 
   const getEntityOptions = useMemo(() => {
     const items = availableOptions.entity;
-    const selectedNames = searchFilters.entity?.split(', ') || [];
+    const selectedNames = searchFilters.entity || [];
 
     if (items.length === 0) {
       return [
@@ -126,7 +126,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
 
   const getFeatureViewOptions = useMemo(() => {
     const items = availableOptions.featureView;
-    const selectedNames = searchFilters.featureView?.split(', ') || [];
+    const selectedNames = searchFilters.featureView || [];
 
     if (items.length === 0) {
       return [
@@ -147,7 +147,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
 
   const getDataSourceOptions = useMemo(() => {
     const items = availableOptions.dataSource;
-    const selectedNames = searchFilters.dataSource?.split(', ') || [];
+    const selectedNames = searchFilters.dataSource || [];
 
     if (items.length === 0) {
       return [
@@ -168,7 +168,7 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
 
   const getFeatureServiceOptions = useMemo(() => {
     const items = availableOptions.featureService;
-    const selectedNames = searchFilters.featureService?.split(', ') || [];
+    const selectedNames = searchFilters.featureService || [];
 
     if (items.length === 0) {
       return [
@@ -256,7 +256,8 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
           delete newFilters[filterType];
         } else {
           const filterValue = typeof value === 'string' ? value : value.value;
-          newFilters[filterType] = filterValue;
+          // Wrap single string from FilterToolbar chip into an array
+          newFilters[filterType] = [filterValue];
         }
         onSearchFiltersChange(newFilters);
       }
@@ -270,13 +271,13 @@ const FeatureStoreLineageToolbar: React.FC<FeatureStoreLineageToolbarProps> = ({
     }
   }, [onSearchFiltersChange]);
 
-  // Memoize filterData to prevent FilterToolbar from remounting
+  // FilterToolbar expects string chip values; join arrays for display only
   const filterData = useMemo(
     () => ({
-      entity: searchFilters.entity,
-      featureView: searchFilters.featureView,
-      dataSource: searchFilters.dataSource,
-      featureService: searchFilters.featureService,
+      entity: searchFilters.entity?.join(', '),
+      featureView: searchFilters.featureView?.join(', '),
+      dataSource: searchFilters.dataSource?.join(', '),
+      featureService: searchFilters.featureService?.join(', '),
     }),
     [
       searchFilters.entity,

--- a/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
+++ b/packages/feature-store/src/screens/lineage/FeatureStoreLineageComponent.tsx
@@ -42,7 +42,6 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
   const [searchFilters, setSearchFilters] = useState<FeatureStoreLineageSearchFilters>({});
   const [currentFilterType, setCurrentFilterType] =
     useState<keyof FeatureStoreLineageSearchFilters>('entity');
-  const [conversionError, setConversionError] = useState<string | null>(null);
   const { triggerCenter, forceCenter } = useLineageCenter();
   const [lineageKey, setLineageKey] = useState(0);
   const featureViewLineageState = useFeatureViewLineage(project, featureViewName);
@@ -66,12 +65,11 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
     [],
   );
 
-  const visualizationData = useMemo(() => {
-    setConversionError(null);
+  const { visualizationData, conversionError } = useMemo(() => {
+    const empty = { nodes: [], edges: [] };
 
     if (!lineageDataLoaded || error) {
-      // Return empty data when loading or error - let the Lineage component handle these states
-      return { nodes: [], edges: [] };
+      return { visualizationData: empty, conversionError: null };
     }
 
     if (featureViewName) {
@@ -89,10 +87,12 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
           searchFilters,
         });
 
-        return filteredResult;
+        return { visualizationData: filteredResult, conversionError: null };
       } catch (err) {
-        setConversionError(`Failed to process feature view lineage data: ${String(err)}`);
-        return { nodes: [], edges: [] };
+        return {
+          visualizationData: empty,
+          conversionError: `Failed to process feature view lineage data: ${String(err)}`,
+        };
       }
     }
 
@@ -108,15 +108,16 @@ const FeatureStoreLineageComponent: React.FC<FeatureStoreLineageComponentProps> 
           searchFilters,
         });
 
-        return filteredResult;
+        return { visualizationData: filteredResult, conversionError: null };
       } catch (err) {
-        setConversionError(`Failed to process lineage data: ${String(err)}`);
-        return { nodes: [], edges: [] };
+        return {
+          visualizationData: empty,
+          conversionError: `Failed to process lineage data: ${String(err)}`,
+        };
       }
     }
 
-    // No data available - return empty data for proper empty state
-    return { nodes: [], edges: [] };
+    return { visualizationData: empty, conversionError: null };
   }, [
     lineageData,
     lineageDataLoaded,

--- a/packages/feature-store/src/screens/lineage/utils.ts
+++ b/packages/feature-store/src/screens/lineage/utils.ts
@@ -196,7 +196,9 @@ export const filterNodesBySearch = (
   data: LineageData,
   searchFilters: FeatureStoreLineageSearchFilters,
 ): LineageData => {
-  const hasActiveFilters = Object.values(searchFilters).some((filter) => filter && filter.trim());
+  const hasActiveFilters = Object.values(searchFilters).some(
+    (filter) => Array.isArray(filter) && filter.length > 0,
+  );
 
   if (!hasActiveFilters) {
     return data;
@@ -209,11 +211,10 @@ export const filterNodesBySearch = (
 
   const matchingNodes = new Set<string>();
 
-  // Helper function to check if node name matches any of the selected values
-  const matchesFilterValues = (nodeName: string, filterValue: string): boolean => {
-    const selectedValues = filterValue.split(', ').map((value) => value.trim().toLowerCase());
+  // Check whether nodeName matches any of the selected filter values
+  const matchesFilterValues = (nodeName: string, filterValues: string[]): boolean => {
     const lowerNodeName = nodeName.toLowerCase();
-    return selectedValues.some((selectedValue) => lowerNodeName.includes(selectedValue));
+    return filterValues.some((value) => lowerNodeName.includes(value.trim().toLowerCase()));
   };
 
   data.nodes.forEach((node) => {
@@ -221,6 +222,7 @@ export const filterNodesBySearch = (
 
     if (
       searchFilters.entity &&
+      searchFilters.entity.length > 0 &&
       fsObjectTypes === 'entity' &&
       matchesFilterValues(name, searchFilters.entity)
     ) {
@@ -229,6 +231,7 @@ export const filterNodesBySearch = (
 
     if (
       searchFilters.featureView &&
+      searchFilters.featureView.length > 0 &&
       fsObjectTypes === 'feature_view' &&
       matchesFilterValues(name, searchFilters.featureView)
     ) {
@@ -237,6 +240,7 @@ export const filterNodesBySearch = (
 
     if (
       searchFilters.dataSource &&
+      searchFilters.dataSource.length > 0 &&
       fsObjectTypes === 'data_source' &&
       matchesFilterValues(name, searchFilters.dataSource)
     ) {
@@ -245,6 +249,7 @@ export const filterNodesBySearch = (
 
     if (
       searchFilters.featureService &&
+      searchFilters.featureService.length > 0 &&
       fsObjectTypes === 'feature_service' &&
       matchesFilterValues(name, searchFilters.featureService)
     ) {

--- a/packages/feature-store/src/types/toolbarTypes.ts
+++ b/packages/feature-store/src/types/toolbarTypes.ts
@@ -54,10 +54,10 @@ export type MultipleLabelForType = Array<{ key: string; onRemove: () => void }>;
 
 // Feature Store Lineage toolbar specific types
 export interface FeatureStoreLineageSearchFilters {
-  entity?: string;
-  featureView?: string;
-  dataSource?: string;
-  featureService?: string;
+  entity?: string[];
+  featureView?: string[];
+  dataSource?: string[];
+  featureService?: string[];
 }
 
 export interface FeatureStoreLineageToolbarProps {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-58677

## Description

Bug fixes for Feature Store global search and lineage toolbar. No new features.

---

### Global Search

- **AbortController moved from `useState` to `useRef`** — state updates are async, so closures inside promise callbacks were holding stale controller references. `useRef` keeps the current value accessible synchronously inside async callbacks.

- **`hasMorePages` not cleared on new search** — if the previous search had more pages, `loadMoreResults` could slip past its guard during the async gap before new results arrived, overwriting the in-flight search's abort controller. Now reset immediately when a new search starts.

- **`setIsSearching(false)` was called twice** — the "no projects" early-return path called it explicitly and `finally` called it again. Removed the redundant one.

- **API errors were silently dropped** — the search API can return soft errors alongside results. Now surfaced via `searchErrors` in the hook return. UI consumer to be wired up in a follow-on.

- **Highlight regex `g` flag removed (`GlobalSearchInput.tsx`)** — `g` makes `RegExp` stateful. Consecutive `.test()` calls alternated `true`/`false`, so every other result in the list wasn't getting highlighted. `split()` finds all occurrences without the flag.

- **`feature` results with no `featureView` navigated to a broken URL (`searchUtils.ts`)** — falls back to the project's Features list page instead.

- **Debounce timer wasn't cancelled on search clear (`useSearchHandlers.ts`)** — typing then immediately clearing would still fire the queued search. Added `clearTimeout` in all clear paths. Also removed the now-dead `featureView ?? ''` fallback.

---

### Lineage

- **`setState` inside `useMemo` removed (`FeatureStoreLineageComponent.tsx`)** — `conversionError` was being set via a state setter inside `useMemo`. Refactored to return `{ visualizationData, conversionError }` directly from the memo.

- **Filter values stored as `string[]` instead of comma-joined strings** — selections were joined with `", "` on write and split on read. Any name containing a comma silently broke filtering. Each value is now its own array element. The `join(', ')` is still used but only for chip display — not for storage or matching.

---

### API hooks

- **Error flash on reload fixed (`useFeatureStoreProjectsAPI.ts`)** — when `apiAvailable` is `false` during initial page load, the hook was rejecting with `Error('API not yet available')`. This caused a visible error banner before the API discovery completed (~200ms later). Changed back to `Promise.resolve(DEFAULT_PROJECT_LIST)` — stays quiet during discovery, loads real data once the API is ready.

- **Wrong error message (`useFeatureServiceByName.ts`)** — "Feature name is required" → "Feature service name is required"

---

## How Has This Been Tested?

- `tsc` and `eslint` pass clean
- Added 13 unit tests for `useFeatureStoreSearch`:
  - Initial state, empty query, API unavailable, no projects
  - Successful search with full result shape validation
  - API error surfacing via `searchErrors`
  - Race condition — stale results from a superseded search are discarded
  - `clearSearch` — state reset and in-flight abort verified
  - `loadMoreResults` — page append and no-op when `hasMorePages` is false
- Existing tests for `useFeatureStoreProjectsAPI` and `searchUtils` still pass
- Manually tested on a local cluster via the port-forwarding script:
  - Page reload no longer shows error flash before API is ready
  - Global search highlights all matching results (not alternating)
  - Selecting a feature result navigates correctly
  - Lineage multi-select filters work and persist correctly

## Test Impact

- **Added:** `useFeatureStoreSearch.spec.ts` — 13 unit tests
- **Updated:** `searchUtils.spec.ts` — corrected expected fallback URL
- **Updated:** `useFeatureStoreProjectsAPI.spec.ts` — whitespace only

Self checklist:

- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search now surfaces error messages when queries fail.

* **Bug Fixes**
  * Improved global search cancellation to prevent outdated results after closing or clearing.
  * Corrected navigation when viewing features without a specific feature view.
  * Updated lineage search filters to use consistent multi-select array values, improving matching and highlighting behavior.
  * Corrected the required-field message for missing feature service name.

* **Tests**
  * Added comprehensive coverage for search lifecycle, pagination, cancellation/race conditions, and updated route generation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->