### PR TITLE
RHOAIENG-68934: Extend Claude Code harness to cover distributions and dasbaord-operator

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,12 +1,13 @@
 ---
-description: ODH Dashboard monorepo architecture, package boundaries, BFF structure, and operator controller
-globs: "packages/**,frontend/**,backend/**,dashboard-operator/**"
+description: ODH Dashboard monorepo architecture, package boundaries, BFF structure, operator controller, and distributions
+globs: "packages/**,frontend/**,backend/**,dashboard-operator/**,distributions/**"
 alwaysApply: false
 paths:
   - "packages/**"
   - "frontend/**"
   - "backend/**"
   - "dashboard-operator/**"
+  - "distributions/**"
 ---
 
 # ODH Dashboard Architecture
@@ -87,9 +88,26 @@ A standalone Kubernetes operator that manages the full lifecycle of the Dashboar
 
 The controller is **not** part of the npm workspace or Turbo pipeline. It has its own `go.mod`, `Makefile`, and CI workflow. See `dashboard-operator/AGENTS.md` and `.claude/rules/operator-controller.md` for detailed conventions.
 
+## Distributions (`distributions/`)
+
+Independently-deployable dashboard variants. These are NOT part of the npm workspace or Turbo pipeline — monorepo-wide `npm run` commands do not apply. Each sub-distribution is self-contained.
+
+| Directory | Description | Has BFF? | Build System |
+|-----------|-------------|----------|--------------|
+| `base/` | Minimal app shell (PatternFly chrome, error boundary, no features) | Stub only | Webpack |
+| `core-bff/` | Full Go BFF + React frontend for sidecar/xKC deployments | Yes (Go 1.25+) | Make + Webpack |
+| `rhaii/` | RHAII-specific distribution | No | Webpack |
+
+- `base/` and `rhaii/` are frontend-only — React + Webpack + Module Federation host configuration
+- `core-bff/` has both a Go BFF (`bff/`) and React frontend (`frontend/`) with its own contract tests (`contract-tests/`)
+- Each distribution has its own `package.json`, `tsconfig.json`, and webpack config
+- `core-bff/` follows contract-first development (OpenAPI → BFF stub → Frontend → Production BFF)
+
+See `distributions/core-bff/AGENTS.md` for the most detailed reference. See `.claude/rules/distributions.md` for distribution-specific conventions and `.claude/rules/bff-go.md` for Go BFF conventions (applies to core-bff BFF code).
+
 ## BFF (Backend-for-Frontend) Architecture
 
-Several packages have a Go-based BFF service: `automl`, `autorag`, `eval-hub`, `gen-ai`, `maas`, `mlflow`, `model-registry`.
+Several packages have a Go-based BFF service: `automl`, `autorag`, `eval-hub`, `gen-ai`, `maas`, `mlflow`, `model-registry`. The `distributions/core-bff` module also has a Go BFF.
 - Located in `bff/` within the package
 - Check each package's `bff/go.mod` for its required Go toolchain version
 - Exposes REST APIs consumed by the package's frontend

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -94,11 +94,12 @@ Independently-deployable dashboard variants. These are NOT part of the npm works
 
 | Directory | Description | Has BFF? | Build System |
 |-----------|-------------|----------|--------------|
-| `base/` | Minimal app shell (PatternFly chrome, error boundary, no features) | Stub only | Webpack |
+| `base/` | Shared app shell library (PatternFly chrome, error boundary, extensibility hooks) — **not deployed on its own** | Stub only | Webpack |
 | `core-bff/` | Full Go BFF + React frontend for sidecar/xKC deployments | Yes (Go 1.25+) | Make + Webpack |
 | `rhaii/` | RHAII-specific distribution | No | Webpack |
 
-- `base/` and `rhaii/` are frontend-only — React + Webpack + Module Federation host configuration
+- `base/` is a shared library/framework (not independently deployed) — it provides the app shell (masthead, sidebar, error boundary, theme context) that `core-bff/` and `rhaii/` extend
+- `rhaii/` is frontend-only — React + Webpack + Module Federation host configuration
 - `core-bff/` has both a Go BFF (`bff/`) and React frontend (`frontend/`) with its own contract tests (`contract-tests/`)
 - Each distribution has its own `package.json`, `tsconfig.json`, and webpack config
 - `core-bff/` follows contract-first development (OpenAPI → BFF stub → Frontend → Production BFF)

--- a/.claude/rules/bff-go.md
+++ b/.claude/rules/bff-go.md
@@ -1,17 +1,18 @@
 ---
