### PR TITLE
Global project indicator on Prompt Management page

### DIFF
--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Bullseye, Divider, Flex, FlexItem, MenuItem, Truncate } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Divider,
+  Flex,
+  FlexItem,
+  MenuGroup,
+  MenuItem,
+  Truncate,
+} from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { getDisplayNameFromK8sResource } from '@odh-dashboard/k8s-core';
 import { ProjectsContext } from '#~/concepts/projects/ProjectsContext';
@@ -14,7 +22,6 @@ type ProjectSelectorProps = {
   getSelectionHref?: (projectName: string) => string | undefined;
   invalidDropdownPlaceholder?: string;
   selectAllProjects?: boolean;
-  /** When set, shows a clear option at the top with this label (e.g. "None"). Selects empty string. */
   clearLabel?: string;
   primary?: boolean;
   showTitle?: boolean;
@@ -24,6 +31,7 @@ type ProjectSelectorProps = {
   isLoading?: boolean;
   namespacesOverride?: Namespace[];
   appendTo?: 'inline' | (() => HTMLElement) | HTMLElement;
+  pinnedNamespace?: { name: string; label: string };
 };
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({
@@ -41,6 +49,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   isLoading = false,
   namespacesOverride,
   appendTo,
+  pinnedNamespace,
 }) => {
   const { projects } = React.useContext(ProjectsContext);
   const namespaces =
@@ -78,6 +87,7 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       searchValue={searchText}
       isLoading={isLoading}
       isDisabled={isLoading}
+      appendTo={appendTo}
       toggleContent={toggleLabel}
       toggleVariant={primary ? 'primary' : undefined}
       {...(appendTo && { appendTo })}
@@ -103,27 +113,60 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             <Divider component="li" />
           </>
         )}
-        {visibleNamespaces.length === 0 && <MenuItem isDisabled>No matching results</MenuItem>}
-        {visibleNamespaces.map((n) => {
-          const selectionHref = getSelectionHref?.(n.name);
+        {(() => {
+          const pinnedItem = pinnedNamespace
+            ? visibleNamespaces.find((n) => n.name === pinnedNamespace.name)
+            : undefined;
+          const otherItems = pinnedNamespace
+            ? visibleNamespaces.filter((n) => n.name !== pinnedNamespace.name)
+            : visibleNamespaces;
+
+          const renderItem = (n: Namespace) => {
+            const selectionHref = getSelectionHref?.(n.name);
+            return (
+              <MenuItem
+                key={n.name}
+                isSelected={n.name === selection?.name}
+                component={
+                  selectionHref
+                    ? (props: React.ComponentProps<'a'>) => <Link {...props} to={selectionHref} />
+                    : undefined
+                }
+                onClick={() => {
+                  setSearchText('');
+                  onSelection(n.name);
+                }}
+              >
+                <Truncate content={n.displayName ?? n.name}>{n.displayName ?? n.name}</Truncate>
+              </MenuItem>
+            );
+          };
+
+          if (!pinnedItem && otherItems.length === 0) {
+            return <MenuItem isDisabled>No matching results</MenuItem>;
+          }
+
           return (
-            <MenuItem
-              key={n.name}
-              isSelected={n.name === selection?.name}
-              component={
-                selectionHref
-                  ? (props: React.ComponentProps<'a'>) => <Link {...props} to={selectionHref} />
-                  : undefined
-              }
-              onClick={() => {
-                setSearchText('');
-                onSelection(n.name);
-              }}
-            >
-              <Truncate content={n.displayName ?? n.name}>{n.displayName ?? n.name}</Truncate>
-            </MenuItem>
+            <>
+              {pinnedItem && pinnedNamespace && (
+                <>
+                  <MenuGroup data-testid="pinned-project-group" label={pinnedNamespace.label}>
+                    {renderItem(pinnedItem)}
+                  </MenuGroup>
+                  {otherItems.length > 0 && <Divider component="li" />}
+                </>
+              )}
+              {otherItems.length > 0 &&
+                (pinnedItem ? (
+                  <MenuGroup data-testid="other-projects-group" label="Projects">
+                    {otherItems.map(renderItem)}
+                  </MenuGroup>
+                ) : (
+                  otherItems.map(renderItem)
+                ))}
+            </>
           );
-        })}
+        })()}
       </>
     </SearchSelector>
   );

