### PR TITLE
dataloader update to accommodate s390X yaml files

### DIFF
--- a/packages/cypress/cypress.config.ts
+++ b/packages/cypress/cypress.config.ts
@@ -182,7 +182,7 @@ export default defineConfig({
         config.env.CY_RETRY !== undefined
           ? { runMode: Math.max(0, parseInt(config.env.CY_RETRY) || 0), openMode: 0 }
           : !config.env.CY_RECORD
-          ? { runMode: 1, openMode: 0 }
+          ? { runMode: 2, openMode: 0 }
           : config.retries;
 
       return {

--- a/packages/cypress/cypress.config.ts
+++ b/packages/cypress/cypress.config.ts
@@ -182,7 +182,7 @@ export default defineConfig({
         config.env.CY_RETRY !== undefined
           ? { runMode: Math.max(0, parseInt(config.env.CY_RETRY) || 0), openMode: 0 }
           : !config.env.CY_RECORD
-          ? { runMode: 2, openMode: 0 }
+          ? { runMode: 1, openMode: 0 }
           : config.retries;
 
       return {

--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -233,6 +233,12 @@ export type CommandLineResult = {
   stderr: string;
 };
 
+// export type FileMapping = {
+//   "resources/yaml/model_registry_database.yaml": string;
+// }
+
+export type FileMapping = Record<string, string>;
+
 export type TestConfig = {
   ODH_DASHBOARD_URL: string;
   TEST_USER: UserAuthConfig;
@@ -250,6 +256,8 @@ export type TestConfig = {
   // BYOIDC cluster authentication settings
   CLUSTER_AUTH?: string;
   CLUSTER_OIDC_ISSUER?: string;
+  //File mappings for s390X
+  FILEMAPPING: FileMapping;
 };
 
 export type DataScienceProjectData = {

--- a/packages/cypress/cypress/utils/dataLoader.ts
+++ b/packages/cypress/cypress/utils/dataLoader.ts
@@ -23,6 +23,7 @@ import type {
   KueueWorkbenchTestData,
   PromptManagementTestData,
   MlflowExperimentsTestData,
+  FileMapping,
 } from '../types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -214,3 +215,25 @@ export const loadMlflowExperimentsFixture = (
 
     return data;
   });
+
+export const resolveFixture = (fixturePath: string): Cypress.Chainable<string> => {
+  const archType = Cypress.env('ARCH_TYPE');
+
+  cy.log(`Using ARCH=${archType}`);
+  cy.log(`Original fixture=${fixturePath}`);
+
+  if (archType === 'x86') {
+    return cy.wrap(fixturePath);
+  }
+
+  const fileMapping = Cypress.env('FILEMAPPING') as FileMapping;
+
+  const resolvedPath = fileMapping[fixturePath] ?? fixturePath;
+
+  cy.log(`Resolved fixture=${resolvedPath}`);
+
+  return cy.wrap(resolvedPath);
+};
+
+export const loadYamlFixture = (fixturePath: string): Cypress.Chainable<string> =>
+  resolveFixture(fixturePath).then((resolvedPath) => cy.fixture(resolvedPath, 'utf8'));

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -160,16 +160,18 @@ export const waitForModelRegistryDatabase = (
   const command = `oc wait --for=condition=Available deployment/${databaseName} -n ${targetNamespace} --timeout=600s`;
 
   cy.log(`Waiting for model registry database '${databaseName}' to be ready...`);
-  return cy.exec(command, { failOnNonZeroExit: false, timeout: 600000 }).then((result: CommandLineResult) => {
-    if (result.stdout) {
-      cy.log(`Database wait result: ${result.stdout}`);
-    }
-    if (result.stderr) {
-      const maskedStderr = maskSensitiveInfo(result.stderr);
-      cy.log(`Database wait stderr: ${maskedStderr}`);
-    }
-    return cy.wrap(result.exitCode === 0);
-  });
+  return cy
+    .exec(command, { failOnNonZeroExit: false, timeout: 600000 })
+    .then((result: CommandLineResult) => {
+      if (result.stdout) {
+        cy.log(`Database wait result: ${result.stdout}`);
+      }
+      if (result.stderr) {
+        const maskedStderr = maskSensitiveInfo(result.stderr);
+        cy.log(`Database wait stderr: ${maskedStderr}`);
+      }
+      return cy.wrap(result.exitCode === 0);
+    });
 };
 
 /**

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -6,6 +6,7 @@ import { applyOpenShiftYaml } from './baseCommands';
 import type { CommandLineResult } from '../../types';
 import { replacePlaceholdersInYaml } from '../yaml_files';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
+import { loadYamlFixture } from '../../utils/dataLoader';
 
 /**
  * Get the model registry namespace based on the environment
@@ -43,8 +44,8 @@ export const ensureOperatorMemoryLimit = (deploymentName: string): Cypress.Chain
   // Check current memory limit
   const checkCommand = `oc get deployment ${deploymentName} -n ${operatorNamespace} -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}'`;
 
-  return cy.exec(checkCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
-    if (result.exitCode !== 0) {
+  return cy.exec(checkCommand, { failOnNonZeroExit: false }).then((result) => {
+    if (result.code !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
       cy.log(`Failed to check operator memory limit: ${maskedStderr}`);
       return cy.wrap(false);
@@ -122,12 +123,10 @@ export const createModelRegistryDatabaseViaYAML = (
         );
         return cy.wrap(checkResult);
       }
-
       // Database doesn't exist, create it
       cy.log(`Database '${databaseName}' does not exist, proceeding with creation`);
-      return cy
-        .fixture('resources/yaml/model_registry_database.yaml')
-        .then((databaseYamlContent) => {
+      return loadYamlFixture('resources/yaml/model_registry_database.yaml').then(
+        (databaseYamlContent) => {
           const modifiedDatabaseYaml = replacePlaceholdersInYaml(
             databaseYamlContent,
             databaseReplacements,
@@ -141,7 +140,8 @@ export const createModelRegistryDatabaseViaYAML = (
               cy.exec(`rm -f ${tempFile}`, { failOnNonZeroExit: false });
               return cy.wrap(result);
             });
-        });
+        },
+      );
     })
     .then((result: CommandLineResult) => {
       return result;
@@ -160,18 +160,17 @@ export const waitForModelRegistryDatabase = (
   const command = `oc wait --for=condition=Available deployment/${databaseName} -n ${targetNamespace} --timeout=600s`;
 
   cy.log(`Waiting for model registry database '${databaseName}' to be ready...`);
-  return cy
-    .exec(command, { failOnNonZeroExit: false, timeout: 600000 })
-    .then((result: CommandLineResult) => {
-      if (result.stdout) {
-        cy.log(`Database wait result: ${result.stdout}`);
-      }
-      if (result.stderr) {
-        const maskedStderr = maskSensitiveInfo(result.stderr);
-        cy.log(`Database wait stderr: ${maskedStderr}`);
-      }
-      return cy.wrap(result.exitCode === 0);
-    });
+  return cy.exec(command, { failOnNonZeroExit: false, timeout: 600000 }).then((result) => {
+    if (result.stdout) {
+      cy.log(`Database wait result: ${result.stdout}`);
+    }
+    if (result.stderr) {
+      const maskedStderr = maskSensitiveInfo(result.stderr);
+      cy.log(`Database wait stderr: ${maskedStderr}`);
+    }
+    cy.log(`exitcode is ${result.code}`);
+    return cy.wrap(result.code === 0);
+  });
 };
 
 /**
@@ -396,8 +395,8 @@ export const deleteModelRegistryDatabase = (
     .exec(`oc get deployment ${databaseName} -n ${targetNamespace}`, {
       failOnNonZeroExit: false,
     })
-    .then((existsResult: CommandLineResult) => {
-      if (existsResult.exitCode !== 0) {
+    .then((existsResult) => {
+      if (existsResult.code !== 0) {
         cy.log(`Model registry database '${databaseName}' does not exist, nothing to delete`);
         return cy.wrap(true);
       }
@@ -467,11 +466,11 @@ export const deleteModelRegistryDatabase = (
 export const checkModelRegistry = (registryName: string): Cypress.Chainable<boolean> => {
   const command = `oc get modelregistry.modelregistry.opendatahub.io --all-namespaces | grep ${registryName}`;
   cy.log(`Running command: ${command}`);
-  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result) => {
     if (result.stdout) {
       cy.log(`Command output: ${result.stdout}`);
     }
-    return cy.wrap(result.exitCode === 0);
+    return cy.wrap(result.code === 0);
   });
 };
 
@@ -486,7 +485,7 @@ export const checkModelRegistryAvailable = (registryName: string): Cypress.Chain
   cy.log(`Waiting for model registry ${registryName} to be available...`);
   return cy
     .exec(command, { failOnNonZeroExit: false, timeout: 480000 })
-    .then((result: CommandLineResult) => {
+    .then((result) => {
       if (result.stdout) {
         cy.log(`Wait result: ${result.stdout}`);
       }
@@ -494,7 +493,8 @@ export const checkModelRegistryAvailable = (registryName: string): Cypress.Chain
         const maskedStderr = maskSensitiveInfo(result.stderr);
         cy.log(`Wait stderr: ${maskedStderr}`);
       }
-      return cy.wrap(result.exitCode === 0);
+      cy.log(`exist code for last one is ${result.code}`);
+      return cy.wrap(result.code === 0);
     })
     .then((isAvailable) => {
       if (isAvailable) {
@@ -528,9 +528,19 @@ export const createModelRegistryViaYAML = (
   cy.log(
     `Creating model registry ${registryName} in namespace ${targetNamespace} using database '${databaseName}'`,
   );
-
-  return cy
-    .fixture('resources/yaml/model_registry.yaml')
+  // let fixtureFile
+  // const arch = Cypress.env('ARCH_TYPE')
+  // switch(arch) {
+  //   case 'x86':
+  //     fixtureFile = 'resources/yaml/model_registry.yaml';
+  //     break
+  //   case 's390X':
+  //     fixtureFile = 'resources/yaml/model_registry_pg.yaml';
+  //     break;
+  //   default:
+  //     throw new Error(`Unsupported ARCH: ${arch}`);
+  // }
+  return loadYamlFixture('resources/yaml/model_registry.yaml')
     .then((registryYamlContent) => {
       const modifiedRegistryYaml = replacePlaceholdersInYaml(
         registryYamlContent,
@@ -584,9 +594,8 @@ export const getModelRegistryDatabaseConfig = (
 }> => {
   const targetNamespace = namespace || getModelRegistryNamespace();
   const command = `oc get modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace} -o json`;
-
-  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
-    if (result.exitCode !== 0) {
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result) => {
+    if (result.code !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
       cy.log(`Failed to get ModelRegistry CR: ${maskedStderr}`);
       return cy.wrap({
@@ -662,7 +671,6 @@ export const deleteModelRegistry = (registryName: string): Cypress.Chainable<Com
   const registryCommand = `oc delete modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace} --timeout=240s`;
 
   cy.log(`Deleting model registry ${registryName} from namespace ${targetNamespace}`);
-
   return cy.exec(registryCommand, { failOnNonZeroExit: false, timeout: 240000 });
 };
 

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -44,8 +44,8 @@ export const ensureOperatorMemoryLimit = (deploymentName: string): Cypress.Chain
   // Check current memory limit
   const checkCommand = `oc get deployment ${deploymentName} -n ${operatorNamespace} -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}'`;
 
-  return cy.exec(checkCommand, { failOnNonZeroExit: false }).then((result) => {
-    if (result.code !== 0) {
+  return cy.exec(checkCommand, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.exitCode !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
       cy.log(`Failed to check operator memory limit: ${maskedStderr}`);
       return cy.wrap(false);
@@ -160,7 +160,7 @@ export const waitForModelRegistryDatabase = (
   const command = `oc wait --for=condition=Available deployment/${databaseName} -n ${targetNamespace} --timeout=600s`;
 
   cy.log(`Waiting for model registry database '${databaseName}' to be ready...`);
-  return cy.exec(command, { failOnNonZeroExit: false, timeout: 600000 }).then((result) => {
+  return cy.exec(command, { failOnNonZeroExit: false, timeout: 600000 }).then((result: CommandLineResult) => {
     if (result.stdout) {
       cy.log(`Database wait result: ${result.stdout}`);
     }
@@ -168,8 +168,7 @@ export const waitForModelRegistryDatabase = (
       const maskedStderr = maskSensitiveInfo(result.stderr);
       cy.log(`Database wait stderr: ${maskedStderr}`);
     }
-    cy.log(`exitcode is ${result.code}`);
-    return cy.wrap(result.code === 0);
+    return cy.wrap(result.exitCode === 0);
   });
 };
 
@@ -395,8 +394,8 @@ export const deleteModelRegistryDatabase = (
     .exec(`oc get deployment ${databaseName} -n ${targetNamespace}`, {
       failOnNonZeroExit: false,
     })
-    .then((existsResult) => {
-      if (existsResult.code !== 0) {
+    .then((existsResult: CommandLineResult) => {
+      if (existsResult.exitCode !== 0) {
         cy.log(`Model registry database '${databaseName}' does not exist, nothing to delete`);
         return cy.wrap(true);
       }
@@ -466,11 +465,11 @@ export const deleteModelRegistryDatabase = (
 export const checkModelRegistry = (registryName: string): Cypress.Chainable<boolean> => {
   const command = `oc get modelregistry.modelregistry.opendatahub.io --all-namespaces | grep ${registryName}`;
   cy.log(`Running command: ${command}`);
-  return cy.exec(command, { failOnNonZeroExit: false }).then((result) => {
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
     if (result.stdout) {
       cy.log(`Command output: ${result.stdout}`);
     }
-    return cy.wrap(result.code === 0);
+    return cy.wrap(result.exitCode === 0);
   });
 };
 
@@ -485,7 +484,7 @@ export const checkModelRegistryAvailable = (registryName: string): Cypress.Chain
   cy.log(`Waiting for model registry ${registryName} to be available...`);
   return cy
     .exec(command, { failOnNonZeroExit: false, timeout: 480000 })
-    .then((result) => {
+    .then((result: CommandLineResult) => {
       if (result.stdout) {
         cy.log(`Wait result: ${result.stdout}`);
       }
@@ -493,8 +492,7 @@ export const checkModelRegistryAvailable = (registryName: string): Cypress.Chain
         const maskedStderr = maskSensitiveInfo(result.stderr);
         cy.log(`Wait stderr: ${maskedStderr}`);
       }
-      cy.log(`exist code for last one is ${result.code}`);
-      return cy.wrap(result.code === 0);
+      return cy.wrap(result.exitCode === 0);
     })
     .then((isAvailable) => {
       if (isAvailable) {
@@ -528,18 +526,6 @@ export const createModelRegistryViaYAML = (
   cy.log(
     `Creating model registry ${registryName} in namespace ${targetNamespace} using database '${databaseName}'`,
   );
-  // let fixtureFile
-  // const arch = Cypress.env('ARCH_TYPE')
-  // switch(arch) {
-  //   case 'x86':
-  //     fixtureFile = 'resources/yaml/model_registry.yaml';
-  //     break
-  //   case 's390X':
-  //     fixtureFile = 'resources/yaml/model_registry_pg.yaml';
-  //     break;
-  //   default:
-  //     throw new Error(`Unsupported ARCH: ${arch}`);
-  // }
   return loadYamlFixture('resources/yaml/model_registry.yaml')
     .then((registryYamlContent) => {
       const modifiedRegistryYaml = replacePlaceholdersInYaml(
@@ -594,8 +580,8 @@ export const getModelRegistryDatabaseConfig = (
 }> => {
   const targetNamespace = namespace || getModelRegistryNamespace();
   const command = `oc get modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace} -o json`;
-  return cy.exec(command, { failOnNonZeroExit: false }).then((result) => {
-    if (result.code !== 0) {
+  return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
+    if (result.exitCode !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
       cy.log(`Failed to get ModelRegistry CR: ${maskedStderr}`);
       return cy.wrap({

--- a/packages/cypress/cypress/utils/testConfig.ts
+++ b/packages/cypress/cypress/utils/testConfig.ts
@@ -23,6 +23,7 @@ const testConfig: TestConfig | undefined = env.CY_TEST_CONFIG
   : undefined;
 
 export const BASE_URL = testConfig?.ODH_DASHBOARD_URL || env.BASE_URL || '';
+console.log('base url is', BASE_URL);
 
 const LDAP_CONTRIBUTOR_USER: UserAuthConfig = testConfig?.TEST_USER_3 ?? {
   AUTH_TYPE: env.TEST_USER_3_AUTH_TYPE || '',
@@ -93,6 +94,8 @@ const OCI_MODEL_URI = testConfig?.OCI_MODEL_URI;
 // BYOIDC cluster authentication settings
 const CLUSTER_AUTH = testConfig?.CLUSTER_AUTH;
 
+const { FILEMAPPING } = testConfig ?? {};
+
 // spread the cypressEnv variables into the cypress config
 export const cypressEnv = {
   LDAP_CONTRIBUTOR_USER,
@@ -109,6 +112,7 @@ export const cypressEnv = {
   OCI_SECRET_VALUE,
   OCI_MODEL_URI,
   CLUSTER_AUTH,
+  FILEMAPPING,
 };
 
 // re-export the updated process env


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
[<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->](https://redhat.atlassian.net/browse/RHOAIENG-64747)

## Description
Current odh-dashboard automation framework supports only x86 related yaml files. I have modifed the code so that it can support s390X yaml files. Jira for this task https://redhat.atlassian.net/browse/RHOAIENG-64747

## How Has This Been Tested?
Currently only test locally as we are blocked in jenkins due to issue https://redhat.atlassian.net/browse/RHOAIENG-64194?actionerId=61f268285a0988006b481255&sourceType=assign

## Test Impact
Will support both x86 and s390X. Added extra Cypress env variable ARCH_TYPE for this. Now need to run like npx cypress run --env ARCH_TYPE=s390X 

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added architecture-aware resolution for fixture paths and file mappings.
  * Introduced YAML fixture loading with automatic path remapping based on system architecture.
  * Extended test configuration/environment with a new file mapping setting.
  * Updated model registry YAML generation to use the shared YAML fixture loader.

* **Chores**
  * Added a startup debug log for the configured base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->