### PR TITLE
Revert "dataloader update to accommodate s390X yaml files"

### DIFF
--- a/packages/cypress/cypress/types.ts
+++ b/packages/cypress/cypress/types.ts
@@ -233,12 +233,6 @@ export type CommandLineResult = {
   stderr: string;
 };
 
-// export type FileMapping = {
-//   "resources/yaml/model_registry_database.yaml": string;
-// }
-
-export type FileMapping = Record<string, string>;
-
 export type TestConfig = {
   ODH_DASHBOARD_URL: string;
   TEST_USER: UserAuthConfig;
@@ -256,8 +250,6 @@ export type TestConfig = {
   // BYOIDC cluster authentication settings
   CLUSTER_AUTH?: string;
   CLUSTER_OIDC_ISSUER?: string;
-  //File mappings for s390X
-  FILEMAPPING: FileMapping;
 };
 
 export type DataScienceProjectData = {

--- a/packages/cypress/cypress/utils/dataLoader.ts
+++ b/packages/cypress/cypress/utils/dataLoader.ts
@@ -23,7 +23,6 @@ import type {
   KueueWorkbenchTestData,
   PromptManagementTestData,
   MlflowExperimentsTestData,
-  FileMapping,
 } from '../types';
 
 // Load fixture function that returns DataScienceProjectData
@@ -215,25 +214,3 @@ export const loadMlflowExperimentsFixture = (
 
     return data;
   });
-
-export const resolveFixture = (fixturePath: string): Cypress.Chainable<string> => {
-  const archType = Cypress.env('ARCH_TYPE');
-
-  cy.log(`Using ARCH=${archType}`);
-  cy.log(`Original fixture=${fixturePath}`);
-
-  if (archType === 'x86') {
-    return cy.wrap(fixturePath);
-  }
-
-  const fileMapping = Cypress.env('FILEMAPPING') as FileMapping;
-
-  const resolvedPath = fileMapping[fixturePath] ?? fixturePath;
-
-  cy.log(`Resolved fixture=${resolvedPath}`);
-
-  return cy.wrap(resolvedPath);
-};
-
-export const loadYamlFixture = (fixturePath: string): Cypress.Chainable<string> =>
-  resolveFixture(fixturePath).then((resolvedPath) => cy.fixture(resolvedPath, 'utf8'));

--- a/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
+++ b/packages/cypress/cypress/utils/oc_commands/modelRegistry.ts
@@ -6,7 +6,6 @@ import { applyOpenShiftYaml } from './baseCommands';
 import type { CommandLineResult } from '../../types';
 import { replacePlaceholdersInYaml } from '../yaml_files';
 import { maskSensitiveInfo } from '../maskSensitiveInfo';
-import { loadYamlFixture } from '../../utils/dataLoader';
 
 /**
  * Get the model registry namespace based on the environment
@@ -123,10 +122,12 @@ export const createModelRegistryDatabaseViaYAML = (
         );
         return cy.wrap(checkResult);
       }
+
       // Database doesn't exist, create it
       cy.log(`Database '${databaseName}' does not exist, proceeding with creation`);
-      return loadYamlFixture('resources/yaml/model_registry_database.yaml').then(
-        (databaseYamlContent) => {
+      return cy
+        .fixture('resources/yaml/model_registry_database.yaml')
+        .then((databaseYamlContent) => {
           const modifiedDatabaseYaml = replacePlaceholdersInYaml(
             databaseYamlContent,
             databaseReplacements,
@@ -140,8 +141,7 @@ export const createModelRegistryDatabaseViaYAML = (
               cy.exec(`rm -f ${tempFile}`, { failOnNonZeroExit: false });
               return cy.wrap(result);
             });
-        },
-      );
+        });
     })
     .then((result: CommandLineResult) => {
       return result;
@@ -528,7 +528,9 @@ export const createModelRegistryViaYAML = (
   cy.log(
     `Creating model registry ${registryName} in namespace ${targetNamespace} using database '${databaseName}'`,
   );
-  return loadYamlFixture('resources/yaml/model_registry.yaml')
+
+  return cy
+    .fixture('resources/yaml/model_registry.yaml')
     .then((registryYamlContent) => {
       const modifiedRegistryYaml = replacePlaceholdersInYaml(
         registryYamlContent,
@@ -582,6 +584,7 @@ export const getModelRegistryDatabaseConfig = (
 }> => {
   const targetNamespace = namespace || getModelRegistryNamespace();
   const command = `oc get modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace} -o json`;
+
   return cy.exec(command, { failOnNonZeroExit: false }).then((result: CommandLineResult) => {
     if (result.exitCode !== 0) {
       const maskedStderr = maskSensitiveInfo(result.stderr);
@@ -659,6 +662,7 @@ export const deleteModelRegistry = (registryName: string): Cypress.Chainable<Com
   const registryCommand = `oc delete modelregistry.modelregistry.opendatahub.io ${registryName} -n ${targetNamespace} --timeout=240s`;
 
   cy.log(`Deleting model registry ${registryName} from namespace ${targetNamespace}`);
+
   return cy.exec(registryCommand, { failOnNonZeroExit: false, timeout: 240000 });
 };
 

--- a/packages/cypress/cypress/utils/testConfig.ts
+++ b/packages/cypress/cypress/utils/testConfig.ts
@@ -23,7 +23,6 @@ const testConfig: TestConfig | undefined = env.CY_TEST_CONFIG
   : undefined;
 
 export const BASE_URL = testConfig?.ODH_DASHBOARD_URL || env.BASE_URL || '';
-console.log('base url is', BASE_URL);
 
 const LDAP_CONTRIBUTOR_USER: UserAuthConfig = testConfig?.TEST_USER_3 ?? {
   AUTH_TYPE: env.TEST_USER_3_AUTH_TYPE || '',
@@ -94,8 +93,6 @@ const OCI_MODEL_URI = testConfig?.OCI_MODEL_URI;
 // BYOIDC cluster authentication settings
 const CLUSTER_AUTH = testConfig?.CLUSTER_AUTH;
 
-const { FILEMAPPING } = testConfig ?? {};
-
 // spread the cypressEnv variables into the cypress config
 export const cypressEnv = {
   LDAP_CONTRIBUTOR_USER,
@@ -112,7 +109,6 @@ export const cypressEnv = {
   OCI_SECRET_VALUE,
   OCI_MODEL_URI,
   CLUSTER_AUTH,
-  FILEMAPPING,
 };
 
 // re-export the updated process env


### PR DESCRIPTION
Reverts opendatahub-io/odh-dashboard#8076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified fixture loading mechanism by removing deprecated path resolution utilities.
  * Removed `FILEMAPPING` configuration field.

* **New Features**
  * Added optional cluster authentication configuration fields for BYOIDC-style configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->