### PR TITLE
Update the target of the image tag to the branch name

### DIFF
--- a/.tekton/mod-arch-maas-push.yaml
+++ b/.tekton/mod-arch-maas-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/mod-arch-maas:v3.4.4-odh
+    value: quay.io/opendatahub/mod-arch-maas:odh-release
   - name: dockerfile
     value: packages/maas/Dockerfile.workspace
   - name: path-context

--- a/.tekton/mod-arch-maas-release-push.yaml
+++ b/.tekton/mod-arch-maas-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/mod-arch-maas:v3.4.4-odh
+    value: quay.io/opendatahub/mod-arch-maas:odh-release
   - name: dockerfile
     value: packages/maas/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-dashboard-push.yaml
+++ b/.tekton/odh-dashboard-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-dashboard:v3.4.4-odh
+    value: quay.io/opendatahub/odh-dashboard:odh-release
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/odh-dashboard-release-push.yaml
+++ b/.tekton/odh-dashboard-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-dashboard:v3.4.4-odh
+    value: quay.io/opendatahub/odh-dashboard:odh-release
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/odh-mod-arch-agent-ops-push.yaml
+++ b/.tekton/odh-mod-arch-agent-ops-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-agent-ops:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-agent-ops:odh-release
   - name: dockerfile
     value: packages/agent-ops/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-automl-ci-on-release-push.yaml
+++ b/.tekton/odh-mod-arch-automl-ci-on-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-automl:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-automl:odh-release
   - name: dockerfile
     value: packages/automl/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-automl-push.yaml
+++ b/.tekton/odh-mod-arch-automl-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-automl:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-automl:odh-release
   - name: dockerfile
     value: packages/automl/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-autorag-ci-on-release-push.yaml
+++ b/.tekton/odh-mod-arch-autorag-ci-on-release-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-autorag:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-autorag:odh-release
   - name: dockerfile
     value: packages/autorag/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-autorag-push.yaml
+++ b/.tekton/odh-mod-arch-autorag-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-autorag:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-autorag:odh-release
   - name: dockerfile
     value: packages/autorag/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-eval-hub-push.yaml
+++ b/.tekton/odh-mod-arch-eval-hub-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-eval-hub:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-eval-hub:odh-release
   - name: dockerfile
     value: packages/eval-hub/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-eval-hub-release-push.yaml
+++ b/.tekton/odh-mod-arch-eval-hub-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-eval-hub:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-eval-hub:odh-release
   - name: dockerfile
     value: packages/eval-hub/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-gen-ai-push.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-gen-ai:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-gen-ai:odh-release
   - name: dockerfile
     value: packages/gen-ai/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-gen-ai-release-push.yaml
+++ b/.tekton/odh-mod-arch-gen-ai-release-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-gen-ai:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-gen-ai:odh-release
   - name: dockerfile
     value: packages/gen-ai/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-mlflow-push.yaml
+++ b/.tekton/odh-mod-arch-mlflow-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-mlflow:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-mlflow:odh-release
   - name: dockerfile
     value: packages/mlflow/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-mlflow-release-push.yaml
+++ b/.tekton/odh-mod-arch-mlflow-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-mlflow:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-mlflow:odh-release
   - name: dockerfile
     value: packages/mlflow/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-modular-architecture-push.yaml
+++ b/.tekton/odh-mod-arch-modular-architecture-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:odh-release
   - name: dockerfile
     value: packages/model-registry/Dockerfile.workspace
   - name: path-context

--- a/.tekton/odh-mod-arch-modular-architecture-release-push.yaml
+++ b/.tekton/odh-mod-arch-modular-architecture-release-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:v3.4.4-odh
+    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:odh-release
   - name: dockerfile
     value: packages/model-registry/Dockerfile.workspace
   - name: path-context


### PR DESCRIPTION
[Slack thread](https://redhat-internal.slack.com/archives/C05SMJ09DD2/p1781539886817129?thread_ts=1781196596.624579&cid=C05SMJ09DD2) -- we are switching the tag of the tekton pipeline to fit the branch name

That way we can manage the quay image via the name of this branch -- and not to the release it uses.

The release tag previous will be used in the last ODH Operator release (3.5 EA2). We'll be improving the process as time goes along, but this will produce an on-going image that one can reference via the tag for the branch.