### PR TITLE
[WIP] feat(nim-serving): migrate NIMAccount status from polling to k8s watch [RHOAIENG-62294]

### DIFF
--- a/packages/cypress/cypress/pages/projects.ts
+++ b/packages/cypress/cypress/pages/projects.ts
@@ -395,6 +395,14 @@ class ProjectDetailsSettingsTab extends ProjectDetails {
   findNIMReplaceKeyButton() {
     return cy.findByTestId('nim-replace-key-button');
   }
+
+  findNIMSettingsCard() {
+    return cy.findByTestId('nim-settings-card');
+  }
+
+  findNIMPermissionsLoading() {
+    return cy.findByTestId('nim-permissions-loading');
+  }
 }
 
 class ProjectDetailsOverviewTab extends ProjectDetails {

--- a/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
+++ b/packages/cypress/cypress/tests/mocked/projects/tabs/projectSettingsNim.cy.ts
@@ -1,3 +1,4 @@
+import type { K8sCondition } from '@odh-dashboard/internal/k8sTypes';
 import {
   mockDashboardConfig,
   mockDscStatus,
@@ -30,8 +31,10 @@ const denyNIMAccess = () => {
 
 const initIntercepts = ({
   nimAccountExists = false,
+  nimAccountConditions,
 }: {
   nimAccountExists?: boolean;
+  nimAccountConditions?: K8sCondition[];
 } = {}) => {
   cy.interceptOdh(
     'GET /api/dsc/status',
@@ -78,7 +81,16 @@ const initIntercepts = ({
 
   cy.interceptK8sList(
     { model: NIMAccountModel, ns: 'test-project' },
-    mockK8sResourceList(nimAccountExists ? [mockNimAccount({ namespace: 'test-project' })] : []),
+    mockK8sResourceList(
+      nimAccountExists
+        ? [
+            mockNimAccount({
+              namespace: 'test-project',
+              ...(nimAccountConditions !== undefined && { conditions: nimAccountConditions }),
+            }),
+          ]
+        : [],
+    ),
   );
 };
 
@@ -136,5 +148,64 @@ describe('NIM Settings Card RBAC', () => {
         .findNIMReplaceKeyButton()
         .should('have.attr', 'aria-disabled', 'true');
     });
+  });
+});
+
+describe('NIM Settings Card Status', () => {
+  beforeEach(() => {
+    asProjectEditUser();
+  });
+
+  it('should show enable button when no NIM account exists', () => {
+    initIntercepts({ nimAccountExists: false });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab.findNIMEnableButton().should('be.visible');
+    projectDetailsSettingsTab.findNIMSettingsCard().should('not.contain.text', 'API key');
+  });
+
+  it('should show success state when NIM account is ready', () => {
+    initIntercepts({
+      nimAccountExists: true,
+      nimAccountConditions: [
+        { type: 'AccountStatus', status: 'True', reason: 'AccountSuccessful' },
+      ],
+    });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab
+      .findNIMSettingsCard()
+      .should('contain.text', 'Your personal API key has been saved.');
+    projectDetailsSettingsTab.findNIMRemoveButton().should('be.visible');
+    projectDetailsSettingsTab.findNIMReplaceKeyButton().should('be.visible');
+  });
+
+  it('should show pending state when NIM account has no conditions', () => {
+    initIntercepts({
+      nimAccountExists: true,
+      nimAccountConditions: [],
+    });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab
+      .findNIMSettingsCard()
+      .should('contain.text', 'Contacting NVIDIA to validate the license key.');
+  });
+
+  it('should show error state when API key validation fails', () => {
+    initIntercepts({
+      nimAccountExists: true,
+      nimAccountConditions: [
+        {
+          type: 'APIKeyValidation',
+          status: 'False',
+          reason: 'ValidationFailed',
+          message: 'Invalid API key provided.',
+        },
+      ],
+    });
+    projectDetailsSettingsTab.visitSettings('test-project');
+    projectDetailsSettingsTab
+      .findNIMSettingsCard()
+      .should('contain.text', 'Invalid API key provided.');
+    projectDetailsSettingsTab.findNIMRemoveButton().should('be.visible');
+    projectDetailsSettingsTab.findNIMReplaceKeyButton().should('be.visible');
   });
 });

--- a/packages/nim-serving/src/api/accounts/__tests__/hooks.spec.ts
+++ b/packages/nim-serving/src/api/accounts/__tests__/hooks.spec.ts
@@ -1,24 +1,33 @@
 import { testHook } from '@odh-dashboard/jest-config/hooks';
 import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
-import { listNIMAccounts } from '../k8s';
+import { useWatchNIMAccounts } from '../watch';
 import useNIMAccountStatus, { NIMAccountStatus } from '../hooks';
 
-jest.mock('../k8s', () => ({
-  listNIMAccounts: jest.fn(),
+jest.mock('../watch', () => ({
+  useWatchNIMAccounts: jest.fn(),
 }));
 
-const mockListNIMAccounts = jest.mocked(listNIMAccounts);
+const mockUseWatchNIMAccounts = jest.mocked(useWatchNIMAccounts);
 
 describe('useNIMAccountStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return NOT_FOUND when no account exists', async () => {
-    mockListNIMAccounts.mockResolvedValue([]);
+  it('should return LOADING when watch has not loaded', () => {
+    mockUseWatchNIMAccounts.mockReturnValue([[], false, undefined]);
 
     const renderResult = testHook(useNIMAccountStatus)('test-ns');
-    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current.status).toBe(NIMAccountStatus.LOADING);
+    expect(renderResult.result.current.nimAccount).toBeNull();
+    expect(renderResult.result.current.loaded).toBe(false);
+  });
+
+  it('should return NOT_FOUND when no account exists', () => {
+    mockUseWatchNIMAccounts.mockReturnValue([[], true, undefined]);
+
+    const renderResult = testHook(useNIMAccountStatus)('test-ns');
 
     expect(renderResult.result.current.status).toBe(NIMAccountStatus.NOT_FOUND);
     expect(renderResult.result.current.nimAccount).toBeNull();
@@ -26,22 +35,21 @@ describe('useNIMAccountStatus', () => {
     expect(renderResult.result.current.loaded).toBe(true);
   });
 
-  it('should return READY when account has AccountStatus True', async () => {
+  it('should return READY when account has AccountStatus True', () => {
     const account = mockNimAccount({
       namespace: 'test-ns',
       conditions: [{ type: 'AccountStatus', status: 'True', reason: 'AccountSuccessful' }],
     });
-    mockListNIMAccounts.mockResolvedValue([account]);
+    mockUseWatchNIMAccounts.mockReturnValue([[account], true, undefined]);
 
     const renderResult = testHook(useNIMAccountStatus)('test-ns');
-    await renderResult.waitForNextUpdate();
 
     expect(renderResult.result.current.status).toBe(NIMAccountStatus.READY);
     expect(renderResult.result.current.nimAccount).toBe(account);
     expect(renderResult.result.current.errorMessages).toEqual([]);
   });
 
-  it('should return ERROR when APIKeyValidation is False', async () => {
+  it('should return ERROR when APIKeyValidation is False', () => {
     const account = mockNimAccount({
       namespace: 'test-ns',
       conditions: [
@@ -53,26 +61,38 @@ describe('useNIMAccountStatus', () => {
         },
       ],
     });
-    mockListNIMAccounts.mockResolvedValue([account]);
+    mockUseWatchNIMAccounts.mockReturnValue([[account], true, undefined]);
 
     const renderResult = testHook(useNIMAccountStatus)('test-ns');
-    await renderResult.waitForNextUpdate();
 
     expect(renderResult.result.current.status).toBe(NIMAccountStatus.ERROR);
     expect(renderResult.result.current.errorMessages).toEqual(['API key failed validation.']);
   });
 
-  it('should return PENDING when account exists but has no definitive conditions', async () => {
+  it('should return PENDING when account exists but has no definitive conditions', () => {
     const account = mockNimAccount({
       namespace: 'test-ns',
       conditions: [],
     });
-    mockListNIMAccounts.mockResolvedValue([account]);
+    mockUseWatchNIMAccounts.mockReturnValue([[account], true, undefined]);
 
     const renderResult = testHook(useNIMAccountStatus)('test-ns');
-    await renderResult.waitForNextUpdate();
 
     expect(renderResult.result.current.status).toBe(NIMAccountStatus.PENDING);
     expect(renderResult.result.current.errorMessages).toEqual([]);
+  });
+
+  it('should ignore accounts with non-matching names', () => {
+    const account = mockNimAccount({
+      name: 'some-other-account',
+      namespace: 'test-ns',
+      conditions: [{ type: 'AccountStatus', status: 'True', reason: 'AccountSuccessful' }],
+    });
+    mockUseWatchNIMAccounts.mockReturnValue([[account], true, undefined]);
+
+    const renderResult = testHook(useNIMAccountStatus)('test-ns');
+
+    expect(renderResult.result.current.status).toBe(NIMAccountStatus.NOT_FOUND);
+    expect(renderResult.result.current.nimAccount).toBeNull();
   });
 });

--- a/packages/nim-serving/src/api/accounts/__tests__/watch.spec.ts
+++ b/packages/nim-serving/src/api/accounts/__tests__/watch.spec.ts
@@ -1,0 +1,42 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import { mockNimAccount } from '@odh-dashboard/internal/__mocks__/mockNimAccount';
+import { NIMAccountModel } from '../k8s';
+import { useWatchNIMAccounts } from '../watch';
+
+jest.mock('@odh-dashboard/internal/utilities/useK8sWatchResourceList');
+
+const mockUseK8sWatchResourceList = jest.mocked(useK8sWatchResourceList);
+
+describe('useWatchNIMAccounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should pass correct resource config when namespace is provided', () => {
+    const accounts = [mockNimAccount({ namespace: 'test-ns' })];
+    mockUseK8sWatchResourceList.mockReturnValue([accounts, true, undefined]);
+
+    const renderResult = testHook(useWatchNIMAccounts)('test-ns');
+
+    expect(mockUseK8sWatchResourceList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isList: true,
+        groupVersionKind: groupVersionKind(NIMAccountModel),
+        namespace: 'test-ns',
+      }),
+      NIMAccountModel,
+      undefined,
+    );
+    expect(renderResult.result.current).toEqual([accounts, true, undefined]);
+  });
+
+  it('should pass null resource config when namespace is undefined', () => {
+    mockUseK8sWatchResourceList.mockReturnValue([[], false, undefined]);
+
+    testHook(useWatchNIMAccounts)(undefined);
+
+    expect(mockUseK8sWatchResourceList).toHaveBeenCalledWith(null, NIMAccountModel, undefined);
+  });
+});

--- a/packages/nim-serving/src/api/accounts/hooks.ts
+++ b/packages/nim-serving/src/api/accounts/hooks.ts
@@ -1,11 +1,6 @@
 import React from 'react';
-import useFetch, {
-  FetchStateCallbackPromise,
-  NotReadyError,
-} from '@odh-dashboard/internal/utilities/useFetch';
-import { POLL_INTERVAL, FAST_POLL_INTERVAL } from '@odh-dashboard/internal/utilities/const';
 import { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
-import { listNIMAccounts } from './k8s';
+import { useWatchNIMAccounts } from './watch';
 import { NIMAccountStatus, deriveAccountStatus, getAccountStatusTransitionTime } from './utils';
 import { NIM_ACCOUNT_NAME, REVALIDATION_TIMEOUT_MS } from './constants';
 
@@ -16,34 +11,21 @@ type NIMAccountStatusResult = {
   nimAccount: NIMAccountKind | null;
   errorMessages: string[];
   loaded: boolean;
-  refresh: () => Promise<NIMAccountKind | null | undefined>;
   startRevalidation: () => void;
 };
 
 const useNIMAccountStatus = (namespace?: string): NIMAccountStatusResult => {
-  const fetchCallback = React.useCallback<
-    FetchStateCallbackPromise<NIMAccountKind | null>
-  >(async () => {
-    if (!namespace) {
-      throw new NotReadyError('No namespace provided');
-    }
-    const accounts = await listNIMAccounts(namespace);
-    return accounts.find((a) => a.metadata.name === NIM_ACCOUNT_NAME) ?? null;
-  }, [namespace]);
+  const [accounts, loaded] = useWatchNIMAccounts(namespace);
 
-  const [pollRate, setPollRate] = React.useState(POLL_INTERVAL);
+  const nimAccount = React.useMemo(
+    () => accounts.find((a) => a.metadata.name === NIM_ACCOUNT_NAME) ?? null,
+    [accounts],
+  );
+
   const [revalidationState, setRevalidationState] = React.useState<{
     transitionTimeAtStart: string | undefined;
     startedAt: number;
   } | null>(null);
-
-  const {
-    data: nimAccount,
-    loaded,
-    refresh,
-  } = useFetch(fetchCallback, null, {
-    refreshRate: pollRate,
-  });
 
   const derived = deriveAccountStatus(nimAccount, loaded);
 
@@ -73,10 +55,6 @@ const useNIMAccountStatus = (namespace?: string): NIMAccountStatusResult => {
   const effectiveStatus = isWaitingForRevalidation ? NIMAccountStatus.PENDING : derived.status;
   const effectiveErrors = isWaitingForRevalidation ? [] : derived.errorMessages;
 
-  React.useEffect(() => {
-    setPollRate(effectiveStatus === NIMAccountStatus.PENDING ? FAST_POLL_INTERVAL : POLL_INTERVAL);
-  }, [effectiveStatus]);
-
   const startRevalidation = React.useCallback(() => {
     setRevalidationState({
       transitionTimeAtStart: getAccountStatusTransitionTime(nimAccount),
@@ -89,7 +67,6 @@ const useNIMAccountStatus = (namespace?: string): NIMAccountStatusResult => {
     nimAccount,
     errorMessages: effectiveErrors,
     loaded,
-    refresh,
     startRevalidation,
   };
 };

--- a/packages/nim-serving/src/api/accounts/watch.ts
+++ b/packages/nim-serving/src/api/accounts/watch.ts
@@ -1,0 +1,22 @@
+import type { K8sAPIOptions } from '@odh-dashboard/internal/k8sTypes';
+import { NIMAccountKind } from '@odh-dashboard/internal/k8sTypes';
+import useK8sWatchResourceList from '@odh-dashboard/internal/utilities/useK8sWatchResourceList';
+import { groupVersionKind } from '@odh-dashboard/internal/api/k8sUtils';
+import type { CustomWatchK8sResult } from '@odh-dashboard/internal/types';
+import { NIMAccountModel } from './k8s';
+
+export const useWatchNIMAccounts = (
+  namespace?: string,
+  opts?: K8sAPIOptions,
+): CustomWatchK8sResult<NIMAccountKind[]> =>
+  useK8sWatchResourceList<NIMAccountKind[]>(
+    namespace
+      ? {
+          isList: true,
+          groupVersionKind: groupVersionKind(NIMAccountModel),
+          namespace,
+        }
+      : null,
+    NIMAccountModel,
+    opts,
+  );

--- a/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMApiKeyModal.tsx
@@ -25,7 +25,6 @@ import { createNIMResources, createOrReplaceSecret } from '../../api/accounts/ap
 type NIMApiKeyModalProps = {
   onClose: () => void;
   namespace: string;
-  refresh: () => Promise<unknown>;
   startRevalidation: () => void;
   accountStatus: NIMAccountStatus;
 };
@@ -33,7 +32,6 @@ type NIMApiKeyModalProps = {
 const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
   onClose,
   namespace,
-  refresh,
   startRevalidation,
   accountStatus,
 }) => {
@@ -59,19 +57,16 @@ const NIMApiKeyModal: React.FC<NIMApiKeyModalProps> = ({
         await createNIMResources(namespace, trimmedKey);
       }
       setSubmitted(true);
-      await refresh();
     } catch (e) {
       setCreateError(e instanceof Error ? e.message : 'Failed to create NIM resources.');
     } finally {
       setIsCreating(false);
     }
-  }, [apiKey, accountStatus, namespace, startRevalidation, refresh]);
+  }, [apiKey, accountStatus, namespace, startRevalidation]);
 
   const handleClose = React.useCallback(() => {
     onClose();
-    // void operator: intentionally not awaiting — we're closing the modal and don't need the result
-    void refresh();
-  }, [onClose, refresh]);
+  }, [onClose]);
 
   const isValidating = submitted && accountStatus === NIMAccountStatus.PENDING;
   const isSuccess = submitted && accountStatus === NIMAccountStatus.READY;

--- a/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/NIMSettingsCard.tsx
@@ -41,7 +41,7 @@ type NIMSettingsCardProps = {
 };
 
 const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
-  const { status, errorMessages, refresh, startRevalidation } = useNIMAccountStatus(namespace);
+  const { status, errorMessages, startRevalidation } = useNIMAccountStatus(namespace);
 
   const { loaded: accessReviewLoaded, allowed } = useNIMSettingsAccessAllowed(namespace);
 
@@ -50,23 +50,12 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [deleteError, setDeleteError] = React.useState<Error>();
 
-  const deleteStatusIntervalRef = React.useRef<ReturnType<typeof setInterval>>();
-  const stopPollingDeleteStatus = React.useCallback((error?: Error) => {
-    if (deleteStatusIntervalRef.current !== undefined) {
-      clearInterval(deleteStatusIntervalRef.current);
-      deleteStatusIntervalRef.current = undefined;
+  React.useEffect(() => {
+    if (isDeleting && status === NIMAccountStatus.NOT_FOUND) {
+      setIsDeleting(false);
+      setIsDeleteModalOpen(false);
     }
-    setDeleteError(error);
-    setIsDeleting(false);
-  }, []);
-  React.useEffect(
-    () => () => {
-      if (deleteStatusIntervalRef.current !== undefined) {
-        clearInterval(deleteStatusIntervalRef.current);
-      }
-    },
-    [],
-  );
+  }, [isDeleting, status]);
 
   const handleRemoveConfirm = React.useCallback(async () => {
     setIsDeleting(true);
@@ -74,25 +63,10 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
     try {
       await deleteNIMResources(namespace);
     } catch (e) {
-      stopPollingDeleteStatus(e instanceof Error ? e : new Error('Failed to remove NIM.'));
-      return;
+      setDeleteError(e instanceof Error ? e : new Error('Failed to remove NIM.'));
+      setIsDeleting(false);
     }
-    let retries = 10;
-    deleteStatusIntervalRef.current = setInterval(async () => {
-      try {
-        const result = await refresh();
-        if (!result) {
-          stopPollingDeleteStatus();
-          setIsDeleteModalOpen(false);
-        } else if (retries === 0) {
-          stopPollingDeleteStatus(new Error('NIM resources were not deleted in time.'));
-        }
-        retries -= 1;
-      } catch (e) {
-        stopPollingDeleteStatus(e instanceof Error ? e : new Error('Failed to remove NIM.'));
-      }
-    }, 1000);
-  }, [namespace, refresh, stopPollingDeleteStatus]);
+  }, [namespace]);
 
   const renderFooterContent = () => {
     if (!accessReviewLoaded || status === NIMAccountStatus.LOADING) {
@@ -202,7 +176,6 @@ const NIMSettingsCard: React.FC<NIMSettingsCardProps> = ({ namespace }) => {
         <NIMApiKeyModal
           onClose={() => setIsApiKeyModalOpen(false)}
           namespace={namespace}
-          refresh={refresh}
           startRevalidation={startRevalidation}
           accountStatus={status}
         />

--- a/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
+++ b/packages/nim-serving/src/pages/projectSettings/__tests__/NIMSettingsCard.spec.tsx
@@ -42,7 +42,6 @@ const mockUseNIMAccountStatus = jest.mocked(useNIMAccountStatus);
 const defaultAccountStatus = {
   status: NIMAccountStatus.NOT_FOUND,
   errorMessages: [],
-  refresh: jest.fn().mockResolvedValue(undefined),
   startRevalidation: jest.fn(),
   nimAccount: null,
   loaded: true,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-62294

**Note: This issue was deprioritized and this AI-generated diff was not human-reviewed. Opening and closing the PR to preserve the work in case it’s helpful in the future, and putting the issue back on the Backlog.**

For Mike’s reference, the claude session was `557efa2c-9999-4833-9abd-ed688c06f726` in the worktree at `~/git/.worktrees/odh-dashboard/RHOAIENG-62294-nim-account-watch`.

## Description

Replace polling-based NIMAccount status tracking with a k8s watch for real-time updates and reduced API load.

**What changed:**
- **New `useWatchNIMAccounts` hook** (`watch.ts`) — uses `useK8sWatchResourceList` matching the established pattern from kserve/llmd-serving/nim-serving deployments
- **Rewrote `useNIMAccountStatus`** (`hooks.ts`) — consumes the watch instead of `useFetch` + `refreshRate` polling (30s normal / 3s when PENDING). Kept the `startRevalidation` mechanism for the key-replacement UX flow
- **Simplified `NIMSettingsCard`** — removed `setInterval`-based deletion polling (1s, 10 retries). The watch now automatically reflects resource deletion via a `useEffect` that closes the delete modal when status becomes `NOT_FOUND`
- **Simplified `NIMApiKeyModal`** — removed `refresh` prop; the watch delivers updates automatically after creating/replacing resources
- **Added Cypress mock tests** for NIM settings card status lifecycle (NOT_FOUND, READY, PENDING, ERROR states)

**What stayed the same:**
- `NIMAccountModel`, CRUD operations, resource assembly (`k8s.ts`)
- Status derivation logic (`utils.ts`) — `deriveAccountStatus`, condition helpers, `NIMAccountStatus` enum
- RBAC hooks (`useNIMSettingsAccessAllowed`) — unaffected
- All existing `data-testid` attributes

## How Has This Been Tested?

- Unit tests pass: 16 suites, 146 tests (2 new watch tests, 2 new hooks tests)
- Type-check passes with no errors
- Lint passes with no errors
- Not yet tested on a cluster

## Test Impact

- **New:** `watch.spec.ts` — 2 tests for `useWatchNIMAccounts` (namespace provided, namespace undefined)
- **Updated:** `hooks.spec.ts` — 6 tests (was 4), now mocks `useWatchNIMAccounts` instead of `listNIMAccounts`, added LOADING and non-matching-name cases
- **Updated:** `NIMSettingsCard.spec.tsx` — removed `refresh` from mock return value
- **New Cypress:** 4 mock tests for NIM settings card status rendering (NOT_FOUND, READY, PENDING, ERROR)

## Request review criteria:

Self checklist (all need to be checked):
- [ ] The developer has manually tested the changes and verified that the changes work
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added (unit or cypress tests for related changes)
- [x] The code follows our [Best Practices](/docs/best-practices.md) (React coding standards, PatternFly usage, performance considerations)
After the PR is posted & before it merges:
- [ ] The developer has tested their solution on a cluster by using the image produced by the PR to `main`