--- a/frontend/src/concepts/projects/ProjectSelector.tsx
+++ b/frontend/src/concepts/projects/ProjectSelector.tsx
@@ -75,6 +75,34 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
 
   const toggleLabel = namespaces.length === 0 ? 'No projects' : selectionDisplayName;
 
+  const pinnedItem = pinnedNamespace
+    ? visibleNamespaces.find((n) => n.name === pinnedNamespace.name)
+    : undefined;
+  const otherItems = pinnedNamespace
+    ? visibleNamespaces.filter((n) => n.name !== pinnedNamespace.name)
+    : visibleNamespaces;
+
+  const renderItem = (n: Namespace) => {
+    const selectionHref = getSelectionHref?.(n.name);
+    return (
+      <MenuItem
+        key={n.name}
+        isSelected={n.name === selection?.name}
+        component={
+          selectionHref
+            ? (props: React.ComponentProps<'a'>) => <Link {...props} to={selectionHref} />
+            : undefined
+        }
+        onClick={() => {
+          setSearchText('');
+          onSelection(n.name);
+        }}
+      >
+        <Truncate content={n.displayName ?? n.name}>{n.displayName ?? n.name}</Truncate>
+      </MenuItem>
+    );
+  };
+
   const selector = (
     <SearchSelector
       dataTestId="project-selector"
@@ -90,7 +118,6 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       appendTo={appendTo}
       toggleContent={toggleLabel}
       toggleVariant={primary ? 'primary' : undefined}
-      {...(appendTo && { appendTo })}
     >
       <>
         {(selectAllProjects || clearLabel) && (
@@ -113,60 +140,28 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             <Divider component="li" />
           </>
         )}
-        {(() => {
-          const pinnedItem = pinnedNamespace
-            ? visibleNamespaces.find((n) => n.name === pinnedNamespace.name)
-            : undefined;
-          const otherItems = pinnedNamespace
-            ? visibleNamespaces.filter((n) => n.name !== pinnedNamespace.name)
-            : visibleNamespaces;
-
-          const renderItem = (n: Namespace) => {
-            const selectionHref = getSelectionHref?.(n.name);
-            return (
-              <MenuItem
-                key={n.name}
-                isSelected={n.name === selection?.name}
-                component={
-                  selectionHref
-                    ? (props: React.ComponentProps<'a'>) => <Link {...props} to={selectionHref} />
-                    : undefined
-                }
-                onClick={() => {
-                  setSearchText('');
-                  onSelection(n.name);
-                }}
-              >
-                <Truncate content={n.displayName ?? n.name}>{n.displayName ?? n.name}</Truncate>
-              </MenuItem>
-            );
-          };
-
-          if (!pinnedItem && otherItems.length === 0) {
-            return <MenuItem isDisabled>No matching results</MenuItem>;
-          }
-
-          return (
-            <>
-              {pinnedItem && pinnedNamespace && (
-                <>
-                  <MenuGroup data-testid="pinned-project-group" label={pinnedNamespace.label}>
-                    {renderItem(pinnedItem)}
-                  </MenuGroup>
-                  {otherItems.length > 0 && <Divider component="li" />}
-                </>
-              )}
-              {otherItems.length > 0 &&
-                (pinnedItem ? (
-                  <MenuGroup data-testid="other-projects-group" label="Projects">
-                    {otherItems.map(renderItem)}
-                  </MenuGroup>
-                ) : (
-                  otherItems.map(renderItem)
-                ))}
-            </>
-          );
-        })()}
+        {!pinnedItem && otherItems.length === 0 ? (
+          <MenuItem isDisabled>No matching results</MenuItem>
+        ) : (
+          <>
+            {pinnedItem && pinnedNamespace && (
+              <>
+                <MenuGroup data-testid="pinned-project-group" label={pinnedNamespace.label}>
+                  {renderItem(pinnedItem)}
+                </MenuGroup>
+                {otherItems.length > 0 && <Divider component="li" />}
+              </>
+            )}
+            {otherItems.length > 0 &&
+              (pinnedItem ? (
+                <MenuGroup data-testid="other-projects-group" label="Projects">
+                  {otherItems.map(renderItem)}
+                </MenuGroup>
+              ) : (
+                otherItems.map(renderItem)
+              ))}
+          </>
+        )}
       </>
     </SearchSelector>
   );

