### PR TITLE
RHOAIENG-68244: Cypress e2e CI fails with File name too long when auto-detected tags are used as results directory name

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -530,6 +530,17 @@ jobs:
       CLUSTER_NAME: ${{ needs.select-cluster.outputs.cluster_name }}
       MATRIX_TAG: ${{ matrix.tag }}
     steps:
+      - name: Validate tag format
+        run: |
+          for tag in $MATRIX_TAG; do
+            if [[ ! "$tag" =~ ^@[a-zA-Z0-9_-]+$ ]]; then
+              echo "❌ Invalid tag format (security): $tag"
+              echo "   Tags must match: ^@[a-zA-Z0-9_-]+$"
+              exit 1
+            fi
+          done
+          echo "✅ Tag format valid: $MATRIX_TAG"
+
       - name: Check Disk Space
         run: |
           echo "📊 Checking available disk space..."
@@ -1259,12 +1270,6 @@ jobs:
           cd frontend
 
           TAG="$MATRIX_TAG"
-          if [[ ! "$TAG" =~ ^[@a-zA-Z0-9_\ -]+$ ]]; then
-            echo "❌ Invalid tag format (security): $TAG"
-            echo "   Tags must contain only: @ a-z A-Z 0-9 _ - space"
-            exit 1
-          fi
-
           if [ ${#TAG} -gt 200 ]; then
             TAG_DIR=$(echo -n "$TAG" | sha256sum | cut -c1-12)
             echo "📁 Tag too long for directory name (${#TAG} chars), using hash: ${TAG_DIR}"

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -528,6 +528,7 @@ jobs:
         tag: ${{ fromJson(needs.get-test-tags.outputs.matrix) }}
     env:
       CLUSTER_NAME: ${{ needs.select-cluster.outputs.cluster_name }}
+      MATRIX_TAG: ${{ matrix.tag }}
     steps:
       - name: Check Disk Space
         run: |
@@ -765,9 +766,9 @@ jobs:
           BASE_PORT=$((4000 + (${{ github.run_id }} % 1000) * 5))
 
           # Add matrix offset to separate concurrent jobs within same PR
-          if [[ "${{ matrix.tag }}" == *"set-1"* ]]; then
+          if [[ "$MATRIX_TAG" == *"set-1"* ]]; then
             MATRIX_OFFSET=0
-          elif [[ "${{ matrix.tag }}" == *"set-2"* ]]; then
+          elif [[ "$MATRIX_TAG" == *"set-2"* ]]; then
             MATRIX_OFFSET=1
           else
             MATRIX_OFFSET=2
@@ -777,7 +778,7 @@ jobs:
           PORT_INFO_DIR="/tmp/gha-ports"
           mkdir -p "$PORT_INFO_DIR"
           
-          echo "📍 Calculated port ${WEBPACK_PORT} for ${{ matrix.tag }} (run_id: ${{ github.run_id }})"
+          echo "📍 Calculated port ${WEBPACK_PORT} for $MATRIX_TAG (run_id: ${{ github.run_id }})"
           
           # SAFE port conflict resolution - only clean orphaned processes
           if lsof -ti:${WEBPACK_PORT} > /dev/null 2>&1; then
@@ -907,7 +908,7 @@ jobs:
           TEST_VARS_FILE="${{ github.workspace }}/packages/cypress/test-variables.yml"
 
           # Extract credentials based on test type
-          if [[ "${{ matrix.tag }}" == "@NonAdmin" ]]; then
+          if [[ "$MATRIX_TAG" == "@NonAdmin" ]]; then
             echo "🔑 Using non-admin credentials (TEST_USER_3) for @NonAdmin tests"
             OC_USERNAME=$(grep -A 10 "^TEST_USER_3:" "$TEST_VARS_FILE" | grep "USERNAME:" | head -1 | sed 's/.*USERNAME: //' | tr -d ' ')
             OC_PASSWORD=$(grep -A 10 "^TEST_USER_3:" "$TEST_VARS_FILE" | grep "PASSWORD:" | head -1 | sed 's/.*PASSWORD: //' | tr -d ' ')
@@ -1257,7 +1258,13 @@ jobs:
         run: |
           cd frontend
 
-          TAG="${{ matrix.tag }}"
+          TAG="$MATRIX_TAG"
+          if [[ ! "$TAG" =~ ^[@a-zA-Z0-9_\ -]+$ ]]; then
+            echo "❌ Invalid tag format (security): $TAG"
+            echo "   Tags must contain only: @ a-z A-Z 0-9 _ - space"
+            exit 1
+          fi
+
           if [ ${#TAG} -gt 200 ]; then
             TAG_DIR=$(echo -n "$TAG" | sha256sum | cut -c1-12)
             echo "📁 Tag too long for directory name (${#TAG} chars), using hash: ${TAG_DIR}"
@@ -1266,7 +1273,7 @@ jobs:
           fi
           echo "TAG_DIR=${TAG_DIR}" >> $GITHUB_ENV
 
-          echo "🧪 Running E2E tests for ${{ matrix.tag }}..."
+          echo "🧪 Running E2E tests for $MATRIX_TAG..."
           echo "🚀 Running tests against live dashboard on port ${WEBPACK_PORT}"
           echo "📌 Tag source: ${{ needs.get-test-tags.outputs.source }}"
 
@@ -1285,13 +1292,13 @@ jobs:
 
           # Set IS_NON_ADMIN_RUN flag for non-admin tests to skip admin-only setup hooks
           EXTRA_CYPRESS_ENV="OC_SERVER=${OC_SERVER},"
-          if [[ "${{ matrix.tag }}" == "@NonAdmin" ]]; then
+          if [[ "$MATRIX_TAG" == "@NonAdmin" ]]; then
             EXTRA_CYPRESS_ENV="${EXTRA_CYPRESS_ENV}IS_NON_ADMIN_RUN=true,"
             echo "🔐 Running in non-admin mode - admin setup hooks will be skipped"
           fi
 
           BASE_URL=http://localhost:${WEBPACK_PORT} npm run cypress:run:chrome -- \
-            --env ${EXTRA_CYPRESS_ENV}skipTags="@Bug @Maintain @NonConcurrent",grepTags="${{ matrix.tag }}",grepFilterSpecs=true \
+            --env ${EXTRA_CYPRESS_ENV}skipTags="@Bug @Maintain @NonConcurrent",grepTags="${MATRIX_TAG}",grepFilterSpecs=true \
             --config video=true,screenshotsFolder="$CY_RESULTS_DIR/screenshots",videosFolder="$CY_RESULTS_DIR/videos"
 
       - name: Upload test results
@@ -1310,7 +1317,7 @@ jobs:
         run: |
           echo "🏁 E2E Test completed!"
           echo "Status: ${{ job.status }}"
-          echo "Test Tag: ${{ matrix.tag }}"
+          echo "Test Tag: $MATRIX_TAG"
           echo "Cluster: $CLUSTER_NAME"
           echo "Run ID: ${{ github.run_id }}"
 

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -532,10 +532,14 @@ jobs:
     steps:
       - name: Validate tag format
         run: |
+          if [[ -z "$MATRIX_TAG" ]]; then
+            echo "❌ MATRIX_TAG is empty or unset"
+            exit 1
+          fi
           for tag in $MATRIX_TAG; do
-            if [[ ! "$tag" =~ ^@[a-zA-Z0-9_-]+$ ]]; then
-              echo "❌ Invalid tag format (security): $tag"
-              echo "   Tags must match: ^@[a-zA-Z0-9_-]+$"
+            if [[ ! "$tag" =~ ^@[a-zA-Z0-9_.:-]+$ ]]; then
+              echo "❌ Invalid tag format: $tag"
+              echo "   Tags must match: ^@[a-zA-Z0-9_.:-]+$"
               exit 1
             fi
           done

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -1257,11 +1257,20 @@ jobs:
         run: |
           cd frontend
 
+          TAG="${{ matrix.tag }}"
+          if [ ${#TAG} -gt 200 ]; then
+            TAG_DIR=$(echo -n "$TAG" | sha256sum | cut -c1-12)
+            echo "📁 Tag too long for directory name (${#TAG} chars), using hash: ${TAG_DIR}"
+          else
+            TAG_DIR="$TAG"
+          fi
+          echo "TAG_DIR=${TAG_DIR}" >> $GITHUB_ENV
+
           echo "🧪 Running E2E tests for ${{ matrix.tag }}..."
           echo "🚀 Running tests against live dashboard on port ${WEBPACK_PORT}"
           echo "📌 Tag source: ${{ needs.get-test-tags.outputs.source }}"
 
-          export CY_RESULTS_DIR="${{ github.workspace }}/packages/cypress/results/${{ matrix.tag }}"
+          export CY_RESULTS_DIR="${{ github.workspace }}/packages/cypress/results/${TAG_DIR}"
           mkdir -p "$CY_RESULTS_DIR"
 
           # Determine OC_SERVER based on cluster (for oc user switching in tests)
@@ -1289,7 +1298,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: e2e-results-${{ matrix.tag }}
+          name: e2e-results-${{ env.TAG_DIR }}
           path: |
             packages/cypress/results/
             packages/cypress/videos/


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-68244

<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

When a PR triggers many auto-detected Cypress tags, they get consolidated into a single space-separated string (e.g., `@AgentOpsCI @AutoMLCI @AutoRAGCI @ConnectionTypesCI ...`) used as `matrix.tag`. This string is used directly as the results directory name and artifact name in the e2e workflow, exceeding the Linux 255-character filename limit and causing `mkdir` to fail with "File name too long".

This fix computes a short 12-character SHA256 hash of the tag string when it exceeds 200 characters, and uses that as the directory/artifact name instead. Short/single tags (e.g., `@NonAdmin`) remain human-readable since they stay under the threshold.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  - Verified the hash logic locally: `echo -n "@AgentOpsCI @AutoMLCI ..." | sha256sum | cut -c1-12` produces a stable, deterministic 12-char identifier
  - The workflow file change cannot be tested via PR CI since GitHub Actions reads workflow definitions from the base branch (`main`) for `pull_request` events — the fix takes effect after merge

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added — this is a CI workflow fix, not application code. The change is a shell conditional in a GitHub Actions step with no corresponding unit test infrastructure.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [X] The developer has manually tested the changes and verified that the changes work
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [X] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI tag handling and added validation to enforce tag format.
  * Test selection and test-run configuration now follow the provided tag value.
  * Test results are organized into a normalized directory name (handles very long tags) for reliable storage.
  * Uploaded test artifacts use matching, normalized names to improve traceability.
  * Completion logs now display the test tag for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->