-description: BFF (Backend For Frontend) API patterns and Go conventions for ODH Dashboard packages
-globs: "packages/*/bff/**,packages/*/upstream/bff/**"
+description: BFF (Backend For Frontend) API patterns and Go conventions for ODH Dashboard packages and distributions
+globs: "packages/*/bff/**,packages/*/upstream/bff/**,distributions/core-bff/bff/**"
 alwaysApply: false
 paths:
   - "packages/*/bff/**"
   - "packages/*/upstream/bff/**"
+  - "distributions/core-bff/bff/**"
 ---
 
 # BFF API Patterns & Go Conventions
 
 ## Which packages have BFFs
 
-gen-ai, model-registry, maas, automl, autorag, mlflow, eval-hub — each with a `bff/` directory containing Go code.
+gen-ai, model-registry, maas, automl, autorag, mlflow, eval-hub — each with a `bff/` directory containing Go code. The `distributions/core-bff` module also has a Go BFF in `distributions/core-bff/bff/`.
 
 ## Directory structure
 

--- a/.claude/rules/distributions.md
+++ b/.claude/rules/distributions.md
@@ -14,9 +14,11 @@ Distributions are independently-deployable dashboard variants in `distributions/
 
 | Directory | Type | Has BFF? | Build |
 |-----------|------|----------|-------|
-| `base/` | App shell framework (PatternFly chrome, no features) | Stub only | `npm run build` |
+| `base/` | Shared app shell library (PatternFly chrome, no features) — **not deployed on its own** | Stub only | `npm run build` |
 | `core-bff/` | Full Go BFF + React frontend for sidecar/xKC deployments | Yes (Go 1.25+) | `make build` |
 | `rhaii/` | RHAII-specific distribution | No | `npm run build` |
+
+> **`base/` is a library, not a deployable distribution.** It provides the shared app shell framework (masthead, sidebar, error boundary, theme context, extensibility hooks) that concrete distributions like `core-bff/` and `rhaii/` extend. Do not treat it as a standalone application.
 
 ## Isolation from npm workspaces
 
@@ -34,11 +36,13 @@ cd distributions/core-bff && make lint
 
 ## Build and dev commands
 
-### `base/` and `rhaii/` (frontend-only)
+### `base/` (shared library) and `rhaii/` (frontend-only)
+
+`base/` is a library — run these commands for development and testing, not for standalone deployment. `rhaii/` is a deployable distribution that extends `base/`.
 
 ```bash
 npm run build         # Webpack production build
