### PR TITLE
Sync from kubeflow/model-registry 3e8c430

### DIFF
--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "fc33e5495dbd839f2ec2d448e7123142b623b802"
+    "commit": "cc51e0b894c39cabdfac6db080ad67b9e8ea1336"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "dfd94a2e94879ba388a288b47270e30360276c9e"
+    "commit": "61f7858d82df30e27f7fe58e139c9634264f71b6"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "1ba1925a4c50c9c2a5456fd17ec8da5cba895839"
+    "commit": "fc33e5495dbd839f2ec2d448e7123142b623b802"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "6ba366d051a496bba4f1b3052d27d4c61cdabb5f"
+    "commit": "51d089d03c5b898ff6be9701768f1194a0db2d55"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "b89ec4f4d7b5efc04dc4c3a0c579f3597af27912"
+    "commit": "9c24b29a78d5dc89e4b4b1fdf8f03d3964a2dde0"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "61f7858d82df30e27f7fe58e139c9634264f71b6"
+    "commit": "6ba366d051a496bba4f1b3052d27d4c61cdabb5f"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "be6e0b3d024bd01bb27f65544f4135532aa997f6"
+    "commit": "3e8c430880aac2fbaf0b26e74d596609a5d95163"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "40fbe26feb3f132f398d1ad3cf7a097ce38fd6e2"
+    "commit": "1ba1925a4c50c9c2a5456fd17ec8da5cba895839"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "6e9c47c5c6dd0e62644b25ea71d3092f51df879c"
+    "commit": "f0ecf6c3d6200d8056c2d43f7e75239722c275b2"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "842ee5a6d0b3f8d69f06122b701964fd2c7657ad"
+    "commit": "6d11dfb73939bd7e27769956c06c960b8854de72"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "6d11dfb73939bd7e27769956c06c960b8854de72"
+    "commit": "b89ec4f4d7b5efc04dc4c3a0c579f3597af27912"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "51d089d03c5b898ff6be9701768f1194a0db2d55"
+    "commit": "9ef971441ccb25d4f84b2c630166f26fddd6dab5"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "a0f8d69238fe60046959842b4a6420c8a9933df6"
+    "commit": "dfd94a2e94879ba388a288b47270e30360276c9e"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "9ef971441ccb25d4f84b2c630166f26fddd6dab5"
+    "commit": "842ee5a6d0b3f8d69f06122b701964fd2c7657ad"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "cc51e0b894c39cabdfac6db080ad67b9e8ea1336"
+    "commit": "6e9c47c5c6dd0e62644b25ea71d3092f51df879c"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "9c24b29a78d5dc89e4b4b1fdf8f03d3964a2dde0"
+    "commit": "40fbe26feb3f132f398d1ad3cf7a097ce38fd6e2"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/package.json
+++ b/packages/model-registry/package.json
@@ -23,7 +23,7 @@
     "branch": "main",
     "src": "clients/ui",
     "target": "upstream",
-    "commit": "f0ecf6c3d6200d8056c2d43f7e75239722c275b2"
+    "commit": "be6e0b3d024bd01bb27f65544f4135532aa997f6"
   },
   "module-federation": {
     "name": "modelRegistry",

--- a/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
+++ b/packages/model-registry/upstream/bff/internal/mocks/static_data_mock.go
@@ -2060,12 +2060,28 @@ func GetFilterOptionMocks() map[string]models.FilterOption {
 		},
 	}
 
