### PR TITLE
chore(notebooks): Notebooks package should sync from midstream instead of upstream

### DIFF
--- a/packages/notebooks/package.json
+++ b/packages/notebooks/package.json
@@ -13,8 +13,8 @@
     "start:dev:wait": "npx wait-on -i 1000 http://localhost:9105"
   },
   "subtree": {
-    "repo": "https://github.com/kubeflow/notebooks.git",
-    "branch": "notebooks-v2",
+    "repo": "https://github.com/opendatahub-io/workbenches.git",
+    "branch": "main",
     "src": "",
     "target": "upstream",
     "commit": "f62ed0495eac6859e93bfbeb6af7119f786d3f10"


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Depends on: https://github.com/opendatahub-io/workbenches/pull/6 due to Golang version discrepancy (#7949)
As a precursor to https://github.com/opendatahub-io/odh-dashboard/pull/7954/, this PR aims to change the source of Notebooks v2 code from Kubeflow (upstream) to ODH Workbenches (midstream). No code changes are involved here. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] Build ODH image
- [ ] Run 
```cd packages/notebooks/upstream/developing
make tilt-up
```

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`
