### PR TITLE
add event tracking for side by side comparison

### DIFF
--- a/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
+++ b/packages/eval-hub/frontend/src/app/components/EvaluationsTable.tsx
@@ -20,7 +20,10 @@ import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/
 import { FilterIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, ThProps } from '@patternfly/react-table';
 import { useNavigate } from 'react-router-dom';
-import { fireSimpleTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
+import {
+  fireMiscTrackingEvent,
+  fireSimpleTrackingEvent,
+} from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import { EvaluationJob, EvaluationJobState } from '~/app/types';
 import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import {
@@ -201,17 +204,31 @@ const EvaluationsTable: React.FC<EvaluationsTableProps> = ({
     setSelectedStatus('');
   }, []);
 
-  const handleSelectionChange = React.useCallback((jobId: string, checked: boolean) => {
-    setSelectedEvaluationIds((prev) => {
-      const next = new Set(prev);
-      if (checked) {
-        next.add(jobId);
-      } else {
-        next.delete(jobId);
-      }
-      return next;
-    });
-  }, []);
+  const handleSelectionChange = React.useCallback(
+    (jobId: string, checked: boolean) => {
+      setSelectedEvaluationIds((prev) => {
+        const next = new Set(prev);
+        if (checked) {
+          next.add(jobId);
+        } else {
+          next.delete(jobId);
+        }
+
+        const job = evaluations.find((j) => j.resource.id === jobId);
+        if (job) {
+          fireMiscTrackingEvent(EVAL_HUB_EVENTS.COMPARE_RUN_SELECTED, {
+            evaluationName: getEvaluationName(job),
+            evaluationType: isBenchmarkSuiteRun(job) ? 'Benchmark suite' : 'Benchmark',
+            isSelected: checked,
+            countOfRuns: next.size,
+          });
+        }
+
+        return next;
+      });
+    },
+    [evaluations],
+  );
 
   const handleCompare = React.useCallback(() => {
     const selectedJobs = evaluations.filter((job) => selectedEvaluationIds.has(job.resource.id));
@@ -220,6 +237,15 @@ const EvaluationsTable: React.FC<EvaluationsTableProps> = ({
     }
 
     const hasSuiteSelections = selectedJobs.some(isBenchmarkSuiteRun);
+    const allSuites = selectedJobs.every(isBenchmarkSuiteRun);
+    const allBenchmarks = selectedJobs.every((job) => !isBenchmarkSuiteRun(job));
+
+    fireMiscTrackingEvent(EVAL_HUB_EVENTS.COMPARE_INITIATED, {
+      countOfRuns: selectedJobs.length,
+      runTypes: allBenchmarks ? 'all_benchmarks' : allSuites ? 'all_suites' : 'mixed',
+      hasCollections: hasSuiteSelections,
+    });
+
     const selectedJobIds = selectedJobs.map((job) => job.resource.id);
 
     if (hasSuiteSelections) {

--- a/packages/eval-hub/frontend/src/app/components/compare/CompareBenchmarksTable.tsx
+++ b/packages/eval-hub/frontend/src/app/components/compare/CompareBenchmarksTable.tsx
@@ -59,7 +59,7 @@ const CompareBenchmarksTable: React.FC<CompareBenchmarksTableProps> = ({
             <Checkbox
               id="compare-select-all-benchmarks"
               aria-label="Select all benchmarks on current page"
-              isChecked={selectAllChecked}
+              isChecked={selectAllChecked ?? false}
               isDisabled={visibleSelectionKeys.length === 0}
               onChange={(_event, checked) => onSelectionChange(visibleSelectionKeys, checked)}
               data-testid="compare-select-all-checkbox"

--- a/packages/eval-hub/frontend/src/app/components/compare/CompareBenchmarksTableRow.tsx
+++ b/packages/eval-hub/frontend/src/app/components/compare/CompareBenchmarksTableRow.tsx
@@ -100,7 +100,7 @@ const CompareBenchmarksTableRow: React.FC<CompareBenchmarksTableRowProps> = ({
           <Checkbox
             id={`compare-run-checkbox-${job.resource.id}`}
             aria-label={`Select benchmarks for ${evaluationRunLabel}`}
-            isChecked={rowCheckboxChecked}
+            isChecked={rowCheckboxChecked ?? false}
             isDisabled={childSelectionKeys.length === 0}
             onChange={(_event, checked) => onSelectionChange(childSelectionKeys, checked)}
             data-testid={`compare-run-checkbox-${job.resource.id}`}

--- a/packages/eval-hub/frontend/src/app/pages/ChooseCompareBenchmarksPage.tsx
+++ b/packages/eval-hub/frontend/src/app/pages/ChooseCompareBenchmarksPage.tsx
@@ -16,15 +16,18 @@ import {
 import DashboardEmptyTableView from '@odh-dashboard/internal/concepts/dashboard/DashboardEmptyTableView';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import ApplicationsPage from '@odh-dashboard/internal/pages/ApplicationsPage';
+import { fireMiscTrackingEvent } from '@odh-dashboard/internal/concepts/analyticsTracking/segmentIOUtils';
 import CompareBenchmarksTable from '~/app/components/compare/CompareBenchmarksTable';
 import { useCollectionNameMap } from '~/app/hooks/useCollectionNameMap';
 import { useEvaluationJobs } from '~/app/hooks/useEvaluationJobs';
 import { EvaluationJob } from '~/app/types';
-import { getEvaluationName } from '~/app/utilities/evaluationUtils';
+import { getBenchmarkDisplayName, getEvaluationName } from '~/app/utilities/evaluationUtils';
+import { EVAL_HUB_EVENTS } from '~/app/tracking/evalhubTrackingConstants';
 import {
   COMPARE_RUNS_PAGE_TITLE,
   buildMlflowCompareSearchParams,
   filterJobsForCompareBenchmarkSearch,
+  getComparableRunsForJob,
   getBenchmarkSelectionsFromKeys,
   parseCsvParam,
   resolveComparableRunsFromSelections,
@@ -83,14 +86,26 @@ const ChooseCompareBenchmarksPage: React.FC = () => {
     }
 
     const jobsById = new Map(selectedJobs.map((job) => [job.resource.id, job]));
-    const selectedRuns = resolveComparableRunsFromSelections(
-      selectedJobs,
-      getBenchmarkSelectionsFromKeys(selectedBenchmarkKeys),
-    );
+    const selections = getBenchmarkSelectionsFromKeys(selectedBenchmarkKeys);
+    const selectedRuns = resolveComparableRunsFromSelections(selectedJobs, selections);
 
     if (selectedRuns.length < 2) {
       return;
     }
+
+    const totalAvailable = selectedJobs.reduce(
+      (sum, job) => sum + getComparableRunsForJob(job).length,
+      0,
+    );
+    const benchmarkNames = [
+      ...new Set(selections.map((s) => getBenchmarkDisplayName(s.benchmarkId))),
+    ];
+
+    fireMiscTrackingEvent(EVAL_HUB_EVENTS.COMPARE_BENCHMARK_CHOSEN, {
+      countOfBenchmarks: selections.length,
+      totalAvailable,
+      benchmarkNames: JSON.stringify(benchmarkNames),
+    });
 
     navigate({
       pathname: evaluationCompareRoute(namespace),

--- a/packages/eval-hub/frontend/src/app/tracking/evalhubTrackingConstants.ts
+++ b/packages/eval-hub/frontend/src/app/tracking/evalhubTrackingConstants.ts
@@ -8,6 +8,9 @@ export const EVAL_HUB_EVENTS = {
   MLFLOW_EXPERIMENT_SELECTED: 'Evaluations MLFlow Experiment Selected',
   RESULT_BENCHMARK_CARD_SELECTED: 'Evaluations Result Benchmark Card Selected',
   BENCHMARK_RUN_SELECTED: 'Evaluations Benchmark Run Selected',
+  COMPARE_RUN_SELECTED: 'Evaluations Compare Run Selected',
+  COMPARE_INITIATED: 'Evaluations Compare Initiated',
+  COMPARE_BENCHMARK_CHOSEN: 'Evaluations Compare Benchmark Chosen',
 } as const;
 
 /**
@@ -69,4 +72,23 @@ export type BenchmarkRunSelectedProperties = {
   benchmarkTypes: string[];
   runType: 'single' | 'collection';
   countOfBenchmarks: number;
+};
+
+export type CompareRunSelectedProperties = {
+  evaluationName: string;
+  evaluationType: 'Benchmark' | 'Benchmark suite';
+  isSelected: boolean;
+  countOfRuns: number;
+};
+
+export type CompareInitiatedProperties = {
+  countOfRuns: number;
+  runTypes: 'all_benchmarks' | 'all_suites' | 'mixed';
+  hasCollections: boolean;
+};
+
+export type CompareBenchmarkChosenProperties = {
+  countOfBenchmarks: number;
+  totalAvailable: number;
+  benchmarkNames: string;
 };


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://issues.redhat.com/browse/RHOAIENG-67562


## Description
Adds Segment event tracking for the side-by-side evaluation comparison flow in Eval Hub. Three new events are introduced to capture user interactions across the comparison funnel:
| Event | Trigger |
|---|---|
| `Evaluations Compare Run Selected` | User selects or deselects an evaluation run checkbox for comparison |
| `Evaluations Compare Initiated` | User clicks the Compare button to start a side-by-side comparison |
| `Evaluations Compare Benchmark Chosen` | User selects specific benchmarks and proceeds to the MLflow compare view |
**Event properties:**
- **Compare Run Selected** — tracks `evaluationName`, `evaluationType` (Benchmark / Benchmark suite), `isSelected`, and `countOfRuns`
- **Compare Initiated** — tracks `countOfRuns`, `runTypes` (all_benchmarks / all_suites / mixed), and `hasCollections`
- **Compare Benchmark Chosen** — tracks `countOfBenchmarks`, `totalAvailable`, and `benchmarkNames` (JSON array)
Also fixes a minor type issue where `isChecked` on comparison table checkboxes could receive `null`; now defaults to `false`.

<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
- Verified tracking events fire correctly in the browser console via Segment debug mode during local development
- Confirmed that selecting/deselecting runs, clicking Compare, and choosing benchmarks all emit the expected events with correct property values


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Test Impact
No new unit or Cypress tests added. These changes are analytics-only (calling `fireMiscTrackingEvent`) with no impact on UI behavior or user-facing logic. The `isChecked` fix is a type-narrowing change with no functional difference.

<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [ ] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox state handling in benchmark comparison tables to properly initialize states and prevent undefined values.

* **Improvements**
  * Added enhanced tracking capabilities to the evaluation comparison workflow for analytics and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->