### PR TITLE
RHOAIENG-68443: Increase Cypress E2E test job timeout from 60 to 90 minutes

### DIFF
--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -521,7 +521,7 @@ jobs:
   e2e-tests:
     needs: [select-cluster, set-pending-status, get-test-tags]
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION


<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
The `e2e-tests` job in `cypress-e2e-test.yml` has `timeout-minutes: 60`, but the full test suite runs 29 specs that take approximately 69 minutes to complete. This causes the job to be cancelled at spec 25 of 29 before finishing, producing incomplete CI results.

Analysis of CI run logs shows the first spec starts at minute ~5 and 25 specs complete in ~55 minutes of test time, extrapolating to ~64 minutes for all 29 specs. With setup overhead, the total is ~69 minutes.

Increase the timeout to 90 minutes to allow all specs to complete with headroom for slower cluster conditions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  - Analyzed CI run logs to measure actual execution time: 25 of 29 specs completed in ~55 minutes of test time, extrapolating to ~64 minutes for all 29 specs plus ~5 minutes of setup
  - Confirmed the job was cancelled due to the timeout and not a test failure

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
No tests added — this is a CI workflow configuration change, not application code.

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains no user-facing changes. The modification updates internal testing infrastructure to improve reliability of automated end-to-end test execution.

* **Chores**
  * Increased testing workflow timeout threshold to allow longer-running test suites to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->