### PR TITLE
Setup for ia redesign

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -68,6 +68,7 @@ export type DashboardConfig = K8sResourceCommon & {
       llmGatewayField: boolean;
       promptManagement: boolean;
       mySubscriptions: boolean;
+      iaRedesign: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
     // groupsConfig?: {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -68,7 +68,7 @@ export type DashboardConfig = K8sResourceCommon & {
       llmGatewayField: boolean;
       promptManagement: boolean;
       mySubscriptions: boolean;
-      iaRedesign: boolean;
+      maasSettingsIaRedesign: boolean;
     };
     // Intentionally disjointed from the CRD, we should move away from this code-wise now; CRD later
     // groupsConfig?: {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -104,7 +104,7 @@ export const blankDashboardCR: DashboardConfig = {
       llmGatewayField: false,
       promptManagement: false,
       mySubscriptions: true,
-      iaRedesign: false,
+      maasSettingsIaRedesign: false,
     },
     notebookController: {
       enabled: true,

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -104,6 +104,7 @@ export const blankDashboardCR: DashboardConfig = {
       llmGatewayField: false,
       promptManagement: false,
       mySubscriptions: true,
+      iaRedesign: false,
     },
     notebookController: {
       enabled: true,

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -89,7 +89,7 @@ type DashboardFeatureFlags struct {
 	LlmGatewayField              bool `json:"llmGatewayField"`
 	PromptManagement             bool `json:"promptManagement"`
 	MySubscriptions              bool `json:"mySubscriptions"`
-	IaRedesign                   bool `json:"iaRedesign"`
+	MaasSettingsIaRedesign       bool `json:"maasSettingsIaRedesign"`
 }
 
 type NotebookController struct {
@@ -179,7 +179,7 @@ var BlankDashboardCR = DashboardConfig{
 			LlmGatewayField:              false,
 			PromptManagement:             false,
 			MySubscriptions:              false,
-			IaRedesign:                   false,
+			MaasSettingsIaRedesign:       false,
 		},
 		NotebookController: &NotebookController{
 			Enabled: true,

--- a/distributions/core-bff/bff/internal/models/dashboard_config.go
+++ b/distributions/core-bff/bff/internal/models/dashboard_config.go
@@ -89,6 +89,7 @@ type DashboardFeatureFlags struct {
 	LlmGatewayField              bool `json:"llmGatewayField"`
 	PromptManagement             bool `json:"promptManagement"`
 	MySubscriptions              bool `json:"mySubscriptions"`
+	IaRedesign                   bool `json:"iaRedesign"`
 }
 
 type NotebookController struct {
@@ -178,6 +179,7 @@ var BlankDashboardCR = DashboardConfig{
 			LlmGatewayField:              false,
 			PromptManagement:             false,
 			MySubscriptions:              false,
+			IaRedesign:                   false,
 		},
 		NotebookController: &NotebookController{
 			Enabled: true,

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -60,6 +60,7 @@ export type MockDashboardConfigType = {
   promptManagement?: boolean;
   nimWizard?: boolean;
   mySubscriptions?: boolean;
+  iaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
   genAiStudioConfig?: {
@@ -122,6 +123,7 @@ export const mockDashboardConfig = ({
   promptManagement = false,
   nimWizard = false,
   mySubscriptions = true,
+  iaRedesign = false,
   agentOps = false,
   roleManagement = false,
   hardwareProfileOrder = ['test-hardware-profile'],
@@ -307,6 +309,7 @@ export const mockDashboardConfig = ({
       promptManagement,
       nimWizard,
       mySubscriptions,
+      iaRedesign,
       agentOps,
       roleManagement,
     },

--- a/frontend/src/__mocks__/mockDashboardConfig.ts
+++ b/frontend/src/__mocks__/mockDashboardConfig.ts
@@ -60,7 +60,7 @@ export type MockDashboardConfigType = {
   promptManagement?: boolean;
   nimWizard?: boolean;
   mySubscriptions?: boolean;
-  iaRedesign?: boolean;
+  maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
   genAiStudioConfig?: {
@@ -123,7 +123,7 @@ export const mockDashboardConfig = ({
   promptManagement = false,
   nimWizard = false,
   mySubscriptions = true,
-  iaRedesign = false,
+  maasSettingsIaRedesign = false,
   agentOps = false,
   roleManagement = false,
   hardwareProfileOrder = ['test-hardware-profile'],
@@ -309,7 +309,7 @@ export const mockDashboardConfig = ({
       promptManagement,
       nimWizard,
       mySubscriptions,
-      iaRedesign,
+      maasSettingsIaRedesign,
       agentOps,
       roleManagement,
     },

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -19,6 +19,7 @@ export const techPreviewFlags = {
   llmGatewayField: false,
   promptManagement: false,
   mySubscriptions: true,
+  iaRedesign: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 export const devTemporaryFeatureFlags = {
@@ -260,6 +261,9 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   },
   [SupportedArea.MY_SUBSCRIPTIONS]: {
     featureFlags: ['mySubscriptions'],
+  },
+  [SupportedArea.IA_REDESIGN]: {
+    featureFlags: ['iaRedesign'],
   },
 };
 

--- a/frontend/src/concepts/areas/const.ts
+++ b/frontend/src/concepts/areas/const.ts
@@ -19,7 +19,7 @@ export const techPreviewFlags = {
   llmGatewayField: false,
   promptManagement: false,
   mySubscriptions: true,
-  iaRedesign: false,
+  maasSettingsIaRedesign: false,
 } satisfies Partial<DashboardCommonConfig>;
 
 export const devTemporaryFeatureFlags = {
@@ -262,8 +262,8 @@ export const SupportedAreasStateMap: SupportedAreasState = {
   [SupportedArea.MY_SUBSCRIPTIONS]: {
     featureFlags: ['mySubscriptions'],
   },
-  [SupportedArea.IA_REDESIGN]: {
-    featureFlags: ['iaRedesign'],
+  [SupportedArea.MAAS_SETTINGS_IA_REDESIGN]: {
+    featureFlags: ['maasSettingsIaRedesign'],
   },
 };
 

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -69,6 +69,7 @@ export enum SupportedArea {
   VLLM_ON_MAAS = 'vllm-on-maas',
   LLMD_GATEWAY_FIELD = 'llmd-gateway-field',
   MY_SUBSCRIPTIONS = 'my-subscriptions',
+  IA_REDESIGN = 'ia-redesign',
 
   /* Distributed Workloads areas */
   DISTRIBUTED_WORKLOADS = 'distributed-workloads',

--- a/frontend/src/concepts/areas/types.ts
+++ b/frontend/src/concepts/areas/types.ts
@@ -69,7 +69,7 @@ export enum SupportedArea {
   VLLM_ON_MAAS = 'vllm-on-maas',
   LLMD_GATEWAY_FIELD = 'llmd-gateway-field',
   MY_SUBSCRIPTIONS = 'my-subscriptions',
-  IA_REDESIGN = 'ia-redesign',
+  MAAS_SETTINGS_IA_REDESIGN = 'maas-settings-ia-redesign',
 
   /* Distributed Workloads areas */
   DISTRIBUTED_WORKLOADS = 'distributed-workloads',

--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1129,6 +1129,39 @@ class SubscriptionsTab {
   }
 }
 
+class SubscriptionManagementPage {
+  visit(tab?: string): void {
+    const path = tab ? `/maas/subscription-management/${tab}` : '/maas/subscription-management';
+    cy.visitWithLogin(path);
+    this.wait();
+  }
+
+  private wait(): void {
+    cy.findByTestId('app-page-title').should('exist');
+    cy.testA11y();
+  }
+
+  findTitle(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('app-page-title');
+  }
+
+  findDescription(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('app-page-description');
+  }
+
+  findOverviewTab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('overview-tab');
+  }
+
+  findSubscriptionsTab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('subscriptions-tab');
+  }
+
+  findAuthPoliciesTab(): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.findByTestId('auth-policies-tab');
+  }
+}
+
 export const maasWizardField = new MaaSWizardField();
 export const apiKeysPage = new APIKeysPage();
 export const subscriptionsTab = new SubscriptionsTab();
@@ -1149,3 +1182,4 @@ export const authPoliciesPage = new AuthPoliciesPage();
 export const deleteAuthPolicyModal = new DeleteAuthPolicyModal();
 export const viewAuthPolicyPage = new ViewAuthPolicyPage();
 export const mySubscriptionsPage = new MySubscriptionsPage();
+export const subscriptionManagementPage = new SubscriptionManagementPage();

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -1,0 +1,93 @@
+import { mockDashboardConfig, mockDscStatus } from '@odh-dashboard/internal/__mocks__';
+import { DataScienceStackComponent } from '@odh-dashboard/internal/concepts/areas/types';
+import { asProductAdminUser } from '../../../utils/mockUsers';
+import {
+  subscriptionManagementPage,
+  subscriptionsPage,
+  authPoliciesPage,
+} from '../../../pages/modelsAsAService';
+import { mockSubscriptions, mockAuthPolicies } from '../../../utils/maasUtils';
+
+const setupCommonIntercepts = () => {
+  asProductAdminUser();
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({ modelAsService: true, iaRedesign: true }),
+  );
+  cy.interceptOdh('GET /maas/api/v1/user', {
+    data: { userId: 'test-user', clusterAdmin: false },
+  });
+  cy.interceptOdh('GET /maas/api/v1/namespaces', { data: [] });
+  cy.interceptOdh(
+    'GET /api/dsc/status',
+    mockDscStatus({
+      components: {
+        [DataScienceStackComponent.OGX_OPERATOR]: { managementState: 'Managed' },
+      },
+      conditions: [{ type: 'ModelsAsServiceReady', status: 'True', reason: 'Ready' }],
+    }),
+  );
+  cy.interceptOdh('GET /maas/api/v1/all-subscriptions', { data: mockSubscriptions() });
+  cy.interceptOdh('GET /maas/api/v1/all-policies', { data: mockAuthPolicies() });
+};
+
+describe('Subscription Management Page', () => {
+  beforeEach(() => {
+    setupCommonIntercepts();
+  });
+
+  it('should display the page with tabs and default to the overview tab', () => {
+    subscriptionManagementPage.visit();
+    subscriptionManagementPage.findTitle().should('contain.text', 'Subscription management');
+    subscriptionManagementPage
+      .findDescription()
+      .should(
+        'contain.text',
+        'Manage subscriptions and authorization policies to control the MaaS models',
+      );
+    subscriptionManagementPage.findOverviewTab().should('have.attr', 'aria-selected', 'true');
+    cy.contains('Subscription overview placeholder').should('exist');
+  });
+
+  it('should navigate between tabs and update the URL', () => {
+    subscriptionManagementPage.visit();
+
+    subscriptionManagementPage.findSubscriptionsTab().click();
+    cy.url().should('include', '/subscription-management/subscriptions');
+    subscriptionsPage.findTable().should('exist');
+    subscriptionsPage.findRows().should('have.length', 6);
+
+    subscriptionManagementPage.findAuthPoliciesTab().click();
+    cy.url().should('include', '/subscription-management/auth-policies');
+    authPoliciesPage.findTable().should('exist');
+    authPoliciesPage.findRows().should('have.length', 6);
+
+    subscriptionManagementPage.findOverviewTab().click();
+    cy.url().should('include', '/subscription-management/overview');
+    cy.contains('Subscription overview placeholder').should('exist');
+  });
+
+  it('should display subscriptions content within the subscriptions tab', () => {
+    subscriptionManagementPage.visit('subscriptions');
+    subscriptionsPage.findTable().should('exist');
+    subscriptionsPage.findRows().should('have.length', 6);
+    subscriptionsPage.findCreateSubscriptionButton().should('exist');
+
+    subscriptionsPage.findFilterInput().type('premium');
+    subscriptionsPage.findRows().should('have.length', 1);
+    subscriptionsPage.findFilterResetButton().click();
+    subscriptionsPage.findRows().should('have.length', 6);
+  });
+
+  it('should display auth policies content within the auth policies tab', () => {
+    subscriptionManagementPage.visit('auth-policies');
+    authPoliciesPage.findTable().should('exist');
+    authPoliciesPage.findRows().should('have.length', 6);
+    authPoliciesPage.findCreateAuthPolicyButton().should('exist');
+
+    authPoliciesPage.findKeywordFilterInput().type('premium');
+    authPoliciesPage.findRows().should('have.length', 1);
+    authPoliciesPage.clearAllFilters();
+    authPoliciesPage.findRows().should('have.length', 6);
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasSubscriptionManagement.cy.ts
@@ -12,7 +12,7 @@ const setupCommonIntercepts = () => {
   asProductAdminUser();
   cy.interceptOdh(
     'GET /api/config',
-    mockDashboardConfig({ modelAsService: true, iaRedesign: true }),
+    mockDashboardConfig({ modelAsService: true, maasSettingsIaRedesign: true }),
   );
   cy.interceptOdh('GET /maas/api/v1/user', {
     data: { userId: 'test-user', clusterAdmin: false },

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -274,6 +274,7 @@ export type DashboardCommonConfig = {
   promptManagement?: boolean;
   nimWizard?: boolean;
   mySubscriptions?: boolean;
+  iaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
   agentProfileManagement?: boolean;

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -274,11 +274,10 @@ export type DashboardCommonConfig = {
   promptManagement?: boolean;
   nimWizard?: boolean;
   mySubscriptions?: boolean;
-  iaRedesign?: boolean;
+  maasSettingsIaRedesign?: boolean;
   agentOps?: boolean;
   roleManagement?: boolean;
   agentProfileManagement?: boolean;
-  iaRedesign?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/k8s-core/src/k8sTypes.ts
+++ b/packages/k8s-core/src/k8sTypes.ts
@@ -277,6 +277,7 @@ export type DashboardCommonConfig = {
   agentOps?: boolean;
   roleManagement?: boolean;
   agentProfileManagement?: boolean;
+  iaRedesign?: boolean;
 };
 
 export type DashboardConfigKind = K8sResourceCommon & {

--- a/packages/maas/frontend/src/app/AppRoutes.tsx
+++ b/packages/maas/frontend/src/app/AppRoutes.tsx
@@ -37,6 +37,7 @@ const AppRoutes: React.FC = () => {
       </Routes>
     );
   }
+  // TODO:Remove old routes when preparing feature for release
   if (isAuthPolicies) {
     return (
       <Routes>
@@ -48,6 +49,7 @@ const AppRoutes: React.FC = () => {
       </Routes>
     );
   }
+  // TODO:Remove old routes when preparing feature for release
   if (isSubscriptions) {
     return (
       <Routes>

--- a/packages/maas/frontend/src/app/AppRoutes.tsx
+++ b/packages/maas/frontend/src/app/AppRoutes.tsx
@@ -13,13 +13,24 @@ import CreateAuthPolicyPage from '~/app/pages/auth-policies/CreateAuthPolicyPage
 import EditAuthPolicyPage from '~/app/pages/auth-policies/EditAuthPolicyPage';
 import ViewAuthPoliciesPage from '~/app/pages/auth-policies/ViewAuthPoliciesPage';
 import ViewMySubscriptionPage from './pages/keys-and-subs/mySubscriptions/ViewMySubscriptionPage';
+import SubscriptionManagementPage from './pages/subscription-management/SubscriptionManagementPage';
 
 const AppRoutes: React.FC = () => {
   const { pathname } = useLocation();
   const isKeysAndSubs = pathname.startsWith(`${URL_PREFIX}/keys-and-subs`);
   const isSubscriptions = pathname.startsWith(`${URL_PREFIX}/subscriptions`);
   const isAuthPolicies = pathname.startsWith(`${URL_PREFIX}/auth-policies`);
+  const isSubscriptionManagement = pathname.startsWith(`${URL_PREFIX}/subscription-management`);
 
+  if (isSubscriptionManagement) {
+    return (
+      <Routes>
+        <Route path="/" element={<SubscriptionManagementPage />} />
+        <Route path="/:tab" element={<SubscriptionManagementPage />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    );
+  }
   if (isAuthPolicies) {
     return (
       <Routes>

--- a/packages/maas/frontend/src/app/AppRoutes.tsx
+++ b/packages/maas/frontend/src/app/AppRoutes.tsx
@@ -27,6 +27,12 @@ const AppRoutes: React.FC = () => {
       <Routes>
         <Route path="/" element={<SubscriptionManagementPage />} />
         <Route path="/:tab" element={<SubscriptionManagementPage />} />
+        <Route path="/subscriptions/create" element={<CreateSubscriptionPage />} />
+        <Route path="/subscriptions/view/:subscriptionName" element={<ViewSubscriptionPage />} />
+        <Route path="/subscriptions/edit/:subscriptionName" element={<EditSubscriptionPage />} />
+        <Route path="/auth-policies/create" element={<CreateAuthPolicyPage />} />
+        <Route path="/auth-policies/view/:authPolicyName" element={<ViewAuthPoliciesPage />} />
+        <Route path="/auth-policies/edit/:authPolicyName" element={<EditAuthPolicyPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     );

--- a/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
@@ -3,15 +3,14 @@ import { Link, useLocation } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
-import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import PolicyForm from './policyForm/PolicyForm';
 
 const CreateAuthPolicyPage: React.FC = () => {
   const [formData, loaded, loadError] = useSubscriptionPolicyFormData();
-  const { state } = useLocation();
-  const returnTo = getReturnToFromState(state);
-  const backUrl = returnTo ?? `${URL_PREFIX}/auth-policies`;
+  const { state, pathname } = useLocation();
+  const backUrl = getBackUrl(pathname, state, 'auth-policies');
+  const returnTo = backUrl;
 
   return (
     <ApplicationsPage

--- a/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
@@ -8,6 +8,15 @@ import PolicyForm from './policyForm/PolicyForm';
 
 const CreateAuthPolicyPage: React.FC = () => {
   const [formData, loaded, loadError] = useSubscriptionPolicyFormData();
+  const { state } = useLocation();
+  const returnTo =
+    state != null &&
+    typeof state === 'object' &&
+    'returnTo' in state &&
+    typeof state.returnTo === 'string'
+      ? state.returnTo
+      : undefined;
+  const backUrl = returnTo ?? `${URL_PREFIX}/auth-policies`;
 
   return (
     <ApplicationsPage
@@ -15,9 +24,7 @@ const CreateAuthPolicyPage: React.FC = () => {
       description="Create a new authorization policy to control which groups can access AI model endpoints."
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to={`${URL_PREFIX}/auth-policies`}>Authorization policies</Link>}
-          />
+          <BreadcrumbItem render={() => <Link to={backUrl}>Authorization policies</Link>} />
           <BreadcrumbItem isActive>Create authorization policy</BreadcrumbItem>
         </Breadcrumb>
       }
@@ -25,7 +32,7 @@ const CreateAuthPolicyPage: React.FC = () => {
       empty={false}
       loadError={loadError}
     >
-      <PolicyForm formData={formData} />
+      <PolicyForm formData={formData} returnTo={returnTo} />
     </ApplicationsPage>
   );
 };

--- a/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/CreateAuthPolicyPage.tsx
@@ -4,18 +4,13 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import PolicyForm from './policyForm/PolicyForm';
 
 const CreateAuthPolicyPage: React.FC = () => {
   const [formData, loaded, loadError] = useSubscriptionPolicyFormData();
   const { state } = useLocation();
-  const returnTo =
-    state != null &&
-    typeof state === 'object' &&
-    'returnTo' in state &&
-    typeof state.returnTo === 'string'
-      ? state.returnTo
-      : undefined;
+  const returnTo = getReturnToFromState(state);
   const backUrl = returnTo ?? `${URL_PREFIX}/auth-policies`;
 
   return (

--- a/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
@@ -4,15 +4,14 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
-import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import PolicyForm from './policyForm/PolicyForm';
 
 const EditAuthPolicyPage: React.FC = () => {
   const { authPolicyName = '' } = useParams<{ authPolicyName: string }>();
-  const { state } = useLocation();
-  const returnTo = getReturnToFromState(state);
-  const base = returnTo ?? `${URL_PREFIX}/auth-policies`;
+  const { state, pathname } = useLocation();
+  const base = getBackUrl(pathname, state, 'auth-policies');
+  const returnTo = base;
   const [policyInfo, policyLoaded, policyError] = useGetPolicyInfo(authPolicyName);
   const [formData, formLoaded, formError] = useSubscriptionPolicyFormData();
 

--- a/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EditAuthPolicyPage.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import PolicyForm from './policyForm/PolicyForm';
 
 const EditAuthPolicyPage: React.FC = () => {
   const { authPolicyName = '' } = useParams<{ authPolicyName: string }>();
+  const { state } = useLocation();
+  const returnTo = getReturnToFromState(state);
+  const base = returnTo ?? `${URL_PREFIX}/auth-policies`;
   const [policyInfo, policyLoaded, policyError] = useGetPolicyInfo(authPolicyName);
   const [formData, formLoaded, formError] = useSubscriptionPolicyFormData();
 
@@ -22,9 +26,7 @@ const EditAuthPolicyPage: React.FC = () => {
       description="Update groups, models, and metadata for this authorization policy."
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to={`${URL_PREFIX}/auth-policies`}>Authorization policies</Link>}
-          />
+          <BreadcrumbItem render={() => <Link to={base}>Authorization policies</Link>} />
           <BreadcrumbItem isActive>{displayName || authPolicyName}</BreadcrumbItem>
         </Breadcrumb>
       }
@@ -38,6 +40,7 @@ const EditAuthPolicyPage: React.FC = () => {
           key={policyInfo.policy.name}
           formData={formData}
           initialPolicy={policyInfo.policy}
+          returnTo={returnTo}
         />
       )}
     </ApplicationsPage>

--- a/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
@@ -20,7 +20,7 @@ const EmptyAuthPoliciesPage: React.FC<EmptyAuthPoliciesPageProps> = ({ returnTo 
           component={(props) => (
             <Link
               {...props}
-              to={`${returnTo ?? `${URL_PREFIX}/auth-policies`}/create`}
+              to={`${(returnTo ?? `${URL_PREFIX}/auth-policies`).split('?')[0]}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
@@ -20,7 +20,7 @@ const EmptyAuthPoliciesPage: React.FC<EmptyAuthPoliciesPageProps> = ({ returnTo 
           component={(props) => (
             <Link
               {...props}
-              to={`${URL_PREFIX}/auth-policies/create`}
+              to={`${returnTo ?? `${URL_PREFIX}/auth-policies`}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/EmptyAuthPoliciesPage.tsx
@@ -4,7 +4,11 @@ import { Button } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 
-const EmptyAuthPoliciesPage: React.FC = () => (
+type EmptyAuthPoliciesPageProps = {
+  returnTo?: string;
+};
+
+const EmptyAuthPoliciesPage: React.FC<EmptyAuthPoliciesPageProps> = ({ returnTo }) => (
   <>
     <EmptyDetailsView
       title="No Policies"
@@ -13,7 +17,13 @@ const EmptyAuthPoliciesPage: React.FC = () => (
       createButton={
         <Button
           variant="primary"
-          component={(props) => <Link {...props} to={`${URL_PREFIX}/auth-policies/create`} />}
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${URL_PREFIX}/auth-policies/create`}
+              state={returnTo ? { returnTo } : undefined}
+            />
+          )}
           data-testid="create-auth-policy-button"
         >
           Create authorization policy

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import {
   Breadcrumb,
@@ -21,6 +21,7 @@ import PolicyGroupsSection from './viewAuthPolicy/PolicyGroupsSection';
 
 type PolicyActionsProps = {
   policy: MaaSAuthPolicy;
+  returnTo?: string;
 };
 
 const viewModelRefSummaries = (info: PolicyInfoResponse): MaaSModelRefSummary[] => {
@@ -41,7 +42,7 @@ const viewModelRefSummaries = (info: PolicyInfoResponse): MaaSModelRefSummary[] 
   });
 };
 
-const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
+const PolicyActions: React.FC<PolicyActionsProps> = ({ policy, returnTo }) => {
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
 
@@ -72,7 +73,7 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
           onClose={(deleted) => {
             setIsDeleteOpen(false);
             if (deleted) {
-              navigate(`${URL_PREFIX}/auth-policies`);
+              navigate(returnTo ?? `${URL_PREFIX}/auth-policies`);
             }
           }}
         />
@@ -83,13 +84,23 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy }) => {
 
 const ViewAuthPoliciesPage: React.FC = () => {
   const { authPolicyName = '' } = useParams<{ authPolicyName: string }>();
+  const location = useLocation();
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [policyInfo, loaded, loadError] = useGetPolicyInfo(authPolicyName);
+
+  const { state } = location;
+  const returnTo =
+    state != null &&
+    typeof state === 'object' &&
+    'returnTo' in state &&
+    typeof state.returnTo === 'string'
+      ? state.returnTo
+      : undefined;
 
   const breadcrumb = (
     <Breadcrumb>
       <BreadcrumbItem>
-        <Link to={`${URL_PREFIX}/auth-policies`} data-testid="breadcrumb-policies-link">
+        <Link to={returnTo ?? `${URL_PREFIX}/auth-policies`} data-testid="breadcrumb-policies-link">
           Authorization policies
         </Link>
       </BreadcrumbItem>
@@ -101,7 +112,7 @@ const ViewAuthPoliciesPage: React.FC = () => {
     <ApplicationsPage
       title={policyInfo?.policy.displayName ?? authPolicyName}
       breadcrumb={breadcrumb}
-      headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} />}
+      headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} returnTo={returnTo} />}
       empty={false}
       loaded={loaded || !!loadError}
       loadError={loadError}

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -14,6 +14,7 @@ import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
 import { MaaSAuthPolicy, MaaSModelRefSummary } from '~/app/types/subscriptions';
 import { PolicyInfoResponse } from '~/app/types/auth-policies';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteAuthPolicyModal from './DeleteAuthPolicyModal';
 import PolicyDetailsSection from './viewAuthPolicy/PolicyDetailsSection';
@@ -45,6 +46,8 @@ const viewModelRefSummaries = (info: PolicyInfoResponse): MaaSModelRefSummary[] 
 const PolicyActions: React.FC<PolicyActionsProps> = ({ policy, returnTo }) => {
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
+  const base = returnTo ?? `${URL_PREFIX}/auth-policies`;
+  const navState = returnTo ? { state: { returnTo } } : undefined;
 
   return (
     <>
@@ -54,8 +57,7 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy, returnTo }) => {
           {
             key: 'edit',
             label: 'Edit',
-            onClick: () =>
-              navigate(`${URL_PREFIX}/auth-policies/edit/${encodeURIComponent(policy.name)}`),
+            onClick: () => navigate(`${base}/edit/${encodeURIComponent(policy.name)}`, navState),
             isDisabled: !!policy.deletionTimestamp,
           },
           { isSpacer: true },
@@ -73,7 +75,7 @@ const PolicyActions: React.FC<PolicyActionsProps> = ({ policy, returnTo }) => {
           onClose={(deleted) => {
             setIsDeleteOpen(false);
             if (deleted) {
-              navigate(returnTo ?? `${URL_PREFIX}/auth-policies`);
+              navigate(base);
             }
           }}
         />
@@ -88,14 +90,7 @@ const ViewAuthPoliciesPage: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [policyInfo, loaded, loadError] = useGetPolicyInfo(authPolicyName);
 
-  const { state } = location;
-  const returnTo =
-    state != null &&
-    typeof state === 'object' &&
-    'returnTo' in state &&
-    typeof state.returnTo === 'string'
-      ? state.returnTo
-      : undefined;
+  const returnTo = getReturnToFromState(location.state);
 
   const breadcrumb = (
     <Breadcrumb>

--- a/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/ViewAuthPoliciesPage.tsx
@@ -14,7 +14,7 @@ import { useGetPolicyInfo } from '~/app/hooks/useGetPolicyInfo';
 import { MaaSAuthPolicy, MaaSModelRefSummary } from '~/app/types/subscriptions';
 import { PolicyInfoResponse } from '~/app/types/auth-policies';
 import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteAuthPolicyModal from './DeleteAuthPolicyModal';
 import PolicyDetailsSection from './viewAuthPolicy/PolicyDetailsSection';
@@ -90,12 +90,12 @@ const ViewAuthPoliciesPage: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [policyInfo, loaded, loadError] = useGetPolicyInfo(authPolicyName);
 
-  const returnTo = getReturnToFromState(location.state);
+  const backUrl = getBackUrl(location.pathname, location.state, 'auth-policies');
 
   const breadcrumb = (
     <Breadcrumb>
       <BreadcrumbItem>
-        <Link to={returnTo ?? `${URL_PREFIX}/auth-policies`} data-testid="breadcrumb-policies-link">
+        <Link to={backUrl} data-testid="breadcrumb-policies-link">
           Authorization policies
         </Link>
       </BreadcrumbItem>
@@ -107,7 +107,7 @@ const ViewAuthPoliciesPage: React.FC = () => {
     <ApplicationsPage
       title={policyInfo?.policy.displayName ?? authPolicyName}
       breadcrumb={breadcrumb}
-      headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} returnTo={returnTo} />}
+      headerAction={policyInfo && <PolicyActions policy={policyInfo.policy} returnTo={backUrl} />}
       empty={false}
       loaded={loaded || !!loadError}
       loadError={loadError}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTable.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTable.tsx
@@ -10,6 +10,7 @@ type AuthPoliciesTableProps = {
   setDeleteAuthPolicy: (authPolicy: MaaSAuthPolicy) => void;
   toolbarContent?: React.ReactElement;
   onClearFilters: () => void;
+  returnTo?: string;
 };
 
 const AuthPoliciesTable: React.FC<AuthPoliciesTableProps> = ({
@@ -17,6 +18,7 @@ const AuthPoliciesTable: React.FC<AuthPoliciesTableProps> = ({
   setDeleteAuthPolicy,
   toolbarContent,
   onClearFilters,
+  returnTo,
 }) => (
   <Table
     data-testid="auth-policies-table"
@@ -28,6 +30,7 @@ const AuthPoliciesTable: React.FC<AuthPoliciesTableProps> = ({
         authPolicy={authPolicy}
         columns={authPoliciesColumns}
         setDeleteAuthPolicy={setDeleteAuthPolicy}
+        returnTo={returnTo}
       />
     )}
     emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -16,6 +16,7 @@ type AuthPoliciesTableRowProps = {
   authPolicy: MaaSAuthPolicy;
   columns: SortableData<MaaSAuthPolicy>[];
   setDeleteAuthPolicy: (authPolicy: MaaSAuthPolicy) => void;
+  returnTo?: string;
 };
 
 const labelHelper = (count: number, singular: string, plural: string) => {
@@ -27,14 +28,16 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
   authPolicy,
   columns,
   setDeleteAuthPolicy,
+  returnTo,
 }) => {
   const navigate = useNavigate();
+  const navState = returnTo ? { state: { returnTo } } : undefined;
   const policyNameSegment = (name: string) => encodeURIComponent(name);
   const onViewDetailsAuthPolicy = (authPolicyName: string) => {
-    navigate(`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicyName)}`);
+    navigate(`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicyName)}`, navState);
   };
   const onEditAuthPolicy = (authPolicyName: string) => {
-    navigate(`${URL_PREFIX}/auth-policies/edit/${policyNameSegment(authPolicyName)}`);
+    navigate(`${URL_PREFIX}/auth-policies/edit/${policyNameSegment(authPolicyName)}`, navState);
   };
   const onDeleteAuthPolicy = (authPolicyToDelete: MaaSAuthPolicy) => {
     setDeleteAuthPolicy(authPolicyToDelete);
@@ -63,7 +66,10 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
               </span>
             ) : (
               <ResourceNameTooltip resource={convertAuthPolicyToK8sResource(authPolicy)}>
-                <Link to={`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicy.name)}`}>
+                <Link
+                  to={`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicy.name)}`}
+                  state={returnTo ? { returnTo } : undefined}
+                >
                   {authPolicy.displayName ?? authPolicy.name}
                 </Link>
               </ResourceNameTooltip>

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTableRow.tsx
@@ -31,13 +31,14 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
   returnTo,
 }) => {
   const navigate = useNavigate();
+  const base = returnTo ?? `${URL_PREFIX}/auth-policies`;
   const navState = returnTo ? { state: { returnTo } } : undefined;
   const policyNameSegment = (name: string) => encodeURIComponent(name);
   const onViewDetailsAuthPolicy = (authPolicyName: string) => {
-    navigate(`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicyName)}`, navState);
+    navigate(`${base}/view/${policyNameSegment(authPolicyName)}`, navState);
   };
   const onEditAuthPolicy = (authPolicyName: string) => {
-    navigate(`${URL_PREFIX}/auth-policies/edit/${policyNameSegment(authPolicyName)}`, navState);
+    navigate(`${base}/edit/${policyNameSegment(authPolicyName)}`, navState);
   };
   const onDeleteAuthPolicy = (authPolicyToDelete: MaaSAuthPolicy) => {
     setDeleteAuthPolicy(authPolicyToDelete);
@@ -67,7 +68,7 @@ const AuthPoliciesTableRow: React.FC<AuthPoliciesTableRowProps> = ({
             ) : (
               <ResourceNameTooltip resource={convertAuthPolicyToK8sResource(authPolicy)}>
                 <Link
-                  to={`${URL_PREFIX}/auth-policies/view/${policyNameSegment(authPolicy.name)}`}
+                  to={`${base}/view/${policyNameSegment(authPolicy.name)}`}
                   state={returnTo ? { returnTo } : undefined}
                 >
                   {authPolicy.displayName ?? authPolicy.name}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -48,7 +48,7 @@ const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
           component={(props) => (
             <Link
               {...props}
-              to={`${returnTo ?? `${URL_PREFIX}/auth-policies`}/create`}
+              to={`${(returnTo ?? `${URL_PREFIX}/auth-policies`).split('?')[0]}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -48,7 +48,7 @@ const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
           component={(props) => (
             <Link
               {...props}
-              to={`${URL_PREFIX}/auth-policies/create`}
+              to={`${returnTo ?? `${URL_PREFIX}/auth-policies`}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar.tsx
@@ -15,11 +15,13 @@ type AuthPoliciesToolbarProps = {
     key: AuthPoliciesFilterOptions,
     value?: string | { label: string; value: string },
   ) => void;
+  returnTo?: string;
 };
 
 const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
   filterData,
   onFilterUpdate,
+  returnTo,
 }) => (
   <FilterToolbar<AuthPoliciesFilterOptions>
     data-testid="auth-policies-table-toolbar"
@@ -43,7 +45,13 @@ const AuthPoliciesToolbar: React.FC<AuthPoliciesToolbarProps> = ({
       <ToolbarItem>
         <Button
           variant="primary"
-          component={(props) => <Link {...props} to={`${URL_PREFIX}/auth-policies/create`} />}
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${URL_PREFIX}/auth-policies/create`}
+              state={returnTo ? { returnTo } : undefined}
+            />
+          )}
           data-testid="create-auth-policy-button"
         >
           Create authorization policy

--- a/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
+++ b/packages/maas/frontend/src/app/pages/auth-policies/policyForm/PolicyForm.tsx
@@ -43,9 +43,10 @@ const policyFormSchema = z.object({
 export type PolicyFormProps = {
   formData: SubscriptionPolicyFormDataResponse;
   initialPolicy?: MaaSAuthPolicy;
+  returnTo?: string;
 };
 
-const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
+const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy, returnTo }) => {
   const navigate = useNavigate();
   const { data: nameDescData, onDataChange: onNameDescChange } = useK8sNameDescriptionFieldData(
     initialPolicy
@@ -131,7 +132,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
         const request: UpdatePolicyRequest = sharedFields;
         await updateAuthPolicy(initialPolicy.name)(apiOpts, request);
       }
-      navigate(`${URL_PREFIX}/auth-policies`);
+      navigate(returnTo ?? `${URL_PREFIX}/auth-policies`);
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : 'Failed to save policy');
     } finally {
@@ -261,7 +262,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({ formData, initialPolicy }) => {
           </Button>
           <Button
             variant="link"
-            onClick={() => navigate(`${URL_PREFIX}/auth-policies`)}
+            onClick={() => navigate(returnTo ?? `${URL_PREFIX}/auth-policies`)}
             isDisabled={isSubmitting}
             data-testid="policy-cancel-button"
           >

--- a/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { useListAuthPolicies } from '~/app/hooks/useListAuthPolicies';
+import { MaaSAuthPolicy } from '~/app/types/subscriptions';
+import AuthPoliciesTable from '~/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTable';
+import EmptyAuthPoliciesPage from '~/app/pages/auth-policies/EmptyAuthPoliciesPage';
+import DeleteAuthPolicyModal from '~/app/pages/auth-policies/DeleteAuthPolicyModal';
+import AuthPoliciesToolbar from '~/app/pages/auth-policies/allAuthPolicies/AuthPoliciesToolbar';
+import {
+  AuthPoliciesFilterDataType,
+  AuthPoliciesFilterOptions,
+  initialAuthPoliciesFilterData,
+} from '~/app/pages/auth-policies/allAuthPolicies/const';
+
+type AuthPoliciesTabProps = {
+  returnTo?: string;
+};
+
+const AuthPoliciesTab: React.FC<AuthPoliciesTabProps> = ({ returnTo }) => {
+  const [authPolicies, loaded, error, refresh] = useListAuthPolicies();
+  const [deleteAuthPolicy, setDeleteAuthPolicy] = React.useState<MaaSAuthPolicy | undefined>(
+    undefined,
+  );
+  const [filterData, setFilterData] = React.useState<AuthPoliciesFilterDataType>(
+    initialAuthPoliciesFilterData,
+  );
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value?: string | { label: string; value: string }) =>
+      setFilterData((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
+
+  const onClearFilters = React.useCallback(() => setFilterData(initialAuthPoliciesFilterData), []);
+
+  const filteredAuthPolicies = React.useMemo(() => {
+    const keyword = filterData[AuthPoliciesFilterOptions.keyword]?.toLowerCase();
+
+    return authPolicies.filter((policy) => {
+      if (keyword) {
+        const displayedName = (policy.displayName ?? policy.name).toLowerCase();
+        return (
+          displayedName.includes(keyword) ||
+          (policy.description ?? '').toLowerCase().includes(keyword)
+        );
+      }
+      return true;
+    });
+  }, [authPolicies, filterData]);
+
+  if (!loaded && !error) {
+    return (
+      <PageSection isFilled>
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      </PageSection>
+    );
+  }
+
+  if (loaded && !error && authPolicies.length === 0) {
+    return <EmptyAuthPoliciesPage returnTo={returnTo} />;
+  }
+
+  return (
+    <>
+      {loaded && (
+        <PageSection isFilled>
+          <AuthPoliciesTable
+            authPolicies={filteredAuthPolicies}
+            setDeleteAuthPolicy={setDeleteAuthPolicy}
+            onClearFilters={onClearFilters}
+            toolbarContent={
+              <AuthPoliciesToolbar
+                filterData={filterData}
+                onFilterUpdate={onFilterUpdate}
+                returnTo={returnTo}
+              />
+            }
+            returnTo={returnTo}
+          />
+        </PageSection>
+      )}
+      {deleteAuthPolicy && (
+        <DeleteAuthPolicyModal
+          authPolicy={deleteAuthPolicy}
+          onClose={(deleted?: boolean) => {
+            if (deleted) {
+              refresh();
+            }
+            setDeleteAuthPolicy(undefined);
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default AuthPoliciesTab;

--- a/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/AuthPoliciesTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { Alert, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { useListAuthPolicies } from '~/app/hooks/useListAuthPolicies';
 import { MaaSAuthPolicy } from '~/app/types/subscriptions';
 import AuthPoliciesTable from '~/app/pages/auth-policies/allAuthPolicies/AuthPoliciesTable';
@@ -58,7 +58,17 @@ const AuthPoliciesTab: React.FC<AuthPoliciesTabProps> = ({ returnTo }) => {
     );
   }
 
-  if (loaded && !error && authPolicies.length === 0) {
+  if (error) {
+    return (
+      <PageSection isFilled>
+        <Alert variant="danger" isInline title="Error loading authorization policies">
+          {error.message}
+        </Alert>
+      </PageSection>
+    );
+  }
+
+  if (authPolicies.length === 0) {
     return <EmptyAuthPoliciesPage returnTo={returnTo} />;
   }
 

--- a/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/OverviewTab.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { PageSection } from '@patternfly/react-core';
+
+const OverviewTab: React.FC = () => (
+  <PageSection isFilled>Subscription overview placeholder</PageSection>
+);
+
+export default OverviewTab;

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionManagementPage.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { useNavigate, useParams } from 'react-router-dom';
+import { URL_PREFIX } from '~/app/utilities/const';
+import OverviewTab from './OverviewTab';
+import SubscriptionsTab from './SubscriptionsTab';
+import AuthPoliciesTab from './AuthPoliciesTab';
+
+const OVERVIEW_TAB = 'overview';
+const SUBSCRIPTIONS_TAB = 'subscriptions';
+const AUTH_POLICIES_TAB = 'auth-policies';
+const VALID_TABS = [OVERVIEW_TAB, SUBSCRIPTIONS_TAB, AUTH_POLICIES_TAB];
+
+const SubscriptionManagementPage: React.FC = () => {
+  const { tab } = useParams<{ tab: string }>();
+  const navigate = useNavigate();
+
+  const activeTab = tab && VALID_TABS.includes(tab) ? tab : OVERVIEW_TAB;
+
+  const onSelectTab = React.useCallback(
+    (_event: React.MouseEvent, tabKey: string | number) => {
+      navigate(`${URL_PREFIX}/subscription-management/${String(tabKey)}`);
+    },
+    [navigate],
+  );
+
+  return (
+    <ApplicationsPage
+      title="Subscription management"
+      description="Manage subscriptions and authorization policies to control the MaaS models that each user group in your organization can access."
+      loaded
+      empty={false}
+    >
+      <Tabs
+        activeKey={activeTab}
+        onSelect={onSelectTab}
+        aria-label="Subscription management tabs"
+        inset={{ default: 'insetNone' }}
+      >
+        <Tab
+          eventKey={OVERVIEW_TAB}
+          title={<TabTitleText>Overview</TabTitleText>}
+          aria-label="Overview tab"
+          data-testid="overview-tab"
+        >
+          <OverviewTab />
+        </Tab>
+        <Tab
+          eventKey={SUBSCRIPTIONS_TAB}
+          title={<TabTitleText>Subscriptions</TabTitleText>}
+          aria-label="Subscriptions tab"
+          data-testid="subscriptions-tab"
+        >
+          <SubscriptionsTab
+            returnTo={`${URL_PREFIX}/subscription-management/${SUBSCRIPTIONS_TAB}`}
+          />
+        </Tab>
+        <Tab
+          eventKey={AUTH_POLICIES_TAB}
+          title={<TabTitleText>Authorization policies</TabTitleText>}
+          aria-label="Authorization policies tab"
+          data-testid="auth-policies-tab"
+        >
+          <AuthPoliciesTab
+            returnTo={`${URL_PREFIX}/subscription-management/${AUTH_POLICIES_TAB}`}
+          />
+        </Tab>
+      </Tabs>
+    </ApplicationsPage>
+  );
+};
+
+export default SubscriptionManagementPage;

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { Alert, Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { useListSubscriptions } from '~/app/hooks/useListSubscriptions';
 import { MaaSSubscription } from '~/app/types/subscriptions';
 import { SubscriptionsTable } from '~/app/pages/subscriptions/allSubscriptions/SubscriptionsTable';
@@ -56,7 +56,17 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ returnTo }) => {
     );
   }
 
-  if (loaded && !error && subscriptions.length === 0) {
+  if (error) {
+    return (
+      <PageSection isFilled>
+        <Alert variant="danger" isInline title="Error loading subscriptions">
+          {error.message}
+        </Alert>
+      </PageSection>
+    );
+  }
+
+  if (subscriptions.length === 0) {
     return <EmptySubscriptionsPage returnTo={returnTo} />;
   }
 

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
@@ -92,9 +92,11 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ returnTo }) => {
       {deleteSubscription && (
         <DeleteSubscriptionModal
           subscription={deleteSubscription}
-          onClose={() => {
+          onClose={(deleted?: boolean) => {
             setDeleteSubscription(undefined);
-            refresh();
+            if (deleted) {
+              refresh();
+            }
           }}
         />
       )}

--- a/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/SubscriptionsTab.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { useListSubscriptions } from '~/app/hooks/useListSubscriptions';
+import { MaaSSubscription } from '~/app/types/subscriptions';
+import { SubscriptionsTable } from '~/app/pages/subscriptions/allSubscriptions/SubscriptionsTable';
+import SubscriptionsToolbar from '~/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar';
+import {
+  initialSubscriptionsFilterData,
+  SubscriptionsFilterDataType,
+  SubscriptionsFilterOptions,
+} from '~/app/pages/subscriptions/allSubscriptions/const';
+import DeleteSubscriptionModal from '~/app/pages/subscriptions/DeleteSubscriptionModal';
+import EmptySubscriptionsPage from '~/app/pages/subscriptions/EmptySubscriptionsPage';
+
+type SubscriptionsTabProps = {
+  returnTo?: string;
+};
+
+const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ returnTo }) => {
+  const [subscriptions, loaded, error, refresh] = useListSubscriptions();
+  const [filterData, setFilterData] = React.useState<SubscriptionsFilterDataType>(
+    initialSubscriptionsFilterData,
+  );
+
+  const onFilterUpdate = React.useCallback(
+    (key: string, value?: string | { label: string; value: string }) =>
+      setFilterData((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
+
+  const onClearFilters = React.useCallback(() => setFilterData(initialSubscriptionsFilterData), []);
+
+  const filteredSubscriptions = React.useMemo(() => {
+    const keyword = filterData[SubscriptionsFilterOptions.keyword]?.toLowerCase();
+    return keyword
+      ? subscriptions.filter(
+          (sub) =>
+            sub.name.toLowerCase().includes(keyword) ||
+            sub.displayName?.toLowerCase().includes(keyword) ||
+            sub.description?.toLowerCase().includes(keyword),
+        )
+      : subscriptions;
+  }, [subscriptions, filterData]);
+
+  const [deleteSubscription, setDeleteSubscription] = React.useState<MaaSSubscription | undefined>(
+    undefined,
+  );
+
+  if (!loaded && !error) {
+    return (
+      <PageSection isFilled>
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      </PageSection>
+    );
+  }
+
+  if (loaded && !error && subscriptions.length === 0) {
+    return <EmptySubscriptionsPage returnTo={returnTo} />;
+  }
+
+  return (
+    <>
+      {loaded && (
+        <PageSection isFilled>
+          <SubscriptionsTable
+            subscriptions={filteredSubscriptions}
+            onClearFilters={onClearFilters}
+            toolbarContent={
+              <SubscriptionsToolbar
+                filterData={filterData}
+                onFilterUpdate={onFilterUpdate}
+                returnTo={returnTo}
+              />
+            }
+            setDeleteSubscription={setDeleteSubscription}
+            returnTo={returnTo}
+          />
+        </PageSection>
+      )}
+      {deleteSubscription && (
+        <DeleteSubscriptionModal
+          subscription={deleteSubscription}
+          onClose={() => {
+            setDeleteSubscription(undefined);
+            refresh();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default SubscriptionsTab;

--- a/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
+++ b/packages/maas/frontend/src/app/pages/subscription-management/__tests__/SubscriptionManagementPage.spec.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SubscriptionManagementPage from '~/app/pages/subscription-management/SubscriptionManagementPage';
+
+const mockNavigate = jest.fn();
+let mockTab: string | undefined;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ tab: mockTab }),
+}));
+
+jest.mock('@odh-dashboard/internal/pages/ApplicationsPage', () => {
+  const MockApplicationsPage = (
+    props: React.PropsWithChildren<{ title: string; description: React.ReactNode }>,
+  ) => (
+    <div>
+      <h1 data-testid="app-page-title">{props.title}</h1>
+      <p data-testid="app-page-description">{props.description}</p>
+      {props.children}
+    </div>
+  );
+  MockApplicationsPage.displayName = 'MockApplicationsPage';
+  return { __esModule: true, default: MockApplicationsPage };
+});
+
+jest.mock('~/app/pages/subscription-management/OverviewTab', () => {
+  const MockOverviewTab = () => <div data-testid="mock-overview-tab">OverviewTab</div>;
+  MockOverviewTab.displayName = 'MockOverviewTab';
+  return { __esModule: true, default: MockOverviewTab };
+});
+
+jest.mock('~/app/pages/subscription-management/SubscriptionsTab', () => {
+  const MockSubscriptionsTab = () => (
+    <div data-testid="mock-subscriptions-tab">SubscriptionsTab</div>
+  );
+  MockSubscriptionsTab.displayName = 'MockSubscriptionsTab';
+  return { __esModule: true, default: MockSubscriptionsTab };
+});
+
+jest.mock('~/app/pages/subscription-management/AuthPoliciesTab', () => {
+  const MockAuthPoliciesTab = () => <div data-testid="mock-auth-policies-tab">AuthPoliciesTab</div>;
+  MockAuthPoliciesTab.displayName = 'MockAuthPoliciesTab';
+  return { __esModule: true, default: MockAuthPoliciesTab };
+});
+
+describe('SubscriptionManagementPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTab = undefined;
+  });
+
+  it('should show title and description', () => {
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('app-page-title')).toHaveTextContent('Subscription management');
+    expect(screen.getByTestId('app-page-description')).toHaveTextContent(
+      'Manage subscriptions and authorization policies',
+    );
+  });
+
+  it('should render all three tabs', () => {
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('overview-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('subscriptions-tab')).toBeInTheDocument();
+    expect(screen.getByTestId('auth-policies-tab')).toBeInTheDocument();
+  });
+
+  it('should default to the overview tab when no tab param is provided', () => {
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('overview-tab')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('mock-overview-tab')).toBeInTheDocument();
+  });
+
+  it('should activate the subscriptions tab when tab param is "subscriptions"', () => {
+    mockTab = 'subscriptions';
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('subscriptions-tab')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should activate the auth policies tab when tab param is "auth-policies"', () => {
+    mockTab = 'auth-policies';
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('auth-policies-tab')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should fall back to overview tab for an invalid tab param', () => {
+    mockTab = 'invalid-tab';
+    render(<SubscriptionManagementPage />);
+
+    expect(screen.getByTestId('overview-tab')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should navigate when a tab is clicked', () => {
+    render(<SubscriptionManagementPage />);
+
+    fireEvent.click(screen.getByTestId('subscriptions-tab'));
+    expect(mockNavigate).toHaveBeenCalledWith('/maas/subscription-management/subscriptions');
+
+    fireEvent.click(screen.getByTestId('auth-policies-tab'));
+    expect(mockNavigate).toHaveBeenCalledWith('/maas/subscription-management/auth-policies');
+  });
+});

--- a/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { URL_PREFIX } from '~/app/utilities/const';
@@ -8,15 +8,22 @@ import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm'
 
 const CreateSubscriptionPage: React.FC = () => {
   const [formData, loaded, error] = useSubscriptionPolicyFormData();
+  const { state } = useLocation();
+  const returnTo =
+    state != null &&
+    typeof state === 'object' &&
+    'returnTo' in state &&
+    typeof state.returnTo === 'string'
+      ? state.returnTo
+      : undefined;
+  const backUrl = returnTo ?? `${URL_PREFIX}/subscriptions`;
 
   return (
     <ApplicationsPage
       title="Create subscription"
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to={`${URL_PREFIX}/subscriptions`}>Subscriptions</Link>}
-          />
+          <BreadcrumbItem render={() => <Link to={backUrl}>Subscriptions</Link>} />
           <BreadcrumbItem isActive>Create subscription</BreadcrumbItem>
         </Breadcrumb>
       }
@@ -24,7 +31,7 @@ const CreateSubscriptionPage: React.FC = () => {
       empty={false}
       loadError={error}
     >
-      <CreateSubscriptionForm formData={formData} />
+      <CreateSubscriptionForm formData={formData} returnTo={returnTo} />
     </ApplicationsPage>
   );
 };

--- a/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
@@ -3,19 +3,14 @@ import { Link, useLocation } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm';
 
 const CreateSubscriptionPage: React.FC = () => {
   const [formData, loaded, error] = useSubscriptionPolicyFormData();
   const { state } = useLocation();
-  const returnTo =
-    state != null &&
-    typeof state === 'object' &&
-    'returnTo' in state &&
-    typeof state.returnTo === 'string'
-      ? state.returnTo
-      : undefined;
+  const returnTo = getReturnToFromState(state);
   const backUrl = returnTo ?? `${URL_PREFIX}/subscriptions`;
 
   return (

--- a/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/CreateSubscriptionPage.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm';
 
 const CreateSubscriptionPage: React.FC = () => {
   const [formData, loaded, error] = useSubscriptionPolicyFormData();
-  const { state } = useLocation();
-  const returnTo = getReturnToFromState(state);
-  const backUrl = returnTo ?? `${URL_PREFIX}/subscriptions`;
+  const { state, pathname } = useLocation();
+  const backUrl = getBackUrl(pathname, state, 'subscriptions');
+  const returnTo = backUrl;
 
   return (
     <ApplicationsPage

--- a/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import { useGetSubscriptionInfo } from '~/app/hooks/useGetSubscriptionInfo';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm';
 
 const EditSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();
+  const { state } = useLocation();
+  const returnTo = getReturnToFromState(state);
+  const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
   const [subscriptionInfo, infoLoaded, infoError] = useGetSubscriptionInfo(subscriptionName);
   const [formData, formLoaded, formError] = useSubscriptionPolicyFormData();
 
@@ -29,12 +33,13 @@ const EditSubscriptionPage: React.FC = () => {
       }
       breadcrumb={
         <Breadcrumb>
-          <BreadcrumbItem
-            render={() => <Link to={`${URL_PREFIX}/subscriptions`}>Subscriptions</Link>}
-          />
+          <BreadcrumbItem render={() => <Link to={base}>Subscriptions</Link>} />
           <BreadcrumbItem
             render={() => (
-              <Link to={`${URL_PREFIX}/subscriptions/view/${subscriptionName}`}>
+              <Link
+                to={`${base}/view/${subscriptionName}`}
+                state={returnTo ? { returnTo } : undefined}
+              >
                 {displayName || subscriptionName}
               </Link>
             )}
@@ -48,7 +53,11 @@ const EditSubscriptionPage: React.FC = () => {
       errorMessage="Unable to load subscription details."
     >
       {subscriptionInfo && (
-        <CreateSubscriptionForm formData={formData} subscriptionInfo={subscriptionInfo} />
+        <CreateSubscriptionForm
+          formData={formData}
+          subscriptionInfo={subscriptionInfo}
+          returnTo={returnTo}
+        />
       )}
     </ApplicationsPage>
   );

--- a/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EditSubscriptionPage.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
-import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import { useGetSubscriptionInfo } from '~/app/hooks/useGetSubscriptionInfo';
 import { useSubscriptionPolicyFormData } from '~/app/hooks/useSubscriptionPolicyFormData';
 import CreateSubscriptionForm from './createSubscription/CreateSubscriptionForm';
 
 const EditSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();
-  const { state } = useLocation();
-  const returnTo = getReturnToFromState(state);
-  const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
+  const { state, pathname } = useLocation();
+  const base = getBackUrl(pathname, state, 'subscriptions');
+  const returnTo = base;
   const [subscriptionInfo, infoLoaded, infoError] = useGetSubscriptionInfo(subscriptionName);
   const [formData, formLoaded, formError] = useSubscriptionPolicyFormData();
 

--- a/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
@@ -20,7 +20,7 @@ const EmptySubscriptionsPage: React.FC<EmptySubscriptionsPageProps> = ({ returnT
           component={(props) => (
             <Link
               {...props}
-              to={`${URL_PREFIX}/subscriptions/create`}
+              to={`${returnTo ?? `${URL_PREFIX}/subscriptions`}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
@@ -20,7 +20,7 @@ const EmptySubscriptionsPage: React.FC<EmptySubscriptionsPageProps> = ({ returnT
           component={(props) => (
             <Link
               {...props}
-              to={`${returnTo ?? `${URL_PREFIX}/subscriptions`}/create`}
+              to={`${(returnTo ?? `${URL_PREFIX}/subscriptions`).split('?')[0]}/create`}
               state={returnTo ? { returnTo } : undefined}
             />
           )}

--- a/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/EmptySubscriptionsPage.tsx
@@ -4,7 +4,11 @@ import { Button } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
 
-const EmptySubscriptionsPage: React.FC = () => (
+type EmptySubscriptionsPageProps = {
+  returnTo?: string;
+};
+
+const EmptySubscriptionsPage: React.FC<EmptySubscriptionsPageProps> = ({ returnTo }) => (
   <>
     <EmptyDetailsView
       title="No Subscriptions"
@@ -13,7 +17,13 @@ const EmptySubscriptionsPage: React.FC = () => (
       createButton={
         <Button
           variant="primary"
-          component={(props) => <Link {...props} to={`${URL_PREFIX}/subscriptions/create`} />}
+          component={(props) => (
+            <Link
+              {...props}
+              to={`${URL_PREFIX}/subscriptions/create`}
+              state={returnTo ? { returnTo } : undefined}
+            />
+          )}
           data-testid="create-subscription-button"
         >
           Create subscription

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import {
   Breadcrumb,
@@ -24,9 +24,10 @@ import SubscriptionGroupsSection from './viewSubscription/SubscriptionGroupsSect
 
 type SubscriptionActionsProps = {
   subscription: MaaSSubscription;
+  returnTo?: string;
 };
 
-const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription }) => {
+const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription, returnTo }) => {
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
 
@@ -56,7 +57,7 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription 
           onClose={(deleted) => {
             setIsDeleteOpen(false);
             if (deleted) {
-              navigate(`${URL_PREFIX}/subscriptions`);
+              navigate(returnTo ?? `${URL_PREFIX}/subscriptions`);
             }
           }}
         />
@@ -87,15 +88,28 @@ const viewModelRefSummaries = (info: SubscriptionInfoResponse): MaaSModelRefSumm
 
 const ViewSubscriptionPage: React.FC = () => {
   const { subscriptionName = '' } = useParams<{ subscriptionName: string }>();
+  const location = useLocation();
   const [activeTab, setActiveTab] = React.useState<string | number>('details');
   const [subscriptionInfo, loaded, loadError] = useGetSubscriptionInfo(subscriptionName);
   const displaySubscriptionName =
     subscriptionInfo?.subscription.displayName?.trim() || subscriptionName;
 
+  const { state } = location;
+  const returnTo =
+    state != null &&
+    typeof state === 'object' &&
+    'returnTo' in state &&
+    typeof state.returnTo === 'string'
+      ? state.returnTo
+      : undefined;
+
   const breadcrumb = (
     <Breadcrumb>
       <BreadcrumbItem>
-        <Link to={`${URL_PREFIX}/subscriptions`} data-testid="breadcrumb-subscriptions-link">
+        <Link
+          to={returnTo ?? `${URL_PREFIX}/subscriptions`}
+          data-testid="breadcrumb-subscriptions-link"
+        >
           Subscriptions
         </Link>
       </BreadcrumbItem>
@@ -108,7 +122,9 @@ const ViewSubscriptionPage: React.FC = () => {
       title={displaySubscriptionName}
       breadcrumb={breadcrumb}
       headerAction={
-        subscriptionInfo && <SubscriptionActions subscription={subscriptionInfo.subscription} />
+        subscriptionInfo && (
+          <SubscriptionActions subscription={subscriptionInfo.subscription} returnTo={returnTo} />
+        )
       }
       empty={false}
       loaded={loaded || !!loadError}

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -17,7 +17,7 @@ import {
   SubscriptionInfoResponse,
 } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
-import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
+import { getBackUrl } from '~/app/utilities/subscriptionManagementNavigation';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteSubscriptionModal from './DeleteSubscriptionModal';
 import SubscriptionDetailsSection from './viewSubscription/SubscriptionDetailsSection';
@@ -97,15 +97,12 @@ const ViewSubscriptionPage: React.FC = () => {
   const displaySubscriptionName =
     subscriptionInfo?.subscription.displayName?.trim() || subscriptionName;
 
-  const returnTo = getReturnToFromState(location.state);
+  const backUrl = getBackUrl(location.pathname, location.state, 'subscriptions');
 
   const breadcrumb = (
     <Breadcrumb>
       <BreadcrumbItem>
-        <Link
-          to={returnTo ?? `${URL_PREFIX}/subscriptions`}
-          data-testid="breadcrumb-subscriptions-link"
-        >
+        <Link to={backUrl} data-testid="breadcrumb-subscriptions-link">
           Subscriptions
         </Link>
       </BreadcrumbItem>
@@ -119,7 +116,7 @@ const ViewSubscriptionPage: React.FC = () => {
       breadcrumb={breadcrumb}
       headerAction={
         subscriptionInfo && (
-          <SubscriptionActions subscription={subscriptionInfo.subscription} returnTo={returnTo} />
+          <SubscriptionActions subscription={subscriptionInfo.subscription} returnTo={backUrl} />
         )
       }
       empty={false}

--- a/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/ViewSubscriptionPage.tsx
@@ -17,6 +17,7 @@ import {
   SubscriptionInfoResponse,
 } from '~/app/types/subscriptions';
 import { URL_PREFIX } from '~/app/utilities/const';
+import { getReturnToFromState } from '~/app/utilities/subscriptionManagementNavigation';
 import MaasModelsSection from '~/app/shared/MaasModelsSection';
 import DeleteSubscriptionModal from './DeleteSubscriptionModal';
 import SubscriptionDetailsSection from './viewSubscription/SubscriptionDetailsSection';
@@ -30,6 +31,8 @@ type SubscriptionActionsProps = {
 const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription, returnTo }) => {
   const navigate = useNavigate();
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
+  const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
+  const navState = returnTo ? { state: { returnTo } } : undefined;
 
   return (
     <>
@@ -39,7 +42,7 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription,
           {
             key: 'edit',
             label: 'Edit',
-            onClick: () => navigate(`${URL_PREFIX}/subscriptions/edit/${subscription.name}`),
+            onClick: () => navigate(`${base}/edit/${subscription.name}`, navState),
             isDisabled: !!subscription.deletionTimestamp,
           },
           { isSpacer: true },
@@ -57,7 +60,7 @@ const SubscriptionActions: React.FC<SubscriptionActionsProps> = ({ subscription,
           onClose={(deleted) => {
             setIsDeleteOpen(false);
             if (deleted) {
-              navigate(returnTo ?? `${URL_PREFIX}/subscriptions`);
+              navigate(base);
             }
           }}
         />
@@ -94,14 +97,7 @@ const ViewSubscriptionPage: React.FC = () => {
   const displaySubscriptionName =
     subscriptionInfo?.subscription.displayName?.trim() || subscriptionName;
 
-  const { state } = location;
-  const returnTo =
-    state != null &&
-    typeof state === 'object' &&
-    'returnTo' in state &&
-    typeof state.returnTo === 'string'
-      ? state.returnTo
-      : undefined;
+  const returnTo = getReturnToFromState(location.state);
 
   const breadcrumb = (
     <Breadcrumb>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -16,20 +16,23 @@ type SubscriptionTableRowProps = {
   subscription: MaaSSubscription;
   key: string;
   setDeleteSubscription: (subscription: MaaSSubscription) => void;
+  returnTo?: string;
 };
 
 const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   subscription,
   key,
   setDeleteSubscription,
+  returnTo,
 }) => {
   const navigate = useNavigate();
+  const navState = returnTo ? { state: { returnTo } } : undefined;
 
   const onViewDetailsSubscription = (subscriptionName: string) => {
-    navigate(`${URL_PREFIX}/subscriptions/view/${subscriptionName}`);
+    navigate(`${URL_PREFIX}/subscriptions/view/${subscriptionName}`, navState);
   };
   const onEditSubscription = (subscriptionName: string) => {
-    navigate(`${URL_PREFIX}/subscriptions/edit/${subscriptionName}`);
+    navigate(`${URL_PREFIX}/subscriptions/edit/${subscriptionName}`, navState);
   };
   const onDeleteSubscription = (subscriptionToDelete: MaaSSubscription) => {
     setDeleteSubscription(subscriptionToDelete);
@@ -57,7 +60,10 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
               </span>
             ) : (
               <ResourceNameTooltip resource={convertSubscriptionToK8sResource(subscription)}>
-                <Link to={`${URL_PREFIX}/subscriptions/view/${subscription.name}`}>
+                <Link
+                  to={`${URL_PREFIX}/subscriptions/view/${subscription.name}`}
+                  state={returnTo ? { returnTo } : undefined}
+                >
                   {subscription.displayName ?? subscription.name}
                 </Link>
               </ResourceNameTooltip>

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionTableRow.tsx
@@ -26,13 +26,14 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   returnTo,
 }) => {
   const navigate = useNavigate();
+  const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
   const navState = returnTo ? { state: { returnTo } } : undefined;
 
   const onViewDetailsSubscription = (subscriptionName: string) => {
-    navigate(`${URL_PREFIX}/subscriptions/view/${subscriptionName}`, navState);
+    navigate(`${base}/view/${subscriptionName}`, navState);
   };
   const onEditSubscription = (subscriptionName: string) => {
-    navigate(`${URL_PREFIX}/subscriptions/edit/${subscriptionName}`, navState);
+    navigate(`${base}/edit/${subscriptionName}`, navState);
   };
   const onDeleteSubscription = (subscriptionToDelete: MaaSSubscription) => {
     setDeleteSubscription(subscriptionToDelete);
@@ -61,7 +62,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
             ) : (
               <ResourceNameTooltip resource={convertSubscriptionToK8sResource(subscription)}>
                 <Link
-                  to={`${URL_PREFIX}/subscriptions/view/${subscription.name}`}
+                  to={`${base}/view/${subscription.name}`}
                   state={returnTo ? { returnTo } : undefined}
                 >
                   {subscription.displayName ?? subscription.name}

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsTable.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsTable.tsx
@@ -10,6 +10,7 @@ type SubscriptionTableProps = {
   toolbarContent?: React.ReactElement;
   onClearFilters: () => void;
   setDeleteSubscription: (subscription: MaaSSubscription) => void;
+  returnTo?: string;
 };
 
 export const SubscriptionsTable: React.FC<SubscriptionTableProps> = ({
@@ -17,6 +18,7 @@ export const SubscriptionsTable: React.FC<SubscriptionTableProps> = ({
   toolbarContent,
   onClearFilters,
   setDeleteSubscription,
+  returnTo,
 }): React.ReactNode => (
   <Table
     data-testid="subscriptions-table"
@@ -28,6 +30,7 @@ export const SubscriptionsTable: React.FC<SubscriptionTableProps> = ({
         key={subscription.name}
         subscription={subscription}
         setDeleteSubscription={setDeleteSubscription}
+        returnTo={returnTo}
       />
     )}
     emptyTableView={<DashboardEmptyTableView onClearFilters={onClearFilters} />}

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
@@ -15,11 +15,13 @@ type SubscriptionsToolbarProps = {
     key: SubscriptionsFilterOptions,
     value?: string | { label: string; value: string },
   ) => void;
+  returnTo?: string;
 };
 
 const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
   filterData,
   onFilterUpdate,
+  returnTo,
 }) => {
   const navigate = useNavigate();
   return (
@@ -46,7 +48,9 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
           <Button
             variant="primary"
             onClick={() => {
-              navigate(`${URL_PREFIX}/subscriptions/create`);
+              navigate(`${URL_PREFIX}/subscriptions/create`, {
+                state: returnTo ? { returnTo } : undefined,
+              });
             }}
             data-testid="create-subscription-button"
           >

--- a/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/allSubscriptions/SubscriptionsToolbar.tsx
@@ -48,7 +48,8 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
           <Button
             variant="primary"
             onClick={() => {
-              navigate(`${URL_PREFIX}/subscriptions/create`, {
+              const base = returnTo ?? `${URL_PREFIX}/subscriptions`;
+              navigate(`${base}/create`, {
                 state: returnTo ? { returnTo } : undefined,
               });
             }}

--- a/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
+++ b/packages/maas/frontend/src/app/pages/subscriptions/createSubscription/CreateSubscriptionForm.tsx
@@ -43,6 +43,7 @@ import EditRateLimitsModal from './EditRateLimitsModal';
 type CreateSubscriptionFormProps = {
   formData: SubscriptionPolicyFormDataResponse;
   subscriptionInfo?: SubscriptionInfoResponse;
+  returnTo?: string;
 };
 const MAX_PRIORITY = 1000000;
 const MIN_PRIORITY = -1000000;
@@ -77,6 +78,7 @@ const buildInitialModels = (info: SubscriptionInfoResponse): SubscriptionModelEn
 const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
   formData,
   subscriptionInfo,
+  returnTo,
 }) => {
   const navigate = useNavigate();
   const isEditing = !!subscriptionInfo;
@@ -247,7 +249,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
         };
         await createSubscription()(apiOpts, request);
       }
-      navigate(`${URL_PREFIX}/subscriptions`);
+      navigate(returnTo ?? `${URL_PREFIX}/subscriptions`);
     } catch (e) {
       setSubmitError(
         e instanceof Error
@@ -505,7 +507,7 @@ const CreateSubscriptionForm: React.FC<CreateSubscriptionFormProps> = ({
           </Button>
           <Button
             variant="link"
-            onClick={() => navigate(`${URL_PREFIX}/subscriptions`)}
+            onClick={() => navigate(returnTo ?? `${URL_PREFIX}/subscriptions`)}
             isDisabled={isSubmitting}
             data-testid="cancel-subscription-button"
           >

--- a/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
+++ b/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
@@ -1,5 +1,7 @@
 import { URL_PREFIX } from './const';
 
+const SUBSCRIPTION_MANAGEMENT_PREFIX = `${URL_PREFIX}/subscription-management`;
+
 export const getReturnToFromState = (state: unknown): string | undefined => {
   if (state == null || typeof state !== 'object' || !('returnTo' in state)) {
     return undefined;
@@ -20,4 +22,21 @@ export const getReturnToFromState = (state: unknown): string | undefined => {
   }
 
   return undefined;
+};
+
+export const getBackUrl = (
+  pathname: string,
+  state: unknown,
+  section: 'subscriptions' | 'auth-policies',
+): string => {
+  const returnTo = getReturnToFromState(state);
+  if (returnTo) {
+    return returnTo;
+  }
+
+  if (pathname.startsWith(`${SUBSCRIPTION_MANAGEMENT_PREFIX}/`)) {
+    return `${SUBSCRIPTION_MANAGEMENT_PREFIX}/${section}`;
+  }
+
+  return `${URL_PREFIX}/${section}`;
 };

--- a/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
+++ b/packages/maas/frontend/src/app/utilities/subscriptionManagementNavigation.ts
@@ -1,0 +1,23 @@
+import { URL_PREFIX } from './const';
+
+export const getReturnToFromState = (state: unknown): string | undefined => {
+  if (state == null || typeof state !== 'object' || !('returnTo' in state)) {
+    return undefined;
+  }
+
+  const obj: Record<string, unknown> = Object.assign({}, state);
+  const { returnTo } = obj;
+  if (typeof returnTo !== 'string') {
+    return undefined;
+  }
+
+  if (returnTo.startsWith(URL_PREFIX)) {
+    return returnTo;
+  }
+
+  if (returnTo.startsWith('/') && !returnTo.startsWith('//')) {
+    return returnTo;
+  }
+
+  return undefined;
+};

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -8,7 +8,7 @@ import {
 export const MODEL_AS_SERVICE_ID = 'modelAsService';
 export const MAAS_AUTH_POLICIES = 'maasAuthPolicies';
 export const MAAS_MY_SUBSCRIPTIONS = 'mySubscriptions';
-export const MAAS_IA_REDESIGN = 'iaRedesign';
+export const MAAS_IA_REDESIGN = 'maasSettingsIaRedesign';
 
 export type ODHExtensions = NavExtension | RouteExtension | AreaExtension | TaskItemExtension;
 const ADMIN_USER = 'ADMIN_USER';
@@ -48,7 +48,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     type: 'app.area',
     properties: {
       id: MAAS_IA_REDESIGN,
-      featureFlags: ['iaRedesign'],
+      featureFlags: ['maasSettingsIaRedesign'],
     },
   },
   {

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -8,6 +8,7 @@ import {
 export const MODEL_AS_SERVICE_ID = 'modelAsService';
 export const MAAS_AUTH_POLICIES = 'maasAuthPolicies';
 export const MAAS_MY_SUBSCRIPTIONS = 'mySubscriptions';
+export const MAAS_IA_REDESIGN = 'iaRedesign';
 
 export type ODHExtensions = NavExtension | RouteExtension | AreaExtension | TaskItemExtension;
 const ADMIN_USER = 'ADMIN_USER';
@@ -44,9 +45,17 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     },
   },
   {
+    type: 'app.area',
+    properties: {
+      id: MAAS_IA_REDESIGN,
+      featureFlags: ['iaRedesign'],
+    },
+  },
+  {
     type: 'app.navigation/href',
     flags: {
       required: [MODEL_AS_SERVICE_ID, ADMIN_USER],
+      disallowed: [MAAS_IA_REDESIGN],
     },
     properties: {
       id: 'maas-subscriptions-view',
@@ -60,6 +69,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     type: 'app.navigation/href',
     flags: {
       required: [MODEL_AS_SERVICE_ID, ADMIN_USER, MAAS_AUTH_POLICIES],
+      disallowed: [MAAS_IA_REDESIGN],
     },
     properties: {
       id: 'maas-auth-policies-view',
@@ -67,6 +77,19 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
       href: '/maas/auth-policies',
       section: 'settings',
       path: '/maas/auth-policies/*',
+    },
+  },
+  {
+    type: 'app.navigation/href',
+    flags: {
+      required: [MODEL_AS_SERVICE_ID, ADMIN_USER, MAAS_IA_REDESIGN],
+    },
+    properties: {
+      id: 'maas-subscription-management-view',
+      title: 'Subscription management',
+      href: '/maas/subscription-management',
+      section: 'settings',
+      path: '/maas/subscription-management/*',
     },
   },
   {
@@ -125,6 +148,16 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     },
     properties: {
       path: '/maas/auth-policies/*',
+      component: () => import('./MaaSWrapper'),
+    },
+  },
+  {
+    type: 'app.route',
+    flags: {
+      required: [MODEL_AS_SERVICE_ID, ADMIN_USER, MAAS_IA_REDESIGN],
+    },
+    properties: {
+      path: '/maas/subscription-management/*',
       component: () => import('./MaaSWrapper'),
     },
   },


### PR DESCRIPTION
Closes: https://redhat.atlassian.net/browse/RHOAIENG-67029

## Description
Sets up for IA redesign. This PR adds in the feature flag, and combines subscriptions and auth policy into subscription management, using tabs to navigate. The new subscription management now has tabs for overview, subscriptions, and authorization policies.
All breadcrumbs and links have also been adjusted to work properly depending on the status of the feature flag
The content and functionality of subscriptions and auth policies remain the same.

## How Has This Been Tested?
Tested locally.

- Enable the iaRedesign feature flag
- See how subscriptions and auth policies in the navigation are replaced by subscription management
- The subscription management tab now holds tabs for overview, subscriptions, and authorization policies.
- Test that you can still create a subscription and auth policy, and that all current functionality still works. Also check breadcrumbs and links to ensure they bring you back to the correct version of the page

## Test Impact
Basic cypress test for new page added. Unit tests added

## Screenshots
<img width="1105" height="571" alt="Screenshot 2026-06-11 at 2 30 35 PM" src="https://github.com/user-attachments/assets/52ade904-565b-4717-b0e6-904f18a391e3" />
<img width="289" height="322" alt="Screenshot 2026-06-11 at 2 30 46 PM" src="https://github.com/user-attachments/assets/4193f75c-8773-49a5-841b-1af6ce444c22" />
<img width="1450" height="719" alt="Screenshot 2026-06-11 at 2 31 01 PM" src="https://github.com/user-attachments/assets/5e350552-6c2b-4c4e-9fef-d7db5d5c8d31" />



https://github.com/user-attachments/assets/c853e060-8dc4-4d04-8635-dad0a8d4bf58


## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Subscription Management page with Overview, Subscriptions, and Authorization Policies tabs, controlled by the `maasSettingsIaRedesign` feature flag.
  * Improved navigation context awareness across subscription and authorization policy pages for better user flow when navigating between sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->