### PR TITLE
fix(ci): serve module federation remotes locally in E2E tests

### DIFF
--- a/.claude/rules/module-onboarding.md
+++ b/.claude/rules/module-onboarding.md
@@ -228,6 +228,38 @@ The `modular-arch-quality-gates.yml` CI workflow checks that modules have:
 - Unit tests in `__tests__/`
 - E2E tests in `packages/cypress/cypress/tests/e2e/<name>/`
 
+### 12. E2E CI: Local module serving
+
+The E2E CI workflow (`.github/workflows/cypress-e2e-test.yml`) automatically detects changed MF packages and serves them locally so that E2E tests exercise PR code instead of the remote cluster's version.
+
+**How it works:**
+
+1. CI detects changed packages with a `module-federation` config AND `cypress:server:build`/`cypress:server` scripts
+2. For each detected package, CI runs `cypress:server:build` (production webpack build) then `cypress:server` (static file server)
+3. The webpack dev server is started with `LOCAL_MODULES=<names>`, which inserts per-module proxy entries that route `/_mf/{name}/*` and BFF API traffic to the local servers — before the catch-all cluster proxy
+
+**What your package needs (automatic — no allowlisting required):**
+
+- `module-federation` config in `package.json` with a `name` and `backend.localService.port` (or `local.port`)
+- `cypress:server:build` script — typically `cd frontend && DIST_DIR=./public-cypress DEPLOYMENT_MODE=federated npm run build`
+- `cypress:server` script — typically `cd frontend && serve ./public-cypress -p <port> -s -L`
+- `bffConfig.port` in `package.json` (if the module has a BFF)
+
+**Security:** The CI step validates package directories against an allowlist (`ALLOWED_DIRS` in the workflow). When onboarding a new module, add its directory name to this allowlist in the "Build & Start Module Frontend Servers" step.
+
+**Local testing with `LOCAL_MODULES`:**
+
+```bash
+# 1. Build and serve the module frontend
+cd packages/<name> && npm run cypress:server:build && npm run cypress:server &
+
+# 2. Start the BFF (if applicable)
+cd packages/<name> && make dev-bff-e2e-cluster &
+
+# 3. Start webpack with LOCAL_MODULES pointing to your module
+cd frontend && LOCAL_MODULES=<mfName> ODH_DASHBOARD_HOST=<cluster> npm run start:dev:ci
+```
+
 ## Checklist
 
 - [ ] `package.json` with `name`, `exports["./extensions"]`
@@ -237,6 +269,8 @@ The `modular-arch-quality-gates.yml` CI workflow checks that modules have:
 - [ ] `SupportedArea` enum entry + area config
 - [ ] Webpack config with correct shared singletons (if federated)
 - [ ] BFF with `/healthcheck` and OpenAPI spec (if applicable)
+- [ ] `cypress:server:build` and `cypress:server` scripts for E2E CI (if federated)
+- [ ] Package directory added to `ALLOWED_DIRS` in CI workflow's "Build & Start Module Frontend Servers" step
 - [ ] Unit tests in `__tests__/`
 - [ ] E2E tests in `packages/cypress/cypress/tests/e2e/<name>/`
 - [ ] Contract tests (if BFF)

--- a/.github/workflows/cypress-e2e-test.yml
+++ b/.github/workflows/cypress-e2e-test.yml
@@ -244,6 +244,7 @@ jobs:
       matrix: ${{ steps.build.outputs.matrix }}
       source: ${{ steps.build.outputs.source }}
       bff_packages: ${{ steps.detect.outputs.bff_packages }}
