### PR TITLE
RHOAIENG-68443: Increase Cypress E2E test job timeout from 30 to 60 minutes

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -521,7 +521,7 @@ jobs:
   e2e-tests:
     needs: [select-cluster, set-pending-status, get-test-tags]
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-68443

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The e2e-tests job in cypress-e2e-test.yml has timeout-minutes: 30, but the full test suite runs 29 specs that should take approximately 50 minutes to complete. This causes the job to be cancelled before all specs finish, producing incomplete CI results.

Analysis of two consecutive CI runs shows the job consistently reaching spec 15–16 of 29 before hitting the 30-minute limit. Extrapolating from actual run times, the full suite needs ~50 minutes including setup.

Increase the timeout to 60 minutes to allow all specs to complete with headroom for slower cluster conditions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Analyzed CI run logs to measure actual execution time: 16 of 29 specs completed in ~26 minutes of test time, extrapolating to ~47 minutes for all 29 specs plus ~4 minutes of setup
- Confirmed the job was cancelled due to the timeout and not a test failure


## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added — this is a CI workflow configuration change, not application code.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI end-to-end test job timeout from 30 to 60 minutes to accommodate longer-running test runs and reduce flaky timeouts.

---

*No user-facing changes in this release.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->