### PR TITLE
RHOAIENG-66095: Add Konflux onboarding Claude Code skill

### DIFF
--- a/.claude/skills/konflux-onboarding/SKILL.md
+++ b/.claude/skills/konflux-onboarding/SKILL.md
@@ -28,6 +28,7 @@ Parse from `$ARGUMENTS`:
    - **Type B — Standalone Go component**: `<name>/` exists at repo root with a `go.mod`. These are Go services/operators with their own Dockerfile.
 
    Validate the component name first, then use quoted path checks:
+
    ```bash
    # Validate component name (lowercase alphanumeric + hyphens only)
    if ! echo "$COMPONENT_NAME" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
@@ -57,7 +58,8 @@ Parse from `$ARGUMENTS`:
    ```
 
 4. Report classification and state to user:
-   ```
+
+   ```text
    Component: <name>
    Type: A (modular-arch package) / B (standalone Go component)
    ODH Dockerfile: ✅ exists / ❌ missing
@@ -273,7 +275,8 @@ Generate from the upstream Dockerfile with these changes:
 - Build flags: `CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -tags strictfipsruntime`
 - Runtime: `registry.access.redhat.com/ubi9/ubi-minimal@sha256:<digest>` (SHA-pinned)
 - Red Hat labels on final stage:
-  ```
+
+  ```dockerfile
   LABEL com.redhat.component="odh-<name>-container" \
         name="managed-open-data-hub/odh-<name>-rhel9" \
         summary="ODH <Display Name>" \
@@ -307,17 +310,20 @@ Reference existing module overlays in `manifests/modular-architecture/modules/` 
 
 This cannot be automated — it requires changes in a separate repository (`openshift/release`).
 
+**Prerequisite**: The component's Quay repository must have the `opendatahub+openshift_ci` robot account with **push** permission. Request this via `#rhoai-devtestops-request` Slack channel if not already configured.
+
 Provide the user with:
 1. The config snippet needed for `ci-operator/config/opendatahub-io/odh-dashboard/`
 2. Reference to existing PRs for similar components
 3. The PR process for `openshift/release`
 
-```
+```text
 To add OpenShift CI for this component:
-1. Create a config file in openshift/release:
+1. Ensure Quay repo has opendatahub+openshift_ci robot account with push permission
+2. Create a config file in openshift/release:
    ci-operator/config/opendatahub-io/odh-dashboard/<name>.yaml
-2. Reference existing configs in the same directory for the pattern
-3. Submit a PR to openshift/release
+3. Reference existing configs in the same directory for the pattern
+4. Submit a PR to openshift/release
 ```
 
 ## Phase 7: Jira Updates
@@ -337,7 +343,7 @@ If a Jira issue key was provided or is known from context, add a comment documen
 
 Print a final report:
 
-```
+```text
 ## Konflux Onboarding Report: <name>
 
 ### Component Classification
@@ -360,8 +366,9 @@ Print a final report:
 ### Remaining Manual Steps
 1. Review and merge Tekton pipeline PRs
 2. Wait for DevOps GitLab CI to process onboarding request (~2-4 hours)
-3. Review and merge DevOps-generated PRs
+3. Review and merge DevOps-generated PRs (check Jira labels for progression)
 4. Commit Dockerfile.konflux.<name> to downstream repo
 5. Submit OpenShift CI config PR to openshift/release
-6. Verify first build succeeds end-to-end
+6. Coordinate operator integration with Platform team (RHOAIENG-37067) — update operator component references, OLM bundle, and test integration
+7. Verify first build succeeds end-to-end (both ODH and RHOAI)
 ```

