### PR TITLE
RHOAIENG-59936: Add Helm bootstrap chart for dashboard module controller

### DIFF
--- a/.github/workflows/dashboard-operator-tests.yml
+++ b/.github/workflows/dashboard-operator-tests.yml
@@ -44,6 +44,13 @@ jobs:
         working-directory: dashboard-operator
         run: make test
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Validate Helm chart
+        working-directory: dashboard-operator
+        run: make chart-validate
+
       - name: Check if there are uncommitted file changes
         working-directory: dashboard-operator
         run: |

--- a/.github/workflows/dashboard-operator-tests.yml
+++ b/.github/workflows/dashboard-operator-tests.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           go-version-file: dashboard-operator/go.mod
 
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+
       - name: Lint
         working-directory: dashboard-operator
         run: make lint
@@ -43,9 +46,6 @@ jobs:
       - name: Test
         working-directory: dashboard-operator
         run: make test
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
 
       - name: Validate Helm chart
         working-directory: dashboard-operator

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -20,9 +20,15 @@ dashboard-operator/
 ├── cmd/
 │   └── manager/
 │       └── main.go                     # Controller entry point
+├── charts/
+│   └── dashboard/                      # ODH Operator bootstrap chart (CRD, RBAC, Deployment, ConfigMap)
+│       ├── Chart.yaml
+│       ├── values.yaml
+│       ├── crds/
+│       └── templates/
 ├── config/
 │   ├── crd/
-│   │   ├── bases/                      # Generated CRD YAML
+│   │   ├── bases/                      # Generated CRD YAML (source of truth; synced to charts/dashboard/crds)
 │   │   └── kustomization.yaml
 │   ├── default/
 │   │   └── kustomization.yaml
@@ -84,6 +90,8 @@ make run              # Run controller locally (requires --namespace and --manif
 # Code generation (run after modifying api/ types)
 make generate         # Generate DeepCopy methods
 make manifests        # Generate CRD YAML from kubebuilder markers
+make sync-chart-crds  # Copy CRD into charts/dashboard/crds
+make chart-validate   # helm lint + template smoke test
 
 # Container
 make docker-build     # Build container image (run from repo root)

--- a/dashboard-operator/AGENTS.md
+++ b/dashboard-operator/AGENTS.md
@@ -188,7 +188,9 @@ CI workflow at `.github/workflows/dashboard-operator-tests.yml` triggers on chan
 2. `make lint`
 3. `make build`
 4. `make test`
-5. Check for uncommitted changes (catches stale generated code)
+5. Install Helm (pinned action SHA)
+6. `make chart-validate`
+7. Check for uncommitted changes (catches stale generated code)
 
 ## Testing
 

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -58,8 +58,8 @@ manifests: controller-gen ## Generate CRD manifests.
 ##@ Helm
 
 CHART_DIR ?= charts/dashboard
-CRD_SOURCE ?= config/crd/bases/dashboard.opendatahub.io_dashboards.yaml
-CRD_CHART ?= $(CHART_DIR)/crds/dashboard.opendatahub.io_dashboards.yaml
+CRD_SOURCE ?= config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
+CRD_CHART ?= $(CHART_DIR)/crds/components.platform.opendatahub.io_dashboards.yaml
 HELM ?= helm
 
 .PHONY: sync-chart-crds

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -55,6 +55,33 @@ generate: controller-gen ## Generate deepcopy code.
 manifests: controller-gen ## Generate CRD manifests.
 	$(CONTROLLER_GEN) crd paths="./api/..." output:crd:artifacts:config=config/crd/bases
 
+##@ Helm
+
+CHART_DIR ?= charts/dashboard
+CRD_SOURCE ?= config/crd/bases/dashboard.opendatahub.io_dashboards.yaml
+CRD_CHART ?= $(CHART_DIR)/crds/dashboard.opendatahub.io_dashboards.yaml
+HELM ?= helm
+
+.PHONY: sync-chart-crds
+sync-chart-crds: manifests ## Copy generated CRD into the Helm chart.
+	mkdir -p $(CHART_DIR)/crds
+	cp $(CRD_SOURCE) $(CRD_CHART)
+
+.PHONY: chart-lint
+chart-lint: sync-chart-crds ## Run helm lint on the bootstrap chart.
+	$(HELM) lint $(CHART_DIR)
+
+.PHONY: chart-template
+chart-template: sync-chart-crds ## Render the chart locally for smoke testing.
+	$(HELM) template dashboard $(CHART_DIR) --namespace opendatahub > /dev/null
+
+.PHONY: chart-validate
+chart-validate: chart-lint chart-template ## Lint and render the Helm chart.
+
+.PHONY: check-chart-crds
+check-chart-crds: sync-chart-crds ## Fail if chart CRD differs from generated CRD.
+	@diff -q $(CRD_SOURCE) $(CRD_CHART) >/dev/null || (echo "Chart CRD is out of sync with $(CRD_SOURCE). Run 'make sync-chart-crds'." && exit 1)
+
 ##@ Container
 
 .PHONY: docker-build

