### PR TITLE
feat(gen-ai): gate agent profile Save As button behind agentProfileManagement dev flag

### DIFF
--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -28,6 +28,7 @@ export const devTemporaryFeatureFlags = {
   nimWizard: false,
   agentOps: false,
   roleManagement: false,
+  agentProfileManagement: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 // Group 1: Core Dashboard Features

--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -1339,6 +1339,7 @@ export type DashboardCommonConfig = {
   mySubscriptions?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
+  agentProfileManagement?: boolean;
 };
 
 // [1] Intentionally disjointed fields from the CRD in this type definition

--- a/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/ChatbotHeaderActions.tsx
@@ -12,7 +12,9 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { CodeIcon, ColumnsIcon, CogIcon, EllipsisVIcon, PlusIcon } from '@patternfly/react-icons';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
+import { AGENT_PROFILES } from '~/odh/extensions';
 import { useChatbotConfigStore, selectSelectedModel, selectConfigIds } from './store';
 
 type ChatbotHeaderActionsProps = {
@@ -26,9 +28,6 @@ type ChatbotHeaderActionsProps = {
   isSettingsOpen: boolean;
   isCompareMode: boolean;
 };
-
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-const RENDER_SAVE_AS_BUTTON = false;
 
 const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   onViewCode,
@@ -47,6 +46,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
   const selectedModel = useChatbotConfigStore(selectSelectedModel(configIds[0]));
   const isViewCodeDisabled = !lastInput || !selectedModel;
   const [isDropdownOpen, setDropdownOpen] = React.useState(false);
+  const [agentProfilesEnabled] = useFeatureFlag(AGENT_PROFILES);
 
   // Get disabled reason for popover
   const getDisabledReason = () => {
@@ -67,9 +67,7 @@ const ChatbotHeaderActions: React.FC<ChatbotHeaderActionsProps> = ({
       <ActionListGroup>
         {lsdStatus?.phase === 'Ready' && (
           <>
-            {/* Temp: serializer test button — remove before feature delivery */}
-            {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-            {!isCompareMode && RENDER_SAVE_AS_BUTTON && (
+            {!isCompareMode && agentProfilesEnabled && (
               <ActionListItem>
                 <Button
                   variant="link"

--- a/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
+++ b/packages/gen-ai/frontend/src/app/Chatbot/__tests__/ChatbotHeaderActions.spec.tsx
@@ -5,6 +5,10 @@ import ChatbotHeaderActions from '~/app/Chatbot/ChatbotHeaderActions';
 import { ChatbotContext } from '~/app/context/ChatbotContext';
 import { useChatbotConfigStore } from '~/app/Chatbot/store';
 
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  useFeatureFlag: jest.fn(() => [false]),
+}));
+
 // Mock the store
 jest.mock('~/app/Chatbot/store', () => ({
   useChatbotConfigStore: jest.fn(),

--- a/packages/gen-ai/frontend/src/odh/extensions.ts
+++ b/packages/gen-ai/frontend/src/odh/extensions.ts
@@ -24,6 +24,7 @@ export const GUARDRAILS = 'guardrails';
 export const PROMPT_MANAGEMENT = 'promptManagement';
 export const AI_ASSET_CUSTOM_ENDPOINTS = 'aiAssetCustomEndpoints';
 export const EXTERNAL_VECTOR_STORES = 'externalVectorStores';
+export const AGENT_PROFILES = 'agentProfileManagement';
 const MODELS_AS_SERVICE_READY = 'ModelsAsServiceReady';
 
 const extensions: (
@@ -84,6 +85,14 @@ const extensions: (
       id: EXTERNAL_VECTOR_STORES,
       reliantAreas: [PLUGIN_GEN_AI],
       featureFlags: [EXTERNAL_VECTOR_STORES],
+    },
+  },
+  {
+    type: 'app.area',
+    properties: {
+      id: AGENT_PROFILES,
+      reliantAreas: [PLUGIN_GEN_AI],
+      featureFlags: [AGENT_PROFILES],
     },
   },
   {


### PR DESCRIPTION
<!-- https://redhat.atlassian.net/browse/RHAISTRAT-1534 -->

## Description

Gates the temporary "Save as" agent profile button behind a proper developer feature flag (`agentProfileManagement`). To be used in other areas.

This is part of the STRAT initiative to support AgentProfile ConfigMap ↔ Playground UI serialization: https://redhat.atlassian.net/browse/RHAISTRAT-1534

**Changes:**

- Added `agentProfileManagement?: boolean` to `DashboardCommonConfig` so the flag is a first-class dashboard config key
- Added `agentProfileManagement: false` to `devTemporaryFeatureFlags` — it now appears in the developer flags panel (off by default)
- Registered `AGENT_PROFILES = 'agentProfileManagement'` constant and a corresponding `app.area` extension in the gen-ai package (same pattern as `GUARDRAILS`, `PROMPT_MANAGEMENT`, `EXTERNAL_VECTOR_STORES`)
- Replaced the static constant + eslint-disable comments in `ChatbotHeaderActions.tsx` with `useFeatureFlag(AGENT_PROFILES)` — the Save As button renders only when the flag is toggled on in the dev panel

## How Has This Been Tested?

- Verified the developer flags panel shows `agentProfileManagement` (default: off)
- Toggled the flag on — Save As button appears to the left of Compare chat, hidden in compare mode
- Toggled off — button is hidden
- All existing `ChatbotHeaderActions` tests pass (21 tests)

## Test Impact

Updated `ChatbotHeaderActions.spec.tsx` to mock `@openshift/dynamic-plugin-sdk`'s `useFeatureFlag` returning `[false]` — consistent with the flag being off by default. No new tests needed; the conditional render behavior is already covered by the existing mock infrastructure.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent profile management feature flag infrastructure to control feature availability.
  * Save as action is now conditionally rendered based on feature flag configuration.

* **Tests**
  * Updated tests to support new feature flag mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->