--- a/.claude/skills/konflux-onboarding/SKILL.md
+++ b/.claude/skills/konflux-onboarding/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: konflux-onboarding
+description: "Guides Konflux CI/CD pipeline onboarding for new components — upstream ODH Dockerfiles & Tekton pipelines, downstream RHOAI Dockerfile generation, DevOps skill integration, manifest overlays, and Jira tracking."
+argument-hint: "<component-name> [--skip-odh] [--skip-downstream] [--skip-jira]"
+---
+
+# Konflux Onboarding
+
+Onboard a component to Konflux CI/CD pipelines for both ODH (upstream) and RHOAI (downstream). This skill handles Dockerfiles, Tekton PipelineRun YAML, DevOps coordination, manifest overlays, and Jira updates.
+
+Companion to `/module-onboarding` which handles Dashboard-side package scaffolding. This skill covers the CI/CD pipeline side.
+
+## Flags
+
+Parse from `$ARGUMENTS`:
+- `--skip-odh` — skip Phases 1-2 (ODH upstream Dockerfile and Tekton pipelines)
+- `--skip-downstream` — skip Phases 3-4 (RHOAI DevOps request and downstream Dockerfile)
+- `--skip-jira` — skip Phase 7 (Jira updates)
+
+## Phase 0: Parse and Classify
+
+**Goal**: Determine component type and detect existing state.
+
+1. Extract the component name from `$ARGUMENTS` (first positional argument). If missing, ask the user.
+
+2. Classify the component:
+   - **Type A — Modular-arch package**: `packages/<name>/` exists. These are Node.js + optional Go BFF packages that use `Dockerfile.workspace` and deploy as Module Federation remotes.
+   - **Type B — Standalone Go component**: `<name>/` exists at repo root with a `go.mod`. These are Go services/operators with their own Dockerfile.
+
+   ```bash
+   if [ -d "packages/$COMPONENT_NAME" ]; then
+     TYPE="A"
+   elif [ -d "$COMPONENT_NAME" ] && [ -f "$COMPONENT_NAME/go.mod" ]; then
+     TYPE="B"
+   else
+     # Ask user to clarify
+   fi
+   ```
+
+3. Detect existing state:
+   ```bash
+   # Check for existing ODH Dockerfile
+   # Type A:
+   ls packages/$COMPONENT_NAME/Dockerfile.workspace 2>/dev/null
+   # Type B:
+   ls $COMPONENT_NAME/Dockerfile 2>/dev/null
+
+   # Check for existing Tekton pipelines
+   ls .tekton/*${COMPONENT_NAME}*push*.yaml 2>/dev/null
+   ls .tekton/*${COMPONENT_NAME}*pull-request*.yaml 2>/dev/null
+   ```
+
+4. Report classification and state to user:
+   ```
+   Component: <name>
+   Type: A (modular-arch package) / B (standalone Go component)
+   ODH Dockerfile: ✅ exists / ❌ missing
+   Tekton push pipeline: ✅ exists / ❌ missing
+   Tekton PR pipeline: ✅ exists / ❌ missing
+   ```
+
+## Phase 1: ODH Upstream Dockerfile
+
+**Goal**: Ensure the component has an upstream Dockerfile for ODH Konflux builds.
+
+Skip if: `--skip-odh` flag, or Dockerfile already exists.
+
+### Type A
+
+Check for `packages/<name>/Dockerfile.workspace`. If missing, scaffold from `packages/plugin-template/Dockerfile.workspace`.
+
+Read the template from `packages/plugin-template/Dockerfile.workspace` and adapt:
+- Set `ARG MODULE_NAME=<name>`
+- Update `UI_SOURCE_CODE` and `BFF_SOURCE_CODE` paths
+- If the package has no BFF (no `packages/<name>/bff/` directory), remove the BFF build stage and adjust the final stage to only copy UI artifacts
+- Check `packages/<name>/bff/go.mod` for the Go version if BFF exists
+
+See [references/dockerfile-templates.md](references/dockerfile-templates.md) § Type A for the full template.
+
+### Type B
+
+Check for `<name>/Dockerfile`. If missing, scaffold using the Type B template.
+
+Read `<name>/go.mod` to determine Go version. Identify the binary build target from `<name>/cmd/*/main.go`.
+
+See [references/dockerfile-templates.md](references/dockerfile-templates.md) § Type B for the full template.
+
+**Verify**: The Dockerfile builds from repo root context (not from the component subdirectory).
+
+## Phase 2: ODH Upstream Tekton Pipelines
+
+**Goal**: Ensure `.tekton/` has push and pull-request pipelines for this component.
+
+Skip if: `--skip-odh` flag, or both pipeline files already exist.
+
+### Type A
+
+Scaffold `odh-mod-arch-<name>-push.yaml` and `odh-mod-arch-<name>-pull-request.yaml`.
+
+Use an existing Type A pipeline as reference (e.g., `.tekton/odh-mod-arch-gen-ai-push.yaml`). Apply substitutions from [references/pipeline-templates.md](references/pipeline-templates.md):
+- `COMPONENT_CI_NAME`: `odh-mod-arch-<name>-ci`
+- `PIPELINE_NAME_PREFIX`: `odh-mod-arch-<name>`
+- `QUAY_IMAGE`: `quay.io/opendatahub/odh-mod-arch-<name>`
+- `DOCKERFILE_PATH`: `packages/<name>/Dockerfile.workspace`
+- `PATH_CHANGED_EXPR`: `packages/<name>/**`
+- `EXTRA_PATH_EXPR`: `|| "Dockerfile.workspace".pathChanged()`
+- `SERVICE_ACCOUNT`: `build-pipeline-<name>` (must be provisioned by DevOps)
+
+### Type B
+
+Scaffold `<name>-push.yaml` and `<name>-pull-request.yaml`.
+
+Use `.tekton/dashboard-operator-push.yaml` as reference. Apply substitutions:
+- `COMPONENT_CI_NAME`: `<name>-ci`
+- `PIPELINE_NAME_PREFIX`: `<name>`
+- `QUAY_IMAGE`: `quay.io/opendatahub/<name>`
+- `DOCKERFILE_PATH`: `<name>/Dockerfile`
+- `PATH_CHANGED_EXPR`: `<name>/**`
+- `EXTRA_PATH_EXPR`: `|| "manifests/**".pathChanged()` (if applicable)
+- `SERVICE_ACCOUNT`: `build-pipeline-<name>`
+
+**Important**: The service account must be provisioned by DevOps before the pipeline can run. Remind the user that Phase 3 (DevOps onboarding) handles this.
+
+## Phase 3: DevOps Onboarding Request
+
+**Goal**: Generate `component_onboarding_details.yaml` files, validate them, and attach to a Jira ticket for DevOps automation.
+
+Skip if: `--skip-downstream` flag.
+
+Read [references/devops-integration.md](references/devops-integration.md) for the full integration guide.
+
+**Important**: Two separate onboarding YAMLs are required — one for **ODH** and one for **RHOAI**. Each has different schema requirements. Run this phase twice.
+
+### Prerequisites
+
+The DevOps skill (`/create-component-onboarding-jira`) is a Claude Code plugin from `opendatahub-io/aiops-infra`. It requires `JIRA_USER_EMAIL` and `JIRA_API_TOKEN` env vars for its Python scripts.
+
+If those env vars are not set, you can do the equivalent work manually:
+1. Generate the YAML using the `generate_onboarding_yaml.py` script
+2. Validate using `validate_yaml_schema.py`
+3. Attach to Jira using the mcp-atlassian MCP tools
+
+Scripts live at: `~/.claude/plugins/cache/opendatahub-skills/aiops-skills/0.1.0/`
+
+### Step 3a: Collect Information (ODH run)
+
+Ask the user for these values (with defaults where possible):
+
+| Field | Q&A Question | Validation | Default |
+|-------|-------------|------------|---------|
+| `product_context` | Which product? | `ODH` or `RHOAI` | — |
+| `build_type` | CI or Release build? (ODH only) | `CI` or `Release` | — |
+| `component_name` | Component name? | Must match `^odh-[a-z0-9]+(-[a-z0-9]+)*$` | `odh-<name>` |
+| `repo_url` | GitHub repo URL? | Must match `^https://github\.com/.+/.+$`, must return HTTP 200 | `https://github.com/opendatahub-io/odh-dashboard` |
+| `repo_branch` | Branch to build? (ODH only) | Non-empty | `main` |
+| `context_path` | Docker build context path? | Non-empty | `./` |
+| `dockerfile_path` | Dockerfile path relative to context? | Non-empty | Type A: `packages/<name>/Dockerfile.workspace`, Type B: `<name>/Dockerfile` |
+| `is_operator` | Is this an operator/controller? | `true` or `false` | — |
+| `operator_manifest_src_path` | Manifest source path? (if operator) | Non-empty | — |
+| `operator_manifest_dest_path` | Manifest dest path? (if operator) | Non-empty | `odh-<name>` |
+
+### Step 3b: Collect Information (RHOAI run)
+
+RHOAI requires additional fields beyond ODH:
+
+| Field | Q&A Question | Validation | Notes |
+|-------|-------------|------------|-------|
+| `target_rhoai_version` | Target RHOAI version? | Regex: `^\d+\.\d+(?:\.0)?(?:-ea[-.]?\d+)?$` | Canonical form: `X.Y` or `X.Y-ea-N` |
+| `architectures` | CPU architectures? | Subset of `[x86_64, arm64, ppc64le, s390x]` | Default: `[x86_64, arm64]` |
+| `release_category` | Release category? | `Generally Available`, `Tech Preview`, or `Beta` | — |
+| `long_description` | Component description (1-2 sentences)? | Non-empty | Auto-suggest from repo README |
+| `short_description` | Short description (noun phrase)? | Non-empty | Auto-suggest from long_description |
+| `repo_url` | GitHub repo URL? | — | `https://github.com/red-hat-data-services/odh-dashboard` |
+| `repo_branch` | **Auto-derived** from version | — | `rhoai-X.Y` or `rhoai-X.Y-ea.N` |
+| `dockerfile_path` | Dockerfile path? | Basename must start with `Dockerfile.konflux` | `Dockerfile.konflux.<name>` |
+
+**Branch derivation** (do NOT ask user):
+- No EA suffix (e.g., `3.5`): `repo_branch = rhoai-3.5`
+- EA suffix (e.g., `3.5-ea-2`): `repo_branch = rhoai-3.5-ea.2`
+
+### Step 3c: Generate and Validate YAML
+
+For each product context (ODH, then RHOAI):
+
+```bash
+cd ~/.claude/plugins/cache/opendatahub-skills/aiops-skills/0.1.0
+WORKDIR=$(mktemp -d)
+YAML_PATH="${WORKDIR}/component_onboarding_details.yaml"
+
+# Generate
+uv run --script scripts/generate_onboarding_yaml.py \
+  --output "$YAML_PATH" \
+  --product-context "<ODH|RHOAI>" \
+  --component-name "<name>" \
+  --repo-url "<url>" \
+  --repo-branch "<branch>" \
+  --context-path "<path>" \
+  --dockerfile-path "<path>" \
+  [--build-type "<CI|Release>"]              # ODH only
+  [--target-rhoai-version "<version>"]       # RHOAI only
+  [--architectures "<arch1,arch2,...>"]       # RHOAI only
+  [--release-category "<category>"]          # RHOAI only
+  [--long-description "<desc>"]              # RHOAI only
+  [--short-description "<desc>"]             # RHOAI only
+  [--is-operator]                            # if operator
+  [--operator-manifest-src-path "<path>"]    # if operator
+  [--operator-manifest-dest-path "<path>"]   # if operator
+
+# Validate against schema
+uv run --script scripts/validate_yaml_schema.py \
+  "$YAML_PATH" \
+  schemas/component_onboarding_details.schema.json
+```
+
+### Step 3d: Dockerfile Digest Check (RHOAI only)
+
+Skip for ODH. For RHOAI, verify all `FROM` instructions use `@sha256:` digests:
+
+```bash
+uv run --script scripts/check_dockerfile_digests.py \
+  --dockerfile-url "<raw-github-url>"
+```
+
+If the downstream branch doesn't exist yet (HTTP 404), verify digests locally against the Dockerfile content from Phase 4 or an existing PR.
+
+### Step 3e: Attach to Jira
+
+Ask user for the Jira issue key and parent feature ID.
+
+Using mcp-atlassian MCP tools (if `JIRA_USER_EMAIL`/`JIRA_API_TOKEN` not set):
+1. `jira_update_issue` — attach the YAML file and add `yaml-attached` label
+2. `jira_create_issue_link` — link to parent feature with "Related" link type
+3. `jira_add_comment` — post a summary comment with component details
+
+Name files distinctly: `component_onboarding_details.yaml` (ODH) and `component_onboarding_details_rhoai.yaml` (RHOAI).
+
+### Step 3f: Post-Attachment Flow
+
+After attaching:
+1. **DevOps GitLab CI** picks up YAML attachments every ~2 hours
+2. Automated PRs are raised for Konflux component registration, release pipelines, Quay repos
+3. PRs require human review and merge
+4. This phase covers: Quay repo creation, Konflux component registration, release pipeline config, Renovate/automerge setup
+
+## Phase 4: RHOAI Downstream Dockerfile
+
+**Goal**: Generate a downstream Dockerfile for the RHOAI build.
+
+Skip if: `--skip-downstream` flag.
+
+Generate `Dockerfile.konflux.<name>` content for the `red-hat-data-services/odh-dashboard` repo root.
+
+### Type A
+
+Based on the upstream `Dockerfile.workspace`, generate a downstream variant with:
+- SHA-pinned base images (use `skopeo inspect` to get current digests, or use placeholder `@sha256:<digest>`)
+- Red Hat labels on the final stage
+- Same FIPS flags as upstream (already uses `CGO_ENABLED=1 -tags strictfipsruntime`)
+
+See [references/dockerfile-templates.md](references/dockerfile-templates.md) § Downstream Type A.
+
+### Type B
+
+Generate from the upstream Dockerfile with these changes:
+- Builder: `registry.redhat.io/ubi9/go-toolset:<version>@sha256:<digest>` (not Docker Hub `golang:`)
+- Add `USER root` after FROM in builder stage (go-toolset runs non-root by default)
+- Build flags: `CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -tags strictfipsruntime`
+- Runtime: `registry.access.redhat.com/ubi9/ubi-minimal@sha256:<digest>` (SHA-pinned)
+- Red Hat labels on final stage:
+  ```
+  LABEL com.redhat.component="odh-<name>-container" \
+        name="managed-open-data-hub/odh-<name>-rhel9" \
+        summary="ODH <Display Name>" \
+        description="<Description> for Red Hat OpenShift AI" \
+        io.k8s.display-name="ODH <Display Name>" \
+        io.k8s.description="<Description> for Red Hat OpenShift AI" \
+        io.openshift.tags="rhods,rhoai,odh,<name>"
+  ```
+
+See [references/dockerfile-templates.md](references/dockerfile-templates.md) § Downstream Type B.
+
+**Output**: Print the full Dockerfile content for the user to commit to the downstream repo. Do NOT write it to the upstream repo.
+
+## Phase 5: Manifest Overlay (Type A only)
+
+**Goal**: Scaffold deployment manifests for a modular-arch package.
+
+Skip if: Type B, or manifests already exist in `manifests/modular-architecture/modules/<name>/`.
+
+For Type A packages, check if `manifests/modular-architecture/modules/<name>/` exists. If not, scaffold:
+- Deployment overlay adding the module container
+- Service port configuration
+- Image parameter for Konflux/operator injection
+- Kustomization.yaml entry
+
+Reference existing module overlays in `manifests/modular-architecture/modules/` for the pattern.
+
+## Phase 6: OpenShift CI (instructions only)
+
+**Goal**: Provide instructions for `openshift/release` repo configuration.
+
+This cannot be automated — it requires changes in a separate repository (`openshift/release`).
+
+Provide the user with:
+1. The config snippet needed for `ci-operator/config/opendatahub-io/odh-dashboard/`
+2. Reference to existing PRs for similar components
+3. The PR process for `openshift/release`
+
+```
+To add OpenShift CI for this component:
+1. Create a config file in openshift/release:
+   ci-operator/config/opendatahub-io/odh-dashboard/<name>.yaml
+2. Reference existing configs in the same directory for the pattern
+3. Submit a PR to openshift/release
+```
+
+## Phase 7: Jira Updates
+
+**Goal**: Update tracking Jira issues with onboarding progress.
+
+Skip if: `--skip-jira` flag.
+
+If a Jira issue key was provided or is known from context, add a comment documenting:
+- What was completed (files created, phases executed)
+- What remains (pending DevOps automation, manual steps)
+- Links to any PRs created
+
+## Phase 8: Verification Report
+
+**Goal**: Summary of all work done and remaining steps.
+
+Print a final report:
+
+```
+## Konflux Onboarding Report: <name>
+
+### Component Classification
+- Type: A/B
+- Component: <name>
+
+### Completed
+- [ ] ODH Dockerfile: <path> (created/already existed/skipped)
+- [ ] Tekton push pipeline: <path> (created/already existed/skipped)
+- [ ] Tekton PR pipeline: <path> (created/already existed/skipped)
+- [ ] DevOps onboarding: requested/skipped
+- [ ] RHOAI Dockerfile: content generated/skipped
+- [ ] Manifest overlay: created/already existed/skipped/N/A
+- [ ] OpenShift CI: instructions provided/skipped
+- [ ] Jira updated: yes/skipped
+
+### Files Created/Modified
+- <list of files>
+
+### Remaining Manual Steps
+1. Review and merge Tekton pipeline PRs
+2. Wait for DevOps GitLab CI to process onboarding request (~2-4 hours)
+3. Review and merge DevOps-generated PRs
+4. Commit Dockerfile.konflux.<name> to downstream repo
+5. Submit OpenShift CI config PR to openshift/release
+6. Verify first build succeeds end-to-end
+```