--- a/packages/cypress/cypress/pages/promptManagement.ts
+++ b/packages/cypress/cypress/pages/promptManagement.ts
@@ -53,6 +53,18 @@ class PromptManagement {
     return cy.findByRole('menuitem', { name });
   }
 
+  findGlobalProjectIndicator() {
+    return cy.findByTestId('global-project-indicator');
+  }
+
+  findPinnedGroupLabel() {
+    return cy.findByTestId('pinned-project-group');
+  }
+
+  findProjectsGroupLabel() {
+    return cy.findByTestId('other-projects-group');
+  }
+
   shouldHaveWorkspace(workspace: string) {
     cy.url().should('include', `workspace=${workspace}`);
   }

--- a/packages/cypress/cypress/tests/mocked/mlflow/promptManagement.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/mlflow/promptManagement.cy.ts
@@ -13,18 +13,33 @@ import { appChrome } from '../../../pages/appChrome';
 
 const PROJECT_A = 'test-project-a';
 const PROJECT_B = 'test-project-b';
+const GLOBAL_PROJECT = 'global-prompts';
 
 const initIntercepts = ({
   mlflowConfigured = true,
   genAiStudio = true,
-}: { mlflowConfigured?: boolean; genAiStudio?: boolean } = {}) => {
+  globalMLflowNamespaces = [] as string[],
+  globalProjectPrompts = false,
+}: {
+  mlflowConfigured?: boolean;
+  genAiStudio?: boolean;
+  globalMLflowNamespaces?: string[];
+  globalProjectPrompts?: boolean;
+} = {}) => {
   asProductAdminUser();
-  cy.interceptOdh('GET /api/config', mockDashboardConfig({ genAiStudio }));
+  cy.interceptOdh(
+    'GET /api/config',
+    mockDashboardConfig({ genAiStudio, globalMLflowNamespaces, globalProjectPrompts }),
+  );
   interceptMlflowStatus(mlflowConfigured);
 
   const projectA = mockProjectK8sResource({ k8sName: PROJECT_A, displayName: PROJECT_A });
   const projectB = mockProjectK8sResource({ k8sName: PROJECT_B, displayName: PROJECT_B });
-  cy.interceptK8sList(ProjectModel, mockK8sResourceList([projectA, projectB]));
+  const globalProject = mockProjectK8sResource({
+    k8sName: GLOBAL_PROJECT,
+    displayName: 'Global Prompts',
+  });
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([projectA, projectB, globalProject]));
   cy.interceptK8s(ProjectModel, projectA);
 };
 
