### PR TITLE
feat(observability): switch model dashboard to tenancy datasource

### DIFF
--- a/manifests/observability/odh/perses-dashboard-model.yaml
+++ b/manifests/observability/odh/perses-dashboard-model.yaml
@@ -107,7 +107,6 @@ spec:
                   datasource:
                     kind: PrometheusDatasource
                     name: cluster-prometheus-tenancy-datasource
-                    name: cluster-prometheus-tenancy-datasource
                   query: group by (model_name, namespace) (kserve_vllm:num_requests_running{model_name=~"$model_name"})
           # Query 2: Total requests - defaults to 0
           - kind: TimeSeriesQuery

--- a/manifests/observability/odh/perses-dashboard-model.yaml
+++ b/manifests/observability/odh/perses-dashboard-model.yaml
@@ -15,14 +15,13 @@ spec:
           name: Project
           description: Filter by project
         allowMultiple: true
-        allowAllValue: true
-        customAllValue: ".*"
-        defaultValue: "$__all"
+        allowAllValue: false
         plugin:
           kind: PrometheusLabelValuesVariable
           spec:
             datasource:
               kind: PrometheusDatasource
+              name: cluster-prometheus-tenancy-datasource
             labelName: namespace
             matchers:
               - kserve_vllm:num_requests_running
@@ -41,9 +40,10 @@ spec:
           spec:
             datasource:
               kind: PrometheusDatasource
+              name: cluster-prometheus-tenancy-datasource
             labelName: model_name
             matchers:
-              - kserve_vllm:num_requests_running{namespace=~"$namespace"}
+              - kserve_vllm:num_requests_running
   panels:
     # Model Deployments Table
     modelDeploymentsTable:
