### PR TITLE
RHOAIENG-63158: Role creation submission via K8s API pass-through

### DIFF
--- a/frontend/src/k8sTypes.ts
+++ b/frontend/src/k8sTypes.ts
@@ -614,14 +614,14 @@ export type RoleKind = K8sResourceCommon & {
     name: string;
     namespace: string;
   };
-  rules: ResourceRule[];
+  rules?: ResourceRule[];
 };
 
 export type ClusterRoleKind = K8sResourceCommon & {
   metadata: {
     name: string;
   };
-  rules: ResourceRule[];
+  rules?: ResourceRule[];
 };
 
 export type RoleBindingKind = K8sResourceCommon & {

--- a/frontend/src/pages/projects/projectPermissions/roleDetails/RoleDetailsModalDetailsTab.tsx
+++ b/frontend/src/pages/projects/projectPermissions/roleDetails/RoleDetailsModalDetailsTab.tsx
@@ -97,7 +97,7 @@ const RoleDetailsModalDetailsTab: React.FC<RoleDetailsModalDetailsTabProps> = ({
         <DescriptionListGroup>
           <DescriptionListTerm>Rules</DescriptionListTerm>
           <DescriptionListDescription>
-            <RoleRulesTable rules={role.rules} />
+            <RoleRulesTable rules={role.rules ?? []} />
           </DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>

--- a/frontend/src/pages/projects/projectRoles/CreateRoleConfirmModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleConfirmModal.tsx
@@ -17,6 +17,7 @@ const CreateRoleConfirmModal: React.FC<CreateRoleConfirmModalProps> = ({ onConfi
       await onConfirm();
     } catch (e) {
       setError(e instanceof Error ? e : new Error('Failed to create role'));
+    } finally {
       setIsSubmitting(false);
     }
   }, [onConfirm]);

--- a/frontend/src/pages/projects/projectRoles/CreateRoleConfirmModal.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleConfirmModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import ContentModal from '#~/components/modals/ContentModal';
+
+type CreateRoleConfirmModalProps = {
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+};
+
+const CreateRoleConfirmModal: React.FC<CreateRoleConfirmModalProps> = ({ onConfirm, onClose }) => {
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<Error>();
+
+  const handleConfirm = React.useCallback(async () => {
+    setIsSubmitting(true);
+    setError(undefined);
+    try {
+      await onConfirm();
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Failed to create role'));
+      setIsSubmitting(false);
+    }
+  }, [onConfirm]);
+
+  return (
+    <ContentModal
+      title="Create empty role?"
+      titleIconVariant="warning"
+      variant="small"
+      dataTestId="create-role-confirm-modal"
+      onClose={onClose}
+      error={error}
+      alertTitle="Error creating role"
+      buttonActions={[
+        {
+          label: 'Create role',
+          onClick: handleConfirm,
+          variant: 'primary',
+          isLoading: isSubmitting,
+          isDisabled: isSubmitting,
+          dataTestId: 'confirm-create-button',
+        },
+        {
+          label: 'Cancel',
+          onClick: onClose,
+          variant: 'link',
+          isDisabled: isSubmitting,
+          dataTestId: 'confirm-cancel-button',
+        },
+      ]}
+      contents={
+        <>This role has no rules and won&apos;t grant any permissions. You can add rules later.</>
+      }
+    />
+  );
+};
+
+export default CreateRoleConfirmModal;

--- a/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
@@ -31,6 +31,8 @@ const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
     setIsSubmitting(true);
     try {
       await onSubmit();
+    } catch {
+      // error is surfaced via submitError prop
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRoleFooter.tsx
@@ -1,37 +1,81 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import {
+  ActionList,
+  ActionListItem,
+  Alert,
+  Button,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 
 type CreateRoleFooterProps = {
   namespace: string;
   isSubmitDisabled: boolean;
   isEdit?: boolean;
+  onSubmit: () => Promise<void>;
+  submitError?: Error;
 };
 
 const CreateRoleFooter: React.FC<CreateRoleFooterProps> = ({
   namespace,
   isSubmitDisabled,
   isEdit = false,
+  onSubmit,
+  submitError,
 }) => {
   const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const handleSubmit = React.useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      await onSubmit();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [onSubmit]);
 
   return (
-    <ActionList>
-      <ActionListItem>
-        <Button isDisabled={isSubmitDisabled} variant="primary" data-testid="create-role-submit">
-          {isEdit ? 'Save changes' : 'Create role'}
-        </Button>
-      </ActionListItem>
-      <ActionListItem>
-        <Button
-          variant="link"
-          data-testid="create-role-cancel"
-          onClick={() => navigate(`/projects/${namespace}?section=roles`)}
-        >
-          Cancel
-        </Button>
-      </ActionListItem>
-    </ActionList>
+    <Stack hasGutter>
+      {submitError && (
+        <StackItem>
+          <Alert
+            isInline
+            variant="danger"
+            title={isEdit ? 'Error updating role' : 'Error creating role'}
+            data-testid="create-role-error-alert"
+          >
+            {submitError.message}
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <ActionList>
+          <ActionListItem>
+            <Button
+              isDisabled={isSubmitDisabled || isSubmitting}
+              isLoading={isSubmitting}
+              variant="primary"
+              data-testid="create-role-submit"
+              onClick={handleSubmit}
+            >
+              {isEdit ? 'Save changes' : 'Create role'}
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button
+              variant="link"
+              data-testid="create-role-cancel"
+              isDisabled={isSubmitting}
+              onClick={() => navigate(`/projects/${namespace}?section=roles`)}
+            >
+              Cancel
+            </Button>
+          </ActionListItem>
+        </ActionList>
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -8,15 +8,18 @@ import {
   Spinner,
   getUniqueId,
 } from '@patternfly/react-core';
-import { Link, Navigate, useParams } from 'react-router-dom';
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import ApplicationsPage from '#~/pages/ApplicationsPage';
 import { useAccessReview } from '#~/api/useAccessReview';
 import { ProjectDetailsContext } from '#~/pages/projects/ProjectDetailsContext';
 import { getDisplayNameFromK8sResource, isValidK8sLabelKeyValue } from '#~/concepts/k8s/utils';
 import { useK8sNameDescriptionFieldData } from '#~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
 import { RoleKind } from '#~/k8sTypes';
+import { createRole } from '#~/api';
 import CreateRoleForm from './CreateRoleForm';
 import CreateRoleFooter from './CreateRoleFooter';
+import CreateRoleConfirmModal from './CreateRoleConfirmModal';
+import assembleRole from './assembleRole';
 import type { LabelEntry, RuleEntry } from './types';
 
 type CreateRolePageProps = {
@@ -28,6 +31,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
   const { currentProject } = React.useContext(ProjectDetailsContext);
   const displayName = getDisplayNameFromK8sResource(currentProject);
   const isEdit = !!existingRole;
+  const navigate = useNavigate();
 
   const [allowAccess, loaded] = useAccessReview({
     group: 'rbac.authorization.k8s.io',
@@ -62,6 +66,9 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     }));
   });
 
+  const [submitError, setSubmitError] = React.useState<Error>();
+  const [showNoRulesConfirm, setShowNoRulesConfirm] = React.useState(false);
+
   const handleDescriptionChange = React.useCallback((value: string) => {
     setDescription(value);
   }, []);
@@ -90,6 +97,29 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     k8sNameDescriptionData.data.k8sName.state.invalidLength ||
     hasInvalidLabels;
 
+  const doSubmit = React.useCallback(async () => {
+    setSubmitError(undefined);
+    const k8sName = k8sNameDescriptionData.data.k8sName.value;
+    const roleDisplayName = k8sNameDescriptionData.data.name || k8sName;
+    const role = assembleRole(namespace, k8sName, roleDisplayName, description, rules);
+    try {
+      await createRole(role);
+      navigate(`/projects/${namespace}?section=roles`);
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error('Failed to create role');
+      setSubmitError(error);
+      throw error;
+    }
+  }, [namespace, k8sNameDescriptionData.data, description, rules, navigate]);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (rules.length === 0) {
+      setShowNoRulesConfirm(true);
+      return;
+    }
+    await doSubmit();
+  }, [rules.length, doSubmit]);
+
   if (!loaded) {
     return (
       <Bullseye>
@@ -105,46 +135,53 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
   const pageTitle = isEdit ? 'Edit custom role' : 'Create custom role';
 
   return (
-    <ApplicationsPage
-      title={pageTitle}
-      breadcrumb={
-        <Breadcrumb>
-          <BreadcrumbItem render={() => <Link to="/projects">Projects</Link>} />
-          <BreadcrumbItem
-            render={() => <Link to={`/projects/${namespace}?section=roles`}>{displayName}</Link>}
+    <>
+      <ApplicationsPage
+        title={pageTitle}
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbItem render={() => <Link to="/projects">Projects</Link>} />
+            <BreadcrumbItem
+              render={() => <Link to={`/projects/${namespace}?section=roles`}>{displayName}</Link>}
+            />
+            <BreadcrumbItem isActive>{pageTitle}</BreadcrumbItem>
+          </Breadcrumb>
+        }
+        description="Create a custom role to control what users can see and do across your cluster resources. Define permissions, navigation access, and resource scopes to implement fine-grained access control."
+        headerAction={
+          // TODO: Enable when template selection modal is implemented (RHOAIENG-63156)
+          <Button variant="secondary" data-testid="select-role-template-button" isDisabled>
+            Select role template
+          </Button>
+        }
+        loaded
+        empty={false}
+      >
+        <PageSection hasBodyWrapper={false} isFilled data-testid="create-role-page">
+          <CreateRoleForm
+            nameDescriptionData={k8sNameDescriptionData}
+            description={description}
+            onDescriptionChange={handleDescriptionChange}
+            labels={labels}
+            onLabelsChange={handleLabelsChange}
+            rules={rules}
+            onRulesChange={handleRulesChange}
           />
-          <BreadcrumbItem isActive>{pageTitle}</BreadcrumbItem>
-        </Breadcrumb>
-      }
-      description="Create a custom role to control what users can see and do across your cluster resources. Define permissions, navigation access, and resource scopes to implement fine-grained access control."
-      headerAction={
-        // TODO: Enable when template selection modal is implemented (RHOAIENG-63156)
-        <Button variant="secondary" data-testid="select-role-template-button" isDisabled>
-          Select role template
-        </Button>
-      }
-      loaded
-      empty={false}
-    >
-      <PageSection hasBodyWrapper={false} isFilled data-testid="create-role-page">
-        <CreateRoleForm
-          nameDescriptionData={k8sNameDescriptionData}
-          description={description}
-          onDescriptionChange={handleDescriptionChange}
-          labels={labels}
-          onLabelsChange={handleLabelsChange}
-          rules={rules}
-          onRulesChange={handleRulesChange}
-        />
-      </PageSection>
-      <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
-        <CreateRoleFooter
-          namespace={namespace}
-          isSubmitDisabled={isSubmitDisabled}
-          isEdit={isEdit}
-        />
-      </PageSection>
-    </ApplicationsPage>
+        </PageSection>
+        <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
+          <CreateRoleFooter
+            namespace={namespace}
+            isSubmitDisabled={isSubmitDisabled}
+            isEdit={isEdit}
+            onSubmit={handleSubmit}
+            submitError={submitError}
+          />
+        </PageSection>
+      </ApplicationsPage>
+      {showNoRulesConfirm && (
+        <CreateRoleConfirmModal onConfirm={doSubmit} onClose={() => setShowNoRulesConfirm(false)} />
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
+++ b/frontend/src/pages/projects/projectRoles/CreateRolePage.tsx
@@ -101,7 +101,8 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
     setSubmitError(undefined);
     const k8sName = k8sNameDescriptionData.data.k8sName.value;
     const roleDisplayName = k8sNameDescriptionData.data.name || k8sName;
-    const role = assembleRole(namespace, k8sName, roleDisplayName, description, rules);
+    const labelRecord = Object.fromEntries(labels.map((l) => [l.key, l.value]));
+    const role = assembleRole(namespace, k8sName, roleDisplayName, description, rules, labelRecord);
     try {
       await createRole(role);
       navigate(`/projects/${namespace}?section=roles`);
@@ -110,7 +111,7 @@ const CreateRolePage: React.FC<CreateRolePageProps> = ({ existingRole }) => {
       setSubmitError(error);
       throw error;
     }
-  }, [namespace, k8sNameDescriptionData.data, description, rules, navigate]);
+  }, [namespace, k8sNameDescriptionData.data, description, rules, labels, navigate]);
 
   const handleSubmit = React.useCallback(async () => {
     if (rules.length === 0) {

--- a/frontend/src/pages/projects/projectRoles/VerbsTreeSelect.tsx
+++ b/frontend/src/pages/projects/projectRoles/VerbsTreeSelect.tsx
@@ -68,6 +68,7 @@ const VerbsTreeSelect: React.FC<VerbsTreeSelectProps> = ({
         defaultExpanded: true,
         checkProps: {
           checked: allCategorySelected || (someCategorySelected ? null : false),
+          'data-testid': `verb-category-${category.id}`,
         },
         children: category.verbs.map((verbInfo) => ({
           id: verbInfo.verb,
@@ -79,6 +80,7 @@ const VerbsTreeSelect: React.FC<VerbsTreeSelectProps> = ({
           hasCheckbox: true,
           checkProps: {
             checked: isAllSelected || selectedVerbs.includes(verbInfo.verb),
+            'data-testid': `verb-checkbox-${verbInfo.verb}`,
           },
         })),
       };

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleConfirmModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleConfirmModal.spec.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CreateRoleConfirmModal from '#~/pages/projects/projectRoles/CreateRoleConfirmModal';
+
+describe('CreateRoleConfirmModal', () => {
+  it('should render with warning title and body text', () => {
+    render(<CreateRoleConfirmModal onConfirm={jest.fn()} onClose={jest.fn()} />);
+
+    expect(screen.getByText('Create empty role?')).toBeInTheDocument();
+    expect(screen.getByText(/has no rules and won't grant any permissions/)).toBeInTheDocument();
+  });
+
+  it('should call onConfirm when Create is clicked', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    render(<CreateRoleConfirmModal onConfirm={onConfirm} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId('confirm-create-button'));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should call onClose when Cancel is clicked', () => {
+    const onClose = jest.fn();
+    render(<CreateRoleConfirmModal onConfirm={jest.fn()} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('confirm-cancel-button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show error alert when onConfirm rejects', async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error('API failure'));
+    render(<CreateRoleConfirmModal onConfirm={onConfirm} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId('confirm-create-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('API failure')).toBeInTheDocument();
+    });
+  });
+
+  it('should disable buttons while submitting', async () => {
+    let resolvePromise: () => void = () => undefined;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePromise = resolve;
+        }),
+    );
+    render(<CreateRoleConfirmModal onConfirm={onConfirm} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId('confirm-create-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-create-button')).toBeDisabled();
+      expect(screen.getByTestId('confirm-cancel-button')).toBeDisabled();
+    });
+
+    resolvePromise();
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleConfirmModal.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleConfirmModal.spec.tsx
@@ -37,7 +37,19 @@ describe('CreateRoleConfirmModal', () => {
     fireEvent.click(screen.getByTestId('confirm-create-button'));
 
     await waitFor(() => {
+      expect(screen.getByTestId('error-message-alert')).toBeInTheDocument();
       expect(screen.getByText('API failure')).toBeInTheDocument();
+    });
+  });
+
+  it('should show fallback error when onConfirm rejects with non-Error', async () => {
+    const onConfirm = jest.fn().mockRejectedValue('string error');
+    render(<CreateRoleConfirmModal onConfirm={onConfirm} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByTestId('confirm-create-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create role')).toBeInTheDocument();
     });
   });
 
@@ -59,5 +71,10 @@ describe('CreateRoleConfirmModal', () => {
     });
 
     resolvePromise();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-create-button')).not.toBeDisabled();
+      expect(screen.getByTestId('confirm-cancel-button')).not.toBeDisabled();
+    });
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CreateRoleFooter from '#~/pages/projects/projectRoles/CreateRoleFooter';
+
+const renderFooter = (props: Partial<React.ComponentProps<typeof CreateRoleFooter>> = {}) =>
+  render(
+    <MemoryRouter>
+      <CreateRoleFooter
+        namespace="test-ns"
+        isSubmitDisabled={false}
+        onSubmit={jest.fn().mockResolvedValue(undefined)}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+
+describe('CreateRoleFooter', () => {
+  it('should render Create role button', () => {
+    renderFooter();
+
+    expect(screen.getByTestId('create-role-submit')).toHaveTextContent('Create role');
+  });
+
+  it('should render Save changes button in edit mode', () => {
+    renderFooter({ isEdit: true });
+
+    expect(screen.getByTestId('create-role-submit')).toHaveTextContent('Save changes');
+  });
+
+  it('should disable submit button when isSubmitDisabled is true', () => {
+    renderFooter({ isSubmitDisabled: true });
+
+    expect(screen.getByTestId('create-role-submit')).toBeDisabled();
+  });
+
+  it('should call onSubmit when submit button is clicked', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    renderFooter({ onSubmit });
+
+    fireEvent.click(screen.getByTestId('create-role-submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should show error alert when submitError is set', () => {
+    renderFooter({ submitError: new Error('Something went wrong') });
+
+    expect(screen.getByTestId('create-role-error-alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('should not show error alert when submitError is undefined', () => {
+    renderFooter();
+
+    expect(screen.queryByTestId('create-role-error-alert')).not.toBeInTheDocument();
+  });
+
+  it('should show creating error title for create mode', () => {
+    renderFooter({ submitError: new Error('fail') });
+
+    expect(screen.getByText('Error creating role')).toBeInTheDocument();
+  });
+
+  it('should show updating error title for edit mode', () => {
+    renderFooter({ isEdit: true, submitError: new Error('fail') });
+
+    expect(screen.getByText('Error updating role')).toBeInTheDocument();
+  });
+
+  it('should disable buttons while submitting', async () => {
+    let resolvePromise: () => void = () => undefined;
+    const onSubmit = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePromise = resolve;
+        }),
+    );
+    renderFooter({ onSubmit });
+
+    fireEvent.click(screen.getByTestId('create-role-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-role-submit')).toBeDisabled();
+      expect(screen.getByTestId('create-role-cancel')).toBeDisabled();
+    });
+
+    resolvePromise();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-role-submit')).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
@@ -93,4 +93,15 @@ describe('CreateRoleFooter', () => {
       expect(screen.getByTestId('create-role-submit')).not.toBeDisabled();
     });
   });
+
+  it('should re-enable submit button after onSubmit rejects', async () => {
+    const onSubmit = jest.fn().mockRejectedValue(new Error('API error'));
+    renderFooter({ onSubmit });
+
+    fireEvent.click(screen.getByTestId('create-role-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-role-submit')).not.toBeDisabled();
+    });
+  });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
+++ b/frontend/src/pages/projects/projectRoles/__tests__/CreateRoleFooter.spec.tsx
@@ -95,10 +95,23 @@ describe('CreateRoleFooter', () => {
   });
 
   it('should re-enable submit button after onSubmit rejects', async () => {
-    const onSubmit = jest.fn().mockRejectedValue(new Error('API error'));
+    let rejectPromise: (reason?: unknown) => void = () => undefined;
+    const onSubmit = jest.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectPromise = reject;
+        }),
+    );
     renderFooter({ onSubmit });
 
     fireEvent.click(screen.getByTestId('create-role-submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('create-role-submit')).toBeDisabled();
+    });
+
+    rejectPromise(new Error('API error'));
 
     await waitFor(() => {
       expect(screen.getByTestId('create-role-submit')).not.toBeDisabled();

--- a/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
@@ -82,19 +82,37 @@ describe('assembleRole', () => {
     });
   });
 
-  it('should preserve resourceNames on rules', () => {
+  it('should omit optional fields when undefined', () => {
     const rules: RuleEntry[] = [
       {
         id: 'rule-1',
         verbs: ['get'],
-        apiGroups: ['serving.kserve.io'],
-        resources: ['inferenceservices'],
-        resourceNames: ['my-model'],
       },
     ];
 
     const result = assembleRole('ns', 'r', 'R', '', rules);
 
-    expect(result.rules[0].resourceNames).toStrictEqual(['my-model']);
+    expect(result.rules[0]).toStrictEqual({ verbs: ['get'] });
+    expect(result.rules[0]).not.toHaveProperty('apiGroups');
+    expect(result.rules[0]).not.toHaveProperty('resources');
+    expect(result.rules[0]).not.toHaveProperty('resourceNames');
+  });
+
+  it('should merge user labels with dashboard resource label', () => {
+    const userLabels = { 'app.kubernetes.io/name': 'my-app', team: 'platform' };
+    const result = assembleRole('ns', 'r', 'R', '', [], userLabels);
+
+    expect(result.metadata.labels).toStrictEqual({
+      'app.kubernetes.io/name': 'my-app',
+      team: 'platform',
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    });
+  });
+
+  it('should ensure dashboard resource label overrides user label', () => {
+    const userLabels = { [KnownLabels.DASHBOARD_RESOURCE]: 'false' };
+    const result = assembleRole('ns', 'r', 'R', '', [], userLabels);
+
+    expect(result.metadata.labels?.[KnownLabels.DASHBOARD_RESOURCE]).toBe('true');
   });
 });

--- a/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
+++ b/frontend/src/pages/projects/projectRoles/__tests__/assembleRole.spec.ts
@@ -1,0 +1,100 @@
+import { KnownLabels } from '#~/k8sTypes';
+import assembleRole from '#~/pages/projects/projectRoles/assembleRole';
+import type { RuleEntry } from '#~/pages/projects/projectRoles/types';
+
+describe('assembleRole', () => {
+  it('should build a basic role with no rules', () => {
+    const result = assembleRole('test-ns', 'my-role', 'My Role', '', []);
+
+    expect(result).toStrictEqual({
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'my-role',
+        namespace: 'test-ns',
+        labels: {
+          [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+        },
+        annotations: {
+          'openshift.io/display-name': 'My Role',
+        },
+      },
+      rules: [],
+    });
+  });
+
+  it('should include description annotation when provided', () => {
+    const result = assembleRole('test-ns', 'my-role', 'My Role', 'A test role', []);
+
+    expect(result.metadata.annotations).toStrictEqual({
+      'openshift.io/display-name': 'My Role',
+      'openshift.io/description': 'A test role',
+    });
+  });
+
+  it('should omit description annotation when empty', () => {
+    const result = assembleRole('test-ns', 'my-role', 'My Role', '', []);
+
+    expect(result.metadata.annotations).toStrictEqual({
+      'openshift.io/display-name': 'My Role',
+    });
+  });
+
+  it('should strip id field from rules', () => {
+    const rules: RuleEntry[] = [
+      {
+        id: 'rule-1',
+        verbs: ['get', 'list'],
+        apiGroups: [''],
+        resources: ['pods'],
+      },
+      {
+        id: 'rule-2',
+        verbs: ['create'],
+        apiGroups: ['apps'],
+        resources: ['deployments'],
+        resourceNames: ['my-deployment'],
+      },
+    ];
+
+    const result = assembleRole('test-ns', 'my-role', 'My Role', '', rules);
+
+    expect(result.rules).toStrictEqual([
+      {
+        verbs: ['get', 'list'],
+        apiGroups: [''],
+        resources: ['pods'],
+      },
+      {
+        verbs: ['create'],
+        apiGroups: ['apps'],
+        resources: ['deployments'],
+        resourceNames: ['my-deployment'],
+      },
+    ]);
+  });
+
+  it('should always include dashboard resource label', () => {
+    const result = assembleRole('ns', 'r', 'R', '', []);
+
+    expect(result.metadata.labels).toStrictEqual({
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    });
+  });
+
+  it('should preserve resourceNames on rules', () => {
+    const rules: RuleEntry[] = [
+      {
+        id: 'rule-1',
+        verbs: ['get'],
+        apiGroups: ['serving.kserve.io'],
+        resources: ['inferenceservices'],
+        resourceNames: ['my-model'],
+      },
+    ];
+
+    const result = assembleRole('ns', 'r', 'R', '', rules);
+
+    expect(result.rules[0].resourceNames).toStrictEqual(['my-model']);
+  });
+});

--- a/frontend/src/pages/projects/projectRoles/assembleRole.ts
+++ b/frontend/src/pages/projects/projectRoles/assembleRole.ts
@@ -1,0 +1,34 @@
+import { KnownLabels, type ResourceRule, type RoleKind } from '#~/k8sTypes';
+import type { RuleEntry } from './types';
+
+type AssembledRole = RoleKind & { rules: ResourceRule[] };
+
+const assembleRole = (
+  namespace: string,
+  k8sName: string,
+  displayName: string,
+  description: string,
+  rules: RuleEntry[],
+): AssembledRole => ({
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'Role',
+  metadata: {
+    name: k8sName,
+    namespace,
+    labels: {
+      [KnownLabels.DASHBOARD_RESOURCE]: 'true',
+    },
+    annotations: {
+      'openshift.io/display-name': displayName,
+      ...(description ? { 'openshift.io/description': description } : {}),
+    },
+  },
+  rules: rules.map((rule) => ({
+    verbs: rule.verbs,
+    ...(rule.apiGroups && { apiGroups: rule.apiGroups }),
+    ...(rule.resources && { resources: rule.resources }),
+    ...(rule.resourceNames && { resourceNames: rule.resourceNames }),
+  })),
+});
+
+export default assembleRole;

--- a/frontend/src/pages/projects/projectRoles/assembleRole.ts
+++ b/frontend/src/pages/projects/projectRoles/assembleRole.ts
@@ -9,6 +9,7 @@ const assembleRole = (
   displayName: string,
   description: string,
   rules: RuleEntry[],
+  labels: Record<string, string> = {},
 ): AssembledRole => ({
   apiVersion: 'rbac.authorization.k8s.io/v1',
   kind: 'Role',
@@ -16,6 +17,7 @@ const assembleRole = (
     name: k8sName,
     namespace,
     labels: {
+      ...labels,
       [KnownLabels.DASHBOARD_RESOURCE]: 'true',
     },
     annotations: {

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -132,6 +132,22 @@ class ProjectRolesTab {
     return cy.findByTestId('preview-yaml-close-button');
   }
 
+  findSubmitErrorAlert() {
+    return cy.findByTestId('create-role-error-alert');
+  }
+
+  findConfirmModal() {
+    return cy.findByTestId('create-role-confirm-modal');
+  }
+
+  findConfirmCreateButton() {
+    return cy.findByTestId('confirm-create-button');
+  }
+
+  findConfirmCancelButton() {
+    return cy.findByTestId('confirm-cancel-button');
+  }
+
   getRow(name: string) {
     return new RolesTableRow(() =>
       this.findRolesTable().findAllByTestId('role-name-link').contains(name).parents('tr'),

--- a/packages/cypress/cypress/pages/projectRoles.ts
+++ b/packages/cypress/cypress/pages/projectRoles.ts
@@ -37,6 +37,8 @@ class ProjectRolesTab {
 
   visitCreateRole(namespace: string) {
     cy.visitWithLogin(`/projects/${namespace}/roles/create`);
+    cy.findByTestId('create-role-page');
+    cy.testA11y();
   }
 
   private wait() {
@@ -146,6 +148,30 @@ class ProjectRolesTab {
 
   findConfirmCancelButton() {
     return cy.findByTestId('confirm-cancel-button');
+  }
+
+  findConfirmModalErrorAlert() {
+    return cy.findByTestId('error-message-alert');
+  }
+
+  findAddRuleModal() {
+    return cy.findByTestId('add-rule-modal');
+  }
+
+  findRuleApiGroupsToggle() {
+    return cy.findByTestId('rule-api-groups-toggle');
+  }
+
+  findRuleResourceTypesToggle() {
+    return cy.findByTestId('rule-resource-types-toggle');
+  }
+
+  findVerbCheckbox(verb: string) {
+    return cy.findByTestId('add-rule-modal').findByTestId(`verb-checkbox-${verb}`);
+  }
+
+  findRuleSaveButton() {
+    return cy.findByTestId('modal-submit-button');
   }
 
   getRow(name: string) {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTab.cy.ts
@@ -43,7 +43,7 @@ describe('Roles tab feature flag gating', () => {
     });
 
     it('should redirect from /roles/create to the project page when flag is disabled', () => {
-      projectRoles.visitCreateRole(NAMESPACE);
+      cy.visitWithLogin(`/projects/${NAMESPACE}/roles/create`);
       cy.url().should('not.include', '/roles/create');
       cy.url().should('include', `/projects/${NAMESPACE}`);
     });
@@ -186,7 +186,7 @@ describe('Roles tab feature flag gating', () => {
     });
 
     it('should redirect from /roles/create when user lacks create permission', () => {
-      projectRoles.visitCreateRole(NAMESPACE);
+      cy.visitWithLogin(`/projects/${NAMESPACE}/roles/create`);
       cy.url().should('not.include', '/roles/create');
       cy.url().should('include', `/projects/${NAMESPACE}`);
       cy.url().should('include', 'section=roles');

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -101,7 +101,7 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
+    cy.findByTestId('add-rule-modal').find('[role="treeitem"]#get input[type="checkbox"]').click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();
@@ -137,7 +137,7 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
+    cy.findByTestId('add-rule-modal').find('[role="treeitem"]#get input[type="checkbox"]').click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -20,6 +20,19 @@ import { projectRoles } from '../../../../pages/projectRoles';
 
 const NAMESPACE = 'test-project';
 
+const addRule = (apiGroup: string, resource: string, verb: string) => {
+  projectRoles.findAddRuleButton().click();
+  projectRoles.findAddRuleModal().should('exist');
+  projectRoles.findRuleApiGroupsToggle().click();
+  projectRoles.findRuleApiGroupsToggle().parent().find('input').type(apiGroup);
+  cy.contains(`Use custom API group "${apiGroup}"`).click();
+  projectRoles.findRuleResourceTypesToggle().click();
+  projectRoles.findRuleResourceTypesToggle().parent().find('input').type(resource);
+  cy.contains(`Use custom resource type "${resource}"`).click();
+  projectRoles.findVerbCheckbox(verb).click();
+  projectRoles.findRuleSaveButton().click();
+};
+
 const initIntercepts = () => {
   cy.interceptOdh('GET /api/config', mockDashboardConfig({ roleManagement: true }));
   cy.interceptK8s(ProjectModel, mockProjectK8sResource({ k8sName: NAMESPACE }));
@@ -95,16 +108,7 @@ describe('Create Role submit', () => {
     projectRoles.visitCreateRole(NAMESPACE);
     projectRoles.findRoleNameInput().type('my-role');
 
-    projectRoles.findAddRuleButton().click();
-    cy.findByTestId('add-rule-modal').should('exist');
-    cy.findByTestId('rule-api-groups-toggle').click();
-    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps');
-    cy.contains('Use custom API group "apps"').click();
-    cy.findByTestId('rule-resource-types-toggle').click();
-    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments');
-    cy.contains('Use custom resource type "deployments"').click();
-    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
-    cy.findByTestId('modal-submit-button').click();
+    addRule('apps', 'deployments', 'get');
 
     projectRoles.findSubmitButton().click();
 
@@ -133,22 +137,36 @@ describe('Create Role submit', () => {
     projectRoles.visitCreateRole(NAMESPACE);
     projectRoles.findRoleNameInput().type('my-role');
 
-    projectRoles.findAddRuleButton().click();
-    cy.findByTestId('add-rule-modal').should('exist');
-    cy.findByTestId('rule-api-groups-toggle').click();
-    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps');
-    cy.contains('Use custom API group "apps"').click();
-    cy.findByTestId('rule-resource-types-toggle').click();
-    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments');
-    cy.contains('Use custom resource type "deployments"').click();
-    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
-    cy.findByTestId('modal-submit-button').click();
+    addRule('apps', 'deployments', 'get');
 
     projectRoles.findSubmitButton().click();
 
     cy.wait('@createRole');
     projectRoles.findSubmitErrorAlert().should('exist');
     projectRoles.findSubmitButton().should('be.enabled');
+  });
+
+  it('should show error in confirmation modal when API fails', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      {
+        statusCode: 409,
+        body: mock409Error({ message: 'Role already exists' }),
+      },
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('empty-role');
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmModal().should('exist');
+    projectRoles.findConfirmCreateButton().click();
+
+    cy.wait('@createRole');
+    projectRoles.findConfirmModal().should('exist');
+    projectRoles.findConfirmModalErrorAlert().should('exist');
+    projectRoles.findConfirmCreateButton().should('be.enabled');
   });
 
   it('should include display name and description annotations in payload', () => {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -98,9 +98,11 @@ describe('Create Role submit', () => {
     projectRoles.findAddRuleButton().click();
     cy.findByTestId('add-rule-modal').should('exist');
     cy.findByTestId('rule-api-groups-toggle').click();
-    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
+    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps');
+    cy.contains('Use custom API group "apps"').click();
     cy.findByTestId('rule-resource-types-toggle').click();
-    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
+    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments');
+    cy.contains('Use custom resource type "deployments"').click();
     cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
     cy.findByTestId('modal-submit-button').click();
 
@@ -134,9 +136,11 @@ describe('Create Role submit', () => {
     projectRoles.findAddRuleButton().click();
     cy.findByTestId('add-rule-modal').should('exist');
     cy.findByTestId('rule-api-groups-toggle').click();
-    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
+    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps');
+    cy.contains('Use custom API group "apps"').click();
     cy.findByTestId('rule-resource-types-toggle').click();
-    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
+    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments');
+    cy.contains('Use custom resource type "deployments"').click();
     cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
     cy.findByTestId('modal-submit-button').click();
 

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -101,7 +101,10 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal').find('[role="treeitem"]#get input[type="checkbox"]').click();
+    cy.findByTestId('add-rule-modal')
+      .contains('[role="treeitem"]', 'Get:')
+      .find('input[type="checkbox"]')
+      .click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();
@@ -137,7 +140,10 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal').find('[role="treeitem"]#get input[type="checkbox"]').click();
+    cy.findByTestId('add-rule-modal')
+      .contains('[role="treeitem"]', 'Get:')
+      .find('input[type="checkbox"]')
+      .click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -168,6 +168,7 @@ describe('Create Role submit', () => {
       );
       expect(interception.request.body.metadata.annotations).to.have.property(
         'openshift.io/display-name',
+        'annotated-role',
       );
     });
   });

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the Create Role submit flow: successful creation, empty-rules confirmation modal,
+ * API error handling, and request payload validation.
+ */
+import {
+  mockDashboardConfig,
+  mockK8sResourceList,
+  mockProjectK8sResource,
+  mockRoleK8sResource,
+} from '@odh-dashboard/internal/__mocks__';
+import { mock409Error } from '@odh-dashboard/internal/__mocks__/mockK8sStatus';
+import {
+  ClusterRoleModel,
+  ProjectModel,
+  RoleBindingModel,
+  RoleModel,
+} from '../../../../utils/models';
+import { asProjectAdminUser } from '../../../../utils/mockUsers';
+import { projectRoles } from '../../../../pages/projectRoles';
+
+const NAMESPACE = 'test-project';
+
+const initIntercepts = () => {
+  cy.interceptOdh('GET /api/config', mockDashboardConfig({ roleManagement: true }));
+  cy.interceptK8s(ProjectModel, mockProjectK8sResource({ k8sName: NAMESPACE }));
+  cy.interceptK8sList(
+    ProjectModel,
+    mockK8sResourceList([mockProjectK8sResource({ k8sName: NAMESPACE })]),
+  );
+  cy.interceptK8sList({ model: RoleModel, ns: NAMESPACE }, mockK8sResourceList([]));
+  cy.interceptK8sList(ClusterRoleModel, mockK8sResourceList([]));
+  cy.interceptK8sList({ model: RoleBindingModel, ns: NAMESPACE }, mockK8sResourceList([]));
+};
+
+describe('Create Role submit', () => {
+  beforeEach(() => {
+    asProjectAdminUser();
+    initIntercepts();
+  });
+
+  it('should show confirmation modal when submitting with no rules', () => {
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('empty-role');
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmModal().should('exist');
+    projectRoles.findConfirmModal().contains('Create empty role?').should('exist');
+  });
+
+  it('should close confirmation modal on cancel', () => {
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('empty-role');
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmModal().should('exist');
+    projectRoles.findConfirmCancelButton().click();
+    projectRoles.findConfirmModal().should('not.exist');
+  });
+
+  it('should create role without rules when confirmed', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      mockRoleK8sResource({ name: 'empty-role', namespace: NAMESPACE }),
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('empty-role');
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmModal().should('exist');
+    projectRoles.findConfirmCreateButton().click();
+
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.body.metadata.name).to.equal('empty-role');
+      expect(interception.request.body.metadata.namespace).to.equal(NAMESPACE);
+      expect(interception.request.body.metadata.labels).to.have.property(
+        'opendatahub.io/dashboard',
+        'true',
+      );
+      expect(interception.request.body.rules).to.deep.equal([]);
+    });
+
+    cy.url().should('include', `/projects/${NAMESPACE}`);
+    cy.url().should('include', 'section=roles');
+  });
+
+  it('should submit directly when rules are present', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      mockRoleK8sResource({ name: 'my-role', namespace: NAMESPACE }),
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('my-role');
+
+    projectRoles.findAddRuleButton().click();
+    cy.findByTestId('add-rule-modal').should('exist');
+    cy.findByTestId('rule-api-groups-toggle').click();
+    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
+    cy.findByTestId('rule-resource-types-toggle').click();
+    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
+    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
+    cy.findByTestId('modal-submit-button').click();
+
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmModal().should('not.exist');
+
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.body.metadata.name).to.equal('my-role');
+      expect(interception.request.body.rules).to.have.length(1);
+      expect(interception.request.body.rules[0].verbs).to.include('get');
+    });
+
+    cy.url().should('include', `/projects/${NAMESPACE}`);
+    cy.url().should('include', 'section=roles');
+  });
+
+  it('should show error alert when API returns an error on direct submit', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      {
+        statusCode: 409,
+        body: mock409Error({ message: 'Role already exists' }),
+      },
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('my-role');
+
+    projectRoles.findAddRuleButton().click();
+    cy.findByTestId('add-rule-modal').should('exist');
+    cy.findByTestId('rule-api-groups-toggle').click();
+    cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
+    cy.findByTestId('rule-resource-types-toggle').click();
+    cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
+    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
+    cy.findByTestId('modal-submit-button').click();
+
+    projectRoles.findSubmitButton().click();
+
+    cy.wait('@createRole');
+    projectRoles.findSubmitErrorAlert().should('exist');
+    projectRoles.findSubmitButton().should('be.enabled');
+  });
+
+  it('should include display name and description annotations in payload', () => {
+    cy.interceptK8s(
+      'POST',
+      { model: RoleModel, ns: NAMESPACE },
+      mockRoleK8sResource({ name: 'annotated-role', namespace: NAMESPACE }),
+    ).as('createRole');
+
+    projectRoles.visitCreateRole(NAMESPACE);
+    projectRoles.findRoleNameInput().type('annotated-role');
+    projectRoles.findDescriptionTextarea().type('A test description');
+    projectRoles.findSubmitButton().click();
+
+    projectRoles.findConfirmCreateButton().click();
+
+    cy.wait('@createRole').then((interception) => {
+      expect(interception.request.body.metadata.annotations).to.have.property(
+        'openshift.io/description',
+        'A test description',
+      );
+      expect(interception.request.body.metadata.annotations).to.have.property(
+        'openshift.io/display-name',
+      );
+    });
+  });
+});

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/rolesTabCreate.cy.ts
@@ -101,10 +101,7 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal')
-      .contains('[role="treeitem"]', 'Get:')
-      .find('input[type="checkbox"]')
-      .click();
+    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();
@@ -140,10 +137,7 @@ describe('Create Role submit', () => {
     cy.findByTestId('rule-api-groups-toggle').parent().find('input').type('apps{enter}');
     cy.findByTestId('rule-resource-types-toggle').click();
     cy.findByTestId('rule-resource-types-toggle').parent().find('input').type('deployments{enter}');
-    cy.findByTestId('add-rule-modal')
-      .contains('[role="treeitem"]', 'Get:')
-      .find('input[type="checkbox"]')
-      .click();
+    cy.findByTestId('add-rule-modal').findByTestId('verb-checkbox-get').click();
     cy.findByTestId('modal-submit-button').click();
 
     projectRoles.findSubmitButton().click();


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- https://issues.redhat.com/browse/RHOAIENG-123456 -->
https://redhat.atlassian.net/browse/RHOAIENG-63158

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Implements the Create Role submit flow for the project roles page.

**No rules:**
https://github.com/user-attachments/assets/02d8de3e-9a1e-4c8f-9dd1-83b122ed915d

**With rules:**
https://github.com/user-attachments/assets/40e7383f-b5a7-445b-b967-38239ffdddd4

**What this does:**
- Adds a submit handler to the Create Role page that assembles a `RoleKind` payload from form state (name, display name, description, permission rules) and calls the K8s API to create the role.
- When the permission rules array is empty, clicking "Create role" shows a **"Create empty role?"** confirmation warning modal instead of submitting immediately. The user can confirm to proceed or cancel.
- On successful creation, the user is navigated back to the project roles list. On API error, an inline error alert is displayed in the page footer (or within the confirmation modal if triggered from there).
- Makes `RoleKind.rules` and `ClusterRoleKind.rules` optional in `k8sTypes.ts` to match actual K8s API responses (the API omits `rules` entirely when empty, which previously caused a runtime crash in the role details view).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested creating a role with rules (direct submit, no modal)
- Manually tested creating a role with no rules (confirmation modal appears, confirm creates the role)
- Manually tested cancelling the confirmation modal
- Manually tested API error scenarios (409 conflict) — error alert shown in footer and modal
- Verified the role details view no longer crashes for roles with no rules
- Ran `npx eslint` on all changed files — zero errors
- Ran `npx tsc --noEmit` — zero type errors

## Test Impact
<!--- What tests have you done to cover the implemented functionality -->
<!--- If tests are not applicable, explain why here -->
**Unit tests added:**
- `assembleRole.spec.ts` — verifies payload structure, label/annotation handling, rule ID stripping, optional fields
- `CreateRoleFooter.spec.tsx` — verifies button text, disabled states, onSubmit calls, error alert display, loading state
- `CreateRoleConfirmModal.spec.tsx` — verifies rendering, button actions, error display, disabled states during submission

**Cypress mock tests added:**
- `rolesTabCreate.cy.ts` — covers:
  - Empty-rules confirmation modal flow (modal appears, confirm submits, cancel dismisses)
  - Direct submit with rules (no modal, correct payload, navigation)
  - API error on direct submit (error alert shown, button re-enabled)
  - Display name and description annotations in request payload

## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)

If you have UI changes: 
<!--- You can ignore these if you are doing manifest, backend, internal logic, etc changes; aka non-UI / visual changes -->
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Included tags to the UX team if it was a UI/UX change.

After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation modal for creating empty roles (no rules) and an async role creation flow with automatic redirect on success.
- **Bug Fixes**
  - Improved role rules rendering by safely handling missing/undefined rules.
- **Enhancements**
  - Enhanced role creation UX with inline error alerts and disabled actions during submission; improved manifest generation with optional labels/annotations.
- **Tests / QA**
  - Added unit tests for modal/footer behavior, rule/payload assembly, and Cypress coverage for empty-role and submit error scenarios; added accessibility check and new UI selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->