+      mf_packages: ${{ steps.detect.outputs.mf_packages }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -425,6 +426,42 @@ jobs:
           fi
 
           echo "bff_packages=$BFF_PACKAGES" >> $GITHUB_OUTPUT
+
+          # --- MF Frontend Package Detection ---
+          # Detect changed packages that have module-federation config and cypress:server scripts
+          echo ""
+          echo "🔍 Detecting MF frontend packages to build and serve locally..."
+          MF_PACKAGES="[]"
+
+          if [[ -n "$CHANGED_PACKAGES" ]]; then
+            for pkg_dir in packages/*/; do
+              pkg_name=$(jq -r '.name // empty' "$pkg_dir/package.json" 2>/dev/null)
+
+              # Check if this package changed
+              if echo "$CHANGED_PACKAGES" | grep -qx "$pkg_name"; then
+                # Check if package has module-federation config AND cypress:server scripts
+                mf_name=$(jq -r '.["module-federation"].name // empty' "$pkg_dir/package.json" 2>/dev/null)
+                has_cy_server_build=$(jq -r '.scripts["cypress:server:build"] // empty' "$pkg_dir/package.json" 2>/dev/null)
+                has_cy_server=$(jq -r '.scripts["cypress:server"] // empty' "$pkg_dir/package.json" 2>/dev/null)
+
+                if [[ -n "$mf_name" && -n "$has_cy_server_build" && -n "$has_cy_server" ]]; then
+                  fe_port=$(jq -r '.["module-federation"].local.port // .["module-federation"].backend.localService.port // 0' "$pkg_dir/package.json" 2>/dev/null)
+                  pkg_dir_name=$(basename "$pkg_dir")
+
+                  echo "  ✅ $pkg_name (mf: $mf_name, port: $fe_port)"
+
+                  MF_PACKAGES=$(echo "$MF_PACKAGES" | jq -c --arg name "$pkg_name" --arg dir "$pkg_dir_name" --arg mfName "$mf_name" --arg port "$fe_port" \
+                    '. + [{"name": $name, "dir": $dir, "mfName": $mfName, "port": ($port | tonumber)}]')
+                fi
+              fi
+            done
+          fi
+
+          if [[ "$MF_PACKAGES" == "[]" ]]; then
+            echo "  ℹ️  No MF frontend packages detected for this change"
+          fi
+
+          echo "mf_packages=$MF_PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Build test matrix
         id: build
@@ -1027,99 +1064,6 @@ jobs:
         run: |
           echo "CY_TEST_CONFIG=${{ github.workspace }}/packages/cypress/test-variables.yml" >> $GITHUB_ENV
 
-      - name: Start Cypress Server
-        run: |
-          echo "🧹 Cleaning up port ${WEBPACK_PORT}..."
-
-          PORT_INFO_DIR="/tmp/gha-ports"
-          PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
-          CURRENT_RUN_ID="${{ github.run_id }}"
-
-          # Check if port is in use
-          if lsof -i:${WEBPACK_PORT} > /dev/null 2>&1; then
-            # Check if there's a run_id file for this port
-            if [ -f "$PORT_INFO_FILE" ]; then
-              PORT_OWNER_RUN_ID=$(cat "$PORT_INFO_FILE")
-              if [ "$PORT_OWNER_RUN_ID" != "$CURRENT_RUN_ID" ]; then
-                echo "⚠️  Port ${WEBPACK_PORT} is owned by different run_id: $PORT_OWNER_RUN_ID"
-                echo "⚠️  This port is in use by another workflow run - will not kill it"
-                # Try to find an alternative port
-                for alt_port in $(seq $((WEBPACK_PORT + 5)) $((WEBPACK_PORT + 50)) 5); do
-                  if ! lsof -i:${alt_port} > /dev/null 2>&1; then
-                    WEBPACK_PORT=$alt_port
-                    PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
-                    echo "✅ Found alternative port: ${WEBPACK_PORT}"
-                    break
-                  fi
-                done
-              else
-                echo "✅ Port ${WEBPACK_PORT} is owned by this run - safe to clean up"
-              fi
-            else
-              # No run_id file - check if process is from a recent GitHub Actions run
-              PORT_PID=$(lsof -ti:${WEBPACK_PORT} 2>/dev/null | head -1)
-              if [ -n "$PORT_PID" ]; then
-                # Check if process is from a GitHub Actions workflow
-                if ps -p "$PORT_PID" -o command= 2>/dev/null | grep -q "webpack.*serve\|node.*40[0-9][0-9]"; then
-                  echo "⚠️  Port ${WEBPACK_PORT} in use by potential GHA process (PID: $PORT_PID)"
-                  echo "⚠️  Being cautious - will not kill without run_id confirmation"
-                  # Find alternative port
-                  for alt_port in $(seq $((WEBPACK_PORT + 5)) $((WEBPACK_PORT + 50)) 5); do
-                    if ! lsof -i:${alt_port} > /dev/null 2>&1; then
-                      WEBPACK_PORT=$alt_port
-                      PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
-                      echo "✅ Found alternative port: ${WEBPACK_PORT}"
-                      break
-                    fi
-                  done
-                else
-                  echo "⚠️  Port ${WEBPACK_PORT} in use by non-GHA process - cleaning up"
-                  kill -9 "$PORT_PID" 2>/dev/null || true
-                fi
-              fi
-            fi
-          fi
-
-          # Verify port is free with retry logic
-          RETRY_COUNT=0
-          while lsof -i:${WEBPACK_PORT} > /dev/null 2>&1; do
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            if [ $RETRY_COUNT -gt 10 ]; then
-              echo "❌ Port ${WEBPACK_PORT} still in use after cleanup!"
-              lsof -i:${WEBPACK_PORT}
-              exit 1
-            fi
-            echo "⏳ Retrying cleanup... (attempt $RETRY_COUNT/10)"
-            sleep 2
-          done
-
-          # Claim the port with our run_id
-          mkdir -p "$PORT_INFO_DIR"
-          echo "$CURRENT_RUN_ID" > "$PORT_INFO_FILE"
-          echo "WEBPACK_PORT=$WEBPACK_PORT" >> $GITHUB_ENV
-          echo "PORT_INFO_FILE=$PORT_INFO_FILE" >> $GITHUB_ENV
-
-          echo "✅ Port ${WEBPACK_PORT} is free and claimed by run_id: $CURRENT_RUN_ID"
-          echo "🚀 Starting webpack dev server on port ${WEBPACK_PORT} ($CLUSTER_NAME)..."
-
-          # Start webpack with explicit dashboard host (ensures correct proxy target for all tests)
-          cd frontend && env ODH_DASHBOARD_HOST=${DASHBOARD_HOST} ODH_PORT=${WEBPACK_PORT} ODH_TOKEN_REFRESH=true npm run start:dev:ext > /tmp/webpack_${WEBPACK_PORT}.log 2>&1 &
-          SERVER_PID=$!
-          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
-          echo "$SERVER_PID" > "$PORT_INFO_DIR/port-${WEBPACK_PORT}.pid"
-
-          # Give server time to initialize
-          sleep 20
-
-          # Show filtered webpack status (hide sensitive cluster URLs)
-          if [ -f /tmp/webpack_${WEBPACK_PORT}.log ]; then
-            tail -20 /tmp/webpack_${WEBPACK_PORT}.log | \
-              grep -v "Dashboard host:" | \
-              grep -v "Proxy created:" | \
-              grep -v "Logged in as user:" | \
-              grep -v "Using project:" || true
-          fi
-
       - name: Install make for BFF builds
         if: needs.get-test-tags.outputs.bff_packages != '[]'
         run: |
@@ -1244,6 +1188,205 @@ jobs:
 
           echo ""
           echo "✅ All BFF services started successfully"
+
+      - name: Build & Start Module Frontend Servers
+        if: needs.get-test-tags.outputs.mf_packages != '[]'
+        env:
+          MF_PACKAGES: ${{ needs.get-test-tags.outputs.mf_packages }}
+        run: |
+          echo "🏗️  Building and serving module frontends locally..."
+
+          MF_INFO_DIR="/tmp/gha-mf/${{ github.run_id }}"
+          mkdir -p "$MF_INFO_DIR"
+
+          # Allowlist of valid package directories (prevent path traversal)
+          ALLOWED_DIRS=("agent-ops" "automl" "autorag" "eval-hub" "gen-ai" "maas" "mlflow" "model-registry")
+
+          MF_COUNT=$(echo "$MF_PACKAGES" | jq 'length')
+          for idx in $(seq 0 $((MF_COUNT - 1))); do
+            MF_NAME=$(echo "$MF_PACKAGES" | jq -r ".[$idx].mfName")
+            MF_DIR=$(echo "$MF_PACKAGES" | jq -r ".[$idx].dir")
+            MF_PORT=$(echo "$MF_PACKAGES" | jq -r ".[$idx].port")
+            PKG_NAME=$(echo "$MF_PACKAGES" | jq -r ".[$idx].name")
+
+            echo ""
+            echo "📦 Building module frontend: $MF_NAME ($PKG_NAME) on port $MF_PORT..."
+
+            # Validate directory against allowlist
+            DIR_VALID=false
+            for allowed in "${ALLOWED_DIRS[@]}"; do
+              if [ "$MF_DIR" = "$allowed" ]; then
+                DIR_VALID=true
+                break
+              fi
+            done
+            if [ "$DIR_VALID" = "false" ]; then
+              echo "  ❌ Rejected untrusted package directory: '$MF_DIR'"
+              echo "  Allowed directories: ${ALLOWED_DIRS[*]}"
+              exit 1
+            fi
+
+            # Validate port is numeric
+            if ! echo "$MF_PORT" | grep -qE '^[0-9]+$'; then
+              echo "  ❌ Invalid frontend port: '$MF_PORT' (must be numeric)"
+              exit 1
+            fi
+
+            # Skip if port is already in use (e.g., from a previous run)
+            if lsof -ti:"$MF_PORT" > /dev/null 2>&1; then
+              if curl -sf "http://localhost:$MF_PORT/remoteEntry.js" > /dev/null 2>&1; then
+                echo "  ♻️ Module $MF_NAME already serving on port $MF_PORT, reusing"
+                echo "$MF_NAME" >> "$MF_INFO_DIR/modules.txt"
+                continue
+              else
+                echo "  ❌ Port $MF_PORT already in use but not serving remoteEntry.js"
+                lsof -i:"$MF_PORT" || true
+                exit 1
+              fi
+            fi
+
+            # Build the module frontend (production webpack build for static serving)
+            echo "  🔨 Running cypress:server:build..."
+            cd "packages/$MF_DIR"
+            npm run cypress:server:build 2>&1 | tail -5
+
+            # Serve the built frontend in background
+            echo "  🚀 Starting cypress:server on port $MF_PORT..."
+            npm run cypress:server > "/tmp/mf_${MF_DIR}.log" 2>&1 &
+            MF_PID=$!
+            cd - > /dev/null
+
+            # Save PID and port for cleanup
+            echo "$MF_PID" >> "$MF_INFO_DIR/pids.txt"
+            echo "$MF_PORT" >> "$MF_INFO_DIR/ports.txt"
+
+            echo "  📍 PID: $MF_PID"
+
+            # Wait for the server to be ready (max 30 seconds)
+            echo "  ⏳ Waiting for module frontend at localhost:$MF_PORT..."
+            for i in {1..15}; do
+              if curl -sf "http://localhost:$MF_PORT/remoteEntry.js" > /dev/null 2>&1; then
+                echo "  ✅ Module $MF_NAME is serving on port $MF_PORT"
+                break
+              fi
+              if [ $i -eq 15 ]; then
+                echo "  ❌ Module $MF_NAME failed to start after 30 seconds"
+                echo "  📋 Module server logs:"
+                tail -30 "/tmp/mf_${MF_DIR}.log" || true
+                exit 1
+              fi
+              sleep 2
+            done
+
+            echo "$MF_NAME" >> "$MF_INFO_DIR/modules.txt"
+          done
+
+          # Build LOCAL_MODULES from the accumulated module names
+          if [ -f "$MF_INFO_DIR/modules.txt" ]; then
+            LOCAL_MODULES_LIST=$(paste -sd',' "$MF_INFO_DIR/modules.txt")
+            echo "LOCAL_MODULES=$LOCAL_MODULES_LIST" >> $GITHUB_ENV
+            echo ""
+            echo "✅ LOCAL_MODULES=$LOCAL_MODULES_LIST"
+          fi
+
+          echo ""
+          echo "✅ All module frontend servers started successfully"
+
+      - name: Start Cypress Server
+        run: |
+          echo "🧹 Cleaning up port ${WEBPACK_PORT}..."
+
+          PORT_INFO_DIR="/tmp/gha-ports"
+          PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
+          CURRENT_RUN_ID="${{ github.run_id }}"
+
+          # Check if port is in use
+          if lsof -i:${WEBPACK_PORT} > /dev/null 2>&1; then
+            # Check if there's a run_id file for this port
+            if [ -f "$PORT_INFO_FILE" ]; then
+              PORT_OWNER_RUN_ID=$(cat "$PORT_INFO_FILE")
+              if [ "$PORT_OWNER_RUN_ID" != "$CURRENT_RUN_ID" ]; then
+                echo "⚠️  Port ${WEBPACK_PORT} is owned by different run_id: $PORT_OWNER_RUN_ID"
+                echo "⚠️  This port is in use by another workflow run - will not kill it"
+                # Try to find an alternative port
+                for alt_port in $(seq $((WEBPACK_PORT + 5)) $((WEBPACK_PORT + 50)) 5); do
+                  if ! lsof -i:${alt_port} > /dev/null 2>&1; then
+                    WEBPACK_PORT=$alt_port
+                    PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
+                    echo "✅ Found alternative port: ${WEBPACK_PORT}"
+                    break
+                  fi
+                done
+              else
+                echo "✅ Port ${WEBPACK_PORT} is owned by this run - safe to clean up"
+              fi
+            else
+              # No run_id file - check if process is from a recent GitHub Actions run
+              PORT_PID=$(lsof -ti:${WEBPACK_PORT} 2>/dev/null | head -1)
+              if [ -n "$PORT_PID" ]; then
+                # Check if process is from a GitHub Actions workflow
+                if ps -p "$PORT_PID" -o command= 2>/dev/null | grep -q "webpack.*serve\|node.*40[0-9][0-9]"; then
+                  echo "⚠️  Port ${WEBPACK_PORT} in use by potential GHA process (PID: $PORT_PID)"
+                  echo "⚠️  Being cautious - will not kill without run_id confirmation"
+                  # Find alternative port
+                  for alt_port in $(seq $((WEBPACK_PORT + 5)) $((WEBPACK_PORT + 50)) 5); do
+                    if ! lsof -i:${alt_port} > /dev/null 2>&1; then
+                      WEBPACK_PORT=$alt_port
+                      PORT_INFO_FILE="$PORT_INFO_DIR/port-${WEBPACK_PORT}.run_id"
+                      echo "✅ Found alternative port: ${WEBPACK_PORT}"
+                      break
+                    fi
+                  done
+                else
+                  echo "⚠️  Port ${WEBPACK_PORT} in use by non-GHA process - cleaning up"
+                  kill -9 "$PORT_PID" 2>/dev/null || true
+                fi
+              fi
+            fi
+          fi
+
+          # Verify port is free with retry logic
+          RETRY_COUNT=0
+          while lsof -i:${WEBPACK_PORT} > /dev/null 2>&1; do
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            if [ $RETRY_COUNT -gt 10 ]; then
+              echo "❌ Port ${WEBPACK_PORT} still in use after cleanup!"
+              lsof -i:${WEBPACK_PORT}
+              exit 1
+            fi
+            echo "⏳ Retrying cleanup... (attempt $RETRY_COUNT/10)"
+            sleep 2
+          done
+
+          # Claim the port with our run_id
+          mkdir -p "$PORT_INFO_DIR"
+          echo "$CURRENT_RUN_ID" > "$PORT_INFO_FILE"
+          echo "WEBPACK_PORT=$WEBPACK_PORT" >> $GITHUB_ENV
+          echo "PORT_INFO_FILE=$PORT_INFO_FILE" >> $GITHUB_ENV
+
+          echo "✅ Port ${WEBPACK_PORT} is free and claimed by run_id: $CURRENT_RUN_ID"
+          echo "🚀 Starting webpack dev server on port ${WEBPACK_PORT} ($CLUSTER_NAME)..."
+
+          # Use start:dev:ci which reads LOCAL_MODULES for per-module proxy routing
+          if [ -n "$LOCAL_MODULES" ]; then
+            echo "📡 LOCAL_MODULES=$LOCAL_MODULES — module traffic will be routed to local servers"
+          fi
+          cd frontend && env ODH_DASHBOARD_HOST=${DASHBOARD_HOST} ODH_PORT=${WEBPACK_PORT} ODH_TOKEN_REFRESH=true npm run start:dev:ci > /tmp/webpack_${WEBPACK_PORT}.log 2>&1 &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+          echo "$SERVER_PID" > "$PORT_INFO_DIR/port-${WEBPACK_PORT}.pid"
+
+          # Give server time to initialize
+          sleep 20
+
+          # Show filtered webpack status (hide sensitive cluster URLs)
+          if [ -f /tmp/webpack_${WEBPACK_PORT}.log ]; then
+            tail -20 /tmp/webpack_${WEBPACK_PORT}.log | \
+              grep -v "Dashboard host:" | \
+              grep -v "Proxy created:" | \
+              grep -v "Logged in as user:" | \
+              grep -v "Using project:" || true
+          fi
 
       - name: Wait for Server Ready
         run: |
@@ -1435,6 +1578,45 @@ jobs:
 
           # Fix read-only envtest binaries and directories so next checkout can clean the workspace
           chmod -R u+w ${{ github.workspace }}/packages/*/bff/bin ${{ github.workspace }}/packages/*/upstream/bff/bin 2>/dev/null || true
+
+      - name: Stop Module Frontend Servers
+        run: |
+          echo "🛑 Stopping module frontend servers for run_id: ${{ github.run_id }}..."
+
+          MF_INFO_DIR="/tmp/gha-mf/${{ github.run_id }}"
+          MF_KILLED_COUNT=0
+
+          if [ -d "$MF_INFO_DIR" ]; then
+            if [ -f "$MF_INFO_DIR/pids.txt" ]; then
+              while read -r pid; do
+                if ps -p "$pid" > /dev/null 2>&1; then
+                  echo "  🛑 Killing module frontend process $pid"
+                  pkill -P "$pid" 2>/dev/null || true
+                  kill "$pid" 2>/dev/null || true
+                  MF_KILLED_COUNT=$((MF_KILLED_COUNT + 1))
+                fi
+              done < "$MF_INFO_DIR/pids.txt"
+            fi
+
+            if [ -f "$MF_INFO_DIR/ports.txt" ]; then
+              while read -r port; do
+                MF_PID=$(lsof -ti:${port} 2>/dev/null | head -1)
+                if [ -n "$MF_PID" ]; then
+                  echo "  🛑 Killing process on module frontend port $port (PID: $MF_PID)"
+                  pkill -P "$MF_PID" 2>/dev/null || true
+                  kill "$MF_PID" 2>/dev/null || true
+                fi
+              done < "$MF_INFO_DIR/ports.txt"
+            fi
+
+            rm -rf "$MF_INFO_DIR"
+          fi
+
+          if [ $MF_KILLED_COUNT -eq 0 ]; then
+            echo "✅ No module frontend processes found for run_id: ${{ github.run_id }}"
+          else
+            echo "✅ Cleaned up $MF_KILLED_COUNT module frontend process(es) for run_id: ${{ github.run_id }}"
+          fi
 
       - name: Stop Cypress Servers
         run: |

--- a/frontend/config/moduleFederation.js
+++ b/frontend/config/moduleFederation.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const { execSync } = require('child_process');
 const { ModuleFederationPlugin } = require('@module-federation/enhanced/webpack');
 const { getRuntimeOdhPackages } = require('./getRuntimeOdhPackages');
@@ -88,6 +90,80 @@ const odhDashboardShared = Object.fromEntries(
   ]),
 );
 
+/**
+ * Scan packages/* directories for module-federation configs.
+ * This catches packages not in the root npm workspace (standalone frontends).
+ * @returns {Array} Array of normalized MF config objects
+ */
+const readModuleFederationConfigFromFilesystem = () => {
+  const configs = [];
+  const packagesDir = path.resolve(__dirname, '../../packages');
+
+  try {
+    const dirs = fs.readdirSync(packagesDir, { withFileTypes: true });
+    for (const dir of dirs) {
+      if (!dir.isDirectory()) {
+        continue;
+      }
+      const pkgJsonPath = path.join(packagesDir, dir.name, 'package.json');
+      if (!fs.existsSync(pkgJsonPath)) {
+        continue;
+      }
+      try {
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+        if (pkgJson['module-federation']) {
+          configs.push(normalizeConfig(pkgJson['module-federation']));
+        }
+      } catch {
+        // skip unreadable package.json
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to scan packages/ for module federation configs:', e.message);
+  }
+
+  return configs;
+};
+
+/**
+ * Read BFF port configuration from packages/* directories.
+ * @returns {Object} Map of { [mfName]: { bffPort, dir } }
+ */
+const readBffPortsFromPackages = () => {
+  const ports = {};
+  const packagesDir = path.resolve(__dirname, '../../packages');
+
+  try {
+    const dirs = fs.readdirSync(packagesDir, { withFileTypes: true });
+    for (const dir of dirs) {
+      if (!dir.isDirectory()) {
+        continue;
+      }
+      const pkgJsonPath = path.join(packagesDir, dir.name, 'package.json');
+      if (!fs.existsSync(pkgJsonPath)) {
+        continue;
+      }
+      try {
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+        const mfConfig = pkgJson['module-federation'];
+        const { bffConfig } = pkgJson;
+        if (mfConfig && bffConfig?.port) {
+          const name = mfConfig.name || mfConfig.backend?.name;
+          if (name) {
+            ports[name] = { bffPort: bffConfig.port, dir: dir.name };
+          }
+        }
+      } catch {
+        // skip
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to scan packages/ for BFF ports:', e.message);
+  }
+
+  return ports;
+};
+
 // Function to read module federation config from workspace packages
 const readModuleFederationConfigFromPackages = () => {
   const configs = [];
@@ -101,6 +177,15 @@ const readModuleFederationConfigFromPackages = () => {
     }
   } catch (e) {
     console.error('Failed to process workspace packages for module federation.', e);
+  }
+
+  // Also scan filesystem for packages not in the root npm workspace
+  const fsConfigs = readModuleFederationConfigFromFilesystem();
+  const existingNames = new Set(configs.map((c) => c.name));
+  for (const config of fsConfigs) {
+    if (!existingNames.has(config.name)) {
+      configs.push(config);
+    }
   }
 
   return configs;
@@ -129,8 +214,11 @@ if (mfConfig.length > 0) {
   );
 }
 
+const moduleBffPorts = readBffPortsFromPackages();
+
 module.exports = {
   moduleFederationConfig: mfConfig,
+  moduleBffPorts,
   moduleFederationPlugins:
     mfConfig.length > 0
       ? [

--- a/frontend/config/webpack.dev.js
+++ b/frontend/config/webpack.dev.js
@@ -11,7 +11,7 @@ const smp = new SpeedMeasurePlugin({ disable: !process.env.MEASURE });
 
 setupDotenvFilesForEnv({ env: 'development' });
 const webpackCommon = require('./webpack.common.js');
-const { moduleFederationConfig } = require('./moduleFederation');
+const { moduleFederationConfig, moduleBffPorts } = require('./moduleFederation');
 
 const RELATIVE_DIRNAME = process.env._ODH_RELATIVE_DIRNAME;
 const IS_PROJECT_ROOT_DIR = process.env._ODH_IS_PROJECT_ROOT_DIR;
@@ -223,7 +223,54 @@ module.exports = smp.wrap(
               headers['x-forwarded-access-token'] = token;
             }
 
+            // Per-module local proxies for CI: intercept before the catch-all cluster proxy
+            const localModuleProxies = [];
+            const localModulesEnv = process.env.LOCAL_MODULES;
+            if (localModulesEnv) {
+              const localModuleNames = localModulesEnv
+                .split(',')
+                .map((n) => n.trim())
+                .filter(Boolean);
+              console.info('LOCAL_MODULES: routing locally →', localModuleNames);
+
+              for (const moduleName of localModuleNames) {
+                const mfCfg = moduleFederationConfig.find((c) => c.name === moduleName);
+                if (!mfCfg) {
+                  console.warn(`  ⚠ Module "${moduleName}" not found in MF config — skipping`);
+                  continue;
+                }
+
+                const fePort = mfCfg.backend?.localService?.port;
+                if (fePort) {
+                  console.info(`  /_mf/${moduleName}/* → localhost:${fePort}`);
+                  localModuleProxies.push({
+                    context: [`/_mf/${moduleName}`],
+                    target: `http://localhost:${fePort}`,
+                    secure: false,
+                    changeOrigin: true,
+                  });
+                }
+
+                const bffInfo = moduleBffPorts[moduleName];
+                if (bffInfo && mfCfg.proxyService) {
+                  for (const proxy of mfCfg.proxyService) {
+                    console.info(`  ${proxy.path} → localhost:${bffInfo.bffPort}`);
+                    localModuleProxies.push({
+                      context: [proxy.path],
+                      target: `http://localhost:${bffInfo.bffPort}`,
+                      secure: false,
+                      changeOrigin: true,
+                      ...(proxy.pathRewrite && {
+                        pathRewrite: { [`^${proxy.path}`]: proxy.pathRewrite },
+                      }),
+                    });
+                  }
+                }
+              }
+            }
+
             return [
+              ...localModuleProxies,
               {
                 context: ['/api', '/_mf', '/mlflow', ...mfProxies],
                 target: `https://${dashboardHost}`,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "start:dev:wait": "npx wait-on -i 1000 http://localhost:4010",
     "start:dev:mf": "cross-env MF_UPDATE_TYPES=true npm run start:dev",
     "start:dev:ext": "cross-env EXT_CLUSTER=true npm run start:dev",
+    "start:dev:ci": "cross-env EXT_CLUSTER=true npm run start:dev",
     "test": "run-s test:lint test:type-check test:unit test:cypress-ci",
     "test:coverage": "run-s test:lint test:type-check test:jest:coverage test:cypress-ci:coverage coverage:merge",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-68565

## Description

The webpack dev server in `EXT_CLUSTER` mode (used by E2E CI) routes **all** `/_mf/*` and BFF API traffic to the remote cluster via a single catch-all proxy. This means E2E tests always exercise the cluster's deployed module code, not the PR's changes. Local BFF services are started but receive no traffic.

**Root cause:** `webpack.dev.js` extracts only path strings from `proxyService` configs and sends everything to `https://${dashboardHost}`. The `localService` routing info is discarded. The backend has per-module routing (`backend/src/routes/module-federation.ts`), but the webpack proxy intercepts first.

**Fix:** Introduce a CI-specific `LOCAL_MODULES` env var that, when set alongside `EXT_CLUSTER`, inserts per-module proxy entries **before** the catch-all. Changed modules' frontend assets (`/_mf/{name}/*`) and BFF API paths are routed to locally running servers. Modules not in `LOCAL_MODULES` fall through to the cluster — unchanged behavior.

### Changes

1. **`frontend/config/moduleFederation.js`** — Added filesystem-based scanning to discover all 11 MF packages (npm workspace query only finds 2). Export `moduleBffPorts` mapping MF names to BFF ports.

2. **`frontend/config/webpack.dev.js`** — When `LOCAL_MODULES` is set in `EXT_CLUSTER` mode, generate per-module proxy entries for frontend assets and BFF API paths, inserted before the catch-all.

3. **`frontend/package.json`** — Added `start:dev:ci` script for CI usage.

4. **`.github/workflows/cypress-e2e-test.yml`**:
   - Detect changed MF packages (new `mf_packages` output)
   - Reorder steps: BFF → MF build → webpack (was: webpack → BFF)
   - New "Build & Start Module Frontend Servers" step with `ALLOWED_DIRS` security validation
   - webpack now uses `start:dev:ci` with `LOCAL_MODULES` in env
   - Added "Stop Module Frontend Servers" cleanup step

5. **`.claude/rules/module-onboarding.md`** — Document E2E CI requirements for new modules.

### Module Coverage

All 8 BFF-enabled MF packages already have the required `cypress:server:build`/`cypress:server` scripts — no package.json changes needed:

| Package | MF Name | FE Port | BFF Port |
|---------|---------|---------|----------|
| agent-ops | agentOps | 9111 | 4021 |
| automl | automl | 9108 | 4003 |
| autorag | autorag | 9107 | 4001 |
| eval-hub | evalHub | 9106 | 4002 |
| gen-ai | genAi | 9102 | 8080 |
| maas | maas | 9104 | 8081 |
| mlflow | mlflow | 9110 | 4020 |
| model-registry | modelRegistry | 9100 | 4000 |

## How Has This Been Tested?

- Verified `moduleFederationConfig` now discovers all 11 MF configs (was 2) and 8 BFF port mappings via a Node.js test script
- Verified `LOCAL_MODULES` proxy generation produces correct per-module entries when set
- Verified that without `LOCAL_MODULES`, behavior is identical to current (catch-all only)
- Reviewed CI workflow step ordering and cleanup logic against existing BFF patterns

## Test Impact

No new automated tests added. This change fixes the E2E CI infrastructure so that *existing* E2E tests actually exercise PR code for module packages. The fix is verified by the E2E tests themselves — when a PR changes a module's UI, the tests should now pass (previously they would fail because the cluster served old code).

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * E2E CI workflow now detects and locally serves federated modules with automatic traffic routing.
  * Dev server supports proxying requests to locally-served federated module backends.

* **Documentation**
  * Updated module onboarding guide with E2E CI local module serving checklist and setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->