@@ -69,6 +84,74 @@ describe('Prompt Management page wrapper', () => {
 
       appChrome.findLightThemeToggle().click();
       promptManagement.getMlflowDarkModeStorageValue().should('equal', 'false');
+    });
+  });
+
+  describe('Global project indicator', () => {
+    it('should show indicator when selected project is the global namespace', () => {
+      initIntercepts({
+        globalProjectPrompts: true,
+        globalMLflowNamespaces: [GLOBAL_PROJECT],
+      });
+      promptManagement.visit(GLOBAL_PROJECT);
+      promptManagement.findGlobalProjectIndicator().should('be.visible');
+    });
+
+    it('should not show indicator when selected project is not the global namespace', () => {
+      initIntercepts({
+        globalProjectPrompts: true,
+        globalMLflowNamespaces: [GLOBAL_PROJECT],
+      });
+      promptManagement.visit(PROJECT_A);
+      promptManagement.findGlobalProjectIndicator().should('not.exist');
+    });
+
+    it('should not show indicator when no global namespace is configured', () => {
+      initIntercepts({ globalMLflowNamespaces: [] });
+      promptManagement.visit(PROJECT_A);
+      promptManagement.findGlobalProjectIndicator().should('not.exist');
+    });
+
+    it('should not show indicator when feature flag is disabled even with namespace configured', () => {
+      initIntercepts({
+        globalProjectPrompts: false,
+        globalMLflowNamespaces: [GLOBAL_PROJECT],
+      });
+      promptManagement.visit(GLOBAL_PROJECT);
+      promptManagement.findGlobalProjectIndicator().should('not.exist');
+    });
+  });
+
+  describe('Pinned namespace in project selector', () => {
+    it('should show global project in a separate group in the dropdown', () => {
+      initIntercepts({
+        globalProjectPrompts: true,
+        globalMLflowNamespaces: [GLOBAL_PROJECT],
+      });
+      promptManagement.visit(PROJECT_A);
+      promptManagement.findProjectSelector().click();
+      promptManagement.findPinnedGroupLabel().should('be.visible');
+      promptManagement.findProjectsGroupLabel().should('be.visible');
+      promptManagement.findProjectInDropdown('Global Prompts').should('be.visible');
+    });
+
+    it('should not show groups when no global namespace is configured', () => {
+      initIntercepts({ globalMLflowNamespaces: [] });
+      promptManagement.visit(PROJECT_A);
+      promptManagement.findProjectSelector().click();
+      promptManagement.findPinnedGroupLabel().should('not.exist');
+      promptManagement.findProjectsGroupLabel().should('not.exist');
+    });
+
+    it('should not show groups when feature flag is disabled even with namespace configured', () => {
+      initIntercepts({
+        globalProjectPrompts: false,
+        globalMLflowNamespaces: [GLOBAL_PROJECT],
+      });
+      promptManagement.visit(PROJECT_A);
+      promptManagement.findProjectSelector().click();
+      promptManagement.findPinnedGroupLabel().should('not.exist');
+      promptManagement.findProjectsGroupLabel().should('not.exist');
     });
   });
 

--- a/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
+++ b/packages/mlflow-embedded/prompts/MlflowPromptManagementPage.tsx
@@ -1,5 +1,15 @@
 import React, { useMemo } from 'react';
-import { Bullseye, Content, Flex, FlexItem, PageSection, Spinner } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Content,
+  Flex,
+  FlexItem,
+  Label,
+  PageSection,
+  Spinner,
+  Tooltip,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useSearchParams } from 'react-router-dom';
 import { loadRemote } from '@module-federation/runtime';
 import { LazyCodeRefComponent } from '@odh-dashboard/plugin-core';
@@ -9,6 +19,11 @@ import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import useIsMlflowCRAvailable from '@odh-dashboard/internal/concepts/mlflow/hooks/useIsMlflowCRAvailable';
 import { ProjectIconWithSize } from '@odh-dashboard/internal/concepts/projects/ProjectIconWithSize';
 import { IconSize } from '@odh-dashboard/internal/types';
+import { useAppContext } from '@odh-dashboard/internal/app/AppContext';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { getDashboardMainContainer } from '@odh-dashboard/internal/utilities/utils';
+// eslint-disable-next-line @odh-dashboard/no-restricted-imports
+import { useUser } from '@odh-dashboard/internal/redux/selectors/user';
 import ProjectSelectorNavigator from '@odh-dashboard/internal/concepts/projects/ProjectSelectorNavigator';
 import TitleWithIcon from '@odh-dashboard/ui-core/design/TitleWithIcon';
 import { ProjectObjectType } from '@odh-dashboard/ui-core';
