### PR TITLE
My subscription microcopy updates

### DIFF
--- a/packages/cypress/cypress/pages/modelsAsAService.ts
+++ b/packages/cypress/cypress/pages/modelsAsAService.ts
@@ -1084,15 +1084,6 @@ class SubscriptionsTab {
     this.findSearchInput().find('button[aria-label="Reset"]').click();
   }
 
-  findSourceFilterToggle(): Cypress.Chainable<JQuery<HTMLElement>> {
-    return cy.findByTestId('subscriptions-source-filter-toggle');
-  }
-
-  selectSourceFilter(source: string): void {
-    this.findSourceFilterToggle().click();
-    cy.findByRole('menuitem', { name: source }).click();
-  }
-
   findSortBySubscriptionButton(): Cypress.Chainable<JQuery<HTMLElement>> {
     return cy.findByTestId('sort-by-subscription');
   }

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -98,12 +98,9 @@ describe('API Keys Page', () => {
 
   it('should display the API keys table page with active and expired keys on initial load', () => {
     apiKeysPage.findTitle().should('contain.text', 'API keys');
-    apiKeysPage
-      .findDescription()
-      .should(
-        'contain.text',
-        'Manage API keys that can be used to authenticate with model endpoints.',
-      );
+    cy.contains('Manage API keys that can be used to authenticate with model endpoints.').should(
+      'exist',
+    );
 
     apiKeysPage.findTable().should('exist');
     apiKeysPage.findRows().should('have.length', 3);
@@ -933,12 +930,9 @@ describe('API keys (mySubscriptions feature flag)', () => {
     cy.wait('@initialSearch');
 
     apiKeysPage.findTitle().should('contain.text', 'API keys');
-    apiKeysPage
-      .findDescription()
-      .should(
-        'contain.text',
-        'Manage API keys that can be used to authenticate with model endpoints.',
-      );
+    cy.contains('Manage API keys that can be used to authenticate with model endpoints.').should(
+      'exist',
+    );
 
     apiKeysPage.findApiKeysTab().should('have.attr', 'aria-selected', 'true');
     apiKeysPage.findTable().should('exist');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -951,7 +951,7 @@ describe('API keys (mySubscriptions feature flag)', () => {
     cy.contains('View your subscriptions and the models they give you access to.').should('exist');
   });
 
-  it('should display subscription view with search and source filter', () => {
+  it('should display subscription view with search', () => {
     apiKeysPage.visitKeysAndSubs();
     cy.wait('@initialSearch');
 
@@ -973,17 +973,11 @@ describe('API keys (mySubscriptions feature flag)', () => {
     subscriptionsTab.clearSearch();
     subscriptionsTab.findSubscriptionRows().should('have.length', 2);
 
-    subscriptionsTab.selectSourceFilter('Internal');
-
-    subscriptionsTab.findSubscriptionRows().should('have.length', 1);
-    subscriptionsTab.findSubscriptionsTable().should('contain.text', 'Premium Team');
-    subscriptionsTab.findSubscriptionsTable().should('not.contain.text', 'Basic Team');
-
     subscriptionsTab.expandSubscriptionRow(0);
     subscriptionsTab.findSubscriptionsTable().should('contain.text', 'Granite 3 8B Instruct');
   });
 
-  it('should display model view with search and source filter', () => {
+  it('should display model view with search', () => {
     apiKeysPage.visitKeysAndSubs();
     cy.wait('@initialSearch');
 
@@ -1000,11 +994,6 @@ describe('API keys (mySubscriptions feature flag)', () => {
 
     subscriptionsTab.clearSearch();
     subscriptionsTab.findModelsTable().should('contain.text', 'Flan T5 Small');
-
-    subscriptionsTab.selectSourceFilter('External');
-
-    subscriptionsTab.findModelsTable().should('contain.text', 'Flan T5 Small');
-    subscriptionsTab.findModelsTable().should('not.contain.text', 'Granite 3 8B Instruct');
 
     subscriptionsTab.expandModelGroupRow(0);
     subscriptionsTab.findModelsTable().should('contain.text', 'Premium Team');

--- a/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/modelsAsAService/maasApiKeys.cy.ts
@@ -100,7 +100,10 @@ describe('API Keys Page', () => {
     apiKeysPage.findTitle().should('contain.text', 'API keys');
     apiKeysPage
       .findDescription()
-      .should('contain.text', 'Manage your API keys and view your subscription access.');
+      .should(
+        'contain.text',
+        'Manage API keys that can be used to authenticate with model endpoints.',
+      );
 
     apiKeysPage.findTable().should('exist');
     apiKeysPage.findRows().should('have.length', 3);
@@ -877,7 +880,7 @@ describe('API Keys Page (Admin)', () => {
   });
 });
 
-describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
+describe('API keys (mySubscriptions feature flag)', () => {
   beforeEach(() => {
     asClusterAdminUser();
     cy.interceptOdh(
@@ -929,10 +932,13 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
     apiKeysPage.visitKeysAndSubs();
     cy.wait('@initialSearch');
 
-    apiKeysPage.findTitle().should('contain.text', 'API keys and subscriptions');
+    apiKeysPage.findTitle().should('contain.text', 'API keys');
     apiKeysPage
       .findDescription()
-      .should('contain.text', 'Manage your API keys and view your subscription access');
+      .should(
+        'contain.text',
+        'Manage API keys that can be used to authenticate with model endpoints.',
+      );
 
     apiKeysPage.findApiKeysTab().should('have.attr', 'aria-selected', 'true');
     apiKeysPage.findTable().should('exist');
@@ -942,9 +948,7 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
     cy.url().should('include', '/maas/keys-and-subs/subscriptions');
     apiKeysPage.findSubscriptionsTab().should('have.attr', 'aria-selected', 'true');
 
-    cy.contains('Models available to you through your subscriptions, with token limits.').should(
-      'exist',
-    );
+    cy.contains('View your subscriptions and the models they give you access to.').should('exist');
   });
 
   it('should display subscription view with search and source filter', () => {
@@ -1046,10 +1050,7 @@ describe('API keys and subscriptions (mySubscriptions feature flag)', () => {
 
     subscriptionsTab.findEmptyState().should('exist');
     subscriptionsTab.findSubscriptionsTable().should('not.exist');
-
-    subscriptionsTab.findSortByModelButton().click();
-    cy.findByTestId('empty-models').should('exist');
-    subscriptionsTab.findModelsTable().should('not.exist');
+    subscriptionsTab.findEmptyState().should('contain.text', 'Request a subscription');
   });
 
   it('should show the correct data on the my subscriptions view page', () => {

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
@@ -44,10 +44,8 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
 
   return (
     <ApplicationsPage
-      title={
-        <TitleWithIcon title="API keys and subscriptions" objectType={ProjectObjectType.apiKeys} />
-      }
-      description="Manage your API keys and view your subscription access."
+      title={<TitleWithIcon title="API keys" objectType={ProjectObjectType.apiKeys} />}
+      description="Manage API keys that can be used to authenticate with model endpoints."
       loaded={isPageLoaded}
       empty={false}
       loadError={pageLoadError}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/ApiKeysAndSubscriptionsPage.tsx
@@ -1,7 +1,7 @@
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
 import TitleWithIcon from '@odh-dashboard/internal/concepts/design/TitleWithIcon';
 import { ProjectObjectType } from '@odh-dashboard/internal/concepts/design/utils';
-import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApiKeysPageLoad } from '~/app/hooks/useApiKeysPageLoad';
@@ -45,7 +45,6 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
   return (
     <ApplicationsPage
       title={<TitleWithIcon title="API keys" objectType={ProjectObjectType.apiKeys} />}
-      description="Manage API keys that can be used to authenticate with model endpoints."
       loaded={isPageLoaded}
       empty={false}
       loadError={pageLoadError}
@@ -65,11 +64,13 @@ const ApiKeysAndSubscriptionsPage: React.FC = () => {
           aria-label="API keys tab"
           data-testid="api-keys-tab"
         >
-          <PageSection isFilled>
-            {!showApiKeysLoadError && (
-              <ApiKeysTab pageState={apiKeysPageState} subscriptions={subscriptions} />
-            )}
-          </PageSection>
+          {!showApiKeysLoadError && (
+            <ApiKeysTab
+              pageState={apiKeysPageState}
+              subscriptions={subscriptions}
+              showDescription
+            />
+          )}
         </Tab>
         <Tab
           eventKey={SUBSCRIPTIONS_TAB}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/__tests__/utils.spec.ts
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { formatApiKeyError, getSourceLabelColor } from '~/app/pages/keys-and-subs/utils';
+import { formatApiKeyError } from '~/app/pages/keys-and-subs/utils';
 import { deriveModelGroups } from '~/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab';
 
 describe('formatApiKeyError', () => {
@@ -42,21 +42,6 @@ describe('formatApiKeyError', () => {
     it('should capitalize a single character string', () => {
       expect(formatApiKeyError('x')).toBe('X');
     });
-  });
-});
-
-describe('getSourceLabelColor', () => {
-  it('should return blue for internal source', () => {
-    expect(getSourceLabelColor('internal')).toBe('blue');
-  });
-
-  it('should return purple for external source', () => {
-    expect(getSourceLabelColor('external')).toBe('purple');
-  });
-
-  it('should return purple for any non-internal source', () => {
-    expect(getSourceLabelColor('partner')).toBe('purple');
-    expect(getSourceLabelColor('')).toBe('purple');
   });
 });
 

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
@@ -1,4 +1,4 @@
-import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
+import { Bullseye, Content, ContentVariants, PageSection, Spinner } from '@patternfly/react-core';
 import React from 'react';
 import { type UseApiKeysPageLoadReturn } from '~/app/hooks/useApiKeysPageLoad';
 import { APIKey } from '~/app/types/api-key';
@@ -96,6 +96,9 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions }) => 
         />
       )}
       <PageSection isFilled>
+        <Content component={ContentVariants.p}>
+          Manage API keys that can be used to authenticate with model endpoints.
+        </Content>
         <ApiKeysTable
           onRevokeApiKey={setRevokeApiKey}
           apiKeys={apiKeys}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/apiKeys/ApiKeysTab.tsx
@@ -12,9 +12,10 @@ import ApiKeysToolbar from './allKeys/ApiKeysToolbar';
 type ApiKeysTabProps = {
   pageState: UseApiKeysPageLoadReturn;
   subscriptions: UserSubscription[];
+  showDescription?: boolean;
 };
 
-const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions }) => {
+const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions, showDescription }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [revokeApiKey, setRevokeApiKey] = React.useState<APIKey | undefined>(undefined);
 
@@ -96,9 +97,11 @@ const ApiKeysTab: React.FC<ApiKeysTabProps> = ({ pageState, subscriptions }) => 
         />
       )}
       <PageSection isFilled>
-        <Content component={ContentVariants.p}>
-          Manage API keys that can be used to authenticate with model endpoints.
-        </Content>
+        {showDescription && (
+          <Content component={ContentVariants.p}>
+            Manage API keys that can be used to authenticate with model endpoints.
+          </Content>
+        )}
         <ApiKeysTable
           onRevokeApiKey={setRevokeApiKey}
           apiKeys={apiKeys}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/EmptySubscriptionsTabState.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/EmptySubscriptionsTabState.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  List,
+  ListItem,
+  Popover,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon, SearchIcon } from '@patternfly/react-icons';
+import apiKeysEmptyStateImg from '@odh-dashboard/internal/images/empty-state-api-keys.svg';
 
 type EmptySubscriptionsTabStateProps = {
   hasData: boolean;
@@ -16,15 +25,37 @@ const EmptySubscriptionsTabState: React.FC<EmptySubscriptionsTabStateProps> = ({
       <EmptyState
         data-testid={`empty-${variant}s`}
         headingLevel="h3"
-        titleText={`No ${variant}s`}
+        titleText="Request a subscription"
         variant="sm"
-        icon={SearchIcon}
+        icon={() => <img src={apiKeysEmptyStateImg} alt="Request a subscription" />}
       >
         <EmptyStateBody>
-          {variant === 'subscription'
-            ? 'You don\u2019t have any subscriptions yet.'
-            : 'You don\u2019t have any models available yet.'}
+          Subscriptions give you access to models. To request a subscription, contact your
+          administrator.
         </EmptyStateBody>
+        <EmptyStateFooter>
+          <Popover
+            headerContent="Who's my administrator?"
+            bodyContent={
+              <>
+                Your administrator might be:
+                <List>
+                  <ListItem>
+                    The person who assigned you your username, or who helped you log in for the
+                    first time
+                  </ListItem>
+                  <ListItem>Someone in your IT department or help desk</ListItem>
+                  <ListItem>A project manager or developer</ListItem>
+                  <ListItem>Your professor (at a school)</ListItem>
+                </List>
+              </>
+            }
+          >
+            <Button variant="link" icon={<OutlinedQuestionCircleIcon />}>
+              Who&#39;s my administrator?
+            </Button>
+          </Popover>
+        </EmptyStateFooter>
       </EmptyState>
     );
   }

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/ModelsViewTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/ModelsViewTable.tsx
@@ -1,9 +1,8 @@
-import { Content, ContentVariants, Flex, FlexItem, Label } from '@patternfly/react-core';
+import { Content, ContentVariants, Flex, FlexItem } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { URL_PREFIX } from '~/app/utilities/const';
-import { getSourceLabelColor } from '~/app/pages/keys-and-subs/utils';
 import ApiKeyCountLabel from '~/app/components/ApiKeyCountLabel';
 import { ModelGroupEntry } from './SubscriptionsViewTable';
 import { ModelInfoPopover, formatTokenLimit } from './SubscriptionModelsTable';
@@ -38,13 +37,6 @@ const ModelGroupRow: React.FC<{
                 description={modelGroup.description}
               />
             </FlexItem>
-            {modelGroup.source && (
-              <FlexItem>
-                <Label isCompact color={getSourceLabelColor(modelGroup.source)}>
-                  {modelGroup.source}
-                </Label>
-              </FlexItem>
-            )}
           </Flex>
           {modelGroup.displayName && modelGroup.name !== modelGroup.displayName && (
             <Content component={ContentVariants.small}>{modelGroup.name}</Content>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionDetails.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/MySubscriptionDetails.tsx
@@ -30,7 +30,7 @@ const MySubscriptionDetails: React.FC<MySubscriptionDetailsProps> = ({ subscript
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>Subscription ID</DescriptionListTerm>
+          <DescriptionListTerm>ID</DescriptionListTerm>
           <DescriptionListDescription>
             <code>{subscription.subscription_id_header}</code>
           </DescriptionListDescription>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionModelsTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionModelsTable.tsx
@@ -5,7 +5,6 @@ import {
   ContentVariants,
   Flex,
   FlexItem,
-  Label,
   Popover,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -13,7 +12,6 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import React from 'react';
 import { ModelRefInfo, TokenRateLimitInfo } from '~/app/types/subscriptions';
 import { formatWindow } from '~/app/utilities/rateLimits';
-import { getSourceLabelColor } from '~/app/pages/keys-and-subs/utils';
 
 export const formatTokenLimit = (limits?: TokenRateLimitInfo[]): string => {
   if (!limits || limits.length === 0) {
@@ -78,13 +76,6 @@ export const ModelRow: React.FC<{ model: ModelRefInfo }> = ({ model }) => (
             description={model.description}
           />
         </FlexItem>
-        {model.source && (
-          <FlexItem>
-            <Label isCompact color={getSourceLabelColor(model.source)}>
-              {model.source}
-            </Label>
-          </FlexItem>
-        )}
       </Flex>
       {model.display_name && model.name !== model.display_name && (
         <Content component={ContentVariants.small}>{model.name}</Content>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionModelsTable.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionModelsTable.tsx
@@ -108,7 +108,7 @@ const SubscriptionModelsTable: React.FC<SubscriptionModelsTableProps> = ({
   <Table aria-label={ariaLabel} data-testid={tableTestId} variant="compact" borders={false}>
     <Thead>
       <Tr>
-        <Th width={60}>Model</Th>
+        <Th width={60}>Name</Th>
         <Th width={40}>Token limits</Th>
       </Tr>
     </Thead>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
@@ -4,6 +4,7 @@ import { UserSubscription } from '~/app/types/subscriptions';
 import SubscriptionsToolbar from './SubscriptionsToolbar';
 import SubscriptionsViewTable, { ModelGroupEntry } from './SubscriptionsViewTable';
 import ModelsViewTable from './ModelsViewTable';
+import EmptySubscriptionsTabState from './EmptySubscriptionsTabState';
 
 export const deriveModelGroups = (subscriptions: UserSubscription[]): ModelGroupEntry[] => {
   const modelMap = new Map<string, ModelGroupEntry>();
@@ -117,11 +118,18 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) =>
     });
   }, [modelGroups, modelSourceFilters, searchValue, modelSortDirection]);
 
+  if (subscriptions.length === 0) {
+    return (
+      <PageSection isFilled>
+        <EmptySubscriptionsTabState hasData={false} variant="subscription" />
+      </PageSection>
+    );
+  }
+
   return (
     <PageSection isFilled>
       <Content component={ContentVariants.p}>
-        Models available to you through your subscriptions, with token limits. Click a subscription
-        to create a key for it.
+        View your subscriptions and the models they give you access to.
       </Content>
       <SubscriptionsToolbar
         sourceFilters={sortField === 'subscription' ? subSourceFilters : modelSourceFilters}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsTab.tsx
@@ -43,8 +43,6 @@ type SubscriptionsTabProps = {
 };
 
 const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) => {
-  const [subSourceFilters, setSubSourceFilters] = React.useState<string[]>([]);
-  const [modelSourceFilters, setModelSourceFilters] = React.useState<string[]>([]);
   const [searchValue, setSearchValue] = React.useState('');
   const [sortField, setSortField] = React.useState<SubscriptionSortField>('subscription');
   const [modelSortDirection, setModelSortDirection] = React.useState<'asc' | 'desc' | undefined>(
@@ -58,12 +56,6 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) =>
 
   const filteredSubscriptions = React.useMemo(() => {
     let result = subscriptions;
-    if (subSourceFilters.length > 0) {
-      const allowed = subSourceFilters.map((f) => f.toLowerCase());
-      result = result.filter((sub) =>
-        sub.model_refs.some((ref) => ref.source && allowed.includes(ref.source.toLowerCase())),
-      );
-    }
     if (searchValue.trim()) {
       const term = searchValue.trim().toLowerCase();
       result = result.filter((sub) => {
@@ -85,16 +77,10 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) =>
       const nameB = (b.display_name || b.subscription_id_header).toLowerCase();
       return subSortDirection === 'asc' ? nameA.localeCompare(nameB) : nameB.localeCompare(nameA);
     });
-  }, [subscriptions, subSourceFilters, searchValue, subSortDirection]);
+  }, [subscriptions, searchValue, subSortDirection]);
 
   const filteredModelGroups = React.useMemo(() => {
     let result = modelGroups;
-    if (modelSourceFilters.length > 0) {
-      const allowed = modelSourceFilters.map((f) => f.toLowerCase());
-      result = result.filter(
-        (group) => group.source && allowed.includes(group.source.toLowerCase()),
-      );
-    }
     if (searchValue.trim()) {
       const term = searchValue.trim().toLowerCase();
       result = result.filter((group) => {
@@ -116,7 +102,7 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) =>
       const nameB = (b.displayName || b.name).toLowerCase();
       return modelSortDirection === 'asc' ? nameA.localeCompare(nameB) : nameB.localeCompare(nameA);
     });
-  }, [modelGroups, modelSourceFilters, searchValue, modelSortDirection]);
+  }, [modelGroups, searchValue, modelSortDirection]);
 
   if (subscriptions.length === 0) {
     return (
@@ -132,21 +118,6 @@ const SubscriptionsTab: React.FC<SubscriptionsTabProps> = ({ subscriptions }) =>
         View your subscriptions and the models they give you access to.
       </Content>
       <SubscriptionsToolbar
-        sourceFilters={sortField === 'subscription' ? subSourceFilters : modelSourceFilters}
-        onSourceToggle={(source) => {
-          const setter = sortField === 'subscription' ? setSubSourceFilters : setModelSourceFilters;
-          setter((prev) =>
-            prev.includes(source) ? prev.filter((f) => f !== source) : [...prev, source],
-          );
-        }}
-        onSourceClear={(source) => {
-          const setter = sortField === 'subscription' ? setSubSourceFilters : setModelSourceFilters;
-          setter((prev) => prev.filter((f) => f !== source));
-        }}
-        onClearAllFilters={() => {
-          const setter = sortField === 'subscription' ? setSubSourceFilters : setModelSourceFilters;
-          setter([]);
-        }}
         searchValue={searchValue}
         onSearchChange={setSearchValue}
         sortField={sortField}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
@@ -108,14 +108,14 @@ const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
           <ToolbarItem>
             <ToggleGroup aria-label="Sort by field" data-testid="subscriptions-sort-toggle">
               <ToggleGroupItem
-                text="Subscription"
+                text="Subscription view"
                 buttonId="sort-subscription"
                 isSelected={sortField === 'subscription'}
                 onChange={() => onSortFieldChange('subscription')}
                 data-testid="sort-by-subscription"
               />
               <ToggleGroupItem
-                text="Model"
+                text="Model view"
                 buttonId="sort-model"
                 isSelected={sortField === 'model'}
                 onChange={() => onSortFieldChange('model')}

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/SubscriptionsToolbar.tsx
@@ -1,28 +1,16 @@
 import React from 'react';
 import {
-  MenuToggle,
   SearchInput,
-  Select,
-  SelectList,
-  SelectOption,
   ToggleGroup,
   ToggleGroupItem,
   Toolbar,
   ToolbarContent,
-  ToolbarFilter,
   ToolbarGroup,
   ToolbarItem,
-  ToolbarToggleGroup,
 } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
-import { ModelSource } from '~/app/pages/keys-and-subs/utils';
 import { SubscriptionSortField } from './SubscriptionsTab';
 
 type SubscriptionsToolbarProps = {
-  sourceFilters: string[];
-  onSourceToggle: (source: string) => void;
-  onSourceClear: (source: string) => void;
-  onClearAllFilters: () => void;
   searchValue: string;
   onSearchChange: (value: string) => void;
   sortField: SubscriptionSortField;
@@ -30,103 +18,47 @@ type SubscriptionsToolbarProps = {
 };
 
 const SubscriptionsToolbar: React.FC<SubscriptionsToolbarProps> = ({
-  sourceFilters,
-  onSourceToggle,
-  onSourceClear,
-  onClearAllFilters,
   searchValue,
   onSearchChange,
   sortField,
   onSortFieldChange,
-}) => {
-  const [isSourceSelectOpen, setIsSourceSelectOpen] = React.useState(false);
-
-  return (
-    <Toolbar clearAllFilters={onClearAllFilters} data-testid="subscriptions-toolbar">
-      <ToolbarContent>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
-          <ToolbarGroup variant="filter-group">
-            <ToolbarFilter
-              labels={sourceFilters}
-              deleteLabel={(_category, label) => {
-                const key = typeof label === 'string' ? label : label.key;
-                onSourceClear(key);
-              }}
-              categoryName="Source"
-            >
-              <Select
-                aria-label="Filter by source"
-                isOpen={isSourceSelectOpen}
-                selected={sourceFilters}
-                onSelect={(_event, value) => onSourceToggle(String(value))}
-                onOpenChange={setIsSourceSelectOpen}
-                toggle={(toggleRef) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    data-testid="subscriptions-source-filter-toggle"
-                    onClick={() => setIsSourceSelectOpen((prev) => !prev)}
-                    isExpanded={isSourceSelectOpen}
-                  >
-                    Source
-                  </MenuToggle>
-                )}
-                popperProps={{ appendTo: 'inline' }}
-              >
-                <SelectList isAriaMultiselectable>
-                  <SelectOption
-                    value={ModelSource.Internal}
-                    hasCheckbox
-                    isSelected={sourceFilters.includes(ModelSource.Internal)}
-                  >
-                    {ModelSource.Internal}
-                  </SelectOption>
-                  <SelectOption
-                    value={ModelSource.External}
-                    hasCheckbox
-                    isSelected={sourceFilters.includes(ModelSource.External)}
-                  >
-                    {ModelSource.External}
-                  </SelectOption>
-                </SelectList>
-              </Select>
-            </ToolbarFilter>
-          </ToolbarGroup>
-        </ToolbarToggleGroup>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <SearchInput
-              aria-label="Search subscriptions"
-              placeholder="Search..."
-              data-testid="subscriptions-search-input"
-              value={searchValue}
-              onChange={(_event, value) => onSearchChange(value)}
-              onClear={() => onSearchChange('')}
+}) => (
+  <Toolbar data-testid="subscriptions-toolbar">
+    <ToolbarContent>
+      <ToolbarGroup>
+        <ToolbarItem>
+          <SearchInput
+            aria-label="Search subscriptions"
+            placeholder="Search..."
+            data-testid="subscriptions-search-input"
+            value={searchValue}
+            onChange={(_event, value) => onSearchChange(value)}
+            onClear={() => onSearchChange('')}
+          />
+        </ToolbarItem>
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <ToolbarItem>
+          <ToggleGroup aria-label="Sort by field" data-testid="subscriptions-sort-toggle">
+            <ToggleGroupItem
+              text="Subscription view"
+              buttonId="sort-subscription"
+              isSelected={sortField === 'subscription'}
+              onChange={() => onSortFieldChange('subscription')}
+              data-testid="sort-by-subscription"
             />
-          </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarGroup>
-          <ToolbarItem>
-            <ToggleGroup aria-label="Sort by field" data-testid="subscriptions-sort-toggle">
-              <ToggleGroupItem
-                text="Subscription view"
-                buttonId="sort-subscription"
-                isSelected={sortField === 'subscription'}
-                onChange={() => onSortFieldChange('subscription')}
-                data-testid="sort-by-subscription"
-              />
-              <ToggleGroupItem
-                text="Model view"
-                buttonId="sort-model"
-                isSelected={sortField === 'model'}
-                onChange={() => onSortFieldChange('model')}
-                data-testid="sort-by-model"
-              />
-            </ToggleGroup>
-          </ToolbarItem>
-        </ToolbarGroup>
-      </ToolbarContent>
-    </Toolbar>
-  );
-};
+            <ToggleGroupItem
+              text="Model view"
+              buttonId="sort-model"
+              isSelected={sortField === 'model'}
+              onChange={() => onSortFieldChange('model')}
+              data-testid="sort-by-model"
+            />
+          </ToggleGroup>
+        </ToolbarItem>
+      </ToolbarGroup>
+    </ToolbarContent>
+  </Toolbar>
+);
 
 export default SubscriptionsToolbar;

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/ViewMySubscriptionPage.tsx
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/mySubscriptions/ViewMySubscriptionPage.tsx
@@ -30,7 +30,6 @@ const ViewSubscriptionPage: React.FC = () => {
   const [subscription, loaded, loadError] = useGetUserSubscription(subscriptionName);
   const displaySubscriptionName = subscription?.display_name?.trim() || subscriptionName;
   const modelRefs = subscription?.model_refs ?? [];
-  const modelRefsCount = modelRefs.length;
 
   const breadcrumb = (
     <Breadcrumb>
@@ -39,7 +38,7 @@ const ViewSubscriptionPage: React.FC = () => {
           to={`${URL_PREFIX}/keys-and-subs/subscriptions`}
           data-testid="breadcrumb-my-subscriptions-link"
         >
-          API keys & subscriptions
+          API keys
         </Link>
       </BreadcrumbItem>
       <BreadcrumbItem isActive>
@@ -93,7 +92,7 @@ const ViewSubscriptionPage: React.FC = () => {
                           >
                             <FlexItem>
                               <Title headingLevel="h2" size="xl">
-                                {`Models ${modelRefsCount > 0 ? `(${modelRefsCount})` : ''}`}
+                                Models
                               </Title>
                             </FlexItem>
                             <FlexItem>

--- a/packages/maas/frontend/src/app/pages/keys-and-subs/utils.ts
+++ b/packages/maas/frontend/src/app/pages/keys-and-subs/utils.ts
@@ -1,8 +1,3 @@
-export enum ModelSource {
-  Internal = 'Internal',
-  External = 'External',
-}
-
 const DEFAULT_API_KEY_VISIBLE_PREFIX_LENGTH = 7;
 
 /** First characters of the key stay readable; the remainder is shown as bullets (matches CreateApiKeyModal). */
@@ -23,6 +18,3 @@ export const formatApiKeyError = (message: string): string => {
   }
   return message.charAt(0).toUpperCase() + message.slice(1);
 };
-
-export const getSourceLabelColor = (source: string): 'blue' | 'purple' =>
-  source.toLowerCase() === ModelSource.Internal.toLowerCase() ? 'blue' : 'purple';

--- a/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
+++ b/packages/maas/frontend/src/odh/odhExtensions/odhExtensions.ts
@@ -102,7 +102,7 @@ const ODH_EXTENSIONS: ODHExtensions[] = [
     },
     properties: {
       id: 'maas-tokens-subscriptions-view',
-      title: 'API keys and subscriptions',
+      title: 'API keys',
       href: '/maas/keys-and-subs',
       section: 'gen-ai-studio',
       path: '/maas/keys-and-subs/*',


### PR DESCRIPTION
Closes: [RHOAIENG-63733](https://redhat.atlassian.net/browse/RHOAIENG-63733)

## Description
Updates microcopy for my subscriptions. Updates the empty page state for the subscriptions tab.

## How Has This Been Tested?
Tested locally. Refer to the docs in the ticket to see areas of changes. I impersonated user2 to see the empty state page for subscriptions. 

## Test Impact
Tests updated where needed to reflect changes

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the subscriptions empty state with clearer “Request a subscription” messaging, administrator guidance, and a richer footer.
* **Style / UX Improvements**
  * Updated page headers, breadcrumbs, and navigation labels to “API keys” with refined descriptions focused on authenticating to model endpoints.
  * Improved tab/toolbar wording (e.g., “Subscription view”, “Model view”), simplified “Models” labeling, renamed “Model” → “Name”, and shortened “Subscription ID” → “ID”.
  * Removed model/source labels and related source-filter interactions from the subscriptions flow.
* **Tests**
  * Updated Cypress UI assertions and adjusted the subscriptions tab flow, including resetting search via the reset control; removed source-filter helpers.
  * Removed unit tests for source-label color logic while keeping existing utility coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->