--- a/.claude/skills/konflux-onboarding/SKILL.md
+++ b/.claude/skills/konflux-onboarding/SKILL.md
@@ -288,7 +288,57 @@ Generate from the upstream Dockerfile with these changes:
 
 See [references/dockerfile-templates.md](references/dockerfile-templates.md) § Downstream Type B.
 
-**Output**: Print the full Dockerfile content for the user to commit to the downstream repo. Do NOT write it to the upstream repo.
+### Pushing to the Downstream Repo
+
+The downstream Dockerfile **must** be committed to the downstream repo (e.g. `red-hat-data-services/odh-dashboard`), **not** to the upstream repo (`opendatahub-io/odh-dashboard`).
+
+1. **Identify the downstream remote.** Scan `git remote -v` for the downstream repo URL (e.g. `red-hat-data-services/odh-dashboard`). The remote name varies by checkout — it may be `origin`, `downstream`, or something else.
+
+   ```bash
+   DOWNSTREAM_REMOTE=$(git remote -v | grep 'red-hat-data-services/odh-dashboard' | head -1 | awk '{print $1}')
+   if [ -z "$DOWNSTREAM_REMOTE" ]; then
+     echo "ERROR: No remote found for red-hat-data-services/odh-dashboard"
+     echo "Add it with: git remote add downstream git@github.com:red-hat-data-services/odh-dashboard.git"
+     exit 1
+   fi
+   echo "Downstream remote: $DOWNSTREAM_REMOTE"
+   ```
+
+2. **Determine the target branch.** Use the `repo_branch` value from Phase 3 (e.g. `rhoai-3.5-ea.2`). Fetch and verify it exists:
+
+   ```bash
+   git fetch "$DOWNSTREAM_REMOTE" "$TARGET_BRANCH"
+   ```
+
+3. **Create a feature branch, add the Dockerfile, and push:**
+
+   ```bash
+   # Create branch from the downstream target
+   git checkout -b "<jira-key>-dockerfile-konflux" "$DOWNSTREAM_REMOTE/$TARGET_BRANCH"
+
+   # Write Dockerfile.konflux.<name> at repo root
+   # (use the content generated above)
+
+   git add "Dockerfile.konflux.<name>"
+   git commit -m "<JIRA-KEY>: Add Dockerfile.konflux.<name> for RHOAI Konflux builds"
+   git push "$DOWNSTREAM_REMOTE" "<jira-key>-dockerfile-konflux"
+   ```
+
+4. **Create a PR against the downstream repo** targeting `$TARGET_BRANCH`:
+
+   ```bash
+   gh pr create \
+     --repo red-hat-data-services/odh-dashboard \
+     --base "$TARGET_BRANCH" \
+     --head "<jira-key>-dockerfile-konflux" \
+     --title "<JIRA-KEY>: Add Dockerfile.konflux.<name>" \
+     --body "Adds the downstream Konflux Dockerfile for the <name> component.
+
+   This Dockerfile uses SHA-pinned base images and FIPS-compliant build flags
+   as required for RHOAI builds."
+   ```
+
+**Do NOT** write the Dockerfile to the upstream repo or create a PR against `opendatahub-io/odh-dashboard` — the downstream Dockerfile only exists in the downstream repo.
 
 ## Phase 5: Manifest Overlay (Type A only)
 