-	// Cold-start load time in milliseconds
-	filterOptions["artifacts.cold_start_load_time_seconds.double_value"] = models.FilterOption{
+	// Cold-start load time in seconds
+	filterOptions["artifacts.cold_start_time_to_load_seconds.double_value"] = models.FilterOption{
 		Type: FilterOptionTypeNumber,
 		Range: &models.FilterRange{
-			Min: float32Ptr(45000),
-			Max: float32Ptr(200000),
+			Min: float32Ptr(47.2),
+			Max: float32Ptr(145.7),
+		},
+	}
+
+	filterOptions["min_vram_gb.double_value"] = models.FilterOption{
+		Type: FilterOptionTypeNumber,
+		Range: &models.FilterRange{
+			Min: float32Ptr(8),
+			Max: float32Ptr(140),
+		},
+	}
+
+	filterOptions["modelcar_image_size.double_value"] = models.FilterOption{
+		Type: FilterOptionTypeNumber,
+		Range: &models.FilterRange{
+			Min: float32Ptr(4),
+			Max: float32Ptr(230),
 		},
 	}
 
@@ -2288,7 +2304,7 @@ func GetNamedQueriesMocks() map[string]map[string]models.FieldFilter {
 			Operator: "<=",
 			Value:    float64(892.6553726196289),
 		},
-		"artifacts.cold_start_load_time_seconds.double_value": {
+		"artifacts.cold_start_time_to_load_seconds.double_value": {
 			Operator: "<=",
 			Value:    "max",
 		},

--- a/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
+++ b/packages/model-registry/upstream/frontend/src/__mocks__/mockCatalogFilterOptionsList.ts
@@ -28,7 +28,7 @@ export const mockNamedQueries: Record<string, NamedQuery> = {
       operator: FilterOperator.LESS_THAN_OR_EQUAL,
       value: 'max', // 'max' means use the max value from the range in filters (300 in mock)
     },
-    [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: {
+    [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: {
       operator: FilterOperator.LESS_THAN_OR_EQUAL,
       value: 'max',
     },
@@ -140,11 +140,11 @@ export const mockCatalogFilterOptionsList = (
         max: 300,
       },
     },
-    [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: {
+    [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: {
       type: 'number',
       range: {
-        min: 45000,
-        max: 200000,
+        min: 32,
+        max: 96,
       },
     },
     // All latency metric combinations for dropdown options (using full filter key format)
@@ -211,6 +211,14 @@ export const mockCatalogFilterOptionsList = (
     'artifacts.itl_p99.double_value': {
       type: 'number' as const,
       range: { min: 15, max: 200 },
+    },
+    [ModelCatalogNumberFilterKey.MIN_VRAM]: {
+      type: 'number' as const,
+      range: { min: 8, max: 140 },
+    },
+    [ModelCatalogNumberFilterKey.IMAGE_SIZE]: {
+      type: 'number' as const,
+      range: { min: 4, max: 230 },
     },
   },
   namedQueries: mockNamedQueries,

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/pages/modelCatalog.ts
@@ -385,7 +385,7 @@ class ModelCatalog {
 
   // Cold start latency filter helpers
   findColdStartLatencyFilter() {
-    return cy.findByTestId('cold-start-latency-filter');
+    return cy.findByTestId('cold-start-load-time-filter');
   }
 
   openColdStartLatencyFilter() {
@@ -394,12 +394,12 @@ class ModelCatalog {
   }
 
   applyColdStartLatencyFilter() {
-    cy.findByTestId('cold-start-latency-apply-filter').click();
+    cy.findByTestId('cold-start-load-time-apply-filter').click();
     return this;
   }
 
   resetColdStartLatencyFilter() {
-    cy.findByTestId('cold-start-latency-reset-filter').click();
+    cy.findByTestId('cold-start-load-time-reset-filter').click();
     return this;
   }
 

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/constants/modelCatalog.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/support/constants/modelCatalog.ts
@@ -16,9 +16,9 @@ export const PERFORMANCE_FILTER_TEST_IDS = {
   latencyReset: 'latency-reset-filter',
   maxRps: 'max-rps-filter',
   maxRpsApply: 'max-rps-apply-filter',
-  coldStartLatency: 'cold-start-latency-filter',
-  coldStartLatencyApply: 'cold-start-latency-apply-filter',
-  coldStartLatencyReset: 'cold-start-latency-reset-filter',
+  coldStartLoadTime: 'cold-start-load-time-filter',
+  coldStartLoadTimeApply: 'cold-start-load-time-apply-filter',
+  coldStartLoadTimeReset: 'cold-start-load-time-reset-filter',
   hardwareTable: 'hardware-configuration-table',
   clearAllFilters: 'clear-all-filters-button',
 } as const;

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -301,7 +301,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
     });
   });
 
-  describe('Cold start latency filter API behavior', () => {
+  describe('Cold start load time filter API behavior', () => {
     it('should include cold_start_load_time_seconds in filterQuery when applied with toggle ON', () => {
       visitWithPerformanceToggle(true);
 

--- a/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
+++ b/packages/model-registry/upstream/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogPerformanceFiltersApi.cy.ts
@@ -32,7 +32,7 @@ const assertPerformanceFiltersVisible = (shouldExist: boolean): void => {
   cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.workloadType).should(assertion);
   cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.latency).should(assertion);
   cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.maxRps).should(assertion);
-  cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLatency).should(assertion);
+  cy.findByTestId(PERFORMANCE_FILTER_TEST_IDS.coldStartLoadTime).should(assertion);
 };
 
 const visitWithPerformanceToggle = (toggleOn: boolean): void => {
@@ -76,7 +76,9 @@ describe('Model Catalog Performance Filters API Behavior', () => {
         expect(url).to.not.include('artifacts.e2e');
         expect(url).to.not.include('artifacts.itl');
         expect(url).to.not.include('artifacts.requests_per_second');
-        expect(url).to.not.include('cold_start_load_time_seconds');
+        expect(url).to.not.include('cold_start_time_to_load_seconds');
+        expect(url).to.not.include('min_vram_gb');
+        expect(url).to.not.include('modelcar_image_size');
         expect(url).to.not.include('targetRPS');
         expect(url).to.not.include('latencyProperty');
 
@@ -159,7 +161,9 @@ describe('Model Catalog Performance Filters API Behavior', () => {
 
         expect(url).to.not.include('artifacts.use_case');
         expect(url).to.not.include('artifacts.ttft');
-        expect(url).to.not.include('cold_start_load_time_seconds');
+        expect(url).to.not.include('cold_start_time_to_load_seconds');
+        expect(url).to.not.include('min_vram_gb');
+        expect(url).to.not.include('modelcar_image_size');
         expect(url).to.not.include('targetRPS');
       });
 
@@ -302,7 +306,7 @@ describe('Model Catalog Performance Filters API Behavior', () => {
   });
 
   describe('Cold start load time filter API behavior', () => {
-    it('should include cold_start_load_time_seconds in filterQuery when applied with toggle ON', () => {
+    it('should include cold_start_time_to_load_seconds in filterQuery when applied with toggle ON', () => {
       visitWithPerformanceToggle(true);
 
       modelCatalog.openColdStartLatencyFilter();
@@ -314,11 +318,11 @@ describe('Model Catalog Performance Filters API Behavior', () => {
 
       cy.wait('@getModelsWithColdStart').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.include('cold_start_load_time_seconds');
+        expect(decodedUrl).to.include('cold_start_time_to_load_seconds');
       });
     });
 
-    it('should NOT include cold_start_load_time_seconds after toggle is turned OFF', () => {
+    it('should NOT include cold_start_time_to_load_seconds after toggle is turned OFF', () => {
       visitWithPerformanceToggle(true);
 
       modelCatalog.openColdStartLatencyFilter();
@@ -333,11 +337,11 @@ describe('Model Catalog Performance Filters API Behavior', () => {
 
       cy.wait('@getModelsWithoutColdStart').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.not.include('cold_start_load_time_seconds');
+        expect(decodedUrl).to.not.include('cold_start_time_to_load_seconds');
       });
     });
 
-    it('should pass cold_start_load_time_seconds as orderBy when cold start sort is selected', () => {
+    it('should pass cold_start_time_to_load_seconds as orderBy when cold start sort is selected', () => {
       visitWithPerformanceToggle(true);
 
       modelCatalog.selectSortOption('sort-option-lowest-cold-start');
@@ -348,8 +352,84 @@ describe('Model Catalog Performance Filters API Behavior', () => {
 
       cy.wait('@getModelsSortedColdStart').then((interception) => {
         const decodedUrl = decodeURIComponent(interception.request.url);
-        expect(decodedUrl).to.include('cold_start_load_time_seconds');
+        expect(decodedUrl).to.include('cold_start_time_to_load_seconds');
         expect(decodedUrl).to.include('sortOrder=ASC');
+      });
+    });
+  });
+
+  describe('Min vRAM and Container size filter API behavior', () => {
+    it('should include min_vram_gb in filterQuery when vRAM filter is applied', () => {
+      visitWithPerformanceToggle(true);
+
+      cy.findByTestId('minimum-vram-filter').scrollIntoView();
+      cy.findByTestId('minimum-vram-filter').click();
+      cy.findByTestId('minimum-vram-apply-filter').should('be.visible').click();
+
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithVramFilter');
+
+      triggerFilterRefresh();
+
+      cy.wait('@getModelsWithVramFilter').then((interception) => {
+        const decodedUrl = decodeURIComponent(interception.request.url);
+        expect(decodedUrl).to.include('min_vram_gb.double_value');
+      });
+    });
+
+    it('should include modelcar_image_size in filterQuery when container size filter is applied', () => {
+      visitWithPerformanceToggle(true);
+
+      cy.findByTestId('container-size-filter').scrollIntoView();
+      cy.findByTestId('container-size-filter').click();
+      cy.findByTestId('container-size-apply-filter').should('be.visible').click();
+
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithContainerSizeFilter');
+
+      triggerFilterRefresh();
+
+      cy.wait('@getModelsWithContainerSizeFilter').then((interception) => {
+        const decodedUrl = decodeURIComponent(interception.request.url);
+        expect(decodedUrl).to.include('modelcar_image_size.double_value');
+      });
+    });
+
+    it('should NOT include min_vram_gb after toggle is turned OFF', () => {
+      visitWithPerformanceToggle(true);
+
+      cy.findByTestId('minimum-vram-filter').scrollIntoView();
+      cy.findByTestId('minimum-vram-filter').click();
+      cy.findByTestId('minimum-vram-apply-filter').should('be.visible').click();
+
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findLoadingState().should('not.exist');
+
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithoutVram');
+
+      triggerFilterRefresh();
+
+      cy.wait('@getModelsWithoutVram').then((interception) => {
+        const decodedUrl = decodeURIComponent(interception.request.url);
+        expect(decodedUrl).to.not.include('min_vram_gb');
+      });
+    });
+
+    it('should NOT include modelcar_image_size after toggle is turned OFF', () => {
+      visitWithPerformanceToggle(true);
+
+      cy.findByTestId('container-size-filter').scrollIntoView();
+      cy.findByTestId('container-size-filter').click();
+      cy.findByTestId('container-size-apply-filter').should('be.visible').click();
+
+      modelCatalog.togglePerformanceView();
+      modelCatalog.findLoadingState().should('not.exist');
+
+      cy.intercept('GET', '**/model_catalog/models*').as('getModelsWithoutContainerSize');
+
+      triggerFilterRefresh();
+
+      cy.wait('@getModelsWithoutContainerSize').then((interception) => {
+        const decodedUrl = decodeURIComponent(interception.request.url);
+        expect(decodedUrl).to.not.include('modelcar_image_size');
       });
     });
   });

--- a/packages/model-registry/upstream/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/context/modelCatalog/ModelCatalogContext.tsx
@@ -49,7 +49,9 @@ const INITIAL_FILTERS: ModelCatalogFilterStates = {
   [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: [],
   [ModelCatalogStringFilterKey.USE_CASE]: [],
   [ModelCatalogNumberFilterKey.MAX_RPS]: undefined,
-  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: undefined,
+  [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: undefined,
+  [ModelCatalogNumberFilterKey.MIN_VRAM]: undefined,
+  [ModelCatalogNumberFilterKey.IMAGE_SIZE]: undefined,
   [ModelCatalogStringFilterKey.TENSOR_TYPE]: [],
   [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: [],
 };
@@ -132,6 +134,8 @@ function useModelCatalogSetup(providerState: CatalogProviderState) {
       baseSetFilterData(latencyKey, undefined);
     });
     baseSetFilterData(ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION, []);
+    baseSetFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, undefined);
+    baseSetFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, undefined);
 
     // Then apply all defaults from namedQueries
     const defaultQuery = filterOptions?.namedQueries?.[DEFAULT_PERFORMANCE_FILTERS_QUERY_NAME];

--- a/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
+++ b/packages/model-registry/upstream/frontend/src/app/hooks/useModelRegistryDashboardConfig.ts
@@ -8,7 +8,7 @@ type ModelRegistryDashboardConfig = {
 const useModelRegistryDashboardConfig = (): ModelRegistryDashboardConfig => {
   const config = React.useContext(DashboardConfigContext);
   return {
-    toolCalling: config?.dashboardConfig.toolCalling ?? true,
+    toolCalling: config === null ? true : (config.dashboardConfig.toolCalling ?? false),
   };
 };
 

--- a/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
+++ b/packages/model-registry/upstream/frontend/src/app/modelCatalogTypes.ts
@@ -101,6 +101,7 @@ export enum CatalogArtifactType {
 export enum MetricsType {
   accuracyMetrics = 'accuracy-metrics',
   performanceMetrics = 'performance-metrics',
+  coldStartMetrics = 'cold-start-metrics',
 }
 
 export enum CategoryName {
@@ -182,9 +183,23 @@ export type CatalogAccuracyMetricsArtifact = Omit<CatalogArtifactBase, 'customPr
   customProperties?: AccuracyMetricsCustomProperties;
 };
 
+export type ColdStartMetricsCustomProperties = {
+  gpu_type?: ModelRegistryCustomPropertyString;
+  gpu_count?: ModelRegistryCustomPropertyInt;
+  cold_start_time_to_load_seconds?: ModelRegistryCustomPropertyDouble;
+  runtime_command?: ModelRegistryCustomPropertyString;
+};
+
+export type CatalogColdStartMetricsArtifact = Omit<CatalogArtifactBase, 'customProperties'> & {
+  artifactType: CatalogArtifactType.metricsArtifact;
+  metricsType: MetricsType.coldStartMetrics;
+  customProperties?: ColdStartMetricsCustomProperties;
+};
+
 export type CatalogMetricsArtifact =
   | CatalogPerformanceMetricsArtifact
-  | CatalogAccuracyMetricsArtifact;
+  | CatalogAccuracyMetricsArtifact
+  | CatalogColdStartMetricsArtifact;
 
 export type CatalogArtifacts = CatalogModelArtifact | CatalogMetricsArtifact;
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationFilterToolbar.tsx
@@ -173,13 +173,13 @@ const HardwareConfigurationFilterToolbar: React.FC<HardwareConfigurationFilterTo
           <ToolbarItem>
             <ColdStartLatencyFilter />
             <Popover
-              bodyContent="The estimated time required to provision hardware resources and initialize the container before the model can accept traffic."
+              bodyContent="Set the maximum acceptable time that it can take for vLLM to load the model. This does not include the time it takes to download the model."
               appendTo={() => document.body}
               position="top"
             >
               <Button
                 variant="plain"
-                aria-label="More info for cold start latency"
+                aria-label="More info for cold start load time"
                 className="pf-v6-u-p-xs"
                 icon={<HelpIcon />}
               />

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableColumns.ts
@@ -358,23 +358,23 @@ export const hardwareConfigColumns: HardwareConfigColumn[] = [
   },
   {
     field: 'cold_start_load_time',
-    label: `Cold start\nlatency`,
+    label: `Cold start load time`,
     info: {
       popover:
-        'The estimated time required to provision hardware resources and initialize the container before the model can accept traffic.',
+        'The time it takes for vLLM to load the model. This does not include the time it takes to download the model.',
       popoverProps: {
         position: 'left',
       },
     },
     sortable: false,
     width: 20,
-    modifier: 'wrap',
   },
   {
     field: 'runtime_command',
     label: 'Runtime Command',
     info: {
-      popover: 'Runtime configuration used to validate this model.',
+      popover:
+        'The vLLM runtime command used to validate the model with the selected hardware configuration.',
       popoverProps: {
         position: 'left',
       },

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/HardwareConfigurationTableRow.tsx
@@ -80,7 +80,7 @@ const HardwareConfigurationTableRow: React.FC<HardwareConfigurationTableRowProps
   const renderModelLevelCell = (field: HardwareConfigColumnField): React.ReactNode => {
     if (field === 'cold_start_load_time') {
       return matchedHardwareConfig
-        ? formatLatency(matchedHardwareConfig.cold_start_time_to_load_seconds * 1000)
+        ? `${matchedHardwareConfig.cold_start_time_to_load_seconds.toFixed(2)} s`
         : EMPTY_CUSTOM_PROPERTY_VALUE;
     }
     if (field === 'runtime_command') {

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogActiveFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogActiveFilters.tsx
@@ -136,15 +136,19 @@ const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         case ModelCatalogNumberFilterKey.MAX_RPS:
           return `${MODEL_CATALOG_FILTER_CHIP_PREFIXES.MAX_RPS} ${value}`;
-        case ModelCatalogNumberFilterKey.COLD_START_LATENCY:
-          return `${MODEL_CATALOG_FILTER_CHIP_PREFIXES.COLD_START_LATENCY} ${value} ms`;
+        case ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME:
+          return `${MODEL_CATALOG_FILTER_CHIP_PREFIXES.COLD_START_LOAD_TIME} ${value} s`;
+        case ModelCatalogNumberFilterKey.MIN_VRAM:
+          return `${MODEL_CATALOG_FILTER_CHIP_PREFIXES.MIN_VRAM} ${value} GB`;
+        case ModelCatalogNumberFilterKey.IMAGE_SIZE:
+          return `${MODEL_CATALOG_FILTER_CHIP_PREFIXES.IMAGE_SIZE} ${value} GB`;
         default:
           return String(value);
       }
     }
 
     const parsed = parseLatencyFilterKey(filterKey);
-    const formattedValue = typeof value === 'number' ? formatLatency(value) : `${value}ms`;
+    const formattedValue = typeof value === 'number' ? formatLatency(value) : `${value}s`;
     return `${parsed.metric} | ${parsed.percentile} | ${formattedValue}`;
   };
 
@@ -237,7 +241,9 @@ const ModelCatalogActiveFilters: React.FC<ModelCatalogActiveFiltersProps> = ({
         const isSingleValuePerformanceFilter =
           filterKey === ModelCatalogStringFilterKey.USE_CASE ||
           filterKey === ModelCatalogNumberFilterKey.MAX_RPS ||
-          filterKey === ModelCatalogNumberFilterKey.COLD_START_LATENCY;
+          filterKey === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME ||
+          filterKey === ModelCatalogNumberFilterKey.MIN_VRAM ||
+          filterKey === ModelCatalogNumberFilterKey.IMAGE_SIZE;
 
         let labels: ToolbarLabel[] = [];
 

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -263,7 +263,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
             {matchedColdStart !== undefined && (
               <Flex direction={{ default: 'column' }}>
                 <span className="pf-v6-u-font-weight-bold" data-testid="validated-model-cold-start">
-                  {formatLatency(matchedColdStart * 1000)}
+                  {matchedColdStart.toFixed(2)} s
                 </span>
                 <Flex alignItems={{ default: 'alignItemsBaseline' }} gap={{ default: 'gapXs' }}>
                   <Content component={ContentVariants.small}>Cold start load time</Content>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogCardBody.tsx
@@ -266,14 +266,13 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                   {formatLatency(matchedColdStart * 1000)}
                 </span>
                 <Flex alignItems={{ default: 'alignItemsBaseline' }} gap={{ default: 'gapXs' }}>
-                  <Content component={ContentVariants.small}>Cold start latency</Content>
+                  <Content component={ContentVariants.small}>Cold start load time</Content>
                   <Popover
                     bodyContent={
                       <div>
                         <p>
-                          <strong>Cold start latency:</strong> The estimated time required to
-                          provision hardware resources and initialize the container before the model
-                          can accept traffic.
+                          This is the initial delay that occurs when a model is triggered after a
+                          period of inactivity.
                         </p>
                       </div>
                     }
@@ -281,7 +280,7 @@ const ModelCatalogCardBody: React.FC<ModelCatalogCardBodyProps> = ({
                     <Button
                       icon={<HelpIcon />}
                       hasNoPadding
-                      aria-label="More info for cold start latency"
+                      aria-label="More info for cold start load time"
                       variant="plain"
                     />
                   </Popover>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Content, ContentVariants } from '@patternfly/react-core';
+import { Content, ContentVariants, Flex } from '@patternfly/react-core';
 import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import {
+  ModelCatalogNumberFilterKey,
   ModelCatalogStringFilterKey,
   MODEL_CATALOG_FILTER_CATEGORY_NAMES,
   MODEL_CATALOG_TASK_NAME_MAPPING,
@@ -17,8 +18,10 @@ import {
   CatalogFilterPanel,
   useCatalogFilterConfigs,
   type FilterPanelItem,
+  type StringFilterPanelItem,
 } from '~/app/shared/components/catalog';
 import ModelPerformanceViewToggleCard from './ModelPerformanceViewToggleCard';
+import SidebarSliderFilter from './SidebarSliderFilter';
 
 const BASIC_STRING_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
   ModelCatalogStringFilterKey.TASK,
@@ -45,8 +48,14 @@ const LABEL_MAPPINGS: Record<string, Record<string, string>> = {
 };
 
 const ModelCatalogFilters: React.FC = () => {
-  const { filterOptions, filterOptionsLoaded, filterOptionsLoadError, filters, setFilters } =
-    React.useContext(ModelCatalogContext);
+  const {
+    filterOptions,
+    filterOptionsLoaded,
+    filterOptionsLoadError,
+    filters,
+    setFilters,
+    performanceViewEnabled,
+  } = React.useContext(ModelCatalogContext);
   const { toolCalling: toolCallingFeatureAvailable } = useModelRegistryDashboardConfig();
 
   React.useEffect(() => {
@@ -92,8 +101,8 @@ const ModelCatalogFilters: React.FC = () => {
 
   const filterPanelItems = React.useMemo((): FilterPanelItem[] => {
     const validatedConfigKey = ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION;
-    return baseFilterItems.map((item) => {
-      const itemWithTestIds: FilterPanelItem = {
+    const items: FilterPanelItem[] = baseFilterItems.map((item) => {
+      const itemWithTestIds: StringFilterPanelItem = {
         ...item,
         testIdBase: `${item.title}-filter`,
         getCheckboxTestId: (value: string) => `${item.title}-${value}-checkbox`,
@@ -114,7 +123,39 @@ const ModelCatalogFilters: React.FC = () => {
       }
       return itemWithTestIds;
     });
-  }, [baseFilterItems, toolCallingFeatureAvailable]);
+
+    const validatedIndex = items.findIndex((item) => item.key === validatedConfigKey);
+    const insertIndex = validatedIndex >= 0 ? validatedIndex + 1 : items.length;
+
+    const sliderItems: FilterPanelItem[] = [
+      {
+        key: 'hardware-slider-filters',
+        title: 'Hardware filters',
+        visible: performanceViewEnabled,
+        customContent: (
+          <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+            <SidebarSliderFilter
+              filterKey={ModelCatalogNumberFilterKey.MIN_VRAM}
+              label="Minimum vRAM"
+              suffix="GB"
+              fallbackMin={4}
+              fallbackMax={480}
+            />
+            <SidebarSliderFilter
+              filterKey={ModelCatalogNumberFilterKey.IMAGE_SIZE}
+              label="Container size"
+              suffix="GB"
+              fallbackMin={4}
+              fallbackMax={500}
+            />
+          </Flex>
+        ),
+      },
+    ];
+
+    items.splice(insertIndex, 0, ...sliderItems);
+    return items;
+  }, [baseFilterItems, toolCallingFeatureAvailable, performanceViewEnabled]);
 
   return (
     <CatalogFilterPanel

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogSortDropdown.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/ModelCatalogSortDropdown.tsx
@@ -52,7 +52,7 @@ const ModelCatalogSortDropdown: React.FC<ModelCatalogSortDropdownProps> = ({
       return 'Latency (Lowest → Highest)';
     }
     if (sortBy === ModelCatalogSortOption.LOWEST_COLD_START) {
-      return 'Cold start latency (Lowest → Highest)';
+      return 'Cold start load time (Lowest → Highest)';
     }
     return 'Publish date (Newest → Oldest)';
   };
@@ -97,7 +97,7 @@ const ModelCatalogSortDropdown: React.FC<ModelCatalogSortDropdownProps> = ({
             value={ModelCatalogSortOption.LOWEST_COLD_START}
             data-testid="sort-option-lowest-cold-start"
           >
-            Cold start latency (Lowest → Highest)
+            Cold start load time (Lowest → Highest)
           </SelectOption>
         </SelectList>
       </Select>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/SidebarSliderFilter.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import {
+  Button,
+  Dropdown,
+  Flex,
+  FlexItem,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import { ModelCatalogNumberFilterKey } from '~/concepts/modelCatalog/const';
+import { useCatalogNumberFilterState } from '~/app/pages/modelCatalog/hooks/useCatalogFilterState';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
+import SliderWithInput from './globalFilters/SliderWithInput';
+
+type SidebarSliderFilterProps = {
+  filterKey: ModelCatalogNumberFilterKey;
+  label: string;
+  suffix?: string;
+  fallbackMin: number;
+  fallbackMax: number;
+};
+
+const SidebarSliderFilter: React.FC<SidebarSliderFilterProps> = ({
+  filterKey,
+  label,
+  suffix = 'GB',
+  fallbackMin,
+  fallbackMax,
+}) => {
+  const { filterOptions, filterOptionsLoaded, performanceViewEnabled } =
+    React.useContext(ModelCatalogContext);
+  const { value: filterValue, setValue: setFilterValue } = useCatalogNumberFilterState(filterKey);
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const range = React.useMemo(() => {
+    const option = filterOptions?.filters?.[filterKey];
+    if (option && option.range) {
+      const { min, max } = option.range;
+      if (min != null && max != null) {
+        return { min, max };
+      }
+    }
+    return { min: fallbackMin, max: fallbackMax };
+  }, [filterOptions, filterKey, fallbackMin, fallbackMax]);
+
+  const isDisabled = !filterOptionsLoaded || range.min === range.max;
+
+  const [localValue, setLocalValue] = React.useState<number>(() => filterValue ?? range.max);
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setLocalValue(filterValue ?? range.max);
+    }
+  }, [isOpen, filterValue, range.max]);
+
+  if (!performanceViewEnabled || !filterOptionsLoaded || !filterOptions?.filters?.[filterKey]) {
+    return null;
+  }
+
+  const hasActiveFilter = filterValue !== undefined;
+
+  const getDisplayText = (): React.ReactNode => {
+    if (hasActiveFilter) {
+      return (
+        <>
+          <strong>{label}:</strong> ≤ {filterValue} {suffix}
+        </>
+      );
+    }
+    return label;
+  };
+
+  const handleApply = () => {
+    setFilterValue(localValue);
+    setIsOpen(false);
+  };
+
+  const handleReset = () => {
+    setLocalValue(filterValue ?? range.max);
+  };
+
+  const clampedValue = Math.min(Math.max(localValue, range.min), range.max);
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      data-testid={`${label.toLowerCase().replace(/\s+/g, '-')}-filter`}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      {getDisplayText()}
+    </MenuToggle>
+  );
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+      shouldFocusToggleOnSelect={false}
+    >
+      <Flex
+        direction={{ default: 'column' }}
+        spaceItems={{ default: 'spaceItemsSm' }}
+        style={{ minWidth: '400px', padding: '16px' }}
+      >
+        <FlexItem>{label}</FlexItem>
+        <FlexItem>
+          <SliderWithInput
+            value={clampedValue}
+            min={range.min}
+            max={range.max}
+            isDisabled={isDisabled}
+            onChange={setLocalValue}
+            suffix={suffix}
+            ariaLabel={`${label} filter value`}
+            showBoundaries
+          />
+        </FlexItem>
+        <FlexItem>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>
+              <Button
+                variant="primary"
+                onClick={handleApply}
+                isDisabled={isDisabled}
+                data-testid={`${label.toLowerCase().replace(/\s+/g, '-')}-apply-filter`}
+              >
+                Apply
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="link"
+                onClick={handleReset}
+                data-testid={`${label.toLowerCase().replace(/\s+/g, '-')}-reset-filter`}
+              >
+                Reset
+              </Button>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      </Flex>
+    </Dropdown>
+  );
+};
+
+export default SidebarSliderFilter;

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
@@ -9,16 +9,33 @@ import {
 } from '@patternfly/react-core';
 import { ModelCatalogNumberFilterKey } from '~/concepts/modelCatalog/const';
 import { useCatalogNumberFilterState } from '~/app/pages/modelCatalog/hooks/useCatalogFilterState';
-import { COLD_START_LATENCY_RANGE } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import { COLD_START_LOAD_TIME_RANGE } from '~/app/pages/modelCatalog/utils/performanceMetricsUtils';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import SliderWithInput from './SliderWithInput';
 
-const filterKey = ModelCatalogNumberFilterKey.COLD_START_LATENCY;
+const filterKey = ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME;
 
 const ColdStartLatencyFilter: React.FC = () => {
+  const { filterOptions } = React.useContext(ModelCatalogContext);
   const { value: filterValue, setValue: setFilterValue } = useCatalogNumberFilterState(filterKey);
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const { minValue, maxValue, isSliderDisabled } = COLD_START_LATENCY_RANGE;
+  const { minValue, maxValue, isSliderDisabled } = React.useMemo(() => {
+    const option = filterOptions?.filters?.[filterKey];
+    if (option && option.range) {
+      const { min, max } = option.range;
+      if (min != null && max != null) {
+        const roundedMin = Math.floor(min);
+        const roundedMax = Math.ceil(max);
+        return {
+          minValue: roundedMin,
+          maxValue: roundedMax,
+          isSliderDisabled: roundedMin === roundedMax,
+        };
+      }
+    }
+    return COLD_START_LOAD_TIME_RANGE;
+  }, [filterOptions]);
 
   const [localValue, setLocalValue] = React.useState<number>(() => filterValue ?? maxValue);
 
@@ -39,7 +56,7 @@ const ColdStartLatencyFilter: React.FC = () => {
     if (hasActiveFilter) {
       return (
         <>
-          <strong>Cold start load time:</strong> ≤ {filterValue} ms
+          <strong>Cold start load time:</strong> {filterValue} s
         </>
       );
     }
@@ -58,7 +75,7 @@ const ColdStartLatencyFilter: React.FC = () => {
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       ref={toggleRef}
-      data-testid="cold-start-latency-filter"
+      data-testid="cold-start-load-time-filter"
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
       isFullHeight
@@ -73,9 +90,9 @@ const ColdStartLatencyFilter: React.FC = () => {
       direction={{ default: 'column' }}
       spaceItems={{ default: 'spaceItemsSm' }}
       flexWrap={{ default: 'wrap' }}
-      style={{ minWidth: '400px', padding: '16px' }}
+      style={{ minWidth: '450px', padding: '16px' }}
     >
-      <FlexItem>Cold start load time (ms)</FlexItem>
+      <FlexItem>Cold start load time (seconds)</FlexItem>
       <FlexItem>
         <SliderWithInput
           value={clampedValue}
@@ -84,6 +101,8 @@ const ColdStartLatencyFilter: React.FC = () => {
           isDisabled={isSliderDisabled}
           onChange={setLocalValue}
           ariaLabel="Cold start load time value input"
+          shouldRound
+          showBoundaries
         />
       </FlexItem>
       <FlexItem>
@@ -93,7 +112,7 @@ const ColdStartLatencyFilter: React.FC = () => {
               variant="primary"
               onClick={handleApplyFilter}
               isDisabled={isSliderDisabled}
-              data-testid="cold-start-latency-apply-filter"
+              data-testid="cold-start-load-time-apply-filter"
             >
               Apply filter
             </Button>
@@ -102,7 +121,7 @@ const ColdStartLatencyFilter: React.FC = () => {
             <Button
               variant="link"
               onClick={handleReset}
-              data-testid="cold-start-latency-reset-filter"
+              data-testid="cold-start-load-time-reset-filter"
             >
               Reset
             </Button>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/components/globalFilters/ColdStartLatencyFilter.tsx
@@ -39,11 +39,11 @@ const ColdStartLatencyFilter: React.FC = () => {
     if (hasActiveFilter) {
       return (
         <>
-          <strong>Cold start latency:</strong> {filterValue} ms
+          <strong>Cold start load time:</strong> ≤ {filterValue} ms
         </>
       );
     }
-    return 'Cold start latency';
+    return 'Cold start load time';
   };
 
   const handleApplyFilter = () => {
@@ -75,7 +75,7 @@ const ColdStartLatencyFilter: React.FC = () => {
       flexWrap={{ default: 'wrap' }}
       style={{ minWidth: '400px', padding: '16px' }}
     >
-      <FlexItem>Cold start latency (ms)</FlexItem>
+      <FlexItem>Cold start load time (ms)</FlexItem>
       <FlexItem>
         <SliderWithInput
           value={clampedValue}
@@ -83,7 +83,7 @@ const ColdStartLatencyFilter: React.FC = () => {
           max={maxValue}
           isDisabled={isSliderDisabled}
           onChange={setLocalValue}
-          ariaLabel="Cold start latency value input"
+          ariaLabel="Cold start load time value input"
         />
       </FlexItem>
       <FlexItem>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/screens/ModelDetailsView.tsx
@@ -263,7 +263,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                       <DescriptionListDescription>{tensorType || 'N/A'}</DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>Size</DescriptionListTerm>
+                      <DescriptionListTerm>Parameter size</DescriptionListTerm>
                       <DescriptionListDescription>{size || 'N/A'}</DescriptionListDescription>
                     </DescriptionListGroup>
                     {minimumVram && (
@@ -320,7 +320,7 @@ const ModelDetailsView: React.FC<ModelDetailsViewProps> = ({
                     )}
                     {modelSize && (
                       <DescriptionListGroup>
-                        <DescriptionListTerm>Image size</DescriptionListTerm>
+                        <DescriptionListTerm>Container size</DescriptionListTerm>
                         <DescriptionListDescription data-testid="image-size">
                           {modelSize}
                         </DescriptionListDescription>

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/__tests__/modelCatalogUtils.spec.ts
@@ -58,6 +58,9 @@ describe('filtersToFilterQuery', () => {
     validatedTasks = [],
     rps_mean = undefined,
     ttft_mean = undefined,
+    cold_start_latency = undefined,
+    min_vram = undefined,
+    image_size = undefined,
   }: {
     tasks?: ModelCatalogTask[];
     license?: string[];
@@ -70,6 +73,9 @@ describe('filtersToFilterQuery', () => {
     tensor_type?: ModelCatalogTensorType[];
     validatedTasks?: string[];
     ttft_mean?: number;
+    cold_start_latency?: number;
+    min_vram?: number;
+    image_size?: number;
   }): ModelCatalogFilterStates => ({
     [ModelCatalogStringFilterKey.TASK]: tasks,
     [ModelCatalogStringFilterKey.PROVIDER]: provider,
@@ -79,7 +85,9 @@ describe('filtersToFilterQuery', () => {
     [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: hardware_configuration,
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
-    [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: undefined,
+    [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: cold_start_latency,
+    [ModelCatalogNumberFilterKey.MIN_VRAM]: min_vram,
+    [ModelCatalogNumberFilterKey.IMAGE_SIZE]: image_size,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
     [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,
@@ -198,6 +206,27 @@ describe('filtersToFilterQuery', () => {
         range: {
           min: 0,
           max: 300,
+        },
+      },
+      [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: {
+        type: 'number',
+        range: {
+          min: 45000,
+          max: 200000,
+        },
+      },
+      [ModelCatalogNumberFilterKey.MIN_VRAM]: {
+        type: 'number',
+        range: {
+          min: 2,
+          max: 80,
+        },
+      },
+      [ModelCatalogNumberFilterKey.IMAGE_SIZE]: {
+        type: 'number',
+        range: {
+          min: 1,
+          max: 50,
         },
       },
       'artifacts.ttft_mean.double_value': {
@@ -427,6 +456,31 @@ describe('filtersToFilterQuery', () => {
   //       );
   //     });
   //   });
+
+  describe('numeric filter target behavior', () => {
+    it('includes cold-start and model-level filters for models target, excludes cold-start for artifacts target', () => {
+      const data = mockFormData({ cold_start_latency: 50, min_vram: 24, image_size: 15 });
+
+      const modelsQuery = filtersToFilterQuery(data, mockFilterOptions, 'models');
+      expect(modelsQuery).toContain('cold_start_time_to_load_seconds');
+      expect(modelsQuery).toContain('min_vram_gb.double_value');
+      expect(modelsQuery).toContain('modelcar_image_size.double_value');
+
+      const artifactsQuery = filtersToFilterQuery(data, mockFilterOptions, 'artifacts');
+      expect(artifactsQuery).not.toContain('cold_start_time_to_load_seconds');
+      expect(artifactsQuery).not.toContain('min_vram_gb');
+      expect(artifactsQuery).not.toContain('modelcar_image_size');
+    });
+
+    it('serializes min_vram and image_size with <= operator', () => {
+      const query = filtersToFilterQuery(
+        mockFormData({ min_vram: 24, image_size: 10 }),
+        mockFilterOptions,
+      );
+      expect(query).toContain('min_vram_gb.double_value <= 24');
+      expect(query).toContain('modelcar_image_size.double_value <= 10');
+    });
+  });
 });
 
 describe('catalog source filtering utilities', () => {
@@ -867,7 +921,9 @@ describe('hasFiltersApplied', () => {
     [ModelCatalogStringFilterKey.HARDWARE_CONFIGURATION]: hardware_configuration,
     [ModelCatalogStringFilterKey.USE_CASE]: use_case,
     [ModelCatalogNumberFilterKey.MAX_RPS]: rps_mean,
-    [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: undefined,
+    [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: undefined,
+    [ModelCatalogNumberFilterKey.MIN_VRAM]: undefined,
+    [ModelCatalogNumberFilterKey.IMAGE_SIZE]: undefined,
     [ModelCatalogStringFilterKey.TENSOR_TYPE]: tensor_type,
     [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: validatedTasks,
     'artifacts.ttft_mean.double_value': ttft_mean,

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -19,6 +19,7 @@ import {
   ToolCallingConfig,
 } from '~/app/modelCatalogTypes';
 import { getLabels, getCustomPropString } from '~/app/pages/modelRegistry/screens/utils';
+import { getDoubleValue } from '~/app/utils';
 import {
   ModelCatalogStringFilterKey,
   ModelCatalogNumberFilterKey,
@@ -226,7 +227,9 @@ const isArrayOfSelections = (
 const KNOWN_NUMERIC_FILTER_IDS: string[] = [
   ...ALL_LATENCY_FILTER_KEYS,
   ModelCatalogNumberFilterKey.MAX_RPS,
-  ModelCatalogNumberFilterKey.COLD_START_LATENCY,
+  ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
+  ModelCatalogNumberFilterKey.MIN_VRAM,
+  ModelCatalogNumberFilterKey.IMAGE_SIZE,
 ];
 
 /**
@@ -253,8 +256,8 @@ const getNumericFilterOperator = (options: CatalogFilterOptionsList, filterId: s
     // Return the operator from the namedQuery (e.g., '<=', '<', '>')
     return fieldFilter.operator;
   }
-  // Fall back to '<' if this filter isn't in the namedQuery
-  return '<';
+  // Fall back to '<=' if this filter isn't in the namedQuery
+  return '<=';
 };
 
 const isFilterIdInMap = (
@@ -313,7 +316,7 @@ export const getSortParams = (
 
   if (effectiveSortBy === ModelCatalogSortOption.LOWEST_COLD_START) {
     return {
-      orderBy: ModelCatalogNumberFilterKey.COLD_START_LATENCY,
+      orderBy: ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
       sortOrder: SortOrder.ASC,
     };
   }
@@ -369,8 +372,14 @@ const shouldIncludeFilter = (filterId: string, target: FilterQueryTarget): boole
     return false;
   }
 
+  // Cold-start filter is excluded from the performance artifacts endpoint
+  // (performance-metrics artifacts don't have this field — it's on cold-start-metrics artifacts).
+  if (filterId === ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME && target === 'artifacts') {
+    return false;
+  }
+
   if (target === 'models') {
-    // For models, include all filters (except RPS which is already excluded)
+    // For models, include all filters (except RPS and cold-start which are already excluded)
     return true;
   }
 
@@ -794,17 +803,29 @@ export const getCatalogModelTypePropertyForRegistration = (
 
 export const getModelSizeFromCustomProperties = (
   customProperties?: ModelRegistryCustomProperties,
-): string =>
-  customProperties
-    ? getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MODEL_SIZE)
-    : '';
+): string => {
+  if (!customProperties) {
+    return '';
+  }
+  const doubleVal = getDoubleValue(customProperties, 'modelcar_image_size');
+  if (doubleVal > 0) {
+    return `${doubleVal.toFixed(2)} GB`;
+  }
+  return getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MODEL_SIZE);
+};
 
 export const getMinimumVramFromCustomProperties = (
   customProperties?: ModelRegistryCustomProperties,
-): string =>
-  customProperties
-    ? getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM)
-    : '';
+): string => {
+  if (!customProperties) {
+    return '';
+  }
+  const doubleVal = getDoubleValue(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM);
+  if (doubleVal > 0) {
+    return `${doubleVal.toFixed(2)} GB`;
+  }
+  return getCustomPropString(customProperties, CatalogModelCustomPropertyKey.MINIMUM_VRAM);
+};
 
 export const getHardwareConfigurationsFromCustomProperties = (
   customProperties?: ModelRegistryCustomProperties,

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/performanceFilterUtils.ts
@@ -89,8 +89,12 @@ export const applyFilterValue = (
     const numberValue = extractNumberValue(value);
     if (filterKey === ModelCatalogNumberFilterKey.MAX_RPS) {
       setFilterData(ModelCatalogNumberFilterKey.MAX_RPS, numberValue);
+    } else if (filterKey === ModelCatalogNumberFilterKey.MIN_VRAM) {
+      setFilterData(ModelCatalogNumberFilterKey.MIN_VRAM, numberValue);
+    } else if (filterKey === ModelCatalogNumberFilterKey.IMAGE_SIZE) {
+      setFilterData(ModelCatalogNumberFilterKey.IMAGE_SIZE, numberValue);
     } else {
-      setFilterData(ModelCatalogNumberFilterKey.COLD_START_LATENCY, numberValue);
+      setFilterData(ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME, numberValue);
     }
     return;
   }
@@ -196,7 +200,7 @@ export const getDefaultFiltersFromNamedQuery = (
         if (fieldName === ModelCatalogNumberFilterKey.MAX_RPS) {
           result[ModelCatalogNumberFilterKey.MAX_RPS] = resolvedValue;
         } else {
-          result[ModelCatalogNumberFilterKey.COLD_START_LATENCY] = resolvedValue;
+          result[ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME] = resolvedValue;
         }
       }
       return;

--- a/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
+++ b/packages/model-registry/upstream/frontend/src/app/pages/modelCatalog/utils/performanceMetricsUtils.ts
@@ -34,9 +34,9 @@ export const FALLBACK_LATENCY_RANGE: SliderRange = {
   isSliderDisabled: false,
 };
 
-export const COLD_START_LATENCY_RANGE: SliderRange = {
-  minValue: 45000,
-  maxValue: 200000,
+export const COLD_START_LOAD_TIME_RANGE: SliderRange = {
+  minValue: 15,
+  maxValue: 1000,
   isSliderDisabled: false,
 };
 

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogFilterPanel.tsx
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/CatalogFilterPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Alert, Divider, Spinner, Stack, StackItem } from '@patternfly/react-core';
 import CatalogStringFilter from './CatalogStringFilter';
-import type { FilterPanelItem } from './hooks/useCatalogFilterConfigs';
+import { isCustomFilterItem, type FilterPanelItem } from './hooks/useCatalogFilterConfigs';
 
 type CatalogFilterPanelProps = {
   loaded: boolean;
@@ -38,16 +38,22 @@ const CatalogFilterPanel: React.FC<CatalogFilterPanelProps> = ({
       {visibleFilters.map((item, index) => (
         <React.Fragment key={item.key}>
           <StackItem>
-            <CatalogStringFilter
-              title={item.title}
-              filterValues={item.filterValues}
-              selectedValues={item.selectedValues}
-              onToggle={item.onToggle}
-              getLabel={item.getLabel}
-              testIdBase={item.testIdBase ?? `${testIdPrefix}-${item.key}`}
-              getCheckboxTestId={item.getCheckboxTestId}
-            />
-            {item.footer}
+            {isCustomFilterItem(item) ? (
+              item.customContent
+            ) : (
+              <>
+                <CatalogStringFilter
+                  title={item.title}
+                  filterValues={item.filterValues}
+                  selectedValues={item.selectedValues}
+                  onToggle={item.onToggle}
+                  getLabel={item.getLabel}
+                  testIdBase={item.testIdBase ?? `${testIdPrefix}-${item.key}`}
+                  getCheckboxTestId={item.getCheckboxTestId}
+                />
+                {item.footer}
+              </>
+            )}
           </StackItem>
           {index < visibleFilters.length - 1 && <Divider />}
         </React.Fragment>

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/hooks/useCatalogFilterConfigs.ts
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/hooks/useCatalogFilterConfigs.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
 import { toggleFilterValue } from '../utils/catalogFilterUtils';
 
-export type FilterPanelItem = {
+export type StringFilterPanelItem = {
   key: string;
   title: string;
   filterValues: string[];
@@ -14,6 +14,18 @@ export type FilterPanelItem = {
   testIdBase?: string;
   getCheckboxTestId?: (value: string) => string;
 };
+
+export type CustomFilterPanelItem = {
+  key: string;
+  title: string;
+  customContent: React.ReactNode;
+  visible?: boolean;
+};
+
+export type FilterPanelItem = StringFilterPanelItem | CustomFilterPanelItem;
+
+export const isCustomFilterItem = (item: FilterPanelItem): item is CustomFilterPanelItem =>
+  'customContent' in item;
 
 type CatalogFilterConfigsInput = {
   filterKeys: string[];
@@ -37,14 +49,14 @@ export function useCatalogFilterConfigs({
   selectedFilters,
   onFilterChange,
   labelMappings,
-}: CatalogFilterConfigsInput): FilterPanelItem[] {
+}: CatalogFilterConfigsInput): StringFilterPanelItem[] {
   const selectedFiltersRef = React.useRef(selectedFilters);
   selectedFiltersRef.current = selectedFilters;
 
   return React.useMemo(
     () =>
       filterKeys
-        .map((filterKey): FilterPanelItem | null => {
+        .map((filterKey): StringFilterPanelItem | null => {
           const filterOption = filterOptions?.[filterKey];
           if (!filterOption?.values || filterOption.values.length === 0) {
             return null;
@@ -74,7 +86,7 @@ export function useCatalogFilterConfigs({
               : undefined,
           };
         })
-        .filter((item): item is FilterPanelItem => item !== null),
+        .filter((item): item is StringFilterPanelItem => item !== null),
     [filterKeys, filterNames, filterOptions, selectedFilters, onFilterChange, labelMappings],
   );
 }

--- a/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/index.ts
+++ b/packages/model-registry/upstream/frontend/src/app/shared/components/catalog/index.ts
@@ -18,7 +18,11 @@ export {
 } from './utils/catalogFilterUtils';
 export { useStringFilterState } from './hooks/useStringFilterState';
 export { useCatalogFilterConfigs } from './hooks/useCatalogFilterConfigs';
-export type { FilterPanelItem } from './hooks/useCatalogFilterConfigs';
+export type {
+  FilterPanelItem,
+  StringFilterPanelItem,
+  CustomFilterPanelItem,
+} from './hooks/useCatalogFilterConfigs';
 export { default as EmptyCatalogState } from './EmptyCatalogState';
 export { default as CatalogCategorySection } from './CatalogCategorySection';
 export { default as CatalogGalleryLayout } from './CatalogGalleryLayout';

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -14,7 +14,9 @@ export enum ModelCatalogStringFilterKey {
 export enum ModelCatalogNumberFilterKey {
   // Performance filter key uses backend format
   MAX_RPS = 'artifacts.requests_per_second.double_value',
-  COLD_START_LATENCY = 'artifacts.cold_start_load_time_seconds.double_value',
+  COLD_START_LOAD_TIME = 'artifacts.cold_start_time_to_load_seconds.double_value',
+  MIN_VRAM = 'min_vram_gb.double_value',
+  IMAGE_SIZE = 'modelcar_image_size.double_value',
 }
 
 /**
@@ -495,7 +497,9 @@ export const DEPLOYMENT_RESOURCE_PREFIXES = ['vllm'];
 export const PERFORMANCE_FILTER_KEYS: ModelCatalogFilterKey[] = [
   ModelCatalogStringFilterKey.USE_CASE,
   ModelCatalogNumberFilterKey.MAX_RPS,
-  ModelCatalogNumberFilterKey.COLD_START_LATENCY,
+  ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
+  ModelCatalogNumberFilterKey.MIN_VRAM,
+  ModelCatalogNumberFilterKey.IMAGE_SIZE,
   ...ALL_LATENCY_FILTER_KEYS,
 ];
 
@@ -520,7 +524,9 @@ export const PERFORMANCE_STRING_FILTER_KEYS: ModelCatalogStringFilterKey[] = [
  */
 export const PERFORMANCE_NUMBER_FILTER_KEYS: ModelCatalogNumberFilterKey[] = [
   ModelCatalogNumberFilterKey.MAX_RPS,
-  ModelCatalogNumberFilterKey.COLD_START_LATENCY,
+  ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME,
+  ModelCatalogNumberFilterKey.MIN_VRAM,
+  ModelCatalogNumberFilterKey.IMAGE_SIZE,
 ];
 
 /**
@@ -595,7 +601,9 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
   [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: 'Validated arguments',
   // Number filter keys
   [ModelCatalogNumberFilterKey.MAX_RPS]: 'Max RPS',
-  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: 'Cold start load time',
+  [ModelCatalogNumberFilterKey.COLD_START_LOAD_TIME]: 'Cold start load time',
+  [ModelCatalogNumberFilterKey.MIN_VRAM]: 'Minimum vRAM',
+  [ModelCatalogNumberFilterKey.IMAGE_SIZE]: 'Container size',
   // Latency field names - all use "Latency" as category name
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   ...(Object.fromEntries(ALL_LATENCY_FILTER_KEYS.map((field) => [field, 'Latency'])) as Record<
@@ -607,7 +615,9 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
 export const MODEL_CATALOG_FILTER_CHIP_PREFIXES = {
   WORKLOAD_TYPE: 'Workload type:',
   MAX_RPS: 'Max RPS:',
-  COLD_START_LATENCY: 'Cold start load time: ≤',
+  COLD_START_LOAD_TIME: 'Cold start load time: ≤',
+  MIN_VRAM: 'Minimum vRAM: ≤',
+  IMAGE_SIZE: 'Container size: ≤',
   LATENCY_METRIC: 'Metric:',
   LATENCY_PERCENTILE: 'Percentile:',
   LATENCY_THRESHOLD: 'Under',

--- a/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
+++ b/packages/model-registry/upstream/frontend/src/concepts/modelCatalog/const.ts
@@ -595,7 +595,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
   [ModelCatalogStringFilterKey.VALIDATED_CONFIGURATION]: 'Validated arguments',
   // Number filter keys
   [ModelCatalogNumberFilterKey.MAX_RPS]: 'Max RPS',
-  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: 'Cold start latency',
+  [ModelCatalogNumberFilterKey.COLD_START_LATENCY]: 'Cold start load time',
   // Latency field names - all use "Latency" as category name
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   ...(Object.fromEntries(ALL_LATENCY_FILTER_KEYS.map((field) => [field, 'Latency'])) as Record<
@@ -607,7 +607,7 @@ export const MODEL_CATALOG_FILTER_CATEGORY_NAMES: Record<ModelCatalogFilterKey, 
 export const MODEL_CATALOG_FILTER_CHIP_PREFIXES = {
   WORKLOAD_TYPE: 'Workload type:',
   MAX_RPS: 'Max RPS:',
-  COLD_START_LATENCY: 'Cold start latency:',
+  COLD_START_LATENCY: 'Cold start load time: ≤',
   LATENCY_METRIC: 'Metric:',
   LATENCY_PERCENTILE: 'Percentile:',
   LATENCY_THRESHOLD: 'Under',


### PR DESCRIPTION
## Description

Sync to pull in changes from:
* https://github.com/kubeflow/model-registry/pull/2807
* https://github.com/kubeflow/model-registry/pull/2810
* https://github.com/kubeflow/model-registry/pull/2816
* https://github.com/kubeflow/model-registry/pull/2811
* https://github.com/kubeflow/model-registry/pull/2792
* https://github.com/kubeflow/model-registry/pull/2815

### Conflicts Resolved

**[#2810 - chore(deps): bump shell-quote from 1.8.3 to 1.8.4](https://github.com/kubeflow/model-registry/pull/2810)**
- `frontend/package-lock.json`

*Nature of conflict:* The lockfile already had `shell-quote` at version 1.8.4, so the patch context didn't match.

*Resolution:* Removed the injected conflict markers — no actual code changes were needed since the file was already at the target state.

---

**[#2816 - chore(ui): update OWNERS - add reviewer and emeritus approvers](https://github.com/kubeflow/model-registry/pull/2816)**
- `OWNERS` (file outside subtree path)

*Nature of conflict:* The OWNERS file lives outside the `clients/ui/` subtree directory, so it doesn't exist in our copy.

*Resolution:* Skipped — no relevant files for the downstream subtree.

---

**[#2815 - feat(catalog): connect cold-start, vRAM, and container size filters to real API](https://github.com/kubeflow/model-registry/pull/2815)**
- `frontend/src/app/pages/modelCatalog/components/ModelCatalogFilters.tsx`
- `frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts`

*Nature of conflict:* Our downstream version of `ModelCatalogFilters.tsx` includes the `useModelRegistryDashboardConfig` hook and tool-calling feature visibility logic (for the "Validated configuration" filter) that don't exist upstream. This caused context mismatches for the patch. Similarly, `modelCatalogUtils.ts` had downstream import ordering differences that prevented automatic application.

*Resolution:* Manually applied all upstream changes (added `Flex` import, `ModelCatalogNumberFilterKey`, `StringFilterPanelItem`, `SidebarSliderFilter` component, `performanceViewEnabled` context value, hardware slider filters panel, renamed `COLD_START_LATENCY` → `COLD_START_LOAD_TIME`, added `MIN_VRAM`/`IMAGE_SIZE` filter keys, updated `getModelSizeFromCustomProperties`/`getMinimumVramFromCustomProperties` to use `getDoubleValue`, added cold-start artifact exclusion, changed fallback operator to `<=`) while preserving all downstream-specific code (`useModelRegistryDashboardConfig` hook, the `toolCallingFeatureAvailable` effect/visibility logic, and the combined useMemo dependencies).

### Additional downstream fix

- Changed `useModelRegistryDashboardConfig` to default `toolCalling` to `false` (was `true`). When the dashboard config doesn't explicitly set the `toolCalling` flag, the "Validated configuration" filter should be hidden rather than visible.

## How Has This Been Tested?

Tested by running the federated model-registry package locally, verifying existing behavior in the files this diff touches, and verifying the incoming changes.

Also ran available test scripts in `packages/model-registry/upstream/frontend`:
- `test:lint` — passed (0 warnings)
- `test:unit` — 823 tests passed
- `test:type-check` — passed

## Test Impact

Upstream changes include their own tests.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model registry subtree reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->