-npm run start:dev     # Webpack dev server
+npm run start:dev     # Webpack dev server (local development/testing only for base/)
 npx eslint src/       # Lint
 npx tsc --noEmit      # Type-check
 ```

--- a/.claude/rules/distributions.md
+++ b/.claude/rules/distributions.md
@@ -1,0 +1,110 @@
+---
+description: Conventions for distribution variants — base app shell, core-bff, and rhaii
+globs: "distributions/**"
+alwaysApply: false
+paths:
+  - "distributions/**"
+---
+
+# Distribution Conventions
+
+Distributions are independently-deployable dashboard variants in `distributions/`. They are NOT part of the npm workspace or Turbo pipeline — monorepo-wide `npm run` commands do not apply.
+
+## Sub-distributions
+
+| Directory | Type | Has BFF? | Build |
+|-----------|------|----------|-------|
+| `base/` | App shell framework (PatternFly chrome, no features) | Stub only | `npm run build` |
+| `core-bff/` | Full Go BFF + React frontend for sidecar/xKC deployments | Yes (Go 1.25+) | `make build` |
+| `rhaii/` | RHAII-specific distribution | No | `npm run build` |
+
+## Isolation from npm workspaces
+
+Distributions are self-contained. Always `cd` into the distribution directory before running commands:
+
+```bash
+# WRONG — distributions are invisible to the root workspace
+npm run lint          # won't touch distributions/
+npm run type-check    # won't touch distributions/
+
+# RIGHT — run from within the distribution
+cd distributions/base && npx eslint src/
+cd distributions/core-bff && make lint
+```
+
+## Build and dev commands
+
+### `base/` and `rhaii/` (frontend-only)
+
+```bash
+npm run build         # Webpack production build
+npm run start:dev     # Webpack dev server
+npx eslint src/       # Lint
+npx tsc --noEmit      # Type-check
+```
+
+### `core-bff/` (Go BFF + React frontend)
+
+```bash
+make dev-start                # Start both BFF and frontend in dev mode (mocked)
+make dev-bff                  # BFF only on port 4000
+make dev-frontend             # Frontend dev server only
+make build                    # Build BFF + frontend
+make dev-start-federated      # Start in federated mode
+```
+
+#### BFF commands (from `bff/`)
+
+```bash
+make run              # Run BFF
+make lint             # golangci-lint
+make test             # Go tests
+make build            # Build binary
+```
+
+#### Frontend commands (from `frontend/`)
+
+```bash
+npm run test          # Full suite (lint + type-check + unit + cypress)
+npm run test:lint     # Lint only
+npm run test:type-check  # TypeScript check
+npm run test:unit     # Jest unit tests
+npm run test:cypress-ci  # Cypress headless
+```
+
+#### Contract tests
+
+```bash
+npm run test:contract           # Both platforms
+npm run test:contract:openshift # Foundation + OpenShift tests
+npm run test:contract:xks       # Foundation + XKS tests
+```
+
+## Module Federation
+
+`base/` and `rhaii/` are Module Federation **hosts** — they load federated remotes at runtime. Webpack configs in `config/` define the host setup. `core-bff/frontend/` also supports federated mode via `config/moduleFederation.js`.
+
+When modifying Module Federation config in distributions, verify that remote names and shared dependencies stay consistent with the host dashboard's expectations.
+
+## core-bff contract-first workflow
+
+`core-bff/` follows a mandatory 4-stage development flow. See `core-bff/AGENTS.md` for full details:
+
+1. **Contract first** — Update OpenAPI spec in `bff/openapi/src/core-bff.yaml`
+2. **BFF stub second** — Implement handlers in `bff/internal/api/`
+3. **Frontend third** — Build UI in `frontend/src/app/`
+4. **Production BFF last** — Replace mocks with real Kubernetes logic
+
+## core-bff deployment modes
+
+| Mode | Description | BFF Port | Frontend Port |
+|------|-------------|----------|---------------|
+| `standalone` | UI served by BFF, isolated deployment | 4000 | 4000 (static) |
+| `federated` | Micro-frontend loaded by host dashboard | 8082 | 9112 (dev) / 8843 (prod) |
+
+## Common mistakes
+
+- **Running `npm install` from a distribution directory without the workspace workaround** — dependencies on internal packages (`@odh-dashboard/eslint-config`, `@odh-dashboard/tsconfig`) won't resolve. See `distributions/base/README.md` for the workaround.
+- **Confusing `core-bff/bff/` with `dashboard-operator/`** — They are separate Go modules with different `go.mod` files and different patterns. `core-bff/bff/` is an HTTP BFF (uses httprouter); `dashboard-operator/` is a Kubernetes controller (uses controller-runtime).
+- **Assuming monorepo-wide lint/test commands cover distributions** — They don't. Always run validation from within the distribution directory.
+- **Forgetting to update the OpenAPI spec** when adding new endpoints to `core-bff/bff/` — Reviewers must see a diff in the OpenAPI file alongside code changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ odh-dashboard/
 │   ├── internal/controller/    # Reconciler, actions, support utilities
 │   └── config/                 # Generated CRD, RBAC, manager manifests
 ├── distributions/               # Independently-deployable dashboard variants
-│   ├── base/                    # Minimal app shell (frontend-only)
+│   ├── base/                    # Shared app shell library (not deployed on its own)
 │   ├── core-bff/                # Full Go BFF + React frontend (has BFF)
 │   └── rhaii/                   # RHAII-specific distribution (frontend-only)
 ├── packages/                    # Feature packages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ odh-dashboard/
 │   ├── cmd/manager/            # Controller entry point
 │   ├── internal/controller/    # Reconciler, actions, support utilities
 │   └── config/                 # Generated CRD, RBAC, manager manifests
+├── distributions/               # Independently-deployable dashboard variants
+│   ├── base/                    # Minimal app shell (frontend-only)
+│   ├── core-bff/                # Full Go BFF + React frontend (has BFF)
+│   └── rhaii/                   # RHAII-specific distribution (frontend-only)
 ├── packages/                    # Feature packages
 │   ├── cypress/                # Cypress test framework and shared tests
 │   ├── gen-ai/                 # Gen AI / LLM features (has BFF)
@@ -92,11 +96,12 @@ Rules live in `.claude/rules/`. Read the relevant rule file before starting the 
 
 | Rule                        | File                          | Trigger                                                                        |
 | --------------------------- | ----------------------------- | ------------------------------------------------------------------------------ |
-| **Architecture**            | `architecture.md`             | When making structural changes, adding packages, or modifying package boundaries |
-| **BFF Go**                  | `bff-go.md`                   | When working on Go BFF code in `packages/*/bff/`                               |
+| **Architecture**            | `architecture.md`             | When making structural changes, adding packages, modifying package boundaries, or working on distributions |
+| **BFF Go**                  | `bff-go.md`                   | When working on Go BFF code in `packages/*/bff/` or `distributions/core-bff/bff/` |
 | **Contract Tests**          | `contract-tests.md`           | When working on contract tests or BFF API validation                           |
 | **Conventions**             | `conventions.md`              | When writing or reviewing TypeScript, React, or backend code                   |
 | **CSS & PatternFly**        | `css-patternfly.md`           | When writing or modifying styles, SCSS, or PatternFly components               |
+| **Distributions**           | `distributions.md`            | When working on code in `distributions/`                                       |
 | **Cypress E2E Tests**       | `cypress-e2e.md`              | When creating or modifying E2E tests, Robot Framework migrations               |
 | **Cypress Mock Tests**      | `cypress-mock.md`             | When creating or modifying mock/component tests                                |
 | **Jira Creation**           | `jira-creation.md`            | When asked to create Jira issues, tickets, bugs, stories, tasks, or epics      |

--- a/BOOKMARKS.md
+++ b/BOOKMARKS.md
@@ -103,6 +103,18 @@ Central index of key documentation in the ODH Dashboard monorepo.
 
 ---
 
+## Distributions
+
+| Doc | Description |
+|-----|-------------|
+| [Core BFF AGENTS.md](distributions/core-bff/AGENTS.md) | Core BFF development guide — contract-first workflow, BFF rules, frontend rules, deployment modes, testing |
+| [Core BFF Frontend Docs](distributions/core-bff/frontend/docs/) | Frontend dev setup, testing, and styling guides |
+| [Core BFF BFF Docs](distributions/core-bff/bff/README.md) | Go BFF documentation |
+| [Core BFF OpenAPI Spec](distributions/core-bff/bff/openapi/src/core-bff.yaml) | OpenAPI specification (contract-first source of truth) |
+| [Base Distribution README](distributions/base/README.md) | App shell setup, dev environment, environment variables |
+
+---
+
 ## Packages
 
 ### Full Docs


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68934

## Description

The AI agent harness (`.claude/rules/`, `AGENTS.md`, `BOOKMARKS.md`) was built for `frontend/`, `backend/`, and `packages/*` but missed `distributions/` entirely and had incomplete coverage for `dashboard-operator/`. Agents working in those directories didn't get rule activations, best-practice guidance, or documentation pointers.

### Changes

**New file:**
- `.claude/rules/distributions.md` — distribution-specific conventions rule covering npm workspace isolation, build commands per distribution, deployment modes, contract-first workflow, Module Federation host setup, and common mistakes

**Updated files:**
- `.claude/rules/bff-go.md` — extended globs to include `distributions/core-bff/bff/**` so core-bff's Go BFF gets BFF conventions
- `.claude/rules/architecture.md` — extended globs to include `distributions/**`, added a Distributions section describing the three sub-distributions
- `AGENTS.md` — added `distributions/` to the repository structure tree, added Distributions rule row to the Specialized Agent Rules table, updated Architecture and BFF Go trigger descriptions
- `BOOKMARKS.md` — added Distributions documentation section with links to core-bff AGENTS.md, frontend/BFF docs, OpenAPI spec, and base README

**Local-only (gitignored):**
- `CLAUDE.md` pointer files for `dashboard-operator/`, `distributions/`, `distributions/core-bff/`, `distributions/base/`, and `distributions/rhaii/` — these are created locally by agents so Claude Code auto-discovers the existing AGENTS.md guidance

## How Has This Been Tested?

- Verified all 6 new files exist at expected paths
- Confirmed glob coverage: `grep -r "distributions" .claude/rules/` returns hits in `bff-go.md`, `architecture.md`, and `distributions.md`
- Confirmed root `AGENTS.md` mentions distributions in the repo structure and rules table
- Verified all BOOKMARKS.md relative links resolve to existing files
- Validated YAML frontmatter in all rule files (proper delimiters, correct field names)

## Test Impact

No tests applicable — this change is purely documentation and AI agent configuration (`.claude/rules/`, `AGENTS.md`, `BOOKMARKS.md`). No runtime code was modified.

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for independently deployable dashboard distribution variants, including build, development, and deployment guidelines.
  * Documented three available distributions: Base, Core BFF, and Rhaii, with their respective architectures and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->