--- a/dashboard-operator/Makefile
+++ b/dashboard-operator/Makefile
@@ -1,4 +1,4 @@
-IMG ?= quay.io/opendatahub/dashboard-operator:latest
+IMG ?= quay.io/opendatahub/odh-dashboard-operator:latest
 
 .PHONY: all
 all: build
@@ -64,23 +64,23 @@ HELM ?= helm
 
 .PHONY: sync-chart-crds
 sync-chart-crds: manifests ## Copy generated CRD into the Helm chart.
-	mkdir -p $(CHART_DIR)/crds
-	cp $(CRD_SOURCE) $(CRD_CHART)
+	mkdir -p "$(CHART_DIR)/crds"
+	cp "$(CRD_SOURCE)" "$(CRD_CHART)"
 
 .PHONY: chart-lint
 chart-lint: sync-chart-crds ## Run helm lint on the bootstrap chart.
-	$(HELM) lint $(CHART_DIR)
+	$(HELM) lint "$(CHART_DIR)"
 
 .PHONY: chart-template
 chart-template: sync-chart-crds ## Render the chart locally for smoke testing.
-	$(HELM) template dashboard $(CHART_DIR) --namespace opendatahub > /dev/null
+	$(HELM) template dashboard "$(CHART_DIR)" --namespace opendatahub > /dev/null
 
 .PHONY: chart-validate
 chart-validate: chart-lint chart-template ## Lint and render the Helm chart.
 
-.PHONY: check-chart-crds
-check-chart-crds: sync-chart-crds ## Fail if chart CRD differs from generated CRD.
-	@diff -q $(CRD_SOURCE) $(CRD_CHART) >/dev/null || (echo "Chart CRD is out of sync with $(CRD_SOURCE). Run 'make sync-chart-crds'." && exit 1)
+.PHONY: check-chart-crds ## Fail if chart CRD differs from generated CRD.
+check-chart-crds:
+	@diff -q "$(CRD_SOURCE)" "$(CRD_CHART)" >/dev/null || (echo "Chart CRD is out of sync with $(CRD_SOURCE). Run 'make sync-chart-crds'." && exit 1)
 
 ##@ Container
 

--- a/dashboard-operator/api/v1alpha1/dashboard_types.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	DashboardComponentName = "dashboard"
-	DashboardInstanceName  = "default"
+	DashboardInstanceName  = "default-dashboard"
 	DashboardKind          = "Dashboard"
 )
 