@@ -106,7 +106,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: group by (model_name, namespace) (kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"})
+                    name: cluster-prometheus-tenancy-datasource
+                    name: cluster-prometheus-tenancy-datasource
+                  query: group by (model_name, namespace) (kserve_vllm:num_requests_running{model_name=~"$model_name"})
           # Query 2: Total requests - defaults to 0
           - kind: TimeSeriesQuery
             spec:
@@ -115,7 +117,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: sum by (model_name, namespace) (increase(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name"}[$__range])) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: sum by (model_name, namespace) (increase(kserve_vllm:request_success_total{model_name=~"$model_name"}[$__range])) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 3: P90 E2E request latency - defaults to 0 (filter NaN with > -Inf)
           - kind: TimeSeriesQuery
             spec:
@@ -124,7 +127,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf)[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf)[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 4: Error rate
           - kind: TimeSeriesQuery
             spec:
@@ -133,7 +137,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{namespace=~"$namespace", finished_reason=~"error|abort", model_name=~"$model_name"}[$__range])) / (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name"}[$__range])) > 0)) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{finished_reason=~"error|abort", model_name=~"$model_name"}[$__range])) / (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{model_name=~"$model_name"}[$__range])) > 0)) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 5: GPU utilization %
           - kind: TimeSeriesQuery
             spec:
@@ -142,7 +147,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((sum by (model_name, namespace) (label_replace(label_replace(accelerator_gpu_utilization{exported_namespace=~"$namespace"}, "namespace", "$1", "exported_namespace", "(.*)"), "pod", "$1", "exported_pod", "(.*)") * on(namespace, pod) group_left(model_name)(0 * max by (namespace, pod, model_name)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}) + 1)) / scalar(count(accelerator_gpu_utilization)))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((sum by (model_name, namespace) (label_replace(label_replace(accelerator_gpu_utilization, "namespace", "$1", "exported_namespace", "(.*)"), "pod", "$1", "exported_pod", "(.*)") * on(namespace, pod) group_left(model_name)(0 * max by (namespace, pod, model_name)(kserve_vllm:num_requests_running{model_name=~"$model_name"}) + 1)) / scalar(count(accelerator_gpu_utilization)))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 6: CPU utilization %
           - kind: TimeSeriesQuery
             spec:
@@ -151,7 +157,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((sum by (model_name, namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"$namespace"} * on(namespace, pod) group_left(model_name) (0 * group by (model_name, namespace, pod)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}) + 1)) / scalar(sum(kube_node_status_allocatable{resource="cpu"})))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((sum by (model_name, namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate * on(namespace, pod) group_left(model_name) (0 * group by (model_name, namespace, pod)(kserve_vllm:num_requests_running{model_name=~"$model_name"}) + 1)) / scalar(sum(kube_node_status_allocatable{resource="cpu"})))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
     # Performance Metrics - Line Charts
     requestQueueLength:
       kind: Panel
@@ -182,8 +189,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Number of requests waiting in queue per model
-                  query: sum by (model_name, namespace) (kserve_vllm:num_requests_waiting{namespace=~"$namespace", model_name=~"$model_name"})
+                  query: sum by (model_name, namespace) (kserve_vllm:num_requests_waiting{model_name=~"$model_name"})
                   seriesNameFormat: "{{model_name}}"
     replicaCount:
       kind: Panel
@@ -214,8 +222,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Ready pods per model - count of pods with vLLM metrics
-                  query: count by (model_name, namespace) (group by (pod, model_name, namespace) (kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: count by (model_name, namespace) (group by (pod, model_name, namespace) (kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     requestLatency:
       kind: Panel
@@ -246,8 +255,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # P90 end-to-end request latency
-                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     timeToFirstToken:
       kind: Panel
@@ -278,8 +288,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # P90 time to first token
-                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:time_to_first_token_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:time_to_first_token_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     tokenThroughput:
       kind: Panel
@@ -310,8 +321,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Token throughput (prompt + generation tokens per second)
-                  query: sum by(model_name, namespace) (rate(kserve_vllm:prompt_tokens_total{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]) + rate(kserve_vllm:generation_tokens_total{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))
+                  query: sum by(model_name, namespace) (rate(kserve_vllm:prompt_tokens_total{model_name=~"$model_name"}[$__rate_interval]) + rate(kserve_vllm:generation_tokens_total{model_name=~"$model_name"}[$__rate_interval]))
                   seriesNameFormat: "{{model_name}}"
     requestSuccessRate:
       kind: Panel
@@ -342,8 +354,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Request success rate (successful requests per second)
-                  query: sum by (model_name, namespace) (rate(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name", finished_reason=~"length|stop"}[$__rate_interval]))
+                  query: sum by (model_name, namespace) (rate(kserve_vllm:request_success_total{model_name=~"$model_name", finished_reason=~"length|stop"}[$__rate_interval]))
                   seriesNameFormat: "{{model_name}}"
     responseTimeDistribution:
       kind: Panel
@@ -364,7 +377,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="+Inf"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="30.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="+Inf"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="30.0"}[$__range])))
                   seriesNameFormat: "Degraded >30s"
           - kind: TimeSeriesQuery
             spec:
@@ -373,7 +387,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="30.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="5.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="30.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="5.0"}[$__range])))
                   seriesNameFormat: "Slow 5-30s"
           - kind: TimeSeriesQuery
             spec:
@@ -382,7 +397,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="5.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="1.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="5.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="1.0"}[$__range])))
                   seriesNameFormat: "Acceptable 1-5s"
           - kind: TimeSeriesQuery
             spec:
@@ -391,7 +407,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="1.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="1.0"}[$__range])))
                   seriesNameFormat: "Fast <1s"
   layouts:
     # Model Deployments Table Section

--- a/manifests/observability/rhoai/perses-dashboard-model.yaml
+++ b/manifests/observability/rhoai/perses-dashboard-model.yaml
@@ -15,14 +15,13 @@ spec:
           name: Project
           description: Filter by project
         allowMultiple: true
-        allowAllValue: true
-        customAllValue: ".*"
-        defaultValue: "$__all"
+        allowAllValue: false
         plugin:
           kind: PrometheusLabelValuesVariable
           spec:
             datasource:
               kind: PrometheusDatasource
+              name: cluster-prometheus-tenancy-datasource
             labelName: namespace
             matchers:
               - kserve_vllm:num_requests_running
@@ -41,9 +40,10 @@ spec:
           spec:
             datasource:
               kind: PrometheusDatasource
+              name: cluster-prometheus-tenancy-datasource
             labelName: model_name
             matchers:
-              - kserve_vllm:num_requests_running{namespace=~"$namespace"}
+              - kserve_vllm:num_requests_running
   panels:
     # Model Deployments Table
     modelDeploymentsTable:
@@ -106,7 +106,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: group by (model_name, namespace) (kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"})
+                    name: cluster-prometheus-tenancy-datasource
+                  query: group by (model_name, namespace) (kserve_vllm:num_requests_running{model_name=~"$model_name"})
           # Query 2: Total requests - defaults to 0
           - kind: TimeSeriesQuery
             spec:
@@ -115,7 +116,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: sum by (model_name, namespace) (increase(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name"}[$__range])) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: sum by (model_name, namespace) (increase(kserve_vllm:request_success_total{model_name=~"$model_name"}[$__range])) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 3: P90 E2E request latency - defaults to 0 (filter NaN with > -Inf)
           - kind: TimeSeriesQuery
             spec:
@@ -124,7 +126,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf)[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf)[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 4: Error rate
           - kind: TimeSeriesQuery
             spec:
@@ -133,7 +136,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{namespace=~"$namespace", finished_reason=~"error|abort", model_name=~"$model_name"}[$__range])) / (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name"}[$__range])) > 0)) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{finished_reason=~"error|abort", model_name=~"$model_name"}[$__range])) / (sum by (model_name, namespace)(increase(kserve_vllm:request_success_total{model_name=~"$model_name"}[$__range])) > 0)) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 5: GPU utilization %
           - kind: TimeSeriesQuery
             spec:
@@ -142,7 +146,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((sum by (model_name, namespace) (label_replace(label_replace(accelerator_gpu_utilization{exported_namespace=~"$namespace"}, "namespace", "$1", "exported_namespace", "(.*)"), "pod", "$1", "exported_pod", "(.*)") * on(namespace, pod) group_left(model_name)(0 * max by (namespace, pod, model_name)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}) + 1)) / scalar(count(accelerator_gpu_utilization)))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((sum by (model_name, namespace) (label_replace(label_replace(accelerator_gpu_utilization, "namespace", "$1", "exported_namespace", "(.*)"), "pod", "$1", "exported_pod", "(.*)") * on(namespace, pod) group_left(model_name)(0 * max by (namespace, pod, model_name)(kserve_vllm:num_requests_running{model_name=~"$model_name"}) + 1)) / scalar(count(accelerator_gpu_utilization)))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
           # Query 6: CPU utilization %
           - kind: TimeSeriesQuery
             spec:
@@ -151,7 +156,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: avg_over_time((sum by (model_name, namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"$namespace"} * on(namespace, pod) group_left(model_name) (0 * group by (model_name, namespace, pod)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}) + 1)) / scalar(sum(kube_node_status_allocatable{resource="cpu"})))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: avg_over_time((sum by (model_name, namespace) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate * on(namespace, pod) group_left(model_name) (0 * group by (model_name, namespace, pod)(kserve_vllm:num_requests_running{model_name=~"$model_name"}) + 1)) / scalar(sum(kube_node_status_allocatable{resource="cpu"})))[$__range:]) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
     # Performance Metrics - Line Charts
     requestQueueLength:
       kind: Panel
@@ -182,8 +188,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Number of requests waiting in queue per model
-                  query: sum by (model_name, namespace) (kserve_vllm:num_requests_waiting{namespace=~"$namespace", model_name=~"$model_name"})
+                  query: sum by (model_name, namespace) (kserve_vllm:num_requests_waiting{model_name=~"$model_name"})
                   seriesNameFormat: "{{model_name}}"
     replicaCount:
       kind: Panel
@@ -214,8 +221,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Ready pods per model - count of pods with vLLM metrics
-                  query: count by (model_name, namespace) (group by (pod, model_name, namespace) (kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: count by (model_name, namespace) (group by (pod, model_name, namespace) (kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     requestLatency:
       kind: Panel
@@ -246,8 +254,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # P90 end-to-end request latency
-                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     timeToFirstToken:
       kind: Panel
@@ -278,8 +287,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # P90 time to first token
-                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:time_to_first_token_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{namespace=~"$namespace", model_name=~"$model_name"}))
+                  query: (histogram_quantile(0.90, sum by (le, model_name, namespace) (rate(kserve_vllm:time_to_first_token_seconds_bucket{model_name=~"$model_name"}[$__rate_interval]))) > -Inf) or (0 * group by (model_name, namespace)(kserve_vllm:num_requests_running{model_name=~"$model_name"}))
                   seriesNameFormat: "{{model_name}}"
     tokenThroughput:
       kind: Panel
@@ -310,8 +320,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Token throughput (prompt + generation tokens per second)
-                  query: sum by(model_name, namespace) (rate(kserve_vllm:prompt_tokens_total{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]) + rate(kserve_vllm:generation_tokens_total{namespace=~"$namespace", model_name=~"$model_name"}[$__rate_interval]))
+                  query: sum by(model_name, namespace) (rate(kserve_vllm:prompt_tokens_total{model_name=~"$model_name"}[$__rate_interval]) + rate(kserve_vllm:generation_tokens_total{model_name=~"$model_name"}[$__rate_interval]))
                   seriesNameFormat: "{{model_name}}"
     requestSuccessRate:
       kind: Panel
@@ -342,8 +353,9 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
+                    name: cluster-prometheus-tenancy-datasource
                   # Request success rate (successful requests per second)
-                  query: sum by (model_name, namespace) (rate(kserve_vllm:request_success_total{namespace=~"$namespace", model_name=~"$model_name", finished_reason=~"length|stop"}[$__rate_interval]))
+                  query: sum by (model_name, namespace) (rate(kserve_vllm:request_success_total{model_name=~"$model_name", finished_reason=~"length|stop"}[$__rate_interval]))
                   seriesNameFormat: "{{model_name}}"
     responseTimeDistribution:
       kind: Panel
@@ -364,7 +376,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="+Inf"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="30.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="+Inf"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="30.0"}[$__range])))
                   seriesNameFormat: "Degraded >30s"
           - kind: TimeSeriesQuery
             spec:
@@ -373,7 +386,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="30.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="5.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="30.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="5.0"}[$__range])))
                   seriesNameFormat: "Slow 5-30s"
           - kind: TimeSeriesQuery
             spec:
@@ -382,7 +396,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="5.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="1.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="5.0"}[$__range]))) - (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="1.0"}[$__range])))
                   seriesNameFormat: "Acceptable 1-5s"
           - kind: TimeSeriesQuery
             spec:
@@ -391,7 +406,8 @@ spec:
                 spec:
                   datasource:
                     kind: PrometheusDatasource
-                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{namespace=~"$namespace", model_name=~"$model_name", le="1.0"}[$__range])))
+                    name: cluster-prometheus-tenancy-datasource
+                  query: (sum(increase(kserve_vllm:e2e_request_latency_seconds_bucket{model_name=~"$model_name", le="1.0"}[$__range])))
                   seriesNameFormat: "Fast <1s"
   layouts:
     # Model Deployments Table Section