@@ -367,7 +417,7 @@ Print a final report:
 1. Review and merge Tekton pipeline PRs
 2. Wait for DevOps GitLab CI to process onboarding request (~2-4 hours)
 3. Review and merge DevOps-generated PRs (check Jira labels for progression)
-4. Commit Dockerfile.konflux.<name> to downstream repo
+4. Review and merge Dockerfile.konflux.<name> PR in the downstream repo
 5. Submit OpenShift CI config PR to openshift/release
 6. Coordinate operator integration with Platform team (RHOAIENG-37067) — update operator component references, OLM bundle, and test integration
 7. Verify first build succeeds end-to-end (both ODH and RHOAI)

--- a/.claude/skills/konflux-onboarding/SKILL.md
+++ b/.claude/skills/konflux-onboarding/SKILL.md
@@ -27,10 +27,16 @@ Parse from `$ARGUMENTS`:
    - **Type A — Modular-arch package**: `packages/<name>/` exists. These are Node.js + optional Go BFF packages that use `Dockerfile.workspace` and deploy as Module Federation remotes.
    - **Type B — Standalone Go component**: `<name>/` exists at repo root with a `go.mod`. These are Go services/operators with their own Dockerfile.
 
+   Validate the component name first, then use quoted path checks:
    ```bash
-   if [ -d "packages/$COMPONENT_NAME" ]; then
+   # Validate component name (lowercase alphanumeric + hyphens only)
+   if ! echo "$COMPONENT_NAME" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+     echo "Invalid component name"; exit 1
+   fi
+
+   if [ -d "packages/${COMPONENT_NAME}" ]; then
      TYPE="A"
-   elif [ -d "$COMPONENT_NAME" ] && [ -f "$COMPONENT_NAME/go.mod" ]; then
+   elif [ -d "${COMPONENT_NAME}" ] && [ -f "${COMPONENT_NAME}/go.mod" ]; then
      TYPE="B"
    else
      # Ask user to clarify
@@ -41,13 +47,13 @@ Parse from `$ARGUMENTS`:
    ```bash
    # Check for existing ODH Dockerfile
    # Type A:
-   ls packages/$COMPONENT_NAME/Dockerfile.workspace 2>/dev/null
+   [ -f "packages/${COMPONENT_NAME}/Dockerfile.workspace" ] && echo "exists"
    # Type B:
-   ls $COMPONENT_NAME/Dockerfile 2>/dev/null
+   [ -f "${COMPONENT_NAME}/Dockerfile" ] && echo "exists"
 
    # Check for existing Tekton pipelines