@@ -160,7 +160,7 @@ type DashboardStatus struct {
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="Dashboard name must be default"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-dashboard'",message="Dashboard name must be default-dashboard"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.observability) || !self.spec.observability.enabled || has(self.spec.observability.persesService)",message="persesService must be specified when observability is enabled"
 
 // Dashboard is the Schema for the dashboards API.

--- a/dashboard-operator/api/v1alpha1/dashboard_types_test.go
+++ b/dashboard-operator/api/v1alpha1/dashboard_types_test.go
@@ -69,7 +69,7 @@ func TestDashboard_GetSetReleaseStatus(t *testing.T) {
 }
 
 func TestDashboard_Constants(t *testing.T) {
-	assert.Equal(t, "default", v1alpha1.DashboardInstanceName)
+	assert.Equal(t, "default-dashboard", v1alpha1.DashboardInstanceName)
 	assert.Equal(t, "Dashboard", v1alpha1.DashboardKind)
 	assert.Equal(t, "dashboard", v1alpha1.DashboardComponentName)
 }

--- a/dashboard-operator/charts/chart_sync_test.go
+++ b/dashboard-operator/charts/chart_sync_test.go
@@ -3,28 +3,172 @@ package charts_test
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func TestDashboardChartCRDInSync(t *testing.T) {
-	t.Helper()
+	root := ".."
+	tests := []struct {
+		name    string
+		input   struct{ sourcePath, chartPath string }
+		wantErr bool
+	}{
+		{
+			name: "dashboard CRD matches generated source",
+			input: struct{ sourcePath, chartPath string }{
+				sourcePath: filepath.Join(root, "config", "crd", "bases", "components.platform.opendatahub.io_dashboards.yaml"),
+				chartPath:  filepath.Join(root, "charts", "dashboard", "crds", "components.platform.opendatahub.io_dashboards.yaml"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := os.ReadFile(tt.input.sourcePath)
+			if err != nil {
+				if tt.wantErr {
+					return
+				}
+				t.Fatalf("read source CRD: %v", err)
+			}
+
+			chart, err := os.ReadFile(tt.input.chartPath)
+			if err != nil {
+				if tt.wantErr {
+					return
+				}
+				t.Fatalf("read chart CRD: %v", err)
+			}
+
+			if tt.wantErr {
+				if bytes.Equal(source, chart) {
+					t.Fatal("expected CRD drift, but files match")
+				}
+				return
+			}
+
+			if !bytes.Equal(source, chart) {
+				t.Fatalf("chart CRD is out of sync with %s; run 'make sync-chart-crds'", tt.input.sourcePath)
+			}
+		})
+	}
+}
+
+func TestDashboardChartRBACInSync(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed")
+	}
 
 	root := ".."
-	sourcePath := filepath.Join(root, "config", "crd", "bases", "components.platform.opendatahub.io_dashboards.yaml")
-	chartPath := filepath.Join(root, "charts", "dashboard", "crds", "components.platform.opendatahub.io_dashboards.yaml")
+	tests := []struct {
+		name    string
+		input   struct{ rolePath, chartDir string }
+		wantErr bool
+	}{
+		{
+			name: "chart ClusterRole rules match config/rbac/role.yaml",
+			input: struct{ rolePath, chartDir string }{
+				rolePath: filepath.Join(root, "config", "rbac", "role.yaml"),
+				chartDir: filepath.Join(root, "charts", "dashboard"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceRole, err := loadClusterRoleRules(tt.input.rolePath)
+			if err != nil {
+				t.Fatalf("load source ClusterRole: %v", err)
+			}
 
-	source, err := os.ReadFile(sourcePath)
+			chartRole, err := renderChartClusterRoleRules(tt.input.chartDir)
+			if err != nil {
+				t.Fatalf("render chart ClusterRole: %v", err)
+			}
+
+			if tt.wantErr {
+				if rulesEqual(sourceRole, chartRole) {
+					t.Fatal("expected RBAC drift, but rules match")
+				}
+				return
+			}
+
+			if !rulesEqual(sourceRole, chartRole) {
+				t.Fatalf("chart ClusterRole rules differ from %s; update charts/dashboard/templates/rbac.yaml", tt.input.rolePath)
+			}
+		})
+	}
+}
+
+func loadClusterRoleRules(path string) ([]rbacv1.PolicyRule, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read source CRD: %v", err)
+		return nil, err
 	}
 
-	chart, err := os.ReadFile(chartPath)
+	var role rbacv1.ClusterRole
+	if err := yaml.Unmarshal(data, &role); err != nil {
+		return nil, err
+	}
+
+	return role.Rules, nil
+}
+
+func renderChartClusterRoleRules(chartDir string) ([]rbacv1.PolicyRule, error) {
+	cmd := exec.Command("helm", "template", "dashboard", chartDir, "--namespace", "opendatahub")
+	output, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("read chart CRD: %v", err)
+		return nil, err
 	}
 
-	if !bytes.Equal(source, chart) {
-		t.Fatalf("chart CRD is out of sync with %s; run 'make sync-chart-crds'", sourcePath)
+	for _, doc := range strings.Split(string(output), "---") {
+		doc = strings.TrimSpace(doc)
+		if doc == "" || !strings.Contains(doc, "kind: ClusterRole") {
+			continue
+		}
+
+		var role rbacv1.ClusterRole
+		if err := yaml.Unmarshal([]byte(doc), &role); err != nil {
+			return nil, err
+		}
+		if role.Kind == "ClusterRole" {
+			return role.Rules, nil
+		}
 	}
+
+	return nil, os.ErrNotExist
+}
+
+func rulesEqual(a, b []rbacv1.PolicyRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !policyRuleEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func policyRuleEqual(a, b rbacv1.PolicyRule) bool {
+	return stringSliceEqual(a.APIGroups, b.APIGroups) &&
+		stringSliceEqual(a.Resources, b.Resources) &&
+		stringSliceEqual(a.Verbs, b.Verbs)
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/dashboard-operator/charts/chart_sync_test.go
+++ b/dashboard-operator/charts/chart_sync_test.go
@@ -11,8 +11,8 @@ func TestDashboardChartCRDInSync(t *testing.T) {
 	t.Helper()
 
 	root := ".."
-	sourcePath := filepath.Join(root, "config", "crd", "bases", "dashboard.opendatahub.io_dashboards.yaml")
-	chartPath := filepath.Join(root, "charts", "dashboard", "crds", "dashboard.opendatahub.io_dashboards.yaml")
+	sourcePath := filepath.Join(root, "config", "crd", "bases", "components.platform.opendatahub.io_dashboards.yaml")
+	chartPath := filepath.Join(root, "charts", "dashboard", "crds", "components.platform.opendatahub.io_dashboards.yaml")
 
 	source, err := os.ReadFile(sourcePath)
 	if err != nil {

--- a/dashboard-operator/charts/chart_sync_test.go
+++ b/dashboard-operator/charts/chart_sync_test.go
@@ -1,0 +1,30 @@
+package charts_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDashboardChartCRDInSync(t *testing.T) {
+	t.Helper()
+
+	root := ".."
+	sourcePath := filepath.Join(root, "config", "crd", "bases", "dashboard.opendatahub.io_dashboards.yaml")
+	chartPath := filepath.Join(root, "charts", "dashboard", "crds", "dashboard.opendatahub.io_dashboards.yaml")
+
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source CRD: %v", err)
+	}
+
+	chart, err := os.ReadFile(chartPath)
+	if err != nil {
+		t.Fatalf("read chart CRD: %v", err)
+	}
+
+	if !bytes.Equal(source, chart) {
+		t.Fatalf("chart CRD is out of sync with %s; run 'make sync-chart-crds'", sourcePath)
+	}
+}

--- a/dashboard-operator/charts/dashboard/.helmignore
+++ b/dashboard-operator/charts/dashboard/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when packaging charts.
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/dashboard-operator/charts/dashboard/Chart.yaml
+++ b/dashboard-operator/charts/dashboard/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: dashboard
+description: Helm chart for the ODH Dashboard module controller bootstrap (CRD, RBAC, Deployment, ConfigMap)
+type: application
+version: 0.1.0
+appVersion: "0.0.0"
+keywords:
+  - dashboard
+  - opendatahub
+  - modular-architecture
+home: https://github.com/opendatahub-io/odh-dashboard
+maintainers:
+  - name: ODH Dashboard Team
+    url: https://github.com/opendatahub-io/odh-dashboard

--- a/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
@@ -273,7 +273,10 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               url:
-                description: URL is the externally-reachable dashboard URL.
+                description: |-
+                  URL is the externally-reachable dashboard URL (last known good).
+                  This value persists across transient route failures — consumers must
+                  check the Ready condition before relying on this endpoint.
                 type: string
             type: object
         type: object

--- a/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/charts/dashboard/crds/components.platform.opendatahub.io_dashboards.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
-  name: dashboards.dashboard.opendatahub.io
+  name: dashboards.components.platform.opendatahub.io
 spec:
-  group: dashboard.opendatahub.io
+  group: components.platform.opendatahub.io
   names:
     kind: Dashboard
     listKind: DashboardList

--- a/dashboard-operator/charts/dashboard/crds/dashboard.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/charts/dashboard/crds/dashboard.opendatahub.io_dashboards.yaml
@@ -1,0 +1,289 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: dashboards.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: Dashboard
+    listKind: DashboardList
+    plural: dashboards
+    singular: dashboard
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management
+      priority: 1
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dashboard is the Schema for the dashboards API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DashboardSpec defines the desired state of the Dashboard
+              module.
+            properties:
+              components:
+                additionalProperties:
+                  description: |-
+                    ComponentAvailability represents a DSC component's availability state
+                    as projected by the orchestrator.
+                  properties:
+                    managementState:
+                      default: Removed
+                      description: |-
+                        ManagementState is the DSC component's management state.
+                        "Managed" or "Unmanaged" means the component is available;
+                        "Removed" means it is not.
+                      enum:
+                      - Managed
+                      - Unmanaged
+                      - Removed
+                      type: string
+                  required:
+                  - managementState
+                  type: object
+                description: |-
+                  Components is a snapshot of DSC component availability, projected by
+                  the ODH Operator onto this CR.
+                type: object
+              gateway:
+                description: Gateway configures the ingress point for the dashboard.
+                properties:
+                  domain:
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$
+                    type: string
+                required:
+                - domain
+                type: object
+              managementState:
+                default: Managed
+                description: |-
+                  ManagementState controls whether the operator actively manages the
+                  component (Managed) or removes it (Removed).
+                enum:
+                - Managed
+                - Removed
+                type: string
+              modules:
+                additionalProperties:
+                  description: |-
+                    ModuleOverride allows the orchestrator or admin to override the
+                    automatic dependency-based module enablement decision.
+                  properties:
+                    state:
+                      description: |-
+                        State overrides automatic module enablement.
+                        If empty or omitted, the controller uses dependency resolution.
+                      enum:
+                      - Enabled
+                      - Disabled
+                      type: string
+                  type: object
+                description: |-
+                  Modules contains per-module override configuration. Map keys are
+                  module names as defined in the controller's internal module registry.
+                type: object
+              observability:
+                description: Observability configures the observability stack integration.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled controls whether the Perses proxy module
+                      is deployed.
+                    type: boolean
+                  persesService:
+                    description: |-
+                      PersesService identifies the target Perses service to proxy to.
+                      Required when Enabled is true.
+                    properties:
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        type: string
+                      port:
+                        default: 8080
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+            type: object
+          status:
+            description: DashboardStatus defines the observed state of the Dashboard.
+            properties:
+              conditions:
+                description: Conditions is the set of condition observations for this
+                  module.
+                items:
+                  description: |-
+                    Condition represents an observation of a module's state at a point in time.
+                    Module controllers set conditions to communicate health signals to the
+                    orchestrator and to human operators.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        Message is a human-readable description providing details about the
+                        condition's last transition.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration is the .metadata.generation of the resource that
+                        the condition was set based upon. If this does not match the resource's
+                        current generation, the condition is likely stale.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        Reason is a programmatic, one-word CamelCase identifier for the
+                        condition's last transition, suitable for machine consumption.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity indicates whether this condition represents an error or is
+                        purely informational. Empty string (default) indicates error severity.
+                      type: string
+                    status:
+                      description: Status is the status of the condition (True, False,
+                        Unknown).
+                      type: string
+                    type:
+                      description: Type is the condition type, e.g. ConditionTypeReady,
+                        ConditionTypeDegraded.
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              moduleStatuses:
+                additionalProperties:
+                  description: ModuleStatus reports the current state of a single
+                    module.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    phase:
+                      description: ModulePhase represents the deployment lifecycle
+                        of an individual module.
+                      enum:
+                      - Deployed
+                      - NotDeployed
+                      - Degraded
+                      - Disabled
+                      type: string
+                    reason:
+                      description: Reason is a one-word CamelCase explanation for
+                        the current phase.
+                      type: string
+                  required:
+                  - phase
+                  type: object
+                description: ModuleStatuses reports the deployment state of each module.
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent .metadata.generation observed
+                  by the controller. It allows consumers to determine whether the
+                  controller has processed the latest spec changes.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the top-level lifecycle phase of the module.
+                type: string
+              releases:
+                description: Releases is the list of deployed component releases.
+                items:
+                  description: ComponentRelease describes a single software component's
+                    release metadata.
+                  properties:
+                    name:
+                      description: Name is the component name, used as the merge key
+                        in lists.
+                      type: string
+                    repoUrl:
+                      description: RepoURL is the source repository URL for this component
+                        release.
+                      type: string
+                    version:
+                      description: Version is the semantic version of the component.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              url:
+                description: URL is the externally-reachable dashboard URL.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: Dashboard name must be default-dashboard
+          rule: self.metadata.name == 'default-dashboard'
+        - message: persesService must be specified when observability is enabled
+          rule: '!has(self.spec.observability) || !self.spec.observability.enabled
+            || has(self.spec.observability.persesService)'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/dashboard-operator/charts/dashboard/templates/_helpers.tpl
+++ b/dashboard-operator/charts/dashboard/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "dashboard.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart and selector labels
+*/}}
+{{- define "dashboard.labels" -}}
+helm.sh/chart: {{ include "dashboard.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: dashboard-operator
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "dashboard.selectorLabels" -}}
+app.kubernetes.io/name: dashboard-operator
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "dashboard.namespace" -}}
+{{- default .Release.Namespace .Values.namespace }}
+{{- end }}
+
+{{- define "dashboard.deploymentName" -}}
+{{- printf "%sdashboard-operator" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- printf "%s%s" .Values.namePrefix (.Values.serviceAccount.name | default "dashboard-operator") }}
+{{- else }}
+{{- .Values.serviceAccount.name | default "default" }}
+{{- end }}
+{{- end }}
+
+{{- define "dashboard.clusterRoleName" -}}
+{{- printf "%sdashboard-operator-role" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.clusterRoleBindingName" -}}
+{{- printf "%sdashboard-operator-rolebinding" .Values.namePrefix }}
+{{- end }}
+
+{{- define "dashboard.configMapName" -}}
+{{- .Values.config.name }}
+{{- end }}
+
+{{- define "dashboard.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}

--- a/dashboard-operator/charts/dashboard/templates/_helpers.tpl
+++ b/dashboard-operator/charts/dashboard/templates/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.serviceAccount.create }}
 {{- printf "%s%s" .Values.namePrefix (.Values.serviceAccount.name | default "dashboard-operator") }}
 {{- else }}
-{{- .Values.serviceAccount.name | default "default" }}
+{{- required "serviceAccount.name must be set when serviceAccount.create=false" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/dashboard-operator/charts/dashboard/templates/configmap.yaml
+++ b/dashboard-operator/charts/dashboard/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dashboard.configMapName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+    platform.opendatahub.io/managed: "true"
+data:
+{{- range $key, $value := .Values.config.data }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}

--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dashboard.deploymentName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+spec:
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      {{- include "dashboard.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dashboard.selectorLabels" . | nindent 8 }}
+        {{- with .Values.manager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.manager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dashboard.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: manager
+          image: {{ include "dashboard.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --namespace=$(OPERATOR_NAMESPACE)
+            - --manifests-base-path={{ .Values.manager.manifestsBasePath }}
+            {{- if .Values.manager.leaderElection }}
+            - --leader-elect
+            {{- end }}
+          env:
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- range $name, $value := .Values.relatedImages }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: health
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.manager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.manager.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.manager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/dashboard-operator/charts/dashboard/templates/deployment.yaml
+++ b/dashboard-operator/charts/dashboard/templates/deployment.yaml
@@ -32,11 +32,34 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "dashboard.serviceAccountName" . }}
+      automountServiceAccountToken: false
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: dashboard-operator-sa-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace
       containers:
         - name: manager
           image: {{ include "dashboard.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: dashboard-operator-sa-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
           args:
             - --namespace=$(OPERATOR_NAMESPACE)
             - --manifests-base-path={{ .Values.manager.manifestsBasePath }}

--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -10,6 +10,8 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 {{- end }}
 ---
 {{- if .Values.rbac.create }}
+# IMPORTANT: Keep ClusterRole rules in sync with config/rbac/role.yaml.
+# chart_sync_test.go validates CRD and RBAC drift in CI via `make test`.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "dashboard.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards
     verbs:
@@ -30,7 +30,7 @@ rules:
       - patch
       - delete
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards/status
     verbs:
@@ -38,7 +38,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - dashboard.opendatahub.io
+      - components.platform.opendatahub.io
     resources:
       - dashboards/finalizers
     verbs:

--- a/dashboard-operator/charts/dashboard/templates/rbac.yaml
+++ b/dashboard-operator/charts/dashboard/templates/rbac.yaml
@@ -1,0 +1,202 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dashboard.serviceAccountName" . }}
+  namespace: {{ include "dashboard.namespace" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+---
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dashboard.clusterRoleName" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - dashboards
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - dashboards/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - dashboards/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+      - serviceaccounts
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - catalogsources
+      - operatorconditions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolelinks
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dashboard.clusterRoleBindingName" . }}
+  labels:
+    {{- include "dashboard.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dashboard.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dashboard.serviceAccountName" . }}
+    namespace: {{ include "dashboard.namespace" . }}
+{{- end }}

--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -1,0 +1,73 @@
+# Default values for the Dashboard module controller bootstrap chart.
+# The ODH Operator renders this chart and injects namespace, image tags, and
+# RELATED_IMAGE_* values at install time.
+
+nameOverride: ""
+fullnameOverride: ""
+namePrefix: odh-
+
+namespace: opendatahub
+
+commonLabels:
+  app.kubernetes.io/part-of: odh-dashboard
+  platform.opendatahub.io/part-of: dashboard
+  components.platform.opendatahub.io/managed-by: opendatahub-operator
+
+image:
+  repository: quay.io/opendatahub/dashboard-operator
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+manager:
+  replicas: 1
+  leaderElection: true
+  manifestsBasePath: /opt/manifests/dashboard
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+  podLabels: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  podSecurityContext:
+    runAsNonRoot: true
+
+serviceAccount:
+  create: true
+  name: dashboard-operator
+  automountServiceAccountToken: false
+
+rbac:
+  create: true
+
+# Downstream application images resolved by the module controller when rendering
+# embedded dashboard manifests. Keys match RELATED_IMAGE_* env var names.
+relatedImages:
+  RELATED_IMAGE_ODH_DASHBOARD_IMAGE: quay.io/opendatahub/odh-dashboard:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE: quay.io/opendatahub/odh-mod-arch-model-registry:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE: quay.io/opendatahub/odh-mod-arch-gen-ai:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE: quay.io/opendatahub/odh-mod-arch-mlflow:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE: quay.io/opendatahub/odh-mod-arch-maas:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE: quay.io/opendatahub/odh-mod-arch-eval-hub:latest
+  RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE: quay.io/opendatahub/odh-kube-rbac-proxy:latest
+  RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE: quay.io/opendatahub/odh-model-registry-job-async-upload:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE: quay.io/opendatahub/odh-mod-arch-automl:latest
+  RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE: quay.io/opendatahub/odh-mod-arch-autorag:latest
+
+config:
+  name: opendatahub-dashboard-config
+  data:
+    distribution.name: Standalone
+    distribution.version: "0.0.0"
+    controller.zap.level: info

--- a/dashboard-operator/charts/dashboard/values.yaml
+++ b/dashboard-operator/charts/dashboard/values.yaml
@@ -14,7 +14,7 @@ commonLabels:
   components.platform.opendatahub.io/managed-by: opendatahub-operator
 
 image:
-  repository: quay.io/opendatahub/dashboard-operator
+  repository: quay.io/opendatahub/odh-dashboard-operator
   tag: latest
   pullPolicy: IfNotPresent
   pullSecrets: []
@@ -64,6 +64,8 @@ relatedImages:
   RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE: quay.io/opendatahub/odh-model-registry-job-async-upload:latest
   RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE: quay.io/opendatahub/odh-mod-arch-automl:latest
   RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE: quay.io/opendatahub/odh-mod-arch-autorag:latest
+  RELATED_IMAGE_ODH_AUTOML_IMAGE: quay.io/opendatahub/odh-automl:latest
+  RELATED_IMAGE_ODH_AUTORAG_IMAGE: quay.io/opendatahub/odh-autorag:latest
 
 config:
   name: opendatahub-dashboard-config

--- a/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
+++ b/dashboard-operator/config/crd/bases/components.platform.opendatahub.io_dashboards.yaml
@@ -273,13 +273,16 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               url:
-                description: URL is the externally-reachable dashboard URL.
+                description: |-
+                  URL is the externally-reachable dashboard URL (last known good).
+                  This value persists across transient route failures — consumers must
+                  check the Ready condition before relying on this endpoint.
                 type: string
             type: object
         type: object
         x-kubernetes-validations:
-        - message: Dashboard name must be default
-          rule: self.metadata.name == 'default'
+        - message: Dashboard name must be default-dashboard
+          rule: self.metadata.name == 'default-dashboard'
         - message: persesService must be specified when observability is enabled
           rule: '!has(self.spec.observability) || !self.spec.observability.enabled
             || has(self.spec.observability.persesService)'

--- a/dashboard-operator/config/manager/kustomization.yaml
+++ b/dashboard-operator/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - manager.yaml
 images:
   - name: controller
-    newName: quay.io/opendatahub/dashboard-operator
+    newName: quay.io/opendatahub/odh-dashboard-operator
     newTag: latest


### PR DESCRIPTION
## Description

Adds a Helm bootstrap chart at `dashboard-operator/charts/dashboard/` for ODH Operator consumption ([RHOAIENG-59936](https://redhat.atlassian.net/browse/RHOAIENG-59936)).

The chart packages **controller bootstrap only** (per the ODH Operator module onboarding guide §3.1):

- **CRD** — `dashboard.opendatahub.io/Dashboard` (synced from `config/crd/bases/`)
- **RBAC** — ServiceAccount, ClusterRole, ClusterRoleBinding
- **Deployment** — dashboard module controller with `RELATED_IMAGE_*` env vars and `--manifests-base-path`
- **ConfigMap** — `opendatahub-dashboard-config` with standalone defaults for platform injection

Dashboard **application** manifests remain embedded in the controller image (`manifests/` → `/opt/manifests/dashboard/`) and are **not** included in this chart.

Also adds Makefile targets (`sync-chart-crds`, `chart-validate`), a CRD drift unit test, and CI Helm validation.

**Follow-up (odh-operator repo):** [RHOAIENG-61029](https://redhat.atlassian.net/browse/RHOAIENG-61029) — register chart in `ODH_COMPONENT_CHARTS` and ModuleHandler.

## How Has This Been Tested?

**Automated:**
- `go test ./...` in `dashboard-operator/` (includes `charts/chart_sync_test.go` CRD sync check)
- CI will run `make chart-validate` (helm lint + template) via updated `dashboard-operator-tests.yml`

**On-cluster (OpenShift 4.21, ROSA):**

Tested the end-to-end integration with [opendatahub-operator PR #3656](https://github.com/opendatahub-io/opendatahub-operator/pull/3656) on a live OpenShift cluster (`api.liday-1.n1ai.p3.openshiftapps.com`).

Setup:
1. Built and ran the odh-operator locally from branch `RHOAIENG-59936` ([PR #3656](https://github.com/opendatahub-io/opendatahub-operator/pull/3656)) using `make run-nowebhook` with `OPERATOR_NAMESPACE=opendatahub DEFAULT_CHARTS_PATH=opt/charts DEFAULT_MANIFESTS_PATH=opt/manifests`
2. The dashboard-operator Helm chart from this PR is already incorporated into the odh-operator repo at `opt/charts/dashboard-operator/`
3. Symlinked `opt/manifests/{hardwareprofiles,osd-configs,connectionAPI,segment}` to their sources under `config/` (normally copied in by the Dockerfile at image build time)
4. Applied CRDs (`oc apply -f config/crd/bases/`), DSCI sample, and DSC sample with `dashboard.managementState: Managed`

Verified:
- [x] Dashboard CR `default-dashboard` created automatically by the module controller, owned by the DSC CR
- [x] Dashboard CR received the gateway domain from GatewayConfig (`rh-ai.apps.rosa.liday-1.n1ai.p3.openshiftapps.com`)
- [x] `dashboard-operator` Deployment created in `opendatahub` namespace via Helm chart rendering
- [x] Deployment includes all 10 `RELATED_IMAGE_*` env vars, leader election args, correct Helm labels (`helm.sh/chart: dashboard-0.1.0`) and platform labels (`platform.opendatahub.io/part-of: dashboard`)
- [x] OwnerReferences set correctly (DSC owns both Dashboard CR and Deployment)
- [x] Supporting resources created: ServiceAccount `dashboard-operator`, ClusterRole `dashboard-operator-role`, ClusterRoleBinding `dashboard-operator-rolebinding`, ConfigMap `opendatahub-dashboard-config`
- [x] Pod in `ImagePullBackOff` — expected since `quay.io/opendatahub/dashboard-operator:latest` image does not exist yet

## Test Impact

- New unit test: `dashboard-operator/charts/chart_sync_test.go` verifies chart CRD matches generated CRD
- CI: Helm install + `make chart-validate` added to dashboard-operator workflow

## Request review criteria:

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes:
- N/A — operator manifests only

After the PR is posted &amp; before it merges:
- [x] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Helm chart deployment for dashboard operator with customizable configuration.
  * Dashboard resources now support component management, module-level configuration, and Perses observability integration.

* **Chores**
  * Dashboard resource API groups have been updated.
  * Added Helm chart validation to CI/CD checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->