--- a/packages/observability/src/utils/__tests__/dashboardUtils.spec.ts
+++ b/packages/observability/src/utils/__tests__/dashboardUtils.spec.ts
@@ -262,7 +262,7 @@ describe('dashboardUtils', () => {
       ];
       expect(
         filterDashboardsByThanosNonTenancyAccess(dashboards, false).map((d) => d.metadata.name),
-      ).toEqual(['dashboard-other']);
+      ).toEqual(['dashboard-1-model', 'dashboard-other']);
     });
   });
 

--- a/packages/observability/src/utils/dashboardUtils.ts
+++ b/packages/observability/src/utils/dashboardUtils.ts
@@ -32,7 +32,6 @@ export const THANOS_QUERIER_NON_TENANCY_ACCESS: AccessReviewResourceAttributes =
  */
 export const THANOS_NON_TENANCY_GATED_DASHBOARD_NAMES: ReadonlySet<string> = new Set([
   'dashboard-0-cluster-admin',
-  'dashboard-1-model',
 ]);
 
 /**


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
https://redhat.atlassian.net/browse/RHOAIENG-51667

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

Switches the Model Deployments dashboard (`dashboard-1-model`) from the non-tenancy Thanos Querier datasource (port 9091) to the tenancy datasource (`cluster-prometheus-tenancy-datasource`, port 9092). This allows users without `cluster-monitoring-view` access to view the model dashboard scoped to their own namespaces.

**Key changes:**

- **Datasource**: All panel queries and variable plugins now reference `cluster-prometheus-tenancy-datasource` instead of the unnamed/default datasource.
- **PromQL queries**: Removed `namespace=~"$namespace"` label matchers from all queries — namespace filtering is now handled by `prom-label-proxy` via the `?namespace=` URL query parameter injected by the Perses frontend.
- **Namespace variable**: Set `allowAllValue: false` (tenancy proxy does not support regex `.*` for namespace). `allowMultiple` remains `true`.
- **Model name variable**: Kept `allowAllValue: true` with `customAllValue: ".*"` since model name is not enforced by prom-label-proxy. Removed `{namespace=~"$namespace"}` from matchers.
- **RBAC gating**: Removed `dashboard-1-model` from `THANOS_NON_TENANCY_GATED_DASHBOARD_NAMES` since it no longer requires cluster-wide Prometheus access.
- **Deleted** `spike-tenancy-datasource.md` — superseded by the `namespace:queryparam` approach.

**Findings from spike testing:**

- `prom-label-proxy` on the tenancy port injects the `namespace` label matcher into PromQL queries automatically based on the `?namespace=` URL parameter. This means namespace filtering in PromQL is redundant and actually conflicts with the proxy's injection.
- `allowAllValue: true` for namespace is **not feasible** with the tenancy datasource because prom-label-proxy rejects the regex value `.*` for the namespace parameter.
- The frontend's `transformNamespaceVariable` replaces the Prometheus-based namespace variable with a static list from K8s projects, so `defaultValue` in the CR is not needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually tested on a dev cluster by patching the PersesDashboard CR and verifying data loads correctly via the tenancy datasource.
- Deployed fake vLLM metrics exporters in two namespaces (`regularuser`, `regularuser2`) to validate multi-namespace selection and namespace-scoped queries.
- Confirmed that selecting individual namespaces and multiple namespaces returns correct results.
- Verified that the `model_name` "All" selection works correctly with the tenancy datasource.
- Unit tests updated and passing (24/24 in `dashboardUtils.spec.ts`).

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

- Updated `dashboardUtils.spec.ts` to reflect that `dashboard-1-model` is no longer in the non-tenancy gated set.
- All existing unit tests pass.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboards updated to filter metrics by model name and explicitly target the tenancy Prometheus datasource; performance panels (latency, throughput, replicas, queues, success rate, response distributions) reflect this.

* **Bug Fixes**
  * Dashboard access logic adjusted so an additional model deployment dashboard is now available to more users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->