@@ -32,6 +47,13 @@ const MlflowPromptManagementPage: React.FC = () => {
     loaded: mlflowLoaded,
     error: mlflowStatusError,
   } = useIsMlflowCRAvailable();
+  const { dashboardConfig } = useAppContext();
+  const { isAdmin } = useUser();
+  const globalProjectPromptsEnabled = dashboardConfig.spec.dashboardConfig.globalProjectPrompts;
+  const globalNamespace = globalProjectPromptsEnabled
+    ? dashboardConfig.spec.globalMLflowNamespaces?.[0]
+    : undefined;
+  const isGlobalProject = !!globalNamespace && workspace === globalNamespace;
 
   const loadWrapper = useMemo(
     () => () =>
@@ -72,10 +94,33 @@ const MlflowPromptManagementPage: React.FC = () => {
                   <ProjectSelectorNavigator
                     getRedirectPath={mlflowPromptManagementBaseRoute}
                     queryParamNamespace={WORKSPACE_QUERY_PARAM}
+                    appendTo={getDashboardMainContainer}
+                    {...(globalNamespace
+                      ? { pinnedNamespace: { name: globalNamespace, label: 'Global project' } }
+                      : {})}
                   />
                 </FlexItem>
               </Flex>
             </FlexItem>
+            {isGlobalProject && (
+              <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
+                <Tooltip
+                  content={
+                    isAdmin
+                      ? 'Prompts in this project are shared across the cluster. Any edits you make will affect all users.'
+                      : 'Prompts in this project are shared across the cluster.'
+                  }
+                >
+                  <Label
+                    data-testid="global-project-indicator"
+                    color="orange"
+                    icon={<InfoCircleIcon />}
+                  >
+                    Global project
+                  </Label>
+                </Tooltip>
+              </FlexItem>
+            )}
           </Flex>
         ) : undefined
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-65183

Depends on (merge first):
- https://github.com/opendatahub-io/odh-dashboard/pull/7866 (CRD + backend API)
- https://github.com/opendatahub-io/odh-dashboard/pull/8067 (Global project section in cluster settings)

## Description

When the selected project on the Prompt Management page matches the global namespace configured in the OdhDashboardConfig CR, a "Global project" label with a tooltip appears next to the project selector. The tooltip text differs for admins vs regular users.

Also adds a `pinnedNamespace` prop to `ProjectSelector` so the global project shows in its own group at the top of the dropdown, separated from the rest of the projects.

https://github.com/user-attachments/assets/68a95839-2d87-4807-8d4a-3f0b6dd732e1

Changes:
- Add `pinnedNamespace` prop to `ProjectSelector` for grouped display
- Use `ProjectSelectorNavigator` with `pinnedNamespace` on the Prompts page
- Add Cypress mock tests for the indicator and pinned namespace grouping
- Add page object methods for the indicator and group labels

## How Has This Been Tested?

- Verified the global project indicator appears when selecting the configured global namespace
- Verified the indicator is hidden for non-global projects
- Verified the pinned namespace appears in its own group in the project dropdown
- Verified no groups appear when no global namespace is configured
- All existing ProjectSelectorNavigator tests pass (7/7)
- Cypress mock tests added (5 new scenarios)

## Test Impact

- Added Cypress mock tests in `packages/cypress/cypress/tests/mocked/mlflow/promptManagement.cy.ts`
- Added page object methods in `packages/cypress/cypress/pages/promptManagement.ts`

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our Best Practices (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for highlighting a configured global project in project selection.
  * Project menus can now pin the global project separately from other projects.
  * Added a global project indicator with role-specific guidance.
  * Improved dropdown placement and customization with clearer labels and grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->