-   ls .tekton/*${COMPONENT_NAME}*push*.yaml 2>/dev/null
-   ls .tekton/*${COMPONENT_NAME}*pull-request*.yaml 2>/dev/null
+   find .tekton -maxdepth 1 -name "*${COMPONENT_NAME}*push*.yaml" -print -quit 2>/dev/null
+   find .tekton -maxdepth 1 -name "*${COMPONENT_NAME}*pull-request*.yaml" -print -quit 2>/dev/null
    ```
 
 4. Report classification and state to user:

--- a/.claude/skills/konflux-onboarding/references/devops-integration.md
+++ b/.claude/skills/konflux-onboarding/references/devops-integration.md
@@ -37,8 +37,9 @@ The DevOps skill handles these items (roughly mapping to RHOAIENG-37060 subtasks
 ### Installation
 
 The skill is a Claude Code plugin from `opendatahub-io/aiops-infra`:
-```
-/plugin install aiops-skills@opendatahub-skills
+
+```text
+/plugin install aiops-skills@opendatahub-skills:0.1.0
 ```
 
 Verify installation:
@@ -170,7 +171,7 @@ After the YAML is attached to a Jira ticket:
 
 | Issue | Resolution |
 |-------|------------|
-| DevOps skill not found | `Plugin install aiops-skills@opendatahub-skills` |
+| DevOps skill not found | `/plugin install aiops-skills@opendatahub-skills:0.1.0` |
 | `JIRA_USER_EMAIL`/`JIRA_API_TOKEN` not set | Use MCP fallback (generate YAML + mcp-atlassian tools) |
 | GitLab CI didn't process YAML | Check GitLab CI pipeline status; may need manual trigger |
 | PRs not appearing | Wait up to 4 hours; check GitLab CI logs for errors |

--- a/.claude/skills/konflux-onboarding/references/devops-integration.md
+++ b/.claude/skills/konflux-onboarding/references/devops-integration.md
@@ -1,0 +1,180 @@
+# DevOps Integration Guide
+
+How the Dashboard Konflux onboarding skill integrates with the DevOps `create-component-onboarding-jira` AI skill for Konflux setup.
+
+## Overview
+
+The DevOps team provides a Claude Code plugin (`create-component-onboarding-jira`) that automates Konflux infrastructure provisioning. It generates a `component_onboarding_details.yaml` validated against a JSON Schema, attaches it to a Jira ticket, and DevOps GitLab CI processes it.
+
+**Two separate runs are required** — one for ODH and one for RHOAI — because each product context has different schema requirements and targets different repos/build pipelines.
+
+## What DevOps Automates
+
+The DevOps skill handles these items (roughly mapping to RHOAIENG-37060 subtasks):
+
+| Step | Description | Related Subtask |
+|------|-------------|-----------------|
+| Quay repository creation | Creates the downstream Quay.io repo for built images | RHOAIENG-37062 |
+| Konflux component registration | Registers the component in the downstream Konflux tenant | RHOAIENG-37062 |
+| Konflux release configuration | Sets up ReleasePlanAdmission, release pipeline, advisory config | RHOAIENG-37064 |
+| CI integration | Configures PipelinesAsCode triggers in the downstream repo | RHOAIENG-37064 |
+| Renovate / automerge | Sets up automated dependency updates (image digest pinning) | RHOAIENG-37068 |
+| GitOps changes | Updates deployment manifests in GitOps repos | RHOAIENG-37068 |
+
+## What Dashboard Handles (Not DevOps)
+
+| Step | Description | Related Subtask |
+|------|-------------|-----------------|
+| ODH upstream Dockerfile | `Dockerfile.workspace` or `<name>/Dockerfile` | RHOAIENG-37063 |
+| ODH Tekton pipelines | `.tekton/` pipeline YAML files | RHOAIENG-37064 (upstream only) |
+| RHOAI downstream Dockerfile | `Dockerfile.konflux.<name>` with FIPS/labels | RHOAIENG-37063, 37068 |
+| Manifest overlays | `manifests/modular-architecture/modules/<name>/` (Type A only) | RHOAIENG-37066 |
+| OpenShift CI config | `openshift/release` repo configuration | RHOAIENG-37065 |
+| Operator integration | OLM bundle / ODH operator references | RHOAIENG-37067 |
+
+## Using the DevOps Skill
+
+### Installation
+
+The skill is a Claude Code plugin from `opendatahub-io/aiops-infra`:
+```
+/plugin install aiops-skills@opendatahub-skills
+```
+
+Verify installation:
+```
+/skills
+```
+Look for `create-component-onboarding-jira` in the list.
+
+### Prerequisites
+
+The skill's Python scripts need:
+- `uv` in PATH
+- `jq` in PATH
+- `JIRA_USER_EMAIL` — Atlassian account email
+- `JIRA_API_TOKEN` — Atlassian Cloud API token
+
+Scripts live at: `~/.claude/plugins/cache/opendatahub-skills/aiops-skills/0.1.0/`
+
+### MCP Fallback (when env vars are not set)
+
+If `JIRA_USER_EMAIL` or `JIRA_API_TOKEN` are not set, the YAML generation and validation scripts still work (they don't need Jira credentials), but the Jira attachment/update scripts will fail. In this case:
+
+1. Generate YAML: `uv run --script scripts/generate_onboarding_yaml.py ...`
+2. Validate: `uv run --script scripts/validate_yaml_schema.py ...`
+3. Use mcp-atlassian MCP tools for Jira operations:
+   - `jira_update_issue` — attach YAML and add labels
+   - `jira_create_issue_link` — link to parent feature
+   - `jira_add_comment` — post summary comment
+
+## Q&A Flow
+
+The skill asks questions sequentially. Each product context has different required fields.
+
+### Common Fields (both ODH and RHOAI)
+
+| # | Question | Field | Validation |
+|---|----------|-------|------------|
+| Q1 | Which product? (ODH/RHOAI) | `product_context` | `ODH` or `RHOAI` |
+| Q3 | Component name? | `component_name` | Regex: `^odh-[a-z0-9]+(-[a-z0-9]+)*$` |
+| Q4 | GitHub repo URL? | `repo_url` | Regex: `^https://github\.com/.+/.+$`, must return HTTP 200 |
+| Q6 | Docker build context path? | `context_path` | Non-empty, default `./` |
+| Q7 | Dockerfile path? | `dockerfile_path` | Non-empty |
+| Q8 | Is this an operator? (yes/no) | `is_operator` | Boolean |
+| Q9a | Manifest source path? (if operator) | `operator_manifest_src_path` | Non-empty |
+| Q9b | Manifest dest path? (if operator) | `operator_manifest_dest_path` | Non-empty |
+
+### ODH-Only Fields
+
+| # | Question | Field | Validation |
+|---|----------|-------|------------|
+| Q2 | CI or Release build? | `build_type` | `CI` or `Release` |
+| Q2.5 | Version tag? (Release only) | `odh_release_tag` | Non-empty |
+| Q5 | Branch to build? | `repo_branch` | Non-empty, default `main` |
+
+### RHOAI-Only Fields
+
+| # | Question | Field | Validation |
+|---|----------|-------|------------|
+| Q2a | Target RHOAI version? | `target_rhoai_version` | Regex: `^\d+\.\d+(?:\.0)?(?:-ea[-.]?\d+)?$` |
+| Q2b | CPU architectures? | `architectures` | Subset of `[x86_64, arm64, ppc64le, s390x]` |
+| Q3.5 | Release category? | `release_category` | `Generally Available`, `Tech Preview`, or `Beta` |
+| Q4.5a | Long description? | `long_description` | Non-empty, auto-suggested from README |
+| Q4.5b | Short description? | `short_description` | Non-empty, auto-suggested from long_description |
+| Q5 | Branch (auto-derived) | `repo_branch` | NOT asked — derived from version |
+| Q7 | Dockerfile path? | `dockerfile_path` | Basename must start with `Dockerfile.konflux` |
+
+### RHOAI Branch Auto-Derivation
+
+The `repo_branch` for RHOAI is derived from `target_rhoai_version` — do NOT ask the user:
+- `3.5` → `rhoai-3.5`
+- `3.5-ea-2` → `rhoai-3.5-ea.2`
+
+### RHOAI Version Canonical Form
+
+Input is normalized:
+- `3.4`, `3.4.0` → `3.4`
+- `3.4-ea2`, `3.4-ea-2`, `3.4-ea.2`, `3.4.0-ea2` → `3.4-ea-2`
+
+## Schema Validation
+
+The YAML is validated against `schemas/component_onboarding_details.schema.json`. Key rules:
+
+- `inputs` wrapper is required
+- ODH requires: `build_type`
+- RHOAI requires: `target_rhoai_version`, `architectures`, `release_category`, `long_description`, `short_description`
+- `component_name` must match `^odh-[a-z0-9]+(-[a-z0-9]+)*$`
+- `repo_url` must match `^https://github\.com/.+/.+$`
+- Conditional validation via `allOf`/`if`/`then` blocks
+
+## Dockerfile Digest Check (RHOAI only)
+
+RHOAI Dockerfiles must pin all `FROM` instructions with `@sha256:` digests:
+
+```bash
+uv run --script scripts/check_dockerfile_digests.py \
+  --dockerfile-url "<raw-github-url>"
+```
+
+If the downstream branch doesn't exist yet (HTTP 404), verify digests locally:
+```bash
+grep "^FROM " <dockerfile-path>
+# All FROM lines must contain @sha256:
+```
+
+## Automated Flow After Attachment
+
+After the YAML is attached to a Jira ticket:
+
+1. **DevOps GitLab CI picks it up** — scheduled job runs every ~2 hours
+2. **Automated PRs are raised** for:
+   - Konflux component registration
+   - Release pipeline configuration
+   - Quay repository setup
+   - PipelinesAsCode triggers
+3. **Human review required** — each PR needs manual review and merge
+4. **Verification** — after PRs merge:
+   - Quay repo exists and is accessible
+   - Konflux component appears in the tenant
+   - A test push triggers a build
+
+## Monitoring Progress
+
+1. Check if the YAML was committed to the onboarding repo
+2. Watch for automated PRs (typically 2-4 hours after YAML commit)
+3. Review and merge each PR
+4. Verify end-to-end by pushing a small change to the downstream repo
+
+## Troubleshooting
+
+| Issue | Resolution |
+|-------|------------|
+| DevOps skill not found | `Plugin install aiops-skills@opendatahub-skills` |
+| `JIRA_USER_EMAIL`/`JIRA_API_TOKEN` not set | Use MCP fallback (generate YAML + mcp-atlassian tools) |
+| GitLab CI didn't process YAML | Check GitLab CI pipeline status; may need manual trigger |
+| PRs not appearing | Wait up to 4 hours; check GitLab CI logs for errors |
+| Dockerfile digest check HTTP 404 | Branch doesn't exist yet; verify digests locally |
+| Build fails after merge | Check Dockerfile path, service account permissions, Quay access |
+| Image not pushed to Quay | Verify robot account has push permissions; check Konflux logs |
+| Schema validation fails | Check conditional required fields per product context |

--- a/.claude/skills/konflux-onboarding/references/devops-integration.md
+++ b/.claude/skills/konflux-onboarding/references/devops-integration.md
@@ -43,7 +43,8 @@ The skill is a Claude Code plugin from `opendatahub-io/aiops-infra`:
 ```
 
 Verify installation:
-```
+
+```text
 /skills
 ```
 Look for `create-component-onboarding-jira` in the list.
@@ -160,12 +161,33 @@ After the YAML is attached to a Jira ticket:
    - Konflux component appears in the tenant
    - A test push triggers a build
 
+## Label Progression
+
+DevOps automation tracks progress via Jira labels. These are added automatically by CI as each step completes:
+
+| Label | Meaning | Added by |
+|-------|---------|----------|
+| `yaml-attached` | Onboarding YAML attached to ticket | `/create-component-onboarding-jira` skill |
+| `validation-successful` | YAML passes schema + Dockerfile digest validation | `/validate-component-onboarding-jira` skill |
+| `component-onboarding` | GitLab CI picked up the request | DevOps automation |
+| `onboarding-in-review` | PRs/MRs have been generated and are pending review | DevOps automation |
+| `okc-pr-merged` | OKC (Konflux component registration) PR merged | DevOps automation |
+| `tekton-pr-merged` | Tekton pipeline configuration PR merged | DevOps automation |
+| `operator-pr-merged` | Operator-related PR merged (if applicable) | DevOps automation |
+| `bundle-pr-merged` | OLM bundle PR merged (if applicable) | DevOps automation |
+| `quay-mr-merged` | Quay repository MR merged | DevOps automation |
+| `krd-mr-merged` | KRD (Konflux Release Definition) MR merged (RHOAI only) | DevOps automation |
+| `component-onboarding-completed` | All onboarding steps finished | DevOps automation |
+
+**Monitoring**: Check the Jira ticket labels to track which stage the onboarding has reached. If labels stop progressing after 4+ hours, check the GitLab CI pipeline logs.
+
 ## Monitoring Progress
 
 1. Check if the YAML was committed to the onboarding repo
 2. Watch for automated PRs (typically 2-4 hours after YAML commit)
-3. Review and merge each PR
-4. Verify end-to-end by pushing a small change to the downstream repo
+3. Check Jira labels for progression (see table above)
+4. Review and merge each PR as it appears
+5. Verify end-to-end by pushing a small change to the downstream repo
 
 ## Troubleshooting
 

--- a/.claude/skills/konflux-onboarding/references/dockerfile-templates.md
+++ b/.claude/skills/konflux-onboarding/references/dockerfile-templates.md
@@ -1,0 +1,209 @@
+# Dockerfile Templates
+
+Templates for container images in `odh-dashboard`. Each component needs up to 2 Dockerfiles:
+1. **Upstream (ODH)**: Used by Konflux CI in `opendatahub-io/odh-dashboard`
+2. **Downstream (RHOAI)**: Used by Konflux in `red-hat-data-services/odh-dashboard`
+
+## Upstream vs Downstream Differences
+
+| Aspect | Upstream (ODH) | Downstream (RHOAI) |
+|--------|----------------|---------------------|
+| Image tags | Tag-based (e.g., `ubi9/nodejs-22:latest`) | **SHA-pinned** (e.g., `ubi9/nodejs-22@sha256:...`) |
+| Go build flags | `CGO_ENABLED=0` (static) | `CGO_ENABLED=1 -tags strictfipsruntime` (FIPS) |
+| Labels | Minimal | Full Red Hat labels required |
+| Location | Component directory or `packages/<name>/` | Repo root as `Dockerfile.konflux.<component>` |
+| Registry | `registry.access.redhat.com` | `registry.access.redhat.com` or `registry.redhat.io` |
+
+## Type A: Modular-Arch Package
+
+### Upstream — `packages/<name>/Dockerfile.workspace`
+
+Multi-stage build with Node.js UI + Go BFF. Build from repo root: `docker build --file ./packages/<name>/Dockerfile.workspace .`
+
+```dockerfile
+# Source code arguments
+ARG MODULE_NAME=<name>
+ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
+ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
+
+# Base images
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22:latest
+ARG GOLANG_BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.24
+ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:latest
+
+# UI build stage
+FROM ${NODE_BASE_IMAGE} AS ui-builder
+ARG UI_SOURCE_CODE
+ARG MODULE_NAME
+WORKDIR /usr/src/workspace
+
+# Workspace setup — copy root manifests + shared packages
+COPY --chown=default:root package.json package-lock.json* ./
+COPY --chown=default:root frontend/package.json ./frontend/
+COPY --chown=default:root packages/plugin-core/ ./packages/plugin-core/
+COPY --chown=default:root packages/tsconfig/ ./packages/tsconfig/
+COPY --chown=default:root frontend/src/ ./frontend/src/
+COPY --chown=default:root ${UI_SOURCE_CODE} ./${UI_SOURCE_CODE}
+
+USER default
+RUN npm cache clean --force
+RUN npm ci --omit=optional --ignore-scripts
+
+WORKDIR /usr/src/workspace/${UI_SOURCE_CODE}
+RUN npm ci --omit=optional --ignore-scripts
+RUN npm run build:prod
+
+# BFF build stage
+FROM ${GOLANG_BASE_IMAGE} AS bff-builder
+ARG BFF_SOURCE_CODE
+ARG TARGETOS
+ARG TARGETARCH
+WORKDIR /usr/src/app
+
+COPY ${BFF_SOURCE_CODE}/go.mod ${BFF_SOURCE_CODE}/go.sum ./
+RUN go mod download
+COPY ${BFF_SOURCE_CODE}/cmd/ cmd/
+COPY ${BFF_SOURCE_CODE}/internal/ internal/
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-s -w" -tags strictfipsruntime -o bff ./cmd
+
+# Final stage
+FROM ${DISTROLESS_BASE_IMAGE}
+ARG UI_SOURCE_CODE
+WORKDIR /
+COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/bff"]
+```
+
+### Downstream — `Dockerfile.konflux.<name>`
+
+Same structure as upstream but with SHA-pinned images and Red Hat labels. Placed at repo root in `red-hat-data-services/odh-dashboard`.
+
+Key differences from upstream:
+- All base images pinned by SHA digest
+- Red Hat labels added to final stage
+- `CACHITO_ENV_FILE` support for hermetic builds (Konflux Cachi2)
+- Additional `io.openshift.build.commit.*` labels
+
+```dockerfile
+# SHA-pinned base images (update digests via Renovate)
+ARG MODULE_NAME=<name>
+ARG UI_SOURCE_CODE=./packages/${MODULE_NAME}/frontend
+ARG BFF_SOURCE_CODE=./packages/${MODULE_NAME}/bff
+
+ARG NODE_BASE_IMAGE=registry.access.redhat.com/ubi9/nodejs-22@sha256:<digest>
+ARG GOLANG_BASE_IMAGE=registry.redhat.io/ubi9/go-toolset@sha256:<digest>
+ARG DISTROLESS_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal@sha256:<digest>
+
+# [same multi-stage build as upstream, but with FIPS flags already in upstream]
+
+# Final stage — add Red Hat labels
+FROM ${DISTROLESS_BASE_IMAGE}
+ARG UI_SOURCE_CODE
+
+LABEL com.redhat.component="odh-<name>-container" \
+      name="managed-open-data-hub/odh-<name>-rhel9" \
+      summary="ODH <Name> Module" \
+      description="<Name> module for Red Hat OpenShift AI Dashboard" \
+      io.k8s.display-name="ODH <Name>" \
+      io.k8s.description="<Name> module for Red Hat OpenShift AI Dashboard" \
+      io.openshift.tags="rhods,rhoai,odh,<name>"
+
+WORKDIR /
+COPY --from=bff-builder /usr/src/app/bff ./
+COPY --from=ui-builder /usr/src/workspace/${UI_SOURCE_CODE}/dist ./static/
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/bff"]
+```
+
+## Type B: Standalone Go Component
+
+### Upstream — `<name>/Dockerfile`
+
+Simple Go builder + UBI minimal runtime. Build from repo root.
+
+```dockerfile
+FROM golang:<go-version> AS builder
+WORKDIR /usr/src/app
+
+COPY <name>/go.mod <name>/go.sum ./
+RUN go mod download
+
+COPY <name>/cmd/ cmd/
+COPY <name>/api/ api/
+COPY <name>/internal/ internal/
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /tmp/<binary-name> ./cmd/manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+WORKDIR /
+COPY --from=builder /tmp/<binary-name> .
+# Copy any required static assets (e.g., manifests)
+COPY manifests/ /opt/manifests/dashboard/
+RUN chmod -R g+w /opt/manifests/dashboard/
+
+USER 65532:65532
+ENTRYPOINT ["/<binary-name>"]
+```
+
+### Downstream — `Dockerfile.konflux.<name>`
+
+SHA-pinned, FIPS-compliant, Red Hat labels. Placed at repo root in `red-hat-data-services/odh-dashboard`.
+
+```dockerfile
+FROM registry.redhat.io/ubi9/go-toolset:<go-version>@sha256:<digest> AS builder
+
+USER root
+WORKDIR /usr/src/app
+
+COPY <name>/go.mod <name>/go.sum ./
+RUN go mod download
+
+COPY <name>/cmd/ cmd/
+COPY <name>/api/ api/
+COPY <name>/internal/ internal/
+
+# FIPS-compliant build: CGO_ENABLED=1 + strictfipsruntime
+RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/<binary-name> ./cmd/manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:<digest>
+
+LABEL com.redhat.component="odh-<name>-container" \
+      name="managed-open-data-hub/odh-<name>-rhel9" \
+      summary="ODH <Name>" \
+      description="<Name> for Red Hat OpenShift AI Dashboard" \
+      io.k8s.display-name="ODH <Name>" \
+      io.k8s.description="<Name> for Red Hat OpenShift AI Dashboard" \
+      io.openshift.tags="rhods,rhoai,odh,<name>"
+
+WORKDIR /
+COPY --from=builder /tmp/<binary-name> .
+COPY manifests/ /opt/manifests/dashboard/
+RUN chmod -R g+w /opt/manifests/dashboard/
+
+USER 65532:65532
+ENTRYPOINT ["/<binary-name>"]
+```
+
+## Go Toolset Notes
+
+- **Upstream**: Docker Hub `golang:<version>` with `CGO_ENABLED=0` (static binary, no FIPS)
+- **Downstream**: `registry.redhat.io/ubi9/go-toolset` with `CGO_ENABLED=1 -tags strictfipsruntime`
+- `go-toolset` requires `USER root` before writing files (runs as non-root by default)
+- The FIPS runtime tag enables BoringCrypto for FIPS 140-2 compliance
+- Check `go.mod` for the required Go toolchain version
+
+## SHA Digest Management
+
+Downstream Dockerfiles use SHA digests instead of tags. To get the current digest:
+
+```bash
+# For a specific image and tag
+skopeo inspect docker://registry.access.redhat.com/ubi9/ubi-minimal:latest --format '{{.Digest}}'
+skopeo inspect docker://registry.redhat.io/ubi9/go-toolset:1.25 --format '{{.Digest}}'
+```
+
+Renovate (or Konflux's automated tooling) will keep these digests up to date after initial setup.

--- a/.claude/skills/konflux-onboarding/references/dockerfile-templates.md
+++ b/.claude/skills/konflux-onboarding/references/dockerfile-templates.md
@@ -9,7 +9,8 @@ Templates for container images in `odh-dashboard`. Each component needs up to 2 
 | Aspect | Upstream (ODH) | Downstream (RHOAI) |
 |--------|----------------|---------------------|
 | Image tags | Tag-based (e.g., `ubi9/nodejs-22:latest`) | **SHA-pinned** (e.g., `ubi9/nodejs-22@sha256:...`) |
-| Go build flags | `CGO_ENABLED=0` (static) | `CGO_ENABLED=1 -tags strictfipsruntime` (FIPS) |
+| Go build flags (Type A) | `CGO_ENABLED=1 -tags strictfipsruntime` (FIPS) | Same as upstream |
+| Go build flags (Type B) | `CGO_ENABLED=0` (static, no FIPS) | `CGO_ENABLED=1 -tags strictfipsruntime` (FIPS) |
 | Labels | Minimal | Full Red Hat labels required |
 | Location | Component directory or `packages/<name>/` | Repo root as `Dockerfile.konflux.<component>` |
 | Registry | `registry.access.redhat.com` | `registry.access.redhat.com` or `registry.redhat.io` |
@@ -136,7 +137,7 @@ COPY <name>/cmd/ cmd/
 COPY <name>/api/ api/
 COPY <name>/internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o /tmp/<binary-name> ./cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /tmp/<binary-name> ./cmd/<entry-dir>
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 WORKDIR /
@@ -167,7 +168,7 @@ COPY <name>/api/ api/
 COPY <name>/internal/ internal/
 
 # FIPS-compliant build: CGO_ENABLED=1 + strictfipsruntime
-RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/<binary-name> ./cmd/manager
+RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -tags strictfipsruntime -o /tmp/<binary-name> ./cmd/<entry-dir>
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:<digest>
 
@@ -190,8 +191,9 @@ ENTRYPOINT ["/<binary-name>"]
 
 ## Go Toolset Notes
 
-- **Upstream**: Docker Hub `golang:<version>` with `CGO_ENABLED=0` (static binary, no FIPS)
-- **Downstream**: `registry.redhat.io/ubi9/go-toolset` with `CGO_ENABLED=1 -tags strictfipsruntime`
+- **Type A upstream (BFF)**: Uses `ubi9/go-toolset` with `CGO_ENABLED=1 -tags strictfipsruntime` (FIPS-enabled, matching downstream)
+- **Type B upstream (standalone)**: Uses Docker Hub `golang:<version>` with `CGO_ENABLED=0` (static binary, no FIPS)
+- **All downstream**: Uses `registry.redhat.io/ubi9/go-toolset` with `CGO_ENABLED=1 -tags strictfipsruntime`
 - `go-toolset` requires `USER root` before writing files (runs as non-root by default)
 - The FIPS runtime tag enables BoringCrypto for FIPS 140-2 compliance
 - Check `go.mod` for the required Go toolchain version

--- a/.claude/skills/konflux-onboarding/references/pipeline-templates.md
+++ b/.claude/skills/konflux-onboarding/references/pipeline-templates.md
@@ -1,0 +1,153 @@
+# Tekton Pipeline Templates
+
+Templates for Konflux CI pipelines in `opendatahub-io/odh-dashboard`. All pipelines use PipelinesAsCode and reference `odh-konflux-central.git` for the actual pipeline definition.
+
+## Substitution Variables
+
+Replace these placeholders when scaffolding from the templates:
+
+| Variable | Description | Example (Type A) | Example (Type B) |
+|----------|-------------|-------------------|-------------------|
+| `{{COMPONENT_NAME}}` | Component identifier | `gen-ai` | `dashboard-operator` |
+| `{{COMPONENT_CI_NAME}}` | Konflux component name | `odh-mod-arch-gen-ai-ci` | `dashboard-operator-ci` |
+| `{{PIPELINE_NAME_PREFIX}}` | Pipeline run name prefix | `odh-mod-arch-gen-ai` | `dashboard-operator` |
+| `{{QUAY_IMAGE}}` | Quay.io image path | `quay.io/opendatahub/odh-mod-arch-gen-ai` | `quay.io/opendatahub/dashboard-operator` |
+| `{{DOCKERFILE_PATH}}` | Path to Dockerfile | `packages/gen-ai/Dockerfile.workspace` | `dashboard-operator/Dockerfile` |
+| `{{PATH_CHANGED_EXPR}}` | CEL path filter | `"packages/gen-ai/**"` | `"dashboard-operator/**"` |
+| `{{EXTRA_PATH_EXPR}}` | Additional path triggers | `\|\| "Dockerfile.workspace".pathChanged()` | `\|\| "manifests/**".pathChanged()` |
+| `{{SERVICE_ACCOUNT}}` | Build pipeline SA | `build-pipeline-genai-poc` | `build-pipeline-dashboard-operator` |
+
+## Naming Conventions
+
+- **Type A** (modular-arch packages): `odh-mod-arch-<name>-{push,pull-request}.yaml`
+- **Type B** (standalone Go components): `<name>-{push,pull-request}.yaml`
+
+## Template: Push Pipeline
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "{{PATH_CHANGED_EXPR}}".pathChanged()
+      || ".tekton/{{PIPELINE_NAME_PREFIX}}-push.yaml".pathChanged() {{EXTRA_PATH_EXPR}}
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: {{COMPONENT_CI_NAME}}
+    pipelines.appstudio.openshift.io/type: build
+  name: {{PIPELINE_NAME_PREFIX}}-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: {{QUAY_IMAGE}}:odh-stable
+  - name: dockerfile
+    value: {{DOCKERFILE_PATH}}
+  - name: path-context
+    value: .
+  - name: additional-tags
+    value:
+    - 'odh-stable-{{revision}}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: {{SERVICE_ACCOUNT}}
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}
+```
+
+## Template: Pull Request Pipeline
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "{{PATH_CHANGED_EXPR}}".pathChanged()
+      || ".tekton/{{PIPELINE_NAME_PREFIX}}-pull-request.yaml".pathChanged() {{EXTRA_PATH_EXPR}}
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: {{COMPONENT_CI_NAME}}
+    pipelines.appstudio.openshift.io/type: build
+  name: {{PIPELINE_NAME_PREFIX}}-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: {{QUAY_IMAGE}}:odh-pr
+  - name: dockerfile
+    value: {{DOCKERFILE_PATH}}
+  - name: path-context
+    value: .
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: {{SERVICE_ACCOUNT}}
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}
+```
+
+## Type A vs Type B Differences
+
+| Aspect | Type A (modular-arch package) | Type B (standalone Go component) |
+|--------|-------------------------------|----------------------------------|
+| File naming | `odh-mod-arch-<name>-*.yaml` | `<name>-*.yaml` |
+| Path filter | `packages/<name>/**` | `<name>/**` |
+| Extra paths | `Dockerfile.workspace` | `manifests/**` |
+| Dockerfile | `packages/<name>/Dockerfile.workspace` | `<name>/Dockerfile` |
+| Image name | `odh-mod-arch-<name>` | `<name>` |
+| SA naming | `build-pipeline-<custom>` | `build-pipeline-<name>` |
+
+## Service Account Provisioning
+
+The `serviceAccountName` must match a service account provisioned in the `open-data-hub-tenant` namespace. This is handled by DevOps as part of Konflux component onboarding — the SA is created along with the Quay repository and Konflux component registration. Do not create pipelines until the SA exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,5 +134,6 @@ Skills provide multi-step workflows. They live in `.claude/skills/`. Read the re
 | **Jira Assign Scrum Team**        | `skills/jira-assign-scrum-team/`       | Assigning a scrum team label based on area-to-scrum mapping during triage |
 | **Jira Eval Review**               | `skills/jira-eval-review/`             | Evaluating PR code changes against Jira acceptance criteria for per-criterion verdicts |
 | **Module Onboarding**              | `skills/module-onboarding/`            | Scaffolding a new federated module under `packages/` — handles installer, port allocation, host registration, and build verification (pass module name as argument) |
+| **Konflux Onboarding**             | `skills/konflux-onboarding/`           | Onboarding a component to Konflux CI/CD — Dockerfiles, Tekton pipelines, DevOps coordination, RHOAI downstream setup |
 
 **Important**: Always read the relevant rule or skill file before starting the task to ensure you follow the project's conventions and patterns.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-66095

## Description

Adds the `/konflux-onboarding` Claude Code skill that guides teams through the complete CI/CD pipeline onboarding process for new components in both ODH (upstream) and RHOAI (downstream).

The skill wraps the DevOps `create-component-onboarding-jira` Claude Code plugin and adds Dashboard-specific steps that DevOps doesn't cover:

**8-phase guided workflow:**
- **Phase 0**: Parse component name and classify as Type A (modular-arch package) or Type B (standalone Go component)
- **Phase 1**: Scaffold ODH upstream Dockerfile (`Dockerfile.workspace` or `<name>/Dockerfile`)
- **Phase 2**: Scaffold ODH Tekton pipelines in `.tekton/` (push + pull-request)
- **Phase 3**: Collect info and guide user through DevOps skill invocation for RHOAI Konflux setup
- **Phase 4**: Generate RHOAI downstream Dockerfile (`Dockerfile.konflux.<name>`) with SHA-pinned images, FIPS compliance, Red Hat labels
- **Phase 5**: Scaffold manifest overlays (Type A only)
- **Phase 6**: Provide OpenShift CI instructions (`openshift/release` repo)
- **Phase 7**: Update tracking Jira issues
- **Phase 8**: Print verification report with remaining manual steps

**Reference documentation:**
- `references/pipeline-templates.md` — Tekton PipelineRun YAML templates with substitution variable table
- `references/dockerfile-templates.md` — 4 Dockerfile variant templates (upstream/downstream × Type A/B)
- `references/devops-integration.md` — DevOps skill usage guide, automation mapping, troubleshooting

**Tested** end-to-end with `dashboard-operator` ([RHOAIENG-65724](https://redhat.atlassian.net/browse/RHOAIENG-65724)) as a Type B component — correctly classified the component, detected existing ODH pipelines, and generated a FIPS-compliant downstream Dockerfile.

Companion to `/module-onboarding` (PR #7885) which handles Dashboard-side package scaffolding. Together these two skills automate the majority of the [RHOAIENG-37060](https://redhat.atlassian.net/browse/RHOAIENG-37060) deployment epic.

## How Has This Been Tested?

- Ran the skill workflow manually against `dashboard-operator` (Type B path):
  - Phase 0 correctly classified as Type B and detected existing ODH Dockerfile + Tekton pipelines
  - Phases 1-2 correctly skipped (existing state detected)
  - Phase 4 generated a valid `Dockerfile.konflux.dashboard-operator` with FIPS flags, SHA-pinned images, and Red Hat labels
- Mentally traced the Type A path against `packages/gen-ai/` to verify template substitutions

## Test Impact

This is a Claude Code skill (agent instructions in `.claude/`), not application code. No unit or Cypress tests are applicable — the skill is validated by running it interactively and verifying the generated artifacts.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Konflux Onboarding” agent skill specification with an argument-driven, multi-phase workflow for orchestrating upstream/downstream Konflux CI/CD setup, DevOps coordination, and a final onboarding report checklist.

* **Documentation**
  * Added a DevOps integration guide covering Jira progress updates (with local YAML fallback), required onboarding Q&A/validation, and digest-pinning/merge verification flows.
  * Added Dockerfile template reference (Type A vs Type B, upstream vs downstream) and Konflux PipelineRun templates (push/PR, change-trigger rules).
  * Updated the skills index for discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->